### PR TITLE
Market data ownership

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3418,8 +3418,8 @@ async fn run_geyser_loop(
                         MarketEventKind::DexPoolAccounts {
                             dex: DexType::PumpFunAmm.to_string(),
                             pool_address: pool_address.to_string(),
-                            base_mint,
-                            quote_mint,
+                            base_mint: base_mint.clone(),
+                            quote_mint: quote_mint.clone(),
                             accounts: pool_accounts.iter().map(|p| p.to_string()).collect(),
                         },
                     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolve Rust ownership errors in `market_data.rs` by cloning `base_mint` and `quote_mint` for `MarketEventKind::DexPoolAccounts`.

The previous change moved `base_mint` and `quote_mint` into `MarketEventKind::DexPoolAccounts`, preventing their subsequent use for `PoolCacheUpdate::new_pool_discovered` due to Rust's ownership rules (E0382).

<div><a href="https://cursor.com/agents/bc-8c2b3843-051f-49f9-b332-1f123b66f32c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c2b3843-051f-49f9-b332-1f123b66f32c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->