### PR TITLE
Scope 13: Meteora CPMM explicit DexPoolReadiness + SLAVE merge

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -78,8 +78,9 @@ const EXECUTION_RESULT_DEDUP_CAPACITY: usize = 4096;
 
 // LivePoolCache - MASTER Cache (Single Source of Truth)
 use ironcrab::execution::live_pool_cache::{
-    parse_pool_account, raydium_amm_readiness_for_pool_cache_update, CachedPoolState,
-    LivePoolCache, PumpAmmState, PumpFunState, RaydiumCpmmState,
+    meteora_cpmm_readiness_for_pool_cache_update, parse_pool_account,
+    raydium_amm_readiness_for_pool_cache_update, CachedPoolState, LivePoolCache, PumpAmmState,
+    PumpFunState, RaydiumCpmmState,
 };
 
 // P1 Crash Isolation: Systemd Watchdog support
@@ -3498,6 +3499,19 @@ async fn run_geyser_loop(
                                                 );
                                             }
                                         }
+                                        if vault_info.dex == "meteora_cpmm" {
+                                            if let Some(CachedPoolState::MeteoraCpmm(ref s)) =
+                                                ctx.live_pool_cache.get(&vault_info.pool_address)
+                                            {
+                                                let readiness =
+                                                    meteora_cpmm_readiness_for_pool_cache_update(s);
+                                                balance_update.set_dex_readiness_in_metadata(readiness);
+                                                ctx.live_pool_cache.merge_meteora_cpmm_pool_readiness(
+                                                    vault_info.pool_address,
+                                                    readiness,
+                                                );
+                                            }
+                                        }
                                         if vault_info.dex == "raydium" {
                                             if let Some(CachedPoolState::RaydiumAmm(ref s)) =
                                                 ctx.live_pool_cache.get(&vault_info.pool_address)
@@ -3700,6 +3714,63 @@ async fn run_geyser_loop(
                                 pc_vault = %pc_vault,
                                 "Registered Raydium CPMM vaults for Geyser reserve subscription"
                             );
+                        }
+                    }
+
+                    // Meteora CPMM: register vault ATAs for Geyser reserve updates (same pattern as Raydium CPMM).
+                    if ctx.config.read().enable_meteora_cpmm {
+                        if let CachedPoolState::MeteoraCpmm(s) = &cached_state {
+                            let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+                            let (base_mint_v, quote_mint_v, vault_base, vault_quote) =
+                                if s.token_1_mint == sol {
+                                    (s.token_0_mint, s.token_1_mint, s.token_0_vault, s.token_1_vault)
+                                } else if s.token_0_mint == sol {
+                                    (s.token_1_mint, s.token_0_mint, s.token_1_vault, s.token_0_vault)
+                                } else {
+                                    (s.token_0_mint, s.token_1_mint, s.token_0_vault, s.token_1_vault)
+                                };
+                            let dex_str = "meteora_cpmm".to_string();
+                            let mut vaults_changed = false;
+                            {
+                                let mut vaults = ctx.tracked_vaults.write();
+                                vaults.entry(vault_base).or_insert_with(|| {
+                                    vaults_changed = true;
+                                    VaultInfo {
+                                        pool_address: account_update.pubkey,
+                                        dex: dex_str.clone(),
+                                        base_mint: base_mint_v,
+                                        quote_mint: quote_mint_v,
+                                        is_base_vault: true,
+                                        last_balance: std::sync::atomic::AtomicU64::new(0),
+                                        active_id: None,
+                                        bin_step: None,
+                                    }
+                                });
+                                vaults.entry(vault_quote).or_insert_with(|| {
+                                    vaults_changed = true;
+                                    VaultInfo {
+                                        pool_address: account_update.pubkey,
+                                        dex: dex_str,
+                                        base_mint: base_mint_v,
+                                        quote_mint: quote_mint_v,
+                                        is_base_vault: false,
+                                        last_balance: std::sync::atomic::AtomicU64::new(0),
+                                        active_id: None,
+                                        bin_step: None,
+                                    }
+                                });
+                            }
+                            if vaults_changed {
+                                let vault_list: Vec<Pubkey> =
+                                    ctx.tracked_vaults.read().keys().copied().collect();
+                                let _ = ctx.tracked_vaults_tx.send(vault_list);
+                                debug!(
+                                    pool = %account_update.pubkey,
+                                    vault_base = %vault_base,
+                                    vault_quote = %vault_quote,
+                                    "Registered Meteora CPMM vaults for Geyser reserve subscription"
+                                );
+                            }
                         }
                     }
 
