### PR TITLE
fix(pump_amm): PumpSwap market parse — fee_config, GVA singleton, creator_vault offset 211

### DIFF
--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -49,6 +49,10 @@ const PUMPFUN_AMM_MARKET_QUOTE_MINT_OFFSET: u64 = 75;
 // global_config appears to be a Pubkey at offset 11, followed by base/quote mints.
 const PUMPFUN_AMM_MARKET_GLOBAL_CONFIG_OFFSET: usize = 11;
 
+// PumpSwap AMM market account (301 bytes on mainnet): seed pubkey for `creator_vault` PDA lives here.
+// Distinct from bonding-curve `creator-vault` (hyphen) — AMM uses underscore `creator_vault` + this seed.
+const PUMPFUN_AMM_MARKET_CREATOR_SEED_OFFSET: usize = 211;
+
 // Observed on-chain: buy_exact_quote_in fee fields sum to 125 bps (lp 2 + protocol 93 + creator 30).
 // We use that as a conservative default for quoting.
 const DEFAULT_TOTAL_FEE_BPS: u32 = 125;
@@ -829,20 +833,98 @@ impl PumpFunAmmDex {
             }
         };
 
-        // Creator vault ATA: prefer an embedded base token account; otherwise derive ATA.
+        // Creator vault: prefer an embedded second base token account; else canonical layout at
+        // offset 211 (`creator_vault` PDA + WSOL ATA); else authority heuristics / legacy PDAs.
         let (coin_creator_vault_authority, coin_creator_vault_ata) = if let Some(t) =
             base_token_accounts
                 .iter()
                 .find(|t| t.address != pool_base_vault)
         {
             (t.token_owner, t.address)
+        } else if data.len() >= PUMPFUN_AMM_MARKET_CREATOR_SEED_OFFSET + 32 {
+            let creator_seed = Pubkey::new_from_array(
+                data[PUMPFUN_AMM_MARKET_CREATOR_SEED_OFFSET
+                    ..PUMPFUN_AMM_MARKET_CREATOR_SEED_OFFSET + 32]
+                    .try_into()
+                    .map_err(|_| anyhow!("market creator_seed slice"))?,
+            );
+            if creator_seed != Pubkey::default() {
+                let (auth, _) = Pubkey::find_program_address(
+                    &[b"creator_vault", creator_seed.as_ref()],
+                    &pump_amm_program,
+                );
+                // On-chain swaps use the creator fee vault as a WSOL (quote) token account for this authority.
+                let ata = Self::derive_ata_with_program(auth, quote_mint, token_program);
+                info!(
+                    pool = %pool_market,
+                    creator_seed = %creator_seed,
+                    coin_creator_vault_authority = %auth,
+                    coin_creator_vault_ata = %ata,
+                    "pump_amm: creator vault from market offset 211 + creator_vault PDA (quote-mint ATA)"
+                );
+                (auth, ata)
+            } else if let Some((auth, ta)) =
+                find_authority_with_existing_token_account(authority_candidates.clone(), base_mint)
+                    .await?
+            {
+                (auth, ta)
+            } else if let Some((auth, ta)) =
+                find_authority_with_existing_token_account(authority_candidates.clone(), quote_mint)
+                    .await?
+            {
+                (auth, ta)
+            } else {
+                match self
+                    .derive_existing_pda(
+                        pump_amm_program,
+                        &[
+                            vec![
+                                b"creator_vault_authority".to_vec(),
+                                pool_market.to_bytes().to_vec(),
+                            ],
+                            vec![b"creator_vault".to_vec(), pool_market.to_bytes().to_vec()],
+                            vec![b"creator".to_vec(), pool_market.to_bytes().to_vec()],
+                            vec![b"vault_authority".to_vec(), pool_market.to_bytes().to_vec()],
+                            vec![b"token_creator".to_vec(), pool_market.to_bytes().to_vec()],
+                        ],
+                    )
+                    .await?
+                {
+                    Some(derived_authority) => {
+                        let derived_ata = Self::derive_ata(derived_authority, base_mint);
+                        warn!(
+                            pool = %pool_market,
+                            base_mint = %base_mint,
+                            derived_ata = %derived_ata,
+                            authority_candidates_count = authority_candidates.len(),
+                            "pump_amm: creator vault ATA not on-chain; using derived address (FIX-32 parity)"
+                        );
+                        (derived_authority, derived_ata)
+                    }
+                    None => {
+                        warn!(
+                            pool = %pool_market,
+                            base_mint = %base_mint,
+                            "pump_amm market parse FAIL: no creator vault token account \
+                             (no embedded ATA; offset 211 path unavailable; no ATA found; no valid PDA; \
+                             authority_candidates_count={})",
+                            authority_candidates.len()
+                        );
+                        return Ok(None);
+                    }
+                }
+            }
         } else if let Some((auth, ta)) =
             find_authority_with_existing_token_account(authority_candidates.clone(), base_mint)
                 .await?
         {
             (auth, ta)
+        } else if let Some((auth, ta)) =
+            find_authority_with_existing_token_account(authority_candidates.clone(), quote_mint)
+                .await?
+        {
+            (auth, ta)
         } else {
-            // Try deriving creator vault authority as PDA from AMM program with common seed patterns
             match self
                 .derive_existing_pda(
                     pump_amm_program,
@@ -860,9 +942,6 @@ impl PumpFunAmmDex {
                 .await?
             {
                 Some(derived_authority) => {
-                    // Derive ATA for creator vault. FIX-32 parity: do not require the ATA to exist
-                    // yet — PumpSwap may create it via CreateIdempotent on swap (same rationale as
-                    // protocol_fee_recipient_ta for quote mint).
                     let derived_ata = Self::derive_ata(derived_authority, base_mint);
                     warn!(
                         pool = %pool_market,
@@ -932,10 +1011,11 @@ impl PumpFunAmmDex {
             sorted.sort_by_key(|m| m.data_len);
             sorted.last().map(|m| m.address).unwrap_or_default()
         } else {
-            // Fallback: try deriving from AMM program
+            // Fallback: try deriving from AMM program (singleton first — matches on-chain PumpSwap).
             self.derive_existing_pda(
                 pump_amm_program,
                 &[
+                    vec![b"global_volume_accumulator".to_vec()],
                     vec![
                         b"global_volume_accumulator".to_vec(),
                         global_config.to_bytes().to_vec(),
@@ -956,6 +1036,13 @@ impl PumpFunAmmDex {
             )
             .await?
             .unwrap_or_default()
+        };
+
+        // Same global fee_config pubkey for all PumpSwap pools (see build_swap_ix_from_pool_accounts).
+        let fee_config = if fee_config == Pubkey::default() {
+            Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG)?
+        } else {
+            fee_config
         };
 
         if fee_config == Pubkey::default() || global_volume_accumulator == Pubkey::default() {

--- a/tests/pump_amm_market_parse_offsets.rs
+++ b/tests/pump_amm_market_parse_offsets.rs
@@ -1,0 +1,73 @@
+//! Regression: PumpSwap market account layout + PDAs used by try_parse_pool_static_from_market_account_inner.
+//! Mainnet fixtures (no RPC in tests).
+
+use base64::Engine;
+use solana_sdk::pubkey::Pubkey;
+use std::str::FromStr;
+
+const PUMPFUN_AMM_PROGRAM: &str = "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA";
+const PUMPFUN_AMM_FEE_CONFIG: &str = "5PHirr8joyTMp9JMm6nW7hNDVyEYdkzDqazxPD7RaTjx";
+const PUMPFUN_AMM_MARKET_CREATOR_SEED_OFFSET: usize = 211;
+
+#[test]
+fn pump_amm_singleton_global_volume_accumulator_pda_matches_mainnet() {
+    let amm = Pubkey::from_str(PUMPFUN_AMM_PROGRAM).unwrap();
+    let (gva, _bump) = Pubkey::find_program_address(&[b"global_volume_accumulator"], &amm);
+    let expected = Pubkey::from_str("C2aFPdENg4A2HQsmrd5rTw5TaYBX5Ku887cWjbFKtZpw").unwrap();
+    assert_eq!(
+        gva, expected,
+        "singleton global_volume_accumulator PDA must match live PumpSwap program"
+    );
+}
+
+#[test]
+fn pump_amm_fee_config_constant_matches_build_swap_convention() {
+    let pk = Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG).unwrap();
+    assert!(!pk.eq(&Pubkey::default()));
+}
+
+#[test]
+fn pump_amm_creator_vault_pda_from_offset_211_gw_qj_pool() {
+    // Pool 5rNMGrJ3V2vUY3GAuxiVKZmKCn6c5N6n7Ld5EWvgceVX — market account 301 bytes.
+    let amm = Pubkey::from_str(PUMPFUN_AMM_PROGRAM).unwrap();
+    let b64 = "8ZptBBGxbbz/AACai0BBbzRLepxzNQv4fUEdt0Z2lNdFokjimACHtmiIUezPgLlU+9lM8/Ofzs8lfBxr9pDv6iI3kBOq+3hRFgQABpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAGWj0C+EyxnXaJ/J6wS8ZkBFTzAFbSlvzoqwlqpLOgAOhS8Icfsr7Rys+wmeOWG/XW+SS7OvdfUke7AU6C7b8m//53rxyt/TB98HUM6fdo3aHU7XRG4VOYrejj5U7Rg/U3SGWxZ0AMAAAjzdrbioivkPftheEW+zQSxRJ/PoEPyIxTj79Xhx75xAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .unwrap();
+    assert!(raw.len() >= PUMPFUN_AMM_MARKET_CREATOR_SEED_OFFSET + 32);
+    let creator_seed = Pubkey::new_from_array(
+        raw[PUMPFUN_AMM_MARKET_CREATOR_SEED_OFFSET..PUMPFUN_AMM_MARKET_CREATOR_SEED_OFFSET + 32]
+            .try_into()
+            .unwrap(),
+    );
+    let (authority, _) =
+        Pubkey::find_program_address(&[b"creator_vault", creator_seed.as_ref()], &amm);
+    let expected = Pubkey::from_str("6tkGUcYBJJ2c1pdtMQayUpEFEpyP3QqY8Lf6pvvpF5Fq").unwrap();
+    assert_eq!(
+        authority, expected,
+        "creator_vault PDA from offset-211 seed must match swap ix account[18] on mainnet"
+    );
+}
+
+#[test]
+fn pump_amm_creator_vault_pda_from_offset_211_e7_ua_pool() {
+    // Pool B8bvg3KzXzGAq51QjirhPTw5ChhiZWn2kNwvQd3YZFN8
+    let amm = Pubkey::from_str(PUMPFUN_AMM_PROGRAM).unwrap();
+    let b64 = "8ZptBBGxbbz+AADFaNoRa55klcAW7+DWqWYaL4wXt/vmI+Z60yGbPtS2fcLQmOioUSn0Ypyh/1QR45c8Rumr0I+K69gWfHjXic+/BpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAEg8VWn3M0V6+sFAV7d7g8VL6SuPdq4xGsV69FYbfNd7OzOMZuzuU1VcAv9CBCss2frCZSgMN3cGvZBJkT47xn0LP95BZ/EPpystn/DXn8e8qAukAKYLaaesYiLvHOoT+WUFWxZ0AMAAFo9zhD4w2iy35YoI+u6fUkjqSSXsJGKfeA6Wz13nqmUAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .unwrap();
+    assert!(raw.len() >= PUMPFUN_AMM_MARKET_CREATOR_SEED_OFFSET + 32);
+    let creator_seed = Pubkey::new_from_array(
+        raw[PUMPFUN_AMM_MARKET_CREATOR_SEED_OFFSET..PUMPFUN_AMM_MARKET_CREATOR_SEED_OFFSET + 32]
+            .try_into()
+            .unwrap(),
+    );
+    let (authority, _) =
+        Pubkey::find_program_address(&[b"creator_vault", creator_seed.as_ref()], &amm);
+    let expected = Pubkey::from_str("AyJm7rZGQLKEAEQ8vHHhip9ycAgGG6arHxXGNwJKvDeu").unwrap();
+    assert_eq!(
+        authority, expected,
+        "creator_vault PDA from offset-211 seed must match swap ix account[18] on mainnet"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes `try_parse_pool_static_from_market_account_inner` so known pool hints (`getAccount` fast path) resolve to full `pool_accounts` for real PumpSwap pools.

### Root causes addressed
1. **E7Ua / B8bvg** — `fee_config` and `global_volume_accumulator` stayed `default` because embedded scans did not surface fee-program / AMM-owned accounts, and GVA derivation did not try the **singleton** PDA `[b"global_volume_accumulator"]` first. `fee_config` now falls back to the global constant `PUMPFUN_AMM_FEE_CONFIG` (same as `build_swap_ix_from_pool_accounts`).

2. **GwQj / 5rNM** — Creator vault resolution failed: wrong seed family (`creator-vault` vs `creator_vault`), wrong mint for ATA (**base** vs **quote/WSOL**), and missing layout field: **creator seed at offset 211** in the 301-byte market account for `[b"creator_vault", seed]` PDA.

### Architecture
- Discovery remains in **market-data** only; execution-engine unchanged.
- No `getProgramAccounts` global scan for hinted pools; only existing `get_multiple_accounts` on candidates + `derive_existing_pda` (cold path).

### Tests
- `tests/pump_amm_market_parse_offsets.rs` — mainnet fixtures for singleton GVA PDA, fee constant, and both pools’ `creator_vault` PDA from offset 211.

### STOP-CHECK (AGENTS / ironcrab-core)
- I-7: No new RPC on hot path; changes are in `PumpFunAmmDex` market parse used from market-data cold discovery.
- I-5/I-6: Cold-path RPC preserved; no removal of safety RPC.
- Level-5: No `Iron_crab-eval/tests` read.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-116040e8-5fca-4849-b838-d3a047ee527b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-116040e8-5fca-4849-b838-d3a047ee527b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

