### PR TITLE
fix(execution-engine): PumpSwap cache hits require explicit Ready for pool_accounts

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -1486,11 +1486,15 @@ enum DiscoveryRequestOutcome {
     Timeout,
 }
 
-/// I-24d: Bounded wait until PumpSwap AMM is quote-ready in SLAVE cache (JetStream path).
+/// I-24d: Bounded wait until PumpSwap AMM is usable for quotes **and** swap account lists in SLAVE cache (JetStream path).
 ///
 /// `ControlResponse=Ok` can correlate before `apply_pool_cache_update` exposes non-degenerate
 /// `base_reserve`/`quote_reserve` (Bug #27): `pool_accounts` alone is a weak readiness signal.
-/// Polls until `LivePoolCache::pump_amm_quote_ready_by_base_mint` is true or timeout.
+/// Bug #36: non-empty `pool_accounts` must not be treated as hot-path ready without explicit
+/// [`DexPoolReadiness::Ready`] (or legacy authoritative heuristic inside
+/// [`LivePoolCache::get_ready_pump_amm_pool_accounts_by_base_mint`]).
+/// Polls until both `pump_amm_quote_ready_by_base_mint` and
+/// `pump_amm_swap_accounts_ready_by_base_mint` are true or timeout.
 async fn wait_for_usable_pump_amm_cache_state(
     cache: &LivePoolCache,
     base_mint: &Pubkey,
@@ -1499,7 +1503,9 @@ async fn wait_for_usable_pump_amm_cache_state(
 ) -> bool {
     let deadline = std::time::Instant::now() + Duration::from_millis(timeout_ms);
     while std::time::Instant::now() < deadline {
-        if cache.pump_amm_quote_ready_by_base_mint(base_mint) {
+        if cache.pump_amm_quote_ready_by_base_mint(base_mint)
+            && cache.pump_amm_swap_accounts_ready_by_base_mint(base_mint)
+        {
             return true;
         }
         tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
@@ -1889,7 +1895,7 @@ impl ExecutionContext {
                 let accounts = match self
                     .live_pool_cache
                     .as_ref()
-                    .and_then(|c| c.get_pump_amm_pool_accounts_by_base_mint(&mint))
+                    .and_then(|c| c.get_ready_pump_amm_pool_accounts_by_base_mint(&mint))
                 {
                     Some(a) if a.len() >= 14 => a,
                     _ => {
@@ -1923,7 +1929,7 @@ impl ExecutionContext {
                                     warn!(mint = %mint_str, "6005-retry: usable PumpAmm cache state not visible after discovery timeout (pool_accounts+reserves)");
                                     return None;
                                 }
-                                match cache.get_pump_amm_pool_accounts_by_base_mint(&mint) {
+                                match cache.get_ready_pump_amm_pool_accounts_by_base_mint(&mint) {
                                     Some(a) if a.len() >= 14 => a,
                                     _ => {
                                         warn!(mint = %mint_str, "6005-retry: pool_accounts still missing after discovery");
@@ -2016,7 +2022,7 @@ impl ExecutionContext {
                                     }
                                 };
                                 let accounts = match cache
-                                    .get_pump_amm_pool_accounts_by_base_mint(&mint)
+                                    .get_ready_pump_amm_pool_accounts_by_base_mint(&mint)
                                 {
                                     Some(a) if a.len() >= 14 => a,
                                     _ => {
@@ -2703,10 +2709,9 @@ impl ExecutionContext {
                             maybe_ping_watchdog();
                             if let Some(pool_id) = q.route.first().cloned() {
                                 // I-24d: Cache-only — no pump_amm.pool_accounts_v1_for_base_mint.
-                                let accounts = ctx
-                                    .live_pool_cache
-                                    .as_ref()
-                                    .and_then(|c| c.get_pump_amm_pool_accounts_by_base_mint(&mint));
+                                let accounts = ctx.live_pool_cache.as_ref().and_then(|c| {
+                                    c.get_ready_pump_amm_pool_accounts_by_base_mint(&mint)
+                                });
                                 match accounts {
                                     Some(accounts) if accounts.len() >= 14 => {
                                         let acct_strings: Vec<String> =
@@ -2727,7 +2732,7 @@ impl ExecutionContext {
                                     _ => {
                                         // I-24d: Request discovery, wait bounded on authoritative cache state.
                                         // pool_id from quote enables fast getAccount path in market-data.
-                                        info!(mint = %mint, pool = %pool_id, "pump_amm quote ok but pool_accounts missing; requesting discovery");
+                                        info!(mint = %mint, pool = %pool_id, "pump_amm quote ok but ready pool_accounts missing; requesting discovery");
                                         match ctx
                                             .request_discovery_and_wait(
                                                 &mint.to_string(),
@@ -2747,7 +2752,7 @@ impl ExecutionContext {
                                                     .await
                                                     {
                                                         let accounts = cache
-                                                            .get_pump_amm_pool_accounts_by_base_mint(&mint);
+                                                            .get_ready_pump_amm_pool_accounts_by_base_mint(&mint);
                                                         if let Some(accounts) = accounts {
                                                             if accounts.len() >= 14 {
                                                                 let acct_strings: Vec<String> =
@@ -2861,7 +2866,7 @@ impl ExecutionContext {
                                                     if let Some(pool_id) = q.route.first().cloned()
                                                     {
                                                         let accounts = cache
-                                                            .get_pump_amm_pool_accounts_by_base_mint(&mint);
+                                                            .get_ready_pump_amm_pool_accounts_by_base_mint(&mint);
                                                         if let Some(accounts) = accounts {
                                                             if accounts.len() >= 14 {
                                                                 let acct_strings: Vec<String> =

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -950,6 +950,15 @@ impl LivePoolCache {
             .unwrap_or(false)
     }
 
+    /// Execution-engine / TX-building: PumpSwap `pool_accounts` usable only when explicitly
+    /// effectively Ready (see [`Self::get_ready_pump_amm_pool_accounts_by_base_mint`]) and
+    /// the v1 account list is complete (≥14). Bug #36: a non-empty cache hit is not `ready`.
+    pub fn pump_amm_swap_accounts_ready_by_base_mint(&self, base_mint: &Pubkey) -> bool {
+        self.get_ready_pump_amm_pool_accounts_by_base_mint(base_mint)
+            .map(|a| a.len() >= 14)
+            .unwrap_or(false)
+    }
+
     // ========================================================================
     // Stats
     // ========================================================================
@@ -1710,6 +1719,35 @@ mod tests {
                 .is_none(),
             "explicit Partial must not be upgraded to Ready by legacy heuristic"
         );
+        assert!(
+            !cache.pump_amm_swap_accounts_ready_by_base_mint(&base_mint),
+            "execution-engine gate: Partial must not count as swap-ready pool_accounts"
+        );
+    }
+
+    #[test]
+    fn test_pump_amm_swap_accounts_ready_matches_get_ready_gate() {
+        let cache = LivePoolCache::new();
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let pool_accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
+
+        cache.upsert(
+            pool_market,
+            make_pump_amm_state(
+                base_mint,
+                quote_mint,
+                Some(1_000_000_000),
+                Some(50_000_000_000),
+                pool_accounts.clone(),
+            ),
+            100,
+        );
+        assert!(cache.pump_amm_swap_accounts_ready_by_base_mint(&base_mint));
+
+        cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Observed);
+        assert!(!cache.pump_amm_swap_accounts_ready_by_base_mint(&base_mint));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns `execution-engine` PumpSwap cold-path flows with PR #41 readiness semantics: non-empty `pool_accounts` in the SLAVE cache is no longer treated as sufficient for building retry intents or liquidation route candidates.

## Changes

- All former uses of `get_pump_amm_pool_accounts_by_base_mint` in `execution_engine` for **usable** account lists now use `get_ready_pump_amm_pool_accounts_by_base_mint`.
- `wait_for_usable_pump_amm_cache_state` now polls until both quote-ready reserves **and** swap-accounts-ready (explicit effective `Ready` per `LivePoolCache`) are satisfied, so I-24d discovery/wait paths still apply when only `Observed`/`Partial` is merged.
- `LivePoolCache::pump_amm_swap_accounts_ready_by_base_mint` plus unit tests (Partial blocks; Observed vs legacy Ready).

## Invariants

- No new RPC; no hot-path changes; no schema/metadata transport changes.

## Tests

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test --features test_helpers`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b7ead73-9247-4280-bb30-c5efebb90e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b7ead73-9247-4280-bb30-c5efebb90e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