@@ -3973,7 +4044,29 @@ async fn run_geyser_loop(
                             (s.token_mint, Pubkey::default(), s.virtual_token_reserves, s.virtual_sol_reserves)
                         }
                         CachedPoolState::MeteoraCpmm(s) => {
-                            (s.token_0_mint, s.token_1_mint, s.reserve_0, s.reserve_1)
+                            let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+                            if s.token_1_mint == sol {
+                                (
+                                    s.token_0_mint,
+                                    s.token_1_mint,
+                                    s.reserve_0,
+                                    s.reserve_1,
+                                )
+                            } else if s.token_0_mint == sol {
+                                (
+                                    s.token_1_mint,
+                                    s.token_0_mint,
+                                    s.reserve_1,
+                                    s.reserve_0,
+                                )
+                            } else {
+                                (
+                                    s.token_0_mint,
+                                    s.token_1_mint,
+                                    s.reserve_0,
+                                    s.reserve_1,
+                                )
+                            }
                         }
                     };
 
@@ -4129,6 +4222,14 @@ async fn run_geyser_loop(
                                 let readiness = raydium_cpmm_readiness_for_pool_cache_update(s);
                                 pool_update.set_dex_readiness_in_metadata(readiness);
                                 ctx.live_pool_cache.merge_raydium_cpmm_pool_readiness(
+                                    account_update.pubkey,
+                                    readiness,
+                                );
+                            }
+                            CachedPoolState::MeteoraCpmm(s) => {
+                                let readiness = meteora_cpmm_readiness_for_pool_cache_update(s);
+                                pool_update.set_dex_readiness_in_metadata(readiness);
+                                ctx.live_pool_cache.merge_meteora_cpmm_pool_readiness(
                                     account_update.pubkey,
                                     readiness,
                                 );

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -34,6 +34,7 @@
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use solana_sdk::pubkey::Pubkey;
+use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -229,6 +230,33 @@ pub struct MeteoraCpmmState {
     pub status: u8,
 }
 
+/// JetStream / MASTER [`DexPoolReadiness`] for Meteora CPMM (conservative, explicit).
+///
+/// This scope treats **non-zero reserves on both normalized pool legs** (base + quote per
+/// [`crate::ipc::NATIVE_SOL_MINT`]-aware ordering, same idea as Raydium CPMM) as the smallest
+/// load-bearing completeness signal. Pool layout fields come from Geyser parse; vault balances
+/// still require both sides before `Ready`.
+#[must_use]
+pub fn meteora_cpmm_readiness_for_pool_cache_update(s: &MeteoraCpmmState) -> DexPoolReadiness {
+    let sol = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap_or_default();
+    let r0 = s.reserve_0;
+    let r1 = s.reserve_1;
+    let (base_side_liq, quote_side_liq) = if s.token_1_mint == sol {
+        (r0 > 0, r1 > 0)
+    } else if s.token_0_mint == sol {
+        (r1 > 0, r0 > 0)
+    } else {
+        (r0 > 0, r1 > 0)
+    };
+    if base_side_liq && quote_side_liq {
+        DexPoolReadiness::Ready
+    } else if r0 > 0 || r1 > 0 {
+        DexPoolReadiness::Partial
+    } else {
+        DexPoolReadiness::Observed
+    }
+}
+
 // ============================================================================
 // Unified cached pool state enum
 // ============================================================================
@@ -346,6 +374,9 @@ pub struct LivePoolCache {
 
     /// Raydium AMM v4 pool address → explicit [`DexPoolReadiness`] from JetStream / MASTER (Bug #36).
     raydium_amm_readiness_by_pool: DashMap<Pubkey, DexPoolReadiness>,
+
+    /// Meteora CPMM pool address → explicit [`DexPoolReadiness`] from JetStream / MASTER (Bug #36).
+    meteora_cpmm_readiness_by_pool: DashMap<Pubkey, DexPoolReadiness>,
 }
 
 /// Which vault position (A/B or X/Y or 0/1) this vault represents
@@ -379,6 +410,7 @@ impl LivePoolCache {
             pumpfun_bonding_readiness_by_curve: DashMap::new(),
             raydium_cpmm_readiness_by_pool: DashMap::new(),
             raydium_amm_readiness_by_pool: DashMap::new(),
+            meteora_cpmm_readiness_by_pool: DashMap::new(),
         }
     }
 
@@ -964,6 +996,14 @@ impl LivePoolCache {
             .or_insert(incoming);
     }
 
