### PR TITLE
Orca Whirlpool: explicit DexPoolReadiness + JetStream metadata for SLAVE coherence

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -34,7 +34,12 @@ use ironcrab::ipc::{
     ControlRequestKind, ControlResponse, ControlResponseStatus, DexPoolReadiness, ExecutionResult,
     ExecutionStatus, IntentTier, MarketEvent, MarketEventKind, PoolCacheUpdate,
     PriorityFeePercentiles, NATIVE_SOL_MINT, POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY,
-    POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY,
+    POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY, POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY,
+    POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY, POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY,
+    POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY,
+    POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY,
+    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use ironcrab::metrics::{
     serve_metrics, set_readiness_control_sub_active, set_readiness_mode,
@@ -79,9 +84,9 @@ const EXECUTION_RESULT_DEDUP_CAPACITY: usize = 4096;
 
 // LivePoolCache - MASTER Cache (Single Source of Truth)
 use ironcrab::execution::live_pool_cache::{
-    meteora_cpmm_readiness_for_pool_cache_update, parse_pool_account,
-    raydium_amm_readiness_for_pool_cache_update, CachedPoolState, LivePoolCache, MeteoraCpmmState,
-    PumpAmmState, PumpFunState, RaydiumCpmmState,
+    meteora_cpmm_readiness_for_pool_cache_update, orca_readiness_for_pool_cache_update,
+    parse_pool_account, raydium_amm_readiness_for_pool_cache_update, CachedPoolState,
+    LivePoolCache, MeteoraCpmmState, PumpAmmState, PumpFunState, RaydiumCpmmState,
 };
 
 // P1 Crash Isolation: Systemd Watchdog support
@@ -598,7 +603,7 @@ fn try_parse_token_account_balance(data: &[u8]) -> Option<u64> {
 /// Wallet `mints_in_wallet` are non-zero balances from bootstrap RPC; pick at most `max_mints`
 /// unique pubkeys that still lack explicit Ready for any modeled slice per
 /// [`LivePoolCache::base_mint_has_any_ready_pool`] (PumpSwap, PumpFun, Raydium CPMM, Meteora CPMM,
-/// Raydium AMM). Preserves iteration order; skips WSOL.
+/// Orca Whirlpool, Raydium AMM). Preserves iteration order; skips WSOL.
 fn wallet_mints_needing_dex_bootstrap_verify(
     cache: &LivePoolCache,
     mints_in_wallet: &[String],
@@ -1828,7 +1833,7 @@ async fn publish_wallet_snapshot(
                 wallet_mints_explicit_ready_count += 1;
                 debug!(
                     mint = %mint_str,
-                    "wallet mint: explicit DexPoolReadiness::Ready (PumpSwap / PumpFun / Raydium CPMM / Raydium AMM)"
+                    "wallet mint: explicit DexPoolReadiness::Ready (PumpSwap / PumpFun / Raydium CPMM / Meteora CPMM / Orca / Raydium AMM)"
                 );
             }
         }
@@ -1838,7 +1843,7 @@ async fn publish_wallet_snapshot(
             wallet = %wallet_str,
             wallet_mints_explicit_ready_count,
             nonzero_wallet_mints = mints_in_wallet.len(),
-            "Wallet snapshot: mints with explicit Ready merge (PumpSwap / PumpFun / Raydium CPMM / Raydium AMM); excludes legacy PumpSwap effective-ready"
+            "Wallet snapshot: mints with explicit Ready merge (PumpSwap / PumpFun / Raydium CPMM / Meteora CPMM / Orca / Raydium AMM); excludes legacy PumpSwap effective-ready"
         );
     }
 
@@ -3785,6 +3790,70 @@ async fn run_geyser_loop(
                                                 );
                                             }
                                         }
