### PR TITLE
DEX cache readiness: Raydium CPMM explicit Ready slice

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -113,6 +113,27 @@ fn raydium_cpmm_vaults_for_pool_cache_update(s: &RaydiumCpmmState) -> String {
     format!("{first_vault},{second_vault}")
 }
 
+/// SOL-aware readiness from pool reserves (single source for BalanceUpdated vs PoolDiscovered paths).
+fn raydium_cpmm_readiness_from_cached_state(s: &RaydiumCpmmState) -> DexPoolReadiness {
+    let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+    let r0 = s.reserve_0.unwrap_or(0);
+    let r1 = s.reserve_1.unwrap_or(0);
+    let (base_side_liq, quote_side_liq) = if s.token_1_mint == sol {
+        (r0 > 0, r1 > 0)
+    } else if s.token_0_mint == sol {
+        (r1 > 0, r0 > 0)
+    } else {
+        (r0 > 0, r1 > 0)
+    };
+    if base_side_liq && quote_side_liq {
+        DexPoolReadiness::Ready
+    } else if r0 > 0 || r1 > 0 {
+        DexPoolReadiness::Partial
+    } else {
+        DexPoolReadiness::Observed
+    }
+}
+
 /// Market data configuration (hot-reloadable via NATS)
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
@@ -3247,24 +3268,8 @@ async fn run_geyser_loop(
                                                     raydium_cpmm_vaults_for_pool_cache_update(s),
                                                 );
                                                 balance_update.metadata = Some(meta);
