### PR TITLE
Scope 14: Bounded Meteora-CPMM-Bootstrap-Verifikation für Wallet-Mints

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -33,7 +33,8 @@ use ironcrab::ipc::{
     BinData, ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, ControlRequest,
     ControlRequestKind, ControlResponse, ControlResponseStatus, DexPoolReadiness, ExecutionResult,
     ExecutionStatus, IntentTier, MarketEvent, MarketEventKind, PoolCacheUpdate,
-    PriorityFeePercentiles, NATIVE_SOL_MINT, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    PriorityFeePercentiles, NATIVE_SOL_MINT, POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY,
+    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use ironcrab::metrics::{
     serve_metrics, set_readiness_control_sub_active, set_readiness_mode,
@@ -79,8 +80,8 @@ const EXECUTION_RESULT_DEDUP_CAPACITY: usize = 4096;
 // LivePoolCache - MASTER Cache (Single Source of Truth)
 use ironcrab::execution::live_pool_cache::{
     meteora_cpmm_readiness_for_pool_cache_update, parse_pool_account,
-    raydium_amm_readiness_for_pool_cache_update, CachedPoolState, LivePoolCache, PumpAmmState,
-    PumpFunState, RaydiumCpmmState,
+    raydium_amm_readiness_for_pool_cache_update, CachedPoolState, LivePoolCache, MeteoraCpmmState,
+    PumpAmmState, PumpFunState, RaydiumCpmmState,
 };
 
 // P1 Crash Isolation: Systemd Watchdog support
@@ -103,6 +104,19 @@ const METEORA_CPMM: &str = "cpmmpPFsKiR4eeYnGSuXgkhLLgGL1j5FUZoJBJU9t9D";
 /// metadata must list vault pubkeys in the same order as `base_mint` / `quote_mint` so SLAVE
 /// `build_minimal_pool_state_with_reserves` maps `token_0_*` ↔ vaults coherently.
 fn raydium_cpmm_vaults_for_pool_cache_update(s: &RaydiumCpmmState) -> String {
+    let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+    let (first_vault, second_vault) = if s.token_1_mint == sol {
+        (s.token_0_vault, s.token_1_vault)
+    } else if s.token_0_mint == sol {
+        (s.token_1_vault, s.token_0_vault)
+    } else {
+        (s.token_0_vault, s.token_1_vault)
+    };
+    format!("{first_vault},{second_vault}")
+}
+
+/// Meteora CPMM: same normalized base/quote vault ordering as Raydium CPMM for JetStream metadata.
+fn meteora_cpmm_vaults_for_pool_cache_update(s: &MeteoraCpmmState) -> String {
     let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
     let (first_vault, second_vault) = if s.token_1_mint == sol {
         (s.token_0_vault, s.token_1_vault)
@@ -577,8 +591,9 @@ fn try_parse_token_account_balance(data: &[u8]) -> Option<u64> {
 }
 
 /// Wallet `mints_in_wallet` are non-zero balances from bootstrap RPC; pick at most `max_mints`
-/// unique pubkeys that still lack explicit PumpSwap/PumpFun/Raydium-CPMM Ready per
-/// [`LivePoolCache::base_mint_has_any_ready_pool`]. Preserves iteration order; skips WSOL.
+/// unique pubkeys that still lack explicit Ready for any modeled slice per
+/// [`LivePoolCache::base_mint_has_any_ready_pool`] (PumpSwap, PumpFun, Raydium CPMM, Meteora CPMM,
+/// Raydium AMM). Preserves iteration order; skips WSOL.
 fn wallet_mints_needing_dex_bootstrap_verify(
     cache: &LivePoolCache,
     mints_in_wallet: &[String],
@@ -610,10 +625,10 @@ fn wallet_mints_needing_dex_bootstrap_verify(
     out
 }
 
-/// Cold-path only: bounded PumpSwap, then PumpFun, then Raydium CPMM (cache-scoped) for
-/// wallet-relevant mints without explicit Ready. Reuses [`handle_ensure_pump_amm_pool_accounts`],
-/// [`handle_ensure_pumpfun_bonding_curve`], and the same JetStream `PoolCacheUpdate` path as
-/// Geyser for Raydium CPMM. Skips periodic snapshots.
+/// Cold-path only: bounded PumpSwap, then PumpFun, then Raydium CPMM, then Meteora CPMM
+/// (cache-scoped) for wallet-relevant mints without explicit Ready. Reuses
+/// [`handle_ensure_pump_amm_pool_accounts`], [`handle_ensure_pumpfun_bonding_curve`], and the same
+/// JetStream `PoolCacheUpdate` path as Geyser for Raydium/Meteora CPMM. Skips periodic snapshots.
 async fn run_bounded_wallet_dex_bootstrap_verify(
     ctx: &MarketDataContext,
     rpc: &Arc<SolanaRpc>,
@@ -640,7 +655,7 @@ async fn run_bounded_wallet_dex_bootstrap_verify(
         count = candidates.len(),
         grace_ms = WALLET_BOOTSTRAP_DEX_VERIFY_GRACE_MS,
         max_mints = WALLET_BOOTSTRAP_DEX_VERIFY_MAX_MINTS,
-        "Wallet bootstrap: bounded DEX readiness verification (PumpSwap, then PumpFun, then Raydium CPMM if still not ready)"
+        "Wallet bootstrap: bounded DEX readiness verification (PumpSwap, PumpFun, Raydium CPMM, Meteora CPMM if still not ready)"
     );
 
     tokio::time::sleep(std::time::Duration::from_millis(
@@ -696,6 +711,22 @@ async fn run_bounded_wallet_dex_bootstrap_verify(
                 rpc,
                 run_id,
                 &request_id_rc,
+                &pk,
+            )
+            .await;
+        }
+
+        if ctx.live_pool_cache.base_mint_has_any_ready_pool(&pk) {
+            continue;
+        }
+
+        if ctx.config.read().enable_meteora_cpmm {
+            let request_id_mc = format!("wallet_bootstrap_mcpmm_{}", Uuid::new_v4());
+            handle_wallet_bootstrap_meteora_cpmm_verify_for_mint(
+                ctx,
+                rpc,
+                run_id,
+                &request_id_mc,
                 &pk,
             )
             .await;
@@ -901,6 +932,216 @@ async fn handle_wallet_bootstrap_raydium_cpmm_verify_for_mint(
                 request_id = %request_id,
                 pool = %pool_addr,
                 "Wallet bootstrap Raydium CPMM: MASTER cache updated but JetStream publish failed — SSOT drift risk"
+            );
+        }
+    }
+}
+
+/// Cold-path only: Meteora CPMM promotion for one wallet mint. Uses **only** pools already present
+/// in [`LivePoolCache`] (from Geyser); no global scan. RPC: per-pool `get_account` + per-vault
+/// balance reads — bounded by the number of matching cache rows.
+///
+/// Publishes [`PoolCacheUpdate`] with [`meteora_cpmm_readiness_for_pool_cache_update`] and
+/// `meteora_cpmm_vaults` metadata (normalized base/quote order) like the Raydium CPMM bootstrap slice.
+async fn handle_wallet_bootstrap_meteora_cpmm_verify_for_mint(
+    ctx: &MarketDataContext,
+    rpc: &Arc<SolanaRpc>,
+    run_id: &str,
+    request_id: &str,
+    base_mint: &Pubkey,
+) {
+    if ctx
+        .live_pool_cache
+        .base_mint_has_explicit_meteora_cpmm_ready_pool(base_mint)
+    {
+        debug!(
+            request_id = %request_id,
+            mint = %base_mint,
+            "Wallet bootstrap Meteora CPMM: already explicit Ready for this mint, skip"
+        );
+        return;
+    }
+
+    let pools = ctx.live_pool_cache.meteora_cpmm_pools_for_mint(base_mint);
+    if pools.is_empty() {
+        debug!(
+            request_id = %request_id,
+            mint = %base_mint,
+            "Wallet bootstrap Meteora CPMM: no CPMM pool rows in LivePoolCache for mint, skip RPC"
+        );
+        return;
+    }
+
+    info!(
+        request_id = %request_id,
+        mint = %base_mint,
+        pools = pools.len(),
+        "Wallet bootstrap Meteora CPMM: verifying cache-scoped pools (cold-path RPC, no global scan)"
+    );
+
+    let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+
+    for (pool_addr, mut state) in pools {
+        if ctx.live_pool_cache.base_mint_has_any_ready_pool(base_mint) {
+            break;
+        }
+        if ctx
+            .live_pool_cache
+            .base_mint_has_explicit_meteora_cpmm_ready_pool(base_mint)
+        {
+            break;
+        }
+
+        let pool_acc = match rpc.get_account_opt_retry(&pool_addr).await {
+            Ok(Some(acc)) => acc,
+            Ok(None) | Err(_) => {
+                debug!(
+                    request_id = %request_id,
+                    pool = %pool_addr,
+                    "Wallet bootstrap Meteora CPMM: pool account fetch miss, skip"
+                );
+                continue;
+            }
+        };
+
+        let meteora_cpmm_program = Pubkey::from_str(METEORA_CPMM).expect("METEORA_CPMM constant");
+        let parsed_state = match parse_pool_account(&meteora_cpmm_program, &pool_acc.data) {
+            Some(CachedPoolState::MeteoraCpmm(s)) => s,
+            _ => {
+                debug!(
+                    request_id = %request_id,
+                    pool = %pool_addr,
+                    data_len = pool_acc.data.len(),
+                    "Wallet bootstrap Meteora CPMM: parse pool failed, skip"
+                );
+                continue;
+            }
+        };
+
+        state.token_0_mint = parsed_state.token_0_mint;
+        state.token_1_mint = parsed_state.token_1_mint;
+        state.token_0_vault = parsed_state.token_0_vault;
+        state.token_1_vault = parsed_state.token_1_vault;
+        state.amm_config = parsed_state.amm_config;
+        state.observation_key = parsed_state.observation_key;
+        state.token_0_program = parsed_state.token_0_program;
+        state.token_1_program = parsed_state.token_1_program;
+        state.mint_0_decimals = parsed_state.mint_0_decimals;
+        state.mint_1_decimals = parsed_state.mint_1_decimals;
+        state.status = parsed_state.status;
+
+        if state.token_0_mint != *base_mint && state.token_1_mint != *base_mint {
+            continue;
+        }
+
+        let vault0 = state.token_0_vault;
+        let vault1 = state.token_1_vault;
+        let bal0 = match rpc.get_account_opt_retry(&vault0).await {
+            Ok(Some(acc)) => try_parse_token_account_balance(&acc.data),
+            _ => None,
+        };
+        let bal1 = match rpc.get_account_opt_retry(&vault1).await {
+            Ok(Some(acc)) => try_parse_token_account_balance(&acc.data),
+            _ => None,
+        };
+        let (b0, b1) = match (bal0, bal1) {
+            (Some(a), Some(b)) => (a, b),
+            _ => {
+                debug!(
+                    request_id = %request_id,
+                    pool = %pool_addr,
+                    "Wallet bootstrap Meteora CPMM: vault balance RPC incomplete, skip"
+                );
+                continue;
+            }
+        };
+
+        state.reserve_0 = b0;
+        state.reserve_1 = b1;
+
+        ctx.live_pool_cache
+            .upsert(pool_addr, CachedPoolState::MeteoraCpmm(state.clone()), 0);
+
+        let readiness = meteora_cpmm_readiness_for_pool_cache_update(&state);
+        ctx.live_pool_cache
+            .merge_meteora_cpmm_pool_readiness(pool_addr, readiness);
+
+        if readiness == DexPoolReadiness::Observed {
+            debug!(
+                request_id = %request_id,
+                pool = %pool_addr,
+                mint = %base_mint,
+                "Wallet bootstrap Meteora CPMM: reserves still degenerate (Observed), no JetStream publish"
+            );
+            continue;
+        }
+
+        let (pub_base_mint, pub_quote_mint, base_r, quote_r) = if state.token_1_mint == sol {
+            (state.token_0_mint, state.token_1_mint, b0, b1)
+        } else if state.token_0_mint == sol {
+            (state.token_1_mint, state.token_0_mint, b1, b0)
+        } else {
+            (state.token_0_mint, state.token_1_mint, b0, b1)
+        };
+
+        let jetstream_ok = if let Some(ref nats) = ctx.nats {
+            let mut balance_update = PoolCacheUpdate::new_balance_updated(
+                "market-data",
+                BUILD_VERSION,
+                run_id,
+                pool_addr.to_string(),
+                "meteora_cpmm".to_string(),
+                pub_base_mint.to_string(),
+                pub_quote_mint.to_string(),
+                base_r,
+                quote_r,
+                0,
+            );
+            let mut meta = std::collections::HashMap::new();
+            meta.insert(
+                POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY.to_string(),
+                meteora_cpmm_vaults_for_pool_cache_update(&state),
+            );
+            balance_update.metadata = Some(meta);
+            balance_update.set_dex_readiness_in_metadata(readiness);
+            let subject = pool_subject(&pool_addr.to_string());
+            match nats.jetstream_publish(&subject, &balance_update).await {
+                Ok(true) => {
+                    info!(
+                        request_id = %request_id,
+                        pool = %pool_addr,
+                        mint = %base_mint,
+                        readiness = ?readiness,
+                        "Wallet bootstrap Meteora CPMM: published PoolCacheUpdate::BalanceUpdated to JetStream"
+                    );
+                    true
+                }
+                Ok(false) => {
+                    warn!(
+                        request_id = %request_id,
+                        pool = %pool_addr,
+                        "Wallet bootstrap Meteora CPMM: JetStream publish failed (timeout or drop)"
+                    );
+                    false
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        request_id = %request_id,
+                        "Wallet bootstrap Meteora CPMM: Failed to publish PoolCacheUpdate to JetStream"
+                    );
+                    false
+                }
+            }
+        } else {
+            false
+        };
+
+        if !jetstream_ok {
+            warn!(
+                request_id = %request_id,
+                pool = %pool_addr,
+                "Wallet bootstrap Meteora CPMM: MASTER cache updated but JetStream publish failed — SSOT drift risk"
             );
         }
     }
@@ -5949,5 +6190,86 @@ mod discovery_tests {
         let rows = cache.raydium_cpmm_pools_for_mint(&m);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].0, p1);
+    }
+
+    #[test]
+    fn test_live_pool_cache_meteora_cpmm_pools_for_mint_bounded_to_cache() {
+        let cache = LivePoolCache::new();
+        let m = Pubkey::new_unique();
+        let other = Pubkey::new_unique();
+        let p1 = Pubkey::new_unique();
+        let p2 = Pubkey::new_unique();
+        let v = MeteoraCpmmState {
+            token_0_mint: m,
+            token_1_mint: other,
+            token_0_vault: Pubkey::new_unique(),
+            token_1_vault: Pubkey::new_unique(),
+            amm_config: Pubkey::new_unique(),
+            observation_key: Pubkey::new_unique(),
+            token_0_program: Pubkey::new_unique(),
+            token_1_program: Pubkey::new_unique(),
+            reserve_0: 0,
+            reserve_1: 0,
+            mint_0_decimals: 6,
+            mint_1_decimals: 9,
+            status: 0,
+        };
+        cache.upsert(p1, CachedPoolState::MeteoraCpmm(v.clone()), 0);
+        cache.upsert(
+            p2,
+            CachedPoolState::MeteoraCpmm(MeteoraCpmmState {
+                token_0_mint: other,
+                token_1_mint: other,
+                token_0_vault: Pubkey::new_unique(),
+                token_1_vault: Pubkey::new_unique(),
+                amm_config: Pubkey::new_unique(),
+                observation_key: Pubkey::new_unique(),
+                token_0_program: Pubkey::new_unique(),
+                token_1_program: Pubkey::new_unique(),
+                reserve_0: 0,
+                reserve_1: 0,
+                mint_0_decimals: 6,
+                mint_1_decimals: 9,
+                status: 0,
+            }),
+            0,
+        );
+        let rows = cache.meteora_cpmm_pools_for_mint(&m);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, p1);
+    }
+
+    #[test]
+    fn test_wallet_mints_needing_dex_bootstrap_verify_skips_meteora_cpmm_explicit_ready() {
+        let cache = LivePoolCache::new();
+        let wsol = WSOL_MINT;
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::new_unique();
+        let pool = Pubkey::new_unique();
+        cache.upsert(
+            pool,
+            CachedPoolState::MeteoraCpmm(MeteoraCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: Pubkey::new_unique(),
+                token_1_vault: Pubkey::new_unique(),
+                amm_config: Pubkey::new_unique(),
+                observation_key: Pubkey::new_unique(),
+                token_0_program: Pubkey::new_unique(),
+                token_1_program: Pubkey::new_unique(),
+                reserve_0: 1,
+                reserve_1: 2,
+                mint_0_decimals: 6,
+                mint_1_decimals: 6,
+                status: 0,
+            }),
+            0,
+        );
+        cache.merge_meteora_cpmm_pool_readiness(pool, DexPoolReadiness::Ready);
+
+        let other = Pubkey::new_unique();
+        let mints = vec![base_mint.to_string(), other.to_string()];
+        let out = wallet_mints_needing_dex_bootstrap_verify(&cache, &mints, wsol, 8);
+        assert_eq!(out, vec![other]);
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -33,8 +33,8 @@ use ironcrab::ipc::{
     BinData, ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, ControlRequest,
     ControlRequestKind, ControlResponse, ControlResponseStatus, DexPoolReadiness, ExecutionResult,
     ExecutionStatus, IntentTier, MarketEvent, MarketEventKind, PoolCacheUpdate,
-    PriorityFeePercentiles, NATIVE_SOL_MINT, POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY,
-    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    PriorityFeePercentiles, NATIVE_SOL_MINT, POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY,
+    POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use ironcrab::metrics::{
     serve_metrics, set_readiness_control_sub_active, set_readiness_mode,
@@ -126,6 +126,11 @@ fn meteora_cpmm_vaults_for_pool_cache_update(s: &MeteoraCpmmState) -> String {
         (s.token_0_vault, s.token_1_vault)
     };
     format!("{first_vault},{second_vault}")
+}
+
+/// On-chain `token_0_mint,token_1_mint` for SLAVE bootstrap when JetStream uses normalized base/quote.
+fn meteora_cpmm_onchain_mints_for_pool_cache_update(s: &MeteoraCpmmState) -> String {
+    format!("{},{}", s.token_0_mint, s.token_1_mint)
 }
 
 /// JetStream readiness for Raydium CPMM (SOL-aware base/quote): single source for BalanceUpdated and PoolDiscovered.
@@ -1101,6 +1106,10 @@ async fn handle_wallet_bootstrap_meteora_cpmm_verify_for_mint(
             meta.insert(
                 POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY.to_string(),
                 meteora_cpmm_vaults_for_pool_cache_update(&state),
+            );
+            meta.insert(
+                POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY.to_string(),
+                meteora_cpmm_onchain_mints_for_pool_cache_update(&state),
             );
             balance_update.metadata = Some(meta);
             balance_update.set_dex_readiness_in_metadata(readiness);
@@ -3744,6 +3753,16 @@ async fn run_geyser_loop(
                                             if let Some(CachedPoolState::MeteoraCpmm(ref s)) =
                                                 ctx.live_pool_cache.get(&vault_info.pool_address)
                                             {
+                                                let mut meta = balance_update.metadata.take().unwrap_or_default();
+                                                meta.insert(
+                                                    POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY.to_string(),
+                                                    meteora_cpmm_vaults_for_pool_cache_update(s),
+                                                );
+                                                meta.insert(
+                                                    POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY.to_string(),
+                                                    meteora_cpmm_onchain_mints_for_pool_cache_update(s),
+                                                );
+                                                balance_update.metadata = Some(meta);
                                                 let readiness =
                                                     meteora_cpmm_readiness_for_pool_cache_update(s);
                                                 balance_update.set_dex_readiness_in_metadata(readiness);
@@ -4468,6 +4487,16 @@ async fn run_geyser_loop(
                                 );
                             }
                             CachedPoolState::MeteoraCpmm(s) => {
+                                let mut meta = std::collections::HashMap::new();
+                                meta.insert(
+                                    POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY.to_string(),
+                                    meteora_cpmm_vaults_for_pool_cache_update(s),
+                                );
+                                meta.insert(
+                                    POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY.to_string(),
+                                    meteora_cpmm_onchain_mints_for_pool_cache_update(s),
+                                );
+                                pool_update.metadata = Some(meta);
                                 let readiness = meteora_cpmm_readiness_for_pool_cache_update(s);
                                 pool_update.set_dex_readiness_in_metadata(readiness);
                                 ctx.live_pool_cache.merge_meteora_cpmm_pool_readiness(

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -1115,6 +1115,21 @@ impl LivePoolCache {
         out
     }
 
+    /// Cold-path bootstrap: Meteora CPMM pools in cache that list `mint` as token_0 or token_1.
+    /// Bounded iteration over the in-memory cache only (no chain scan).
+    #[must_use]
+    pub fn meteora_cpmm_pools_for_mint(&self, mint: &Pubkey) -> Vec<(Pubkey, MeteoraCpmmState)> {
+        let mut out = Vec::new();
+        for entry in self.pools.iter() {
+            if let CachedPoolState::MeteoraCpmm(s) = &entry.value().state {
+                if s.token_0_mint == *mint || s.token_1_mint == *mint {
+                    out.push((*entry.key(), s.clone()));
+                }
+            }
+        }
+        out
+    }
+
     /// `true` only after explicit JetStream / control-path merge recorded [`DexPoolReadiness::Ready`]
     /// for this bonding curve (Bug #36: cache hit alone is not ready).
     #[must_use]

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -25,8 +25,8 @@ use crate::execution::live_pool_cache::{
     PumpAmmState, PumpFunState, RaydiumAmmState, RaydiumCpmmState,
 };
 use crate::ipc::{
-    PoolCacheUpdate, PoolCacheUpdateType, POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY,
-    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    PoolCacheUpdate, PoolCacheUpdateType, POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY,
+    POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use crate::nats::{slave_consumer_config, NatsClient, STREAM_NAME};
 
@@ -143,21 +143,84 @@ fn build_minimal_pool_state_with_reserves(
             reserve_x_balance: Some(base_reserve),
             reserve_y_balance: Some(quote_reserve),
         }),
-        "meteora_cpmm" => CachedPoolState::MeteoraCpmm(MeteoraCpmmState {
-            token_0_mint: base_mint,
-            token_1_mint: quote_mint,
-            token_0_vault: Pubkey::default(),
-            token_1_vault: Pubkey::default(),
-            amm_config: Pubkey::default(),
-            observation_key: Pubkey::default(),
-            token_0_program: Pubkey::default(),
-            token_1_program: Pubkey::default(),
-            reserve_0: base_reserve,
-            reserve_1: quote_reserve,
-            mint_0_decimals: 0,
-            mint_1_decimals: 0,
-            status: 0,
-        }),
+        "meteora_cpmm" => {
+            // `base_mint` / `quote_mint` / reserves are normalized (non-SOL first). On-chain
+            // Meteora pool state uses token_0 / token_1 — may be SOL,base. Optional metadata carries
+            // true on-chain mint order so SLAVE bootstrap from BalanceUpdated alone stays correct.
+            let meta = update.metadata.as_ref();
+            let (token_0_mint, token_1_mint, reserve_0, reserve_1) = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY))
+                .and_then(|s| {
+                    let mut it = s.split(',').filter_map(|a| Pubkey::from_str(a.trim()).ok());
+                    match (it.next(), it.next()) {
+                        (Some(t0), Some(t1)) => Some((t0, t1)),
+                        _ => None,
+                    }
+                })
+                .map(|(t0, t1)| {
+                    let (r0, r1) = if t0 == base_mint && t1 == quote_mint {
+                        (base_reserve, quote_reserve)
+                    } else if t0 == quote_mint && t1 == base_mint {
+                        (quote_reserve, base_reserve)
+                    } else {
+                        (base_reserve, quote_reserve)
+                    };
+                    (t0, t1, r0, r1)
+                })
+                .unwrap_or((base_mint, quote_mint, base_reserve, quote_reserve));
+
+            // Only map vaults here when on-chain mint order is known. Otherwise leave defaults so
+            // `BalanceUpdated` merge can use existing Geyser row + normalized vault metadata.
+            let onchain_meta = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY))
+                .is_some();
+            let (token_0_vault, token_1_vault) = if onchain_meta {
+                meta.and_then(|m| m.get(POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY))
+                    .and_then(|s| {
+                        let mut it = s.split(',').filter_map(|a| Pubkey::from_str(a.trim()).ok());
+                        match (it.next(), it.next()) {
+                            (Some(bv), Some(qv)) => Some((bv, qv)),
+                            _ => None,
+                        }
+                    })
+                    .map(|(bv, qv)| {
+                        let v0 = if token_0_mint == base_mint {
+                            bv
+                        } else if token_0_mint == quote_mint {
+                            qv
+                        } else {
+                            Pubkey::default()
+                        };
+                        let v1 = if token_1_mint == base_mint {
+                            bv
+                        } else if token_1_mint == quote_mint {
+                            qv
+                        } else {
+                            Pubkey::default()
+                        };
+                        (v0, v1)
+                    })
+                    .unwrap_or((Pubkey::default(), Pubkey::default()))
+            } else {
+                (Pubkey::default(), Pubkey::default())
+            };
+
+            CachedPoolState::MeteoraCpmm(MeteoraCpmmState {
+                token_0_mint,
+                token_1_mint,
+                token_0_vault,
+                token_1_vault,
+                amm_config: Pubkey::default(),
+                observation_key: Pubkey::default(),
+                token_0_program: Pubkey::default(),
+                token_1_program: Pubkey::default(),
+                reserve_0,
+                reserve_1,
+                mint_0_decimals: 0,
+                mint_1_decimals: 0,
+                status: 0,
+            })
+        }
         "pump_amm" => {
             let creator = update
                 .metadata
@@ -727,8 +790,8 @@ pub async fn bootstrap_pool_cache_from_jetstream(
 mod tests {
     use super::*;
     use crate::ipc::{
-        DexPoolReadiness, POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY,
-        POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+        DexPoolReadiness, POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY,
+        POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
     };
 
     /// A.30 Regression: cashback_enabled must be true when JetStream metadata contains
@@ -1449,6 +1512,56 @@ mod tests {
             CachedPoolState::MeteoraCpmm(s) => {
                 assert_eq!(s.token_0_vault, quote_vault, "SOL leg vault");
                 assert_eq!(s.token_1_vault, base_vault, "base-mint leg vault");
+            }
+            other => panic!("expected MeteoraCpmm, got {:?}", other),
+        }
+    }
+
+    /// PR #53 follow-up: LastPerSubject bootstrap may replay only `BalanceUpdated` with no prior
+    /// SLAVE row. `meteora_cpmm_onchain_mints` + normalized vault metadata must reconstruct true
+    /// on-chain token_0/token_1, reserves, and vaults when SOL is token_0.
+    #[test]
+    fn test_meteora_cpmm_balance_updated_cold_bootstrap_sol_token_0_no_existing_cache() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let sol = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let base_vault = Pubkey::new_unique();
+        let quote_vault = Pubkey::new_unique();
+
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY.to_string(),
+            format!("{base_vault},{quote_vault}"),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY.to_string(),
+            format!("{sol},{base_mint}"),
+        );
+        let mut bal = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "meteora_cpmm".to_string(),
+            base_mint.to_string(),
+            sol.to_string(),
+            100,
+            50_000_000_000,
+            2,
+        );
+        bal.metadata = Some(meta);
+        bal.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+        assert!(apply_pool_cache_update(&cache, &bal));
+
+        match cache.get(&pool).expect("pool in cache") {
+            CachedPoolState::MeteoraCpmm(s) => {
+                assert_eq!(s.token_0_mint, sol);
+                assert_eq!(s.token_1_mint, base_mint);
+                assert_eq!(s.reserve_0, 50_000_000_000, "SOL reserve on token_0 leg");
+                assert_eq!(s.reserve_1, 100, "base mint reserve on token_1 leg");
+                assert_eq!(s.token_0_vault, quote_vault);
+                assert_eq!(s.token_1_vault, base_vault);
             }
             other => panic!("expected MeteoraCpmm, got {:?}", other),
         }

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -531,6 +531,40 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 // programs/config/decimals/status from existing Meteora CPMM (minimal JetStream row).
                 if update.dex == "meteora_cpmm" {
                     if let CachedPoolState::MeteoraCpmm(ref mut new_cpmm) = minimal_state {
+                        // Without `meteora_cpmm_onchain_mints`, scalar mints are normalized base/quote only.
+                        // Preserve on-chain token_0/token_1 from an existing SLAVE row so vault metadata
+                        // remap stays consistent (SOL-as-token_0 + vault-only metadata).
+                        let update_has_onchain_mints = update
+                            .metadata
+                            .as_ref()
+                            .and_then(|m| m.get(POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY))
+                            .is_some();
+                        if !update_has_onchain_mints {
+                            if let Some(CachedPoolState::MeteoraCpmm(ex)) = existing.as_ref() {
+                                new_cpmm.token_0_mint = ex.token_0_mint;
+                                new_cpmm.token_1_mint = ex.token_1_mint;
+                                if let (Ok(up_base), Ok(up_quote)) = (
+                                    Pubkey::from_str(&update.base_mint),
+                                    Pubkey::from_str(&update.quote_mint),
+                                ) {
+                                    new_cpmm.reserve_0 = if ex.token_0_mint == up_base {
+                                        base_reserve
+                                    } else if ex.token_0_mint == up_quote {
+                                        quote_reserve
+                                    } else {
+                                        new_cpmm.reserve_0
+                                    };
+                                    new_cpmm.reserve_1 = if ex.token_1_mint == up_base {
+                                        base_reserve
+                                    } else if ex.token_1_mint == up_quote {
+                                        quote_reserve
+                                    } else {
+                                        new_cpmm.reserve_1
+                                    };
+                                }
+                            }
+                        }
+
                         let from_existing_vaults = existing.as_ref().and_then(|ex| {
                             if let CachedPoolState::MeteoraCpmm(s) = ex {
                                 if s.token_0_vault != Pubkey::default()
@@ -556,60 +590,50 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                                     }
                                 })
                         });
+                        // Existing Geyser/JetStream row: vault pair is already token_0_vault,token_1_vault
+                        // (on-chain order). Do not run base/quote remap on it — that double-swaps when
+                        // SOL is token_0 but PoolCacheUpdate uses normalized mints.
                         if let Some((t0v, t1v)) = from_existing_vaults {
-                            // Already on-chain token_0 / token_1 vault order — do not remap (remap
-                            // below assumes normalized base_vault,quote_vault metadata).
                             if new_cpmm.token_0_vault == Pubkey::default() {
                                 new_cpmm.token_0_vault = t0v;
                             }
                             if new_cpmm.token_1_vault == Pubkey::default() {
                                 new_cpmm.token_1_vault = t1v;
                             }
-                        } else if let Some((bv, qv)) = from_meta_vaults {
-                            let sol =
-                                Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap_or_default();
-                            // Map normalized `base_vault,quote_vault` metadata onto **on-chain**
-                            // token_0/token_1. Prefer matching against existing Geyser mint order when
-                            // present (SOL can be token_0 on-chain while updates use non-SOL-first).
-                            let (t0v, t1v) = if let Some(CachedPoolState::MeteoraCpmm(ex)) =
-                                existing.as_ref()
-                            {
-                                if let (Ok(up_base), Ok(up_quote)) = (
-                                    Pubkey::from_str(&update.base_mint),
-                                    Pubkey::from_str(&update.quote_mint),
-                                ) {
-                                    if ex.token_0_mint == up_base && ex.token_1_mint == up_quote {
-                                        (bv, qv)
-                                    } else if ex.token_0_mint == up_quote
-                                        && ex.token_1_mint == up_base
-                                    {
-                                        (qv, bv)
-                                    } else if new_cpmm.token_1_mint == sol {
-                                        (bv, qv)
-                                    } else if new_cpmm.token_0_mint == sol {
-                                        (qv, bv)
-                                    } else {
-                                        (bv, qv)
-                                    }
-                                } else if new_cpmm.token_1_mint == sol {
-                                    (bv, qv)
-                                } else if new_cpmm.token_0_mint == sol {
-                                    (qv, bv)
+                        } else if let Some((base_vault, quote_vault)) = from_meta_vaults {
+                            // Metadata: `base_vault,quote_vault` matches normalized update.base_mint /
+                            // update.quote_mint. Map onto token_0/token_1 using authoritative on-chain
+                            // mint order when SLAVE already has it; else minimal state's mints.
+                            let (auth_t0_mint, auth_t1_mint) =
+                                if let Some(CachedPoolState::MeteoraCpmm(ex)) = existing.as_ref() {
+                                    (ex.token_0_mint, ex.token_1_mint)
                                 } else {
-                                    (bv, qv)
+                                    (new_cpmm.token_0_mint, new_cpmm.token_1_mint)
+                                };
+                            if let (Ok(up_base), Ok(up_quote)) = (
+                                Pubkey::from_str(&update.base_mint),
+                                Pubkey::from_str(&update.quote_mint),
+                            ) {
+                                let t0v = if auth_t0_mint == up_base {
+                                    base_vault
+                                } else if auth_t0_mint == up_quote {
+                                    quote_vault
+                                } else {
+                                    Pubkey::default()
+                                };
+                                let t1v = if auth_t1_mint == up_base {
+                                    base_vault
+                                } else if auth_t1_mint == up_quote {
+                                    quote_vault
+                                } else {
+                                    Pubkey::default()
+                                };
+                                if new_cpmm.token_0_vault == Pubkey::default() {
+                                    new_cpmm.token_0_vault = t0v;
                                 }
-                            } else if new_cpmm.token_1_mint == sol {
-                                (bv, qv)
-                            } else if new_cpmm.token_0_mint == sol {
-                                (qv, bv)
-                            } else {
-                                (bv, qv)
-                            };
-                            if new_cpmm.token_0_vault == Pubkey::default() {
-                                new_cpmm.token_0_vault = t0v;
-                            }
-                            if new_cpmm.token_1_vault == Pubkey::default() {
-                                new_cpmm.token_1_vault = t1v;
+                                if new_cpmm.token_1_vault == Pubkey::default() {
+                                    new_cpmm.token_1_vault = t1v;
+                                }
                             }
                         }
                         if let Some(CachedPoolState::MeteoraCpmm(ex)) = existing.as_ref() {
@@ -1465,8 +1489,10 @@ mod tests {
         }
     }
 
-    /// Same as [`test_meteora_cpmm_balance_updated_metadata_vaults_normalized_order`] but SOL is
-    /// token_0 on-chain; metadata remains base_vault,quote_vault (non-SOL base first).
+    /// SOL is on-chain `token_0`; JetStream uses normalized `base_mint` / `quote_mint` and
+    /// `meteora_cpmm_vaults` = `base_vault,quote_vault` for that pair. Merge must assign
+    /// `quote_vault` → `token_0_vault` (SOL) and `base_vault` → `token_1_vault` without applying
+    /// the old SOL-heuristic swap on top of already-normalized metadata (double-swap bug).
     #[test]
     fn test_meteora_cpmm_balance_updated_metadata_vaults_sol_token_0_swap() {
         let cache = LivePoolCache::new();
@@ -1519,8 +1545,12 @@ mod tests {
 
         match cache.get(&pool).expect("pool in cache") {
             CachedPoolState::MeteoraCpmm(s) => {
-                assert_eq!(s.token_0_vault, quote_vault, "SOL leg vault");
-                assert_eq!(s.token_1_vault, base_vault, "base-mint leg vault");
+                assert_eq!(s.token_0_mint, sol);
+                assert_eq!(s.token_1_mint, base_mint);
+                assert_eq!(s.reserve_0, 20, "SOL leg reserve (quote in update)");
+                assert_eq!(s.reserve_1, 10, "base leg reserve");
+                assert_eq!(s.token_0_vault, quote_vault, "SOL / quote_mint vault");
+                assert_eq!(s.token_1_vault, base_vault, "base_mint vault");
             }
             other => panic!("expected MeteoraCpmm, got {:?}", other),
         }

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -556,7 +556,16 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                                     }
                                 })
                         });
-                        if let Some((bv, qv)) = from_existing_vaults.or(from_meta_vaults) {
+                        if let Some((t0v, t1v)) = from_existing_vaults {
+                            // Already on-chain token_0 / token_1 vault order — do not remap (remap
+                            // below assumes normalized base_vault,quote_vault metadata).
+                            if new_cpmm.token_0_vault == Pubkey::default() {
+                                new_cpmm.token_0_vault = t0v;
+                            }
+                            if new_cpmm.token_1_vault == Pubkey::default() {
+                                new_cpmm.token_1_vault = t1v;
+                            }
+                        } else if let Some((bv, qv)) = from_meta_vaults {
                             let sol =
                                 Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap_or_default();
                             // Map normalized `base_vault,quote_vault` metadata onto **on-chain**

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -25,8 +25,9 @@ use crate::execution::live_pool_cache::{
     PumpAmmState, PumpFunState, RaydiumAmmState, RaydiumCpmmState,
 };
 use crate::ipc::{
-    PoolCacheUpdate, PoolCacheUpdateType, POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY,
-    POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    PoolCacheUpdate, PoolCacheUpdateType, NATIVE_SOL_MINT,
+    POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY, POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY,
+    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use crate::nats::{slave_consumer_config, NatsClient, STREAM_NAME};
 
@@ -45,7 +46,19 @@ fn extract_reserves(state: &CachedPoolState) -> (u64, u64) {
         ),
         CachedPoolState::PumpAmm(s) => (s.base_reserve.unwrap_or(0), s.quote_reserve.unwrap_or(0)),
         CachedPoolState::PumpFun(s) => (s.virtual_token_reserves, s.virtual_sol_reserves),
-        CachedPoolState::MeteoraCpmm(s) => (s.reserve_0, s.reserve_1),
+        CachedPoolState::MeteoraCpmm(s) => {
+            // SLAVE may store reserves in on-chain token_0/token_1 order (when on-chain mint metadata
+            // is present). BalanceUpdated merge treats the tuple as normalized (base, quote); map
+            // like `meteora_cpmm_readiness_for_pool_cache_update` (non-SOL leg = base when SOL present).
+            let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+            if s.token_1_mint == sol {
+                (s.reserve_0, s.reserve_1)
+            } else if s.token_0_mint == sol {
+                (s.reserve_1, s.reserve_0)
+            } else {
+                (s.reserve_0, s.reserve_1)
+            }
+        }
     }
 }
 

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -24,7 +24,10 @@ use crate::execution::live_pool_cache::{
     CachedPoolState, LivePoolCache, MeteoraCpmmState, MeteoraState, OrcaWhirlpoolState,
     PumpAmmState, PumpFunState, RaydiumAmmState, RaydiumCpmmState,
 };
-use crate::ipc::{PoolCacheUpdate, PoolCacheUpdateType, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY};
+use crate::ipc::{
+    PoolCacheUpdate, PoolCacheUpdateType, POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY,
+    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+};
 use crate::nats::{slave_consumer_config, NatsClient, STREAM_NAME};
 
 /// Extract base_reserve and quote_reserve from CachedPoolState (for merge logic).
@@ -461,15 +464,83 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         }
                     }
                 }
