### PR TITLE
fix(I-24d): Discovery Request/Reply Pfad - pool_address hint + Diagnostik

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -1715,8 +1715,16 @@ impl ExecutionContext {
                     Some(a) if a.len() >= 14 => a,
                     _ => {
                         // I-24d: Request from market-data, wait bounded on authoritative cache state.
-                        info!(mint = %mint_str, "6005-retry: pool_accounts cache miss, requesting discovery from market-data");
-                        match self.request_discovery_and_wait(&mint_str).await {
+                        let pool_hint = self
+                            .live_pool_cache
+                            .as_ref()
+                            .and_then(|c| c.get_pump_amm_pool_address_by_base_mint(&mint))
+                            .map(|p| p.to_string());
+                        info!(mint = %mint_str, pool_address = ?pool_hint, "6005-retry: pool_accounts cache miss, requesting discovery from market-data");
+                        match self
+                            .request_discovery_and_wait(&mint_str, pool_hint.as_deref())
+                            .await
+                        {
                             DiscoveryRequestOutcome::Ok => {
                                 let cache = match self.live_pool_cache.as_ref() {
                                     Some(c) => c,
@@ -1784,7 +1792,15 @@ impl ExecutionContext {
                     mint = %mint_str,
                     "6005-retry: quote cache miss, requesting discovery from market-data"
                 );
-                match self.request_discovery_and_wait(&mint_str).await {
+                let pool_hint = self
+                    .live_pool_cache
+                    .as_ref()
+                    .and_then(|c| c.get_pump_amm_pool_address_by_base_mint(&mint))
+                    .map(|p| p.to_string());
+                match self
+                    .request_discovery_and_wait(&mint_str, pool_hint.as_deref())
+                    .await
+                {
                     DiscoveryRequestOutcome::Ok => {
                         let cache = match self.live_pool_cache.as_ref() {
                             Some(c) => c,
@@ -1887,9 +1903,18 @@ impl ExecutionContext {
     /// I-24d: Request PumpSwap pool_accounts discovery from market-data (Cold Path only).
     /// Sends EnsurePumpAmmPoolAccounts, waits bounded for ControlResponse, returns outcome.
     /// Does NOT write to SLAVE cache — market-data publishes to JetStream, SLAVE consumes.
-    async fn request_discovery_and_wait(&self, base_mint: &str) -> DiscoveryRequestOutcome {
+    /// When pool_address is provided, market-data uses fast getAccount path (<1s) instead of slow getProgramAccounts.
+    async fn request_discovery_and_wait(
+        &self,
+        base_mint: &str,
+        pool_address: Option<&str>,
+    ) -> DiscoveryRequestOutcome {
         let Some(ref nats) = self.nats else {
-            warn!("Discovery request: NATS not connected");
+            warn!(
+                request_id = "n/a",
+                base_mint = %base_mint,
+                "I-24d Discovery: NATS not connected"
+            );
             return DiscoveryRequestOutcome::Error("NATS not connected".to_string());
         };
 
@@ -1901,6 +1926,7 @@ impl ExecutionContext {
             pending.insert(request_id.clone(), tx);
         }
 
+        let pool_address_owned = pool_address.map(String::from);
         let req = ControlRequest::new(
             "execution-engine",
             BUILD_VERSION,
@@ -1909,13 +1935,26 @@ impl ExecutionContext {
             "market-data",
             ControlRequestKind::EnsurePumpAmmPoolAccounts {
                 base_mint: base_mint.to_string(),
+                pool_address: pool_address_owned.clone(),
             },
+        );
+
+        info!(
+            request_id = %request_id,
+            base_mint = %base_mint,
+            target = "market-data",
+            pool_address = ?pool_address,
+            "I-24d Discovery: publishing EnsurePumpAmmPoolAccounts request"
         );
 
         if nats.publish(TOPIC_CONTROL_REQUESTS, &req).await.is_err() {
             let mut pending = self.pending_discovery_responses.lock().await;
             pending.remove(&request_id);
-            warn!(base_mint = %base_mint, "Discovery request: publish failed");
+            warn!(
+                request_id = %request_id,
+                base_mint = %base_mint,
+                "I-24d Discovery: publish failed"
+            );
             return DiscoveryRequestOutcome::Error("publish failed".to_string());
         }
 
@@ -1923,15 +1962,41 @@ impl ExecutionContext {
             match tokio::time::timeout(Duration::from_secs(DISCOVERY_REQUEST_TIMEOUT_SECS), rx)
                 .await
             {
-                Ok(Ok(resp)) => match resp.status {
-                    ControlResponseStatus::Ok => DiscoveryRequestOutcome::Ok,
-                    ControlResponseStatus::NotFound => DiscoveryRequestOutcome::NotFound,
-                    ControlResponseStatus::Error => DiscoveryRequestOutcome::Error(
-                        resp.message.unwrap_or_else(|| "unknown error".to_string()),
-                    ),
-                },
-                Ok(Err(_)) => DiscoveryRequestOutcome::Error("channel closed".to_string()),
-                Err(_) => DiscoveryRequestOutcome::Timeout,
+                Ok(Ok(resp)) => {
+                    let status_str = format!("{:?}", resp.status);
+                    let pool = resp.pool_address.as_deref();
+                    info!(
+                        request_id = %request_id,
+                        base_mint = %base_mint,
+                        status = %status_str,
+                        pool_address = ?pool,
+                        "I-24d Discovery: response received and correlated"
+                    );
+                    match resp.status {
+                        ControlResponseStatus::Ok => DiscoveryRequestOutcome::Ok,
+                        ControlResponseStatus::NotFound => DiscoveryRequestOutcome::NotFound,
+                        ControlResponseStatus::Error => DiscoveryRequestOutcome::Error(
+                            resp.message.unwrap_or_else(|| "unknown error".to_string()),
+                        ),
+                    }
+                }
+                Ok(Err(_)) => {
+                    warn!(
+                        request_id = %request_id,
+                        base_mint = %base_mint,
+                        "I-24d Discovery: channel closed before response"
+                    );
+                    DiscoveryRequestOutcome::Error("channel closed".to_string())
+                }
+                Err(_) => {
+                    warn!(
+                        request_id = %request_id,
+                        base_mint = %base_mint,
+                        timeout_secs = DISCOVERY_REQUEST_TIMEOUT_SECS,
+                        "I-24d Discovery: timeout (no correlated response)"
+                    );
+                    DiscoveryRequestOutcome::Timeout
+                }
             };
 
         // Cleanup pending entry (may have been removed by subscription)
@@ -2309,9 +2374,13 @@ impl ExecutionContext {
                                     }
                                     _ => {
                                         // I-24d: Request discovery, wait bounded on authoritative cache state.
-                                        info!(mint = %mint, "pump_amm quote ok but pool_accounts missing; requesting discovery");
+                                        // pool_id from quote enables fast getAccount path in market-data.
+                                        info!(mint = %mint, pool = %pool_id, "pump_amm quote ok but pool_accounts missing; requesting discovery");
                                         match ctx
-                                            .request_discovery_and_wait(&mint.to_string())
+                                            .request_discovery_and_wait(
+                                                &mint.to_string(),
+                                                Some(pool_id.as_str()),
+                                            )
                                             .await
                                         {
                                             DiscoveryRequestOutcome::Ok => {
@@ -2395,7 +2464,15 @@ impl ExecutionContext {
                                 mint = %mint,
                                 "pump_amm quote cache miss; requesting discovery from market-data"
                             );
-                            match ctx.request_discovery_and_wait(&mint.to_string()).await {
+                            let pool_hint = ctx
+                                .live_pool_cache
+                                .as_ref()
+                                .and_then(|c| c.get_pump_amm_pool_address_by_base_mint(&mint))
+                                .map(|p| p.to_string());
+                            match ctx
+                                .request_discovery_and_wait(&mint.to_string(), pool_hint.as_deref())
+                                .await
+                            {
                                 DiscoveryRequestOutcome::Ok => {
                                     if let Some(cache) = ctx.live_pool_cache.as_ref() {
                                         if wait_for_pool_accounts_in_cache(
@@ -5814,9 +5891,22 @@ async fn main() -> Result<()> {
                                 match msg.deserialize::<ControlResponse>() {
                                     Ok(resp) => {
                                         let request_id = resp.request_id.clone();
+                                        let status_str = format!("{:?}", resp.status);
+                                        let pool = resp.pool_address.clone();
                                         let mut map = pending.lock().await;
                                         if let Some(tx) = map.remove(&request_id) {
+                                            info!(
+                                                request_id = %request_id,
+                                                status = %status_str,
+                                                pool_address = ?pool,
+                                                "I-24d Discovery: ControlResponse received, correlated and delivered"
+                                            );
                                             let _ = tx.send(resp);
+                                        } else {
+                                            debug!(
+                                                request_id = %request_id,
+                                                "I-24d Discovery: ControlResponse received but no pending request (stale or other consumer)"
+                                            );
                                         }
                                     }
                                     Err(e) => {
@@ -9531,7 +9621,43 @@ async fn spawn_rebroadcast_loop(
 
 #[cfg(test)]
 mod execution_engine_tests {
-    use super::{select_best_route, RouteCandidate};
+    use super::{select_best_route, DiscoveryRequestOutcome, RouteCandidate};
+    use ironcrab::ipc::{ControlResponse, ControlResponseStatus};
+
+    /// I-24d: Verifies that ControlResponse status maps correctly to DiscoveryRequestOutcome.
+    /// NotFound and Error must NOT be confused with Timeout (terminal outcomes are distinct).
+    #[test]
+    fn discovery_response_status_maps_to_outcome() {
+        for status in [
+            ControlResponseStatus::Ok,
+            ControlResponseStatus::NotFound,
+            ControlResponseStatus::Error,
+        ] {
+            let mut resp = ControlResponse::new(
+                "market-data",
+                "v0.1.0",
+                "run-1",
+                "req-1".to_string(),
+                "market-data",
+                status,
+            );
+            if matches!(status, ControlResponseStatus::Error) {
+                resp = resp.with_message("test".to_string());
+            }
+            let actual = match resp.status {
+                ControlResponseStatus::Ok => DiscoveryRequestOutcome::Ok,
+                ControlResponseStatus::NotFound => DiscoveryRequestOutcome::NotFound,
+                ControlResponseStatus::Error => DiscoveryRequestOutcome::Error(
+                    resp.message.unwrap_or_else(|| "unknown".to_string()),
+                ),
+            };
+            assert!(
+                !matches!(actual, DiscoveryRequestOutcome::Timeout),
+                "status {:?} must map to Ok/NotFound/Error, never Timeout",
+                status
+            );
+        }
+    }
 
     #[test]
     fn select_best_route_prefers_highest_and_keeps_first_on_tie() {

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -1926,8 +1926,7 @@ impl ExecutionContext {
             pending.insert(request_id.clone(), tx);
         }
 
-        let pool_address_owned = pool_address.map(String::from);
-        let req = ControlRequest::new(
+        let mut req = ControlRequest::new(
             "execution-engine",
             BUILD_VERSION,
             &self.run_id,
@@ -1935,9 +1934,9 @@ impl ExecutionContext {
             "market-data",
             ControlRequestKind::EnsurePumpAmmPoolAccounts {
                 base_mint: base_mint.to_string(),
-                pool_address: pool_address_owned.clone(),
             },
         );
+        req.pool_address_hint = pool_address.map(String::from);
 
         info!(
             request_id = %request_id,

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1582,12 +1582,14 @@ async fn main() -> Result<()> {
 /// Performs RPC-based discovery (Cold Path), updates MASTER cache, publishes
 /// JetStream PoolCacheUpdate (SSOT), and ControlResponse (correlation only).
 /// Uses shared PumpFunAmmDex for dedupe/storm protection.
+/// When pool_address_hint is provided, uses fast getAccount path (<1s) instead of slow getProgramAccounts.
 async fn handle_ensure_pump_amm_pool_accounts(
     ctx: &MarketDataContext,
     dex: &ironcrab::solana::dex::pumpfun_amm::PumpFunAmmDex,
     run_id: &str,
     request_id: &str,
     base_mint_str: &str,
+    pool_address_hint: Option<&str>,
 ) {
     let base_mint = match Pubkey::from_str(base_mint_str) {
         Ok(p) => p,
@@ -1608,7 +1610,11 @@ async fn handle_ensure_pump_amm_pool_accounts(
         }
     };
 
-    match dex.pool_accounts_v1_for_base_mint(base_mint).await {
+    let pool_hint = pool_address_hint.and_then(|s| Pubkey::from_str(s).ok());
+    match dex
+        .pool_accounts_v1_for_base_mint_with_hint(base_mint, pool_hint)
+        .await
+    {
         Ok(Some(accounts)) if accounts.len() >= 14 => {
             let pool_address = accounts[0];
             let pool_address_str = pool_address.to_string();
@@ -1696,8 +1702,19 @@ async fn handle_ensure_pump_amm_pool_accounts(
 
             if let Some(ref nats) = ctx.nats {
                 let (status, message) = if jetstream_ok {
+                    info!(
+                        request_id = %request_id,
+                        base_mint = %base_mint_str,
+                        pool_address = %pool_address_str,
+                        "I-24d Discovery: terminal outcome ok"
+                    );
                     (ControlResponseStatus::Ok, None)
                 } else {
+                    warn!(
+                        request_id = %request_id,
+                        base_mint = %base_mint_str,
+                        "I-24d Discovery: terminal outcome error (JetStream publish failed)"
+                    );
                     (
                         ControlResponseStatus::Error,
                         Some("JetStream publish failed".to_string()),
@@ -1715,7 +1732,11 @@ async fn handle_ensure_pump_amm_pool_accounts(
             }
         }
         Ok(Some(_)) => {
-            warn!(base_mint = %base_mint_str, "EnsurePumpAmmPoolAccounts: pool_accounts incomplete (<14)");
+            warn!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                "I-24d Discovery: terminal outcome error (pool_accounts incomplete <14)"
+            );
             if let Some(ref nats) = ctx.nats {
                 publish_control_response(
                     nats,
@@ -1729,7 +1750,11 @@ async fn handle_ensure_pump_amm_pool_accounts(
             }
         }
         Ok(None) => {
-            info!(base_mint = %base_mint_str, "EnsurePumpAmmPoolAccounts: pool not found");
+            info!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                "I-24d Discovery: terminal outcome not_found"
+            );
             if let Some(ref nats) = ctx.nats {
                 publish_control_response(
                     nats,
@@ -1743,7 +1768,12 @@ async fn handle_ensure_pump_amm_pool_accounts(
             }
         }
         Err(e) => {
-            warn!(base_mint = %base_mint_str, error = %e, "EnsurePumpAmmPoolAccounts: discovery failed");
+            warn!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                error = %e,
+                "I-24d Discovery: terminal outcome error (discovery failed)"
+            );
             if let Some(ref nats) = ctx.nats {
                 publish_control_response(
                     nats,
@@ -1775,14 +1805,29 @@ async fn publish_control_response(
         "market-data",
         status,
     );
+    let pool_for_log = pool_address.clone();
     if let Some(pa) = pool_address {
         resp = resp.with_pool_address(pa);
     }
     if let Some(m) = message {
         resp = resp.with_message(m);
     }
+    let status_str = format!("{:?}", status);
     if let Err(e) = nats.publish(TOPIC_CONTROL_RESPONSES, &resp).await {
-        warn!(error = %e, "Failed to publish ControlResponse");
+        warn!(
+            request_id = %request_id,
+            status = %status_str,
+            pool_address = ?pool_for_log,
+            error = %e,
+            "I-24d Discovery: Failed to publish ControlResponse"
+        );
+    } else {
+        info!(
+            request_id = %request_id,
+            status = %status_str,
+            pool_address = ?pool_for_log,
+            "I-24d Discovery: ControlResponse published"
+        );
     }
 }
 
@@ -2001,9 +2046,19 @@ async fn run_geyser_loop(
                         Ok(req) => {
                             if req.target != "market-data" {
                                 debug!(target = %req.target, "Ignoring ControlRequest for other target");
-                            } else if let ControlRequestKind::EnsurePumpAmmPoolAccounts { base_mint } = req.kind {
+                            } else if let ControlRequestKind::EnsurePumpAmmPoolAccounts {
+                                base_mint,
+                                pool_address,
+                            } = req.kind
+                            {
                                 let run_id = ctx.run_id.clone();
                                 let request_id = req.request_id.clone();
+                                info!(
+                                    request_id = %request_id,
+                                    base_mint = %base_mint,
+                                    pool_address = ?pool_address,
+                                    "I-24d Discovery: EnsurePumpAmmPoolAccounts received"
+                                );
                                 let ctx_clone = ctx.clone();
                                 let dex_clone = Arc::clone(&pump_amm_dex);
                                 tokio::spawn(async move {
@@ -2013,6 +2068,7 @@ async fn run_geyser_loop(
                                         run_id.as_str(),
                                         &request_id,
                                         &base_mint,
+                                        pool_address.as_deref(),
                                     )
                                     .await;
                                 });
@@ -4410,9 +4466,19 @@ async fn run_simulation_loop(
                         Ok(req) => {
                             if req.target != "market-data" {
                                 debug!(target = %req.target, "Ignoring ControlRequest for other target");
-                            } else if let ControlRequestKind::EnsurePumpAmmPoolAccounts { base_mint } = req.kind {
+                            } else if let ControlRequestKind::EnsurePumpAmmPoolAccounts {
+                                base_mint,
+                                pool_address,
+                            } = req.kind
+                            {
                                 let run_id = ctx.run_id.clone();
                                 let request_id = req.request_id.clone();
+                                info!(
+                                    request_id = %request_id,
+                                    base_mint = %base_mint,
+                                    pool_address = ?pool_address,
+                                    "I-24d Discovery: EnsurePumpAmmPoolAccounts received (simulation)"
+                                );
                                 let ctx_clone = ctx.clone();
                                 let dex_clone = Arc::clone(&pump_amm_dex);
                                 tokio::spawn(async move {
@@ -4422,6 +4488,7 @@ async fn run_simulation_loop(
                                         run_id.as_str(),
                                         &request_id,
                                         &base_mint,
+                                        pool_address.as_deref(),
                                     )
                                     .await;
                                 });

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2048,15 +2048,15 @@ async fn run_geyser_loop(
                                 debug!(target = %req.target, "Ignoring ControlRequest for other target");
                             } else if let ControlRequestKind::EnsurePumpAmmPoolAccounts {
                                 base_mint,
-                                pool_address,
                             } = req.kind
                             {
                                 let run_id = ctx.run_id.clone();
                                 let request_id = req.request_id.clone();
+                                let pool_hint = req.pool_address_hint.clone();
                                 info!(
                                     request_id = %request_id,
                                     base_mint = %base_mint,
-                                    pool_address = ?pool_address,
+                                    pool_address_hint = ?pool_hint,
                                     "I-24d Discovery: EnsurePumpAmmPoolAccounts received"
                                 );
                                 let ctx_clone = ctx.clone();
@@ -2068,7 +2068,7 @@ async fn run_geyser_loop(
                                         run_id.as_str(),
                                         &request_id,
                                         &base_mint,
-                                        pool_address.as_deref(),
+                                        pool_hint.as_deref(),
                                     )
                                     .await;
                                 });
@@ -4468,15 +4468,15 @@ async fn run_simulation_loop(
                                 debug!(target = %req.target, "Ignoring ControlRequest for other target");
                             } else if let ControlRequestKind::EnsurePumpAmmPoolAccounts {
                                 base_mint,
-                                pool_address,
                             } = req.kind
                             {
                                 let run_id = ctx.run_id.clone();
                                 let request_id = req.request_id.clone();
+                                let pool_hint = req.pool_address_hint.clone();
                                 info!(
                                     request_id = %request_id,
                                     base_mint = %base_mint,
-                                    pool_address = ?pool_address,
+                                    pool_address_hint = ?pool_hint,
                                     "I-24d Discovery: EnsurePumpAmmPoolAccounts received (simulation)"
                                 );
                                 let ctx_clone = ctx.clone();
@@ -4488,7 +4488,7 @@ async fn run_simulation_loop(
                                         run_id.as_str(),
                                         &request_id,
                                         &base_mint,
-                                        pool_address.as_deref(),
+                                        pool_hint.as_deref(),
                                     )
                                     .await;
                                 });

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -1101,12 +1101,12 @@ pub enum ControlRequestKind {
     /// Sent by execution-engine (Cold Path) when pool_accounts are needed but missing in SLAVE cache.
     /// market-data performs discovery, updates MASTER cache, publishes JetStream PoolCacheUpdate,
     /// and replies with ControlResponse. Truth Source = JetStream, not the reply.
+    ///
+    /// Optional pool address hint: use top-level `pool_address_hint` on ControlRequest for
+    /// backward-compatible fast-path (avoids breaking enum variant shape for external callers).
     EnsurePumpAmmPoolAccounts {
         /// Base mint address (base58) of the PumpSwap pool to discover.
         base_mint: String,
-        /// Optional pool address (base58) when known. Enables fast getAccount path instead of slow getProgramAccounts.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pool_address: Option<String>,
     },
 }
 
@@ -1126,6 +1126,11 @@ pub struct ControlRequest {
     /// Target component (e.g., "execution-engine").
     pub target: String,
 
+    /// Optional pool address hint for EnsurePumpAmmPoolAccounts. Enables fast getAccount path.
+    /// Kept at top-level for backward compatibility (no enum variant shape change).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub pool_address_hint: Option<String>,
+
     #[serde(flatten)]
     pub kind: ControlRequestKind,
 }
@@ -1143,6 +1148,7 @@ impl ControlRequest {
             header: RecordHeader::new(component, build, run_id),
             request_id,
             target: target.to_string(),
+            pool_address_hint: None,
             kind,
         }
     }
@@ -2077,7 +2083,8 @@ mod tests {
 
     #[test]
     fn test_control_request_ensure_pump_amm_pool_accounts_serde() {
-        let req = ControlRequest::new(
+        // Source-compatible: old callers use only base_mint (no pool_address in enum).
+        let mut req = ControlRequest::new(
             "execution-engine",
             "v0.1.0",
             "run-123",
@@ -2085,13 +2092,14 @@ mod tests {
             "market-data",
             ControlRequestKind::EnsurePumpAmmPoolAccounts {
                 base_mint: "TokenMint11111111111111111111111111111111".to_string(),
-                pool_address: Some("PoolAddr11111111111111111111111111111111".to_string()),
             },
         );
+        req.pool_address_hint = Some("PoolAddr11111111111111111111111111111111".to_string());
 
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("ensure_pump_amm_pool_accounts"));
         assert!(json.contains("TokenMint11111111111111111111111111111111"));
+        assert!(json.contains("pool_address_hint"));
         assert!(json.contains("PoolAddr11111111111111111111111111111111"));
         assert!(json.contains("market-data"));
         assert!(json.contains("req-ensure-001"));
@@ -2099,21 +2107,18 @@ mod tests {
         let parsed: ControlRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.request_id, "req-ensure-001");
         assert_eq!(parsed.target, "market-data");
+        assert_eq!(
+            parsed.pool_address_hint.as_deref(),
+            Some("PoolAddr11111111111111111111111111111111")
+        );
         match &parsed.kind {
-            ControlRequestKind::EnsurePumpAmmPoolAccounts {
-                base_mint,
-                pool_address,
-            } => {
+            ControlRequestKind::EnsurePumpAmmPoolAccounts { base_mint } => {
                 assert_eq!(base_mint, "TokenMint11111111111111111111111111111111");
-                assert_eq!(
-                    pool_address.as_deref(),
-                    Some("PoolAddr11111111111111111111111111111111")
-                );
             }
             _ => panic!("expected EnsurePumpAmmPoolAccounts"),
         }
 
-        // Backward compatibility: request without pool_address (base_mint only)
+        // Backward compatibility: request without pool_address_hint (old wire format).
         let req_no_pool = ControlRequest::new(
             "execution-engine",
             "v0.1.0",
@@ -2122,19 +2127,15 @@ mod tests {
             "market-data",
             ControlRequestKind::EnsurePumpAmmPoolAccounts {
                 base_mint: "Mint22222222222222222222222222222222".to_string(),
-                pool_address: None,
             },
         );
         let json_no_pool = serde_json::to_string(&req_no_pool).unwrap();
-        assert!(!json_no_pool.contains("pool_address"));
+        assert!(!json_no_pool.contains("pool_address_hint"));
         let parsed_no_pool: ControlRequest = serde_json::from_str(&json_no_pool).unwrap();
+        assert!(parsed_no_pool.pool_address_hint.is_none());
         match &parsed_no_pool.kind {
-            ControlRequestKind::EnsurePumpAmmPoolAccounts {
-                base_mint,
-                pool_address,
-            } => {
+            ControlRequestKind::EnsurePumpAmmPoolAccounts { base_mint } => {
                 assert_eq!(base_mint, "Mint22222222222222222222222222222222");
-                assert!(pool_address.is_none());
             }
             _ => panic!("expected EnsurePumpAmmPoolAccounts"),
         }

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -1104,6 +1104,9 @@ pub enum ControlRequestKind {
     EnsurePumpAmmPoolAccounts {
         /// Base mint address (base58) of the PumpSwap pool to discover.
         base_mint: String,
+        /// Optional pool address (base58) when known. Enables fast getAccount path instead of slow getProgramAccounts.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pool_address: Option<String>,
     },
 }
 
@@ -2082,12 +2085,14 @@ mod tests {
             "market-data",
             ControlRequestKind::EnsurePumpAmmPoolAccounts {
                 base_mint: "TokenMint11111111111111111111111111111111".to_string(),
+                pool_address: Some("PoolAddr11111111111111111111111111111111".to_string()),
             },
         );
 
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("ensure_pump_amm_pool_accounts"));
         assert!(json.contains("TokenMint11111111111111111111111111111111"));
+        assert!(json.contains("PoolAddr11111111111111111111111111111111"));
         assert!(json.contains("market-data"));
         assert!(json.contains("req-ensure-001"));
 
@@ -2095,8 +2100,41 @@ mod tests {
         assert_eq!(parsed.request_id, "req-ensure-001");
         assert_eq!(parsed.target, "market-data");
         match &parsed.kind {
-            ControlRequestKind::EnsurePumpAmmPoolAccounts { base_mint } => {
+            ControlRequestKind::EnsurePumpAmmPoolAccounts {
+                base_mint,
+                pool_address,
+            } => {
                 assert_eq!(base_mint, "TokenMint11111111111111111111111111111111");
+                assert_eq!(
+                    pool_address.as_deref(),
+                    Some("PoolAddr11111111111111111111111111111111")
+                );
+            }
+            _ => panic!("expected EnsurePumpAmmPoolAccounts"),
+        }
+
+        // Backward compatibility: request without pool_address (base_mint only)
+        let req_no_pool = ControlRequest::new(
+            "execution-engine",
+            "v0.1.0",
+            "run-123",
+            "req-ensure-002".to_string(),
+            "market-data",
+            ControlRequestKind::EnsurePumpAmmPoolAccounts {
+                base_mint: "Mint22222222222222222222222222222222".to_string(),
+                pool_address: None,
+            },
+        );
+        let json_no_pool = serde_json::to_string(&req_no_pool).unwrap();
+        assert!(!json_no_pool.contains("pool_address"));
+        let parsed_no_pool: ControlRequest = serde_json::from_str(&json_no_pool).unwrap();
+        match &parsed_no_pool.kind {
+            ControlRequestKind::EnsurePumpAmmPoolAccounts {
+                base_mint,
+                pool_address,
+            } => {
+                assert_eq!(base_mint, "Mint22222222222222222222222222222222");
+                assert!(pool_address.is_none());
             }
             _ => panic!("expected EnsurePumpAmmPoolAccounts"),
         }

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -188,9 +188,12 @@ impl PumpFunAmmDex {
     /// [7] protocol_fee_recipient_ta, [8] event_authority, [9] coin_creator_vault_ata,
     /// [10] coin_creator_vault_authority, [11] global_volume_accumulator,
     /// [12] fee_config, [13] fee_program
-    pub async fn pool_accounts_v1_for_base_mint(
+    /// Optional pool_address hint for fast-path discovery (single getAccount vs slow getProgramAccounts).
+    /// Used by I-24d EnsurePumpAmmPoolAccounts when execution-engine knows pool from cache/position.
+    pub async fn pool_accounts_v1_for_base_mint_with_hint(
         &self,
         base_mint: Pubkey,
+        pool_address_hint: Option<Pubkey>,
     ) -> Result<Option<Vec<Pubkey>>> {
         // GEYSER-FIRST: Check LivePoolCache for pre-cached pool_accounts before RPC discovery.
         // These come from DexPoolAccounts events (parsed from verified on-chain swap txs)
@@ -210,6 +213,61 @@ impl PumpFunAmmDex {
             if !self.allow_rpc_on_miss {
                 debug!(base_mint = %base_mint, "pump_amm: pool_accounts cache miss, returning None (no RPC)");
                 return Ok(None);
+            }
+        }
+
+        // I-24d FAST PATH: When pool_address_hint provided, try single getAccount first.
+        // Avoids slow getProgramAccounts scan that routinely exceeds 15s discovery timeout.
+        if let Some(pool_market) = pool_address_hint {
+            info!(
+                base_mint = %base_mint,
+                pool = %pool_market,
+                "pump_amm: pool_address hint provided, trying direct getAccount (fast path)"
+            );
+            match self
+                .try_parse_pool_static_from_market_account(pool_market, base_mint)
+                .await
+            {
+                Ok(Some(pool)) => {
+                    self.pools_by_base.insert(base_mint, pool.clone());
+                    self.pools_by_market.insert(pool.pool_market, base_mint);
+                    info!(
+                        base_mint = %base_mint,
+                        pool_market = %pool.pool_market,
+                        "pump_amm: PumpAmmPoolStatic from pool_address hint (fast path)"
+                    );
+                    return Ok(Some(vec![
+                        pool.pool_market,
+                        pool.global_config,
+                        pool.base_mint,
+                        pool.quote_mint,
+                        pool.pool_base_vault,
+                        pool.pool_quote_vault,
+                        pool.protocol_fee_recipient,
+                        pool.protocol_fee_recipient_ta,
+                        pool.event_authority,
+                        pool.coin_creator_vault_ata,
+                        pool.coin_creator_vault_authority,
+                        pool.global_volume_accumulator,
+                        pool.fee_config,
+                        pool.fee_program,
+                    ]));
+                }
+                Ok(None) => {
+                    warn!(
+                        base_mint = %base_mint,
+                        pool = %pool_market,
+                        "pump_amm: pool_address hint parse returned None, falling through to discover_pool_static"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        base_mint = %base_mint,
+                        pool = %pool_market,
+                        error = %e,
+                        "pump_amm: pool_address hint parse failed, falling through to discover_pool_static"
+                    );
+                }
             }
         }
 
@@ -238,6 +296,15 @@ impl PumpFunAmmDex {
             pool.fee_config,                   // [12]
             pool.fee_program,                  // [13]
         ]))
+    }
+
+    /// Convenience wrapper: pool_accounts_v1_for_base_mint without hint.
+    pub async fn pool_accounts_v1_for_base_mint(
+        &self,
+        base_mint: Pubkey,
+    ) -> Result<Option<Vec<Pubkey>>> {
+        self.pool_accounts_v1_for_base_mint_with_hint(base_mint, None)
+            .await
     }
 
     fn derive_user_volume_accumulator(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zusammenfassung

Behebt den I-24d Request/Reply-Bruchpunkt bei `kill + liquidate` nach Restart: PumpSwap-Positionen endeten in `discovery timeout`, obwohl market-data die Anfrage verarbeiten konnte.

**Update (API-Kompatibilität)**: `pool_address` wurde aus der Enum-Variante entfernt und als optionales Top-Level-Feld `pool_address_hint` auf `ControlRequest` verschoben. Eval-Callsites mit `EnsurePumpAmmPoolAccounts { base_mint }` kompilieren wieder.

## Bruchstelle

**Ursache**: `discover_pool_static` in market-data nutzt bei Cache-Miss `getProgramAccounts` (>15s). Der execution-engine Timeout (15s) feuert, bevor die Response ankommt.

**Fix**: Optionales `pool_address_hint` auf `ControlRequest`. Wenn execution-engine die Pool-Adresse kennt, wird sie mitgesendet. market-data nutzt dann den Fast-Path: einzelner `getAccount`-Call (<1s).

## Hint-Transport (backward-compatible)

- **Wo**: Top-Level-Feld `ControlRequest.pool_address_hint: Option<String>` mit `#[serde(default)]`
- **Warum source-kompatibel**: `EnsurePumpAmmPoolAccounts` hat wieder nur `{ base_mint }` – keine neue Pflichtfeld-Erweiterung
- **Warum I-24d intakt**: market-data bleibt Discovery-Autorität, execution-engine sendet nur den Hint, keine lokale Discovery
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6710e3a2-a221-46a0-975a-d06ae385a6d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6710e3a2-a221-46a0-975a-d06ae385a6d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

