### PR TITLE
Scope 4: Strategy gate — PumpSwap requires verified DexPoolAccounts

### DIFF
--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -1559,6 +1559,13 @@ impl ArbContext {
 // Intent Generation
 // ============================================================================
 
+/// PumpSwap (`pump_amm`) needs the full verified 14-account static set from
+/// `DexPoolAccounts` (market-data verification). Partial or observation-only
+/// cache rows must not produce swap intents.
+fn pump_amm_pool_accounts_valid_for_swap(pool_address: &str, accounts: &[String]) -> bool {
+    accounts.len() == 14 && accounts.first().map(|s| s.as_str()) == Some(pool_address)
+}
+
 /// Creates an arb intent from the opportunity.
 /// Returns None if required DexPoolAccounts are missing for ANY pool.
 ///
@@ -1567,6 +1574,8 @@ impl ArbContext {
 /// - DexPoolAccounts must be available for BOTH buy and sell pools
 /// - If Geyser hasn't delivered the data, RPC won't have it either (same validator)
 /// - Missing data = REJECT intent, don't try RPC fallback
+/// - For PumpSwap (`pump_amm`), cached accounts must be the full verified 14-account
+///   set matching `pool_address` (not merely "some" accounts from observation).
 fn create_arb_intent(ctx: &ArbContext, opp: &ArbOpportunity) -> Option<TradeIntent> {
     let config = ctx.config.read();
 
@@ -1602,6 +1611,31 @@ fn create_arb_intent(ctx: &ArbContext, opp: &ArbOpportunity) -> Option<TradeInte
     // Both pools have accounts - safe to proceed
     let buy_accts = buy_accounts.unwrap();
     let sell_accts = sell_accounts.unwrap();
+
+    if opp.buy_dex == "pump_amm"
+        && !pump_amm_pool_accounts_valid_for_swap(&opp.buy_pool, &buy_accts)
+    {
+        debug!(
+            buy_pool = %opp.buy_pool,
+            mint = %opp.base_mint,
+            buy_accounts_len = buy_accts.len(),
+            "Rejecting arb: buy pool has incomplete PumpSwap DexPoolAccounts (need 14 + accounts[0]==pool)"
+        );
+        ARB_REJECTED_MISSING_ACCOUNTS.fetch_add(1, Ordering::Relaxed);
+        return None;
+    }
+    if opp.sell_dex == "pump_amm"
+        && !pump_amm_pool_accounts_valid_for_swap(&opp.sell_pool, &sell_accts)
+    {
+        debug!(
+            sell_pool = %opp.sell_pool,
+            mint = %opp.base_mint,
+            sell_accounts_len = sell_accts.len(),
+            "Rejecting arb: sell pool has incomplete PumpSwap DexPoolAccounts (need 14 + accounts[0]==pool)"
+        );
+        ARB_REJECTED_MISSING_ACCOUNTS.fetch_add(1, Ordering::Relaxed);
+        return None;
+    }
 
     // Combine accounts: buy pool accounts + sell pool accounts
     // Format: buy accounts are prefixed with "buy:" and sell with "sell:" for disambiguation
@@ -2577,5 +2611,28 @@ async fn handle_market_event(ctx: &ArbContext, event: &MarketEvent) -> Option<Tr
         }
 
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod pump_amm_strategy_tests {
+    use super::pump_amm_pool_accounts_valid_for_swap;
+
+    #[test]
+    fn pump_amm_requires_14_accounts_with_pool_as_first() {
+        let pool = "PoolPubkey1111111111111111111111111111111111";
+        let mut ok: Vec<String> = (0..14).map(|i| format!("A{i}")).collect();
+        ok[0] = pool.to_string();
+        assert!(pump_amm_pool_accounts_valid_for_swap(pool, &ok));
+    }
+
+    #[test]
+    fn pump_amm_rejects_short_or_mismatched_accounts() {
+        let pool = "PoolPubkey1111111111111111111111111111111111";
+        let short: Vec<String> = (0..5).map(|i| format!("A{i}")).collect();
+        assert!(!pump_amm_pool_accounts_valid_for_swap(pool, &short));
+
+        let wrong_first: Vec<String> = (0..14).map(|i| format!("A{i}")).collect();
+        assert!(!pump_amm_pool_accounts_valid_for_swap(pool, &wrong_first));
     }
 }

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -2488,6 +2488,9 @@ impl MomentumContext {
             })
     }
 