-                // BalanceUpdated often omits metadata: preserve Serum static accounts + vault pubkeys
-                // from existing Raydium AMM state so SLAVE readiness does not spuriously downgrade.
-                // BalanceUpdated has no on-chain layout fields: preserve vaults / config / programs /
-                // decimals / status from existing Geyser-parsed Meteora CPMM so SLAVE stays coherent.
+                // BalanceUpdated: vault pubkeys only in metadata or existing Geyser state; preserve
+                // programs/config/decimals/status from existing Meteora CPMM (minimal JetStream row).
                 if update.dex == "meteora_cpmm" {
                     if let CachedPoolState::MeteoraCpmm(ref mut new_cpmm) = minimal_state {
+                        let from_existing_vaults = existing.as_ref().and_then(|ex| {
+                            if let CachedPoolState::MeteoraCpmm(s) = ex {
+                                if s.token_0_vault != Pubkey::default()
+                                    && s.token_1_vault != Pubkey::default()
+                                {
+                                    Some((s.token_0_vault, s.token_1_vault))
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            }
+                        });
+                        let from_meta_vaults = update.metadata.as_ref().and_then(|m| {
+                            m.get(POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY)
+                                .and_then(|s| {
+                                    let mut it = s
+                                        .split(',')
+                                        .filter_map(|a| Pubkey::from_str(a.trim()).ok());
+                                    match (it.next(), it.next()) {
+                                        (Some(v0), Some(v1)) => Some((v0, v1)),
+                                        _ => None,
+                                    }
+                                })
+                        });
+                        if let Some((bv, qv)) = from_existing_vaults.or(from_meta_vaults) {
+                            let sol =
+                                Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap_or_default();
+                            // Map normalized `base_vault,quote_vault` metadata onto **on-chain**
+                            // token_0/token_1. Prefer matching against existing Geyser mint order when
+                            // present (SOL can be token_0 on-chain while updates use non-SOL-first).
+                            let (t0v, t1v) = if let Some(CachedPoolState::MeteoraCpmm(ex)) =
+                                existing.as_ref()
+                            {
+                                if let (Ok(up_base), Ok(up_quote)) = (
+                                    Pubkey::from_str(&update.base_mint),
+                                    Pubkey::from_str(&update.quote_mint),
+                                ) {
+                                    if ex.token_0_mint == up_base && ex.token_1_mint == up_quote {
+                                        (bv, qv)
+                                    } else if ex.token_0_mint == up_quote
+                                        && ex.token_1_mint == up_base
+                                    {
+                                        (qv, bv)
+                                    } else if new_cpmm.token_1_mint == sol {
+                                        (bv, qv)
+                                    } else if new_cpmm.token_0_mint == sol {
+                                        (qv, bv)
+                                    } else {
+                                        (bv, qv)
+                                    }
+                                } else if new_cpmm.token_1_mint == sol {
+                                    (bv, qv)
+                                } else if new_cpmm.token_0_mint == sol {
+                                    (qv, bv)
+                                } else {
+                                    (bv, qv)
+                                }
+                            } else if new_cpmm.token_1_mint == sol {
+                                (bv, qv)
+                            } else if new_cpmm.token_0_mint == sol {
+                                (qv, bv)
+                            } else {
+                                (bv, qv)
+                            };
+                            if new_cpmm.token_0_vault == Pubkey::default() {
+                                new_cpmm.token_0_vault = t0v;
+                            }
+                            if new_cpmm.token_1_vault == Pubkey::default() {
+                                new_cpmm.token_1_vault = t1v;
+                            }
+                        }
                         if let Some(CachedPoolState::MeteoraCpmm(ex)) = existing.as_ref() {
-                            // Minimal JetStream rebuild uses 0 for decimals/status; always take chain
-                            // values from existing Geyser state when present (0 decimals is valid).
                             new_cpmm.mint_0_decimals = ex.mint_0_decimals;
                             new_cpmm.mint_1_decimals = ex.mint_1_decimals;
                             new_cpmm.status = ex.status;
@@ -506,6 +577,8 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         }
                     }
                 }
+                // BalanceUpdated often omits metadata: preserve Serum static accounts + vault pubkeys
+                // from existing Raydium AMM state so SLAVE readiness does not spuriously downgrade.
                 if update.dex == "raydium" {
                     if let CachedPoolState::RaydiumAmm(ref mut new_am) = minimal_state {
                         if let Some(CachedPoolState::RaydiumAmm(ex)) = existing.as_ref() {
@@ -653,7 +726,10 @@ pub async fn bootstrap_pool_cache_from_jetstream(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ipc::{DexPoolReadiness, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY};
+    use crate::ipc::{
+        DexPoolReadiness, POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY,
+        POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    };
 
     /// A.30 Regression: cashback_enabled must be true when JetStream metadata contains
     /// cashback_enabled="true". Verifies pool_cache_sync propagates metadata correctly.
@@ -1249,6 +1325,130 @@ mod tests {
                     "token_0 side must be preserved when update has 0"
                 );
                 assert_eq!(s.reserve_1, 9_999_999);
+            }
+            other => panic!("expected MeteoraCpmm, got {:?}", other),
+        }
+    }
+
+    /// Wallet-bootstrap JetStream publishes `meteora_cpmm_vaults` in normalized base/quote order;
+    /// SLAVE merge must map them onto on-chain token_0/token_1 vault fields.
+    #[test]
+    fn test_meteora_cpmm_balance_updated_metadata_vaults_normalized_order() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let base_vault = Pubkey::new_unique();
+        let quote_vault = Pubkey::new_unique();
+
+        cache.upsert(
+            pool,
+            CachedPoolState::MeteoraCpmm(MeteoraCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote_mint,
+                token_0_vault: Pubkey::default(),
+                token_1_vault: Pubkey::default(),
+                amm_config: Pubkey::default(),
+                observation_key: Pubkey::default(),
+                token_0_program: Pubkey::default(),
+                token_1_program: Pubkey::default(),
+                reserve_0: 100,
+                reserve_1: 200,
+                mint_0_decimals: 0,
+                mint_1_decimals: 0,
+                status: 0,
+            }),
+            1,
+        );
+
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY.to_string(),
+            format!("{base_vault},{quote_vault}"),
+        );
+        let mut bal = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "meteora_cpmm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            300,
+            400,
+            2,
+        );
+        bal.metadata = Some(meta);
+        bal.set_dex_readiness_in_metadata(DexPoolReadiness::Partial);
+        assert!(apply_pool_cache_update(&cache, &bal));
+
+        match cache.get(&pool).expect("pool in cache") {
+            CachedPoolState::MeteoraCpmm(s) => {
+                assert_eq!(s.token_0_vault, base_vault);
+                assert_eq!(s.token_1_vault, quote_vault);
+                assert_eq!(s.reserve_0, 300);
+                assert_eq!(s.reserve_1, 400);
+            }
+            other => panic!("expected MeteoraCpmm, got {:?}", other),
+        }
+    }
+
+    /// Same as [`test_meteora_cpmm_balance_updated_metadata_vaults_normalized_order`] but SOL is
+    /// token_0 on-chain; metadata remains base_vault,quote_vault (non-SOL base first).
+    #[test]
+    fn test_meteora_cpmm_balance_updated_metadata_vaults_sol_token_0_swap() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let sol = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let base_vault = Pubkey::new_unique();
+        let quote_vault = Pubkey::new_unique();
+
+        cache.upsert(
+            pool,
+            CachedPoolState::MeteoraCpmm(MeteoraCpmmState {
+                token_0_mint: sol,
+                token_1_mint: base_mint,
+                token_0_vault: Pubkey::default(),
+                token_1_vault: Pubkey::default(),
+                amm_config: Pubkey::default(),
+                observation_key: Pubkey::default(),
+                token_0_program: Pubkey::default(),
+                token_1_program: Pubkey::default(),
+                reserve_0: 1,
+                reserve_1: 2,
+                mint_0_decimals: 0,
+                mint_1_decimals: 0,
+                status: 0,
+            }),
+            1,
+        );
+
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY.to_string(),
+            format!("{base_vault},{quote_vault}"),
+        );
+        let mut bal = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "meteora_cpmm".to_string(),
+            base_mint.to_string(),
+            sol.to_string(),
+            10,
+            20,
+            2,
+        );
+        bal.metadata = Some(meta);
+        bal.set_dex_readiness_in_metadata(DexPoolReadiness::Partial);
+        assert!(apply_pool_cache_update(&cache, &bal));
+
+        match cache.get(&pool).expect("pool in cache") {
+            CachedPoolState::MeteoraCpmm(s) => {
+                assert_eq!(s.token_0_vault, quote_vault, "SOL leg vault");
+                assert_eq!(s.token_1_vault, base_vault, "base-mint leg vault");
             }
             other => panic!("expected MeteoraCpmm, got {:?}", other),
         }

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -2390,6 +2390,13 @@ pub const POOL_CACHE_UPDATE_POOL_ACCOUNTS_KEY: &str = "pool_accounts";
 /// update only carries reserve scalars (same pattern as PumpSwap `pool_accounts`).
 pub const POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY: &str = "raydium_cpmm_vaults";
 