+    /// Merge Meteora CPMM pool readiness for `pool` (monotonic — never downgrade).
+    pub fn merge_meteora_cpmm_pool_readiness(&self, pool: Pubkey, incoming: DexPoolReadiness) {
+        self.meteora_cpmm_readiness_by_pool
+            .entry(pool)
+            .and_modify(|stored| *stored = stored.merge(incoming))
+            .or_insert(incoming);
+    }
+
     /// `true` only when JetStream merge recorded [`DexPoolReadiness::Ready`] for this Raydium CPMM pool.
     #[must_use]
     pub fn raydium_cpmm_pool_explicitly_ready(&self, pool: &Pubkey) -> bool {
@@ -994,6 +1034,21 @@ impl LivePoolCache {
         self.raydium_amm_readiness_by_pool.get(pool).map(|r| *r)
     }
 
+    /// `true` only when JetStream merge recorded [`DexPoolReadiness::Ready`] for this Meteora CPMM pool.
+    #[must_use]
+    pub fn meteora_cpmm_pool_explicitly_ready(&self, pool: &Pubkey) -> bool {
+        self.meteora_cpmm_readiness_by_pool
+            .get(pool)
+            .map(|r| *r == DexPoolReadiness::Ready)
+            .unwrap_or(false)
+    }
+
+    /// Monotonic merge result for this Meteora CPMM pool (tests / diagnostics).
+    #[must_use]
+    pub fn meteora_cpmm_readiness(&self, pool: &Pubkey) -> Option<DexPoolReadiness> {
+        self.meteora_cpmm_readiness_by_pool.get(pool).map(|r| *r)
+    }
+
     /// Mint-level helper: Raydium CPMM slice — explicit `Ready` only (no cache-hit heuristic).
     #[must_use]
     pub fn base_mint_has_explicit_raydium_cpmm_ready_pool(&self, base_mint: &Pubkey) -> bool {
@@ -1004,6 +1059,23 @@ impl LivePoolCache {
                 }
                 let pool = entry.key();
                 if self.raydium_cpmm_pool_explicitly_ready(pool) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Mint-level helper: Meteora CPMM slice — explicit `Ready` only (no cache-hit heuristic).
+    #[must_use]
+    pub fn base_mint_has_explicit_meteora_cpmm_ready_pool(&self, base_mint: &Pubkey) -> bool {
+        for entry in self.pools.iter() {
+            if let CachedPoolState::MeteoraCpmm(s) = &entry.value().state {
+                if s.token_0_mint != *base_mint && s.token_1_mint != *base_mint {
+                    continue;
+                }
+                let pool = entry.key();
+                if self.meteora_cpmm_pool_explicitly_ready(pool) {
                     return true;
                 }
             }
@@ -1160,8 +1232,10 @@ impl LivePoolCache {
     ///   [`DexPoolReadiness::Ready`] in [`Self::raydium_cpmm_readiness_by_pool`] only.
     /// - Raydium AMM v4: [`Self::base_mint_has_explicit_raydium_amm_ready_pool`] — explicit
     ///   [`DexPoolReadiness::Ready`] in [`Self::raydium_amm_readiness_by_pool`] only.
+    /// - Meteora CPMM: [`Self::base_mint_has_explicit_meteora_cpmm_ready_pool`] — explicit
+    ///   [`DexPoolReadiness::Ready`] in [`Self::meteora_cpmm_readiness_by_pool`] only.
     ///
-    /// **Conservative:** Orca, Meteora, etc. are **not** treated as ready here until they have an
+    /// **Conservative:** Orca, Meteora DLMM, etc. are **not** treated as ready here until they have an
     /// explicit readiness path.
     #[must_use]
     pub fn base_mint_has_any_ready_pool(&self, base_mint: &Pubkey) -> bool {
@@ -1169,6 +1243,9 @@ impl LivePoolCache {
             return true;
         }
         if self.base_mint_has_explicit_raydium_cpmm_ready_pool(base_mint) {
+            return true;
+        }
+        if self.base_mint_has_explicit_meteora_cpmm_ready_pool(base_mint) {
             return true;
         }
         if self.base_mint_has_explicit_raydium_amm_ready_pool(base_mint) {
@@ -2543,6 +2620,143 @@ mod tests {
         assert!(cache.base_mint_has_any_ready_pool(&base_mint));
 
         cache.merge_raydium_cpmm_pool_readiness(pool, DexPoolReadiness::Observed);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    fn make_meteora_cpmm_state(
+        token_0_mint: Pubkey,
+        token_1_mint: Pubkey,
+        reserve_0: u64,
+        reserve_1: u64,
+    ) -> MeteoraCpmmState {
+        MeteoraCpmmState {
+            token_0_mint,
+            token_1_mint,
+            token_0_vault: Pubkey::new_unique(),
+            token_1_vault: Pubkey::new_unique(),
+            amm_config: Pubkey::new_unique(),
+            observation_key: Pubkey::new_unique(),
+            token_0_program: Pubkey::new_unique(),
+            token_1_program: Pubkey::new_unique(),
+            reserve_0,
+            reserve_1,
+            mint_0_decimals: 6,
+            mint_1_decimals: 9,
+            status: 1,
+        }
+    }
+
+    #[test]
+    fn test_meteora_cpmm_readiness_helper_sol_quote_both_sides_ready() {
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let s = make_meteora_cpmm_state(base, quote, 1_000_000, 50_000_000_000);
+        assert_eq!(
+            meteora_cpmm_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Ready
+        );
+    }
+
+    #[test]
+    fn test_meteora_cpmm_readiness_helper_sol_as_token_0_one_side_only_partial() {
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let s = make_meteora_cpmm_state(quote, base, 50_000_000_000, 0);
+        assert_eq!(
+            meteora_cpmm_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Partial
+        );
+    }
+
+    #[test]
+    fn test_meteora_cpmm_readiness_helper_non_sol_pair_both_sides_ready() {
+        let a = Pubkey::new_unique();
+        let b = Pubkey::new_unique();
+        let s = make_meteora_cpmm_state(a, b, 100, 200);
+        assert_eq!(
+            meteora_cpmm_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Ready
+        );
+    }
+
+    #[test]
+    fn test_meteora_cpmm_readiness_helper_observed_when_zero_reserves() {
+        let a = Pubkey::new_unique();
+        let b = Pubkey::new_unique();
+        let s = make_meteora_cpmm_state(a, b, 0, 0);
+        assert_eq!(
+            meteora_cpmm_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Observed
+        );
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_meteora_cpmm_cache_hit_without_explicit_merge_is_false() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        cache.upsert(
+            pool,
+            CachedPoolState::MeteoraCpmm(make_meteora_cpmm_state(
+                base_mint,
+                quote_mint,
+                1_000_000,
+                50_000_000_000,
+            )),
+            100,
+        );
+        assert!(
+            !cache.base_mint_has_any_ready_pool(&base_mint),
+            "Bug #36: reserves in cache must not imply mint-level ready without explicit merge"
+        );
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_meteora_cpmm_explicit_ready() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        cache.upsert(
+            pool,
+            CachedPoolState::MeteoraCpmm(make_meteora_cpmm_state(base_mint, quote_mint, 1, 2)),
+            100,
+        );
+        cache.merge_meteora_cpmm_pool_readiness(pool, DexPoolReadiness::Ready);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+        assert!(cache.base_mint_has_explicit_meteora_cpmm_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_meteora_cpmm_partial_does_not_count() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        cache.upsert(
+            pool,
+            CachedPoolState::MeteoraCpmm(make_meteora_cpmm_state(base_mint, quote_mint, 1, 0)),
+            100,
+        );
+        cache.merge_meteora_cpmm_pool_readiness(pool, DexPoolReadiness::Partial);
+        assert!(!cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_meteora_cpmm_readiness_merge_monotone() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        cache.upsert(
+            pool,
+            CachedPoolState::MeteoraCpmm(make_meteora_cpmm_state(base_mint, quote_mint, 1, 2)),
+            100,
+        );
+        cache.merge_meteora_cpmm_pool_readiness(pool, DexPoolReadiness::Ready);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+        cache.merge_meteora_cpmm_pool_readiness(pool, DexPoolReadiness::Observed);
         assert!(cache.base_mint_has_any_ready_pool(&base_mint));
     }
 

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -345,6 +345,12 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         update.effective_dex_readiness(),
                     );
                 }
+                if update.dex == "meteora_cpmm" {
+                    cache.merge_meteora_cpmm_pool_readiness(
+                        pool_addr,
+                        update.effective_dex_readiness(),
+                    );
+                }
                 // P3 #13: Propagate base_decimals and quote_decimals to SLAVE cache
                 apply_decimals_from_metadata(cache, update);
                 return true;
@@ -541,6 +547,9 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 }
                 if update.dex == "pumpfun" {
                     cache.merge_pumpfun_bonding_readiness(addr, update.effective_dex_readiness());
+                }
+                if update.dex == "meteora_cpmm" {
+                    cache.merge_meteora_cpmm_pool_readiness(addr, update.effective_dex_readiness());
                 }
                 // P3 #13: Apply decimals from metadata when present (e.g. BalanceUpdated with metadata)
                 apply_decimals_from_metadata(cache, update);
@@ -1438,6 +1447,51 @@ mod tests {
         assert_eq!(
             cache.raydium_amm_readiness(&pool),
             Some(DexPoolReadiness::Ready)
+        );
+    }
+
+    #[test]
+    fn test_meteora_cpmm_readiness_merge_never_downgrades() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+
+        let mut ready_up = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "meteora_cpmm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1,
+            1,
+            None,
+            1,
+        );
+        ready_up.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+        assert!(apply_pool_cache_update(&cache, &ready_up));
+        assert!(cache.meteora_cpmm_pool_explicitly_ready(&pool));
+
+        let mut weak = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "meteora_cpmm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1,
+            1,
+            None,
+            2,
+        );
+        weak.set_dex_readiness_in_metadata(DexPoolReadiness::Observed);
+        assert!(apply_pool_cache_update(&cache, &weak));
+        assert!(
+            cache.meteora_cpmm_pool_explicitly_ready(&pool),
+            "merge must not downgrade Ready to Observed for Meteora CPMM"
         );
     }
 }

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -1473,6 +1473,10 @@ mod tests {
         ready_up.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
         assert!(apply_pool_cache_update(&cache, &ready_up));
         assert!(cache.meteora_cpmm_pool_explicitly_ready(&pool));
+        assert_eq!(
+            cache.meteora_cpmm_readiness(&pool),
+            Some(DexPoolReadiness::Ready)
+        );
 
         let mut weak = PoolCacheUpdate::new_pool_discovered(
             "test",
@@ -1492,6 +1496,10 @@ mod tests {
         assert!(
             cache.meteora_cpmm_pool_explicitly_ready(&pool),
             "merge must not downgrade Ready to Observed for Meteora CPMM"
+        );
+        assert_eq!(
+            cache.meteora_cpmm_readiness(&pool),
+            Some(DexPoolReadiness::Ready)
         );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces an explicit `DexPoolReadiness` path for **Meteora CPMM** in the market-data → JetStream → SLAVE flow, aligned with Raydium CPMM: conservative classification from Geyser-fed reserves, monotonic merge on the SLAVE, and mint-level `base_mint_has_any_ready_pool` only when JetStream recorded explicit `Ready` (no cache-hit heuristic).

**Follow-up:** `meteora_cpmm_readiness` is now asserted in `test_meteora_cpmm_readiness_merge_never_downgrades` (parity with `raydium_cpmm_readiness` / `raydium_amm_readiness` in pool_cache_sync tests) so the diagnostic getter is not dead code.

## Meteora CPMM completeness (this scope)

- **Ready**: SOL-aware normalized base/quote (same ordering as Raydium CPMM for SOL pairs) and **both** reserve legs **> 0**.
- **Partial**: at least one reserve **> 0** but not both normalized legs.
- **Observed**: pool parsed / in cache but both reserves **0** (typical right after pool account parse before vault updates).

Not in scope: extra static-account checks beyond this reserve gate, Meteora DLMM/Orca, bounded bootstrap verify for Meteora CPMM.

## Files

- `src/execution/live_pool_cache.rs` — `meteora_cpmm_readiness_for_pool_cache_update`, `merge_meteora_cpmm_pool_readiness`, mint helper, `base_mint_has_any_ready_pool` extension, tests.
- `src/execution/pool_cache_sync.rs` — merge on `PoolDiscovered` / `BalanceUpdated`, monotone merge test (+ `meteora_cpmm_readiness` assertions).
- `src/bin/market_data.rs` — vault registration for Meteora CPMM (when `enable_meteora_cpmm`), readiness on `PoolDiscovered` and vault `BalanceUpdated`, normalized base/quote mints in `PoolCacheUpdate` for SOL pairs.

## STOP-CHECK (AGENTS.md)

1. **Hot-path RPC**: No new RPC; only Geyser-driven cache/JetStream paths.
2. **Pattern**: Matches Raydium CPMM explicit readiness + merge maps.
3. **Scope**: Only allowed files touched.
4. **Simulation**: Unchanged.
5. **Eval repo**: Not read.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79829faf-38c1-4c25-856b-32f524606a9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79829faf-38c1-4c25-856b-32f524606a9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

