### PR TITLE
fix(pool-cache): Meteora DLMM JetStream/SLAVE Shape (vaults, active_id, bin_step)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -35,12 +35,13 @@ use ironcrab::ipc::{
     ControlRequestKind, ControlResponse, ControlResponseStatus, DexPoolReadiness, ExecutionResult,
     ExecutionStatus, IntentTier, MarketEvent, MarketEventKind, PoolCacheUpdate,
     PriorityFeePercentiles, NATIVE_SOL_MINT, POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY,
-    POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY,
-    POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY, POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY,
-    POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY, POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY,
-    POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY,
-    POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY,
-    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY,
+    POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY,
+    POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY,
+    POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY,
+    POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY, POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY,
+    POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY,
+    POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use ironcrab::metrics::{
     serve_metrics, set_readiness_control_sub_active, set_readiness_mode,
@@ -87,7 +88,7 @@ const EXECUTION_RESULT_DEDUP_CAPACITY: usize = 4096;
 use ironcrab::execution::live_pool_cache::{
     meteora_cpmm_readiness_for_pool_cache_update, orca_readiness_for_pool_cache_update,
     parse_pool_account, raydium_amm_readiness_for_pool_cache_update, CachedPoolState,
-    LivePoolCache, MeteoraCpmmState, OrcaWhirlpoolState, PumpAmmState, PumpFunState,
+    LivePoolCache, MeteoraCpmmState, MeteoraState, OrcaWhirlpoolState, PumpAmmState, PumpFunState,
     RaydiumCpmmState,
 };
 
@@ -183,6 +184,24 @@ fn orca_metadata_for_pool_cache_update(s: &OrcaWhirlpoolState) -> HashMap<String
             p.to_string(),
         );
     }
+    meta
+}
+
+/// Meteora DLMM: vault pubkeys + static pool fields for JetStream / SLAVE bootstrap.
+fn meteora_dlmm_metadata_for_pool_cache_update(s: &MeteoraState) -> HashMap<String, String> {
+    let mut meta = HashMap::new();
+    meta.insert(
+        POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY.to_string(),
+        format!("{},{}", s.reserve_x, s.reserve_y),
+    );
+    meta.insert(
+        POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY.to_string(),
+        s.active_id.to_string(),
+    );
+    meta.insert(
+        POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY.to_string(),
+        s.bin_step.to_string(),
+    );
     meta
 }
 
@@ -3859,6 +3878,20 @@ async fn run_geyser_loop(
                                                 );
                                             }
                                         }
