### PR TITLE
Pump.fun AMM rpc-fallback

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2583,7 +2583,34 @@ async fn run_geyser_loop(
                                     );
                                 }
                             }
-                            (s.base_mint, s.quote_mint, s.base_reserve.unwrap_or(0), s.quote_reserve.unwrap_or(0))
+                            {
+                                let (base_r, quote_r) = if s.base_reserve.is_none() || s.quote_reserve.is_none() {
+                                    let base_vault = s.pool_base_token_account;
+                                    let quote_vault = s.pool_quote_token_account;
+                                    let base_bal = match rpc.get_account_opt_retry(&base_vault).await {
+                                        Ok(Some(acc)) => try_parse_token_account_balance(&acc.data).unwrap_or(0),
+                                        _ => 0,
+                                    };
+                                    let quote_bal = match rpc.get_account_opt_retry(&quote_vault).await {
+                                        Ok(Some(acc)) => try_parse_token_account_balance(&acc.data).unwrap_or(0),
+                                        _ => 0,
+                                    };
+                                    if base_bal > 0 || quote_bal > 0 {
+                                        info!(
+                                            pool = %account_update.pubkey,
+                                            base_vault = %base_vault,
+                                            quote_vault = %quote_vault,
+                                            base_bal,
+                                            quote_bal,
+                                            "pump_amm: pre-loaded vault balances via RPC (Cold Start Bootstrap)"
+                                        );
+                                    }
+                                    (base_bal, quote_bal)
+                                } else {
+                                    (s.base_reserve.unwrap_or(0), s.quote_reserve.unwrap_or(0))
+                                };
+                                (s.base_mint, s.quote_mint, base_r, quote_r)
+                            }
                         }
                         CachedPoolState::PumpFun(s) => {
                             (s.token_mint, Pubkey::default(), s.virtual_token_reserves, s.virtual_sol_reserves)

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -2224,29 +2224,38 @@ impl Dex for PumpFunAmmDex {
                 let (amount_out, price_impact_bps) =
                     self.quote_cp(amount_in, in_reserve, out_reserve, DEFAULT_TOTAL_FEE_BPS);
                 if amount_out == 0 {
-                    return Ok(None);
+                    if self.allow_rpc_on_miss {
+                        warn!(
+                            base_mint = %base_mint_str,
+                            base_reserve = base_r,
+                            quote_reserve = quote_r,
+                            "pump_amm: cache reserves degenerate (one side=0), Cold Path falling through to RPC"
+                        );
+                    } else {
+                        return Ok(None);
+                    }
+                } else {
+                    debug!(
+                        base_mint = %base_mint_str,
+                        pool = %pool_market,
+                        base_reserve = base_r,
+                        quote_reserve = quote_r,
+                        amount_out,
+                        "pump_amm: quote from LivePoolCache (ZERO RPC)"
+                    );
+
+                    return Ok(Some(Quote {
+                        amount_out,
+                        price_impact_bps,
+                        route: vec![pool_market.to_string()],
+                        fee_bps: DEFAULT_TOTAL_FEE_BPS,
+                        in_reserve,
+                        out_reserve,
+                        input_mint: input_mint.to_string(),
+                        output_mint: output_mint.to_string(),
+                        tick_spacing: None,
+                    }));
                 }
-
-                debug!(
-                    base_mint = %base_mint_str,
-                    pool = %pool_market,
-                    base_reserve = base_r,
-                    quote_reserve = quote_r,
-                    amount_out,
-                    "pump_amm: quote from LivePoolCache (ZERO RPC)"
-                );
-
-                return Ok(Some(Quote {
-                    amount_out,
-                    price_impact_bps,
-                    route: vec![pool_market.to_string()],
-                    fee_bps: DEFAULT_TOTAL_FEE_BPS,
-                    in_reserve,
-                    out_reserve,
-                    input_mint: input_mint.to_string(),
-                    output_mint: output_mint.to_string(),
-                    tick_spacing: None,
-                }));
             }
             // Cache miss: Hot Path (allow_rpc_on_miss=false) → None. Cold Path (true) → RPC fallback. P3 #12.
             if !self.allow_rpc_on_miss {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes PumpSwap AMM degenerate cache reserves by adding RPC fallbacks for zero `amount_out` in `quote_exact_in()` (Cold Path) and for missing vault balances in `market_data.rs`.

This addresses Bug #27, ensuring that `PoolDiscovered` events contain valid reserves instead of `(0, 0)` and allowing the Cold Path of `quote_exact_in()` to fall back to RPC when `amount_out` is zero.

<div><a href="https://cursor.com/agents/bc-4aaf88ba-1338-4387-9ea4-29cfe827a2dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4aaf88ba-1338-4387-9ea4-29cfe827a2dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->