### PR TITLE
Scope 7: Mint-level ready gate (base_mint_has_any_ready_pool)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1175,8 +1175,9 @@ async fn publish_wallet_snapshot(
         warn!(error = %e, "Failed to write WalletSnapshotComplete (bootstrap) to JSONL");
     }
 
-    // 4b) Cold-path inventory: count wallet-held mints with explicit multi-DEX ready coverage
-    // (PumpSwap + PumpFun bonding today). Not derived from snapshot completeness alone.
+    // 4b) Cold-path inventory: count wallet-held mints where LivePoolCache reports explicit
+    // readiness only — PumpSwap: merge_pump_amm_pool_accounts_readiness(Ready); PumpFun:
+    // merge_pumpfun_bonding_readiness(Ready). No legacy PumpSwap heuristic / snapshot completeness.
     let mut wallet_mints_explicit_ready_count: usize = 0;
     for mint_str in &mints_in_wallet {
         if let Ok(pk) = Pubkey::from_str(mint_str) {
@@ -1184,7 +1185,7 @@ async fn publish_wallet_snapshot(
                 wallet_mints_explicit_ready_count += 1;
                 debug!(
                     mint = %mint_str,
-                    "wallet mint: explicit ready pool present (PumpSwap and/or PumpFun bonding)"
+                    "wallet mint: explicit DexPoolReadiness::Ready (PumpSwap map and/or PumpFun bonding)"
                 );
             }
         }
@@ -1194,7 +1195,7 @@ async fn publish_wallet_snapshot(
             wallet = %wallet_str,
             wallet_mints_explicit_ready_count,
             nonzero_wallet_mints = mints_in_wallet.len(),
-            "Wallet snapshot: mint-level explicit ready coverage (DEX slices with readiness model; not cache-presence)"
+            "Wallet snapshot: mints with explicit Ready merge (PumpSwap/PumpFun); excludes legacy PumpSwap effective-ready"
         );
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1175,6 +1175,29 @@ async fn publish_wallet_snapshot(
         warn!(error = %e, "Failed to write WalletSnapshotComplete (bootstrap) to JSONL");
     }
 
+    // 4b) Cold-path inventory: count wallet-held mints with explicit multi-DEX ready coverage
+    // (PumpSwap + PumpFun bonding today). Not derived from snapshot completeness alone.
+    let mut wallet_mints_explicit_ready_count: usize = 0;
+    for mint_str in &mints_in_wallet {
+        if let Ok(pk) = Pubkey::from_str(mint_str) {
+            if ctx.live_pool_cache.base_mint_has_any_ready_pool(&pk) {
+                wallet_mints_explicit_ready_count += 1;
+                debug!(
+                    mint = %mint_str,
+                    "wallet mint: explicit ready pool present (PumpSwap and/or PumpFun bonding)"
+                );
+            }
+        }
+    }
+    if !mints_in_wallet.is_empty() {
+        info!(
+            wallet = %wallet_str,
+            wallet_mints_explicit_ready_count,
+            nonzero_wallet_mints = mints_in_wallet.len(),
+            "Wallet snapshot: mint-level explicit ready coverage (DEX slices with readiness model; not cache-presence)"
+        );
+    }
+
     // 5) Publish SOL + WSOL as WalletBalanceSnapshot to JetStream (SSOT for bot state).
     //    execution-engine/WsolManager bootstrap from JetStream on startup.
     if !is_periodic {

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -986,6 +986,39 @@ impl LivePoolCache {
             .unwrap_or(false)
     }
 
+    /// DEX-agnostic mint-level gate: does this **base mint** currently have **at least one**
+    /// pool that is explicitly ready for the wallet-relevant slices we model today?
+    ///
+    /// This does **not** infer readiness from mint presence, `WalletSnapshotComplete`,
+    /// `tracked_mints`, or a mere cache hit (Bug #36).
+    ///
+    /// **Signals consumed today:**
+    /// - PumpSwap: [`Self::pump_amm_swap_accounts_ready_by_base_mint`] (explicit
+    ///   [`DexPoolReadiness::Ready`] merge and/or legacy authoritative PumpAmm state inside
+    ///   [`Self::pump_amm_effective_ready_for_cache_first_accounts`]).
+    /// - PumpFun bonding curve: [`Self::pumpfun_bonding_curve_explicitly_ready`] on the
+    ///   bonding-curve account for a cached [`PumpFunState`] whose `token_mint` equals `base_mint`.
+    ///
+    /// **Conservative:** pools on Raydium, Orca, Meteora, etc. are **not** treated as ready here
+    /// until they have an explicit readiness path — returns `false` unless PumpSwap or PumpFun
+    /// conditions above hold.
+    #[must_use]
+    pub fn base_mint_has_any_ready_pool(&self, base_mint: &Pubkey) -> bool {
+        if self.pump_amm_swap_accounts_ready_by_base_mint(base_mint) {
+            return true;
+        }
+        for entry in self.pools.iter() {
+            if let CachedPoolState::PumpFun(s) = &entry.value().state {
+                if s.token_mint == *base_mint
+                    && self.pumpfun_bonding_curve_explicitly_ready(entry.key())
+                {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     // ========================================================================
     // Stats
     // ========================================================================
@@ -1997,6 +2030,164 @@ mod tests {
         } else {
             panic!("Expected PumpFun state");
         }
+    }
+
+    fn make_pumpfun_state_for_curve(token_mint: Pubkey, bonding_curve: Pubkey) -> CachedPoolState {
+        CachedPoolState::PumpFun(PumpFunState {
+            token_mint,
+            bonding_curve,
+            associated_bonding_curve: Pubkey::new_unique(),
+            virtual_sol_reserves: 30_000_000_000,
+            virtual_token_reserves: 1_000_000_000_000_000,
+            real_sol_reserves: 0,
+            real_token_reserves: 793_100_000_000_000,
+            complete: false,
+            creator: Pubkey::new_unique(),
+            cashback_enabled: false,
+        })
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_pumpswap_ready() {
+        let cache = LivePoolCache::new();
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let pool_accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
+
+        cache.upsert(
+            pool_market,
+            make_pump_amm_state(
+                base_mint,
+                quote_mint,
+                Some(1_000_000_000),
+                Some(50_000_000_000),
+                pool_accounts,
+            ),
+            100,
+        );
+        cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Ready);
+
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_pumpfun_bonding_ready() {
+        let cache = LivePoolCache::new();
+        let bonding_curve = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+
+        cache.upsert(
+            bonding_curve,
+            make_pumpfun_state_for_curve(base_mint, bonding_curve),
+            100,
+        );
+        cache.merge_pumpfun_bonding_readiness(bonding_curve, DexPoolReadiness::Ready);
+
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_false_when_pumpswap_observed_only() {
+        let cache = LivePoolCache::new();
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let pool_accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
+
+        cache.upsert(
+            pool_market,
+            make_pump_amm_state(
+                base_mint,
+                quote_mint,
+                Some(1_000_000_000),
+                Some(50_000_000_000),
+                pool_accounts,
+            ),
+            100,
+        );
+        cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Observed);
+
+        assert!(!cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_false_when_pumpswap_partial_only() {
+        let cache = LivePoolCache::new();
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let pool_accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
+
+        cache.upsert(
+            pool_market,
+            make_pump_amm_state(
+                base_mint,
+                quote_mint,
+                Some(1_000_000_000),
+                Some(50_000_000_000),
+                pool_accounts,
+            ),
+            100,
+        );
+        cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Partial);
+
+        assert!(!cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_false_raydium_only_in_cache() {
+        let cache = LivePoolCache::new();
+        let base_mint = Pubkey::new_unique();
+        let other = Pubkey::new_unique();
+
+        cache.upsert(
+            Pubkey::new_unique(),
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: other,
+                token_0_vault: Pubkey::new_unique(),
+                token_1_vault: Pubkey::new_unique(),
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            100,
+        );
+
+        assert!(!cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_pumpfun_cached_without_explicit_ready() {
+        let cache = LivePoolCache::new();
+        let bonding_curve = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+
+        cache.upsert(
+            bonding_curve,
+            make_pumpfun_state_for_curve(base_mint, bonding_curve),
+            100,
+        );
+
+        assert!(!cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_pumpfun_merge_monotone() {
+        let cache = LivePoolCache::new();
+        let bonding_curve = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+
+        cache.upsert(
+            bonding_curve,
+            make_pumpfun_state_for_curve(base_mint, bonding_curve),
+            100,
+        );
+        cache.merge_pumpfun_bonding_readiness(bonding_curve, DexPoolReadiness::Ready);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+
+        cache.merge_pumpfun_bonding_readiness(bonding_curve, DexPoolReadiness::Observed);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
     }
 
     #[test]

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -986,6 +986,35 @@ impl LivePoolCache {
             .unwrap_or(false)
     }
 
+    /// PumpSwap only, for mint-level **explicit** readiness: a pool for `base_mint` counts iff
+    /// [`Self::pool_accounts_readiness_by_market`] has [`DexPoolReadiness::Ready`] for that
+    /// pool market **and** `pool_accounts` is non-empty with ≥14 entries (swap v1 layout).
+    ///
+    /// Does **not** use the legacy fallback inside [`Self::pump_amm_effective_ready_for_cache_first_accounts`]
+    /// (no readiness-map entry but 14+ accounts + reserves). That path remains for
+    /// [`Self::get_ready_pump_amm_pool_accounts_by_base_mint`] / execution; this helper is
+    /// intentionally narrower for [`Self::base_mint_has_any_ready_pool`].
+    #[must_use]
+    pub fn base_mint_has_explicit_pump_amm_ready_pool(&self, base_mint: &Pubkey) -> bool {
+        for entry in self.pools.iter() {
+            if let CachedPoolState::PumpAmm(ref s) = entry.value().state {
+                if s.base_mint != *base_mint {
+                    continue;
+                }
+                let pool_market = entry.key();
+                let explicit_ready = self
+                    .pool_accounts_readiness_by_market
+                    .get(pool_market)
+                    .map(|r| *r == DexPoolReadiness::Ready)
+                    .unwrap_or(false);
+                if explicit_ready && !s.pool_accounts.is_empty() && s.pool_accounts.len() >= 14 {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     /// DEX-agnostic mint-level gate: does this **base mint** currently have **at least one**
     /// pool that is explicitly ready for the wallet-relevant slices we model today?
     ///
@@ -993,9 +1022,9 @@ impl LivePoolCache {
     /// `tracked_mints`, or a mere cache hit (Bug #36).
     ///
     /// **Signals consumed today:**
-    /// - PumpSwap: [`Self::pump_amm_swap_accounts_ready_by_base_mint`] (explicit
-    ///   [`DexPoolReadiness::Ready`] merge and/or legacy authoritative PumpAmm state inside
-    ///   [`Self::pump_amm_effective_ready_for_cache_first_accounts`]).
+    /// - PumpSwap: [`Self::base_mint_has_explicit_pump_amm_ready_pool`] only — explicit
+    ///   [`DexPoolReadiness::Ready`] in [`Self::pool_accounts_readiness_by_market`], no legacy
+    ///   effective-ready fallback (see [`Self::pump_amm_effective_ready_for_cache_first_accounts`]).
     /// - PumpFun bonding curve: [`Self::pumpfun_bonding_curve_explicitly_ready`] on the
     ///   bonding-curve account for a cached [`PumpFunState`] whose `token_mint` equals `base_mint`.
     ///
@@ -1004,7 +1033,7 @@ impl LivePoolCache {
     /// conditions above hold.
     #[must_use]
     pub fn base_mint_has_any_ready_pool(&self, base_mint: &Pubkey) -> bool {
-        if self.pump_amm_swap_accounts_ready_by_base_mint(base_mint) {
+        if self.base_mint_has_explicit_pump_amm_ready_pool(base_mint) {
             return true;
         }
         for entry in self.pools.iter() {
@@ -2069,6 +2098,45 @@ mod tests {
         cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Ready);
 
         assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+        assert!(cache.base_mint_has_explicit_pump_amm_ready_pool(&base_mint));
+    }
+
+    /// Legacy authoritative PumpAmm upsert (no `pool_accounts_readiness_by_market` entry) is
+    /// swap-ready via [`Self::pump_amm_swap_accounts_ready_by_base_mint`] but must **not**
+    /// satisfy [`Self::base_mint_has_any_ready_pool`] (explicit Ready merge only).
+    #[test]
+    fn test_base_mint_has_any_ready_pool_pumpswap_legacy_without_explicit_merge_is_false() {
+        let cache = LivePoolCache::new();
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let pool_accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
+
+        cache.upsert(
+            pool_market,
+            make_pump_amm_state(
+                base_mint,
+                quote_mint,
+                Some(1_000_000_000),
+                Some(50_000_000_000),
+                pool_accounts,
+            ),
+            100,
+        );
+
+        assert!(
+            cache.pump_amm_swap_accounts_ready_by_base_mint(&base_mint),
+            "legacy path still counts as swap-ready for execution-engine"
+        );
+        assert!(
+            !cache.base_mint_has_explicit_pump_amm_ready_pool(&base_mint),
+            "mint-level gate: no explicit Ready merge"
+        );
+        assert!(!cache.base_mint_has_any_ready_pool(&base_mint));
+
+        cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Ready);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+        assert!(cache.base_mint_has_explicit_pump_amm_ready_pool(&base_mint));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ziel

Erster gemeinsamer, DEX-übergreifend benannter Helper: **Hat ein Base-Mint mindestens einen explizit `ready`-Pool?** — nur auf Basis bereits modellierter Ready-Signale (PumpSwap + PumpFun Bonding Curve), ohne Cache-/Wallet-Heuristik.

## Änderungen

- **`LivePoolCache::base_mint_has_any_ready_pool`** in `src/execution/live_pool_cache.rs`
  - **PumpSwap (fix):** nutzt **`LivePoolCache::base_mint_has_explicit_pump_amm_ready_pool`** — nur wenn `pool_accounts_readiness_by_market[pool] == DexPoolReadiness::Ready` **und** `pool_accounts` nicht leer und `>= 14`. **Kein** Legacy-Fallback aus `pump_amm_effective_ready_for_cache_first_accounts` (der bleibt für `get_ready_pump_amm_pool_accounts_by_base_mint` / Execution).
  - **PumpFun:** unverändert — `pumpfun_bonding_curve_explicitly_ready` auf Bonding-Curve-Key
  - Andere DEXe: konservativ `false`
- **Konsument (Cold/Bootstrap):** Nach `WalletSnapshotComplete` — Log-Texte spiegeln „nur explizite Ready-Merges“, keine Legacy-PumpSwap-effective-ready
- **Tests:** u.a. `test_base_mint_has_any_ready_pool_pumpswap_legacy_without_explicit_merge_is_false`

## Prüfungen

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`

## STOP-CHECK (Kurz)

Kein neuer RPC; nur Cache-Reads; Logging im Wallet-Bootstrap (Cold Path).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6988c22d-31fc-4495-b497-f3cdf396470e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6988c22d-31fc-4495-b497-f3cdf396470e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