+                                        if vault_info.dex == "orca" {
+                                            if let Some(CachedPoolState::Orca(ref s)) =
+                                                ctx.live_pool_cache.get(&vault_info.pool_address)
+                                            {
+                                                let mut meta = balance_update
+                                                    .metadata
+                                                    .take()
+                                                    .unwrap_or_default();
+                                                meta.insert(
+                                                    POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY
+                                                        .to_string(),
+                                                    format!("{},{}", s.token_vault_a, s.token_vault_b),
+                                                );
+                                                meta.insert(
+                                                    POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY
+                                                        .to_string(),
+                                                    s.tick_current_index.to_string(),
+                                                );
+                                                meta.insert(
+                                                    POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY
+                                                        .to_string(),
+                                                    s.tick_spacing.to_string(),
+                                                );
+                                                meta.insert(
+                                                    POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY.to_string(),
+                                                    s.sqrt_price.to_string(),
+                                                );
+                                                meta.insert(
+                                                    POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY.to_string(),
+                                                    s.liquidity.to_string(),
+                                                );
+                                                meta.insert(
+                                                    POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY.to_string(),
+                                                    s.fee_rate.to_string(),
+                                                );
+                                                meta.insert(
+                                                    POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY
+                                                        .to_string(),
+                                                    s.protocol_fee_rate.to_string(),
+                                                );
+                                                if let Some(p) = s.token_a_program {
+                                                    meta.insert(
+                                                        POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY
+                                                            .to_string(),
+                                                        p.to_string(),
+                                                    );
+                                                }
+                                                if let Some(p) = s.token_b_program {
+                                                    meta.insert(
+                                                        POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY
+                                                            .to_string(),
+                                                        p.to_string(),
+                                                    );
+                                                }
+                                                balance_update.metadata = Some(meta);
+                                                let readiness =
+                                                    orca_readiness_for_pool_cache_update(s);
+                                                balance_update.set_dex_readiness_in_metadata(readiness);
+                                                ctx.live_pool_cache.merge_orca_pool_readiness(
+                                                    vault_info.pool_address,
+                                                    readiness,
+                                                );
+                                            }
+                                        }
                                         let subject = pool_subject(&vault_info.pool_address.to_string());
                                         if let Err(e) = nats.jetstream_publish(&subject, &balance_update).await {
                                             warn!(error = %e, "Failed to publish PoolCacheUpdate::BalanceUpdated to JetStream");
@@ -4500,6 +4569,56 @@ async fn run_geyser_loop(
                                 let readiness = meteora_cpmm_readiness_for_pool_cache_update(s);
                                 pool_update.set_dex_readiness_in_metadata(readiness);
                                 ctx.live_pool_cache.merge_meteora_cpmm_pool_readiness(
+                                    account_update.pubkey,
+                                    readiness,
+                                );
+                            }
+                            CachedPoolState::Orca(s) => {
+                                let mut meta = std::collections::HashMap::new();
+                                meta.insert(
+                                    POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY.to_string(),
+                                    format!("{},{}", s.token_vault_a, s.token_vault_b),
+                                );
+                                meta.insert(
+                                    POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY.to_string(),
+                                    s.tick_current_index.to_string(),
+                                );
+                                meta.insert(
+                                    POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY.to_string(),
+                                    s.tick_spacing.to_string(),
+                                );
+                                meta.insert(
+                                    POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY.to_string(),
+                                    s.sqrt_price.to_string(),
+                                );
+                                meta.insert(
+                                    POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY.to_string(),
+                                    s.liquidity.to_string(),
+                                );
+                                meta.insert(
+                                    POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY.to_string(),
+                                    s.fee_rate.to_string(),
+                                );
+                                meta.insert(
+                                    POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY.to_string(),
+                                    s.protocol_fee_rate.to_string(),
+                                );
+                                if let Some(p) = s.token_a_program {
+                                    meta.insert(
+                                        POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY.to_string(),
+                                        p.to_string(),
+                                    );
+                                }
+                                if let Some(p) = s.token_b_program {
+                                    meta.insert(
+                                        POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY.to_string(),
+                                        p.to_string(),
+                                    );
+                                }
+                                pool_update.metadata = Some(meta);
+                                let readiness = orca_readiness_for_pool_cache_update(s);
+                                pool_update.set_dex_readiness_in_metadata(readiness);
+                                ctx.live_pool_cache.merge_orca_pool_readiness(
                                     account_update.pubkey,
                                     readiness,
                                 );

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -20,6 +20,7 @@
 use anyhow::Result;
 use clap::Parser;
 use solana_sdk::pubkey::Pubkey;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::Ordering;
@@ -86,7 +87,8 @@ const EXECUTION_RESULT_DEDUP_CAPACITY: usize = 4096;
 use ironcrab::execution::live_pool_cache::{
     meteora_cpmm_readiness_for_pool_cache_update, orca_readiness_for_pool_cache_update,
     parse_pool_account, raydium_amm_readiness_for_pool_cache_update, CachedPoolState,
-    LivePoolCache, MeteoraCpmmState, PumpAmmState, PumpFunState, RaydiumCpmmState,
+    LivePoolCache, MeteoraCpmmState, OrcaWhirlpoolState, PumpAmmState, PumpFunState,
+    RaydiumCpmmState,
 };
 
 // P1 Crash Isolation: Systemd Watchdog support
@@ -136,6 +138,52 @@ fn meteora_cpmm_vaults_for_pool_cache_update(s: &MeteoraCpmmState) -> String {
 /// On-chain `token_0_mint,token_1_mint` for SLAVE bootstrap when JetStream uses normalized base/quote.
 fn meteora_cpmm_onchain_mints_for_pool_cache_update(s: &MeteoraCpmmState) -> String {
     format!("{},{}", s.token_0_mint, s.token_1_mint)
+}
+
+/// Orca Whirlpool: PoolCacheUpdate metadata keys for SLAVE bootstrap (BalanceUpdated + PoolDiscovered).
+fn orca_metadata_for_pool_cache_update(s: &OrcaWhirlpoolState) -> HashMap<String, String> {
+    let mut meta = HashMap::new();
+    meta.insert(
+        POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY.to_string(),
+        format!("{},{}", s.token_vault_a, s.token_vault_b),
+    );
+    meta.insert(
+        POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY.to_string(),
+        s.tick_current_index.to_string(),
+    );
+    meta.insert(
+        POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY.to_string(),
+        s.tick_spacing.to_string(),
+    );
+    meta.insert(
+        POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY.to_string(),
+        s.sqrt_price.to_string(),
+    );
+    meta.insert(
+        POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY.to_string(),
+        s.liquidity.to_string(),
+    );
+    meta.insert(
+        POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY.to_string(),
+        s.fee_rate.to_string(),
+    );
+    meta.insert(
+        POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY.to_string(),
+        s.protocol_fee_rate.to_string(),
+    );
+    if let Some(p) = s.token_a_program {
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY.to_string(),
+            p.to_string(),
+        );
+    }
+    if let Some(p) = s.token_b_program {
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY.to_string(),
+            p.to_string(),
+        );
+    }
+    meta
 }
 
 /// JetStream readiness for Raydium CPMM (SOL-aware base/quote): single source for BalanceUpdated and PoolDiscovered.
@@ -3798,51 +3846,8 @@ async fn run_geyser_loop(
                                                     .metadata
                                                     .take()
                                                     .unwrap_or_default();
-                                                meta.insert(
-                                                    POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY
-                                                        .to_string(),
-                                                    format!("{},{}", s.token_vault_a, s.token_vault_b),
-                                                );
-                                                meta.insert(
-                                                    POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY
-                                                        .to_string(),
-                                                    s.tick_current_index.to_string(),
-                                                );
-                                                meta.insert(
-                                                    POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY
-                                                        .to_string(),
-                                                    s.tick_spacing.to_string(),
-                                                );
-                                                meta.insert(
-                                                    POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY.to_string(),
-                                                    s.sqrt_price.to_string(),
-                                                );
-                                                meta.insert(
-                                                    POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY.to_string(),
-                                                    s.liquidity.to_string(),
-                                                );
-                                                meta.insert(
-                                                    POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY.to_string(),
-                                                    s.fee_rate.to_string(),
-                                                );
-                                                meta.insert(
-                                                    POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY
-                                                        .to_string(),
-                                                    s.protocol_fee_rate.to_string(),
-                                                );
-                                                if let Some(p) = s.token_a_program {
-                                                    meta.insert(
-                                                        POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY
-                                                            .to_string(),
-                                                        p.to_string(),
-                                                    );
-                                                }
-                                                if let Some(p) = s.token_b_program {
-                                                    meta.insert(
-                                                        POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY
-                                                            .to_string(),
-                                                        p.to_string(),
-                                                    );
+                                                for (k, v) in orca_metadata_for_pool_cache_update(s) {
+                                                    meta.insert(k, v);
                                                 }
                                                 balance_update.metadata = Some(meta);
                                                 let readiness =
@@ -4574,48 +4579,8 @@ async fn run_geyser_loop(
                                 );
                             }
                             CachedPoolState::Orca(s) => {
-                                let mut meta = std::collections::HashMap::new();
-                                meta.insert(
-                                    POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY.to_string(),
-                                    format!("{},{}", s.token_vault_a, s.token_vault_b),
-                                );
-                                meta.insert(
-                                    POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY.to_string(),
-                                    s.tick_current_index.to_string(),
-                                );
-                                meta.insert(
-                                    POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY.to_string(),
-                                    s.tick_spacing.to_string(),
-                                );
-                                meta.insert(
-                                    POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY.to_string(),
-                                    s.sqrt_price.to_string(),
-                                );
-                                meta.insert(
-                                    POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY.to_string(),
-                                    s.liquidity.to_string(),
-                                );
-                                meta.insert(
-                                    POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY.to_string(),
-                                    s.fee_rate.to_string(),
-                                );
-                                meta.insert(
-                                    POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY.to_string(),
-                                    s.protocol_fee_rate.to_string(),
-                                );
-                                if let Some(p) = s.token_a_program {
-                                    meta.insert(
-                                        POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY.to_string(),
-                                        p.to_string(),
-                                    );
-                                }
-                                if let Some(p) = s.token_b_program {
-                                    meta.insert(
-                                        POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY.to_string(),
-                                        p.to_string(),
-                                    );
-                                }
-                                pool_update.metadata = Some(meta);
+                                pool_update.metadata =
+                                    Some(orca_metadata_for_pool_cache_update(s));
                                 let readiness = orca_readiness_for_pool_cache_update(s);
                                 pool_update.set_dex_readiness_in_metadata(readiness);
                                 ctx.live_pool_cache.merge_orca_pool_readiness(

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -94,6 +94,31 @@ impl From<WhirlpoolParsed> for OrcaWhirlpoolState {
     }
 }
 
+/// JetStream / MASTER [`DexPoolReadiness`] for Orca Whirlpool (conservative, explicit).
+///
+/// `Ready` only when the whirlpool layout is present (non-default vaults, valid tick spacing and
+/// price state from Geyser) **and** both vault balances are known and non-zero — matching what
+/// [`crate::execution::quote_calculator`] and Orca swap building need for believable reserves.
+///
+/// Token programs are **not** required for `Ready` (Orca can fall back to classic SPL with a
+/// trace warning; marking `Observed` until programs are known would be overly strict for mint-gate).
+#[must_use]
+pub fn orca_readiness_for_pool_cache_update(s: &OrcaWhirlpoolState) -> DexPoolReadiness {
+    let static_ok = s.token_vault_a != Pubkey::default()
+        && s.token_vault_b != Pubkey::default()
+        && s.tick_spacing > 0
+        && s.sqrt_price > 0;
+    let va = s.vault_a_balance.unwrap_or(0);
+    let vb = s.vault_b_balance.unwrap_or(0);
+    if static_ok && va > 0 && vb > 0 {
+        DexPoolReadiness::Ready
+    } else if va > 0 || vb > 0 || static_ok {
+        DexPoolReadiness::Partial
+    } else {
+        DexPoolReadiness::Observed
+    }
+}
+
 /// Raydium AMM V4 cached state
 #[derive(Debug, Clone)]
 pub struct RaydiumAmmState {
@@ -377,6 +402,9 @@ pub struct LivePoolCache {
 
     /// Meteora CPMM pool address → explicit [`DexPoolReadiness`] from JetStream / MASTER (Bug #36).
     meteora_cpmm_readiness_by_pool: DashMap<Pubkey, DexPoolReadiness>,
+
+    /// Orca Whirlpool pool address → explicit [`DexPoolReadiness`] from JetStream / MASTER (Bug #36).
+    orca_readiness_by_pool: DashMap<Pubkey, DexPoolReadiness>,
 }
 
 /// Which vault position (A/B or X/Y or 0/1) this vault represents
@@ -411,6 +439,7 @@ impl LivePoolCache {
             raydium_cpmm_readiness_by_pool: DashMap::new(),
             raydium_amm_readiness_by_pool: DashMap::new(),
             meteora_cpmm_readiness_by_pool: DashMap::new(),
+            orca_readiness_by_pool: DashMap::new(),
         }
     }
 
@@ -1004,6 +1033,14 @@ impl LivePoolCache {
             .or_insert(incoming);
     }
 
+    /// Merge Orca Whirlpool pool readiness for `pool` (monotonic — never downgrade).
+    pub fn merge_orca_pool_readiness(&self, pool: Pubkey, incoming: DexPoolReadiness) {
+        self.orca_readiness_by_pool
+            .entry(pool)
+            .and_modify(|stored| *stored = stored.merge(incoming))
+            .or_insert(incoming);
+    }
+
     /// `true` only when JetStream merge recorded [`DexPoolReadiness::Ready`] for this Raydium CPMM pool.
     #[must_use]
     pub fn raydium_cpmm_pool_explicitly_ready(&self, pool: &Pubkey) -> bool {
@@ -1047,6 +1084,21 @@ impl LivePoolCache {
     #[must_use]
     pub fn meteora_cpmm_readiness(&self, pool: &Pubkey) -> Option<DexPoolReadiness> {
         self.meteora_cpmm_readiness_by_pool.get(pool).map(|r| *r)
+    }
+
+    /// `true` only when JetStream merge recorded [`DexPoolReadiness::Ready`] for this Orca pool.
+    #[must_use]
+    pub fn orca_pool_explicitly_ready(&self, pool: &Pubkey) -> bool {
+        self.orca_readiness_by_pool
+            .get(pool)
+            .map(|r| *r == DexPoolReadiness::Ready)
+            .unwrap_or(false)
+    }
+
+    /// Monotonic merge result for this Orca pool (tests / diagnostics).
+    #[must_use]
+    pub fn orca_readiness(&self, pool: &Pubkey) -> Option<DexPoolReadiness> {
+        self.orca_readiness_by_pool.get(pool).map(|r| *r)
     }
 
     /// Mint-level helper: Raydium CPMM slice — explicit `Ready` only (no cache-hit heuristic).
@@ -1093,6 +1145,23 @@ impl LivePoolCache {
                 }
                 let pool = entry.key();
                 if self.raydium_amm_pool_explicitly_ready(pool) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Mint-level helper: Orca Whirlpool — explicit `Ready` only (no cache-hit heuristic).
+    #[must_use]
+    pub fn base_mint_has_explicit_orca_ready_pool(&self, base_mint: &Pubkey) -> bool {
+        for entry in self.pools.iter() {
+            if let CachedPoolState::Orca(s) = &entry.value().state {
+                if s.token_mint_a != *base_mint && s.token_mint_b != *base_mint {
+                    continue;
+                }
+                let pool = entry.key();
+                if self.orca_pool_explicitly_ready(pool) {
                     return true;
                 }
             }
@@ -1249,9 +1318,11 @@ impl LivePoolCache {
     ///   [`DexPoolReadiness::Ready`] in [`Self::raydium_amm_readiness_by_pool`] only.
     /// - Meteora CPMM: [`Self::base_mint_has_explicit_meteora_cpmm_ready_pool`] — explicit
     ///   [`DexPoolReadiness::Ready`] in [`Self::meteora_cpmm_readiness_by_pool`] only.
+    /// - Orca Whirlpool: [`Self::base_mint_has_explicit_orca_ready_pool`] — explicit
+    ///   [`DexPoolReadiness::Ready`] in [`Self::orca_readiness_by_pool`] only.
     ///
-    /// **Conservative:** Orca, Meteora DLMM, etc. are **not** treated as ready here until they have an
-    /// explicit readiness path.
+    /// **Conservative:** Meteora DLMM and other DEXes are **not** treated as ready here until they
+    /// have an explicit readiness path.
     #[must_use]
     pub fn base_mint_has_any_ready_pool(&self, base_mint: &Pubkey) -> bool {
         if self.base_mint_has_explicit_pump_amm_ready_pool(base_mint) {
@@ -1261,6 +1332,9 @@ impl LivePoolCache {
             return true;
         }
         if self.base_mint_has_explicit_meteora_cpmm_ready_pool(base_mint) {
+            return true;
+        }
+        if self.base_mint_has_explicit_orca_ready_pool(base_mint) {
             return true;
         }
         if self.base_mint_has_explicit_raydium_amm_ready_pool(base_mint) {
@@ -2432,6 +2506,156 @@ mod tests {
         cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Partial);
 
         assert!(!cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    fn make_orca_state(
+        token_mint_a: Pubkey,
+        token_mint_b: Pubkey,
+        vault_a_balance: Option<u64>,
+        vault_b_balance: Option<u64>,
+    ) -> OrcaWhirlpoolState {
+        OrcaWhirlpoolState {
+            token_mint_a,
+            token_mint_b,
+            token_vault_a: Pubkey::new_unique(),
+            token_vault_b: Pubkey::new_unique(),
+            tick_current_index: -42,
+            sqrt_price: 1u128 << 64,
+            liquidity: 1_000_000,
+            fee_rate: 3000,
+            protocol_fee_rate: 300,
+            tick_spacing: 64,
+            vault_a_balance,
+            vault_b_balance,
+            token_a_program: None,
+            token_b_program: None,
+        }
+    }
+
+    #[test]
+    fn test_orca_readiness_helper_partial_when_reserves_but_vault_pubkeys_missing() {
+        let a = Pubkey::new_unique();
+        let b = Pubkey::new_unique();
+        let mut s = make_orca_state(a, b, Some(100), Some(200));
+        s.token_vault_a = Pubkey::default();
+        assert_eq!(
+            orca_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Partial,
+            "not Ready: static layout incomplete; reserve scalars alone are partial signal"
+        );
+    }
+
+    #[test]
+    fn test_orca_readiness_helper_observed_when_no_static_and_no_balances() {
+        let a = Pubkey::new_unique();
+        let b = Pubkey::new_unique();
+        let mut s = make_orca_state(a, b, None, None);
+        s.token_vault_a = Pubkey::default();
+        s.token_vault_b = Pubkey::default();
+        s.tick_spacing = 0;
+        s.sqrt_price = 0;
+        assert_eq!(
+            orca_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Observed
+        );
+    }
+
+    #[test]
+    fn test_orca_readiness_helper_partial_static_only_no_balances() {
+        let a = Pubkey::new_unique();
+        let b = Pubkey::new_unique();
+        let s = make_orca_state(a, b, None, None);
+        assert_eq!(
+            orca_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Partial
+        );
+    }
+
+    #[test]
+    fn test_orca_readiness_helper_partial_one_vault_balance() {
+        let a = Pubkey::new_unique();
+        let b = Pubkey::new_unique();
+        let s = make_orca_state(a, b, Some(1), None);
+        assert_eq!(
+            orca_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Partial
+        );
+    }
+
+    #[test]
+    fn test_orca_readiness_helper_ready_full_state() {
+        let a = Pubkey::new_unique();
+        let b = Pubkey::new_unique();
+        let s = make_orca_state(a, b, Some(1_000_000), Some(50_000_000_000));
+        assert_eq!(
+            orca_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Ready
+        );
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_orca_cache_hit_without_explicit_merge_is_false() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        cache.upsert(
+            pool,
+            CachedPoolState::Orca(make_orca_state(base_mint, quote_mint, Some(1), Some(2))),
+            100,
+        );
+        assert!(
+            !cache.base_mint_has_any_ready_pool(&base_mint),
+            "Bug #36: Orca cache row must not imply mint-level ready without explicit merge"
+        );
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_orca_explicit_ready() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        cache.upsert(
+            pool,
+            CachedPoolState::Orca(make_orca_state(base_mint, quote_mint, Some(1), Some(2))),
+            100,
+        );
+        cache.merge_orca_pool_readiness(pool, DexPoolReadiness::Ready);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+        assert!(cache.base_mint_has_explicit_orca_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_orca_partial_does_not_count() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        cache.upsert(
+            pool,
+            CachedPoolState::Orca(make_orca_state(base_mint, quote_mint, Some(1), None)),
+            100,
+        );
+        cache.merge_orca_pool_readiness(pool, DexPoolReadiness::Partial);
+        assert!(!cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_orca_readiness_merge_monotone() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        cache.upsert(
+            pool,
+            CachedPoolState::Orca(make_orca_state(base_mint, quote_mint, Some(1), Some(2))),
+            100,
+        );
+        cache.merge_orca_pool_readiness(pool, DexPoolReadiness::Ready);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+        cache.merge_orca_pool_readiness(pool, DexPoolReadiness::Observed);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
     }
 
     #[test]

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -27,7 +27,11 @@ use crate::execution::live_pool_cache::{
 use crate::ipc::{
     PoolCacheUpdate, PoolCacheUpdateType, NATIVE_SOL_MINT,
     POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY, POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY,
-    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY,
+    POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY,
+    POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY, POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY,
+    POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY,
+    POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use crate::nats::{slave_consumer_config, NatsClient, STREAM_NAME};
 
@@ -84,22 +88,68 @@ fn build_minimal_pool_state_with_reserves(
 
     // Build minimal state based on DEX type
     let state = match update.dex.as_str() {
-        "orca" => CachedPoolState::Orca(OrcaWhirlpoolState {
-            token_mint_a: base_mint,
-            token_mint_b: quote_mint,
-            token_vault_a: Pubkey::default(),
-            token_vault_b: Pubkey::default(),
-            tick_current_index: 0,
-            sqrt_price: 0,
-            liquidity: 0,
-            fee_rate: 0,
-            protocol_fee_rate: 0,
-            tick_spacing: 0,
-            vault_a_balance: Some(base_reserve),
-            vault_b_balance: Some(quote_reserve),
-            token_a_program: None,
-            token_b_program: None,
-        }),
+        "orca" => {
+            let meta = update.metadata.as_ref();
+            let (token_vault_a, token_vault_b) = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY))
+                .and_then(|s| {
+                    let mut it = s.split(',').filter_map(|a| Pubkey::from_str(a.trim()).ok());
+                    match (it.next(), it.next()) {
+                        (Some(va), Some(vb)) => Some((va, vb)),
+                        _ => None,
+                    }
+                })
+                .unwrap_or((Pubkey::default(), Pubkey::default()));
+
+            let tick_current_index = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY))
+                .and_then(|s| s.parse::<i32>().ok())
+                .unwrap_or(0);
+            let tick_spacing = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY))
+                .and_then(|s| s.parse::<u16>().ok())
+                .unwrap_or(0);
+            let sqrt_price = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY))
+                .and_then(|s| s.parse::<u128>().ok())
+                .unwrap_or(0);
+            let liquidity = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY))
+                .and_then(|s| s.parse::<u128>().ok())
+                .unwrap_or(0);
+            let fee_rate = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY))
+                .and_then(|s| s.parse::<u16>().ok())
+                .unwrap_or(0);
+            let protocol_fee_rate = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY))
+                .and_then(|s| s.parse::<u16>().ok())
+                .unwrap_or(0);
+
+            let token_a_program = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY))
+                .and_then(|s| Pubkey::from_str(s.trim()).ok());
+            let token_b_program = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY))
+                .and_then(|s| Pubkey::from_str(s.trim()).ok());
+
+            CachedPoolState::Orca(OrcaWhirlpoolState {
+                token_mint_a: base_mint,
+                token_mint_b: quote_mint,
+                token_vault_a,
+                token_vault_b,
+                tick_current_index,
+                sqrt_price,
+                liquidity,
+                fee_rate,
+                protocol_fee_rate,
+                tick_spacing,
+                vault_a_balance: Some(base_reserve),
+                vault_b_balance: Some(quote_reserve),
+                token_a_program,
+                token_b_program,
+            })
+        }
         "raydium" => {
             let serum_bids = update
                 .metadata
@@ -430,6 +480,9 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         update.effective_dex_readiness(),
                     );
                 }
