### PR TITLE
fix(pump_amm): Token-2022 base program für PumpSwap-SELL (Custom 6023)

### DIFF
--- a/src/execution/tx_builder.rs
+++ b/src/execution/tx_builder.rs
@@ -13,6 +13,7 @@ use solana_sdk::instruction::AccountMeta;
 use solana_sdk::instruction::Instruction;
 use solana_sdk::pubkey::Pubkey;
 use spl_token::solana_program::pubkey::Pubkey as SplProgramPubkey;
+use spl_token_2022;
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::warn;
@@ -825,12 +826,30 @@ pub async fn build_tx_plan(
             });
         }
 
-        // Parse token_program from intent for Token-2022 support (same as pumpfun path)
-        let token_program_override = intent
+        // Parse token_program from intent for Token-2022 support (same as pumpfun path).
+        // TradeResources documents token_program as "output_mint" — on SELL, output is WSOL (SPL Token).
+        // Producers may therefore set SPL Token program here even when the *input* (base) mint uses
+        // Token-2022: wrong base ATA derivation → on-chain Custom(6023) NotEnoughTokensToSell.
+        // Geyser-cached mint owner (LivePoolCache) is authoritative for the base mint's program.
+        let token_2022_pk = Pubkey::new_from_array(spl_token_2022::id().to_bytes());
+
+        let mut token_program_override = intent
             .resources
             .token_program
             .as_ref()
-            .and_then(|s| Pubkey::from_str(s).ok());
+            .and_then(|s| Pubkey::from_str(s.trim()).ok());
+
+        if let (Ok(input_mint_pk), Some(c)) =
+            (Pubkey::from_str(&intent.resources.input_mint), cache)
+        {
+            if let Some(cached_tp) = c.get_mint_program(&input_mint_pk) {
+                if cached_tp == token_2022_pk {
+                    token_program_override = Some(token_2022_pk);
+                } else if token_program_override.is_none() {
+                    token_program_override = Some(cached_tp);
+                }
+            }
+        }
 
         let mut ixs = match PumpFunAmmDex::build_swap_ix_from_pool_accounts(
             &intent.resources.input_mint,

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -3335,6 +3335,58 @@ mod tests {
         assert_eq!(ixs[0].accounts[10].pubkey, expected_pfr_ta);
     }
 
+    /// SELL path: Token-2022 base mint — ix[11] must be Token-2022 program; user base ATA (ix[5]) must match derivation.
+    /// Wrong SPL program → wrong ATA → Custom(6023) NotEnoughTokensToSell on-chain.
+    #[test]
+    fn test_pumpswap_sell_token2022_base_program_and_user_ata() {
+        let wsol = Pubkey::from_str(WSOL_MINT).unwrap();
+        let base_mint = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let token_2022 = Pubkey::new_from_array(spl_token_2022::id().to_bytes());
+
+        let pool_accounts: Vec<Pubkey> = vec![
+            Pubkey::new_unique(),
+            Pubkey::from_str(PUMPFUN_AMM_GLOBAL_CONFIG).unwrap(),
+            base_mint,
+            wsol,
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+        ];
+        assert_eq!(pool_accounts.len(), 14);
+
+        let ixs = PumpFunAmmDex::build_swap_ix_from_pool_accounts(
+            &base_mint.to_string(),
+            WSOL_MINT,
+            1_000_000,
+            1,
+            user,
+            &pool_accounts,
+            Some(token_2022),
+        )
+        .expect("SELL build Token-2022");
+
+        assert_eq!(ixs[0].accounts[11].pubkey, token_2022);
+        let owner_spl = SplProgramPubkey::new_from_array(user.to_bytes());
+        let mint_spl = SplProgramPubkey::new_from_array(base_mint.to_bytes());
+        let token_program_spl = SplProgramPubkey::new_from_array(token_2022.to_bytes());
+        let expected_user_base =
+            spl_associated_token_account::get_associated_token_address_with_program_id(
+                &owner_spl,
+                &mint_spl,
+                &token_program_spl,
+            );
+        let expected_user_base = Pubkey::new_from_array(expected_user_base.to_bytes());
+        assert_eq!(ixs[0].accounts[5].pubkey, expected_user_base);
+    }
+
     /// Cached/sync `build_swap_ix`: stale `PumpAmmPoolStatic.protocol_fee_*` must not reach ix #9/#10.
     #[test]
     fn test_build_swap_ix_protocol_fee_metas_canonical_despite_stale_cached_pool() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
PumpSwap-Liquidation/SELL scheiterte nach den Kanonisierungs-Fixes mit `Custom(6023)` (`NotEnoughTokensToSell`). Ursache: `resources.token_program` ist schema-seitig als Programm für **output_mint** dokumentiert — bei SELL ist das oft WSOL (SPL). Wird dort fälschlich SPL gesetzt, leitet `build_swap_ix_from_pool_accounts` die **falsche** User-Base-ATA ab (SPL-PDA statt Token-2022-PDA) → Swap debited ein leeres/falsches Konto → 6023.

## Fix
In `tx_builder.rs` (Pump-Amm-Zweig): `base_token_program` für `input_mint` zusätzlich aus `LivePoolCache::get_mint_program` auflösen (Geyser-Mint-Owner). Wenn der Cache **Token-2022** meldet, gewinnt das für Account 11 / ATA-Derivation — **ohne** neuen RPC (nur bestehender Cache).

## Tests
- Neuer Unit-Test in `pumpfun_amm.rs`: SELL mit `Some(Tokenz…)` — ix[11] und ix[5] (User-Base-ATA) konsistent.

## STOP-CHECK
- I-7: Kein RPC im Hot Path; nur Cache-Lookup.
- I-9: Kein Simulation-Bypass.
- Keine Eval-Repo-Änderungen.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-658adc0f-0c4b-49f2-9299-f4008337ff36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-658adc0f-0c4b-49f2-9299-f4008337ff36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

