### PR TITLE
fix(pumpfun): Cold Path verifiziert cashback_enabled per RPC auch bei Cache-HIT (Bug #25)

### DIFF
--- a/src/solana/dex/pumpfun.rs
+++ b/src/solana/dex/pumpfun.rs
@@ -1187,27 +1187,36 @@ impl PumpFunDex {
         // 2. Cached creator (from DashMap, populated from previous lookups)
         // 3. LivePoolCache (GEYSER-FIRST, populated by market-data)
         // 4. RPC fallback (DEPRECATED - should not happen in production)
+        // Cashback resolution: Cold Path MUST verify via RPC — Cache-HIT with stale
+        // cashback_enabled=false must NOT short-circuit (Bug #25). If RPC fails → Err.
+        // Hot Path: trust Geyser-fed cache only (I-7: no RPC).
+        let cashback_from_rpc_or_cache = |allow_rpc: bool| async move {
+            if allow_rpc {
+                // Cold Path: ALWAYS verify via RPC. No fallback to cache on RPC failure.
+                match self.fetch_bonding_curve(&bonding_curve).await {
+                    Ok(state) => Ok(state.cashback_enabled),
+                    Err(e) => Err(anyhow!(
+                        "Cold Path: RPC verification of cashback_enabled failed for bonding curve {} — \
+                         cannot proceed without authoritative on-chain state (RPC unreachable): {}",
+                        bonding_curve,
+                        e
+                    )),
+                }
+            } else {
+                Ok(self
+                    .get_bonding_curve_from_cache(&bonding_curve)
+                    .map(|s| s.cashback_enabled)
+                    .unwrap_or(false))
+            }
+        };
+
         let (creator, cashback_enabled) = if let Some(c) = fallback_creator {
             debug!(
                 token_mint = %token_mint_str,
                 creator = %c,
                 "pump.fun: using creator from producer"
             );
-            let cashback = if allow_rpc_fallback {
-                // Cold Path (Liquidation): ALWAYS verify via RPC — JetStream cache may have stale cashback_enabled
-                match self.fetch_bonding_curve_fast(&bonding_curve).await {
-                    Some(state) => state.cashback_enabled,
-                    None => self
-                        .get_bonding_curve_from_cache(&bonding_curve)
-                        .map(|s| s.cashback_enabled)
-                        .unwrap_or(false),
-                }
-            } else {
-                // Hot Path: trust Geyser-fed cache (I-7: no RPC)
-                self.get_bonding_curve_from_cache(&bonding_curve)
-                    .map(|s| s.cashback_enabled)
-                    .unwrap_or(false)
-            };
+            let cashback = cashback_from_rpc_or_cache(allow_rpc_fallback).await?;
             (c, cashback)
         } else if let Some(c) = self.get_cached_creator(&token_mint) {
             debug!(
@@ -1215,21 +1224,7 @@ impl PumpFunDex {
                 creator = %c,
                 "pump.fun: using creator from DashMap cache"
             );
-            let cashback = if allow_rpc_fallback {
-                // Cold Path (Liquidation): ALWAYS verify via RPC — JetStream cache may have stale cashback_enabled
-                match self.fetch_bonding_curve_fast(&bonding_curve).await {
-                    Some(state) => state.cashback_enabled,
-                    None => self
-                        .get_bonding_curve_from_cache(&bonding_curve)
-                        .map(|s| s.cashback_enabled)
-                        .unwrap_or(false),
-                }
-            } else {
-                // Hot Path: trust Geyser-fed cache (I-7: no RPC)
-                self.get_bonding_curve_from_cache(&bonding_curve)
-                    .map(|s| s.cashback_enabled)
-                    .unwrap_or(false)
-            };
+            let cashback = cashback_from_rpc_or_cache(allow_rpc_fallback).await?;
             (c, cashback)
         } else if let Some(c) = self.get_creator_from_cache(&bonding_curve) {
             debug!(
@@ -1239,21 +1234,7 @@ impl PumpFunDex {
             );
             // Also cache in DashMap for faster subsequent lookups
             self.cached_creators.insert(token_mint, c);
-            let cashback = if allow_rpc_fallback {
-                // Cold Path (Liquidation): ALWAYS verify via RPC — JetStream cache may have stale cashback_enabled
-                match self.fetch_bonding_curve_fast(&bonding_curve).await {
-                    Some(state) => state.cashback_enabled,
-                    None => self
-                        .get_bonding_curve_from_cache(&bonding_curve)
-                        .map(|s| s.cashback_enabled)
-                        .unwrap_or(false),
-                }
-            } else {
-                // Hot Path: trust Geyser-fed cache (I-7: no RPC)
-                self.get_bonding_curve_from_cache(&bonding_curve)
-                    .map(|s| s.cashback_enabled)
-                    .unwrap_or(false)
-            };
+            let cashback = cashback_from_rpc_or_cache(allow_rpc_fallback).await?;
             (c, cashback)
         } else {
             // RPC FALLBACK - Only allowed in Cold Path (Liquidation).

--- a/tests/execution_pumpfun_builder.rs
+++ b/tests/execution_pumpfun_builder.rs
@@ -206,3 +206,48 @@ async fn test_tx_builder_supports_pumpfun_sell_pure_derivation() {
         "SELL ix must have at least 15 accounts (bonding_curve_v2 required since Feb 2026)"
     );
 }
+
+/// Regression test for Bug #25: Cold Path must verify cashback_enabled via RPC even on Cache-HIT.
+/// When allow_rpc_fallback=true and RPC is unreachable, build must return Err (no silent fallback
+/// to stale cache with cashback_enabled=false).
+/// Ignored by default: uses unreachable RPC, can take 30s+ due to retries. Run with:
+///   cargo test test_pumpfun_cold_path_rpc_verification_required -- --ignored --nocapture
+#[tokio::test]
+#[ignore]
+async fn test_pumpfun_cold_path_rpc_verification_required() {
+    // Use unreachable RPC — Cold Path requires verification, must fail clearly
+    let rpc = Arc::new(SolanaRpc::new("http://127.0.0.1:1"));
+    let mut dex = PumpFunDex::new(rpc, None).expect("PumpFunDex::new");
+
+    let wallet =
+        Pubkey::from_str("Ase7z1mRLps2cTNQnRHpLyQL4Q5FHwonjmZnYCTuUDZM").expect("wallet pubkey");
+    dex.set_user_authority(wallet);
+
+    let creator =
+        Pubkey::from_str("2tFqgkJX6kqz8q6o9tFv3oJ9nQx7n1m3fHk2m8f3oKpZ").expect("creator pubkey");
+    let token_mint = "9xQeWvG816bUx9EPfKJb9N9dKz5wW7Yy2hBzXv4mQ4kG";
+
+    let result = dex
+        .build_swap_ix_async_with_slippage(
+            "So11111111111111111111111111111111111111112",
+            token_mint,
+            1_000_000,
+            123_456,
+            Some(creator),
+            500,
+            None,
+            false, // market_order
+            true,  // allow_rpc_fallback: Cold Path — must verify via RPC
+        )
+        .await;
+
+    // Cold Path with unreachable RPC must return Err, not silently use stale cache
+    let err = result
+        .expect_err("Cold Path with unreachable RPC must fail (Err), not succeed with stale cache");
+    let err_str = err.to_string();
+    assert!(
+        err_str.contains("Cold Path") || err_str.contains("RPC verification"),
+        "error should mention Cold Path / RPC verification: {}",
+        err_str
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zusammenfassung

Behebt den verbleibenden PumpFun-Bonding-Curve-Cold-Path-Fehler aus Bug #25: Ein Cache-HIT mit stale `cashback_enabled=false` darf im Cold Path die RPC-Verifikation nicht mehr kurzschliessen.

## Änderungen

### `src/solana/dex/pumpfun.rs`
- **Cache-HIT darf Cold Path nicht kurzschliessen**: Bei `allow_rpc_fallback=true` wird `cashback_enabled` nun **immer** per RPC verifiziert (`fetch_bonding_curve`), auch wenn Creator bereits aus Cache vorhanden ist.
- **Klarer Failure bei RPC-Unreachability**: Wenn RPC-Verifikation fehlschlägt, wird `Err` zurückgegeben statt still auf Cache zurückzufallen.
- **Hot Path unverändert**: Bei `allow_rpc_fallback=false` bleibt das geyser-/cache-basierte Verhalten (I-7: kein RPC).

### `tests/execution_pumpfun_builder.rs`
- Neuer Regressionstest `test_pumpfun_cold_path_rpc_verification_required`: Verifiziert, dass Cold Path mit unreachable RPC ein klares `Err` zurückgibt.
- Test ist `#[ignore]` (nutzt unreachable RPC, kann 30s+ dauern). Manuell: `cargo test test_pumpfun_cold_path_rpc_verification_required -- --ignored --nocapture`

## STOP-CHECK

- **I-7**: RPC nur im Cold Path (`allow_rpc_fallback=true`). Hot Path unverändert.
- **Pattern**: Konsistent mit Bug #25 (c) und allow_rpc_fallback in anderen DEX-Modulen.
- **Architektur**: Nur `pumpfun.rs` und Test geändert.
- **I-9**: Keine Änderung an Simulation/Send.
- **Repo-Isolation**: Keine Eval-Tests gelesen.

## Erfolgskriterien

- [x] Cold Path verifiziert `cashback_enabled` auch bei Cache-HIT
- [x] Stale Cache-`false` führt nicht mehr zu blindem falschem Layout
- [x] Bei fehlender RPC-Verifikation klarer Failure statt stillem Success
- [x] Hot Path bleibt RPC-frei
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` grün
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa845c2e-abd7-4b71-a235-66d3c69ac52b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa845c2e-abd7-4b71-a235-66d3c69ac52b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

