### PR TITLE
DEX cache readiness: Raydium AMM v4 explicit Ready slice

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3736,6 +3736,9 @@ async fn run_geyser_loop(
                                                         };
                                                     cache.merge_raydium_amm_pool_readiness(pool_pk, readiness);
                                                     if let Some(ref nats) = nats_spawn {
+                                                        // `geyser_slot` must match the cache entry's last update slot (vault /
+                                                        // pool upserts), not the original discovery event — RPC may finish much
+                                                        // later while reserves already advanced on newer Geyser updates.
                                                         if let Some((
                                                             CachedPoolState::RaydiumAmm(st),
                                                             pool_slot,
@@ -5559,6 +5562,7 @@ async fn run_simulation_loop(
 #[cfg(test)]
 mod discovery_tests {
     use super::*;
+    use ironcrab::execution::live_pool_cache::RaydiumAmmState;
 
     /// Positive Ack ONLY when JetStream write succeeds (I-24a).
     /// This helper encodes the invariant; the handler uses the same logic.
@@ -5579,6 +5583,82 @@ mod discovery_tests {
         assert_eq!(
             discovery_response_status_for_jetstream(false),
             ControlResponseStatus::Error
+        );
+    }
+
+    /// PR #50 follow-up: async Serum RPC may finish long after the pool discovery Geyser slot.
+    /// JetStream `PoolCacheUpdate::geyser_slot` for the post-fetch publish must reflect the **current**
+    /// cache entry slot (latest vault / pool update), not the stale discovery slot, so reserves and
+    /// freshness metadata stay aligned (I-24a).
+    #[test]
+    fn test_raydium_amm_post_serum_jetstream_publish_slot_matches_cache_not_discovery() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        let market_id = Pubkey::new_unique();
+        let bids = Pubkey::new_unique();
+        let asks = Pubkey::new_unique();
+        let eq = Pubkey::new_unique();
+
+        const DISCOVERY_SLOT: u64 = 100;
+        const VAULT_SLOT: u64 = 9_999;
+
+        cache.upsert(
+            pool,
+            CachedPoolState::RaydiumAmm(RaydiumAmmState {
+                base_mint,
+                quote_mint,
+                coin_vault,
+                pc_vault,
+                base_decimals: 9,
+                quote_decimals: 9,
+                coin_reserve: None,
+                pc_reserve: None,
+                market_id,
+                serum_bids: None,
+                serum_asks: None,
+                serum_event_queue: None,
+            }),
+            DISCOVERY_SLOT,
+        );
+        cache.update_vault_balance(&coin_vault, 10, VAULT_SLOT);
+        cache.update_vault_balance(&pc_vault, 20, VAULT_SLOT);
+        cache.set_raydium_serum_accounts(&pool, bids, asks, eq);
+
+        let (_, cache_slot, _) = cache.get_with_metadata(&pool).expect("pool in cache");
+        assert_eq!(
+            cache_slot, VAULT_SLOT,
+            "vault updates should advance entry slot past discovery"
+        );
+
+        let st = match cache.get(&pool).expect("state") {
+            CachedPoolState::RaydiumAmm(s) => s,
+            other => panic!("expected RaydiumAmm, got {:?}", other),
+        };
+        let readiness = raydium_amm_readiness_for_pool_cache_update(&st);
+        assert_eq!(readiness, DexPoolReadiness::Ready);
+
+        let mut pool_update = PoolCacheUpdate::new_balance_updated(
+            "market-data",
+            BUILD_VERSION,
+            "run-test",
+            pool.to_string(),
+            "raydium".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            st.coin_reserve.unwrap_or(0),
+            st.pc_reserve.unwrap_or(0),
+            cache_slot,
+        );
+        pool_update.set_dex_readiness_in_metadata(readiness);
+
+        assert_eq!(pool_update.geyser_slot, VAULT_SLOT);
+        assert_ne!(
+            pool_update.geyser_slot, DISCOVERY_SLOT,
+            "must not label fresh reserves with stale discovery slot"
         );
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3714,7 +3714,6 @@ async fn run_geyser_loop(
                                 let rpc = Arc::clone(&rpc);
                                 let cache = Arc::clone(&ctx.live_pool_cache);
                                 let market_id = s.market_id;
-                                let slot = account_update.slot;
                                 let run_id_spawn = ctx.run_id.clone();
                                 let nats_spawn = ctx
                                     .nats
@@ -3737,8 +3736,11 @@ async fn run_geyser_loop(
                                                         };
                                                     cache.merge_raydium_amm_pool_readiness(pool_pk, readiness);
                                                     if let Some(ref nats) = nats_spawn {
-                                                        if let Some(CachedPoolState::RaydiumAmm(st)) =
-                                                            cache.get(&pool_pk)
+                                                        if let Some((
+                                                            CachedPoolState::RaydiumAmm(st),
+                                                            pool_slot,
+                                                            _age_ms,
+                                                        )) = cache.get_with_metadata(&pool_pk)
                                                         {
                                                             let mut pool_update =
                                                                 PoolCacheUpdate::new_balance_updated(
@@ -3751,7 +3753,7 @@ async fn run_geyser_loop(
                                                                     st.quote_mint.to_string(),
                                                                     st.coin_reserve.unwrap_or(0),
                                                                     st.pc_reserve.unwrap_or(0),
-                                                                    slot,
+                                                                    pool_slot,
                                                                 );
                                                             let mut meta = std::collections::HashMap::new();
                                                             if st.market_id != Pubkey::default() {

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -78,8 +78,8 @@ const EXECUTION_RESULT_DEDUP_CAPACITY: usize = 4096;
 
 // LivePoolCache - MASTER Cache (Single Source of Truth)
 use ironcrab::execution::live_pool_cache::{
-    parse_pool_account, CachedPoolState, LivePoolCache, PumpAmmState, PumpFunState,
-    RaydiumCpmmState,
+    parse_pool_account, raydium_amm_readiness_for_pool_cache_update, CachedPoolState,
+    LivePoolCache, PumpAmmState, PumpFunState, RaydiumCpmmState,
 };
 
 // P1 Crash Isolation: Systemd Watchdog support
@@ -1577,7 +1577,7 @@ async fn publish_wallet_snapshot(
                 wallet_mints_explicit_ready_count += 1;
                 debug!(
                     mint = %mint_str,
-                    "wallet mint: explicit DexPoolReadiness::Ready (PumpSwap / PumpFun / Raydium CPMM)"
+                    "wallet mint: explicit DexPoolReadiness::Ready (PumpSwap / PumpFun / Raydium CPMM / Raydium AMM)"
                 );
             }
         }
@@ -1587,7 +1587,7 @@ async fn publish_wallet_snapshot(
             wallet = %wallet_str,
             wallet_mints_explicit_ready_count,
             nonzero_wallet_mints = mints_in_wallet.len(),
-            "Wallet snapshot: mints with explicit Ready merge (PumpSwap / PumpFun / Raydium CPMM); excludes legacy PumpSwap effective-ready"
+            "Wallet snapshot: mints with explicit Ready merge (PumpSwap / PumpFun / Raydium CPMM / Raydium AMM); excludes legacy PumpSwap effective-ready"
         );
     }
 
@@ -3498,6 +3498,19 @@ async fn run_geyser_loop(
                                                 );
                                             }
                                         }
+                                        if vault_info.dex == "raydium" {
+                                            if let Some(CachedPoolState::RaydiumAmm(ref s)) =
+                                                ctx.live_pool_cache.get(&vault_info.pool_address)
+                                            {
+                                                let readiness =
+                                                    raydium_amm_readiness_for_pool_cache_update(s);
+                                                balance_update.set_dex_readiness_in_metadata(readiness);
+                                                ctx.live_pool_cache.merge_raydium_amm_pool_readiness(
+                                                    vault_info.pool_address,
+                                                    readiness,
+                                                );
+                                            }
+                                        }
                                         let subject = pool_subject(&vault_info.pool_address.to_string());
                                         if let Err(e) = nats.jetstream_publish(&subject, &balance_update).await {
                                             warn!(error = %e, "Failed to publish PoolCacheUpdate::BalanceUpdated to JetStream");
@@ -3701,6 +3714,12 @@ async fn run_geyser_loop(
                                 let rpc = Arc::clone(&rpc);
                                 let cache = Arc::clone(&ctx.live_pool_cache);
                                 let market_id = s.market_id;
+                                let slot = account_update.slot;
+                                let run_id_spawn = ctx.run_id.clone();
+                                let nats_spawn = ctx
+                                    .nats
+                                    .as_ref()
+                                    .map(|n| n.clone_for_spawned_publish());
                                 tokio::spawn(async move {
                                     match rpc.get_account_retry(&market_id).await {
                                         Ok(account) => {
@@ -3709,6 +3728,78 @@ async fn run_geyser_loop(
                                             {
                                                 if let (Some(b), Some(a), Some(e)) = (bids, asks, eq) {
                                                     cache.set_raydium_serum_accounts(&pool_pk, b, a, e);
+                                                    let readiness =
+                                                        match cache.get(&pool_pk).as_ref() {
+                                                            Some(CachedPoolState::RaydiumAmm(st)) => {
+                                                                raydium_amm_readiness_for_pool_cache_update(st)
+                                                            }
+                                                            _ => DexPoolReadiness::Observed,
+                                                        };
+                                                    cache.merge_raydium_amm_pool_readiness(pool_pk, readiness);
+                                                    if let Some(ref nats) = nats_spawn {
+                                                        if let Some(CachedPoolState::RaydiumAmm(st)) =
+                                                            cache.get(&pool_pk)
+                                                        {
+                                                            let mut pool_update =
+                                                                PoolCacheUpdate::new_balance_updated(
+                                                                    "market-data",
+                                                                    BUILD_VERSION,
+                                                                    &run_id_spawn,
+                                                                    pool_pk.to_string(),
+                                                                    "raydium".to_string(),
+                                                                    st.base_mint.to_string(),
+                                                                    st.quote_mint.to_string(),
+                                                                    st.coin_reserve.unwrap_or(0),
+                                                                    st.pc_reserve.unwrap_or(0),
+                                                                    slot,
+                                                                );
+                                                            let mut meta = std::collections::HashMap::new();
+                                                            if st.market_id != Pubkey::default() {
+                                                                meta.insert(
+                                                                    "market_id".to_string(),
+                                                                    st.market_id.to_string(),
+                                                                );
+                                                            }
+                                                            if let (Some(bids), Some(asks), Some(eq)) = (
+                                                                st.serum_bids,
+                                                                st.serum_asks,
+                                                                st.serum_event_queue,
+                                                            ) {
+                                                                meta.insert(
+                                                                    "serum_bids".to_string(),
+                                                                    bids.to_string(),
+                                                                );
+                                                                meta.insert(
+                                                                    "serum_asks".to_string(),
+                                                                    asks.to_string(),
+                                                                );
+                                                                meta.insert(
+                                                                    "serum_event_queue".to_string(),
+                                                                    eq.to_string(),
+                                                                );
+                                                            }
+                                                            if !meta.is_empty() {
+                                                                pool_update.metadata = Some(meta);
+                                                            }
+                                                            pool_update.set_dex_readiness_in_metadata(readiness);
+                                                            let subject =
+                                                                pool_subject(&pool_pk.to_string());
+                                                            if let Err(e) = nats
+                                                                .jetstream_publish(&subject, &pool_update)
+                                                                .await
+                                                            {
+                                                                warn!(
+                                                                    error = %e,
+                                                                    "Failed to publish Raydium AMM PoolCacheUpdate after serum fetch"
+                                                                );
+                                                                NATS_ERRORS_TOTAL
+                                                                    .fetch_add(1, Ordering::Relaxed);
+                                                            } else {
+                                                                NATS_MESSAGES_PUBLISHED_TOTAL
+                                                                    .fetch_add(1, Ordering::Relaxed);
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }
@@ -4016,6 +4107,12 @@ async fn run_geyser_loop(
                                 if !meta.is_empty() {
                                     pool_update.metadata = Some(meta);
                                 }
+                                let readiness = raydium_amm_readiness_for_pool_cache_update(s);
+                                pool_update.set_dex_readiness_in_metadata(readiness);
+                                ctx.live_pool_cache.merge_raydium_amm_pool_readiness(
+                                    account_update.pubkey,
+                                    readiness,
+                                );
                             }
                             CachedPoolState::RaydiumCpmm(s) => {
                                 let mut meta = std::collections::HashMap::new();

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -113,6 +113,32 @@ pub struct RaydiumAmmState {
     pub serum_event_queue: Option<Pubkey>,
 }
 
+/// JetStream / MASTER [`DexPoolReadiness`] for Raydium AMM v4 (conservative, explicit).
+///
+/// `Ready` only when the static Serum/OpenBook accounts required for swap building are present
+/// (`market_id`, bids, asks, event queue from Geyser parse or one-time cold-path fill) **and**
+/// both vault reserves are known and non-zero (matches [`crate::execution::quote_calculator`] needs).
+///
+/// Reserves alone never imply `Ready` (swap path still needs Serum accounts — see `RaydiumSwapAccounts`).
+#[must_use]
+pub fn raydium_amm_readiness_for_pool_cache_update(s: &RaydiumAmmState) -> DexPoolReadiness {
+    let static_ok = s.market_id != Pubkey::default()
+        && s.serum_bids.is_some()
+        && s.serum_asks.is_some()
+        && s.serum_event_queue.is_some();
+    let r_coin = s.coin_reserve.unwrap_or(0);
+    let r_pc = s.pc_reserve.unwrap_or(0);
+    // `coin_reserve` / `pc_reserve` are the two pool legs; both must be non-zero for a usable
+    // constant-product quote (same idea as Raydium CPMM non-SOL pair).
+    if static_ok && r_coin > 0 && r_pc > 0 {
+        DexPoolReadiness::Ready
+    } else if r_coin > 0 || r_pc > 0 {
+        DexPoolReadiness::Partial
+    } else {
+        DexPoolReadiness::Observed
+    }
+}
+
 /// Raydium CPMM cached state
 #[derive(Debug, Clone)]
 pub struct RaydiumCpmmState {
@@ -317,6 +343,9 @@ pub struct LivePoolCache {
 
     /// Raydium CPMM pool address → explicit [`DexPoolReadiness`] from JetStream / MASTER (Bug #36).
     raydium_cpmm_readiness_by_pool: DashMap<Pubkey, DexPoolReadiness>,
+
+    /// Raydium AMM v4 pool address → explicit [`DexPoolReadiness`] from JetStream / MASTER (Bug #36).
+    raydium_amm_readiness_by_pool: DashMap<Pubkey, DexPoolReadiness>,
 }
 
 /// Which vault position (A/B or X/Y or 0/1) this vault represents
@@ -349,6 +378,7 @@ impl LivePoolCache {
             pool_accounts_readiness_by_market: DashMap::new(),
             pumpfun_bonding_readiness_by_curve: DashMap::new(),
             raydium_cpmm_readiness_by_pool: DashMap::new(),
+            raydium_amm_readiness_by_pool: DashMap::new(),
         }
     }
 
@@ -926,6 +956,14 @@ impl LivePoolCache {
             .or_insert(incoming);
     }
 
+    /// Merge Raydium AMM v4 pool readiness for `pool` (monotonic — never downgrade).
+    pub fn merge_raydium_amm_pool_readiness(&self, pool: Pubkey, incoming: DexPoolReadiness) {
+        self.raydium_amm_readiness_by_pool
+            .entry(pool)
+            .and_modify(|stored| *stored = stored.merge(incoming))
+            .or_insert(incoming);
+    }
+
     /// `true` only when JetStream merge recorded [`DexPoolReadiness::Ready`] for this Raydium CPMM pool.
     #[must_use]
     pub fn raydium_cpmm_pool_explicitly_ready(&self, pool: &Pubkey) -> bool {
@@ -941,6 +979,21 @@ impl LivePoolCache {
         self.raydium_cpmm_readiness_by_pool.get(pool).map(|r| *r)
     }
 
+    /// `true` only when JetStream merge recorded [`DexPoolReadiness::Ready`] for this Raydium AMM pool.
+    #[must_use]
+    pub fn raydium_amm_pool_explicitly_ready(&self, pool: &Pubkey) -> bool {
+        self.raydium_amm_readiness_by_pool
+            .get(pool)
+            .map(|r| *r == DexPoolReadiness::Ready)
+            .unwrap_or(false)
+    }
+
+    /// Monotonic merge result for this Raydium AMM pool (tests / diagnostics).
+    #[must_use]
+    pub fn raydium_amm_readiness(&self, pool: &Pubkey) -> Option<DexPoolReadiness> {
+        self.raydium_amm_readiness_by_pool.get(pool).map(|r| *r)
+    }
+
     /// Mint-level helper: Raydium CPMM slice — explicit `Ready` only (no cache-hit heuristic).
     #[must_use]
     pub fn base_mint_has_explicit_raydium_cpmm_ready_pool(&self, base_mint: &Pubkey) -> bool {
@@ -951,6 +1004,23 @@ impl LivePoolCache {
                 }
                 let pool = entry.key();
                 if self.raydium_cpmm_pool_explicitly_ready(pool) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Mint-level helper: Raydium AMM v4 slice — explicit `Ready` only (no cache-hit heuristic).
+    #[must_use]
+    pub fn base_mint_has_explicit_raydium_amm_ready_pool(&self, base_mint: &Pubkey) -> bool {
+        for entry in self.pools.iter() {
+            if let CachedPoolState::RaydiumAmm(s) = &entry.value().state {
+                if s.base_mint != *base_mint && s.quote_mint != *base_mint {
+                    continue;
+                }
+                let pool = entry.key();
+                if self.raydium_amm_pool_explicitly_ready(pool) {
                     return true;
                 }
             }
@@ -1088,15 +1158,20 @@ impl LivePoolCache {
     ///   bonding-curve account for a cached [`PumpFunState`] whose `token_mint` equals `base_mint`.
     /// - Raydium CPMM: [`Self::base_mint_has_explicit_raydium_cpmm_ready_pool`] — explicit
     ///   [`DexPoolReadiness::Ready`] in [`Self::raydium_cpmm_readiness_by_pool`] only.
+    /// - Raydium AMM v4: [`Self::base_mint_has_explicit_raydium_amm_ready_pool`] — explicit
+    ///   [`DexPoolReadiness::Ready`] in [`Self::raydium_amm_readiness_by_pool`] only.
     ///
-    /// **Conservative:** Orca, Meteora, Raydium AMM v4, etc. are **not** treated as ready here
-    /// until they have an explicit readiness path.
+    /// **Conservative:** Orca, Meteora, etc. are **not** treated as ready here until they have an
+    /// explicit readiness path.
     #[must_use]
     pub fn base_mint_has_any_ready_pool(&self, base_mint: &Pubkey) -> bool {
         if self.base_mint_has_explicit_pump_amm_ready_pool(base_mint) {
             return true;
         }
         if self.base_mint_has_explicit_raydium_cpmm_ready_pool(base_mint) {
+            return true;
+        }
+        if self.base_mint_has_explicit_raydium_amm_ready_pool(base_mint) {
             return true;
         }
         for entry in self.pools.iter() {
@@ -1392,6 +1467,7 @@ pub fn create_shared_cache() -> SharedLivePoolCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn test_cache_basic_operations() {
@@ -2286,6 +2362,113 @@ mod tests {
         );
 
         assert!(!cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_raydium_amm_readiness_helper_reserves_only_is_partial() {
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let s = RaydiumAmmState {
+            base_mint: base,
+            quote_mint: quote,
+            coin_vault: Pubkey::new_unique(),
+            pc_vault: Pubkey::new_unique(),
+            base_decimals: 9,
+            quote_decimals: 9,
+            coin_reserve: Some(100),
+            pc_reserve: Some(200),
+            market_id: Pubkey::new_unique(),
+            serum_bids: None,
+            serum_asks: None,
+            serum_event_queue: None,
+        };
+        assert_eq!(
+            raydium_amm_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Partial
+        );
+    }
+
+    #[test]
+    fn test_raydium_amm_readiness_helper_ready_when_static_and_both_sides_liquid() {
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let s = RaydiumAmmState {
+            base_mint: base,
+            quote_mint: quote,
+            coin_vault: Pubkey::new_unique(),
+            pc_vault: Pubkey::new_unique(),
+            base_decimals: 9,
+            quote_decimals: 9,
+            coin_reserve: Some(100),
+            pc_reserve: Some(200),
+            market_id: Pubkey::new_unique(),
+            serum_bids: Some(Pubkey::new_unique()),
+            serum_asks: Some(Pubkey::new_unique()),
+            serum_event_queue: Some(Pubkey::new_unique()),
+        };
+        assert_eq!(
+            raydium_amm_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Ready
+        );
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_raydium_amm_explicit_ready() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        cache.upsert(
+            pool,
+            CachedPoolState::RaydiumAmm(RaydiumAmmState {
+                base_mint,
+                quote_mint,
+                coin_vault: Pubkey::new_unique(),
+                pc_vault: Pubkey::new_unique(),
+                base_decimals: 9,
+                quote_decimals: 9,
+                coin_reserve: Some(1),
+                pc_reserve: Some(2),
+                market_id: Pubkey::new_unique(),
+                serum_bids: Some(Pubkey::new_unique()),
+                serum_asks: Some(Pubkey::new_unique()),
+                serum_event_queue: Some(Pubkey::new_unique()),
+            }),
+            100,
+        );
+        cache.merge_raydium_amm_pool_readiness(pool, DexPoolReadiness::Ready);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+        assert!(cache.base_mint_has_explicit_raydium_amm_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_raydium_amm_readiness_merge_monotone() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        cache.upsert(
+            pool,
+            CachedPoolState::RaydiumAmm(RaydiumAmmState {
+                base_mint,
+                quote_mint,
+                coin_vault: Pubkey::new_unique(),
+                pc_vault: Pubkey::new_unique(),
+                base_decimals: 9,
+                quote_decimals: 9,
+                coin_reserve: Some(1),
+                pc_reserve: Some(2),
+                market_id: Pubkey::new_unique(),
+                serum_bids: Some(Pubkey::new_unique()),
+                serum_asks: Some(Pubkey::new_unique()),
+                serum_event_queue: Some(Pubkey::new_unique()),
+            }),
+            100,
+        );
+        cache.merge_raydium_amm_pool_readiness(pool, DexPoolReadiness::Ready);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+        cache.merge_raydium_amm_pool_readiness(pool, DexPoolReadiness::Observed);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
     }
 
     #[test]

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -1161,6 +1161,10 @@ mod tests {
         disc.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
         assert!(apply_pool_cache_update(&cache, &disc));
         assert!(cache.raydium_amm_pool_explicitly_ready(&pool));
+        assert_eq!(
+            cache.raydium_amm_readiness(&pool),
+            Some(DexPoolReadiness::Ready)
+        );
 
         let mut bal = PoolCacheUpdate::new_balance_updated(
             "test",
@@ -1189,6 +1193,10 @@ mod tests {
         assert!(
             cache.raydium_amm_pool_explicitly_ready(&pool),
             "merge must not downgrade Ready to Observed for Raydium AMM"
+        );
+        assert_eq!(
+            cache.raydium_amm_readiness(&pool),
+            Some(DexPoolReadiness::Ready)
         );
     }
 }

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -318,6 +318,12 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         update.effective_dex_readiness(),
                     );
                 }
+                if update.dex == "raydium" {
+                    cache.merge_raydium_amm_pool_readiness(
+                        pool_addr,
+                        update.effective_dex_readiness(),
+                    );
+                }
                 if update.dex == "pumpfun" {
                     cache.merge_pumpfun_bonding_readiness(
                         pool_addr,
@@ -434,6 +440,34 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         }
                     }
                 }
+                // BalanceUpdated often omits metadata: preserve Serum static accounts + vault pubkeys
+                // from existing Raydium AMM state so SLAVE readiness does not spuriously downgrade.
+                if update.dex == "raydium" {
+                    if let CachedPoolState::RaydiumAmm(ref mut new_am) = minimal_state {
+                        if let Some(CachedPoolState::RaydiumAmm(ex)) = existing.as_ref() {
+                            if new_am.market_id == Pubkey::default()
+                                && ex.market_id != Pubkey::default()
+                            {
+                                new_am.market_id = ex.market_id;
+                            }
+                            if new_am.serum_bids.is_none() {
+                                new_am.serum_bids = ex.serum_bids;
+                            }
+                            if new_am.serum_asks.is_none() {
+                                new_am.serum_asks = ex.serum_asks;
+                            }
+                            if new_am.serum_event_queue.is_none() {
+                                new_am.serum_event_queue = ex.serum_event_queue;
+                            }
+                            if new_am.coin_vault == Pubkey::default() {
+                                new_am.coin_vault = ex.coin_vault;
+                            }
+                            if new_am.pc_vault == Pubkey::default() {
+                                new_am.pc_vault = ex.pc_vault;
+                            }
+                        }
+                    }
+                }
                 cache.upsert(addr, minimal_state, update.geyser_slot);
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_pool_accounts_readiness(
@@ -443,6 +477,9 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 }
                 if update.dex == "raydium_cpmm" {
                     cache.merge_raydium_cpmm_pool_readiness(addr, update.effective_dex_readiness());
+                }
+                if update.dex == "raydium" {
+                    cache.merge_raydium_amm_pool_readiness(addr, update.effective_dex_readiness());
                 }
                 if update.dex == "pumpfun" {
                     cache.merge_pumpfun_bonding_readiness(addr, update.effective_dex_readiness());
@@ -1085,6 +1122,73 @@ mod tests {
         assert!(
             cache.raydium_cpmm_pool_explicitly_ready(&pool),
             "merge must not downgrade Ready to Observed for Raydium CPMM"
+        );
+    }
+
+    /// BalanceUpdated for `raydium` omits metadata: SLAVE must keep Serum static accounts from
+    /// existing state so readiness does not spuriously downgrade.
+    #[test]
+    fn test_raydium_amm_balance_updated_preserves_serum_and_merges_readiness() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let market_id = Pubkey::new_unique();
+        let bids = Pubkey::new_unique();
+        let asks = Pubkey::new_unique();
+        let eq = Pubkey::new_unique();
+
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("market_id".to_string(), market_id.to_string());
+        meta.insert("serum_bids".to_string(), bids.to_string());
+        meta.insert("serum_asks".to_string(), asks.to_string());
+        meta.insert("serum_event_queue".to_string(), eq.to_string());
+
+        let mut disc = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "raydium".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1_000_000,
+            50_000_000_000,
+            None,
+            1,
+        );
+        disc.metadata = Some(meta);
+        disc.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+        assert!(apply_pool_cache_update(&cache, &disc));
+        assert!(cache.raydium_amm_pool_explicitly_ready(&pool));
+
+        let mut bal = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "raydium".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            2_000_000,
+            60_000_000_000,
+            2,
+        );
+        bal.set_dex_readiness_in_metadata(DexPoolReadiness::Observed);
+        assert!(apply_pool_cache_update(&cache, &bal));
+
+        match cache.get(&pool).expect("pool in cache") {
+            CachedPoolState::RaydiumAmm(s) => {
+                assert_eq!(s.market_id, market_id);
+                assert_eq!(s.serum_bids, Some(bids));
+                assert_eq!(s.serum_asks, Some(asks));
+                assert_eq!(s.serum_event_queue, Some(eq));
+            }
+            other => panic!("expected RaydiumAmm, got {:?}", other),
+        }
+        assert!(
+            cache.raydium_amm_pool_explicitly_ready(&pool),
+            "merge must not downgrade Ready to Observed for Raydium AMM"
         );
     }
 }

--- a/src/solana/dex/raydium.rs
+++ b/src/solana/dex/raydium.rs
@@ -8,6 +8,10 @@ use tracing::debug;
 
 use super::{Dex, Quote};
 use crate::execution::live_pool_cache::{CachedPoolState, SharedLivePoolCache};
+
+/// Re-export: conservative [`crate::ipc::DexPoolReadiness`] for Raydium AMM v4 pool cache / JetStream
+/// (static Serum accounts + both-side liquidity; reserves alone are never `Ready`).
+pub use crate::execution::live_pool_cache::raydium_amm_readiness_for_pool_cache_update;
 use crate::solana::rpc::SolanaRpc;
 use dashmap::DashMap;
 #[cfg(feature = "rpc_fallback")]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds explicit `DexPoolReadiness` (Observed / Partial / Ready) for Raydium AMM v4, aligned with PumpSwap / PumpFun / Raydium CPMM patterns: conservative `Ready`, monotonic JetStream merge, and mint-level helper integration.

## Follow-up (Bugbot / PR #50)

- **Stale slot after async Serum fetch:** `PoolCacheUpdate::new_balance_updated` after the cold-path Serum RPC uses `LivePoolCache::get_with_metadata` so `geyser_slot` matches the **current** cache entry slot (latest vault/pool update), not the original discovery event slot.
- **`raydium_amm_readiness`:** Kept as a diagnostics/test accessor (used by `pool_cache_sync` tests), symmetric to `raydium_cpmm_readiness`.

**Latest push:** adds regression test `discovery_tests::test_raydium_amm_post_serum_jetstream_publish_slot_matches_cache_not_discovery` (constructs the publish the same way as production: current reserves + `geyser_slot` from `get_with_metadata`).

## Vollständigkeitsbegriff (Raydium AMM)

- **Ready**: `market_id != default`, Serum `bids`/`asks`/`event_queue` all present, **and** both `coin_reserve` and `pc_reserve` non-zero (usable constant-product quote path).
- **Partial**: at least one reserve non-zero but not all Ready conditions met.
- **Observed**: no meaningful reserves yet.

## STOP-CHECK

I-7: no Hot-Path RPC changes. Scope: allowed files only.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d413574-6e64-4669-8d6e-d67473b75905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d413574-6e64-4669-8d6e-d67473b75905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

