### PR TITLE
PumpFun bonding curve: explicit DexPoolReadiness (Scope 6)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -1516,9 +1516,12 @@ async fn wait_for_usable_pump_amm_cache_state(
 /// After `EnsurePumpfunBondingCurve` + JetStream merge: wait until SLAVE cache reflects a change
 /// vs the pre-request snapshot (or new entry appears).
 ///
-/// When `require_explicit_ready` is true (cold-path recovery after RPC refresh), Bug #34/#36 require
-/// [`LivePoolCache::pumpfun_bonding_curve_explicitly_ready`]: a mere reserve snapshot change from a
-/// weak Geyser update is not sufficient.
+/// When `require_explicit_ready` is true (cold-path recovery after RPC refresh), we require both:
+/// - [`LivePoolCache::pumpfun_bonding_curve_explicitly_ready`] (JetStream carried `Ready`), **and**
+/// - a **fresh** bonding-curve snapshot vs `before` (proves this request’s merge, not a stale Ready).
+///
+/// Without the snapshot check, an older `Ready` + unchanged reserves could satisfy the wait
+/// immediately after `ControlResponse::Ok` (Bug #34).
 async fn wait_for_pumpfun_bonding_cache_refresh(
     cache: &LivePoolCache,
     bonding_curve: &Pubkey,
@@ -1529,19 +1532,16 @@ async fn wait_for_pumpfun_bonding_cache_refresh(
 ) -> bool {
     let deadline = Instant::now() + Duration::from_millis(timeout_ms);
     while Instant::now() < deadline {
+        let after = cache.pumpfun_bonding_curve_reserves_snapshot(bonding_curve);
         if require_explicit_ready {
             if cache.pumpfun_bonding_curve_explicitly_ready(bonding_curve)
-                && cache
-                    .pumpfun_bonding_curve_reserves_snapshot(bonding_curve)
-                    .is_some()
+                && after.is_some()
+                && after != before
             {
                 return true;
             }
-        } else {
-            let after = cache.pumpfun_bonding_curve_reserves_snapshot(bonding_curve);
-            if after != before {
-                return true;
-            }
+        } else if after != before {
+            return true;
         }
         tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
     }
@@ -10530,7 +10530,8 @@ mod execution_engine_tests {
         assert!(!ok);
     }
 
-    /// Bug #36 / #34: cold-path wait requires explicit Ready merge, not only reserve snapshot equality.
+    /// Bug #36 / #34: cold-path wait needs explicit Ready **and** a snapshot change vs pre-request
+    /// (proves fresh JetStream merge for this EnsurePumpfunBondingCurve request).
     #[test]
     fn wait_for_pumpfun_bonding_cache_refresh_require_ready_requires_explicit_merge() {
         let mint_str = "Mint444444444444444444444444444444444444444";
@@ -10570,7 +10571,36 @@ mod execution_engine_tests {
         );
 
         cache.merge_pumpfun_bonding_readiness(bonding_curve, DexPoolReadiness::Ready);
-        let ok_ready = rt.block_on(wait_for_pumpfun_bonding_cache_refresh(
+        let ok_stale_ready_same_snap = rt.block_on(wait_for_pumpfun_bonding_cache_refresh(
+            &cache,
+            &bonding_curve,
+            Some(snap),
+            80,
+            10,
+            true,
+        ));
+        assert!(
+            !ok_stale_ready_same_snap,
+            "pre-existing Ready + unchanged snapshot must not satisfy wait (no fresh merge proof)"
+        );
+
+        cache.upsert(
+            bonding_curve,
+            CachedPoolState::PumpFun(PumpFunState {
+                token_mint: mint,
+                bonding_curve,
+                associated_bonding_curve: Pubkey::new_unique(),
+                virtual_sol_reserves: snap.1,
+                virtual_token_reserves: snap.0 + 1,
+                real_sol_reserves: snap.3,
+                real_token_reserves: snap.2,
+                complete: snap.4,
+                creator: Pubkey::new_unique(),
+                cashback_enabled: snap.5,
+            }),
+            1,
+        );
+        let ok_fresh = rt.block_on(wait_for_pumpfun_bonding_cache_refresh(
             &cache,
             &bonding_curve,
             Some(snap),
@@ -10579,8 +10609,8 @@ mod execution_engine_tests {
             true,
         ));
         assert!(
-            ok_ready,
-            "explicit Ready + snapshot must satisfy cold-path wait"
+            ok_fresh,
+            "explicit Ready + snapshot change vs before must satisfy cold-path wait"
         );
     }
 

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -1515,18 +1515,33 @@ async fn wait_for_usable_pump_amm_cache_state(
 
 /// After `EnsurePumpfunBondingCurve` + JetStream merge: wait until SLAVE cache reflects a change
 /// vs the pre-request snapshot (or new entry appears).
+///
+/// When `require_explicit_ready` is true (cold-path recovery after RPC refresh), Bug #34/#36 require
+/// [`LivePoolCache::pumpfun_bonding_curve_explicitly_ready`]: a mere reserve snapshot change from a
+/// weak Geyser update is not sufficient.
 async fn wait_for_pumpfun_bonding_cache_refresh(
     cache: &LivePoolCache,
     bonding_curve: &Pubkey,
     before: Option<(u64, u64, u64, u64, bool, bool)>,
     timeout_ms: u64,
     poll_interval_ms: u64,
+    require_explicit_ready: bool,
 ) -> bool {
     let deadline = Instant::now() + Duration::from_millis(timeout_ms);
     while Instant::now() < deadline {
-        let after = cache.pumpfun_bonding_curve_reserves_snapshot(bonding_curve);
-        if after != before {
-            return true;
+        if require_explicit_ready {
+            if cache.pumpfun_bonding_curve_explicitly_ready(bonding_curve)
+                && cache
+                    .pumpfun_bonding_curve_reserves_snapshot(bonding_curve)
+                    .is_some()
+            {
+                return true;
+            }
+        } else {
+            let after = cache.pumpfun_bonding_curve_reserves_snapshot(bonding_curve);
+            if after != before {
+                return true;
+            }
         }
         tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
     }
@@ -8454,6 +8469,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                             before_snap,
                             DISCOVERY_CACHE_WAIT_TIMEOUT_MS,
                             DISCOVERY_CACHE_POLL_INTERVAL_MS,
+                            true,
                         )
                         .await
                         {
@@ -10252,8 +10268,8 @@ mod execution_engine_tests {
     };
     use ironcrab::execution::live_pool_cache::{CachedPoolState, LivePoolCache, PumpFunState};
     use ironcrab::ipc::{
-        ControlResponse, ControlResponseStatus, ExplicitAmount, IntentOrigin, IntentTier,
-        TradeIntent, TradeResources, TradeSide, TradingRegime,
+        ControlResponse, ControlResponseStatus, DexPoolReadiness, ExplicitAmount, IntentOrigin,
+        IntentTier, TradeIntent, TradeResources, TradeSide, TradingRegime,
     };
     use ironcrab::solana::dex::pumpfun::PumpFunDex;
     use parking_lot::Mutex as ParkingMutex;
@@ -10470,6 +10486,7 @@ mod execution_engine_tests {
             Some(before),
             500,
             5,
+            false,
         ));
         assert!(
             ok,
@@ -10508,8 +10525,63 @@ mod execution_engine_tests {
             Some(snap),
             80,
             10,
+            false,
         ));
         assert!(!ok);
+    }
+
+    /// Bug #36 / #34: cold-path wait requires explicit Ready merge, not only reserve snapshot equality.
+    #[test]
+    fn wait_for_pumpfun_bonding_cache_refresh_require_ready_requires_explicit_merge() {
+        let mint_str = "Mint444444444444444444444444444444444444444";
+        let mint = Pubkey::from_str(mint_str).unwrap();
+        let (bonding_curve, _) = PumpFunDex::derive_bonding_curve_static(&mint);
+        let snap = (50u64, 60u64, 1u64, 2u64, false, true);
+        let cache = LivePoolCache::new();
+        cache.upsert(
+            bonding_curve,
+            CachedPoolState::PumpFun(PumpFunState {
+                token_mint: mint,
+                bonding_curve,
+                associated_bonding_curve: Pubkey::new_unique(),
+                virtual_sol_reserves: snap.1,
+                virtual_token_reserves: snap.0,
+                real_sol_reserves: snap.3,
+                real_token_reserves: snap.2,
+                complete: snap.4,
+                creator: Pubkey::new_unique(),
+                cashback_enabled: snap.5,
+            }),
+            0,
+        );
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let ok_no_ready = rt.block_on(wait_for_pumpfun_bonding_cache_refresh(
+            &cache,
+            &bonding_curve,
+            Some(snap),
+            60,
+            10,
+            true,
+        ));
+        assert!(
+            !ok_no_ready,
+            "without explicit Ready merge, must not succeed even when snapshot matches"
+        );
+
+        cache.merge_pumpfun_bonding_readiness(bonding_curve, DexPoolReadiness::Ready);
+        let ok_ready = rt.block_on(wait_for_pumpfun_bonding_cache_refresh(
+            &cache,
+            &bonding_curve,
+            Some(snap),
+            200,
+            5,
+            true,
+        ));
+        assert!(
+            ok_ready,
+            "explicit Ready + snapshot must satisfy cold-path wait"
+        );
     }
 
     /// I-24d: Verifies that ControlResponse status maps correctly to DiscoveryRequestOutcome.

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2086,6 +2086,10 @@ async fn handle_ensure_pumpfun_bonding_curve(
             state.cashback_enabled.to_string(),
         );
         pool_update.metadata = Some(meta);
+        // Cold-path RPC refresh: explicit Ready for JetStream / SLAVE (Bug #36).
+        pool_update.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+        ctx.live_pool_cache
+            .merge_pumpfun_bonding_readiness(bonding_curve, DexPoolReadiness::Ready);
         let subject = pool_subject(&bonding_curve_str);
         match nats.jetstream_publish(&subject, &pool_update).await {
             Ok(true) => {
@@ -3383,6 +3387,8 @@ async fn run_geyser_loop(
                         // without needing RPC fallbacks.
                         match &cached_state {
                             CachedPoolState::PumpFun(s) => {
+                                // SLAVE minimal state uses quote_mint for SOL side; must not be default.
+                                pool_update.quote_mint = NATIVE_SOL_MINT.to_string();
                                 // Always propagate real_reserves + complete for SELL validation
                                 // in execution-engine's SLAVE cache.
                                 let mut meta = std::collections::HashMap::new();
@@ -3395,6 +3401,12 @@ async fn run_geyser_loop(
                                 meta.insert("real_sol_reserves".to_string(), s.real_sol_reserves.to_string());
                                 meta.insert("cashback_enabled".to_string(), s.cashback_enabled.to_string());
                                 pool_update.metadata = Some(meta);
+                                // Geyser-fed bonding curve: observation / partial only — not cold-path verified Ready.
+                                pool_update.set_dex_readiness_in_metadata(DexPoolReadiness::Partial);
+                                ctx.live_pool_cache.merge_pumpfun_bonding_readiness(
+                                    account_update.pubkey,
+                                    DexPoolReadiness::Partial,
+                                );
 
                                 // === BondingCurveProgress event for momentum-bot exit signal ===
                                 // PumpFun initial real_token_reserves = 793_100_000_000_000
@@ -3677,6 +3689,12 @@ async fn run_geyser_loop(
                             }
                         }
                         pool_update.metadata = Some(meta);
+                        // Fallback path: weaker than full Geyser parse — observed only.
+                        pool_update.set_dex_readiness_in_metadata(DexPoolReadiness::Observed);
+                        ctx.live_pool_cache.merge_pumpfun_bonding_readiness(
+                            *pool_address,
+                            DexPoolReadiness::Observed,
+                        );
 
                         if let Some(ref nats) = ctx.nats {
                             let subject = pool_subject(&pool_str);

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -310,6 +310,10 @@ pub struct LivePoolCache {
     /// Monotonic: [`DexPoolReadiness::merge`] on update; never stored inside `PumpAmmState` to avoid
     /// touching every constructor site.
     pool_accounts_readiness_by_market: DashMap<Pubkey, DexPoolReadiness>,
+
+    /// PumpFun bonding-curve account → explicit [`DexPoolReadiness`] from JetStream / MASTER (Bug #36).
+    /// Monotonic merge; not implied by [`Self::contains`] or non-empty bonding-curve state.
+    pumpfun_bonding_readiness_by_curve: DashMap<Pubkey, DexPoolReadiness>,
 }
 
 /// Which vault position (A/B or X/Y or 0/1) this vault represents
@@ -340,6 +344,7 @@ impl LivePoolCache {
             vault_update_tx: Mutex::new(None),
             last_notified_vault_count: AtomicU64::new(0),
             pool_accounts_readiness_by_market: DashMap::new(),
+            pumpfun_bonding_readiness_by_curve: DashMap::new(),
         }
     }
 
@@ -895,6 +900,28 @@ impl LivePoolCache {
             .entry(pool_market)
             .and_modify(|stored| *stored = stored.merge(incoming))
             .or_insert(incoming);
+    }
+
+    /// Merge PumpFun bonding-curve readiness for `bonding_curve` (monotonic — never downgrade).
+    pub fn merge_pumpfun_bonding_readiness(
+        &self,
+        bonding_curve: Pubkey,
+        incoming: DexPoolReadiness,
+    ) {
+        self.pumpfun_bonding_readiness_by_curve
+            .entry(bonding_curve)
+            .and_modify(|stored| *stored = stored.merge(incoming))
+            .or_insert(incoming);
+    }
+
+    /// `true` only after explicit JetStream / control-path merge recorded [`DexPoolReadiness::Ready`]
+    /// for this bonding curve (Bug #36: cache hit alone is not ready).
+    #[must_use]
+    pub fn pumpfun_bonding_curve_explicitly_ready(&self, bonding_curve: &Pubkey) -> bool {
+        self.pumpfun_bonding_readiness_by_curve
+            .get(bonding_curve)
+            .map(|r| *r == DexPoolReadiness::Ready)
+            .unwrap_or(false)
     }
 
     /// Hot-path readiness for PumpSwap `pool_accounts`: explicit JetStream merge wins; if **no** entry

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -298,6 +298,12 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         update.effective_dex_readiness(),
                     );
                 }
+                if update.dex == "pumpfun" {
+                    cache.merge_pumpfun_bonding_readiness(
+                        pool_addr,
+                        update.effective_dex_readiness(),
+                    );
+                }
                 // P3 #13: Propagate base_decimals and quote_decimals to SLAVE cache
                 apply_decimals_from_metadata(cache, update);
                 return true;
@@ -371,6 +377,9 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         addr,
                         update.effective_dex_readiness(),
                     );
+                }
+                if update.dex == "pumpfun" {
+                    cache.merge_pumpfun_bonding_readiness(addr, update.effective_dex_readiness());
                 }
                 // P3 #13: Apply decimals from metadata when present (e.g. BalanceUpdated with metadata)
                 apply_decimals_from_metadata(cache, update);
@@ -695,6 +704,105 @@ mod tests {
                 .get_ready_pump_amm_pool_accounts_by_base_mint(&base_mint)
                 .is_some(),
             "merge must not downgrade Ready to Observed"
+        );
+    }
+
+    /// Bug #36 (PumpFun): Geyser / partial JetStream must not imply explicit Ready for bonding curve.
+    #[test]
+    fn test_pumpfun_partial_jetstream_not_explicit_ready() {
+        let cache = LivePoolCache::new();
+        let pool_addr = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+
+        let mut update = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool_addr.to_string(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1_000_000,
+            100_000_000,
+            Some(0),
+            1,
+        );
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("creator".to_string(), Pubkey::new_unique().to_string());
+        meta.insert(
+            "associated_bonding_curve".to_string(),
+            Pubkey::new_unique().to_string(),
+        );
+        meta.insert("complete".to_string(), "false".to_string());
+        meta.insert("real_token_reserves".to_string(), "100".to_string());
+        meta.insert("real_sol_reserves".to_string(), "200".to_string());
+        meta.insert("cashback_enabled".to_string(), "false".to_string());
+        update.metadata = Some(meta);
+        update.set_dex_readiness_in_metadata(DexPoolReadiness::Partial);
+
+        assert!(apply_pool_cache_update(&cache, &update));
+        assert!(
+            !cache.pumpfun_bonding_curve_explicitly_ready(&pool_addr),
+            "Partial Geyser path must not set explicit Ready"
+        );
+    }
+
+    /// Bug #36: explicit Ready from cold-path style message; merge Observed must not downgrade.
+    #[test]
+    fn test_pumpfun_readiness_merge_ready_then_observed_stays_ready() {
+        let cache = LivePoolCache::new();
+        let pool_addr = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+
+        let mut ready_up = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool_addr.to_string(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1,
+            2,
+            Some(0),
+            1,
+        );
+        let mut m = std::collections::HashMap::new();
+        m.insert("creator".to_string(), Pubkey::new_unique().to_string());
+        m.insert(
+            "associated_bonding_curve".to_string(),
+            Pubkey::new_unique().to_string(),
+        );
+        m.insert("complete".to_string(), "false".to_string());
+        m.insert("real_token_reserves".to_string(), "1".to_string());
+        m.insert("real_sol_reserves".to_string(), "2".to_string());
+        m.insert("cashback_enabled".to_string(), "false".to_string());
+        ready_up.metadata = Some(m.clone());
+        ready_up.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+        assert!(apply_pool_cache_update(&cache, &ready_up));
+        assert!(cache.pumpfun_bonding_curve_explicitly_ready(&pool_addr));
+
+        let mut weak = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool_addr.to_string(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1,
+            2,
+            Some(0),
+            2,
+        );
+        weak.metadata = Some(m);
+        weak.set_dex_readiness_in_metadata(DexPoolReadiness::Observed);
+        assert!(apply_pool_cache_update(&cache, &weak));
+        assert!(
+            cache.pumpfun_bonding_curve_explicitly_ready(&pool_addr),
+            "merge must not downgrade Ready to Observed for PumpFun"
         );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns PumpFun bonding-curve cache/JetStream with explicit `DexPoolReadiness` semantics (Bug #36): Geyser and fallback paths no longer imply `Ready`; cold-path `EnsurePumpfunBondingCurve` RPC refresh publishes `Ready` and merges monotonically into MASTER/SLAVE.

**Follow-up:** Cold-path `wait_for_pumpfun_bonding_cache_refresh(..., require_explicit_ready=true)` now requires **both** explicit `Ready` **and** a bonding-curve snapshot **change vs `before`** (Bug #34): a stale Ready from a prior merge cannot satisfy the wait immediately after `ControlResponse::Ok`.

## Changes

- **market-data**: Tag `PoolCacheUpdate` for PumpFun — Geyser full parse → `Partial` + MASTER merge; P2#7 BondingCurveUpdate fallback → `Observed`; `EnsurePumpfunBondingCurve` after RPC → `Ready` + MASTER merge. Geyser publish now sets `quote_mint` to native SOL (was default pubkey in struct).
- **LivePoolCache / pool_cache_sync**: New `pumpfun_bonding_readiness_by_curve` + `merge_pumpfun_bonding_readiness` / `pumpfun_bonding_curve_explicitly_ready`; SLAVE applies readiness merge on `pumpfun` updates like PumpSwap.
- **execution-engine**: `wait_for_pumpfun_bonding_cache_refresh` for cold-path recovery: explicit Ready **and** `after != before` (fresh merge proof).

## Tests

- `pool_cache_sync`: partial JetStream does not mark explicit ready; Ready then Observed merge does not downgrade.
- `execution_engine`: cold-path wait requires explicit Ready; pre-existing Ready + unchanged snapshot does not pass; Ready + snapshot change passes.

## STOP-CHECK

- No Hot-Path RPC added.
- No eval-repo changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d2ae7df-d078-4c98-a355-e0d75a957441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d2ae7df-d078-4c98-a355-e0d75a957441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