+                                        if vault_info.dex == "meteora_dlmm" {
+                                            if let Some(CachedPoolState::Meteora(ref s)) =
+                                                ctx.live_pool_cache.get(&vault_info.pool_address)
+                                            {
+                                                let mut meta = balance_update
+                                                    .metadata
+                                                    .take()
+                                                    .unwrap_or_default();
+                                                for (k, v) in meteora_dlmm_metadata_for_pool_cache_update(s) {
+                                                    meta.insert(k, v);
+                                                }
+                                                balance_update.metadata = Some(meta);
+                                            }
+                                        }
                                         let subject = pool_subject(&vault_info.pool_address.to_string());
                                         if let Err(e) = nats.jetstream_publish(&subject, &balance_update).await {
                                             warn!(error = %e, "Failed to publish PoolCacheUpdate::BalanceUpdated to JetStream");
@@ -4103,6 +4136,54 @@ async fn run_geyser_loop(
                                     vault_base = %vault_base,
                                     vault_quote = %vault_quote,
                                     "Registered Meteora CPMM vaults for Geyser reserve subscription"
+                                );
+                            }
+                        }
+                    }
+
+                    // Meteora DLMM: register reserve vault ATAs (on-chain token_x / token_y order).
+                    if ctx.config.read().enable_meteora_dlmm {
+                        if let CachedPoolState::Meteora(s) = &cached_state {
+                            let dex_str = "meteora_dlmm".to_string();
+                            let mut vaults_changed = false;
+                            {
+                                let mut vaults = ctx.tracked_vaults.write();
+                                vaults.entry(s.reserve_x).or_insert_with(|| {
+                                    vaults_changed = true;
+                                    VaultInfo {
+                                        pool_address: account_update.pubkey,
+                                        dex: dex_str.clone(),
+                                        base_mint: s.token_x_mint,
+                                        quote_mint: s.token_y_mint,
+                                        is_base_vault: true,
+                                        last_balance: std::sync::atomic::AtomicU64::new(0),
+                                        active_id: Some(s.active_id),
+                                        bin_step: Some(s.bin_step),
+                                    }
+                                });
+                                vaults.entry(s.reserve_y).or_insert_with(|| {
+                                    vaults_changed = true;
+                                    VaultInfo {
+                                        pool_address: account_update.pubkey,
+                                        dex: dex_str,
+                                        base_mint: s.token_x_mint,
+                                        quote_mint: s.token_y_mint,
+                                        is_base_vault: false,
+                                        last_balance: std::sync::atomic::AtomicU64::new(0),
+                                        active_id: Some(s.active_id),
+                                        bin_step: Some(s.bin_step),
+                                    }
+                                });
+                            }
+                            if vaults_changed {
+                                let vault_list: Vec<Pubkey> =
+                                    ctx.tracked_vaults.read().keys().copied().collect();
+                                let _ = ctx.tracked_vaults_tx.send(vault_list);
+                                debug!(
+                                    pool = %account_update.pubkey,
+                                    reserve_x = %s.reserve_x,
+                                    reserve_y = %s.reserve_y,
+                                    "Registered Meteora DLMM vaults for Geyser reserve subscription"
                                 );
                             }
                         }
@@ -4588,7 +4669,10 @@ async fn run_geyser_loop(
                                     readiness,
                                 );
                             }
-                            _ => {}
+                            CachedPoolState::Meteora(s) => {
+                                pool_update.metadata =
+                                    Some(meteora_dlmm_metadata_for_pool_cache_update(s));
+                            }
                         }
                         // P3 #13: Propagate base_decimals and quote_decimals to SLAVE caches (all DEX types)
                         {

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -27,11 +27,13 @@ use crate::execution::live_pool_cache::{
 use crate::ipc::{
     PoolCacheUpdate, PoolCacheUpdateType, NATIVE_SOL_MINT,
     POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY, POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY,
-    POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY,
-    POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY,
-    POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY, POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY,
-    POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY,
-    POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY,
+    POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY, POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY,
+    POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY, POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY,
+    POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY, POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY,
+    POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY,
+    POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY,
+    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use crate::nats::{slave_consumer_config, NatsClient, STREAM_NAME};
 
@@ -196,16 +198,39 @@ fn build_minimal_pool_state_with_reserves(
             reserve_0: Some(base_reserve),
             reserve_1: Some(quote_reserve),
         }),
-        "meteora_dlmm" => CachedPoolState::Meteora(MeteoraState {
-            token_x_mint: base_mint,
-            token_y_mint: quote_mint,
-            reserve_x: Pubkey::default(),
-            reserve_y: Pubkey::default(),
-            active_id: 0,
-            bin_step: 0,
-            reserve_x_balance: Some(base_reserve),
-            reserve_y_balance: Some(quote_reserve),
-        }),
+        "meteora_dlmm" => {
+            let meta = update.metadata.as_ref();
+            let (reserve_x, reserve_y) = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY))
+                .and_then(|s| {
+                    let mut it = s.split(',').filter_map(|a| Pubkey::from_str(a.trim()).ok());
+                    match (it.next(), it.next()) {
+                        (Some(vx), Some(vy)) => Some((vx, vy)),
+                        _ => None,
+                    }
+                })
+                .unwrap_or((Pubkey::default(), Pubkey::default()));
+
+            let active_id = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY))
+                .and_then(|s| s.parse::<i32>().ok())
+                .unwrap_or(0);
+            let bin_step = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY))
+                .and_then(|s| s.parse::<u16>().ok())
+                .unwrap_or(0);
+
+            CachedPoolState::Meteora(MeteoraState {
+                token_x_mint: base_mint,
+                token_y_mint: quote_mint,
+                reserve_x,
+                reserve_y,
+                active_id,
+                bin_step,
+                reserve_x_balance: Some(base_reserve),
+                reserve_y_balance: Some(quote_reserve),
+            })
+        }
         "meteora_cpmm" => {
             // `base_mint` / `quote_mint` / reserves are normalized (non-SOL first). On-chain
             // Meteora pool state uses token_0 / token_1 — may be SOL,base. Optional metadata carries
@@ -445,6 +470,36 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                                     new_cpmm.token_0_vault = v0;
                                     new_cpmm.token_1_vault = v1;
                                 }
