### PR TITLE
Fmt clippy zustand

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -4654,8 +4654,7 @@ async fn main() -> Result<()> {
                 count = pools_needing_accounts.len(),
                 "Startup: seeding pool_accounts for PumpSwap pools via getAccountInfo"
             );
-            let pump_amm =
-                PumpFunAmmDex::new_with_cache(Arc::clone(&rpc), Arc::clone(cache), true);
+            let pump_amm = PumpFunAmmDex::new_with_cache(Arc::clone(&rpc), Arc::clone(cache), true);
             let mut seeded = 0u32;
             for (pool_addr, base_mint) in &pools_needing_accounts {
                 match pump_amm.pool_accounts_v1_for_base_mint(*base_mint).await {

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -311,50 +311,6 @@ impl PumpFunAmmDex {
         Pubkey::new_from_array(ata_spl.to_bytes())
     }
 
-    async fn find_token_account_by_owner_and_mint(
-        &self,
-        token_program: Pubkey,
-        token_owner: Pubkey,
-        mint: Pubkey,
-    ) -> Result<Option<Pubkey>> {
-        // Query by program and filter client-side by mint (covers SPL Token and Token-2022).
-        let accounts = self
-            .rpc
-            .get_token_accounts_by_owner_with_filter(&token_owner, &token_program)
-            .await
-            .map_err(|e| anyhow!("get_token_accounts_by_owner failed: {e}"))?;
-
-        for (pk, acc) in accounts {
-            if let Some((acc_mint, acc_owner)) =
-                Self::parse_spl_token_account_mint_and_owner(&acc.data)
-            {
-                if acc_mint == mint && acc_owner == token_owner {
-                    return Ok(Some(pk));
-                }
-            }
-        }
-
-        Ok(None)
-    }
-
-    async fn find_any_token_account_for_owner_and_mint(
-        &self,
-        token_owner: Pubkey,
-        mint: Pubkey,
-        token_program: Pubkey,
-        token_2022_program: Pubkey,
-    ) -> Result<Option<Pubkey>> {
-        // Prefer the legacy SPL Token program first.
-        if let Some(ta) = self
-            .find_token_account_by_owner_and_mint(token_program, token_owner, mint)
-            .await?
-        {
-            return Ok(Some(ta));
-        }
-        self.find_token_account_by_owner_and_mint(token_2022_program, token_owner, mint)
-            .await
-    }
-
     async fn derive_existing_pda(
         &self,
         program_id: Pubkey,
@@ -584,7 +540,10 @@ impl PumpFunAmmDex {
                         derived_ata = %derived_ata,
                         "pump_amm: ATA not on-chain, using derived address (PumpSwap will create via CreateIdempotent)"
                     );
-                    return Ok::<Option<(Pubkey, Pubkey)>, anyhow::Error>(Some((cand, derived_ata)));
+                    return Ok::<Option<(Pubkey, Pubkey)>, anyhow::Error>(Some((
+                        cand,
+                        derived_ata,
+                    )));
                 }
             }
             Ok::<Option<(Pubkey, Pubkey)>, anyhow::Error>(None)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix `cargo fmt` and `clippy::dead_code` warnings by applying formatting and removing unused private methods.

The `dead_code` warnings for `find_token_account_by_owner_and_mint` and `find_any_token_account_for_owner_and_mint` in `pumpfun_amm.rs` were resolved by removing these methods, as they were confirmed to be uncalled and thus truly dead code. This aligns with the task's directive to remove unused private helper code rather than suppressing warnings. The formatting changes address pure stylistic deviations reported by `cargo fmt --check`. All changes are minimal and behavior-neutral.

<div><a href="https://cursor.com/agents/bc-230f0206-31c6-4b04-986a-ebba29a995b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-230f0206-31c6-4b04-986a-ebba29a995b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->