### PR TITLE
PumpSwap: asynchroner pool_accounts-Refresh bei Hot-Path-SimFail (6023/Overflow)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -155,6 +155,15 @@ fn pump_amm_pool_market_hint_pk(intent: &TradeIntent, ctx: &ExecutionContext) ->
     pump_amm_pool_market_hint_merge(intent_pool, cache_pool)
 }
 
+/// Stale/wrong PumpSwap `pool_accounts` (e.g. creator vault) → simulation Overflow / Custom(6023) / 0x1787.
+/// Must match the liquidation cold-path recovery matcher.
+#[inline]
+fn is_pump_amm_structural_sim_error(error_code: Option<&str>) -> bool {
+    error_code
+        .map(|e| e.contains("6023") || e.contains("Overflow") || e.contains("0x1787"))
+        .unwrap_or(false)
+}
+
 fn extract_owner_mint_delta_raw(
     tx: &EncodedConfirmedTransactionWithStatusMeta,
     owner: &Pubkey,
@@ -2045,6 +2054,54 @@ impl ExecutionContext {
             .remove(&request_id);
 
         outcome
+    }
+
+    /// Hot-path healing: publish `EnsurePumpAmmPoolAccounts` to market-data with `force_refresh=true`
+    /// without registering for ControlResponse (no wait, no retry in the same intent).
+    /// RPC work happens only in market-data (Cold Path); this path is fire-and-forget NATS publish.
+    fn fire_pump_amm_pool_accounts_refresh_async(
+        nats: &NatsClient,
+        run_id: String,
+        base_mint: String,
+        pool_address_hint: Option<String>,
+    ) {
+        let nats = nats.clone_for_spawned_publish();
+        tokio::spawn(async move {
+            let request_id = Uuid::new_v4().to_string();
+            let mut req = ControlRequest::new(
+                "execution-engine",
+                BUILD_VERSION,
+                &run_id,
+                request_id,
+                "market-data",
+                ControlRequestKind::EnsurePumpAmmPoolAccounts {
+                    base_mint: base_mint.clone(),
+                },
+            );
+            req.pool_address_hint = pool_address_hint.clone();
+            req.force_refresh = true;
+
+            match nats.publish(TOPIC_CONTROL_REQUESTS, &req).await {
+                Ok(true) => {}
+                Ok(false) => {
+                    warn!(
+                        request_id = %req.request_id,
+                        base_mint = %base_mint,
+                        pool_address_hint = ?pool_address_hint,
+                        "PumpSwap hot-path: async EnsurePumpAmmPoolAccounts publish dropped or failed (NATS)"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        request_id = %req.request_id,
+                        base_mint = %base_mint,
+                        pool_address_hint = ?pool_address_hint,
+                        error = %e,
+                        "PumpSwap hot-path: async EnsurePumpAmmPoolAccounts publish error"
+                    );
+                }
+            }
+        });
     }
 
     async fn run_liquidation_job(
@@ -7941,16 +7998,44 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
             );
         }
 
+        // Regular PumpSwap SELL hot path: on structural sim failure, trigger async pool_accounts refresh
+        // (no wait, no retry this intent). Liquidation uses synchronous wait+retry below.
+        if !ctx.replay_mode
+            && !is_liquidation_sell
+            && intent.side == TradeSide::Sell
+            && intent.metadata.get("dex").map(|s| s.as_str()) == Some("pump_amm")
+            && is_pump_amm_structural_sim_error(sim_result.error_code.as_deref())
+        {
+            let pool_hint_str = pump_amm_pool_market_hint_pk(&intent, ctx).map(|p| p.to_string());
+            warn!(
+                intent_id = %intent.intent_id,
+                mint = %intent.resources.input_mint,
+                pool_hint = ?pool_hint_str,
+                sim_error = ?sim_result.error_code,
+                "PumpSwap regular SELL: simulation structural error (6023/Overflow family); triggering async non-blocking EnsurePumpAmmPoolAccounts force_refresh to market-data (no wait, no retry this intent)"
+            );
+            if let Some(ref nats) = ctx.nats {
+                ExecutionContext::fire_pump_amm_pool_accounts_refresh_async(
+                    nats,
+                    ctx.run_id.clone(),
+                    intent.resources.input_mint.clone(),
+                    pool_hint_str,
+                );
+            } else {
+                warn!(
+                    intent_id = %intent.intent_id,
+                    mint = %intent.resources.input_mint,
+                    "PumpSwap regular SELL: async healing skipped — NATS not connected"
+                );
+            }
+        }
+
         // PumpSwap SELL: stale/wrong creator-vault accounts in cached pool_accounts → Overflow Custom(6023).
         // Cold-path recovery: one EnsurePumpAmmPoolAccounts with force_refresh (RPC market parse).
         if !pump_amm_recovery_attempted
             && is_liquidation_sell
             && intent.metadata.get("dex").map(|s| s.as_str()) == Some("pump_amm")