+/// Metadata key for Meteora CPMM: `base_vault,quote_vault` (comma-separated base58).
+///
+/// **Order matches normalized [`PoolCacheUpdate::base_mint`] / [`PoolCacheUpdate::quote_mint`]**
+/// (non-SOL base first, SOL quote second when SOL is involved), same contract as
+/// [`POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY`].
+pub const POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY: &str = "meteora_cpmm_vaults";
+
 /// Pool cache update type
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -2397,6 +2397,14 @@ pub const POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY: &str = "raydium_cpmm_vaults
 /// [`POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY`].
 pub const POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY: &str = "meteora_cpmm_vaults";
 
+/// Metadata key for Meteora CPMM: `token_0_mint,token_1_mint` (comma-separated base58), **on-chain**
+/// pool account order (not normalized base/quote).
+///
+/// Lets SLAVE `build_minimal_pool_state` map JetStream `base_reserve`/`quote_reserve` (always
+/// normalized: non-SOL base first) onto the correct `reserve_0`/`reserve_1` even when SOL is
+/// token_0 on-chain (I-24a).
+pub const POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY: &str = "meteora_cpmm_onchain_mints";
+
 /// Pool cache update type
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ziel

Erweiterung des bestehenden bounded Wallet-Bootstrap-DEX-Verify um **Meteora CPMM** (analog Raydium CPMM): nur **wallet-relevante** Mints ohne `base_mint_has_any_ready_pool`, nach Grace-Period und nach PumpSwap/PumpFun/Raydium-CPMM-Versuch.

