### PR TITLE
PumpFun bonding curve cold-path recovery (market-data RPC refresh)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -167,6 +167,21 @@ fn is_pump_amm_structural_sim_error(error_code: Option<&str>) -> bool {
         .unwrap_or(false)
 }
 
+/// PumpFun bonding curve: stale reserves / wrong account count (cashback) → Custom(6023/6024), Overflow.
+/// Cold-path recovery matcher (liquidation / manual); must stay aligned with handler below.
+#[inline]
+fn is_pumpfun_bonding_curve_structural_sim_error(error_code: Option<&str>) -> bool {
+    error_code
+        .map(|e| {
+            e.contains("6023")
+                || e.contains("6024")
+                || e.contains("Overflow")
+                || e.contains("0x1787")
+                || e.contains("0x1788")
+        })
+        .unwrap_or(false)
+}
+
 /// Scope-1 async PumpSwap healing: only **regular momentum strategy** SELLs (hot path).
 ///
 /// Excludes cold-path / manual safety tooling (e.g. `sell-all` uses `source == "sell-all"` and
@@ -1466,6 +1481,26 @@ async fn wait_for_usable_pump_amm_cache_state(
     false
 }
 
+/// After `EnsurePumpfunBondingCurve` + JetStream merge: wait until SLAVE cache reflects a change
+/// vs the pre-request snapshot (or new entry appears).
+async fn wait_for_pumpfun_bonding_cache_refresh(
+    cache: &LivePoolCache,
+    bonding_curve: &Pubkey,
+    before: Option<(u64, u64, u64, u64, bool, bool)>,
+    timeout_ms: u64,
+    poll_interval_ms: u64,
+) -> bool {
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+    while Instant::now() < deadline {
+        let after = cache.pumpfun_bonding_curve_reserves_snapshot(bonding_curve);
+        if after != before {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
+    }
+    false
+}
+
 /// Runtime context for execution-engine
 struct ExecutionContext {
     run_id: String,
@@ -2121,6 +2156,110 @@ impl ExecutionContext {
             };
 
         // Cleanup pending entry (may have been removed by subscription)
+        let _ = self
+            .pending_discovery_responses
+            .lock()
+            .await
+            .remove(&request_id);
+
+        outcome
+    }
+
+    /// I-24d: Request PumpFun bonding curve RPC refresh from market-data (Cold Path only).
+    /// Sends EnsurePumpfunBondingCurve with `force_refresh_pumpfun=true`, waits bounded for ControlResponse.
+    /// Does NOT write to SLAVE cache — market-data publishes PoolCacheUpdate to JetStream.
+    async fn request_pumpfun_bonding_recovery_and_wait(
+        &self,
+        base_mint: &str,
+    ) -> DiscoveryRequestOutcome {
+        let Some(ref nats) = self.nats else {
+            warn!(
+                request_id = "n/a",
+                base_mint = %base_mint,
+                "PumpFun bonding recovery: NATS not connected"
+            );
+            return DiscoveryRequestOutcome::Error("NATS not connected".to_string());
+        };
+
+        let request_id = Uuid::new_v4().to_string();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        {
+            let mut pending = self.pending_discovery_responses.lock().await;
+            pending.insert(request_id.clone(), tx);
+        }
+
+        let mut req = ControlRequest::new(
+            "execution-engine",
+            BUILD_VERSION,
+            &self.run_id,
+            request_id.clone(),
+            "market-data",
+            ControlRequestKind::EnsurePumpfunBondingCurve {
+                base_mint: base_mint.to_string(),
+            },
+        );
+        req.force_refresh_pumpfun = true;
+
+        warn!(
+            request_id = %request_id,
+            base_mint = %base_mint,
+            target = "market-data",
+            "PumpFun cold-path: EnsurePumpfunBondingCurve force_refresh (stale bonding-curve sim fail recovery)"
+        );
+
+        if nats.publish(TOPIC_CONTROL_REQUESTS, &req).await.is_err() {
+            let mut pending = self.pending_discovery_responses.lock().await;
+            pending.remove(&request_id);
+            warn!(
+                request_id = %request_id,
+                base_mint = %base_mint,
+                "PumpFun bonding recovery: publish failed"
+            );
+            return DiscoveryRequestOutcome::Error("publish failed".to_string());
+        }
+
+        let outcome =
+            match tokio::time::timeout(Duration::from_secs(DISCOVERY_REQUEST_TIMEOUT_SECS), rx)
+                .await
+            {
+                Ok(Ok(resp)) => {
+                    let status_str = format!("{:?}", resp.status);
+                    let pool = resp.pool_address.as_deref();
+                    info!(
+                        request_id = %request_id,
+                        base_mint = %base_mint,
+                        status = %status_str,
+                        pool_address = ?pool,
+                        "PumpFun bonding recovery: ControlResponse received"
+                    );
+                    match resp.status {
+                        ControlResponseStatus::Ok => DiscoveryRequestOutcome::Ok,
+                        ControlResponseStatus::NotFound => DiscoveryRequestOutcome::NotFound,
+                        ControlResponseStatus::Error => DiscoveryRequestOutcome::Error(
+                            resp.message.unwrap_or_else(|| "unknown error".to_string()),
+                        ),
+                    }
+                }
+                Ok(Err(_)) => {
+                    warn!(
+                        request_id = %request_id,
+                        base_mint = %base_mint,
+                        "PumpFun bonding recovery: channel closed before response"
+                    );
+                    DiscoveryRequestOutcome::Error("channel closed".to_string())
+                }
+                Err(_) => {
+                    warn!(
+                        request_id = %request_id,
+                        base_mint = %base_mint,
+                        timeout_secs = DISCOVERY_REQUEST_TIMEOUT_SECS,
+                        "PumpFun bonding recovery: timeout (no correlated response)"
+                    );
+                    DiscoveryRequestOutcome::Timeout
+                }
+            };
+
         let _ = self
             .pending_discovery_responses
             .lock()
@@ -7796,6 +7935,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
     // tx_builder::build_tx_plan (which requires metadata.dex and pools_len==1).
     let checks_len_before_tx_plan_build = checks.len();
     let mut pump_amm_recovery_attempted = false;
+    let mut pumpfun_bonding_recovery_attempted = false;
     let (
         tx_plan,
         plan_hash_str,
@@ -7805,7 +7945,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
         wallet_pubkey,
         bundle_tip_lamports,
     ) = loop {
-        if pump_amm_recovery_attempted {
+        if pump_amm_recovery_attempted || pumpfun_bonding_recovery_attempted {
             checks.truncate(checks_len_before_tx_plan_build);
         }
         let (tx_plan, plan_hash_str) = {
@@ -8216,6 +8356,81 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                                 intent_id = %intent.intent_id,
                                 pool = %pool_pk,
                                 "PumpSwap liquidation: simulation 6023/Overflow — force-refresh pool_accounts (market-data RPC), rebuilding tx (one retry)"
+                            );
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+
+        // PumpFun bonding curve SELL: stale virtual/real reserves or cashback layout → 6023/6024/Overflow.
+        // Cold-path recovery: EnsurePumpfunBondingCurve with force_refresh (RPC in market-data), bounded JetStream wait, one retry.
+        if !pumpfun_bonding_recovery_attempted
+            && is_liquidation_sell
+            && intent.metadata.get("dex").map(|s| s.as_str()) == Some("pumpfun")
+            && intent.resources.pools.len() == 1
+            && is_pumpfun_bonding_curve_structural_sim_error(sim_result.error_code.as_deref())
+        {
+            let base_mint_pk = match Pubkey::from_str(&intent.resources.input_mint) {
+                Ok(p) => p,
+                Err(_) => {
+                    break (
+                        tx_plan,
+                        plan_hash_str,
+                        sim_result,
+                        requires_bundle,
+                        bundle_tip_ix,
+                        wallet_pubkey,
+                        bundle_tip_lamports,
+                    )
+                }
+            };
+            let pumpfun = match PumpFunDex::new(Arc::clone(&ctx.rpc), None) {
+                Ok(d) => d,
+                Err(_) => {
+                    break (
+                        tx_plan,
+                        plan_hash_str,
+                        sim_result,
+                        requires_bundle,
+                        bundle_tip_ix,
+                        wallet_pubkey,
+                        bundle_tip_lamports,
+                    )
+                }
+            };
+            let (bonding_curve, _) = pumpfun.derive_bonding_curve(&base_mint_pk);
+            let pool_str = intent.resources.pools[0].as_str();
+            let pool_ok = Pubkey::from_str(pool_str)
+                .map(|p| p == bonding_curve)
+                .unwrap_or(false);
+            if pool_ok {
+                let before_snap = ctx
+                    .live_pool_cache
+                    .as_ref()
+                    .and_then(|c| c.pumpfun_bonding_curve_reserves_snapshot(&bonding_curve));
+                if let DiscoveryRequestOutcome::Ok = ctx
+                    .request_pumpfun_bonding_recovery_and_wait(&intent.resources.input_mint)
+                    .await
+                {
+                    if let Some(cache) = ctx.live_pool_cache.as_ref() {
+                        if wait_for_pumpfun_bonding_cache_refresh(
+                            cache,
+                            &bonding_curve,
+                            before_snap,
+                            DISCOVERY_CACHE_WAIT_TIMEOUT_MS,
+                            DISCOVERY_CACHE_POLL_INTERVAL_MS,
+                        )
+                        .await
+                        {
+                            pumpfun_bonding_recovery_attempted = true;
+                            warn!(
+                                intent_id = %intent.intent_id,
+                                mint = %intent.resources.input_mint,
+                                bonding_curve = %bonding_curve,
+                                sim_error = ?sim_result.error_code,
+                                "PumpFun liquidation: bonding-curve structural sim fail — force_refresh via market-data RPC, one tx rebuild retry"
                             );
                             continue;
                         }

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -182,6 +182,32 @@ fn is_pumpfun_bonding_curve_structural_sim_error(error_code: Option<&str>) -> bo
         .unwrap_or(false)
 }
 
+/// Cold Path only: PumpFun bonding-curve recovery (`EnsurePumpfunBondingCurve`) is allowed for
+/// kill-switch/liquidation sells **and** explicit manual sell-all tooling (`sell_all=true`).
+///
+/// Rationale: `sell-all` / keyless tooling may tag `sell_all=true` without `purpose=liquidation`;
+/// that path is still Cold Path (not momentum hot path). PumpSwap recovery stays gated on
+/// `is_liquidation_sell` only.
+#[inline]
+fn is_pumpfun_bonding_curve_cold_path_recovery_sell(intent: &TradeIntent) -> bool {
+    if intent.side != TradeSide::Sell {
+        return false;
+    }
+    if intent.metadata.get("sell_all").map(|v| v.as_str()) == Some("true") {
+        return true;
+    }
+    intent
+        .metadata
+        .get("purpose")
+        .map(|v| v == "liquidation")
+        .unwrap_or(false)
+        || intent
+            .metadata
+            .get("kill_switch")
+            .map(|v| v == "true")
+            .unwrap_or(false)
+}
+
 /// Scope-1 async PumpSwap healing: only **regular momentum strategy** SELLs (hot path).
 ///
 /// Excludes cold-path / manual safety tooling (e.g. `sell-all` uses `source == "sell-all"` and
@@ -8367,7 +8393,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
         // PumpFun bonding curve SELL: stale virtual/real reserves or cashback layout → 6023/6024/Overflow.
         // Cold-path recovery: EnsurePumpfunBondingCurve with force_refresh (RPC in market-data), bounded JetStream wait, one retry.
         if !pumpfun_bonding_recovery_attempted
-            && is_liquidation_sell
+            && is_pumpfun_bonding_curve_cold_path_recovery_sell(&intent)
             && intent.metadata.get("dex").map(|s| s.as_str()) == Some("pumpfun")
             && intent.resources.pools.len() == 1
             && is_pumpfun_bonding_curve_structural_sim_error(sim_result.error_code.as_deref())
@@ -10210,9 +10236,10 @@ async fn spawn_rebroadcast_loop(
 #[cfg(test)]
 mod execution_engine_tests {
     use super::{
-        is_pump_amm_structural_sim_error, is_regular_momentum_hot_path_sell,
-        pump_amm_pool_market_hint_merge, record_pump_amm_hot_path_refresh_after_success,
-        select_best_route, try_pump_amm_hot_path_refresh_publish, DiscoveryRequestOutcome,
+        is_pump_amm_structural_sim_error, is_pumpfun_bonding_curve_cold_path_recovery_sell,
+        is_regular_momentum_hot_path_sell, pump_amm_pool_market_hint_merge,
+        record_pump_amm_hot_path_refresh_after_success, select_best_route,
+        try_pump_amm_hot_path_refresh_publish, DiscoveryRequestOutcome,
         PumpAmmHotPathRefreshDecision, RouteCandidate, PUMP_AMM_HOT_PATH_REFRESH_COOLDOWN,
     };
     use ironcrab::ipc::{
@@ -10268,6 +10295,87 @@ mod execution_engine_tests {
             .metadata
             .insert("sell_all".to_string(), "true".to_string());
         assert!(!is_regular_momentum_hot_path_sell(&intent));
+    }
+
+    #[test]
+    fn pumpfun_bonding_recovery_cold_path_includes_sell_all_without_purpose_liquidation() {
+        let mut intent = TradeIntent::new_sell(
+            "sell-all",
+            "v0.1.0",
+            "run-1",
+            "id-sa".to_string(),
+            "sell-all",
+            IntentTier::Tier0,
+            IntentOrigin::StrategyA,
+            "Mint111111111111111111111111111111111111111".to_string(),
+            6,
+            ironcrab::ipc::NATIVE_SOL_MINT.to_string(),
+            1_000_000,
+            0,
+            200,
+            TradingRegime::NotApplicable,
+        );
+        intent
+            .metadata
+            .insert("sell_all".to_string(), "true".to_string());
+        intent
+            .metadata
+            .insert("dex".to_string(), "pumpfun".to_string());
+        assert!(is_pumpfun_bonding_curve_cold_path_recovery_sell(&intent));
+    }
+
+    #[test]
+    fn pumpfun_bonding_recovery_cold_path_includes_liquidation_and_kill_switch() {
+        let mut intent = TradeIntent::new_sell(
+            "execution-engine",
+            "v0.1.0",
+            "run-1",
+            "id-liq".to_string(),
+            "execution-engine",
+            IntentTier::Tier0,
+            IntentOrigin::ExecutionMevB,
+            "Mint222222222222222222222222222222222222222".to_string(),
+            6,
+            ironcrab::ipc::NATIVE_SOL_MINT.to_string(),
+            1_000_000,
+            0,
+            200,
+            TradingRegime::NotApplicable,
+        );
+        intent
+            .metadata
+            .insert("purpose".to_string(), "liquidation".to_string());
+        assert!(is_pumpfun_bonding_curve_cold_path_recovery_sell(&intent));
+
+        intent.metadata.remove("purpose");
+        intent
+            .metadata
+            .insert("kill_switch".to_string(), "true".to_string());
+        assert!(is_pumpfun_bonding_curve_cold_path_recovery_sell(&intent));
+    }
+
+    #[test]
+    fn pumpfun_bonding_recovery_not_momentum_hot_path_sell() {
+        let mut intent = TradeIntent::new_sell(
+            "momentum-bot",
+            "v0.1.0",
+            "run-1",
+            "id-mo".to_string(),
+            "momentum-bot",
+            IntentTier::Tier1,
+            IntentOrigin::StrategyA,
+            "Mint333333333333333333333333333333333333333".to_string(),
+            6,
+            ironcrab::ipc::NATIVE_SOL_MINT.to_string(),
+            1_000_000,
+            0,
+            200,
+            TradingRegime::Early,
+        );
+        intent
+            .metadata
+            .insert("dex".to_string(), "pumpfun".to_string());
+        assert!(!is_pumpfun_bonding_curve_cold_path_recovery_sell(&intent));
     }
 
     /// I-24d: Verifies that ControlResponse status maps correctly to DiscoveryRequestOutcome.

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -52,6 +52,7 @@ use ironcrab::nats::{
 use ironcrab::solana::dex::meteora_bin_array_layout::BinArray;
 use ironcrab::solana::dex::meteora_dlmm::METEORA_DLMM_PROGRAM;
 use ironcrab::solana::dex::meteora_swap_builder::MeteoraDlmmSwapBuilder;
+use ironcrab::solana::dex::pumpfun::{BondingCurveState, PumpFunDex};
 use ironcrab::solana::dex::pumpfun_amm::PumpFunAmmDex;
 use ironcrab::solana::dex_parser::{
     parse_account_update, parse_transaction_update_with_pool_lookup, DexType, OrcaPoolInfo,
@@ -1900,6 +1901,235 @@ async fn handle_ensure_pump_amm_pool_accounts(
     }
 }
 
+/// Cold-path recovery: fetch PumpFun bonding curve account via RPC (force_refresh), update MASTER
+/// cache, publish JetStream PoolCacheUpdate. Does not short-circuit on cache when `force_refresh`.
+async fn handle_ensure_pumpfun_bonding_curve(
+    ctx: &MarketDataContext,
+    rpc: &Arc<SolanaRpc>,
+    run_id: &str,
+    request_id: &str,
+    base_mint_str: &str,
+    force_refresh: bool,
+) {
+    let base_mint = match Pubkey::from_str(base_mint_str) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(base_mint = %base_mint_str, error = %e, "EnsurePumpfunBondingCurve: invalid base_mint");
+            if let Some(ref nats) = ctx.nats {
+                publish_control_response(
+                    nats,
+                    &ctx.run_id,
+                    request_id,
+                    ControlResponseStatus::Error,
+                    None,
+                    Some(e.to_string()),
+                )
+                .await;
+            }
+            return;
+        }
+    };
+
+    let pumpfun = match PumpFunDex::new(Arc::clone(rpc), Some(ctx.live_pool_cache.clone())) {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(error = %e, "EnsurePumpfunBondingCurve: PumpFunDex init failed");
+            if let Some(ref nats) = ctx.nats {
+                publish_control_response(
+                    nats,
+                    &ctx.run_id,
+                    request_id,
+                    ControlResponseStatus::Error,
+                    None,
+                    Some(e.to_string()),
+                )
+                .await;
+            }
+            return;
+        }
+    };
+
+    let (bonding_curve, _) = pumpfun.derive_bonding_curve(&base_mint);
+    let bonding_curve_str = bonding_curve.to_string();
+
+    if !force_refresh {
+        if let Some(CachedPoolState::PumpFun(_)) = ctx.live_pool_cache.get(&bonding_curve) {
+            info!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                pool = %bonding_curve_str,
+                "EnsurePumpfunBondingCurve: cache hit (skip RPC)"
+            );
+            if let Some(ref nats) = ctx.nats {
+                publish_control_response(
+                    nats,
+                    &ctx.run_id,
+                    request_id,
+                    ControlResponseStatus::Ok,
+                    Some(bonding_curve_str),
+                    None,
+                )
+                .await;
+            }
+            return;
+        }
+    } else {
+        warn!(
+            request_id = %request_id,
+            base_mint = %base_mint_str,
+            pool = %bonding_curve_str,
+            "EnsurePumpfunBondingCurve: force_refresh — always fetching bonding curve via RPC (no cache-first)"
+        );
+    }
+
+    let state = match rpc.get_account_retry(&bonding_curve).await {
+        Ok(acct) => match BondingCurveState::parse(&acct.data) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(
+                    request_id = %request_id,
+                    pool = %bonding_curve_str,
+                    error = %e,
+                    "EnsurePumpfunBondingCurve: parse bonding curve failed"
+                );
+                if let Some(ref nats) = ctx.nats {
+                    publish_control_response(
+                        nats,
+                        &ctx.run_id,
+                        request_id,
+                        ControlResponseStatus::Error,
+                        Some(bonding_curve_str),
+                        Some(format!("parse error: {e}")),
+                    )
+                    .await;
+                }
+                return;
+            }
+        },
+        Err(e) => {
+            warn!(
+                request_id = %request_id,
+                pool = %bonding_curve_str,
+                error = %e,
+                "EnsurePumpfunBondingCurve: RPC get_account failed"
+            );
+            if let Some(ref nats) = ctx.nats {
+                publish_control_response(
+                    nats,
+                    &ctx.run_id,
+                    request_id,
+                    ControlResponseStatus::Error,
+                    Some(bonding_curve_str),
+                    Some(e.to_string()),
+                )
+                .await;
+            }
+            return;
+        }
+    };
+
+    let token_program = ctx
+        .live_pool_cache
+        .get_mint_program(&base_mint)
+        .unwrap_or_else(|| Pubkey::new_from_array(spl_token::id().to_bytes()));
+    let (associated_bonding_curve, _) =
+        pumpfun.derive_associated_bonding_curve(&bonding_curve, &base_mint, &token_program);
+
+    let cached = CachedPoolState::PumpFun(PumpFunState {
+        token_mint: base_mint,
+        bonding_curve,
+        associated_bonding_curve,
+        virtual_sol_reserves: state.virtual_sol_reserves,
+        virtual_token_reserves: state.virtual_token_reserves,
+        real_sol_reserves: state.real_sol_reserves,
+        real_token_reserves: state.real_token_reserves,
+        complete: state.complete,
+        creator: state.creator,
+        cashback_enabled: state.cashback_enabled,
+    });
+    ctx.live_pool_cache.upsert(bonding_curve, cached, 0);
+
+    let jetstream_ok = if let Some(ref nats) = ctx.nats {
+        let mut pool_update = PoolCacheUpdate::new_pool_discovered(
+            "market-data",
+            BUILD_VERSION,
+            run_id,
+            bonding_curve_str.clone(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            NATIVE_SOL_MINT.to_string(),
+            state.virtual_token_reserves,
+            state.virtual_sol_reserves,
+            Some(0),
+            0,
+        );
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("creator".to_string(), state.creator.to_string());
+        meta.insert(
+            "associated_bonding_curve".to_string(),
+            associated_bonding_curve.to_string(),
+        );
+        meta.insert("complete".to_string(), state.complete.to_string());
+        meta.insert(
+            "real_token_reserves".to_string(),
+            state.real_token_reserves.to_string(),
+        );
+        meta.insert(
+            "real_sol_reserves".to_string(),
+            state.real_sol_reserves.to_string(),
+        );
+        meta.insert(
+            "cashback_enabled".to_string(),
+            state.cashback_enabled.to_string(),
+        );
+        pool_update.metadata = Some(meta);
+        let subject = pool_subject(&bonding_curve_str);
+        match nats.jetstream_publish(&subject, &pool_update).await {
+            Ok(true) => {
+                info!(
+                    pool = %bonding_curve_str,
+                    base_mint = %base_mint_str,
+                    "EnsurePumpfunBondingCurve: Published PoolCacheUpdate to JetStream"
+                );
+                true
+            }
+            Ok(false) => {
+                warn!("EnsurePumpfunBondingCurve: JetStream publish failed (timeout or drop)");
+                false
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "EnsurePumpfunBondingCurve: Failed to publish PoolCacheUpdate to JetStream"
+                );
+                false
+            }
+        }
+    } else {
+        false
+    };
+
+    if let Some(ref nats) = ctx.nats {
+        let (status, message) = if jetstream_ok {
+            (ControlResponseStatus::Ok, None)
+        } else {
+            (
+                ControlResponseStatus::Error,
+                Some("JetStream publish failed".to_string()),
+            )
+        };
+        publish_control_response(
+            nats,
+            &ctx.run_id,
+            request_id,
+            status,
+            Some(bonding_curve_str),
+            message,
+        )
+        .await;
+    }
+}
+
 async fn publish_control_response(
     nats: &NatsClient,
     run_id: &str,
@@ -2157,37 +2387,64 @@ async fn run_geyser_loop(
                         Ok(req) => {
                             if req.target != "market-data" {
                                 debug!(target = %req.target, "Ignoring ControlRequest for other target");
-                            } else if let ControlRequestKind::EnsurePumpAmmPoolAccounts {
-                                base_mint,
-                            } = req.kind
-                            {
-                                let run_id = ctx.run_id.clone();
-                                let request_id = req.request_id.clone();
-                                let pool_hint = req.pool_address_hint.clone();
-                                let force_refresh = req.force_refresh;
-                                info!(
-                                    request_id = %request_id,
-                                    base_mint = %base_mint,
-                                    pool_address_hint = ?pool_hint,
-                                    force_refresh = %force_refresh,
-                                    "I-24d Discovery: EnsurePumpAmmPoolAccounts received"
-                                );
-                                let ctx_clone = ctx.clone();
-                                let dex_clone = Arc::clone(&pump_amm_dex);
-                                tokio::spawn(async move {
-                                    handle_ensure_pump_amm_pool_accounts(
-                                        &ctx_clone,
-                                        dex_clone.as_ref(),
-                                        run_id.as_str(),
-                                        &request_id,
-                                        &base_mint,
-                                        pool_hint.as_deref(),
-                                        force_refresh,
-                                    )
-                                    .await;
-                                });
+                            } else {
+                                match req.kind {
+                                    ControlRequestKind::EnsurePumpAmmPoolAccounts { base_mint } => {
+                                        let run_id = ctx.run_id.clone();
+                                        let request_id = req.request_id.clone();
+                                        let pool_hint = req.pool_address_hint.clone();
+                                        let force_refresh = req.force_refresh;
+                                        info!(
+                                            request_id = %request_id,
+                                            base_mint = %base_mint,
+                                            pool_address_hint = ?pool_hint,
+                                            force_refresh = %force_refresh,
+                                            "I-24d Discovery: EnsurePumpAmmPoolAccounts received"
+                                        );
+                                        let ctx_clone = ctx.clone();
+                                        let dex_clone = Arc::clone(&pump_amm_dex);
+                                        tokio::spawn(async move {
+                                            handle_ensure_pump_amm_pool_accounts(
+                                                &ctx_clone,
+                                                dex_clone.as_ref(),
+                                                run_id.as_str(),
+                                                &request_id,
+                                                &base_mint,
+                                                pool_hint.as_deref(),
+                                                force_refresh,
+                                            )
+                                            .await;
+                                        });
+                                    }
+                                    ControlRequestKind::EnsurePumpfunBondingCurve { base_mint } => {
+                                        let run_id = ctx.run_id.clone();
+                                        let request_id = req.request_id.clone();
+                                        let force_refresh = req.force_refresh_pumpfun;
+                                        info!(
+                                            request_id = %request_id,
+                                            base_mint = %base_mint,
+                                            force_refresh_pumpfun = %force_refresh,
+                                            "EnsurePumpfunBondingCurve received"
+                                        );
+                                        let ctx_clone = ctx.clone();
+                                        let rpc_clone = rpc.clone();
+                                        tokio::spawn(async move {
+                                            handle_ensure_pumpfun_bonding_curve(
+                                                &ctx_clone,
+                                                &rpc_clone,
+                                                run_id.as_str(),
+                                                &request_id,
+                                                &base_mint,
+                                                force_refresh,
+                                            )
+                                            .await;
+                                        });
+                                    }
+                                    _ => {
+                                        debug!(kind = ?req.kind, "Ignoring ControlRequest kind for market-data");
+                                    }
+                                }
                             }
-                            // Other ControlRequestKind variants are for execution-engine, ignore.
                         }
                         Err(e) => {
                             warn!(error = %e, "Failed to deserialize ControlRequest");
@@ -4485,7 +4742,7 @@ async fn run_simulation_loop(
     };
 
     let pump_amm_dex = Arc::new(PumpFunAmmDex::new_with_cache(
-        rpc,
+        Arc::clone(&rpc),
         ctx.live_pool_cache.clone(),
         true, // allow_rpc_on_miss: Cold Path Discovery
     ));
@@ -4580,35 +4837,63 @@ async fn run_simulation_loop(
                         Ok(req) => {
                             if req.target != "market-data" {
                                 debug!(target = %req.target, "Ignoring ControlRequest for other target");
-                            } else if let ControlRequestKind::EnsurePumpAmmPoolAccounts {
-                                base_mint,
-                            } = req.kind
-                            {
-                                let run_id = ctx.run_id.clone();
-                                let request_id = req.request_id.clone();
-                                let pool_hint = req.pool_address_hint.clone();
-                                let force_refresh = req.force_refresh;
-                                info!(
-                                    request_id = %request_id,
-                                    base_mint = %base_mint,
-                                    pool_address_hint = ?pool_hint,
-                                    force_refresh = %force_refresh,
-                                    "I-24d Discovery: EnsurePumpAmmPoolAccounts received (simulation)"
-                                );
-                                let ctx_clone = ctx.clone();
-                                let dex_clone = Arc::clone(&pump_amm_dex);
-                                tokio::spawn(async move {
-                                    handle_ensure_pump_amm_pool_accounts(
-                                        &ctx_clone,
-                                        dex_clone.as_ref(),
-                                        run_id.as_str(),
-                                        &request_id,
-                                        &base_mint,
-                                        pool_hint.as_deref(),
-                                        force_refresh,
-                                    )
-                                    .await;
-                                });
+                            } else {
+                                match req.kind {
+                                    ControlRequestKind::EnsurePumpAmmPoolAccounts { base_mint } => {
+                                        let run_id = ctx.run_id.clone();
+                                        let request_id = req.request_id.clone();
+                                        let pool_hint = req.pool_address_hint.clone();
+                                        let force_refresh = req.force_refresh;
+                                        info!(
+                                            request_id = %request_id,
+                                            base_mint = %base_mint,
+                                            pool_address_hint = ?pool_hint,
+                                            force_refresh = %force_refresh,
+                                            "I-24d Discovery: EnsurePumpAmmPoolAccounts received (simulation)"
+                                        );
+                                        let ctx_clone = ctx.clone();
+                                        let dex_clone = Arc::clone(&pump_amm_dex);
+                                        tokio::spawn(async move {
+                                            handle_ensure_pump_amm_pool_accounts(
+                                                &ctx_clone,
+                                                dex_clone.as_ref(),
+                                                run_id.as_str(),
+                                                &request_id,
+                                                &base_mint,
+                                                pool_hint.as_deref(),
+                                                force_refresh,
+                                            )
+                                            .await;
+                                        });
+                                    }
+                                    ControlRequestKind::EnsurePumpfunBondingCurve { base_mint } => {
+                                        let run_id = ctx.run_id.clone();
+                                        let request_id = req.request_id.clone();
+                                        let force_refresh = req.force_refresh_pumpfun;
+                                        info!(
+                                            request_id = %request_id,
+                                            base_mint = %base_mint,
+                                            force_refresh_pumpfun = %force_refresh,
+                                            "EnsurePumpfunBondingCurve received (simulation)"
+                                        );
+                                        let ctx_clone = ctx.clone();
+                                        let rpc_clone = rpc.clone();
+                                        tokio::spawn(async move {
+                                            handle_ensure_pumpfun_bonding_curve(
+                                                &ctx_clone,
+                                                &rpc_clone,
+                                                run_id.as_str(),
+                                                &request_id,
+                                                &base_mint,
+                                                force_refresh,
+                                            )
+                                            .await;
+                                        });
+                                    }
+                                    _ => {
+                                        debug!(kind = ?req.kind, "Ignoring ControlRequest kind for market-data (simulation)");
+                                    }
+                                }
                             }
                         }
                         Err(e) => {

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -609,6 +609,27 @@ impl LivePoolCache {
         self.mint_decimals.entry(mint).or_insert(decimals);
     }
 
+    /// Fields from cached PumpFun bonding curve relevant to SELL simulation / recovery waits.
+    ///
+    /// Used by execution-engine to detect JetStream-applied `PoolCacheUpdate` after market-data
+    /// RPC refresh (Cold Path recovery).
+    pub fn pumpfun_bonding_curve_reserves_snapshot(
+        &self,
+        bonding_curve: &Pubkey,
+    ) -> Option<(u64, u64, u64, u64, bool, bool)> {
+        match self.get(bonding_curve)? {
+            CachedPoolState::PumpFun(s) => Some((
+                s.virtual_token_reserves,
+                s.virtual_sol_reserves,
+                s.real_token_reserves,
+                s.real_sol_reserves,
+                s.complete,
+                s.cashback_enabled,
+            )),
+            _ => None,
+        }
+    }
+
     /// Get the creator from a PumpFun bonding curve cached state
     /// Returns None if the bonding curve is not cached or is not a PumpFun pool
     /// This is the GEYSER-FIRST source of truth - NO RPC calls needed!

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -1108,6 +1108,16 @@ pub enum ControlRequestKind {
         /// Base mint address (base58) of the PumpSwap pool to discover.
         base_mint: String,
     },
+
+    /// Cold-path recovery: refresh PumpFun bonding curve state from RPC and publish PoolCacheUpdate.
+    ///
+    /// Sent by execution-engine when a liquidation/manual PumpFun bonding-curve SELL fails
+    /// simulation with a stale-state signature. market-data performs authoritative RPC fetch,
+    /// updates MASTER cache, publishes JetStream `PoolCacheUpdate`. Truth source = JetStream.
+    EnsurePumpfunBondingCurve {
+        /// Token mint (base58) whose bonding curve PDA should be refreshed.
+        base_mint: String,
+    },
 }
 
 fn default_true() -> bool {
@@ -1137,6 +1147,12 @@ pub struct ControlRequest {
     #[serde(default)]
     pub force_refresh: bool,
 
+    /// When true, market-data must **not** answer EnsurePumpfunBondingCurve from LivePoolCache
+    /// alone: fetch bonding curve account via RPC and publish PoolCacheUpdate. Cold-path recovery
+    /// only (I-5); default false for backward-compatible wire format.
+    #[serde(default)]
+    pub force_refresh_pumpfun: bool,
+
     #[serde(flatten)]
     pub kind: ControlRequestKind,
 }
@@ -1156,6 +1172,7 @@ impl ControlRequest {
             target: target.to_string(),
             pool_address_hint: None,
             force_refresh: false,
+            force_refresh_pumpfun: false,
             kind,
         }
     }
@@ -2164,6 +2181,34 @@ mod tests {
         assert!(json_force.contains("\"force_refresh\":true"));
         let parsed_force: ControlRequest = serde_json::from_str(&json_force).unwrap();
         assert!(parsed_force.force_refresh);
+    }
+
+    #[test]
+    fn test_control_request_ensure_pumpfun_bonding_curve_serde() {
+        let mut req = ControlRequest::new(
+            "execution-engine",
+            "v0.1.0",
+            "run-123",
+            "req-pumpfun-bc-001".to_string(),
+            "market-data",
+            ControlRequestKind::EnsurePumpfunBondingCurve {
+                base_mint: "MintPumpFun111111111111111111111111111111".to_string(),
+            },
+        );
+        req.force_refresh_pumpfun = true;
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("ensure_pumpfun_bonding_curve"));
+        assert!(json.contains("MintPumpFun111111111111111111111111111111"));
+        assert!(json.contains("\"force_refresh_pumpfun\":true"));
+
+        let parsed: ControlRequest = serde_json::from_str(&json).unwrap();
+        assert!(parsed.force_refresh_pumpfun);
+        match &parsed.kind {
+            ControlRequestKind::EnsurePumpfunBondingCurve { base_mint } => {
+                assert_eq!(base_mint, "MintPumpFun111111111111111111111111111111");
+            }
+            _ => panic!("expected EnsurePumpfunBondingCurve"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Scope 1** PumpFun **bonding curve** cold-path recovery when simulation fails with a **stale-state / structural** signature (6023, 6024, Overflow, hex variants aligned with PumpSwap matcher).

### Follow-up (review)

- Recovery gate now uses `is_pumpfun_bonding_curve_cold_path_recovery_sell`: **`purpose=liquidation` OR `kill_switch=true` OR `sell_all=true`** (covers manual sell-all tooling even if `purpose` is omitted). PumpSwap recovery remains gated on `is_liquidation_sell` only.

## Behavior

- **execution-engine** (cold path per gate above, `dex=pumpfun`, pool = derived bonding curve PDA): on matching sim failure → `EnsurePumpfunBondingCurve` to **market-data** with `force_refresh_pumpfun=true` → bounded wait for SLAVE `LivePoolCache` → **exactly one** rebuild/simulate retry.

## IPC

- `ControlRequestKind::EnsurePumpfunBondingCurve { base_mint }`
- `ControlRequest::force_refresh_pumpfun`

## Tests / checks

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`

## STOP-CHECK

- **I-7**: No new RPC on hot path; recovery not for momentum sells without cold-path markers.
- **I-24d**: Refresh via market-data + JetStream only.
- **I-9**: Unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14ea3395-60fb-43fe-b324-b3bf98b134b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14ea3395-60fb-43fe-b324-b3bf98b134b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