+                            }
+                        }
+                    }
+                }
+                // PoolDiscovered without DLMM metadata (legacy JetStream): keep structural fields from SLAVE.
+                if update.dex == "meteora_dlmm" {
+                    let um = update.metadata.as_ref();
+                    if let CachedPoolState::Meteora(ref mut new_m) = minimal_state {
+                        if let Some(CachedPoolState::Meteora(ex)) = cache.get(&pool_addr).as_ref() {
+                            if new_m.reserve_x == Pubkey::default()
+                                && ex.reserve_x != Pubkey::default()
+                            {
+                                new_m.reserve_x = ex.reserve_x;
+                            }
+                            if new_m.reserve_y == Pubkey::default()
+                                && ex.reserve_y != Pubkey::default()
+                            {
+                                new_m.reserve_y = ex.reserve_y;
+                            }
+                            if um
+                                .and_then(|m| m.get(POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY))
+                                .is_none()
+                            {
+                                new_m.active_id = ex.active_id;
+                            }
+                            if um
+                                .and_then(|m| m.get(POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY))
+                                .is_none()
+                            {
+                                new_m.bin_step = ex.bin_step;
                             }
                         }
                     }
@@ -834,6 +889,36 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         }
                     }
                 }
+                // BalanceUpdated may omit DLMM static fields; `active_id == 0` / `bin_step == 0` are valid on-chain.
+                if update.dex == "meteora_dlmm" {
+                    let um = update.metadata.as_ref();
+                    if let CachedPoolState::Meteora(ref mut new_m) = minimal_state {
+                        if let Some(CachedPoolState::Meteora(ex)) = existing.as_ref() {
+                            if new_m.reserve_x == Pubkey::default()
+                                && ex.reserve_x != Pubkey::default()
+                            {
+                                new_m.reserve_x = ex.reserve_x;
+                            }
+                            if new_m.reserve_y == Pubkey::default()
+                                && ex.reserve_y != Pubkey::default()
+                            {
+                                new_m.reserve_y = ex.reserve_y;
+                            }
+                            if um
+                                .and_then(|m| m.get(POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY))
+                                .is_none()
+                            {
+                                new_m.active_id = ex.active_id;
+                            }
+                            if um
+                                .and_then(|m| m.get(POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY))
+                                .is_none()
+                            {
+                                new_m.bin_step = ex.bin_step;
+                            }
+                        }
+                    }
+                }
                 cache.upsert(addr, minimal_state, update.geyser_slot);
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_pool_accounts_readiness(
@@ -960,11 +1045,12 @@ mod tests {
     use super::*;
     use crate::ipc::{
         DexPoolReadiness, POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY,
-        POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY,
-        POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY, POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY,
-        POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY, POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY,
-        POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY, POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY,
-        POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+        POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY,
+        POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY,
+        POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY,
+        POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY,
+        POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY, POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY,
+        POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
     };
 
     /// A.30 Regression: cashback_enabled must be true when JetStream metadata contains
@@ -1512,6 +1598,189 @@ mod tests {
                 assert_eq!(s.token_y_mint, token_y);
                 assert_eq!(s.reserve_x_balance, Some(100));
                 assert_eq!(s.reserve_y_balance, Some(200));
+            }
+            other => panic!("expected Meteora (DLMM), got {:?}", other),
+        }
+    }
+
+    /// JetStream `PoolDiscovered` with DLMM metadata must reconstruct vaults + static fields.
+    #[test]
+    fn test_meteora_dlmm_pool_discovered_metadata_reconstructs_shape() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let token_x = Pubkey::new_unique();
+        let token_y = Pubkey::new_unique();
+        let vx = Pubkey::new_unique();
+        let vy = Pubkey::new_unique();
+
+        let mut update = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "meteora_dlmm".to_string(),
+            token_x.to_string(),
+            token_y.to_string(),
+            1,
+            2,
+            None,
+            1,
+        );
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY.to_string(),
+            format!("{vx},{vy}"),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY.to_string(),
+            "-42".to_string(),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY.to_string(),
+            "100".to_string(),
+        );
+        update.metadata = Some(meta);
+
+        assert!(apply_pool_cache_update(&cache, &update));
+
+        match cache.get(&pool).expect("pool in cache") {
+            CachedPoolState::Meteora(s) => {
+                assert_eq!(s.reserve_x, vx);
+                assert_eq!(s.reserve_y, vy);
+                assert_eq!(s.active_id, -42);
+                assert_eq!(s.bin_step, 100);
+                assert_eq!(s.reserve_x_balance, Some(1));
+                assert_eq!(s.reserve_y_balance, Some(2));
+            }
+            other => panic!("expected Meteora (DLMM), got {:?}", other),
+        }
+    }
+
+    /// `active_id == 0` and `bin_step == 0` are valid on-chain; BalanceUpdated without DLMM keys must not clobber them.
+    #[test]
+    fn test_meteora_dlmm_balance_updated_without_metadata_preserves_zero_static_fields() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let token_x = Pubkey::new_unique();
+        let token_y = Pubkey::new_unique();
+        let vx = Pubkey::new_unique();
+        let vy = Pubkey::new_unique();
+
+        let mut disc = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "meteora_dlmm".to_string(),
+            token_x.to_string(),
+            token_y.to_string(),
+            10,
+            20,
+            None,
+            1,
+        );
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY.to_string(),
+            format!("{vx},{vy}"),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY.to_string(),
+            "0".to_string(),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY.to_string(),
+            "0".to_string(),
+        );
+        disc.metadata = Some(meta);
+        assert!(apply_pool_cache_update(&cache, &disc));
+
+        let bal = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "meteora_dlmm".to_string(),
+            token_x.to_string(),
+            token_y.to_string(),
+            0,
+            99,
+            2,
+        );
+        assert!(apply_pool_cache_update(&cache, &bal));
+
+        match cache.get(&pool).expect("pool in cache") {
+            CachedPoolState::Meteora(s) => {
+                assert_eq!(s.active_id, 0);
+                assert_eq!(s.bin_step, 0);
+                assert_eq!(s.reserve_x, vx);
+                assert_eq!(s.reserve_y, vy);
+                assert_eq!(s.reserve_x_balance, Some(10));
+                assert_eq!(s.reserve_y_balance, Some(99));
+            }
+            other => panic!("expected Meteora (DLMM), got {:?}", other),
+        }
+    }
+
+    /// BalanceUpdated without metadata must keep prior non-zero static fields (not re-derived from unwrap defaults).
+    #[test]
+    fn test_meteora_dlmm_balance_updated_preserves_static_when_metadata_absent() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let token_x = Pubkey::new_unique();
+        let token_y = Pubkey::new_unique();
+        let vx = Pubkey::new_unique();
+        let vy = Pubkey::new_unique();
+
+        let mut disc = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "meteora_dlmm".to_string(),
+            token_x.to_string(),
+            token_y.to_string(),
+            5,
+            6,
+            None,
+            1,
+        );
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY.to_string(),
+            format!("{vx},{vy}"),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY.to_string(),
+            "7".to_string(),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY.to_string(),
+            "8".to_string(),
+        );
+        disc.metadata = Some(meta);
+        assert!(apply_pool_cache_update(&cache, &disc));
+
+        let bal = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "meteora_dlmm".to_string(),
+            token_x.to_string(),
+            token_y.to_string(),
+            100,
+            200,
+            2,
+        );
+        assert!(apply_pool_cache_update(&cache, &bal));
+
+        match cache.get(&pool).expect("pool in cache") {
+            CachedPoolState::Meteora(s) => {
+                assert_eq!(s.active_id, 7);
+                assert_eq!(s.bin_step, 8);
+                assert_eq!(s.reserve_x, vx);
+                assert_eq!(s.reserve_y, vy);
             }
             other => panic!("expected Meteora (DLMM), got {:?}", other),
         }

