### PR TITLE
E2E-Readiness-Schnittstelle

### DIFF
--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -34,9 +34,10 @@ use ironcrab::ipc::{
     TradeSide, TradingRegime,
 };
 use ironcrab::metrics::{
-    serve_metrics, ARB_REJECTED_MISSING_ACCOUNTS, ARB_TRIANGLE_OPPORTUNITIES,
-    INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
-    NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
+    serve_metrics, set_readiness_nats_connected, MetricsComponent, ARB_REJECTED_MISSING_ACCOUNTS,
+    ARB_TRIANGLE_OPPORTUNITIES, INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL,
+    NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE,
+    TOKENS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, slave_consumer_config, CONFIG_STREAM_NAME, STREAM_NAME,
@@ -1912,7 +1913,7 @@ async fn main() -> Result<()> {
     // Start metrics server
     let metrics_addr = std::net::SocketAddr::from(([0, 0, 0, 0], args.metrics_port));
     tokio::spawn(async move {
-        if let Err(e) = serve_metrics(metrics_addr).await {
+        if let Err(e) = serve_metrics(metrics_addr, MetricsComponent::ArbStrategy).await {
             error!(error = %e, "Metrics server failed");
         }
     });
@@ -1951,6 +1952,7 @@ async fn main() -> Result<()> {
             return Err(e);
         }
         info!(url = %args.nats_url, "Connected to NATS");
+        set_readiness_nats_connected(true);
         Some(client)
     };
 

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -73,16 +73,17 @@ use ironcrab::metrics::{
     record_recent_trade, record_tx_slot_to_send_ms, serve_metrics,
     set_readiness_control_response_sub_active, set_readiness_control_sub_active,
     set_readiness_mode, set_readiness_nats_connected, set_readiness_state_paths_initialized,
-    MetricsComponent, RecentTrade, ACTIVE_CAPITAL_LOCKS, ACTIVE_RESOURCE_LOCKS,
-    AVAILABLE_SOL_LAMPORTS, CONCURRENT_INTENTS_GAUGE, INTENTS_EXECUTED_TOTAL,
-    INTENTS_RECEIVED_TOTAL, INTENTS_REJECTED_TOTAL, JITO_BUNDLES_LANDED_TOTAL,
-    JITO_BUNDLES_REJECTED_TOTAL, JITO_BUNDLES_SUBMITTED_TOTAL, JITO_BUNDLES_TIMEOUT_TOTAL,
-    JITO_TIP_LAMPORTS_TOTAL, KILL_SWITCH_ACTIVE, NATS_MESSAGES_RECEIVED_TOTAL,
-    OPEN_POSITIONS_GAUGE, REJECT_CAPITAL_LOCK, REJECT_DUPLICATE, REJECT_RESOURCE_LOCK,
-    REJECT_SEND_FAILED, REJECT_SIMULATION_FAIL, SIMULATION_FAILURES_TOTAL, TX_CONFIRMED_TOTAL,
-    TX_CONFIRM_GEYSER_TOTAL, TX_CONFIRM_LATENCY_MS, TX_CONFIRM_RPC_FALLBACK_TOTAL,
-    TX_CONFIRM_TIMEOUT_TOTAL, TX_SEND_ATTEMPTS_TOTAL, TX_SEND_JITO_TOTAL, TX_SEND_RPC_TOTAL,
-    TX_SEND_SUCCESS_TOTAL, TX_SEND_TPU_TOTAL, WALLET_TOTAL_SOL_LAMPORTS,
+    update_readiness_execution_engine_current, MetricsComponent, RecentTrade, ACTIVE_CAPITAL_LOCKS,
+    ACTIVE_RESOURCE_LOCKS, AVAILABLE_SOL_LAMPORTS, CONCURRENT_INTENTS_GAUGE,
+    INTENTS_EXECUTED_TOTAL, INTENTS_RECEIVED_TOTAL, INTENTS_REJECTED_TOTAL,
+    JITO_BUNDLES_LANDED_TOTAL, JITO_BUNDLES_REJECTED_TOTAL, JITO_BUNDLES_SUBMITTED_TOTAL,
+    JITO_BUNDLES_TIMEOUT_TOTAL, JITO_TIP_LAMPORTS_TOTAL, KILL_SWITCH_ACTIVE,
+    NATS_MESSAGES_RECEIVED_TOTAL, OPEN_POSITIONS_GAUGE, REJECT_CAPITAL_LOCK, REJECT_DUPLICATE,
+    REJECT_RESOURCE_LOCK, REJECT_SEND_FAILED, REJECT_SIMULATION_FAIL, SIMULATION_FAILURES_TOTAL,
+    TX_CONFIRMED_TOTAL, TX_CONFIRM_GEYSER_TOTAL, TX_CONFIRM_LATENCY_MS,
+    TX_CONFIRM_RPC_FALLBACK_TOTAL, TX_CONFIRM_TIMEOUT_TOTAL, TX_SEND_ATTEMPTS_TOTAL,
+    TX_SEND_JITO_TOTAL, TX_SEND_RPC_TOTAL, TX_SEND_SUCCESS_TOTAL, TX_SEND_TPU_TOTAL,
+    WALLET_TOTAL_SOL_LAMPORTS,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
@@ -6191,6 +6192,10 @@ async fn main() -> Result<()> {
 
                 // Keep /ready fresh even when no intents flow.
                 ironcrab::metrics::record_activity();
+
+                // Refresh readiness from current state (not startup-latch)
+                let nats_connected = ctx.nats.as_ref().is_some_and(|n| n.is_connected());
+                update_readiness_execution_engine_current(nats_connected);
 
                 // Process any available PoolCacheUpdates from JetStream Consumer
                 if let Some(ref mut consumer) = pool_cache_consumer_opt {

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -5720,6 +5720,20 @@ async fn main() -> Result<()> {
         });
     }
 
+    // Subscription liveness: updated by tasks so /status reflects current contract state
+    let control_sub_last_activity = Arc::new(std::sync::atomic::AtomicU64::new(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    ));
+    let control_response_last_activity = Arc::new(std::sync::atomic::AtomicU64::new(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    ));
+
     // Spawn dedicated task for ControlRequests subscription
     if let Some(ref nats) = ctx.nats {
         match nats.subscribe(TOPIC_CONTROL_REQUESTS).await {
@@ -5730,19 +5744,42 @@ async fn main() -> Result<()> {
                 );
                 set_readiness_control_sub_active(true);
                 let tx = control_tx.clone();
+                let last_activity = Arc::clone(&control_sub_last_activity);
                 tokio::spawn(async move {
-                    while let Some(msg) = control_sub.next().await {
-                        info!("Received raw ControlRequest message from NATS");
-                        match msg.deserialize::<ControlRequest>() {
-                            Ok(req) => {
-                                info!(target = %req.target, kind = ?req.kind, "Parsed ControlRequest, forwarding to main loop");
-                                if tx.send(req).await.is_err() {
-                                    warn!("ControlRequest channel closed, stopping subscription");
-                                    break;
+                    let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(5));
+                    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                    loop {
+                        tokio::select! {
+                            Some(msg) = control_sub.next() => {
+                                info!("Received raw ControlRequest message from NATS");
+                                match msg.deserialize::<ControlRequest>() {
+                                    Ok(req) => {
+                                        info!(target = %req.target, kind = ?req.kind, "Parsed ControlRequest, forwarding to main loop");
+                                        if tx.send(req).await.is_err() {
+                                            warn!("ControlRequest channel closed, stopping subscription");
+                                            break;
+                                        }
+                                    }
+                                    Err(e) => {
+                                        warn!(error = %e, "Failed to deserialize ControlRequest");
+                                    }
                                 }
+                                last_activity.store(
+                                    std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .unwrap()
+                                        .as_secs(),
+                                    Ordering::Relaxed,
+                                );
                             }
-                            Err(e) => {
-                                warn!(error = %e, "Failed to deserialize ControlRequest");
+                            _ = heartbeat.tick() => {
+                                last_activity.store(
+                                    std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .unwrap()
+                                        .as_secs(),
+                                    Ordering::Relaxed,
+                                );
                             }
                         }
                     }
@@ -5762,18 +5799,41 @@ async fn main() -> Result<()> {
                 );
                 set_readiness_control_response_sub_active(true);
                 let pending = Arc::clone(&ctx.pending_discovery_responses);
+                let last_activity = Arc::clone(&control_response_last_activity);
                 tokio::spawn(async move {
-                    while let Some(msg) = resp_sub.next().await {
-                        match msg.deserialize::<ControlResponse>() {
-                            Ok(resp) => {
-                                let request_id = resp.request_id.clone();
-                                let mut map = pending.lock().await;
-                                if let Some(tx) = map.remove(&request_id) {
-                                    let _ = tx.send(resp);
+                    let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(5));
+                    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                    loop {
+                        tokio::select! {
+                            Some(msg) = resp_sub.next() => {
+                                match msg.deserialize::<ControlResponse>() {
+                                    Ok(resp) => {
+                                        let request_id = resp.request_id.clone();
+                                        let mut map = pending.lock().await;
+                                        if let Some(tx) = map.remove(&request_id) {
+                                            let _ = tx.send(resp);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        warn!(error = %e, "Failed to deserialize ControlResponse");
+                                    }
                                 }
+                                last_activity.store(
+                                    std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .unwrap()
+                                        .as_secs(),
+                                    Ordering::Relaxed,
+                                );
                             }
-                            Err(e) => {
-                                warn!(error = %e, "Failed to deserialize ControlResponse");
+                            _ = heartbeat.tick() => {
+                                last_activity.store(
+                                    std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .unwrap()
+                                        .as_secs(),
+                                    Ordering::Relaxed,
+                                );
                             }
                         }
                     }
@@ -6193,9 +6253,15 @@ async fn main() -> Result<()> {
                 // Keep /ready fresh even when no intents flow.
                 ironcrab::metrics::record_activity();
 
-                // Refresh readiness from current state (not startup-latch)
+                // Refresh readiness from current runtime state (subscription heartbeats)
                 let nats_connected = ctx.nats.as_ref().is_some_and(|n| n.is_connected());
-                update_readiness_execution_engine_current(nats_connected);
+                let control_sub_secs = control_sub_last_activity.load(Ordering::Relaxed);
+                let control_response_secs = control_response_last_activity.load(Ordering::Relaxed);
+                update_readiness_execution_engine_current(
+                    nats_connected,
+                    control_sub_secs,
+                    control_response_secs,
+                );
 
                 // Process any available PoolCacheUpdates from JetStream Consumer
                 if let Some(ref mut consumer) = pool_cache_consumer_opt {

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -70,17 +70,19 @@ use ironcrab::ipc::{
 };
 use ironcrab::ipc::{ControlRequest, ControlRequestKind, ControlResponse, ControlResponseStatus};
 use ironcrab::metrics::{
-    record_recent_trade, record_tx_slot_to_send_ms, serve_metrics, RecentTrade,
-    ACTIVE_CAPITAL_LOCKS, ACTIVE_RESOURCE_LOCKS, AVAILABLE_SOL_LAMPORTS, CONCURRENT_INTENTS_GAUGE,
-    INTENTS_EXECUTED_TOTAL, INTENTS_RECEIVED_TOTAL, INTENTS_REJECTED_TOTAL,
-    JITO_BUNDLES_LANDED_TOTAL, JITO_BUNDLES_REJECTED_TOTAL, JITO_BUNDLES_SUBMITTED_TOTAL,
-    JITO_BUNDLES_TIMEOUT_TOTAL, JITO_TIP_LAMPORTS_TOTAL, KILL_SWITCH_ACTIVE,
-    NATS_MESSAGES_RECEIVED_TOTAL, OPEN_POSITIONS_GAUGE, REJECT_CAPITAL_LOCK, REJECT_DUPLICATE,
-    REJECT_RESOURCE_LOCK, REJECT_SEND_FAILED, REJECT_SIMULATION_FAIL, SIMULATION_FAILURES_TOTAL,
-    TX_CONFIRMED_TOTAL, TX_CONFIRM_GEYSER_TOTAL, TX_CONFIRM_LATENCY_MS,
-    TX_CONFIRM_RPC_FALLBACK_TOTAL, TX_CONFIRM_TIMEOUT_TOTAL, TX_SEND_ATTEMPTS_TOTAL,
-    TX_SEND_JITO_TOTAL, TX_SEND_RPC_TOTAL, TX_SEND_SUCCESS_TOTAL, TX_SEND_TPU_TOTAL,
-    WALLET_TOTAL_SOL_LAMPORTS,
+    record_recent_trade, record_tx_slot_to_send_ms, serve_metrics,
+    set_readiness_control_response_sub_active, set_readiness_control_sub_active,
+    set_readiness_mode, set_readiness_nats_connected, set_readiness_state_paths_initialized,
+    MetricsComponent, RecentTrade, ACTIVE_CAPITAL_LOCKS, ACTIVE_RESOURCE_LOCKS,
+    AVAILABLE_SOL_LAMPORTS, CONCURRENT_INTENTS_GAUGE, INTENTS_EXECUTED_TOTAL,
+    INTENTS_RECEIVED_TOTAL, INTENTS_REJECTED_TOTAL, JITO_BUNDLES_LANDED_TOTAL,
+    JITO_BUNDLES_REJECTED_TOTAL, JITO_BUNDLES_SUBMITTED_TOTAL, JITO_BUNDLES_TIMEOUT_TOTAL,
+    JITO_TIP_LAMPORTS_TOTAL, KILL_SWITCH_ACTIVE, NATS_MESSAGES_RECEIVED_TOTAL,
+    OPEN_POSITIONS_GAUGE, REJECT_CAPITAL_LOCK, REJECT_DUPLICATE, REJECT_RESOURCE_LOCK,
+    REJECT_SEND_FAILED, REJECT_SIMULATION_FAIL, SIMULATION_FAILURES_TOTAL, TX_CONFIRMED_TOTAL,
+    TX_CONFIRM_GEYSER_TOTAL, TX_CONFIRM_LATENCY_MS, TX_CONFIRM_RPC_FALLBACK_TOTAL,
+    TX_CONFIRM_TIMEOUT_TOTAL, TX_SEND_ATTEMPTS_TOTAL, TX_SEND_JITO_TOTAL, TX_SEND_RPC_TOTAL,
+    TX_SEND_SUCCESS_TOTAL, TX_SEND_TPU_TOTAL, WALLET_TOTAL_SOL_LAMPORTS,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
@@ -4612,10 +4614,19 @@ async fn main() -> Result<()> {
         "Starting execution-engine service"
     );
 
+    // Set readiness mode for /status (E2E blackbox)
+    set_readiness_mode(if args.dry_run {
+        1
+    } else if args.simulate_only {
+        3
+    } else {
+        0
+    });
+
     // Start metrics server
     let metrics_addr = std::net::SocketAddr::from(([0, 0, 0, 0], args.metrics_port));
     tokio::spawn(async move {
-        if let Err(e) = serve_metrics(metrics_addr).await {
+        if let Err(e) = serve_metrics(metrics_addr, MetricsComponent::ExecutionEngine).await {
             error!(error = %e, "Metrics server failed");
         }
     });
@@ -4938,6 +4949,7 @@ async fn main() -> Result<()> {
             None
         } else {
             info!(url = %args.nats_url, "Connected to NATS");
+            set_readiness_nats_connected(true);
             Some(client)
         }
     };
@@ -5715,6 +5727,7 @@ async fn main() -> Result<()> {
                     topic = TOPIC_CONTROL_REQUESTS,
                     "Subscribed to ControlRequests"
                 );
+                set_readiness_control_sub_active(true);
                 let tx = control_tx.clone();
                 tokio::spawn(async move {
                     while let Some(msg) = control_sub.next().await {
@@ -5746,6 +5759,7 @@ async fn main() -> Result<()> {
                     topic = TOPIC_CONTROL_RESPONSES,
                     "Subscribed to ControlResponses (Discovery Request/Reply)"
                 );
+                set_readiness_control_response_sub_active(true);
                 let pending = Arc::clone(&ctx.pending_discovery_responses);
                 tokio::spawn(async move {
                     while let Some(msg) = resp_sub.next().await {
@@ -6021,6 +6035,9 @@ async fn main() -> Result<()> {
     };
 
     let mut wallet_snapshot_consumer_opt = wallet_snapshot_consumer;
+
+    // E2E Readiness: consuming state paths (LockManager, LivePoolCache, JetStream consumers) initialized
+    set_readiness_state_paths_initialized(true);
 
     // FIX-31: Track spawned intent tasks for graceful shutdown
     let mut task_set = tokio::task::JoinSet::new();

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -36,10 +36,10 @@ use ironcrab::ipc::{
     NATIVE_SOL_MINT,
 };
 use ironcrab::metrics::{
-    serve_metrics, set_readiness_control_sub_active, set_readiness_jetstream_initialized,
-    set_readiness_mode, set_readiness_nats_connected, update_readiness_market_data_current,
-    MetricsComponent, MARKET_EVENTS_PUBLISHED_TOTAL, MARKET_EVENTS_RECEIVED_TOTAL,
-    NATS_ERRORS_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL, POOLS_TRACKED_GAUGE,
+    serve_metrics, set_readiness_control_sub_active, set_readiness_mode,
+    set_readiness_nats_connected, update_readiness_market_data_current, MetricsComponent,
+    MARKET_EVENTS_PUBLISHED_TOTAL, MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL,
+    NATS_MESSAGES_PUBLISHED_TOTAL, POOLS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
@@ -1344,49 +1344,36 @@ async fn main() -> Result<()> {
     info!(log_dir = %log_dir.display(), "JSONL writer initialized");
 
     // Setup NATS (optional in dry-run mode)
-    let (nats, jetstream_initialized_at_startup) = if args.dry_run {
+    let nats = if args.dry_run {
         info!("Dry-run mode: NATS publishing disabled");
-        (None, false)
+        None
     } else {
         let config = NatsConfig::new(&args.nats_url, "market-data");
         let mut client = NatsClient::new(config);
         if let Err(e) = client.connect().await {
             warn!(error = %e, "Failed to connect to NATS (continuing without)");
-            (None, false)
+            None
         } else {
             info!(url = %args.nats_url, "Connected to NATS");
             set_readiness_nats_connected(true);
 
             // Initialize JetStream stream for PoolCacheUpdates (persistent state)
-            let pool_cache_ok = match ensure_pool_cache_stream(client.client()).await {
-                Ok(()) => {
-                    info!("JetStream POOL_CACHE stream ready for persistent state recovery");
-                    true
-                }
-                Err(e) => {
-                    error!(error = %e, "Failed to create/update JetStream POOL_CACHE stream");
-                    error!("PoolCacheUpdates will not persist across restarts!");
-                    error!("Check that nats-server is running with -js flag");
-                    false
-                }
-            };
+            if let Err(e) = ensure_pool_cache_stream(client.client()).await {
+                error!(error = %e, "Failed to create/update JetStream POOL_CACHE stream");
+                error!("PoolCacheUpdates will not persist across restarts!");
+                error!("Check that nats-server is running with -js flag");
+            } else {
+                info!("JetStream POOL_CACHE stream ready for persistent state recovery");
+            }
 
             // Initialize JetStream stream for WalletBalanceSnapshot (position reconciliation)
-            let wallet_snapshot_ok = match ensure_wallet_snapshot_stream(client.client()).await {
-                Ok(()) => {
-                    info!("JetStream WALLET_SNAPSHOT stream ready for position reconciliation");
-                    true
-                }
-                Err(e) => {
-                    error!(error = %e, "Failed to create/update JetStream WALLET_SNAPSHOT stream");
-                    error!("WalletBalanceSnapshot persistence disabled!");
-                    error!("Check that nats-server is running with -js flag");
-                    false
-                }
-            };
-
-            let js_ok = pool_cache_ok && wallet_snapshot_ok;
-            set_readiness_jetstream_initialized(js_ok);
+            if let Err(e) = ensure_wallet_snapshot_stream(client.client()).await {
+                error!(error = %e, "Failed to create/update JetStream WALLET_SNAPSHOT stream");
+                error!("WalletBalanceSnapshot persistence disabled!");
+                error!("Check that nats-server is running with -js flag");
+            } else {
+                info!("JetStream WALLET_SNAPSHOT stream ready for position reconciliation");
+            }
 
             // Initialize JetStream stream for ExecutionResults (wallet ATA tracking)
             if let Err(e) = ensure_execution_results_stream(client.client()).await {
@@ -1395,7 +1382,7 @@ async fn main() -> Result<()> {
                 info!("JetStream EXECUTION_RESULTS stream ready for wallet ATA tracking");
             }
 
-            (Some(client), js_ok)
+            Some(client)
         }
     };
 
@@ -1579,7 +1566,6 @@ async fn main() -> Result<()> {
             tracked_bin_arrays_rx,
             tracked_wallet_rx,
             args.wallet_snapshot_only,
-            jetstream_initialized_at_startup,
         )
         .await?;
     }
@@ -1812,7 +1798,6 @@ async fn run_geyser_loop(
     tracked_bin_arrays_rx: watch::Receiver<Vec<Pubkey>>,
     tracked_wallet_rx: watch::Receiver<Vec<Pubkey>>,
     wallet_snapshot_only: bool,
-    jetstream_initialized_at_startup: bool,
 ) -> Result<()> {
     // Initialize RPC client for fallback/metadata (prefer local RPC, fallback to Helius)
     let rpc_url =
@@ -2064,10 +2049,26 @@ async fn run_geyser_loop(
             _ = activity_interval.tick() => {
                 ironcrab::metrics::record_activity();
 
-                // Refresh readiness from current state (not startup-latch)
+                // Refresh readiness from current runtime state (not startup-latch)
                 let nats_connected = ctx.nats.as_ref().is_some_and(|n| n.is_connected());
                 let control_sub_active = nats_connected && control_subscription.is_some();
-                let jetstream_ready = nats_connected && jetstream_initialized_at_startup;
+                let jetstream_ready = if nats_connected {
+                    if let Some(ref nats) = ctx.nats {
+                        use async_nats::jetstream;
+                        use ironcrab::nats::STREAM_NAME;
+                        tokio::time::timeout(
+                            std::time::Duration::from_secs(2),
+                            jetstream::new(nats.client().clone()).get_stream(STREAM_NAME),
+                        )
+                        .await
+                        .map(|r| r.is_ok())
+                        .unwrap_or(false)
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
                 update_readiness_market_data_current(nats_connected, control_sub_active, jetstream_ready);
 
                 // P1 Crash Isolation: Ping systemd watchdog frequently enough.

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -37,9 +37,9 @@ use ironcrab::ipc::{
 };
 use ironcrab::metrics::{
     serve_metrics, set_readiness_control_sub_active, set_readiness_jetstream_initialized,
-    set_readiness_mode, set_readiness_nats_connected, MetricsComponent,
-    MARKET_EVENTS_PUBLISHED_TOTAL, MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL,
-    NATS_MESSAGES_PUBLISHED_TOTAL, POOLS_TRACKED_GAUGE,
+    set_readiness_mode, set_readiness_nats_connected, update_readiness_market_data_current,
+    MetricsComponent, MARKET_EVENTS_PUBLISHED_TOTAL, MARKET_EVENTS_RECEIVED_TOTAL,
+    NATS_ERRORS_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL, POOLS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
@@ -1344,15 +1344,15 @@ async fn main() -> Result<()> {
     info!(log_dir = %log_dir.display(), "JSONL writer initialized");
 
     // Setup NATS (optional in dry-run mode)
-    let nats = if args.dry_run {
+    let (nats, jetstream_initialized_at_startup) = if args.dry_run {
         info!("Dry-run mode: NATS publishing disabled");
-        None
+        (None, false)
     } else {
         let config = NatsConfig::new(&args.nats_url, "market-data");
         let mut client = NatsClient::new(config);
         if let Err(e) = client.connect().await {
             warn!(error = %e, "Failed to connect to NATS (continuing without)");
-            None
+            (None, false)
         } else {
             info!(url = %args.nats_url, "Connected to NATS");
             set_readiness_nats_connected(true);
@@ -1385,7 +1385,8 @@ async fn main() -> Result<()> {
                 }
             };
 
-            set_readiness_jetstream_initialized(pool_cache_ok && wallet_snapshot_ok);
+            let js_ok = pool_cache_ok && wallet_snapshot_ok;
+            set_readiness_jetstream_initialized(js_ok);
 
             // Initialize JetStream stream for ExecutionResults (wallet ATA tracking)
             if let Err(e) = ensure_execution_results_stream(client.client()).await {
@@ -1394,7 +1395,7 @@ async fn main() -> Result<()> {
                 info!("JetStream EXECUTION_RESULTS stream ready for wallet ATA tracking");
             }
 
-            Some(client)
+            (Some(client), js_ok)
         }
     };
 
@@ -1578,6 +1579,7 @@ async fn main() -> Result<()> {
             tracked_bin_arrays_rx,
             tracked_wallet_rx,
             args.wallet_snapshot_only,
+            jetstream_initialized_at_startup,
         )
         .await?;
     }
@@ -1810,6 +1812,7 @@ async fn run_geyser_loop(
     tracked_bin_arrays_rx: watch::Receiver<Vec<Pubkey>>,
     tracked_wallet_rx: watch::Receiver<Vec<Pubkey>>,
     wallet_snapshot_only: bool,
+    jetstream_initialized_at_startup: bool,
 ) -> Result<()> {
     // Initialize RPC client for fallback/metadata (prefer local RPC, fallback to Helius)
     let rpc_url =
@@ -2060,6 +2063,12 @@ async fn run_geyser_loop(
             // Keep /ready fresh even if Geyser/NATS are quiet.
             _ = activity_interval.tick() => {
                 ironcrab::metrics::record_activity();
+
+                // Refresh readiness from current state (not startup-latch)
+                let nats_connected = ctx.nats.as_ref().is_some_and(|n| n.is_connected());
+                let control_sub_active = nats_connected && control_subscription.is_some();
+                let jetstream_ready = nats_connected && jetstream_initialized_at_startup;
+                update_readiness_market_data_current(nats_connected, control_sub_active, jetstream_ready);
 
                 // P1 Crash Isolation: Ping systemd watchdog frequently enough.
                 #[cfg(unix)]
@@ -4292,6 +4301,10 @@ async fn run_simulation_loop(
 
                 // Keep /ready fresh even when only simulating.
                 ironcrab::metrics::record_activity();
+
+                // Refresh readiness (simulate: no control_sub, no jetstream)
+                let nats_connected = ctx.nats.as_ref().is_some_and(|n| n.is_connected());
+                update_readiness_market_data_current(nats_connected, false, false);
 
                 let event = MarketEvent::new(
                     "market-data",

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -36,7 +36,9 @@ use ironcrab::ipc::{
     NATIVE_SOL_MINT,
 };
 use ironcrab::metrics::{
-    serve_metrics, MARKET_EVENTS_PUBLISHED_TOTAL, MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL,
+    serve_metrics, set_readiness_control_sub_active, set_readiness_jetstream_initialized,
+    set_readiness_mode, set_readiness_nats_connected, MetricsComponent,
+    MARKET_EVENTS_PUBLISHED_TOTAL, MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL,
     NATS_MESSAGES_PUBLISHED_TOTAL, POOLS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
@@ -1299,10 +1301,19 @@ async fn main() -> Result<()> {
         "Starting market-data service"
     );
 
+    // Set readiness mode for /status (E2E blackbox)
+    set_readiness_mode(if args.dry_run {
+        1
+    } else if args.simulate {
+        2
+    } else {
+        0
+    });
+
     // Start metrics server
     let metrics_addr = std::net::SocketAddr::from(([0, 0, 0, 0], args.metrics_port));
     tokio::spawn(async move {
-        if let Err(e) = serve_metrics(metrics_addr).await {
+        if let Err(e) = serve_metrics(metrics_addr, MetricsComponent::MarketData).await {
             error!(error = %e, "Metrics server failed");
         }
     });
@@ -1344,24 +1355,37 @@ async fn main() -> Result<()> {
             None
         } else {
             info!(url = %args.nats_url, "Connected to NATS");
+            set_readiness_nats_connected(true);
 
             // Initialize JetStream stream for PoolCacheUpdates (persistent state)
-            if let Err(e) = ensure_pool_cache_stream(client.client()).await {
-                error!(error = %e, "Failed to create/update JetStream POOL_CACHE stream");
-                error!("PoolCacheUpdates will not persist across restarts!");
-                error!("Check that nats-server is running with -js flag");
-            } else {
-                info!("JetStream POOL_CACHE stream ready for persistent state recovery");
-            }
+            let pool_cache_ok = match ensure_pool_cache_stream(client.client()).await {
+                Ok(()) => {
+                    info!("JetStream POOL_CACHE stream ready for persistent state recovery");
+                    true
+                }
+                Err(e) => {
+                    error!(error = %e, "Failed to create/update JetStream POOL_CACHE stream");
+                    error!("PoolCacheUpdates will not persist across restarts!");
+                    error!("Check that nats-server is running with -js flag");
+                    false
+                }
+            };
 
             // Initialize JetStream stream for WalletBalanceSnapshot (position reconciliation)
-            if let Err(e) = ensure_wallet_snapshot_stream(client.client()).await {
-                error!(error = %e, "Failed to create/update JetStream WALLET_SNAPSHOT stream");
-                error!("WalletBalanceSnapshot persistence disabled!");
-                error!("Check that nats-server is running with -js flag");
-            } else {
-                info!("JetStream WALLET_SNAPSHOT stream ready for position reconciliation");
-            }
+            let wallet_snapshot_ok = match ensure_wallet_snapshot_stream(client.client()).await {
+                Ok(()) => {
+                    info!("JetStream WALLET_SNAPSHOT stream ready for position reconciliation");
+                    true
+                }
+                Err(e) => {
+                    error!(error = %e, "Failed to create/update JetStream WALLET_SNAPSHOT stream");
+                    error!("WalletBalanceSnapshot persistence disabled!");
+                    error!("Check that nats-server is running with -js flag");
+                    false
+                }
+            };
+
+            set_readiness_jetstream_initialized(pool_cache_ok && wallet_snapshot_ok);
 
             // Initialize JetStream stream for ExecutionResults (wallet ATA tracking)
             if let Err(e) = ensure_execution_results_stream(client.client()).await {
@@ -1955,6 +1979,7 @@ async fn run_geyser_loop(
                     topic = TOPIC_CONTROL_REQUESTS,
                     "Subscribed to ControlRequests (Discovery)"
                 );
+                set_readiness_control_sub_active(true);
                 Some(sub)
             }
             Err(e) => {

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4303,9 +4303,26 @@ async fn run_simulation_loop(
                 // Keep /ready fresh even when only simulating.
                 ironcrab::metrics::record_activity();
 
-                // Refresh readiness (simulate: no control_sub, no jetstream)
+                // Refresh readiness from current runtime state (simulate: no control_sub)
                 let nats_connected = ctx.nats.as_ref().is_some_and(|n| n.is_connected());
-                update_readiness_market_data_current(nats_connected, false, false);
+                let jetstream_ready = if nats_connected {
+                    if let Some(ref nats) = ctx.nats {
+                        use async_nats::jetstream;
+                        use ironcrab::nats::STREAM_NAME;
+                        tokio::time::timeout(
+                            std::time::Duration::from_secs(2),
+                            jetstream::new(nats.client().clone()).get_stream(STREAM_NAME),
+                        )
+                        .await
+                        .map(|r| r.is_ok())
+                        .unwrap_or(false)
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
+                update_readiness_market_data_current(nats_connected, false, jetstream_ready);
 
                 let event = MarketEvent::new(
                     "market-data",

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -45,11 +45,12 @@ use ironcrab::ipc::{
     TradeExecutionConstraints, TradeIntent, TradeResources, TradeSide, TradingRegime,
 };
 use ironcrab::metrics::{
-    serve_metrics, EXITS_GENERATED_TOTAL, FILTER_PASSED_TOTAL, FILTER_REJECTED_BUYER_QUALITY,
-    FILTER_REJECTED_DEV_BEHAVIOR, FILTER_REJECTED_INFLOW, FILTER_REJECTED_LIQUIDITY,
-    FILTER_REJECTED_TOTAL, FILTER_REJECTED_VELOCITY, INTENTS_GENERATED_TOTAL,
-    MARKET_EVENTS_CONSUMED_TOTAL, NATS_ERRORS_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
-    NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
+    serve_metrics, set_readiness_nats_connected, MetricsComponent, EXITS_GENERATED_TOTAL,
+    FILTER_PASSED_TOTAL, FILTER_REJECTED_BUYER_QUALITY, FILTER_REJECTED_DEV_BEHAVIOR,
+    FILTER_REJECTED_INFLOW, FILTER_REJECTED_LIQUIDITY, FILTER_REJECTED_TOTAL,
+    FILTER_REJECTED_VELOCITY, INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL,
+    NATS_ERRORS_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL,
+    POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
@@ -5204,7 +5205,7 @@ async fn main() -> Result<()> {
     // Start metrics server
     let metrics_addr = std::net::SocketAddr::from(([0, 0, 0, 0], args.metrics_port));
     tokio::spawn(async move {
-        if let Err(e) = serve_metrics(metrics_addr).await {
+        if let Err(e) = serve_metrics(metrics_addr, MetricsComponent::MomentumBot).await {
             error!(error = %e, "Metrics server failed");
         }
     });
@@ -5297,6 +5298,7 @@ async fn main() -> Result<()> {
             None
         } else {
             info!(url = %args.nats_url, "Connected to NATS");
+            set_readiness_nats_connected(true);
             // Ensure TRADE_INTENTS JetStream stream exists (avoids Core NATS startup race)
             if let Err(e) = ensure_trade_intents_stream(client.client()).await {
                 warn!(error = %e, "Failed to ensure TRADE_INTENTS stream (intents may be lost)");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -303,8 +303,8 @@ pub static READINESS_CONTROL_SUB_ACTIVE: Lazy<AtomicBool> = Lazy::new(|| AtomicB
 /// Control-Response subscription active (execution-engine only)
 pub static READINESS_CONTROL_RESPONSE_SUB_ACTIVE: Lazy<AtomicBool> =
     Lazy::new(|| AtomicBool::new(false));
-/// JetStream / state-recovery infrastructure initialized (market-data: streams; execution-engine: bootstrap)
-pub static READINESS_JETSTREAM_INITIALIZED: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
+/// JetStream currently usable (market-data: runtime get_stream check; not startup-latch)
+pub static READINESS_JETSTREAM_READY: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
 /// Consuming state paths initialized (execution-engine: LockManager, LivePoolCache bootstrap)
 pub static READINESS_STATE_PATHS_INITIALIZED: Lazy<AtomicBool> =
     Lazy::new(|| AtomicBool::new(false));
@@ -335,9 +335,9 @@ pub fn set_readiness_control_response_sub_active(active: bool) {
     READINESS_CONTROL_RESPONSE_SUB_ACTIVE.store(active, Ordering::Relaxed);
 }
 
-/// Set readiness: JetStream / state-recovery initialized
-pub fn set_readiness_jetstream_initialized(initialized: bool) {
-    READINESS_JETSTREAM_INITIALIZED.store(initialized, Ordering::Relaxed);
+/// Set readiness: JetStream currently usable (runtime state, not startup-latch)
+pub fn set_readiness_jetstream_ready(ready: bool) {
+    READINESS_JETSTREAM_READY.store(ready, Ordering::Relaxed);
 }
 
 /// Set readiness: State paths initialized (execution-engine)
@@ -359,7 +359,7 @@ pub fn update_readiness_market_data_current(
 ) {
     READINESS_NATS_CONNECTED.store(nats_connected, Ordering::Relaxed);
     READINESS_CONTROL_SUB_ACTIVE.store(control_sub_active, Ordering::Relaxed);
-    READINESS_JETSTREAM_INITIALIZED.store(jetstream_ready, Ordering::Relaxed);
+    READINESS_JETSTREAM_READY.store(jetstream_ready, Ordering::Relaxed);
 }
 
 /// Stale threshold for subscription liveness (seconds): if no heartbeat in this time, consider dead.
@@ -1613,7 +1613,7 @@ fn status_response(component: MetricsComponent) -> String {
     let nats = READINESS_NATS_CONNECTED.load(Ordering::Relaxed);
     let control_sub = READINESS_CONTROL_SUB_ACTIVE.load(Ordering::Relaxed);
     let control_resp = READINESS_CONTROL_RESPONSE_SUB_ACTIVE.load(Ordering::Relaxed);
-    let jetstream = READINESS_JETSTREAM_INITIALIZED.load(Ordering::Relaxed);
+    let jetstream = READINESS_JETSTREAM_READY.load(Ordering::Relaxed);
     let state_paths = READINESS_STATE_PATHS_INITIALIZED.load(Ordering::Relaxed);
     let mode_u64 = READINESS_MODE.load(Ordering::Relaxed);
     let mode_str = match mode_u64 {
@@ -1646,7 +1646,7 @@ fn status_response(component: MetricsComponent) -> String {
                     missing.push("control_request_sub_active".to_string());
                 }
                 if !jetstream {
-                    missing.push("jetstream_initialized".to_string());
+                    missing.push("jetstream_ready".to_string());
                 }
                 let ready = nats && control_sub && jetstream;
                 ("market-data", ready, missing)
@@ -1698,6 +1698,8 @@ fn status_response(component: MetricsComponent) -> String {
     struct ReadinessSection {
         nats_connected: bool,
         public_http_ready: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        jetstream_ready: Option<bool>,
         mode: &'static str,
         #[serde(skip_serializing_if = "Option::is_none")]
         reason_not_ready: Option<String>,
@@ -1719,6 +1721,11 @@ fn status_response(component: MetricsComponent) -> String {
         _ => None,
     };
 
+    let jetstream_ready_field = match component {
+        MetricsComponent::MarketData => Some(jetstream),
+        _ => None,
+    };
+
     let payload = StatusPayload {
         component: component_name,
         ready,
@@ -1726,6 +1733,7 @@ fn status_response(component: MetricsComponent) -> String {
         readiness: ReadinessSection {
             nats_connected: nats,
             public_http_ready: true,
+            jetstream_ready: jetstream_ready_field,
             mode: mode_str,
             reason_not_ready,
             missing_checks,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -362,14 +362,33 @@ pub fn update_readiness_market_data_current(
     READINESS_JETSTREAM_INITIALIZED.store(jetstream_ready, Ordering::Relaxed);
 }
 
+/// Stale threshold for subscription liveness (seconds): if no heartbeat in this time, consider dead.
+const SUBSCRIPTION_STALE_THRESHOLD_SECS: u64 = 15;
+
 /// Refresh readiness from current runtime state (not startup-latch).
-/// When NATS disconnects, control subs are cleared (they are tied to the connection).
-pub fn update_readiness_execution_engine_current(nats_connected: bool) {
+/// Control subs are active only when NATS connected AND subscription task has sent heartbeat recently.
+pub fn update_readiness_execution_engine_current(
+    nats_connected: bool,
+    control_sub_last_activity_secs: u64,
+    control_response_last_activity_secs: u64,
+) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
     READINESS_NATS_CONNECTED.store(nats_connected, Ordering::Relaxed);
-    if !nats_connected {
-        READINESS_CONTROL_SUB_ACTIVE.store(false, Ordering::Relaxed);
-        READINESS_CONTROL_RESPONSE_SUB_ACTIVE.store(false, Ordering::Relaxed);
-    }
+    READINESS_CONTROL_SUB_ACTIVE.store(
+        nats_connected
+            && now.saturating_sub(control_sub_last_activity_secs)
+                <= SUBSCRIPTION_STALE_THRESHOLD_SECS,
+        Ordering::Relaxed,
+    );
+    READINESS_CONTROL_RESPONSE_SUB_ACTIVE.store(
+        nats_connected
+            && now.saturating_sub(control_response_last_activity_secs)
+                <= SUBSCRIPTION_STALE_THRESHOLD_SECS,
+        Ordering::Relaxed,
+    );
 }
 
 // --- WsolManager metrics ---

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -289,6 +289,67 @@ pub static WALLET_TOTAL_SOL_LAMPORTS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::
 /// Control plane queries this via /status to sync UI display after restarts.
 pub static KILL_SWITCH_ACTIVE: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
 
+// =============================================================================
+// E2E Readiness (market-data, execution-engine) – Blackbox-stable Status
+// =============================================================================
+// Process-local statics. Each binary sets its own values. Used by /status for
+// structured readiness so Eval-E2E-Harness can verify contract readiness without
+// reading Iron_crab/src, logs, or NATS connz.
+
+/// NATS connected (set by binary when connection established)
+pub static READINESS_NATS_CONNECTED: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
+/// Control-Request subscription active (market-data) or ControlRequests+ControlResponses (execution-engine)
+pub static READINESS_CONTROL_SUB_ACTIVE: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
+/// Control-Response subscription active (execution-engine only)
+pub static READINESS_CONTROL_RESPONSE_SUB_ACTIVE: Lazy<AtomicBool> =
+    Lazy::new(|| AtomicBool::new(false));
+/// JetStream / state-recovery infrastructure initialized (market-data: streams; execution-engine: bootstrap)
+pub static READINESS_JETSTREAM_INITIALIZED: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
+/// Consuming state paths initialized (execution-engine: LockManager, LivePoolCache bootstrap)
+pub static READINESS_STATE_PATHS_INITIALIZED: Lazy<AtomicBool> =
+    Lazy::new(|| AtomicBool::new(false));
+/// Mode: 0=live, 1=dry_run, 2=simulate, 3=simulate_only
+pub static READINESS_MODE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// Component identifier for /status JSON (determines which readiness checks apply)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricsComponent {
+    MarketData,
+    ExecutionEngine,
+    MomentumBot,
+    ArbStrategy,
+}
+
+/// Set readiness: NATS connected
+pub fn set_readiness_nats_connected(connected: bool) {
+    READINESS_NATS_CONNECTED.store(connected, Ordering::Relaxed);
+}
+
+/// Set readiness: Control-Request subscription active
+pub fn set_readiness_control_sub_active(active: bool) {
+    READINESS_CONTROL_SUB_ACTIVE.store(active, Ordering::Relaxed);
+}
+
+/// Set readiness: Control-Response subscription active (execution-engine)
+pub fn set_readiness_control_response_sub_active(active: bool) {
+    READINESS_CONTROL_RESPONSE_SUB_ACTIVE.store(active, Ordering::Relaxed);
+}
+
+/// Set readiness: JetStream / state-recovery initialized
+pub fn set_readiness_jetstream_initialized(initialized: bool) {
+    READINESS_JETSTREAM_INITIALIZED.store(initialized, Ordering::Relaxed);
+}
+
+/// Set readiness: State paths initialized (execution-engine)
+pub fn set_readiness_state_paths_initialized(initialized: bool) {
+    READINESS_STATE_PATHS_INITIALIZED.store(initialized, Ordering::Relaxed);
+}
+
+/// Set readiness mode: 0=live, 1=dry_run, 2=simulate, 3=simulate_only
+pub fn set_readiness_mode(mode: u8) {
+    READINESS_MODE.store(mode as u64, Ordering::Relaxed);
+}
+
 // --- WsolManager metrics ---
 pub static WSOL_BALANCE_LAMPORTS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static WSOL_WRAP_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -1506,63 +1567,180 @@ async fn metrics_response() -> Response<Body> {
         .unwrap()
 }
 
-pub async fn serve_metrics(addr: SocketAddr) -> anyhow::Result<()> {
-    let make_svc = make_service_fn(|_conn| async {
-        Ok::<_, hyper::Error>(service_fn(|req: Request<Body>| async move {
-            let path = req.uri().path();
-            if path == "/metrics" {
-                record_activity();
-                return Ok::<_, hyper::Error>(metrics_response().await);
+/// Build structured /status JSON for E2E Readiness (market-data, execution-engine)
+fn status_response(component: MetricsComponent) -> String {
+    let nats = READINESS_NATS_CONNECTED.load(Ordering::Relaxed);
+    let control_sub = READINESS_CONTROL_SUB_ACTIVE.load(Ordering::Relaxed);
+    let control_resp = READINESS_CONTROL_RESPONSE_SUB_ACTIVE.load(Ordering::Relaxed);
+    let jetstream = READINESS_JETSTREAM_INITIALIZED.load(Ordering::Relaxed);
+    let state_paths = READINESS_STATE_PATHS_INITIALIZED.load(Ordering::Relaxed);
+    let mode_u64 = READINESS_MODE.load(Ordering::Relaxed);
+    let mode_str = match mode_u64 {
+        1 => "dry_run",
+        2 => "simulate",
+        3 => "simulate_only",
+        _ => "live",
+    };
+
+    let (component_name, ready, missing_checks): (&str, bool, Vec<String>) = match component {
+        MetricsComponent::MarketData => {
+            let mut missing = Vec::new();
+            if !nats {
+                missing.push("nats_connected".to_string());
             }
-            if path == "/trades" {
-                // Return recent trades as JSON for Grafana
-                let json = get_recent_trades_json();
-                return Ok::<_, hyper::Error>(
-                    Response::builder()
-                        .status(200)
-                        .header("Content-Type", "application/json")
-                        .header("Access-Control-Allow-Origin", "*")
-                        .body(Body::from(json))
-                        .unwrap(),
-                );
+            if !control_sub {
+                missing.push("control_request_sub_active".to_string());
             }
-            if path == "/live" {
-                record_activity();
-                return Ok::<_, hyper::Error>(Response::new(Body::from("ok")));
+            if !jetstream {
+                missing.push("jetstream_initialized".to_string());
             }
-            if path == "/status" {
-                // JSON status for control plane (kill switch sync after restarts)
-                record_activity();
-                let active = KILL_SWITCH_ACTIVE.load(Ordering::Relaxed);
-                let json = format!(r#"{{"kill_switch_active":{}}}"#, active);
-                return Ok::<_, hyper::Error>(
-                    Response::builder()
-                        .status(200)
-                        .header("Content-Type", "application/json")
-                        .header("Access-Control-Allow-Origin", "*")
-                        .body(Body::from(json))
-                        .unwrap(),
-                );
+            let ready = nats && control_sub && jetstream;
+            ("market-data", ready, missing)
+        }
+        MetricsComponent::ExecutionEngine => {
+            let mut missing = Vec::new();
+            if !nats {
+                missing.push("nats_connected".to_string());
             }
-            if path == "/ready" {
-                let now = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs();
-                let last = LAST_ACTIVITY_TS.load(Ordering::Relaxed);
-                if last > 0 && now.saturating_sub(last) <= 120 {
-                    return Ok::<_, hyper::Error>(Response::new(Body::from("ready")));
+            if !control_sub {
+                missing.push("control_request_sub_active".to_string());
+            }
+            if !control_resp {
+                missing.push("control_response_sub_active".to_string());
+            }
+            if !state_paths {
+                missing.push("state_paths_initialized".to_string());
+            }
+            let ready = nats && control_sub && control_resp && state_paths;
+            ("execution-engine", ready, missing)
+        }
+        MetricsComponent::MomentumBot | MetricsComponent::ArbStrategy => {
+            let name = match component {
+                MetricsComponent::MomentumBot => "momentum-bot",
+                _ => "arb-strategy",
+            };
+            (
+                name,
+                nats,
+                if nats {
+                    vec![]
                 } else {
-                    return Ok::<_, hyper::Error>(
-                        Response::builder()
-                            .status(503)
-                            .body(Body::from("stale"))
-                            .unwrap(),
-                    );
+                    vec!["nats_connected".to_string()]
+                },
+            )
+        }
+    };
+
+    let reason_not_ready = if !ready && !missing_checks.is_empty() {
+        Some(format!("missing: {}", missing_checks.join(", ")))
+    } else {
+        None
+    };
+
+    #[derive(serde::Serialize)]
+    struct ReadinessSection {
+        nats_connected: bool,
+        public_http_ready: bool,
+        mode: &'static str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason_not_ready: Option<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        missing_checks: Vec<String>,
+    }
+
+    #[derive(serde::Serialize)]
+    struct StatusPayload<'a> {
+        component: &'a str,
+        ready: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        kill_switch_active: Option<bool>,
+        readiness: ReadinessSection,
+    }
+
+    let kill_switch = match component {
+        MetricsComponent::ExecutionEngine => Some(KILL_SWITCH_ACTIVE.load(Ordering::Relaxed)),
+        _ => None,
+    };
+
+    let payload = StatusPayload {
+        component: component_name,
+        ready,
+        kill_switch_active: kill_switch,
+        readiness: ReadinessSection {
+            nats_connected: nats,
+            public_http_ready: true,
+            mode: mode_str,
+            reason_not_ready,
+            missing_checks,
+        },
+    };
+
+    serde_json::to_string(&payload)
+        .unwrap_or_else(|_| r#"{"component":"unknown","ready":false}"#.to_string())
+}
+
+pub async fn serve_metrics(addr: SocketAddr, component: MetricsComponent) -> anyhow::Result<()> {
+    let make_svc = make_service_fn(move |_conn| {
+        let component = component;
+        async move {
+            Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
+                let component = component;
+                async move {
+                    let path = req.uri().path();
+                    if path == "/metrics" {
+                        record_activity();
+                        return Ok::<_, hyper::Error>(metrics_response().await);
+                    }
+                    if path == "/trades" {
+                        // Return recent trades as JSON for Grafana
+                        let json = get_recent_trades_json();
+                        return Ok::<_, hyper::Error>(
+                            Response::builder()
+                                .status(200)
+                                .header("Content-Type", "application/json")
+                                .header("Access-Control-Allow-Origin", "*")
+                                .body(Body::from(json))
+                                .unwrap(),
+                        );
+                    }
+                    if path == "/live" {
+                        record_activity();
+                        return Ok::<_, hyper::Error>(Response::new(Body::from("ok")));
+                    }
+                    if path == "/status" {
+                        // JSON status: structured readiness for E2E, backward-compat kill_switch_active
+                        record_activity();
+                        let json = status_response(component);
+                        return Ok::<_, hyper::Error>(
+                            Response::builder()
+                                .status(200)
+                                .header("Content-Type", "application/json")
+                                .header("Access-Control-Allow-Origin", "*")
+                                .body(Body::from(json))
+                                .unwrap(),
+                        );
+                    }
+                    if path == "/ready" {
+                        let now = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap()
+                            .as_secs();
+                        let last = LAST_ACTIVITY_TS.load(Ordering::Relaxed);
+                        if last > 0 && now.saturating_sub(last) <= 120 {
+                            return Ok::<_, hyper::Error>(Response::new(Body::from("ready")));
+                        } else {
+                            return Ok::<_, hyper::Error>(
+                                Response::builder()
+                                    .status(503)
+                                    .body(Body::from("stale"))
+                                    .unwrap(),
+                            );
+                        }
+                    }
+                    Ok::<_, hyper::Error>(metrics_response().await)
                 }
-            }
-            Ok::<_, hyper::Error>(metrics_response().await)
-        }))
+            }))
+        }
     });
     Server::bind(&addr).serve(make_svc).await?;
     Ok(())

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -350,6 +350,28 @@ pub fn set_readiness_mode(mode: u8) {
     READINESS_MODE.store(mode as u64, Ordering::Relaxed);
 }
 
+/// Refresh readiness from current runtime state (not startup-latch).
+/// Call periodically from main loop so /status reflects actual communication health.
+pub fn update_readiness_market_data_current(
+    nats_connected: bool,
+    control_sub_active: bool,
+    jetstream_ready: bool,
+) {
+    READINESS_NATS_CONNECTED.store(nats_connected, Ordering::Relaxed);
+    READINESS_CONTROL_SUB_ACTIVE.store(control_sub_active, Ordering::Relaxed);
+    READINESS_JETSTREAM_INITIALIZED.store(jetstream_ready, Ordering::Relaxed);
+}
+
+/// Refresh readiness from current runtime state (not startup-latch).
+/// When NATS disconnects, control subs are cleared (they are tied to the connection).
+pub fn update_readiness_execution_engine_current(nats_connected: bool) {
+    READINESS_NATS_CONNECTED.store(nats_connected, Ordering::Relaxed);
+    if !nats_connected {
+        READINESS_CONTROL_SUB_ACTIVE.store(false, Ordering::Relaxed);
+        READINESS_CONTROL_RESPONSE_SUB_ACTIVE.store(false, Ordering::Relaxed);
+    }
+}
+
 // --- WsolManager metrics ---
 pub static WSOL_BALANCE_LAMPORTS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static WSOL_WRAP_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -1584,20 +1606,36 @@ fn status_response(component: MetricsComponent) -> String {
 
     let (component_name, ready, missing_checks): (&str, bool, Vec<String>) = match component {
         MetricsComponent::MarketData => {
-            let mut missing = Vec::new();
-            if !nats {
-                missing.push("nats_connected".to_string());
+            // Mode-sensitive: dry_run/simulate intentionally disable parts – don't count as missing
+            if mode_u64 == 1 {
+                // dry_run: no NATS, no ControlRequests, no JetStream – ready if HTTP serving
+                ("market-data", true, vec![])
+            } else if mode_u64 == 2 {
+                // simulate: fake Geyser, may have NATS for publish; no ControlRequests sub – require only nats
+                let mut missing = Vec::new();
+                if !nats {
+                    missing.push("nats_connected".to_string());
+                }
+                let ready = nats;
+                ("market-data", ready, missing)
+            } else {
+                let mut missing = Vec::new();
+                if !nats {
+                    missing.push("nats_connected".to_string());
+                }
+                if !control_sub {
+                    missing.push("control_request_sub_active".to_string());
+                }
+                if !jetstream {
+                    missing.push("jetstream_initialized".to_string());
+                }
+                let ready = nats && control_sub && jetstream;
+                ("market-data", ready, missing)
             }
-            if !control_sub {
-                missing.push("control_request_sub_active".to_string());
-            }
-            if !jetstream {
-                missing.push("jetstream_initialized".to_string());
-            }
-            let ready = nats && control_sub && jetstream;
-            ("market-data", ready, missing)
         }
         MetricsComponent::ExecutionEngine => {
+            // Mode-sensitive: dry_run/simulate_only don't disable NATS (still consume intents)
+            // Only live-mode semantics; no intentionally disabled parts to skip
             let mut missing = Vec::new();
             if !nats {
                 missing.push("nats_connected".to_string());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement a public, structured readiness interface for `market-data` and `execution-engine` to enable robust blackbox E2E testing.

The existing `/status` HTTP endpoint is extended to include a structured `readiness` section. This section provides detailed, component-specific readiness checks (e.g., NATS connection, JetStream initialization, subscription activity) and indicates the operational `mode` (live, dry_run, simulate). It also offers `reason_not_ready` and `missing_checks` for diagnostic purposes, providing a stable, public status contract for E2E harnesses without relying on NATS `connz` or log scraping.

<div><a href="https://cursor.com/agents/bc-b58eda22-4875-4db2-ac6d-d3972f062975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b58eda22-4875-4db2-ac6d-d3972f062975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->