-            && sim_result
-                .error_code
-                .as_ref()
-                .map(|e| e.contains("6023") || e.contains("Overflow") || e.contains("0x1787"))
-                .unwrap_or(false)
+            && is_pump_amm_structural_sim_error(sim_result.error_code.as_deref())
         {
             let base_mint_pk = match Pubkey::from_str(&intent.resources.input_mint) {
                 Ok(p) => p,
@@ -9769,10 +9854,22 @@ async fn spawn_rebroadcast_loop(
 #[cfg(test)]
 mod execution_engine_tests {
     use super::{
-        pump_amm_pool_market_hint_merge, select_best_route, DiscoveryRequestOutcome, RouteCandidate,
+        is_pump_amm_structural_sim_error, pump_amm_pool_market_hint_merge, select_best_route,
+        DiscoveryRequestOutcome, RouteCandidate,
     };
     use ironcrab::ipc::{ControlResponse, ControlResponseStatus};
     use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn pump_amm_structural_sim_error_matches_liquidation_pattern() {
+        assert!(is_pump_amm_structural_sim_error(Some(
+            "Simulation failed: Custom(6023)"
+        )));
+        assert!(is_pump_amm_structural_sim_error(Some("Overflow")));
+        assert!(is_pump_amm_structural_sim_error(Some("0x1787")));
+        assert!(!is_pump_amm_structural_sim_error(Some("Custom(6005)")));
+        assert!(!is_pump_amm_structural_sim_error(None));
+    }
 
     /// I-24d: Verifies that ControlResponse status maps correctly to DiscoveryRequestOutcome.
     /// NotFound and Error must NOT be confused with Timeout (terminal outcomes are distinct).

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -164,6 +164,26 @@ fn is_pump_amm_structural_sim_error(error_code: Option<&str>) -> bool {
         .unwrap_or(false)
 }
 
+/// Scope-1 async PumpSwap healing: only **regular momentum strategy** SELLs (hot path).
+///
+/// Excludes cold-path / manual safety tooling (e.g. `sell-all` uses `source == "sell-all"` and
+/// `sell_all == "true"`), and anything already classified as liquidation/kill-switch sell via
+/// `is_liquidation_sell` (`purpose=liquidation` or `kill_switch=true`).
+#[inline]
+fn is_regular_momentum_hot_path_sell(intent: &TradeIntent) -> bool {
+    if intent.side != TradeSide::Sell {
+        return false;
+    }
+    if intent.source != "momentum-bot" {
+        return false;
+    }
+    // Belt-and-suspenders: sell-all / liquidation helpers may set this marker.
+    if intent.metadata.get("sell_all").map(|v| v.as_str()) == Some("true") {
+        return false;
+    }
+    true
+}
+
 fn extract_owner_mint_delta_raw(
     tx: &EncodedConfirmedTransactionWithStatusMeta,
     owner: &Pubkey,
@@ -8002,7 +8022,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
         // (no wait, no retry this intent). Liquidation uses synchronous wait+retry below.
         if !ctx.replay_mode
             && !is_liquidation_sell
-            && intent.side == TradeSide::Sell
+            && is_regular_momentum_hot_path_sell(&intent)
             && intent.metadata.get("dex").map(|s| s.as_str()) == Some("pump_amm")
             && is_pump_amm_structural_sim_error(sim_result.error_code.as_deref())
         {
@@ -9854,10 +9874,14 @@ async fn spawn_rebroadcast_loop(
 #[cfg(test)]
 mod execution_engine_tests {
     use super::{
-        is_pump_amm_structural_sim_error, pump_amm_pool_market_hint_merge, select_best_route,
-        DiscoveryRequestOutcome, RouteCandidate,
+        is_pump_amm_structural_sim_error, is_regular_momentum_hot_path_sell,
+        pump_amm_pool_market_hint_merge, select_best_route, DiscoveryRequestOutcome,
+        RouteCandidate,
     };
-    use ironcrab::ipc::{ControlResponse, ControlResponseStatus};
+    use ironcrab::ipc::{
+        ControlResponse, ControlResponseStatus, ExplicitAmount, IntentOrigin, IntentTier,
+        TradeIntent, TradeResources, TradeSide, TradingRegime,
+    };
     use solana_sdk::pubkey::Pubkey;
 
     #[test]
@@ -9869,6 +9893,41 @@ mod execution_engine_tests {
         assert!(is_pump_amm_structural_sim_error(Some("0x1787")));
         assert!(!is_pump_amm_structural_sim_error(Some("Custom(6005)")));
         assert!(!is_pump_amm_structural_sim_error(None));
+    }
+
+    #[test]
+    fn regular_momentum_hot_path_sell_requires_momentum_source_and_not_sell_all() {
+        let mut intent = TradeIntent::new(
+            "momentum-bot",
+            "v0.1.0",
+            "run-1",
+            "id-1".to_string(),
+            "momentum-bot",
+            IntentTier::Tier1,
+            IntentOrigin::StrategyA,
+            ExplicitAmount::new(1_000_000, 6),
+            TradeResources {
+                input_mint: "Mint111111111111111111111111111111111111111".to_string(),
+                output_mint: ironcrab::ipc::NATIVE_SOL_MINT.to_string(),
+                pools: vec!["Pool123".to_string()],
+                accounts: vec![],
+                token_program: None,
+            },
+            0,
+            200,
+            TradeSide::Sell,
+            TradingRegime::Early,
+        );
+        assert!(is_regular_momentum_hot_path_sell(&intent));
+
+        intent.source = "sell-all".to_string();
+        assert!(!is_regular_momentum_hot_path_sell(&intent));
+
+        intent.source = "momentum-bot".to_string();
+        intent
+            .metadata
+            .insert("sell_all".to_string(), "true".to_string());
+        assert!(!is_regular_momentum_hot_path_sell(&intent));
     }
 
     /// I-24d: Verifies that ControlResponse status maps correctly to DiscoveryRequestOutcome.

--- a/src/nats/client.rs
+++ b/src/nats/client.rs
@@ -77,6 +77,16 @@ impl NatsClient {
         }
     }
 
+    /// Second handle for `tokio::spawn` publish paths (metrics counters are per-handle).
+    pub fn clone_for_spawned_publish(&self) -> Self {
+        Self {
+            config: self.config.clone(),
+            client: self.client.clone(),
+            messages_published: std::sync::atomic::AtomicU64::new(0),
+            messages_dropped: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
     pub async fn connect(&mut self) -> anyhow::Result<()> {
         info!(url = %self.config.url, name = %self.config.name, "Connecting to NATS");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ziel

Reguläre PumpSwap-SELLs im Hot Path: Bei strukturellem Simulationsfehler (gleiche Familie wie Liquidation: 6023 / Overflow / 0x1787) wird **ein** nicht-blockierender `EnsurePumpAmmPoolAccounts`-Request mit `force_refresh=true` an `market-data` gesendet. Kein Warten, kein Retry im selben Intent. Liquidation/Cold-Path-Recovery unverändert (weiterhin synchrones Wait + ein Retry).

**Scope-Update (Supervisor):** Der Async-Trigger gilt nur noch für echte **Momentum-Strategie**-SELLs: `intent.source == "momentum-bot"`, kein `metadata.sell_all == "true"` (sell-all / manuelle Liquidations-Tools), weiterhin `!is_liquidation_sell` und `dex == pump_amm` + struktureller Sim-Fehler.

## Technik

- `is_regular_momentum_hot_path_sell` kapselt die obige Abgrenzung.
- Neuer Matcher `is_pump_amm_structural_sim_error` (identisch zur bestehenden Liquidations-Bedingung).
- `ExecutionContext::fire_pump_amm_pool_accounts_refresh_async`: `tokio::spawn` + `publish` auf `TOPIC_CONTROL_REQUESTS`, **ohne** Eintrag in `pending_discovery_responses`.
- `NatsClient::clone_for_spawned_publish`: schlanke Kopie für den Spawn (async-nats `Client` ist `Clone`).
- Unit-Tests für String-Matcher und Momentum-Quelle.

## Checks

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cac9474-2221-4d11-a526-811a17ee6dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cac9474-2221-4d11-a526-811a17ee6dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