+                if update.dex == "orca" {
+                    cache.merge_orca_pool_readiness(pool_addr, update.effective_dex_readiness());
+                }
                 // P3 #13: Propagate base_decimals and quote_decimals to SLAVE cache
                 apply_decimals_from_metadata(cache, update);
                 return true;
@@ -714,6 +767,73 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         }
                     }
                 }
+                // BalanceUpdated from vault path may omit whirlpool static metadata; preserve from SLAVE row
+                // when this message does not carry the corresponding keys (tick 0 is valid — do not use `== 0` heuristics).
+                if update.dex == "orca" {
+                    let um = update.metadata.as_ref();
+                    if let CachedPoolState::Orca(ref mut new_o) = minimal_state {
+                        if let Some(CachedPoolState::Orca(ex)) = existing.as_ref() {
+                            if new_o.token_vault_a == Pubkey::default()
+                                && ex.token_vault_a != Pubkey::default()
+                            {
+                                new_o.token_vault_a = ex.token_vault_a;
+                            }
+                            if new_o.token_vault_b == Pubkey::default()
+                                && ex.token_vault_b != Pubkey::default()
+                            {
+                                new_o.token_vault_b = ex.token_vault_b;
+                            }
+                            if um
+                                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY))
+                                .is_none()
+                            {
+                                new_o.tick_current_index = ex.tick_current_index;
+                            }
+                            if um
+                                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY))
+                                .is_none()
+                            {
+                                new_o.tick_spacing = ex.tick_spacing;
+                            }
+                            if um
+                                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY))
+                                .is_none()
+                            {
+                                new_o.sqrt_price = ex.sqrt_price;
+                            }
+                            if um
+                                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY))
+                                .is_none()
+                            {
+                                new_o.liquidity = ex.liquidity;
+                            }
+                            if um
+                                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY))
+                                .is_none()
+                            {
+                                new_o.fee_rate = ex.fee_rate;
+                            }
+                            if um
+                                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY))
+                                .is_none()
+                            {
+                                new_o.protocol_fee_rate = ex.protocol_fee_rate;
+                            }
+                            if um
+                                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY))
+                                .is_none()
+                            {
+                                new_o.token_a_program = ex.token_a_program;
+                            }
+                            if um
+                                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY))
+                                .is_none()
+                            {
+                                new_o.token_b_program = ex.token_b_program;
+                            }
+                        }
+                    }
+                }
                 cache.upsert(addr, minimal_state, update.geyser_slot);
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_pool_accounts_readiness(
@@ -732,6 +852,9 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 }
                 if update.dex == "meteora_cpmm" {
                     cache.merge_meteora_cpmm_pool_readiness(addr, update.effective_dex_readiness());
+                }
+                if update.dex == "orca" {
+                    cache.merge_orca_pool_readiness(addr, update.effective_dex_readiness());
                 }
                 // P3 #13: Apply decimals from metadata when present (e.g. BalanceUpdated with metadata)
                 apply_decimals_from_metadata(cache, update);
