### PR TITLE
Pool discovery architektur rollback

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -4645,38 +4645,9 @@ async fn main() -> Result<()> {
         None
     };
 
-    // FIX-33: Proactively seed pool_accounts for PumpSwap pools
-    // that came from JetStream bootstrap without pool_accounts.
-    if let Some(ref cache) = live_pool_cache {
-        let pools_needing_accounts = cache.get_pump_amm_pools_without_accounts();
-        if !pools_needing_accounts.is_empty() {
-            info!(
-                count = pools_needing_accounts.len(),
-                "Startup: seeding pool_accounts for PumpSwap pools via getAccountInfo"
-            );
-            let pump_amm = PumpFunAmmDex::new_with_cache(Arc::clone(&rpc), Arc::clone(cache), true);
-            let mut seeded = 0u32;
-            for (pool_addr, base_mint) in &pools_needing_accounts {
-                match pump_amm.pool_accounts_v1_for_base_mint(*base_mint).await {
-                    Ok(Some(accounts)) => {
-                        cache.set_pump_amm_pool_accounts(pool_addr, accounts);
-                        seeded += 1;
-                    }
-                    Ok(None) => {
-                        debug!(pool = %pool_addr, "Startup seeding: pool parse returned None (may be non-WSOL pair)");
-                    }
-                    Err(e) => {
-                        warn!(pool = %pool_addr, error = %e, "Startup seeding: pool discovery failed");
-                    }
-                }
-            }
-            info!(
-                seeded = seeded,
-                total = pools_needing_accounts.len(),
-                "Startup: pool_accounts seeding complete"
-            );
-        }
-    }
+    // I-24c: execution-engine is consumer/executor only. No global discovery/seeding rebuild.
+    // Pool state comes from JetStream (bootstrap) + incremental PoolCacheUpdate from market-data.
+    // market-data is the discovery authority and publishes pool_accounts to JetStream.
 
     // FIX-32: Initialize Geyser-based TX confirmation tracker
     let tx_confirm = {

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -823,20 +823,6 @@ impl LivePoolCache {
         None
     }
 
-    /// Get all PumpAmm pools that have empty pool_accounts.
-    /// Returns Vec<(pool_address, base_mint)> for pools that need pool_accounts seeding.
-    pub fn get_pump_amm_pools_without_accounts(&self) -> Vec<(Pubkey, Pubkey)> {
-        let mut result = Vec::new();
-        for entry in self.pools.iter() {
-            if let CachedPoolState::PumpAmm(ref s) = entry.value().state {
-                if s.pool_accounts.is_empty() {
-                    result.push((*entry.key(), s.base_mint));
-                }
-            }
-        }
-        result
-    }
-
     /// Get PumpAmm pool_accounts for a given base_mint from cache.
     ///
     /// Returns `Some(Vec<Pubkey>)` if the pool_accounts are non-empty in the cache.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Performs a targeted functional rollback of global pool discovery/bootstrap changes in `execution-engine` to restore `market-data` as the sole discovery authority.

The `execution-engine` was observed in production performing global startup seeding/discovery, causing restart cycles and issues with kill-switch/liquidation. This rollback specifically removes the `execution-engine`'s ability to initiate global discovery, aligning with invariant I-24c which designates `market-data` as the exclusive authority for global pool/market discovery and `execution-engine` as a consumer. Changes in `market_data.rs` and `pumpfun_amm.rs` from `e80e8cd` related to JetStream persistence and ATA derivation (FIX-32/33) were retained as they do not violate this architectural principle.

<div><a href="https://cursor.com/agents/bc-1319183e-6c4f-4762-a187-980afc819f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1319183e-6c4f-4762-a187-980afc819f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->