### PR TITLE
fix(liquidation): PumpSwap pool_accounts length guard after discovery

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -2392,25 +2392,33 @@ impl ExecutionContext {
                                                     )
                                                     .await
                                                     {
-                                                        if let Some(accounts) = cache
-                                                            .get_pump_amm_pool_accounts_by_base_mint(&mint)
-                                                        {
-                                                            let acct_strings: Vec<String> = accounts
-                                                                .into_iter()
-                                                                .map(|p| p.to_string())
-                                                                .collect();
-                                                            quote_attempts.push(format!(
-                                                                "pump_amm=ok amount_out={} pool={} accounts_len={} (after discovery)",
-                                                                q.amount_out,
-                                                                pool_id,
-                                                                acct_strings.len()
-                                                            ));
-                                                            record_candidate(
-                                                                "pump_amm",
-                                                                q.amount_out,
-                                                                pool_id,
-                                                                acct_strings,
-                                                            );
+                                                        let accounts = cache
+                                                            .get_pump_amm_pool_accounts_by_base_mint(&mint);
+                                                        if let Some(accounts) = accounts {
+                                                            if accounts.len() >= 14 {
+                                                                let acct_strings: Vec<String> =
+                                                                    accounts
+                                                                        .into_iter()
+                                                                        .map(|p| p.to_string())
+                                                                        .collect();
+                                                                quote_attempts.push(format!(
+                                                                    "pump_amm=ok amount_out={} pool={} accounts_len={} (after discovery)",
+                                                                    q.amount_out,
+                                                                    pool_id,
+                                                                    acct_strings.len()
+                                                                ));
+                                                                record_candidate(
+                                                                    "pump_amm",
+                                                                    q.amount_out,
+                                                                    pool_id,
+                                                                    acct_strings,
+                                                                );
+                                                            } else {
+                                                                quote_attempts.push(format!(
+                                                                    "pump_amm=skip no_pool_accounts amount_out={} pool={}",
+                                                                    q.amount_out, pool_id
+                                                                ));
+                                                            }
                                                         } else {
                                                             warn!(mint = %mint, "pump_amm pool_accounts still missing after discovery");
                                                             quote_attempts.push(format!(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Bugbot (PR #16): Im Liquidation-Pfad nach `request_discovery_and_wait` → `DiscoveryRequestOutcome::Ok` wurde `get_pump_amm_pool_accounts_by_base_mint` ohne `accounts.len() >= 14` an `record_candidate` übergeben. `wait_for_pool_accounts_in_cache` prüft nur `Some`, nicht die Mindestlänge.

## Fix
Gleiches Muster wie im Retry-Zweig (`Ok(None)` → Discovery → `quote_exact_in` retry): `if let Some(accounts)` und inner `if accounts.len() >= 14` vor `record_candidate`; bei zu kurzer Liste derselbe Skip-String `pump_amm=skip no_pool_accounts` wie bei unvollständigen Accounts im Retry.

## STOP-CHECK
- I-7: keine RPC-Änderung
- Pattern: konsistent mit Zeilen ~2358 und ~2499–2522 in `execution_engine.rs`
- Scope: nur `src/bin/execution_engine.rs`
- Kein Eval-Repo

## Tests
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`, `cargo test --features test_helpers`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fa608a3-15b0-4449-8eb7-5e62f243e133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fa608a3-15b0-4449-8eb7-5e62f243e133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