-                                                let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
-                                                let r0 = s.reserve_0.unwrap_or(0);
-                                                let r1 = s.reserve_1.unwrap_or(0);
-                                                let (base_side_liq, quote_side_liq) =
-                                                    if s.token_1_mint == sol {
-                                                        (r0 > 0, r1 > 0)
-                                                    } else if s.token_0_mint == sol {
-                                                        (r1 > 0, r0 > 0)
-                                                    } else {
-                                                        (r0 > 0, r1 > 0)
-                                                    };
-                                                let readiness = if base_side_liq && quote_side_liq {
-                                                    DexPoolReadiness::Ready
-                                                } else if r0 > 0 || r1 > 0 {
-                                                    DexPoolReadiness::Partial
-                                                } else {
-                                                    DexPoolReadiness::Observed
-                                                };
+                                                let readiness =
+                                                    raydium_cpmm_readiness_from_cached_state(s);
                                                 balance_update.set_dex_readiness_in_metadata(readiness);
                                                 ctx.live_pool_cache.merge_raydium_cpmm_pool_readiness(
                                                     vault_info.pool_address,
@@ -3798,23 +3803,7 @@ async fn run_geyser_loop(
                                     raydium_cpmm_vaults_for_pool_cache_update(s),
                                 );
                                 pool_update.metadata = Some(meta);
-                                let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
-                                let r0 = s.reserve_0.unwrap_or(0);
-                                let r1 = s.reserve_1.unwrap_or(0);
-                                let (base_side_liq, quote_side_liq) = if s.token_1_mint == sol {
-                                    (r0 > 0, r1 > 0)
-                                } else if s.token_0_mint == sol {
-                                    (r1 > 0, r0 > 0)
-                                } else {
-                                    (r0 > 0, r1 > 0)
-                                };
-                                let readiness = if base_side_liq && quote_side_liq {
-                                    DexPoolReadiness::Ready
-                                } else if r0 > 0 || r1 > 0 {
-                                    DexPoolReadiness::Partial
-                                } else {
-                                    DexPoolReadiness::Observed
-                                };
+                                let readiness = raydium_cpmm_readiness_from_cached_state(s);
                                 pool_update.set_dex_readiness_in_metadata(readiness);
                                 ctx.live_pool_cache.merge_raydium_cpmm_pool_readiness(
                                     account_update.pubkey,

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3238,13 +3238,13 @@ async fn run_geyser_loop(
                                             account_update.slot,
                                         );
                                         if vault_info.dex == "raydium_cpmm" {
-                                            if let Some(CachedPoolState::RaydiumCpmm(s)) =
+                                            if let Some(CachedPoolState::RaydiumCpmm(ref s)) =
                                                 ctx.live_pool_cache.get(&vault_info.pool_address)
                                             {
                                                 let mut meta = std::collections::HashMap::new();
                                                 meta.insert(
                                                     POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY.to_string(),
-                                                    raydium_cpmm_vaults_for_pool_cache_update(&s),
+                                                    raydium_cpmm_vaults_for_pool_cache_update(s),
                                                 );
                                                 balance_update.metadata = Some(meta);
                                                 let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -33,7 +33,7 @@ use ironcrab::ipc::{
     BinData, ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, ControlRequest,
     ControlRequestKind, ControlResponse, ControlResponseStatus, DexPoolReadiness, ExecutionResult,
     ExecutionStatus, IntentTier, MarketEvent, MarketEventKind, PoolCacheUpdate,
-    PriorityFeePercentiles, NATIVE_SOL_MINT,
+    PriorityFeePercentiles, NATIVE_SOL_MINT, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use ironcrab::metrics::{
     serve_metrics, set_readiness_control_sub_active, set_readiness_mode,
@@ -3209,7 +3209,7 @@ async fn run_geyser_loop(
 
                                     // Publish PoolCacheUpdate::BalanceUpdated to JetStream (persistent state)
                                     if let Some(ref nats) = ctx.nats {
-                                        let balance_update = PoolCacheUpdate::new_balance_updated(
+                                        let mut balance_update = PoolCacheUpdate::new_balance_updated(
                                             "market-data",
                                             BUILD_VERSION,
                                             run_id,
@@ -3221,6 +3221,41 @@ async fn run_geyser_loop(
                                             final_quote,
                                             account_update.slot,
                                         );
+                                        if vault_info.dex == "raydium_cpmm" {
+                                            if let Some(CachedPoolState::RaydiumCpmm(s)) =
+                                                ctx.live_pool_cache.get(&vault_info.pool_address)
+                                            {
+                                                let mut meta = std::collections::HashMap::new();
+                                                meta.insert(
+                                                    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY.to_string(),
+                                                    format!("{},{}", s.token_0_vault, s.token_1_vault),
+                                                );
+                                                balance_update.metadata = Some(meta);
+                                                let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+                                                let r0 = s.reserve_0.unwrap_or(0);
+                                                let r1 = s.reserve_1.unwrap_or(0);
+                                                let (base_side_liq, quote_side_liq) =
+                                                    if s.token_1_mint == sol {
+                                                        (r0 > 0, r1 > 0)
+                                                    } else if s.token_0_mint == sol {
+                                                        (r1 > 0, r0 > 0)
+                                                    } else {
+                                                        (r0 > 0, r1 > 0)
+                                                    };
+                                                let readiness = if base_side_liq && quote_side_liq {
+                                                    DexPoolReadiness::Ready
+                                                } else if r0 > 0 || r1 > 0 {
+                                                    DexPoolReadiness::Partial
+                                                } else {
+                                                    DexPoolReadiness::Observed
+                                                };
+                                                balance_update.set_dex_readiness_in_metadata(readiness);
+                                                ctx.live_pool_cache.merge_raydium_cpmm_pool_readiness(
+                                                    vault_info.pool_address,
+                                                    readiness,
+                                                );
+                                            }
+                                        }
                                         let subject = pool_subject(&vault_info.pool_address.to_string());
                                         if let Err(e) = nats.jetstream_publish(&subject, &balance_update).await {
                                             warn!(error = %e, "Failed to publish PoolCacheUpdate::BalanceUpdated to JetStream");
@@ -3358,6 +3393,61 @@ async fn run_geyser_loop(
                     // Update MASTER LivePoolCache (Single Source of Truth)
                     ctx.live_pool_cache.upsert(account_update.pubkey, cached_state.clone(), account_update.slot);
 
+                    // Raydium CPMM: register vault ATAs for Geyser reserve updates (enables non-RPC reserve path).
+                    if let CachedPoolState::RaydiumCpmm(s) = &cached_state {
+                        let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+                        let (base_mint_v, quote_mint_v, coin_vault, pc_vault) =
+                            if s.token_1_mint == sol {
+                                (s.token_0_mint, s.token_1_mint, s.token_0_vault, s.token_1_vault)
+                            } else if s.token_0_mint == sol {
+                                (s.token_1_mint, s.token_0_mint, s.token_1_vault, s.token_0_vault)
+                            } else {
+                                (s.token_0_mint, s.token_1_mint, s.token_0_vault, s.token_1_vault)
+                            };
+                        let dex_str = "raydium_cpmm".to_string();
+                        let mut vaults_changed = false;
+                        {
+                            let mut vaults = ctx.tracked_vaults.write();
+                            vaults.entry(coin_vault).or_insert_with(|| {
+                                vaults_changed = true;
+                                VaultInfo {
+                                    pool_address: account_update.pubkey,
+                                    dex: dex_str.clone(),
+                                    base_mint: base_mint_v,
+                                    quote_mint: quote_mint_v,
+                                    is_base_vault: true,
+                                    last_balance: std::sync::atomic::AtomicU64::new(0),
+                                    active_id: None,
+                                    bin_step: None,
+                                }
+                            });
+                            vaults.entry(pc_vault).or_insert_with(|| {
+                                vaults_changed = true;
+                                VaultInfo {
+                                    pool_address: account_update.pubkey,
+                                    dex: dex_str,
+                                    base_mint: base_mint_v,
+                                    quote_mint: quote_mint_v,
+                                    is_base_vault: false,
+                                    last_balance: std::sync::atomic::AtomicU64::new(0),
+                                    active_id: None,
+                                    bin_step: None,
+                                }
+                            });
+                        }
+                        if vaults_changed {
+                            let vault_list: Vec<Pubkey> =
+                                ctx.tracked_vaults.read().keys().copied().collect();
+                            let _ = ctx.tracked_vaults_tx.send(vault_list);
+                            debug!(
+                                pool = %account_update.pubkey,
+                                coin_vault = %coin_vault,
+                                pc_vault = %pc_vault,
+                                "Registered Raydium CPMM vaults for Geyser reserve subscription"
+                            );
+                        }
+                    }
+
                     // FIX-29: One-time Cold Path RPC to fetch Serum/OpenBook accounts for Raydium AMM.
                     // These are static (never change) — fetch once, cache forever.
                     if let CachedPoolState::RaydiumAmm(ref s) = cached_state {
@@ -3403,7 +3493,29 @@ async fn run_geyser_loop(
                             (s.base_mint, s.quote_mint, s.coin_reserve.unwrap_or(0), s.pc_reserve.unwrap_or(0))
                         }
                         CachedPoolState::RaydiumCpmm(s) => {
-                            (s.token_0_mint, s.token_1_mint, s.reserve_0.unwrap_or(0), s.reserve_1.unwrap_or(0))
+                            let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+                            if s.token_1_mint == sol {
+                                (
+                                    s.token_0_mint,
+                                    s.token_1_mint,
+                                    s.reserve_0.unwrap_or(0),
+                                    s.reserve_1.unwrap_or(0),
+                                )
+                            } else if s.token_0_mint == sol {
+                                (
+                                    s.token_1_mint,
+                                    s.token_0_mint,
+                                    s.reserve_1.unwrap_or(0),
+                                    s.reserve_0.unwrap_or(0),
+                                )
+                            } else {
+                                (
+                                    s.token_0_mint,
+                                    s.token_1_mint,
+                                    s.reserve_0.unwrap_or(0),
+                                    s.reserve_1.unwrap_or(0),
+                                )
+                            }
                         }
                         CachedPoolState::Meteora(s) => {
                             (s.token_x_mint, s.token_y_mint, s.reserve_x_balance.unwrap_or(0), s.reserve_y_balance.unwrap_or(0))
@@ -3662,6 +3774,36 @@ async fn run_geyser_loop(
                                 if !meta.is_empty() {
                                     pool_update.metadata = Some(meta);
                                 }
+                            }
+                            CachedPoolState::RaydiumCpmm(s) => {
+                                let mut meta = std::collections::HashMap::new();
+                                meta.insert(
+                                    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY.to_string(),
+                                    format!("{},{}", s.token_0_vault, s.token_1_vault),
+                                );
+                                pool_update.metadata = Some(meta);
+                                let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+                                let r0 = s.reserve_0.unwrap_or(0);
+                                let r1 = s.reserve_1.unwrap_or(0);
+                                let (base_side_liq, quote_side_liq) = if s.token_1_mint == sol {
+                                    (r0 > 0, r1 > 0)
+                                } else if s.token_0_mint == sol {
+                                    (r1 > 0, r0 > 0)
+                                } else {
+                                    (r0 > 0, r1 > 0)
+                                };
+                                let readiness = if base_side_liq && quote_side_liq {
+                                    DexPoolReadiness::Ready
+                                } else if r0 > 0 || r1 > 0 {
+                                    DexPoolReadiness::Partial
+                                } else {
+                                    DexPoolReadiness::Observed
+                                };
+                                pool_update.set_dex_readiness_in_metadata(readiness);
+                                ctx.live_pool_cache.merge_raydium_cpmm_pool_readiness(
+                                    account_update.pubkey,
+                                    readiness,
+                                );
                             }
                             _ => {}
                         }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -113,8 +113,8 @@ fn raydium_cpmm_vaults_for_pool_cache_update(s: &RaydiumCpmmState) -> String {
     format!("{first_vault},{second_vault}")
 }
 
-/// SOL-aware readiness from pool reserves (single source for BalanceUpdated vs PoolDiscovered paths).
-fn raydium_cpmm_readiness_from_cached_state(s: &RaydiumCpmmState) -> DexPoolReadiness {
+/// JetStream readiness for Raydium CPMM (SOL-aware base/quote): single source for BalanceUpdated and PoolDiscovered.
+fn raydium_cpmm_readiness_for_pool_cache_update(s: &RaydiumCpmmState) -> DexPoolReadiness {
     let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
     let r0 = s.reserve_0.unwrap_or(0);
     let r1 = s.reserve_1.unwrap_or(0);
@@ -3269,7 +3269,7 @@ async fn run_geyser_loop(
                                                 );
                                                 balance_update.metadata = Some(meta);
                                                 let readiness =
-                                                    raydium_cpmm_readiness_from_cached_state(s);
+                                                    raydium_cpmm_readiness_for_pool_cache_update(s);
                                                 balance_update.set_dex_readiness_in_metadata(readiness);
                                                 ctx.live_pool_cache.merge_raydium_cpmm_pool_readiness(
                                                     vault_info.pool_address,
@@ -3803,7 +3803,7 @@ async fn run_geyser_loop(
                                     raydium_cpmm_vaults_for_pool_cache_update(s),
                                 );
                                 pool_update.metadata = Some(meta);
-                                let readiness = raydium_cpmm_readiness_from_cached_state(s);
+                                let readiness = raydium_cpmm_readiness_for_pool_cache_update(s);
                                 pool_update.set_dex_readiness_in_metadata(readiness);
                                 ctx.live_pool_cache.merge_raydium_cpmm_pool_readiness(
                                     account_update.pubkey,
@@ -5342,6 +5342,78 @@ mod discovery_tests {
         assert!(
             !cache.pumpfun_bonding_curve_explicitly_ready(&bonding_curve),
             "explicit Ready must be absent for this regression scenario"
+        );
+    }
+
+    #[test]
+    fn test_raydium_cpmm_readiness_helper_sol_quote_both_sides() {
+        let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let base = Pubkey::new_unique();
+        let s = RaydiumCpmmState {
+            token_0_mint: base,
+            token_1_mint: sol,
+            token_0_vault: Pubkey::default(),
+            token_1_vault: Pubkey::default(),
+            reserve_0: Some(100),
+            reserve_1: Some(200),
+        };
+        assert_eq!(
+            raydium_cpmm_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Ready
+        );
+    }
+
+    #[test]
+    fn test_raydium_cpmm_readiness_helper_sol_as_token_0_one_side_only_partial() {
+        let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let base = Pubkey::new_unique();
+        let s = RaydiumCpmmState {
+            token_0_mint: sol,
+            token_1_mint: base,
+            token_0_vault: Pubkey::default(),
+            token_1_vault: Pubkey::default(),
+            reserve_0: Some(50),
+            reserve_1: Some(0),
+        };
+        assert_eq!(
+            raydium_cpmm_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Partial
+        );
+    }
+
+    #[test]
+    fn test_raydium_cpmm_readiness_helper_non_sol_pair_both_sides_ready() {
+        let a = Pubkey::new_unique();
+        let b = Pubkey::new_unique();
+        let s = RaydiumCpmmState {
+            token_0_mint: a,
+            token_1_mint: b,
+            token_0_vault: Pubkey::default(),
+            token_1_vault: Pubkey::default(),
+            reserve_0: Some(1),
+            reserve_1: Some(2),
+        };
+        assert_eq!(
+            raydium_cpmm_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Ready
+        );
+    }
+
+    #[test]
+    fn test_raydium_cpmm_readiness_helper_observed_when_zero_reserves() {
+        let a = Pubkey::new_unique();
+        let b = Pubkey::new_unique();
+        let s = RaydiumCpmmState {
+            token_0_mint: a,
+            token_1_mint: b,
+            token_0_vault: Pubkey::default(),
+            token_1_vault: Pubkey::default(),
+            reserve_0: Some(0),
+            reserve_1: Some(0),
+        };
+        assert_eq!(
+            raydium_cpmm_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Observed
         );
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -79,6 +79,7 @@ const EXECUTION_RESULT_DEDUP_CAPACITY: usize = 4096;
 // LivePoolCache - MASTER Cache (Single Source of Truth)
 use ironcrab::execution::live_pool_cache::{
     parse_pool_account, CachedPoolState, LivePoolCache, PumpAmmState, PumpFunState,
+    RaydiumCpmmState,
 };
 
 // P1 Crash Isolation: Systemd Watchdog support
@@ -96,6 +97,21 @@ const PUMPFUN_PROGRAM: &str = "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P";
 const PUMPFUN_AMM_PROGRAM: &str = "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA";
 const METEORA_DLMM: &str = "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo";
 const METEORA_CPMM: &str = "cpmmpPFsKiR4eeYnGSuXgkhLLgGL1j5FUZoJBJU9t9D";
+
+/// Raydium CPMM: `PoolCacheUpdate` uses normalized base/quote (non-SOL first). JetStream vault
+/// metadata must list vault pubkeys in the same order as `base_mint` / `quote_mint` so SLAVE
+/// `build_minimal_pool_state_with_reserves` maps `token_0_*` ↔ vaults coherently.
+fn raydium_cpmm_vaults_for_pool_cache_update(s: &RaydiumCpmmState) -> String {
+    let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+    let (first_vault, second_vault) = if s.token_1_mint == sol {
+        (s.token_0_vault, s.token_1_vault)
+    } else if s.token_0_mint == sol {
+        (s.token_1_vault, s.token_0_vault)
+    } else {
+        (s.token_0_vault, s.token_1_vault)
+    };
+    format!("{first_vault},{second_vault}")
+}
 
 /// Market data configuration (hot-reloadable via NATS)
 #[allow(dead_code)]
@@ -3228,7 +3244,7 @@ async fn run_geyser_loop(
                                                 let mut meta = std::collections::HashMap::new();
                                                 meta.insert(
                                                     POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY.to_string(),
-                                                    format!("{},{}", s.token_0_vault, s.token_1_vault),
+                                                    raydium_cpmm_vaults_for_pool_cache_update(&s),
                                                 );
                                                 balance_update.metadata = Some(meta);
                                                 let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
@@ -3779,7 +3795,7 @@ async fn run_geyser_loop(
                                 let mut meta = std::collections::HashMap::new();
                                 meta.insert(
                                     POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY.to_string(),
-                                    format!("{},{}", s.token_0_vault, s.token_1_vault),
+                                    raydium_cpmm_vaults_for_pool_cache_update(s),
                                 );
                                 pool_update.metadata = Some(meta);
                                 let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -935,6 +935,12 @@ impl LivePoolCache {
             .unwrap_or(false)
     }
 
+    /// Monotonic merge result for this pool (tests / diagnostics).
+    #[must_use]
+    pub fn raydium_cpmm_readiness(&self, pool: &Pubkey) -> Option<DexPoolReadiness> {
+        self.raydium_cpmm_readiness_by_pool.get(pool).map(|r| *r)
+    }
+
     /// Mint-level helper: Raydium CPMM slice — explicit `Ready` only (no cache-hit heuristic).
     #[must_use]
     pub fn base_mint_has_explicit_raydium_cpmm_ready_pool(&self, base_mint: &Pubkey) -> bool {

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -314,6 +314,9 @@ pub struct LivePoolCache {
     /// PumpFun bonding-curve account → explicit [`DexPoolReadiness`] from JetStream / MASTER (Bug #36).
     /// Monotonic merge; not implied by [`Self::contains`] or non-empty bonding-curve state.
     pumpfun_bonding_readiness_by_curve: DashMap<Pubkey, DexPoolReadiness>,
+
+    /// Raydium CPMM pool address → explicit [`DexPoolReadiness`] from JetStream / MASTER (Bug #36).
+    raydium_cpmm_readiness_by_pool: DashMap<Pubkey, DexPoolReadiness>,
 }
 
 /// Which vault position (A/B or X/Y or 0/1) this vault represents
@@ -345,6 +348,7 @@ impl LivePoolCache {
             last_notified_vault_count: AtomicU64::new(0),
             pool_accounts_readiness_by_market: DashMap::new(),
             pumpfun_bonding_readiness_by_curve: DashMap::new(),
+            raydium_cpmm_readiness_by_pool: DashMap::new(),
         }
     }
 
@@ -914,6 +918,40 @@ impl LivePoolCache {
             .or_insert(incoming);
     }
 
+    /// Merge Raydium CPMM pool readiness for `pool` (monotonic — never downgrade).
+    pub fn merge_raydium_cpmm_pool_readiness(&self, pool: Pubkey, incoming: DexPoolReadiness) {
+        self.raydium_cpmm_readiness_by_pool
+            .entry(pool)
+            .and_modify(|stored| *stored = stored.merge(incoming))
+            .or_insert(incoming);
+    }
+
+    /// `true` only when JetStream merge recorded [`DexPoolReadiness::Ready`] for this Raydium CPMM pool.
+    #[must_use]
+    pub fn raydium_cpmm_pool_explicitly_ready(&self, pool: &Pubkey) -> bool {
+        self.raydium_cpmm_readiness_by_pool
+            .get(pool)
+            .map(|r| *r == DexPoolReadiness::Ready)
+            .unwrap_or(false)
+    }
+
+    /// Mint-level helper: Raydium CPMM slice — explicit `Ready` only (no cache-hit heuristic).
+    #[must_use]
+    pub fn base_mint_has_explicit_raydium_cpmm_ready_pool(&self, base_mint: &Pubkey) -> bool {
+        for entry in self.pools.iter() {
+            if let CachedPoolState::RaydiumCpmm(s) = &entry.value().state {
+                if s.token_0_mint != *base_mint && s.token_1_mint != *base_mint {
+                    continue;
+                }
+                let pool = entry.key();
+                if self.raydium_cpmm_pool_explicitly_ready(pool) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     /// `true` only after explicit JetStream / control-path merge recorded [`DexPoolReadiness::Ready`]
     /// for this bonding curve (Bug #36: cache hit alone is not ready).
     #[must_use]
@@ -1027,13 +1065,17 @@ impl LivePoolCache {
     ///   effective-ready fallback (see [`Self::pump_amm_effective_ready_for_cache_first_accounts`]).
     /// - PumpFun bonding curve: [`Self::pumpfun_bonding_curve_explicitly_ready`] on the
     ///   bonding-curve account for a cached [`PumpFunState`] whose `token_mint` equals `base_mint`.
+    /// - Raydium CPMM: [`Self::base_mint_has_explicit_raydium_cpmm_ready_pool`] — explicit
+    ///   [`DexPoolReadiness::Ready`] in [`Self::raydium_cpmm_readiness_by_pool`] only.
     ///
-    /// **Conservative:** pools on Raydium, Orca, Meteora, etc. are **not** treated as ready here
-    /// until they have an explicit readiness path — returns `false` unless PumpSwap or PumpFun
-    /// conditions above hold.
+    /// **Conservative:** Orca, Meteora, Raydium AMM v4, etc. are **not** treated as ready here
+    /// until they have an explicit readiness path.
     #[must_use]
     pub fn base_mint_has_any_ready_pool(&self, base_mint: &Pubkey) -> bool {
         if self.base_mint_has_explicit_pump_amm_ready_pool(base_mint) {
+            return true;
+        }
+        if self.base_mint_has_explicit_raydium_cpmm_ready_pool(base_mint) {
             return true;
         }
         for entry in self.pools.iter() {
@@ -2223,6 +2265,81 @@ mod tests {
         );
 
         assert!(!cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_raydium_cpmm_explicit_ready() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+
+        cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote_mint,
+                token_0_vault: Pubkey::new_unique(),
+                token_1_vault: Pubkey::new_unique(),
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            100,
+        );
+        cache.merge_raydium_cpmm_pool_readiness(pool, DexPoolReadiness::Ready);
+
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+        assert!(cache.base_mint_has_explicit_raydium_cpmm_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_raydium_cpmm_partial_does_not_count() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+
+        cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote_mint,
+                token_0_vault: Pubkey::new_unique(),
+                token_1_vault: Pubkey::new_unique(),
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(0),
+            }),
+            100,
+        );
+        cache.merge_raydium_cpmm_pool_readiness(pool, DexPoolReadiness::Partial);
+
+        assert!(!cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_raydium_cpmm_readiness_merge_monotone() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+
+        cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote_mint,
+                token_0_vault: Pubkey::new_unique(),
+                token_1_vault: Pubkey::new_unique(),
+                reserve_0: Some(1),
+                reserve_1: Some(2),
+            }),
+            100,
+        );
+        cache.merge_raydium_cpmm_pool_readiness(pool, DexPoolReadiness::Ready);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+
+        cache.merge_raydium_cpmm_pool_readiness(pool, DexPoolReadiness::Observed);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
     }
 
     #[test]

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -392,7 +392,8 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                     }
                 }
                 // BalanceUpdated has no vault pubkeys in the scalar fields — preserve from existing
-                // or from metadata (`raydium_cpmm_vaults`) so reserve updates stay coherent.
+                // or from metadata (`raydium_cpmm_vaults`: base_vault,quote_vault matching normalized
+                // base_mint/quote_mint on the update) so reserve updates stay coherent.
                 if update.dex == "raydium_cpmm" {
                     if let CachedPoolState::RaydiumCpmm(ref mut new_cpmm) = minimal_state {
                         // Prefer existing vaults only when both are non-default. Legacy JetStream
@@ -986,6 +987,50 @@ mod tests {
             cache.raydium_cpmm_readiness(&pool),
             Some(DexPoolReadiness::Partial)
         );
+    }
+
+    /// On-chain `token_0 == SOL`: publisher sends normalized base/quote mints and base/quote vault order in metadata.
+    #[test]
+    fn test_raydium_cpmm_pool_discovered_metadata_vaults_match_normalized_mints_when_sol_is_token_0(
+    ) {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let sol = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let base_mint = Pubkey::new_unique();
+        let v_non_sol_vault = Pubkey::new_unique();
+        let v_sol_vault = Pubkey::new_unique();
+
+        let mut update = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "raydium_cpmm".to_string(),
+            base_mint.to_string(),
+            sol.to_string(),
+            1_000_000,
+            50_000_000_000,
+            None,
+            1,
+        );
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY.to_string(),
+            format!("{v_non_sol_vault},{v_sol_vault}"),
+        );
+        update.metadata = Some(meta);
+        update.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+        assert!(apply_pool_cache_update(&cache, &update));
+
+        match cache.get(&pool).expect("pool in cache") {
+            CachedPoolState::RaydiumCpmm(s) => {
+                assert_eq!(s.token_0_mint, base_mint);
+                assert_eq!(s.token_1_mint, sol);
+                assert_eq!(s.token_0_vault, v_non_sol_vault);
+                assert_eq!(s.token_1_vault, v_sol_vault);
+            }
+            other => panic!("expected RaydiumCpmm, got {:?}", other),
+        }
     }
 
     #[test]

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -395,9 +395,18 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 // or from metadata (`raydium_cpmm_vaults`) so reserve updates stay coherent.
                 if update.dex == "raydium_cpmm" {
                     if let CachedPoolState::RaydiumCpmm(ref mut new_cpmm) = minimal_state {
+                        // Prefer existing vaults only when both are non-default. Legacy JetStream
+                        // rows without `raydium_cpmm_vaults` can leave default vaults in cache; a
+                        // newer BalanceUpdated with metadata must still win (restart / upgrade).
                         let from_existing = existing.as_ref().and_then(|ex| {
                             if let CachedPoolState::RaydiumCpmm(s) = ex {
-                                Some((s.token_0_vault, s.token_1_vault))
+                                if s.token_0_vault != Pubkey::default()
+                                    && s.token_1_vault != Pubkey::default()
+                                {
+                                    Some((s.token_0_vault, s.token_1_vault))
+                                } else {
+                                    None
+                                }
                             } else {
                                 None
                             }
@@ -918,6 +927,65 @@ mod tests {
             other => panic!("expected RaydiumCpmm, got {:?}", other),
         }
         assert!(cache.raydium_cpmm_pool_explicitly_ready(&pool));
+    }
+
+    /// Legacy SLAVE state: default vaults from old JetStream messages must not block metadata vaults.
+    #[test]
+    fn test_raydium_cpmm_balance_updated_metadata_vaults_when_existing_defaults() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let v0 = Pubkey::new_unique();
+        let v1 = Pubkey::new_unique();
+
+        cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote_mint,
+                token_0_vault: Pubkey::default(),
+                token_1_vault: Pubkey::default(),
+                reserve_0: Some(100),
+                reserve_1: Some(200),
+            }),
+            1,
+        );
+
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY.to_string(),
+            format!("{v0},{v1}"),
+        );
+        let mut bal = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "raydium_cpmm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1_000_000,
+            50_000_000_000,
+            2,
+        );
+        bal.metadata = Some(meta);
+        bal.set_dex_readiness_in_metadata(DexPoolReadiness::Partial);
+        assert!(apply_pool_cache_update(&cache, &bal));
+
+        match cache.get(&pool).expect("pool in cache") {
+            CachedPoolState::RaydiumCpmm(s) => {
+                assert_eq!(s.token_0_vault, v0);
+                assert_eq!(s.token_1_vault, v1);
+                assert_ne!(s.token_0_vault, Pubkey::default());
+                assert_ne!(s.token_1_vault, Pubkey::default());
+            }
+            other => panic!("expected RaydiumCpmm, got {:?}", other),
+        }
+        assert_eq!(
+            cache.raydium_cpmm_readiness(&pool),
+            Some(DexPoolReadiness::Partial)
+        );
     }
 
     #[test]

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -24,7 +24,7 @@ use crate::execution::live_pool_cache::{
     CachedPoolState, LivePoolCache, MeteoraState, OrcaWhirlpoolState, PumpAmmState, PumpFunState,
     RaydiumAmmState, RaydiumCpmmState,
 };
-use crate::ipc::{PoolCacheUpdate, PoolCacheUpdateType};
+use crate::ipc::{PoolCacheUpdate, PoolCacheUpdateType, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY};
 use crate::nats::{slave_consumer_config, NatsClient, STREAM_NAME};
 
 /// Extract base_reserve and quote_reserve from CachedPoolState (for merge logic).
@@ -291,9 +291,29 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         }
                     }
                 }
+                if update.dex == "raydium_cpmm" {
+                    if let CachedPoolState::RaydiumCpmm(ref mut new_cpmm) = minimal_state {
+                        if let Some(m) = update.metadata.as_ref() {
+                            if let Some(s) = m.get(POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY) {
+                                let mut it =
+                                    s.split(',').filter_map(|a| Pubkey::from_str(a.trim()).ok());
+                                if let (Some(v0), Some(v1)) = (it.next(), it.next()) {
+                                    new_cpmm.token_0_vault = v0;
+                                    new_cpmm.token_1_vault = v1;
+                                }
+                            }
+                        }
+                    }
+                }
                 cache.upsert(pool_addr, minimal_state, update.geyser_slot);
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_pool_accounts_readiness(
+                        pool_addr,
+                        update.effective_dex_readiness(),
+                    );
+                }
+                if update.dex == "raydium_cpmm" {
+                    cache.merge_raydium_cpmm_pool_readiness(
                         pool_addr,
                         update.effective_dex_readiness(),
                     );
@@ -371,12 +391,48 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         }
                     }
                 }
+                // BalanceUpdated has no vault pubkeys in the scalar fields — preserve from existing
+                // or from metadata (`raydium_cpmm_vaults`) so reserve updates stay coherent.
+                if update.dex == "raydium_cpmm" {
+                    if let CachedPoolState::RaydiumCpmm(ref mut new_cpmm) = minimal_state {
+                        let from_existing = existing.as_ref().and_then(|ex| {
+                            if let CachedPoolState::RaydiumCpmm(s) = ex {
+                                Some((s.token_0_vault, s.token_1_vault))
+                            } else {
+                                None
+                            }
+                        });
+                        let from_meta = update.metadata.as_ref().and_then(|m| {
+                            m.get(POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY)
+                                .and_then(|s| {
+                                    let mut it = s
+                                        .split(',')
+                                        .filter_map(|a| Pubkey::from_str(a.trim()).ok());
+                                    match (it.next(), it.next()) {
+                                        (Some(v0), Some(v1)) => Some((v0, v1)),
+                                        _ => None,
+                                    }
+                                })
+                        });
+                        if let Some((v0, v1)) = from_existing.or(from_meta) {
+                            if new_cpmm.token_0_vault == Pubkey::default() {
+                                new_cpmm.token_0_vault = v0;
+                            }
+                            if new_cpmm.token_1_vault == Pubkey::default() {
+                                new_cpmm.token_1_vault = v1;
+                            }
+                        }
+                    }
+                }
                 cache.upsert(addr, minimal_state, update.geyser_slot);
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_pool_accounts_readiness(
                         addr,
                         update.effective_dex_readiness(),
                     );
+                }
+                if update.dex == "raydium_cpmm" {
+                    cache.merge_raydium_cpmm_pool_readiness(addr, update.effective_dex_readiness());
                 }
                 if update.dex == "pumpfun" {
                     cache.merge_pumpfun_bonding_readiness(addr, update.effective_dex_readiness());
@@ -483,7 +539,7 @@ pub async fn bootstrap_pool_cache_from_jetstream(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ipc::DexPoolReadiness;
+    use crate::ipc::{DexPoolReadiness, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY};
 
     /// A.30 Regression: cashback_enabled must be true when JetStream metadata contains
     /// cashback_enabled="true". Verifies pool_cache_sync propagates metadata correctly.
@@ -803,6 +859,119 @@ mod tests {
         assert!(
             cache.pumpfun_bonding_curve_explicitly_ready(&pool_addr),
             "merge must not downgrade Ready to Observed for PumpFun"
+        );
+    }
+
+    #[test]
+    fn test_raydium_cpmm_balance_updated_preserves_vaults_and_merges_readiness() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let v0 = Pubkey::new_unique();
+        let v1 = Pubkey::new_unique();
+
+        let mut discovered = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "raydium_cpmm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            0,
+            0,
+            None,
+            1,
+        );
+        let mut m = std::collections::HashMap::new();
+        m.insert(
+            POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY.to_string(),
+            format!("{v0},{v1}"),
+        );
+        discovered.metadata = Some(m);
+        discovered.set_dex_readiness_in_metadata(DexPoolReadiness::Observed);
+        assert!(apply_pool_cache_update(&cache, &discovered));
+
+        let mut bal = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "raydium_cpmm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1_000_000,
+            50_000_000_000,
+            2,
+        );
+        bal.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+        assert!(apply_pool_cache_update(&cache, &bal));
+
+        match cache.get(&pool).expect("pool in cache") {
+            CachedPoolState::RaydiumCpmm(s) => {
+                assert_eq!(s.token_0_vault, v0);
+                assert_eq!(s.token_1_vault, v1);
+                assert_eq!(s.reserve_0, Some(1_000_000));
+                assert_eq!(s.reserve_1, Some(50_000_000_000));
+            }
+            other => panic!("expected RaydiumCpmm, got {:?}", other),
+        }
+        assert!(cache.raydium_cpmm_pool_explicitly_ready(&pool));
+    }
+
+    #[test]
+    fn test_raydium_cpmm_readiness_merge_never_downgrades() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let v0 = Pubkey::new_unique();
+        let v1 = Pubkey::new_unique();
+
+        let mut m = std::collections::HashMap::new();
+        m.insert(
+            POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY.to_string(),
+            format!("{v0},{v1}"),
+        );
+
+        let mut ready_up = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "raydium_cpmm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1,
+            1,
+            None,
+            1,
+        );
+        ready_up.metadata = Some(m.clone());
+        ready_up.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+        assert!(apply_pool_cache_update(&cache, &ready_up));
+        assert!(cache.raydium_cpmm_pool_explicitly_ready(&pool));
+
+        let mut weak = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "raydium_cpmm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1,
+            1,
+            None,
+            2,
+        );
+        weak.metadata = Some(m);
+        weak.set_dex_readiness_in_metadata(DexPoolReadiness::Observed);
+        assert!(apply_pool_cache_update(&cache, &weak));
+        assert!(
+            cache.raydium_cpmm_pool_explicitly_ready(&pool),
+            "merge must not downgrade Ready to Observed for Raydium CPMM"
         );
     }
 }

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -2382,6 +2382,12 @@ pub const POOL_CACHE_UPDATE_DEX_READINESS_KEY: &str = "dex_pool_readiness";
 /// Metadata key for comma-separated PumpSwap account pubkeys on [`PoolCacheUpdate`].
 pub const POOL_CACHE_UPDATE_POOL_ACCOUNTS_KEY: &str = "pool_accounts";
 
+/// Metadata key for Raydium CPMM: `token_0_vault,token_1_vault` (comma-separated base58).
+///
+/// Lets SLAVE [`PoolCacheUpdate::BalanceUpdated`] merge preserve vault pubkeys when the
+/// update only carries reserve scalars (same pattern as PumpSwap `pool_accounts`).
+pub const POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY: &str = "raydium_cpmm_vaults";
+
 /// Pool cache update type
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -2382,8 +2382,10 @@ pub const POOL_CACHE_UPDATE_DEX_READINESS_KEY: &str = "dex_pool_readiness";
 /// Metadata key for comma-separated PumpSwap account pubkeys on [`PoolCacheUpdate`].
 pub const POOL_CACHE_UPDATE_POOL_ACCOUNTS_KEY: &str = "pool_accounts";
 
-/// Metadata key for Raydium CPMM: `token_0_vault,token_1_vault` (comma-separated base58).
+/// Metadata key for Raydium CPMM: `base_vault,quote_vault` (comma-separated base58).
 ///
+/// **Order matches normalized [`PoolCacheUpdate::base_mint`] / [`PoolCacheUpdate::quote_mint`]**
+/// (non-SOL base first, SOL quote second when SOL is involved), not raw on-chain token_0/token_1.
 /// Lets SLAVE [`PoolCacheUpdate::BalanceUpdated`] merge preserve vault pubkeys when the
 /// update only carries reserve scalars (same pattern as PumpSwap `pool_accounts`).
 pub const POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY: &str = "raydium_cpmm_vaults";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds explicit `DexPoolReadiness` for Raydium CPMM on the market-data → JetStream → SLAVE path, extends the shared mint-level helper to consider Raydium CPMM only via explicit merge (Bug #36), and fixes SLAVE `BalanceUpdated` handling so CPMM vault pubkeys are not zeroed when JetStream carries only reserve scalars.

## Follow-up (merge/bootstrap)

- `BalanceUpdated` for `raydium_cpmm`: `from_existing` only applies when **both** vaults are non-`default`; otherwise metadata `raydium_cpmm_vaults` wins (fixes restart/upgrade when legacy JetStream left default vaults).

## Raydium CPMM completeness (this scope)

**Ready** when the pool state shows liquidity on **both** sides relative to SOL pairing: for SOL-quote pools, both token vault reserves are non-zero; for non-SOL pairs, both token reserves are non-zero. **Partial** if at least one side has liquidity; **Observed** if pool account is known but both reserves are zero/unknown.

## Tests

- `live_pool_cache`: explicit Ready vs Partial, monotone merge, mint helper
- `pool_cache_sync`: vault preservation + readiness merge on `BalanceUpdated`, Ready never downgrades to Observed, **default vaults + BalanceUpdated with metadata**

## STOP-CHECK

- I-7: No new RPC on hot path (Geyser-only readiness; existing Raydium cold RPC paths unchanged)
- Pattern: `merge_raydium_cpmm_pool_readiness` mirrors PumpSwap/PumpFun maps
- Scope: allowed files only; no bootstrap/execution_engine changes
- I-9: N/A
- Level-5: no eval repo reads

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60dd860e-2864-4aa5-a9ff-f100b44fc9b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60dd860e-2864-4aa5-a9ff-f100b44fc9b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