## Änderungen

- `run_bounded_wallet_dex_bootstrap_verify`: bei `enable_meteora_cpmm` Aufruf von `handle_wallet_bootstrap_meteora_cpmm_verify_for_mint` (nur wenn weiterhin kein explizites Ready über alle modellierten Slices).
- `LivePoolCache::meteora_cpmm_pools_for_mint`: cache-scoped Iteration (kein Chain-Scan).
- Cold-Path-RPC: `get_account` Pool + Vault-Balances; Parse via `parse_pool_account`; Readiness via `meteora_cpmm_readiness_for_pool_cache_update`; Merge + JetStream `PoolCacheUpdate::BalanceUpdated` mit Metadata `meteora_cpmm_vaults` und **`meteora_cpmm_onchain_mints`** (on-chain token_0/token_1 order for SLAVE bootstrap / I-24a).
- `pool_cache_sync`: `build_minimal_pool_state_with_reserves` maps normalized base/quote reserves onto true `reserve_0`/`reserve_1` when on-chain mint metadata present; vault mapping in minimal build only when onchain key present (legacy BalanceUpdated + existing row unchanged).

## Tests

- `pool_cache_sync`: vault metadata merge; cold bootstrap `BalanceUpdated` only, SOL token_0, empty cache.
- `market_data` discovery_tests: `meteora_cpmm_pools_for_mint` bounded; Wallet-Mint-Skip bei explizitem Meteora-CPMM-Ready.

## STOP-CHECK (vor Änderung)

1. Kein Hot-Path-RPC (nur market-data Cold-Path Bootstrap).
2. Pattern konsistent zu Raydium-CPMM-Bootstrap-Slice.
3. Scope: erlaubte Dateien.
4. Keine Simulation-Gate-Änderung.
5. Kein Eval-Repo.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo test --features test_helpers`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc766a12-bb16-44a1-afd7-9a83358369f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc766a12-bb16-44a1-afd7-9a83358369f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