@@ -837,7 +960,11 @@ mod tests {
     use super::*;
     use crate::ipc::{
         DexPoolReadiness, POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY,
-        POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+        POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY,
+        POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY, POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY,
+        POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY, POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY,
+        POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY, POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY,
+        POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
     };
 
     /// A.30 Regression: cashback_enabled must be true when JetStream metadata contains
@@ -1866,5 +1993,219 @@ mod tests {
             cache.meteora_cpmm_readiness(&pool),
             Some(DexPoolReadiness::Ready)
         );
+    }
+
+    #[test]
+    fn test_orca_pool_discovered_jetstream_reconstructs_static_fields() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let va = Pubkey::new_unique();
+        let vb = Pubkey::new_unique();
+
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY.to_string(),
+            format!("{va},{vb}"),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY.to_string(),
+            "-7".to_string(),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY.to_string(),
+            "64".to_string(),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY.to_string(),
+            "12345678901234567890".to_string(),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY.to_string(),
+            "999888777666".to_string(),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY.to_string(),
+            "3000".to_string(),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY.to_string(),
+            "300".to_string(),
+        );
+
+        let mut disc = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "orca".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            5,
+            6,
+            None,
+            1,
+        );
+        disc.metadata = Some(meta);
+        disc.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+        assert!(apply_pool_cache_update(&cache, &disc));
+
+        match cache.get(&pool).expect("pool in cache") {
+            CachedPoolState::Orca(s) => {
+                assert_eq!(s.token_mint_a, base_mint);
+                assert_eq!(s.token_mint_b, quote_mint);
+                assert_eq!(s.token_vault_a, va);
+                assert_eq!(s.token_vault_b, vb);
+                assert_eq!(s.tick_current_index, -7);
+                assert_eq!(s.tick_spacing, 64);
+                assert_eq!(s.sqrt_price, 12_345_678_901_234_567_890u128);
+                assert_eq!(s.liquidity, 999_888_777_666);
+                assert_eq!(s.fee_rate, 3000);
+                assert_eq!(s.protocol_fee_rate, 300);
+                assert_eq!(s.vault_a_balance, Some(5));
+                assert_eq!(s.vault_b_balance, Some(6));
+            }
+            other => panic!("expected Orca, got {:?}", other),
+        }
+        assert!(cache.orca_pool_explicitly_ready(&pool));
+    }
+
+    /// `tick_current_index == 0` is valid; BalanceUpdated without tick metadata must not overwrite from a bogus default.
+    #[test]
+    fn test_orca_balance_updated_preserves_tick_zero_when_metadata_omits_tick() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let va = Pubkey::new_unique();
+        let vb = Pubkey::new_unique();
+
+        cache.upsert(
+            pool,
+            CachedPoolState::Orca(OrcaWhirlpoolState {
+                token_mint_a: base_mint,
+                token_mint_b: quote_mint,
+                token_vault_a: va,
+                token_vault_b: vb,
+                tick_current_index: 0,
+                sqrt_price: 42,
+                liquidity: 100,
+                fee_rate: 1,
+                protocol_fee_rate: 2,
+                tick_spacing: 8,
+                vault_a_balance: Some(10),
+                vault_b_balance: Some(20),
+                token_a_program: None,
+                token_b_program: None,
+            }),
+            1,
+        );
+
+        let mut bal = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "orca".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            11,
+            21,
+            2,
+        );
+        bal.set_dex_readiness_in_metadata(DexPoolReadiness::Observed);
+        assert!(apply_pool_cache_update(&cache, &bal));
+
+        match cache.get(&pool).expect("pool in cache") {
+            CachedPoolState::Orca(s) => {
+                assert_eq!(s.tick_current_index, 0);
+                assert_eq!(s.sqrt_price, 42);
+                assert_eq!(s.tick_spacing, 8);
+                assert_eq!(s.vault_a_balance, Some(11));
+                assert_eq!(s.vault_b_balance, Some(21));
+            }
+            other => panic!("expected Orca, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_orca_readiness_merge_never_downgrades() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let va = Pubkey::new_unique();
+        let vb = Pubkey::new_unique();
+
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY.to_string(),
+            format!("{va},{vb}"),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY.to_string(),
+            "1".to_string(),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY.to_string(),
+            "8".to_string(),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY.to_string(),
+            "100".to_string(),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY.to_string(),
+            "200".to_string(),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY.to_string(),
+            "1".to_string(),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY.to_string(),
+            "2".to_string(),
+        );
+
+        let mut ready_up = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "orca".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1,
+            1,
+            None,
+            1,
+        );
+        ready_up.metadata = Some(meta.clone());
+        ready_up.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+        assert!(apply_pool_cache_update(&cache, &ready_up));
+        assert!(cache.orca_pool_explicitly_ready(&pool));
+
+        let mut weak = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "orca".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1,
+            1,
+            None,
+            2,
+        );
+        weak.metadata = Some(meta);
+        weak.set_dex_readiness_in_metadata(DexPoolReadiness::Observed);
+        assert!(apply_pool_cache_update(&cache, &weak));
+        assert!(
+            cache.orca_pool_explicitly_ready(&pool),
+            "merge must not downgrade Ready to Observed for Orca"
+        );
+        assert_eq!(cache.orca_readiness(&pool), Some(DexPoolReadiness::Ready));
     }
 }

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -2405,6 +2405,25 @@ pub const POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY: &str = "meteora_cpmm_vaults
 /// token_0 on-chain (I-24a).
 pub const POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY: &str = "meteora_cpmm_onchain_mints";
 