--- a/src/execution/tx_builder.rs
+++ b/src/execution/tx_builder.rs
@@ -1,4 +1,4 @@
-use crate::execution::live_pool_cache::{CachedPoolState, SharedLivePoolCache};
+use crate::execution::live_pool_cache::{CachedPoolState, MeteoraState, SharedLivePoolCache};
 use crate::ipc::{RejectReason, SwapHop, TradeIntent, TradeSide};
 use crate::solana::dex::meteora_dlmm::MeteoraDlmm;
 use crate::solana::dex::orca::Orca;
@@ -17,6 +17,16 @@ use spl_token_2022;
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::warn;
+
+/// Whether a [`MeteoraState`] row from LivePoolCache is structurally usable for DLMM planning.
+///
+/// `active_id` and `bin_step` may legitimately be zero on-chain; rejecting cache injection on
+/// `active_id != 0` breaks JetStream/SLAVE rows that preserve real zeros (see pool_cache_sync).
+/// Default vault pubkeys indicate a degenerate/minimal cache row, not “stale active_id”.
+#[must_use]
+fn meteora_dlmm_cache_state_injectable(state: &MeteoraState) -> bool {
+    state.reserve_x != Pubkey::default() && state.reserve_y != Pubkey::default()
+}
 
 /// System program ID
 const SYSTEM_PROGRAM_ID: &str = "11111111111111111111111111111111";
