### PR TITLE
fix(I-24d): PumpSwap Reserve-Hydration nach EnsurePumpAmmPoolAccounts

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1577,6 +1577,64 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+/// Cold Path: merge existing PumpAmm reserves with authoritative vault RPC reads for I-24d Ensure.
+///
+/// If the cache already has both reserves present and strictly positive, keep them (Geyser may be
+/// fresher). Otherwise load `[4]`/`[5]` vault balances via RPC so PoolCacheUpdate is not published
+/// as degenerate 0/0 after successful discovery when on-chain balances are available.
+async fn resolve_pump_amm_reserves_for_ensure_discovery(
+    request_id: &str,
+    base_mint_str: &str,
+    pool_address_str: &str,
+    existing: Option<&CachedPoolState>,
+    pool_accounts: &[Pubkey],
+    dex: &ironcrab::solana::dex::pumpfun_amm::PumpFunAmmDex,
+) -> (u64, u64) {
+    if let Some(CachedPoolState::PumpAmm(s)) = existing {
+        if let (Some(br), Some(qr)) = (s.base_reserve, s.quote_reserve) {
+            if br > 0 && qr > 0 {
+                info!(
+                    request_id = %request_id,
+                    base_mint = %base_mint_str,
+                    pool = %pool_address_str,
+                    base_reserve = br,
+                    quote_reserve = qr,
+                    "EnsurePumpAmmPoolAccounts: using existing non-degenerate reserves (skip vault RPC)"
+                );
+                return (br, qr);
+            }
+        }
+    }
+
+    match dex.fetch_pump_amm_vault_reserves(pool_accounts).await {
+        Ok((b, q)) => {
+            info!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                pool = %pool_address_str,
+                base_reserve = b,
+                quote_reserve = q,
+                "EnsurePumpAmmPoolAccounts: hydrated vault reserves via RPC (Cold Path)"
+            );
+            (b, q)
+        }
+        Err(e) => {
+            warn!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                pool = %pool_address_str,
+                error = %e,
+                "EnsurePumpAmmPoolAccounts: vault reserve RPC failed; falling back to existing or zero"
+            );
+            if let Some(CachedPoolState::PumpAmm(s)) = existing {
+                (s.base_reserve.unwrap_or(0), s.quote_reserve.unwrap_or(0))
+            } else {
+                (0, 0)
+            }
+        }
+    }
+}
+
 /// I-24d: Handle EnsurePumpAmmPoolAccounts Discovery Request.
 ///
 /// Performs RPC-based discovery (Cold Path), updates MASTER cache, publishes