+/// Metadata key for Orca Whirlpool: `token_vault_a,token_vault_b` (comma-separated base58).
+///
+/// Order matches on-chain Whirlpool layout (`token_mint_a` / `token_mint_b` on the pool), which is
+/// the same order as [`PoolCacheUpdate::base_mint`] / [`PoolCacheUpdate::quote_mint`] for Orca
+/// publishes from market-data (token A then token B).
+pub const POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY: &str = "orca_whirlpool_vaults";
+
+/// Orca Whirlpool static fields from the pool account (Geyser parse), as decimal strings in metadata.
+pub const POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY: &str = "orca_tick_current_index";
+pub const POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY: &str = "orca_tick_spacing";
+pub const POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY: &str = "orca_sqrt_price";
+pub const POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY: &str = "orca_liquidity";
+pub const POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY: &str = "orca_fee_rate";
+pub const POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY: &str = "orca_protocol_fee_rate";
+
+/// Optional: SPL Token program for `token_mint_a` / `token_mint_b` when known (Token-2022 safe path).
+pub const POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY: &str = "orca_token_a_program";
+pub const POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY: &str = "orca_token_b_program";
+
 /// Pool cache update type
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an explicit `DexPoolReadiness` path for **Orca Whirlpool** in the market-data → JetStream → SLAVE flow, aligned with Raydium/Meteora CPMM patterns.

