### PR TITLE
fix: I-24d PumpSwap hint path — terminal outcome, no global scan, creator vault FIX-32 parity

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1611,11 +1611,25 @@ async fn handle_ensure_pump_amm_pool_accounts(
     };
 
     let pool_hint = pool_address_hint.and_then(|s| Pubkey::from_str(s).ok());
+    info!(
+        request_id = %request_id,
+        base_mint = %base_mint_str,
+        pool_address_hint = ?pool_address_hint,
+        has_pool_hint = pool_hint.is_some(),
+        "I-24d Discovery: EnsurePumpAmmPoolAccounts start (Geyser cache check then RPC fast path if hint)"
+    );
     match dex
         .pool_accounts_v1_for_base_mint_with_hint(base_mint, pool_hint)
         .await
     {
         Ok(Some(accounts)) if accounts.len() >= 14 => {
+            info!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                outcome = "ok",
+                rpc_global_scan = "no",
+                "I-24d Discovery: pump_amm pool_accounts resolved (terminal)"
+            );
             let pool_address = accounts[0];
             let pool_address_str = pool_address.to_string();
             let base_mint_str = base_mint.to_string();
@@ -1706,6 +1720,8 @@ async fn handle_ensure_pump_amm_pool_accounts(
                         request_id = %request_id,
                         base_mint = %base_mint_str,
                         pool_address = %pool_address_str,
+                        rpc_global_scan = "no",
+                        control_response = "pending_publish",
                         "I-24d Discovery: terminal outcome ok"
                     );
                     (ControlResponseStatus::Ok, None)
@@ -1735,6 +1751,8 @@ async fn handle_ensure_pump_amm_pool_accounts(
             warn!(
                 request_id = %request_id,
                 base_mint = %base_mint_str,
+                outcome = "error",
+                reason = "pool_accounts_incomplete",
                 "I-24d Discovery: terminal outcome error (pool_accounts incomplete <14)"
             );
             if let Some(ref nats) = ctx.nats {
@@ -1753,6 +1771,7 @@ async fn handle_ensure_pump_amm_pool_accounts(
             info!(
                 request_id = %request_id,
                 base_mint = %base_mint_str,
+                outcome = "not_found",
                 "I-24d Discovery: terminal outcome not_found"
             );
             if let Some(ref nats) = ctx.nats {
@@ -1771,6 +1790,7 @@ async fn handle_ensure_pump_amm_pool_accounts(
             warn!(
                 request_id = %request_id,
                 base_mint = %base_mint_str,
+                outcome = "error",
                 error = %e,
                 "I-24d Discovery: terminal outcome error (discovery failed)"
             );

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -257,16 +257,25 @@ impl PumpFunAmmDex {
                     warn!(
                         base_mint = %base_mint,
                         pool = %pool_market,
-                        "pump_amm: pool_address hint parse returned None, falling through to discover_pool_static"
+                        "pump_amm: pool_address hint parse returned None; refusing discover_pool_static (no unbounded getProgramAccounts)"
                     );
+                    return Err(anyhow!(
+                        "pump_amm: pool_address hint parse returned no usable pool (base_mint={}, pool={}); refusing unbounded RPC discovery (I-24d)",
+                        base_mint,
+                        pool_market
+                    ));
                 }
                 Err(e) => {
                     warn!(
                         base_mint = %base_mint,
                         pool = %pool_market,
                         error = %e,
-                        "pump_amm: pool_address hint parse failed, falling through to discover_pool_static"
+                        "pump_amm: pool_address hint parse failed; refusing discover_pool_static (no unbounded getProgramAccounts)"
                     );
+                    return Err(e.context(format!(
+                        "pump_amm: pool_address hint parse error (base_mint={}, pool={}); refusing unbounded RPC discovery (I-24d)",
+                        base_mint, pool_market
+                    )));
                 }
             }
         }
@@ -851,27 +860,18 @@ impl PumpFunAmmDex {
                 .await?
             {
                 Some(derived_authority) => {
-                    // Derive ATA for creator vault
+                    // Derive ATA for creator vault. FIX-32 parity: do not require the ATA to exist
+                    // yet — PumpSwap may create it via CreateIdempotent on swap (same rationale as
+                    // protocol_fee_recipient_ta for quote mint).
                     let derived_ata = Self::derive_ata(derived_authority, base_mint);
-
-                    // Verify ATA exists
-                    match self
-                        .rpc_get_account_owner_and_executable(derived_ata)
-                        .await?
-                    {
-                        Some(_) => (derived_authority, derived_ata),
-                        None => {
-                            warn!(
-                                pool = %pool_market,
-                                base_mint = %base_mint,
-                                "pump_amm market parse FAIL: no creator vault token account \
-                                 (no embedded creator ATA; PDA derivation ATA does not exist; \
-                                 authority_candidates_count={})",
-                                authority_candidates.len()
-                            );
-                            return Ok(None);
-                        }
-                    }
+                    warn!(
+                        pool = %pool_market,
+                        base_mint = %base_mint,
+                        derived_ata = %derived_ata,
+                        authority_candidates_count = authority_candidates.len(),
+                        "pump_amm: creator vault ATA not on-chain; using derived address (FIX-32 parity)"
+                    );
+                    (derived_authority, derived_ata)
                 }
                 None => {
                     warn!(
@@ -1435,16 +1435,25 @@ impl PumpFunAmmDex {
                         warn!(
                             base_mint = %base_mint,
                             pool = %pool_address,
-                            "pump_amm: direct getAccount parse returned None, falling through to getProgramAccounts"
+                            "pump_amm: cached pool address parse returned None; refusing getProgramAccounts (no unbounded scan)"
                         );
+                        return Err(anyhow!(
+                            "pump_amm: LivePoolCache pool address present but market parse returned no usable pool (base_mint={}, pool={}); refusing unbounded RPC discovery",
+                            base_mint,
+                            pool_address
+                        ));
                     }
                     Err(e) => {
                         warn!(
                             base_mint = %base_mint,
                             pool = %pool_address,
                             error = %e,
-                            "pump_amm: direct getAccount parse failed, falling through to getProgramAccounts"
+                            "pump_amm: cached pool address parse failed; refusing getProgramAccounts (no unbounded scan)"
                         );
+                        return Err(e.context(format!(
+                            "pump_amm: cached pool address parse error (base_mint={}, pool={}); refusing unbounded RPC discovery",
+                            base_mint, pool_address
+                        )));
                     }
                 }
             }
@@ -2857,6 +2866,32 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
+    }
+
+    /// I-24d: A bad `pool_address_hint` must not fall through to `getProgramAccounts` (~20s+).
+    #[tokio::test]
+    async fn test_pool_address_hint_parse_fail_errors_without_global_scan() {
+        let base_mint = Pubkey::new_unique();
+        // Missing account → try_parse returns Ok(None) after one cheap RPC attempt.
+        let bad_hint = Pubkey::new_unique();
+        let cache = make_empty_cache();
+        let rpc = Arc::new(SolanaRpc::new("http://127.0.0.1:0"));
+        let dex = PumpFunAmmDex::new_with_cache(rpc, cache, true);
+
+        let fut = dex.pool_accounts_v1_for_base_mint_with_hint(base_mint, Some(bad_hint));
+        let completed = tokio::time::timeout(std::time::Duration::from_secs(3), fut)
+            .await
+            .expect("must not block on getProgramAccounts global scan");
+
+        assert!(
+            completed.is_err(),
+            "expected Err for failed hint parse; got {completed:?}"
+        );
+        let msg = format!("{:#}", completed.unwrap_err());
+        assert!(
+            msg.contains("I-24d") || msg.contains("pool_address hint"),
+            "unexpected error message: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **GwQj / creator parse**: Fast-path market parse failed because the PDA-based creator vault branch required the creator **base-mint ATA to already exist on-chain**; when it did not, the parser returned `Ok(None)` and fell through to `discover_pool_static` → `getProgramAccounts` (~23s). Aligned with **FIX-32**: use the **derived** creator vault ATA even if not yet created (PumpSwap may create via CreateIdempotent), with a clear warn log.
- **E7Ua / no terminal outcome**: After a failed fast path, the code called `discover_pool_static`, which triggered an unbounded global scan and exceeded the execution-engine **15s** wait — no `ControlResponse` in time. **Fix**: If `pool_address_hint` is present and the single-`getAccount` parse fails (`Ok(None)` or `Err`), return **`Err` immediately** — no silent fallback to global scan. Same for **FIX-31** path in `discover_pool_static` when the cache has a pool address but parse fails.
- **market-data**: Extra structured logs per `request_id` (start, outcome, `rpc_global_scan=no` on success path).
- **Test**: `test_pool_address_hint_parse_fail_errors_without_global_scan` — bad hint must return within 3s with `Err` containing I-24d message.

## STOP-CHECK (AGENTS / ironcrab-core)
1. **I-7 Hot-path RPC**: No change to hot path; changes are cold-path discovery in market-data / `PumpFunAmmDex` with existing RPC patterns.
2. **Pattern**: `allow_rpc_on_miss` unchanged; hint path now fails fast instead of unconditional slow RPC.
3. **Scope**: Only allowed files touched.
4. **I-9 Simulation**: N/A.
5. **Level-5**: No eval tests read.

## Commands
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f78750bf-a3bd-4c87-a9d1-dc7785dae1ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f78750bf-a3bd-4c87-a9d1-dc7785dae1ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