@@ -947,7 +957,7 @@ pub async fn build_tx_plan(
             let mut used_cache = false;
             if let Some(cache) = cache {
                 if let Some(CachedPoolState::Meteora(dlmm_state)) = cache.get(&_pool_id) {
-                    if dlmm_state.active_id != 0 {
+                    if meteora_dlmm_cache_state_injectable(&dlmm_state) {
                         if let Ok(true) =
                             meteora.inject_cached_meteora_state(&_pool_id, &dlmm_state)
                         {
@@ -1785,8 +1795,7 @@ async fn build_hop_meteora_dlmm(
     let mut used_cache = false;
     if let Some(cache) = cache {
         if let Some(CachedPoolState::Meteora(dlmm_state)) = cache.get(pool_address) {
-            // Only use if active_id != 0 (real Geyser data, not default)
-            if dlmm_state.active_id != 0 {
+            if meteora_dlmm_cache_state_injectable(&dlmm_state) {
                 if let Ok(true) = meteora.inject_cached_meteora_state(pool_address, &dlmm_state) {
                     tracing::debug!(
                         pool = %pool_address,
@@ -1795,11 +1804,6 @@ async fn build_hop_meteora_dlmm(
                     );
                     used_cache = true;
                 }
-            } else {
-                tracing::warn!(
-                    pool = %pool_address,
-                    "multi-hop meteora: active_id=0 (stale cache), skipping injection"
-                );
             }
         }
     }
@@ -1835,6 +1839,7 @@ async fn build_hop_meteora_dlmm(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::execution::live_pool_cache::MeteoraState;
     use crate::ipc::{
         ExplicitAmount, IntentOrigin, IntentTier, TradeExecutionConstraints, TradeResources,
         TradingRegime,
@@ -1942,5 +1947,38 @@ mod tests {
         let intent = base_intent();
         let parsed = super::min_out_raw_from_intent(&intent);
         assert_eq!(parsed, None);
+    }
+
+    /// Regression: `active_id == 0` / `bin_step == 0` are valid on-chain; cache must not be rejected on that alone.
+    #[test]
+    fn meteora_dlmm_cache_injectable_accepts_zero_active_id_with_real_vaults() {
+        let vx = Pubkey::new_unique();
+        let vy = Pubkey::new_unique();
+        let s = MeteoraState {
+            token_x_mint: Pubkey::new_unique(),
+            token_y_mint: Pubkey::new_unique(),
+            reserve_x: vx,
+            reserve_y: vy,
+            active_id: 0,
+            bin_step: 0,
+            reserve_x_balance: Some(1),
+            reserve_y_balance: Some(2),
+        };
+        assert!(super::meteora_dlmm_cache_state_injectable(&s));
+    }
+
+    #[test]
+    fn meteora_dlmm_cache_injectable_rejects_default_vaults() {
+        let s = MeteoraState {
+            token_x_mint: Pubkey::new_unique(),
+            token_y_mint: Pubkey::new_unique(),
+            reserve_x: Pubkey::default(),
+            reserve_y: Pubkey::new_unique(),
+            active_id: 42,
+            bin_step: 10,
+            reserve_x_balance: Some(1),
+            reserve_y_balance: Some(2),
+        };
+        assert!(!super::meteora_dlmm_cache_state_injectable(&s));
     }
 }

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -2424,6 +2424,19 @@ pub const POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY: &str = "orca_protocol_fe
 pub const POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY: &str = "orca_token_a_program";
 pub const POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY: &str = "orca_token_b_program";
 
+/// Meteora DLMM: `reserve_x_vault,reserve_y_vault` (comma-separated base58).
+///
+/// Order matches on-chain LB pair layout (`token_x_mint` / `token_y_mint`), which is the same as
+/// [`PoolCacheUpdate::base_mint`] / [`PoolCacheUpdate::quote_mint`] for Meteora DLMM publishes from
+/// market-data (`token_x` → base, `token_y` → quote).
+pub const POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY: &str = "meteora_dlmm_vaults";
+
+/// Meteora DLMM: active bin id from pool account (decimal string, signed i32).
+pub const POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY: &str = "meteora_dlmm_active_id";
+
+/// Meteora DLMM: bin step from pool account (decimal string, u16).
+pub const POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY: &str = "meteora_dlmm_bin_step";
+
 /// Pool cache update type
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ziel

Schließt die SSOT-Lücke für Meteora DLMM: `PoolCacheUpdate` transportiert jetzt die minimalen statischen DLMM-Felder, und `pool_cache_sync` rekonstruiert bzw. erhält sie bei Bootstrap und `BalanceUpdated` (ohne Ready-Gate, ohne neue Hot-Path-RPCs).

## Änderungen

- **Schema (`ipc/schema.rs`):** Konstanten `meteora_dlmm_vaults` (`reserve_x,reserve_y`), `meteora_dlmm_active_id`, `meteora_dlmm_bin_step`.
- **market-data:** Bei Geyser-`PoolDiscovered` für `CachedPoolState::Meteora` werden diese Keys gesetzt; DLMM-Reserve-Vaults werden für Geyser-Subscription registriert (wie CPMM). Bei `BalanceUpdated` vom Vault-Pfad werden dieselben Metadaten aus dem MASTER-Cache angehängt.
- **pool_cache_sync:** `build_minimal_pool_state_with_reserves` liest die Metadaten; bei `PoolDiscovered`/`BalanceUpdated` werden fehlende Keys aus dem bestehenden SLAVE-Zustand übernommen (Orca-Pattern: Präsenz der Keys, nicht `== 0`).
- **tx_builder (Review-Follow-up):** Cache-Injektion für DLMM nicht mehr an `active_id != 0` gekoppelt (legitime Nullen). Stattdessen `meteora_dlmm_cache_state_injectable`: beide Vault-Pubkeys müssen non-default sein — das entspricht dem JetStream-Shape-Fix und vermeidet weiterhin degenerate Minimalzeilen ohne Vaults.

## Tests

- `test_meteora_dlmm_pool_discovered_metadata_reconstructs_shape`
- `test_meteora_dlmm_balance_updated_without_metadata_preserves_zero_static_fields`
- `test_meteora_dlmm_balance_updated_preserves_static_when_metadata_absent`
- `meteora_dlmm_cache_injectable_accepts_zero_active_id_with_real_vaults`
- `meteora_dlmm_cache_injectable_rejects_default_vaults`

## Nicht im Scope

Kein `DexPoolReadiness` für DLMM, kein Mint-Gate, kein Bootstrap-Scheduler, keine Änderungen an execution-engine/momentum/arb (außer tx_builder-Injektionsheuristik oben).

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo test --features test_helpers`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a55d4f4-ae25-44f1-8ea3-4e9aefe57092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a55d4f4-ae25-44f1-8ea3-4e9aefe57092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

