### PR TITLE
docs: Grafana-Alerts für PumpSwap Async Hot-Path Healing (Scope 4)

### DIFF
--- a/docs/grafana_alert_rules.json
+++ b/docs/grafana_alert_rules.json
@@ -814,6 +814,286 @@
     },
     {
       "orgId": 1,
+      "name": "IronCrab PumpSwap Hot-Path Healing",
+      "folder": "IronCrab Alerts",
+      "interval": "1m",
+      "rules": [
+        {
+          "uid": "ironcrab-pumpswap-healing-skipped-no-nats",
+          "title": "PumpSwap Healing Skipped (No NATS)",
+          "condition": "C",
+          "data": [
+            {
+              "refId": "A",
+              "relativeTimeRange": {
+                "from": 600,
+                "to": 0
+              },
+              "datasourceUid": "bf5zln2g4x5vka",
+              "model": {
+                "expr": "increase(pumpswap_hot_path_healing_skipped_no_nats_total[5m])",
+                "intervalMs": 1000,
+                "maxDataPoints": 43200,
+                "refId": "A"
+              }
+            },
+            {
+              "refId": "B",
+              "relativeTimeRange": {
+                "from": 600,
+                "to": 0
+              },
+              "datasourceUid": "__expr__",
+              "model": {
+                "expression": "A",
+                "reducer": "last",
+                "refId": "B",
+                "type": "reduce"
+              }
+            },
+            {
+              "refId": "C",
+              "relativeTimeRange": {
+                "from": 600,
+                "to": 0
+              },
+              "datasourceUid": "__expr__",
+              "model": {
+                "conditions": [
+                  {
+                    "evaluator": {
+                      "params": [0],
+                      "type": "gt"
+                    }
+                  }
+                ],
+                "expression": "B",
+                "refId": "C",
+                "type": "threshold"
+              }
+            }
+          ],
+          "noDataState": "OK",
+          "execErrState": "OK",
+          "for": "2m",
+          "annotations": {
+            "summary": "PumpSwap async healing reached but cannot publish (no NATS)",
+            "description": "pumpswap_hot_path_healing_skipped_no_nats_total increased in the last 5m window. Hot-path healing cannot enqueue work; check NATS connectivity and execution-engine messaging."
+          },
+          "labels": {
+            "severity": "warning",
+            "component": "execution-engine",
+            "type": "pumpswap_healing"
+          }
+        },
+        {
+          "uid": "ironcrab-pumpswap-healing-async-publish-fail",
+          "title": "PumpSwap Healing Async Publish Failures",
+          "condition": "C",
+          "data": [
+            {
+              "refId": "A",
+              "relativeTimeRange": {
+                "from": 900,
+                "to": 0
+              },
+              "datasourceUid": "bf5zln2g4x5vka",
+              "model": {
+                "expr": "rate(pumpswap_hot_path_healing_async_publish_fail_total[5m])",
+                "intervalMs": 1000,
+                "maxDataPoints": 43200,
+                "refId": "A"
+              }
+            },
+            {
+              "refId": "B",
+              "relativeTimeRange": {
+                "from": 900,
+                "to": 0
+              },
+              "datasourceUid": "__expr__",
+              "model": {
+                "expression": "A",
+                "reducer": "mean",
+                "refId": "B",
+                "type": "reduce"
+              }
+            },
+            {
+              "refId": "C",
+              "relativeTimeRange": {
+                "from": 900,
+                "to": 0
+              },
+              "datasourceUid": "__expr__",
+              "model": {
+                "conditions": [
+                  {
+                    "evaluator": {
+                      "params": [0.02],
+                      "type": "gt"
+                    }
+                  }
+                ],
+                "expression": "B",
+                "refId": "C",
+                "type": "threshold"
+              }
+            }
+          ],
+          "noDataState": "OK",
+          "execErrState": "OK",
+          "for": "5m",
+          "annotations": {
+            "summary": "PumpSwap healing async publish is failing repeatedly",
+            "description": "rate(pumpswap_hot_path_healing_async_publish_fail_total[5m]) exceeds 0.02/s sustained. The async healing path is degraded; investigate NATS/JetStream and execution-engine logs."
+          },
+          "labels": {
+            "severity": "warning",
+            "component": "execution-engine",
+            "type": "pumpswap_healing"
+          }
+        },
+        {
+          "uid": "ironcrab-pumpswap-healing-trigger-spike",
+          "title": "PumpSwap Healing Trigger Rate Unusually High",
+          "condition": "C",
+          "data": [
+            {
+              "refId": "A",
+              "relativeTimeRange": {
+                "from": 1200,
+                "to": 0
+              },
+              "datasourceUid": "bf5zln2g4x5vka",
+              "model": {
+                "expr": "rate(pumpswap_hot_path_healing_trigger_total[5m])",
+                "intervalMs": 1000,
+                "maxDataPoints": 43200,
+                "refId": "A"
+              }
+            },
+            {
+              "refId": "B",
+              "relativeTimeRange": {
+                "from": 1200,
+                "to": 0
+              },
+              "datasourceUid": "__expr__",
+              "model": {
+                "expression": "A",
+                "reducer": "mean",
+                "refId": "B",
+                "type": "reduce"
+              }
+            },
+            {
+              "refId": "C",
+              "relativeTimeRange": {
+                "from": 1200,
+                "to": 0
+              },
+              "datasourceUid": "__expr__",
+              "model": {
+                "conditions": [
+                  {
+                    "evaluator": {
+                      "params": [0.03],
+                      "type": "gt"
+                    }
+                  }
+                ],
+                "expression": "B",
+                "refId": "C",
+                "type": "threshold"
+              }
+            }
+          ],
+          "noDataState": "OK",
+          "execErrState": "OK",
+          "for": "10m",
+          "annotations": {
+            "summary": "PumpSwap hot-path healing triggers much more often than expected",
+            "description": "rate(pumpswap_hot_path_healing_trigger_total[5m]) exceeds 0.03/s for 10m. Edge-case healing should be rare; investigate stale pools, Geyser/LivePoolCache health, and repeated mint/pool failures."
+          },
+          "labels": {
+            "severity": "warning",
+            "component": "execution-engine",
+            "type": "pumpswap_healing"
+          }
+        },
+        {
+          "uid": "ironcrab-pumpswap-healing-cooldown-suppressed-spike",
+          "title": "PumpSwap Healing Cooldown Suppressions High",
+          "condition": "C",
+          "data": [
+            {
+              "refId": "A",
+              "relativeTimeRange": {
+                "from": 1200,
+                "to": 0
+              },
+              "datasourceUid": "bf5zln2g4x5vka",
+              "model": {
+                "expr": "increase(pumpswap_hot_path_healing_cooldown_suppressed_total[15m])",
+                "intervalMs": 1000,
+                "maxDataPoints": 43200,
+                "refId": "A"
+              }
+            },
+            {
+              "refId": "B",
+              "relativeTimeRange": {
+                "from": 1200,
+                "to": 0
+              },
+              "datasourceUid": "__expr__",
+              "model": {
+                "expression": "A",
+                "reducer": "last",
+                "refId": "B",
+                "type": "reduce"
+              }
+            },
+            {
+              "refId": "C",
+              "relativeTimeRange": {
+                "from": 1200,
+                "to": 0
+              },
+              "datasourceUid": "__expr__",
+              "model": {
+                "conditions": [
+                  {
+                    "evaluator": {
+                      "params": [12],
+                      "type": "gt"
+                    }
+                  }
+                ],
+                "expression": "B",
+                "refId": "C",
+                "type": "threshold"
+              }
+            }
+          ],
+          "noDataState": "OK",
+          "execErrState": "OK",
+          "for": "5m",
+          "annotations": {
+            "summary": "Many PumpSwap healing attempts suppressed by cooldown",
+            "description": "increase(pumpswap_hot_path_healing_cooldown_suppressed_total[15m]) exceeds 12. Suggests repeated structural failures for the same mint/pool; cross-check with healing trigger and pool/Geyser health."
+          },
+          "labels": {
+            "severity": "warning",
+            "component": "execution-engine",
+            "type": "pumpswap_healing"
+          }
+        }
+      ]
+    },
+    {
+      "orgId": 1,
       "name": "Validator Health",
       "folder": "IronCrab Alerts",
       "interval": "30s",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Kurzbeschreibung

Kleine Ergänzung zu `docs/grafana_alert_rules.json`: neue Alert-Gruppe **IronCrab PumpSwap Hot-Path Healing** mit vier Regeln auf den bestehenden Countern aus Scope 3.

**Scope:** ausschließlich `docs/grafana_alert_rules.json` (keine Runtime-, UI-, Lockfile-, Dashboard- oder Eval-Änderungen).

## Neue Regeln

| UID | Signal | Ausdruck / Fenster | Schwellwert | `for` |
|-----|--------|-------------------|-------------|-------|
| `ironcrab-pumpswap-healing-skipped-no-nats` | Healing ohne Publish (kein NATS) | `increase(...skipped_no_nats_total[5m])` | > 0 | 2m |
| `ironcrab-pumpswap-healing-async-publish-fail` | wiederholte Publish-Fails | `rate(...async_publish_fail_total[5m])` | > 0.02/s | 5m |
| `ironcrab-pumpswap-healing-trigger-spike` | ungewöhnlich viele Triggers | `rate(...trigger_total[5m])` | > 0.03/s | 10m |
| `ironcrab-pumpswap-healing-cooldown-suppressed-spike` | viele Cooldown-Suppressions | `increase(...cooldown_suppressed_total[15m])` | > 12 | 5m |

Schwellen bewusst konservativ (Edge-Case-Pfad soll nicht dauernd alarmieren).

## Checks

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo test --features test_helpers` — grün.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f654d0d-92ae-4fff-aa8b-43885841303a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f654d0d-92ae-4fff-aa8b-43885841303a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