@@ -1636,33 +1694,33 @@ async fn handle_ensure_pump_amm_pool_accounts(
             let quote_mint = accounts[3];
             let quote_mint_str = quote_mint.to_string();
 
-            // Preserve existing reserves/creator: only set pool_accounts if pool exists,
-            // else upsert minimal state. Never degrade existing good data with 0/0.
             let existing = ctx.live_pool_cache.get(&pool_address);
-            if let Some(CachedPoolState::PumpAmm(ref _existing_pump)) = existing {
-                ctx.live_pool_cache
-                    .set_pump_amm_pool_accounts(&pool_address, accounts.clone());
-            } else {
-                let state = CachedPoolState::PumpAmm(PumpAmmState {
-                    base_mint,
-                    quote_mint,
-                    pool_base_token_account: accounts[4],
-                    pool_quote_token_account: accounts[5],
-                    base_reserve: None,
-                    quote_reserve: None,
-                    pool_accounts: accounts.clone(),
-                    creator: None,
-                });
-                ctx.live_pool_cache.upsert(pool_address, state, 0);
-            }
+            let creator_opt = existing.as_ref().and_then(|st| match st {
+                CachedPoolState::PumpAmm(s) => s.creator,
+                _ => None,
+            });
 
-            // Use existing reserves for JetStream publish when available (don't degrade with 0/0).
-            let (base_reserve, quote_reserve) =
-                if let Some(CachedPoolState::PumpAmm(ref s)) = existing {
-                    (s.base_reserve.unwrap_or(0), s.quote_reserve.unwrap_or(0))
-                } else {
-                    (0u64, 0u64)
-                };
+            let (base_reserve, quote_reserve) = resolve_pump_amm_reserves_for_ensure_discovery(
+                request_id,
+                &base_mint_str,
+                &pool_address_str,
+                existing.as_ref(),
+                &accounts,
+                dex,
+            )
+            .await;
+
+            let state = CachedPoolState::PumpAmm(PumpAmmState {
+                base_mint,
+                quote_mint,
+                pool_base_token_account: accounts[4],
+                pool_quote_token_account: accounts[5],
+                base_reserve: Some(base_reserve),
+                quote_reserve: Some(quote_reserve),
+                pool_accounts: accounts.clone(),
+                creator: creator_opt,
+            });
+            ctx.live_pool_cache.upsert(pool_address, state, 0);
 
             // Publish JetStream PoolCacheUpdate (authoritative SSOT).
             // Reply Ok ONLY when JetStream write succeeds (I-24a).
@@ -1683,10 +1741,8 @@ async fn handle_ensure_pump_amm_pool_accounts(
                 let mut meta = std::collections::HashMap::new();
                 let accounts_str: Vec<String> = accounts.iter().map(|p| p.to_string()).collect();
                 meta.insert("pool_accounts".to_string(), accounts_str.join(","));
-                if let Some(CachedPoolState::PumpAmm(ref s)) = existing {
-                    if let Some(creator) = s.creator {
-                        meta.insert("creator".to_string(), creator.to_string());
-                    }
+                if let Some(creator) = creator_opt {
+                    meta.insert("creator".to_string(), creator.to_string());
                 }
                 pool_update.metadata = Some(meta);
                 let subject = pool_subject(&pool_address_str);

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1579,9 +1579,10 @@ async fn main() -> Result<()> {
 
 /// Cold Path: merge existing PumpAmm reserves with authoritative vault RPC reads for I-24d Ensure.
 ///
-/// If the cache already has both reserves present and strictly positive, keep them (Geyser may be
-/// fresher). Otherwise load `[4]`/`[5]` vault balances via RPC so PoolCacheUpdate is not published
-/// as degenerate 0/0 after successful discovery when on-chain balances are available.
+/// - If the cache already has **both** reserves present and strictly positive, returns `Ok` with
+///   those values (skip vault RPC).
+/// - Otherwise vault RPC **must** succeed. On RPC failure there is **no** silent fallback to
+///   `0/0` — that would let the handler publish a false “success” SSOT (I-24d / I-12).
 async fn resolve_pump_amm_reserves_for_ensure_discovery(
     request_id: &str,
     base_mint_str: &str,
@@ -1589,7 +1590,7 @@ async fn resolve_pump_amm_reserves_for_ensure_discovery(
     existing: Option<&CachedPoolState>,
     pool_accounts: &[Pubkey],
     dex: &ironcrab::solana::dex::pumpfun_amm::PumpFunAmmDex,
-) -> (u64, u64) {
+) -> Result<(u64, u64), String> {
     if let Some(CachedPoolState::PumpAmm(s)) = existing {
         if let (Some(br), Some(qr)) = (s.base_reserve, s.quote_reserve) {
             if br > 0 && qr > 0 {
@@ -1601,7 +1602,7 @@ async fn resolve_pump_amm_reserves_for_ensure_discovery(
                     quote_reserve = qr,
                     "EnsurePumpAmmPoolAccounts: using existing non-degenerate reserves (skip vault RPC)"
                 );
-                return (br, qr);
+                return Ok((br, qr));
             }
         }
     }
@@ -1616,7 +1617,7 @@ async fn resolve_pump_amm_reserves_for_ensure_discovery(
                 quote_reserve = q,
                 "EnsurePumpAmmPoolAccounts: hydrated vault reserves via RPC (Cold Path)"
             );
-            (b, q)
+            Ok((b, q))
         }
         Err(e) => {
             warn!(
@@ -1624,13 +1625,9 @@ async fn resolve_pump_amm_reserves_for_ensure_discovery(
                 base_mint = %base_mint_str,
                 pool = %pool_address_str,
                 error = %e,
-                "EnsurePumpAmmPoolAccounts: vault reserve RPC failed; falling back to existing or zero"
+                "EnsurePumpAmmPoolAccounts: vault reserve RPC failed (no non-degenerate cached reserves)"
             );
-            if let Some(CachedPoolState::PumpAmm(s)) = existing {
-                (s.base_reserve.unwrap_or(0), s.quote_reserve.unwrap_or(0))
-            } else {
-                (0, 0)
-            }
+            Err(format!("vault reserve RPC failed: {e}"))
         }
     }
 }
@@ -1700,15 +1697,40 @@ async fn handle_ensure_pump_amm_pool_accounts(
                 _ => None,
             });
 
-            let (base_reserve, quote_reserve) = resolve_pump_amm_reserves_for_ensure_discovery(
-                request_id,
-                &base_mint_str,
-                &pool_address_str,
-                existing.as_ref(),
-                &accounts,
-                dex,
-            )
-            .await;
+            let (base_reserve, quote_reserve) =
+                match resolve_pump_amm_reserves_for_ensure_discovery(
+                    request_id,
+                    &base_mint_str,
+                    &pool_address_str,
+                    existing.as_ref(),
+                    &accounts,
+                    dex,
+                )
+                .await
+                {
+                    Ok(pair) => pair,
+                    Err(msg) => {
+                        warn!(
+                            request_id = %request_id,
+                            base_mint = %base_mint_str,
+                            pool = %pool_address_str,
+                            error = %msg,
+                            "I-24d Discovery: terminal outcome error (reserve hydration required)"
+                        );
+                        if let Some(ref nats) = ctx.nats {
+                            publish_control_response(
+                                nats,
+                                &ctx.run_id,
+                                request_id,
+                                ControlResponseStatus::Error,
+                                Some(pool_address_str),
+                                Some(msg),
+                            )
+                            .await;
+                        }
+                        return;
+                    }
+                };
 
             let state = CachedPoolState::PumpAmm(PumpAmmState {
                 base_mint,

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -2035,6 +2035,31 @@ impl PumpFunAmmDex {
             .ok_or_else(|| anyhow!("invalid token account data for {ta}"))
     }
 
+    /// Cold Path only: authoritative SPL token balances for PumpSwap pool vaults.
+    ///
+    /// `pool_accounts` must follow the canonical layout where `[4]` is `pool_base_vault` and
+    /// `[5]` is `pool_quote_vault` (same as `PumpAmmState::pool_base_token_account` / quote).
+    /// Used after successful I-24d discovery so JetStream/SLAVE caches receive non-degenerate
+    /// reserves without local healing in execution-engine.
+    pub async fn fetch_pump_amm_vault_reserves(
+        &self,
+        pool_accounts: &[Pubkey],
+    ) -> Result<(u64, u64)> {
+        if pool_accounts.len() < 6 {
+            return Err(anyhow!(
+                "pool_accounts len {} < 6 (cannot read vault pubkeys)",
+                pool_accounts.len()
+            ));
+        }
+        let base_vault = pool_accounts[4];
+        let quote_vault = pool_accounts[5];
+        let (base_res, quote_res) = tokio::try_join!(
+            self.get_vault_amount(base_vault),
+            self.get_vault_amount(quote_vault),
+        )?;
+        Ok((base_res, quote_res))
+    }
+
     fn quote_cp(
         &self,
         amount_in: u64,
@@ -2886,6 +2911,21 @@ mod tests {
         assert!(quote.amount_out > 0);
         assert!(quote.route.contains(&pool_market.to_string()));
         assert_eq!(quote.fee_bps, 125);
+    }
+
+    #[tokio::test]
+    async fn fetch_pump_amm_vault_reserves_rejects_short_accounts() {
+        let rpc = Arc::new(SolanaRpc::new("http://127.0.0.1:0"));
+        let dex = PumpFunAmmDex::new_with_cache(rpc, make_empty_cache(), false);
+        let short = vec![Pubkey::new_unique(); 5];
+        let err = dex
+            .fetch_pump_amm_vault_reserves(&short)
+            .await
+            .expect_err("expected err");
+        assert!(
+            err.to_string().contains("pool_accounts len"),
+            "unexpected err: {err}"
+        );
     }
 
     #[tokio::test]

--- a/tests/pump_amm_geyser_first_test.rs
+++ b/tests/pump_amm_geyser_first_test.rs
@@ -173,3 +173,22 @@ fn test_build_swap_ix_with_cached_accounts() {
     );
     assert!(!ixs[0].data.is_empty());
 }
+
+/// I-24d / Bug #27: After successful EnsurePumpAmmPoolAccounts, market-data must hydrate SPL vault
+/// balances for `pool_accounts[4]` / `[5]` so JetStream PoolCacheUpdate is not degenerate 0/0.
+/// This test guards the public Cold-Path helper used for that hydration.
+#[tokio::test]
+async fn pump_amm_fetch_vault_reserves_requires_canonical_layout_len() {
+    let rpc = Arc::new(SolanaRpc::new("http://127.0.0.1:0"));
+    let cache = Arc::new(LivePoolCache::new());
+    let dex = PumpFunAmmDex::new_with_cache(rpc, cache, false);
+    let short = vec![Pubkey::new_unique(); 5];
+    let err = dex
+        .fetch_pump_amm_vault_reserves(&short)
+        .await
+        .expect_err("short pool_accounts must error");
+    assert!(
+        err.to_string().contains("pool_accounts len"),
+        "unexpected err: {err}"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Nach erfolgreicher I-24d Discovery wurden `pool_accounts` korrekt aufgebaut, aber `PoolCacheUpdate` mit **0/0 Reserves** publiziert, weil neue Cache-Einträge `base_reserve`/`quote_reserve` als `None` angelegt und nur aus `existing` übernommen wurden – bei **Cold-Start ohne Geyser** war `existing` leer.

## Lösung (Stand 2)
- **RPC-Hydration**: `fetch_pump_amm_vault_reserves` für `[4]`/`[5]`.
- **Merge**: Cache mit **beiden** Reserves **> 0** → behalten, kein RPC.
- **Follow-up (Blocker)**: Wenn **weder** gültige Cache-Reserves **noch** erfolgreiche Vault-RPC-Hydration: **`Result::Err`** — kein `upsert` mit 0/0, kein JetStream-„Ok“, sondern `ControlResponse::Error` mit Fehlertext (kein stilles Erfolgs-SSOT).

## STOP-CHECK
- I-7: nur market-data Cold Path.
- Keine execution-engine-Änderungen.

## Tests
- Unit + Integration wie zuvor (`fetch_pump_amm_vault_reserves` Contract).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d34322f1-fcae-44f9-b64d-21f0687bbe2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d34322f1-fcae-44f9-b64d-21f0687bbe2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

