### PR TITLE
feat(market-data): Request/Reply im Simulationsmodus für I-24d E2E nutzbar

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4288,6 +4288,38 @@ async fn run_simulation_loop(
     run_id: &str,
     mut config_subscription: Option<ironcrab::nats::NatsSubscription>,
 ) -> Result<()> {
+    // RPC client for EnsurePumpAmmPoolAccounts (Cold Path Discovery, same handler as Normalmodus)
+    let rpc_url =
+        std::env::var("SOLANA_RPC_URL").unwrap_or_else(|_| "http://127.0.0.1:8899".to_string());
+    let rpc = Arc::new(SolanaRpc::new(&rpc_url));
+    info!(rpc_url = %rpc_url, "Simulation mode: RPC client for ControlRequest Discovery");
+
+    // I-24d: Subscribe to ControlRequests (same contract as Normalmodus)
+    let mut control_subscription = if let Some(ref nats) = ctx.nats {
+        match nats.subscribe(TOPIC_CONTROL_REQUESTS).await {
+            Ok(sub) => {
+                info!(
+                    topic = TOPIC_CONTROL_REQUESTS,
+                    "Simulation mode: Subscribed to ControlRequests (Discovery)"
+                );
+                set_readiness_control_sub_active(true);
+                Some(sub)
+            }
+            Err(e) => {
+                warn!(error = %e, "Simulation mode: Failed to subscribe to ControlRequests");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let pump_amm_dex = Arc::new(PumpFunAmmDex::new_with_cache(
+        rpc,
+        ctx.live_pool_cache.clone(),
+        true, // allow_rpc_on_miss: Cold Path Discovery
+    ));
+
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
     let mut slot: u64 = 0;
 
@@ -4303,8 +4335,9 @@ async fn run_simulation_loop(
                 // Keep /ready fresh even when only simulating.
                 ironcrab::metrics::record_activity();
 
-                // Refresh readiness from current runtime state (simulate: no control_sub)
+                // Refresh readiness from current runtime state (simulate: control_sub if subscribed)
                 let nats_connected = ctx.nats.as_ref().is_some_and(|n| n.is_connected());
+                let control_sub_active = nats_connected && control_subscription.is_some();
                 let jetstream_ready = if nats_connected {
                     if let Some(ref nats) = ctx.nats {
                         use async_nats::jetstream;
@@ -4322,7 +4355,7 @@ async fn run_simulation_loop(
                 } else {
                     false
                 };
-                update_readiness_market_data_current(nats_connected, false, jetstream_ready);
+                update_readiness_market_data_current(nats_connected, control_sub_active, jetstream_ready);
 
                 let event = MarketEvent::new(
                     "market-data",
@@ -4361,6 +4394,43 @@ async fn run_simulation_loop(
                 if slot % 10 == 0 {
                     #[cfg(unix)]
                     let _ = sd_notify::notify(false, &[NotifyState::Watchdog]);
+                }
+            }
+
+            // I-24d: ControlRequests (EnsurePumpAmmPoolAccounts Discovery, same handler as Normalmodus)
+            msg = async {
+                if let Some(ref mut sub) = control_subscription {
+                    sub.next().await
+                } else {
+                    std::future::pending::<Option<ironcrab::nats::NatsMessage>>().await
+                }
+            } => {
+                if let Some(nats_msg) = msg {
+                    match nats_msg.deserialize::<ControlRequest>() {
+                        Ok(req) => {
+                            if req.target != "market-data" {
+                                debug!(target = %req.target, "Ignoring ControlRequest for other target");
+                            } else if let ControlRequestKind::EnsurePumpAmmPoolAccounts { base_mint } = req.kind {
+                                let run_id = ctx.run_id.clone();
+                                let request_id = req.request_id.clone();
+                                let ctx_clone = ctx.clone();
+                                let dex_clone = Arc::clone(&pump_amm_dex);
+                                tokio::spawn(async move {
+                                    handle_ensure_pump_amm_pool_accounts(
+                                        &ctx_clone,
+                                        dex_clone.as_ref(),
+                                        run_id.as_str(),
+                                        &request_id,
+                                        &base_mint,
+                                    )
+                                    .await;
+                                });
+                            }
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "Failed to deserialize ControlRequest");
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ziel

Macht den Cold-Path-Request/Reply-Contract für PumpSwap `pool_accounts` in `market-data` auch im Simulationsmodus (`--simulate`) für Blackbox-E2E-Tests nutzbar.

## Hintergrund

- Eval PR #7 testet den echten On-Wire-Contract für I-24d
- Der Test-Harness startet `market-data` mit `--simulate` (kein echter Geyser-Stream)
- Bisher verarbeitete `market-data` `ControlRequestKind::EnsurePumpAmmPoolAccounts` nur im Geyser-/Normalmodus
- In `--simulate` kam keine korrelierte `ControlResponse` zurück → Test-Timeout

## Änderungen

1. **Request/Reply-Pfad im Simulationsmodus aktiviert**
   - `run_simulation_loop` abonniert jetzt `TOPIC_CONTROL_REQUESTS`
   - RPC-Client und `PumpFunAmmDex` werden wie im Normalmodus erstellt
   - Derselbe Handler `handle_ensure_pump_amm_pool_accounts` wird verwendet
   - Kein duplizierter Codepfad, keine Fake-Responses

2. **Readiness/`/status` im Simulationsmodus**
   - `control_sub_active` wird korrekt gesetzt: `nats_connected && control_subscription.is_some()`
   - `/status` bildet den Vertragszustand im Simulationsmodus korrekt ab

## STOP-CHECKs vor der Änderung

- **I-7 (Hot Path RPC)**: EnsurePumpAmmPoolAccounts ist Cold-Path Discovery (Liquidation, Manual, 6005-Retry) – kein Hot-Path-Verstoß
- **Pattern-Konsistenz**: Gleicher Handler und gleiches Pattern wie `run_geyser_loop`
- **Architektur-Grenzen**: Nur `market_data.rs` geändert, Scope eingehalten
- **I-9 (Simulation-Gate)**: N/A – market-data sendet keine TXs
- **Level-5-Trennung**: Keine Eval-Tests gelesen oder geändert

## Erfolgskriterien

- [x] `market-data --simulate` verarbeitet `EnsurePumpAmmPoolAccounts` auf `TOPIC_CONTROL_REQUESTS`
- [x] Korrelierte `ControlResponse` auf `TOPIC_CONTROL_RESPONSES`
- [x] Echter Handler, echter Outcome (ok/not_found/error)
- [x] `/status` bildet Vertragszustand im Simulationsmodus korrekt ab
- [x] Keine neuen Topics, keine Fake-APIs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52aa57a7-9a87-4237-b329-1a6e54c3d6e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52aa57a7-9a87-4237-b329-1a6e54c3d6e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

