### PR TITLE
fix(i-24d): PumpAmm cache readiness after discovery (reserves + pool_accounts)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -1317,10 +1317,10 @@ const MAX_BLOCKHASH_AGE_SECS: u64 = 30;
 /// I-24d: Bounded wait timeout for Discovery Request/Reply (market-data).
 const DISCOVERY_REQUEST_TIMEOUT_SECS: u64 = 15;
 
-/// I-24d: Bounded wait for authoritative SLAVE cache state (pool_accounts from JetStream).
+/// I-24d: Bounded wait for authoritative SLAVE PumpAmm state (JetStream `PoolCacheUpdate` merge).
 const DISCOVERY_CACHE_WAIT_TIMEOUT_MS: u64 = 10_000;
 
-/// I-24d: Poll interval when waiting for pool_accounts in SLAVE cache.
+/// I-24d: Poll interval when waiting for usable PumpAmm cache state in SLAVE cache.
 const DISCOVERY_CACHE_POLL_INTERVAL_MS: u64 = 100;
 
 /// Outcome of a Discovery Request (I-24d). Used for bounded wait + single retry.
@@ -1332,9 +1332,12 @@ enum DiscoveryRequestOutcome {
     Timeout,
 }
 
-/// I-24d: Wait bounded for authoritative pool_accounts in SLAVE cache (from JetStream).
-/// Polls until pool_accounts present or timeout. Returns true if found.
-async fn wait_for_pool_accounts_in_cache(
+/// I-24d: Bounded wait until PumpSwap AMM is quote-ready in SLAVE cache (JetStream path).
+///
+/// `ControlResponse=Ok` can correlate before `apply_pool_cache_update` exposes non-degenerate
+/// `base_reserve`/`quote_reserve` (Bug #27): `pool_accounts` alone is a weak readiness signal.
+/// Polls until `LivePoolCache::pump_amm_quote_ready_by_base_mint` is true or timeout.
+async fn wait_for_usable_pump_amm_cache_state(
     cache: &LivePoolCache,
     base_mint: &Pubkey,
     timeout_ms: u64,
@@ -1342,10 +1345,7 @@ async fn wait_for_pool_accounts_in_cache(
 ) -> bool {
     let deadline = std::time::Instant::now() + Duration::from_millis(timeout_ms);
     while std::time::Instant::now() < deadline {
-        if cache
-            .get_pump_amm_pool_accounts_by_base_mint(base_mint)
-            .is_some()
-        {
+        if cache.pump_amm_quote_ready_by_base_mint(base_mint) {
             return true;
         }
         tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
@@ -1733,7 +1733,7 @@ impl ExecutionContext {
                                         return None;
                                     }
                                 };
-                                if !wait_for_pool_accounts_in_cache(
+                                if !wait_for_usable_pump_amm_cache_state(
                                     cache,
                                     &mint,
                                     DISCOVERY_CACHE_WAIT_TIMEOUT_MS,
@@ -1741,7 +1741,7 @@ impl ExecutionContext {
                                 )
                                 .await
                                 {
-                                    warn!(mint = %mint_str, "6005-retry: pool_accounts not in cache after discovery timeout");
+                                    warn!(mint = %mint_str, "6005-retry: usable PumpAmm cache state not visible after discovery timeout (pool_accounts+reserves)");
                                     return None;
                                 }
                                 match cache.get_pump_amm_pool_accounts_by_base_mint(&mint) {
@@ -1809,7 +1809,7 @@ impl ExecutionContext {
                                 return None;
                             }
                         };
-                        if !wait_for_pool_accounts_in_cache(
+                        if !wait_for_usable_pump_amm_cache_state(
                             cache,
                             &mint,
                             DISCOVERY_CACHE_WAIT_TIMEOUT_MS,
@@ -1819,7 +1819,7 @@ impl ExecutionContext {
                         {
                             warn!(
                                 mint = %mint_str,
-                                "6005-retry: pool_accounts not in cache after discovery timeout"
+                                "6005-retry: usable PumpAmm cache state not visible after discovery timeout (pool_accounts+reserves)"
                             );
                             return None;
                         }
@@ -2384,7 +2384,7 @@ impl ExecutionContext {
                                         {
                                             DiscoveryRequestOutcome::Ok => {
                                                 if let Some(cache) = ctx.live_pool_cache.as_ref() {
-                                                    if wait_for_pool_accounts_in_cache(
+                                                    if wait_for_usable_pump_amm_cache_state(
                                                         cache,
                                                         &mint,
                                                         DISCOVERY_CACHE_WAIT_TIMEOUT_MS,
@@ -2427,7 +2427,7 @@ impl ExecutionContext {
                                                             ));
                                                         }
                                                     } else {
-                                                        warn!(mint = %mint, "pump_amm pool_accounts not in cache after discovery timeout");
+                                                        warn!(mint = %mint, "pump_amm: usable cache state not visible after discovery timeout (pool_accounts+nonzero reserves)");
                                                         quote_attempts.push(format!(
                                                             "pump_amm=skip timeout amount_out={} pool={}",
                                                             q.amount_out, pool_id
@@ -2482,7 +2482,7 @@ impl ExecutionContext {
                             {
                                 DiscoveryRequestOutcome::Ok => {
                                     if let Some(cache) = ctx.live_pool_cache.as_ref() {
-                                        if wait_for_pool_accounts_in_cache(
+                                        if wait_for_usable_pump_amm_cache_state(
                                             cache,
                                             &mint,
                                             DISCOVERY_CACHE_WAIT_TIMEOUT_MS,

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -856,6 +856,22 @@ impl LivePoolCache {
         None
     }
 
+    /// I-24d / Bug #27: Readiness for PumpSwap quotes after authoritative `PoolCacheUpdate`.
+    ///
+    /// `pool_accounts` alone is insufficient: SLAVE cache can still show stale
+    /// `base_reserve`/`quote_reserve` (e.g. `None` or 0) until JetStream merge completes.
+    /// Matches what [`crate::execution::quote_calculator::quote_output_amount`] requires
+    /// for `CachedPoolState::PumpAmm`.
+    pub fn pump_amm_quote_ready_by_base_mint(&self, base_mint: &Pubkey) -> bool {
+        match self.get_pump_amm_pool_accounts_by_base_mint(base_mint) {
+            Some(a) if a.len() >= 14 => {}
+            _ => return false,
+        }
+        self.get_pump_amm_reserves_by_base_mint(base_mint)
+            .map(|(b, q, _)| b > 0 && q > 0)
+            .unwrap_or(false)
+    }
+
     // ========================================================================
     // Stats
     // ========================================================================
@@ -1583,6 +1599,65 @@ mod tests {
 
         let result = cache.get_pump_amm_pool_accounts_by_base_mint(&base_mint);
         assert_eq!(result, None);
+    }
+
+    /// I-24d: After `ControlResponse=Ok`, execution-engine must not treat `pool_accounts`
+    /// alone as quote-ready — reserves must be non-degenerate (matches incident B8bvg…).
+    #[test]
+    fn test_pump_amm_quote_ready_requires_accounts_and_nonzero_reserves() {
+        let cache = LivePoolCache::new();
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let pool_accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
+
+        cache.upsert(
+            pool_market,
+            make_pump_amm_state(
+                base_mint,
+                quote_mint,
+                Some(1_000_000_000),
+                Some(50_000_000_000),
+                pool_accounts.clone(),
+            ),
+            100,
+        );
+        assert!(cache.pump_amm_quote_ready_by_base_mint(&base_mint));
+
+        // Stale / pre-hydration: accounts present but reserves missing (quote would fail).
+        cache.upsert(
+            pool_market,
+            make_pump_amm_state(base_mint, quote_mint, None, None, pool_accounts.clone()),
+            101,
+        );
+        assert!(!cache.pump_amm_quote_ready_by_base_mint(&base_mint));
+
+        // Degenerate reserves
+        cache.upsert(
+            pool_market,
+            make_pump_amm_state(
+                base_mint,
+                quote_mint,
+                Some(0),
+                Some(0),
+                pool_accounts.clone(),
+            ),
+            102,
+        );
+        assert!(!cache.pump_amm_quote_ready_by_base_mint(&base_mint));
+
+        cache.upsert(
+            pool_market,
+            make_pump_amm_state(
+                base_mint,
+                quote_mint,
+                Some(1_000_000_000),
+                Some(50_000_000_000),
+                pool_accounts,
+            ),
+            103,
+        );
+        assert!(cache.pump_amm_quote_ready_by_base_mint(&base_mint));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Strengthens I-24d cold-path readiness after `ControlResponse=Ok`: bounded wait until **usable** PumpSwap AMM state is visible in the SLAVE `LivePoolCache` (not only `pool_accounts`).
- Adds `LivePoolCache::pump_amm_quote_ready_by_base_mint` (≥14 `pool_accounts`, both reserves `Some` and `> 0`), matching `quote_output_amount` requirements for PumpAmm.
- Replaces `wait_for_pool_accounts_in_cache` with `wait_for_usable_pump_amm_cache_state` in liquidation + 6005-retry paths.

## Root cause (incident)
`ControlResponse=Ok` could correlate while JetStream `PoolCacheUpdate` had not yet merged non-degenerate reserves; the old wait returned immediately if **stale** `pool_accounts` were already present, so the next `quote_exact_in` still saw `slot=0` / missing reserves.

## Tests
- Unit: `test_pump_amm_quote_ready_requires_accounts_and_nonzero_reserves` in `live_pool_cache.rs`
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo test --features test_helpers`

## STOP-CHECK
- No new RPC in execution-engine; cold-path polling on local cache only.
- No local reserve healing; market-data remains authority.
- No eval-repo changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c54cf3bf-a43b-4bc4-bb69-37c0ed4d2327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c54cf3bf-a43b-4bc4-bb69-37c0ed4d2327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