## Changes

- **`orca_readiness_for_pool_cache_update`**: `Ready` only when whirlpool static layout is present (non-default vault pubkeys, `tick_spacing > 0`, `sqrt_price > 0`) **and** both vault balances are known and non-zero. Weaker states map to `Partial` / `Observed` (no cache-hit → Ready).
- **`LivePoolCache`**: `orca_readiness_by_pool` with monotonic `merge_orca_pool_readiness`; `base_mint_has_any_ready_pool` now includes `base_mint_has_explicit_orca_ready_pool` (explicit JetStream merge only).
- **`PoolCacheUpdate` metadata** (new keys in `schema.rs`): `orca_whirlpool_vaults`, tick/spacing/sqrt_price/liquidity/fee fields, optional token program pubkeys.
- **`market_data`**: On Orca `PoolDiscovered` and vault-driven `BalanceUpdated`, attach metadata, set readiness from current MASTER state, merge locally, publish to JetStream.
- **`pool_cache_sync`**: SLAVE reconstructs full `OrcaWhirlpoolState` from JetStream metadata; `BalanceUpdated` without tick metadata preserves `tick_current_index == 0` and other static fields from the existing row.

## Tests

- `live_pool_cache`: readiness tiers, mint-level gate (cache hit ≠ ready), partial ≠ ready, merge monotonicity.
- `pool_cache_sync`: JetStream roundtrip for Orca static fields, tick-zero preservation, readiness merge never downgrades.

## STOP-CHECK (pre-change)

1. **I-7 Hot-path RPC**: No new RPC; market-data changes use existing Geyser paths only.
2. **Pattern**: Matches explicit readiness + metadata propagation used for Raydium CPMM / Meteora CPMM.
3. **Scope**: Only allowed files touched.
4. **I-9**: No execution/send path changed.
5. **Level-5**: No eval repo reads.

## Not in scope

- Orca bounded bootstrap verify, request/reply recovery, Meteora DLMM readiness, execution_engine/momentum_bot/arb_strategy refactors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fb2f0be-1e3c-4b05-b0e0-559297e4433a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fb2f0be-1e3c-4b05-b0e0-559297e4433a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