+    /// Cache verified `DexPoolAccounts` from market-data for deterministic BUY IX building.
+    /// PoolCreated / trade observation alone does not populate this — partial or short rows
+    /// (especially for PumpSwap) are dropped so BUY cannot proceed on stale fragments.
     fn record_dex_pool_accounts(
         &self,
         dex: &str,
@@ -7480,6 +7483,110 @@ mod tests {
         let candidates = ctx.collect_timed_exit_reconcile_candidates(now);
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].mint, "mint");
+    }
+
+    /// PumpSwap BUY must not use partial account lists; `record_dex_pool_accounts` rejects them.
+    #[test]
+    fn pump_amm_dex_pool_accounts_short_list_not_cached() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+
+        let ctx = MomentumContext {
+            run_id: "test".to_string(),
+            config: parking_lot::RwLock::new(MomentumConfig::default()),
+            nats: None,
+            jsonl_writer,
+            intent_counter: std::sync::atomic::AtomicU64::new(0),
+            pool_first_seen: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            pending_dev_info: parking_lot::RwLock::new(HashMap::new()),
+            pending_pool_accounts: parking_lot::RwLock::new(HashMap::new()),
+            mint_infos: parking_lot::RwLock::new(HashMap::new()),
+            token_trackers: parking_lot::RwLock::new(HashMap::new()),
+            positions: parking_lot::RwLock::new(HashMap::new()),
+            pending_intents: parking_lot::RwLock::new(HashMap::new()),
+            mint_pools: parking_lot::RwLock::new(HashMap::new()),
+            live_pool_cache: LivePoolCache::new(),
+            position_kv: tokio::sync::OnceCell::new(),
+            orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            tokens_tracked: std::sync::atomic::AtomicU64::new(0),
+            tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
+            intents_generated: std::sync::atomic::AtomicU64::new(0),
+            exits_generated: std::sync::atomic::AtomicU64::new(0),
+            last_event_slot: std::sync::atomic::AtomicU64::new(0),
+            last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+        };
+
+        let mint = "TokenMint1111111111111111111111111111111111";
+        let pool = "PoolPubkey1111111111111111111111111111111111";
+        let wsol = "So11111111111111111111111111111111111111112";
+
+        ctx.token_trackers.write().insert(
+            mint.to_string(),
+            TokenTracker::new(mint, pool, "pump_amm", 1, 0),
+        );
+
+        let short: Vec<String> = (0..5).map(|i| format!("A{i}")).collect();
+        ctx.record_dex_pool_accounts("pump_amm", pool, mint, wsol, &short);
+
+        assert!(
+            ctx.try_get_dex_pool_accounts_for_mint(mint).is_none(),
+            "short PumpSwap account list must not satisfy BUY"
+        );
+        assert!(ctx.pending_pool_accounts.read().get(mint).is_none());
+    }
+
+    /// Full verified 14-account `DexPoolAccounts` row is required before BUY can resolve accounts.
+    #[test]
+    fn pump_amm_dex_pool_accounts_full_list_cached_for_buy() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+
+        let ctx = MomentumContext {
+            run_id: "test".to_string(),
+            config: parking_lot::RwLock::new(MomentumConfig::default()),
+            nats: None,
+            jsonl_writer,
+            intent_counter: std::sync::atomic::AtomicU64::new(0),
+            pool_first_seen: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            pending_dev_info: parking_lot::RwLock::new(HashMap::new()),
+            pending_pool_accounts: parking_lot::RwLock::new(HashMap::new()),
+            mint_infos: parking_lot::RwLock::new(HashMap::new()),
+            token_trackers: parking_lot::RwLock::new(HashMap::new()),
+            positions: parking_lot::RwLock::new(HashMap::new()),
+            pending_intents: parking_lot::RwLock::new(HashMap::new()),
+            mint_pools: parking_lot::RwLock::new(HashMap::new()),
+            live_pool_cache: LivePoolCache::new(),
+            position_kv: tokio::sync::OnceCell::new(),
+            orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            tokens_tracked: std::sync::atomic::AtomicU64::new(0),
+            tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
+            intents_generated: std::sync::atomic::AtomicU64::new(0),
+            exits_generated: std::sync::atomic::AtomicU64::new(0),
+            last_event_slot: std::sync::atomic::AtomicU64::new(0),
+            last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+        };
+
+        let mint = "TokenMint2222222222222222222222222222222222";
+        let pool = "PoolPubkey2222222222222222222222222222222222";
+        let wsol = "So11111111111111111111111111111111111111112";
+
+        ctx.token_trackers.write().insert(
+            mint.to_string(),
+            TokenTracker::new(mint, pool, "pump_amm", 1, 0),
+        );
+
+        let mut accounts: Vec<String> = (0..14).map(|i| format!("Acc{i:02}")).collect();
+        accounts[0] = pool.to_string();
+
+        ctx.record_dex_pool_accounts("pump_amm", pool, mint, wsol, &accounts);
+
+        let got = ctx
+            .try_get_dex_pool_accounts_for_mint(mint)
+            .expect("full verified PumpSwap account set should be available for BUY");
+        assert_eq!(got.len(), 14);
+        assert_eq!(got[0], pool);
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tightens **2-hop arbitrage** intent generation for PumpSwap (`pump_amm`): both legs must have the **full verified 14-account** static set with `accounts[0] == pool_address`, matching momentum BUY validation and avoiding partial/stale account rows.

Adds **regression tests**:
- `arb_strategy`: `pump_amm_pool_accounts_valid_for_swap` unit tests.
- `momentum_bot`: `record_dex_pool_accounts` rejects short lists; accepts full 14-account verified rows for BUY resolution.

## Notes

- No new RPC; strategy remains cache/event-driven.
- Multi-hop arb path unchanged (still empty `accounts` / separate code path).
- Documentation comments clarify that PoolCreated/trade observation alone does not satisfy PumpSwap BUY/arb account requirements.

## Checks

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test --features test_helpers`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-234d682f-d982-4ee8-9bed-5a1be4b7a456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-234d682f-d982-4ee8-9bed-5a1be4b7a456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

