### PR TITLE
Cashback enabled propagierung

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2624,6 +2624,7 @@ async fn run_geyser_loop(
                                 meta.insert("complete".to_string(), s.complete.to_string());
                                 meta.insert("real_token_reserves".to_string(), s.real_token_reserves.to_string());
                                 meta.insert("real_sol_reserves".to_string(), s.real_sol_reserves.to_string());
+                                meta.insert("cashback_enabled".to_string(), s.cashback_enabled.to_string());
                                 pool_update.metadata = Some(meta);
 
                                 // === BondingCurveProgress event for momentum-bot exit signal ===

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -224,7 +224,12 @@ fn build_minimal_pool_state_with_reserves(
                 real_token_reserves,
                 complete,
                 creator,
-                cashback_enabled: false, // JetStream metadata may not have it; safe default — resolved at TX build time via RPC
+                cashback_enabled: update
+                    .metadata
+                    .as_ref()
+                    .and_then(|m| m.get("cashback_enabled"))
+                    .map(|v| v == "true")
+                    .unwrap_or(false), // Resolved from JetStream metadata (propagated by market-data from Geyser)
             })
         }
         _ => {

--- a/src/solana/dex/pumpfun.rs
+++ b/src/solana/dex/pumpfun.rs
@@ -1193,26 +1193,20 @@ impl PumpFunDex {
                 creator = %c,
                 "pump.fun: using creator from producer"
             );
-            let cashback = match self.get_bonding_curve_from_cache(&bonding_curve) {
-                Some(state) => state.cashback_enabled,
-                None => {
-                    if allow_rpc_fallback {
-                        match self.fetch_bonding_curve_fast(&bonding_curve).await {
-                            Some(state) => {
-                                warn!(
-                                    bonding_curve = %bonding_curve,
-                                    cashback_enabled = state.cashback_enabled,
-                                    "cashback_enabled resolved via RPC fallback (cache miss)"
-                                );
-                                state.cashback_enabled
-                            }
-                            None => false,
-                        }
-                    } else {
-                        // Hot Path: Cache miss → cashback_enabled=false (I-7, no RPC)
-                        false
-                    }
+            let cashback = if allow_rpc_fallback {
+                // Cold Path (Liquidation): ALWAYS verify via RPC — JetStream cache may have stale cashback_enabled
+                match self.fetch_bonding_curve_fast(&bonding_curve).await {
+                    Some(state) => state.cashback_enabled,
+                    None => self
+                        .get_bonding_curve_from_cache(&bonding_curve)
+                        .map(|s| s.cashback_enabled)
+                        .unwrap_or(false),
                 }
+            } else {
+                // Hot Path: trust Geyser-fed cache (I-7: no RPC)
+                self.get_bonding_curve_from_cache(&bonding_curve)
+                    .map(|s| s.cashback_enabled)
+                    .unwrap_or(false)
             };
             (c, cashback)
         } else if let Some(c) = self.get_cached_creator(&token_mint) {
@@ -1221,26 +1215,20 @@ impl PumpFunDex {
                 creator = %c,
                 "pump.fun: using creator from DashMap cache"
             );
-            let cashback = match self.get_bonding_curve_from_cache(&bonding_curve) {
-                Some(state) => state.cashback_enabled,
-                None => {
-                    if allow_rpc_fallback {
-                        match self.fetch_bonding_curve_fast(&bonding_curve).await {
-                            Some(state) => {
-                                warn!(
-                                    bonding_curve = %bonding_curve,
-                                    cashback_enabled = state.cashback_enabled,
-                                    "cashback_enabled resolved via RPC fallback (cache miss)"
-                                );
-                                state.cashback_enabled
-                            }
-                            None => false,
-                        }
-                    } else {
-                        // Hot Path: Cache miss → cashback_enabled=false (I-7, no RPC)
-                        false
-                    }
+            let cashback = if allow_rpc_fallback {
+                // Cold Path (Liquidation): ALWAYS verify via RPC — JetStream cache may have stale cashback_enabled
+                match self.fetch_bonding_curve_fast(&bonding_curve).await {
+                    Some(state) => state.cashback_enabled,
+                    None => self
+                        .get_bonding_curve_from_cache(&bonding_curve)
+                        .map(|s| s.cashback_enabled)
+                        .unwrap_or(false),
                 }
+            } else {
+                // Hot Path: trust Geyser-fed cache (I-7: no RPC)
+                self.get_bonding_curve_from_cache(&bonding_curve)
+                    .map(|s| s.cashback_enabled)
+                    .unwrap_or(false)
             };
             (c, cashback)
         } else if let Some(c) = self.get_creator_from_cache(&bonding_curve) {
@@ -1251,26 +1239,20 @@ impl PumpFunDex {
             );
             // Also cache in DashMap for faster subsequent lookups
             self.cached_creators.insert(token_mint, c);
-            let cashback = match self.get_bonding_curve_from_cache(&bonding_curve) {
-                Some(state) => state.cashback_enabled,
-                None => {
-                    if allow_rpc_fallback {
-                        match self.fetch_bonding_curve_fast(&bonding_curve).await {
-                            Some(state) => {
-                                warn!(
-                                    bonding_curve = %bonding_curve,
-                                    cashback_enabled = state.cashback_enabled,
-                                    "cashback_enabled resolved via RPC fallback (cache miss)"
-                                );
-                                state.cashback_enabled
-                            }
-                            None => false,
-                        }
-                    } else {
-                        // Hot Path: Cache miss → cashback_enabled=false (I-7, no RPC)
-                        false
-                    }
+            let cashback = if allow_rpc_fallback {
+                // Cold Path (Liquidation): ALWAYS verify via RPC — JetStream cache may have stale cashback_enabled
+                match self.fetch_bonding_curve_fast(&bonding_curve).await {
+                    Some(state) => state.cashback_enabled,
+                    None => self
+                        .get_bonding_curve_from_cache(&bonding_curve)
+                        .map(|s| s.cashback_enabled)
+                        .unwrap_or(false),
                 }
+            } else {
+                // Hot Path: trust Geyser-fed cache (I-7: no RPC)
+                self.get_bonding_curve_from_cache(&bonding_curve)
+                    .map(|s| s.cashback_enabled)
+                    .unwrap_or(false)
             };
             (c, cashback)
         } else {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the `cashback_enabled` JetStream propagation bug (Custom 6024 Overflow) by ensuring the flag is correctly propagated and verified in Pump.fun's cold path.

This PR addresses the `cashback_enabled` JetStream propagation bug, identified as Custom 6024 Overflow and detailed in `docs/KNOWN_BUG_PATTERNS.md` entry 25. The fix involves three parts: propagating `cashback_enabled` in JetStream PoolCacheUpdate metadata in `market_data.rs`, reading this metadata in `pool_cache_sync.rs` instead of hardcoding `false`, and always verifying `cashback_enabled` via RPC in the cold path (`allow_rpc_fallback=true`) for Pump.fun swaps in `pumpfun.rs`, even on cache hits, while adhering to Invariant I-7 (no new RPC in the hot path).

<div><a href="https://cursor.com/agents/bc-990bf8ab-3aa3-4833-9035-34a853ac8681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-990bf8ab-3aa3-4833-9035-34a853ac8681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->