### PR TITLE
Scope 17: Meteora DLMM explizite DexPoolReadiness (JetStream/SLAVE)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -86,10 +86,10 @@ const EXECUTION_RESULT_DEDUP_CAPACITY: usize = 4096;
 
 // LivePoolCache - MASTER Cache (Single Source of Truth)
 use ironcrab::execution::live_pool_cache::{
-    meteora_cpmm_readiness_for_pool_cache_update, orca_readiness_for_pool_cache_update,
-    parse_pool_account, raydium_amm_readiness_for_pool_cache_update, CachedPoolState,
-    LivePoolCache, MeteoraCpmmState, MeteoraState, OrcaWhirlpoolState, PumpAmmState, PumpFunState,
-    RaydiumCpmmState,
+    meteora_cpmm_readiness_for_pool_cache_update, meteora_dlmm_readiness_for_pool_cache_update,
+    orca_readiness_for_pool_cache_update, parse_pool_account,
+    raydium_amm_readiness_for_pool_cache_update, CachedPoolState, LivePoolCache, MeteoraCpmmState,
+    MeteoraState, OrcaWhirlpoolState, PumpAmmState, PumpFunState, RaydiumCpmmState,
 };
 
 // P1 Crash Isolation: Systemd Watchdog support
@@ -3890,6 +3890,13 @@ async fn run_geyser_loop(
                                                     meta.insert(k, v);
                                                 }
                                                 balance_update.metadata = Some(meta);
+                                                let readiness =
+                                                    meteora_dlmm_readiness_for_pool_cache_update(s);
+                                                balance_update.set_dex_readiness_in_metadata(readiness);
+                                                ctx.live_pool_cache.merge_meteora_dlmm_pool_readiness(
+                                                    vault_info.pool_address,
+                                                    readiness,
+                                                );
                                             }
                                         }
                                         let subject = pool_subject(&vault_info.pool_address.to_string());
@@ -4672,6 +4679,12 @@ async fn run_geyser_loop(
                             CachedPoolState::Meteora(s) => {
                                 pool_update.metadata =
                                     Some(meteora_dlmm_metadata_for_pool_cache_update(s));
+                                let readiness = meteora_dlmm_readiness_for_pool_cache_update(s);
+                                pool_update.set_dex_readiness_in_metadata(readiness);
+                                ctx.live_pool_cache.merge_meteora_dlmm_pool_readiness(
+                                    account_update.pubkey,
+                                    readiness,
+                                );
                             }
                         }
                         // P3 #13: Propagate base_decimals and quote_decimals to SLAVE caches (all DEX types)

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -282,6 +282,29 @@ pub fn meteora_cpmm_readiness_for_pool_cache_update(s: &MeteoraCpmmState) -> Dex
     }
 }
 
+/// JetStream / MASTER [`DexPoolReadiness`] for Meteora DLMM (conservative, explicit).
+///
+/// `Ready` only when **both** reserve vault pubkeys are non-default (real on-chain vaults from the LB
+/// pair) **and** both vault balances are known and non-zero — matching quote/builder needs for
+/// believable two-sided liquidity. `active_id` / `bin_step` are **not** part of readiness (legitimate
+/// zero values must not block `Ready` after the Scope 16 shape fix).
+#[must_use]
+pub fn meteora_dlmm_readiness_for_pool_cache_update(s: &MeteoraState) -> DexPoolReadiness {
+    let real_vaults = s.reserve_x != Pubkey::default() && s.reserve_y != Pubkey::default();
+    let rx = s.reserve_x_balance;
+    let ry = s.reserve_y_balance;
+    let ready_reserves = matches!((rx, ry), (Some(a), Some(b)) if a > 0 && b > 0);
+    let any_reserve_signal =
+        rx.map(|v| v > 0).unwrap_or(false) || ry.map(|v| v > 0).unwrap_or(false);
+    if real_vaults && ready_reserves {
+        DexPoolReadiness::Ready
+    } else if real_vaults || any_reserve_signal {
+        DexPoolReadiness::Partial
+    } else {
+        DexPoolReadiness::Observed
+    }
+}
+
 // ============================================================================
 // Unified cached pool state enum
 // ============================================================================
@@ -405,6 +428,9 @@ pub struct LivePoolCache {
 
     /// Orca Whirlpool pool address → explicit [`DexPoolReadiness`] from JetStream / MASTER (Bug #36).
     orca_readiness_by_pool: DashMap<Pubkey, DexPoolReadiness>,
+
+    /// Meteora DLMM pool address → explicit [`DexPoolReadiness`] from JetStream / MASTER (Bug #36).
+    meteora_dlmm_readiness_by_pool: DashMap<Pubkey, DexPoolReadiness>,
 }
 
 /// Which vault position (A/B or X/Y or 0/1) this vault represents
@@ -440,6 +466,7 @@ impl LivePoolCache {
             raydium_amm_readiness_by_pool: DashMap::new(),
             meteora_cpmm_readiness_by_pool: DashMap::new(),
             orca_readiness_by_pool: DashMap::new(),
+            meteora_dlmm_readiness_by_pool: DashMap::new(),
         }
     }
 
@@ -1041,6 +1068,14 @@ impl LivePoolCache {
             .or_insert(incoming);
     }
 
+    /// Merge Meteora DLMM pool readiness for `pool` (monotonic — never downgrade).
+    pub fn merge_meteora_dlmm_pool_readiness(&self, pool: Pubkey, incoming: DexPoolReadiness) {
+        self.meteora_dlmm_readiness_by_pool
+            .entry(pool)
+            .and_modify(|stored| *stored = stored.merge(incoming))
+            .or_insert(incoming);
+    }
+
     /// `true` only when JetStream merge recorded [`DexPoolReadiness::Ready`] for this Raydium CPMM pool.
     #[must_use]
     pub fn raydium_cpmm_pool_explicitly_ready(&self, pool: &Pubkey) -> bool {
@@ -1099,6 +1134,38 @@ impl LivePoolCache {
     #[must_use]
     pub fn orca_readiness(&self, pool: &Pubkey) -> Option<DexPoolReadiness> {
         self.orca_readiness_by_pool.get(pool).map(|r| *r)
+    }
+
+    /// `true` only when JetStream merge recorded [`DexPoolReadiness::Ready`] for this Meteora DLMM pool.
+    #[must_use]
+    pub fn meteora_dlmm_pool_explicitly_ready(&self, pool: &Pubkey) -> bool {
+        self.meteora_dlmm_readiness_by_pool
+            .get(pool)
+            .map(|r| *r == DexPoolReadiness::Ready)
+            .unwrap_or(false)
+    }
+
+    /// Monotonic merge result for this Meteora DLMM pool (tests / diagnostics).
+    #[must_use]
+    pub fn meteora_dlmm_readiness(&self, pool: &Pubkey) -> Option<DexPoolReadiness> {
+        self.meteora_dlmm_readiness_by_pool.get(pool).map(|r| *r)
+    }
+
+    /// Mint-level helper: Meteora DLMM slice — explicit `Ready` only (no cache-hit heuristic).
+    #[must_use]
+    pub fn base_mint_has_explicit_meteora_dlmm_ready_pool(&self, base_mint: &Pubkey) -> bool {
+        for entry in self.pools.iter() {
+            if let CachedPoolState::Meteora(s) = &entry.value().state {
+                if s.token_x_mint != *base_mint && s.token_y_mint != *base_mint {
+                    continue;
+                }
+                let pool = entry.key();
+                if self.meteora_dlmm_pool_explicitly_ready(pool) {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     /// Mint-level helper: Raydium CPMM slice — explicit `Ready` only (no cache-hit heuristic).
@@ -1318,11 +1385,10 @@ impl LivePoolCache {
     ///   [`DexPoolReadiness::Ready`] in [`Self::raydium_amm_readiness_by_pool`] only.
     /// - Meteora CPMM: [`Self::base_mint_has_explicit_meteora_cpmm_ready_pool`] — explicit
     ///   [`DexPoolReadiness::Ready`] in [`Self::meteora_cpmm_readiness_by_pool`] only.
+    /// - Meteora DLMM: [`Self::base_mint_has_explicit_meteora_dlmm_ready_pool`] — explicit
+    ///   [`DexPoolReadiness::Ready`] in [`Self::meteora_dlmm_readiness_by_pool`] only.
     /// - Orca Whirlpool: [`Self::base_mint_has_explicit_orca_ready_pool`] — explicit
     ///   [`DexPoolReadiness::Ready`] in [`Self::orca_readiness_by_pool`] only.
-    ///
-    /// **Conservative:** Meteora DLMM and other DEXes are **not** treated as ready here until they
-    /// have an explicit readiness path.
     #[must_use]
     pub fn base_mint_has_any_ready_pool(&self, base_mint: &Pubkey) -> bool {
         if self.base_mint_has_explicit_pump_amm_ready_pool(base_mint) {
@@ -1332,6 +1398,9 @@ impl LivePoolCache {
             return true;
         }
         if self.base_mint_has_explicit_meteora_cpmm_ready_pool(base_mint) {
+            return true;
+        }
+        if self.base_mint_has_explicit_meteora_dlmm_ready_pool(base_mint) {
             return true;
         }
         if self.base_mint_has_explicit_orca_ready_pool(base_mint) {
@@ -2996,6 +3065,184 @@ mod tests {
         cache.merge_meteora_cpmm_pool_readiness(pool, DexPoolReadiness::Ready);
         assert!(cache.base_mint_has_any_ready_pool(&base_mint));
         cache.merge_meteora_cpmm_pool_readiness(pool, DexPoolReadiness::Observed);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn make_meteora_dlmm_state(
+        token_x_mint: Pubkey,
+        token_y_mint: Pubkey,
+        reserve_x: Pubkey,
+        reserve_y: Pubkey,
+        active_id: i32,
+        bin_step: u16,
+        reserve_x_balance: Option<u64>,
+        reserve_y_balance: Option<u64>,
+    ) -> MeteoraState {
+        MeteoraState {
+            token_x_mint,
+            token_y_mint,
+            reserve_x,
+            reserve_y,
+            active_id,
+            bin_step,
+            reserve_x_balance,
+            reserve_y_balance,
+        }
+    }
+
+    #[test]
+    fn test_meteora_dlmm_readiness_helper_weak_default_vaults_observed() {
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::new_unique();
+        let s = make_meteora_dlmm_state(
+            base,
+            quote,
+            Pubkey::default(),
+            Pubkey::default(),
+            0,
+            0,
+            None,
+            None,
+        );
+        assert_eq!(
+            meteora_dlmm_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Observed
+        );
+    }
+
+    #[test]
+    fn test_meteora_dlmm_readiness_helper_ready_with_zero_active_id_and_bin_step() {
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::new_unique();
+        let vx = Pubkey::new_unique();
+        let vy = Pubkey::new_unique();
+        let s = make_meteora_dlmm_state(base, quote, vx, vy, 0, 0, Some(100), Some(200));
+        assert_eq!(
+            meteora_dlmm_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Ready
+        );
+    }
+
+    #[test]
+    fn test_meteora_dlmm_readiness_helper_real_vaults_incomplete_balances_partial() {
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::new_unique();
+        let vx = Pubkey::new_unique();
+        let vy = Pubkey::new_unique();
+        let s = make_meteora_dlmm_state(base, quote, vx, vy, -5, 0, Some(1), None);
+        assert_eq!(
+            meteora_dlmm_readiness_for_pool_cache_update(&s),
+            DexPoolReadiness::Partial
+        );
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_meteora_dlmm_cache_hit_without_explicit_merge_is_false() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let vx = Pubkey::new_unique();
+        let vy = Pubkey::new_unique();
+        cache.upsert(
+            pool,
+            CachedPoolState::Meteora(make_meteora_dlmm_state(
+                base_mint,
+                quote_mint,
+                vx,
+                vy,
+                0,
+                0,
+                Some(100),
+                Some(200),
+            )),
+            100,
+        );
+        assert!(
+            !cache.base_mint_has_any_ready_pool(&base_mint),
+            "Bug #36: DLMM row in cache must not imply mint-level ready without explicit merge"
+        );
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_meteora_dlmm_explicit_ready() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let vx = Pubkey::new_unique();
+        let vy = Pubkey::new_unique();
+        cache.upsert(
+            pool,
+            CachedPoolState::Meteora(make_meteora_dlmm_state(
+                base_mint,
+                quote_mint,
+                vx,
+                vy,
+                0,
+                0,
+                Some(1),
+                Some(2),
+            )),
+            100,
+        );
+        cache.merge_meteora_dlmm_pool_readiness(pool, DexPoolReadiness::Ready);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+        assert!(cache.base_mint_has_explicit_meteora_dlmm_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_base_mint_has_any_ready_pool_meteora_dlmm_partial_does_not_count() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let vx = Pubkey::new_unique();
+        let vy = Pubkey::new_unique();
+        cache.upsert(
+            pool,
+            CachedPoolState::Meteora(make_meteora_dlmm_state(
+                base_mint,
+                quote_mint,
+                vx,
+                vy,
+                0,
+                0,
+                Some(1),
+                Some(2),
+            )),
+            100,
+        );
+        cache.merge_meteora_dlmm_pool_readiness(pool, DexPoolReadiness::Partial);
+        assert!(!cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_meteora_dlmm_readiness_merge_monotone() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let vx = Pubkey::new_unique();
+        let vy = Pubkey::new_unique();
+        cache.upsert(
+            pool,
+            CachedPoolState::Meteora(make_meteora_dlmm_state(
+                base_mint,
+                quote_mint,
+                vx,
+                vy,
+                0,
+                0,
+                Some(1),
+                Some(2),
+            )),
+            100,
+        );
+        cache.merge_meteora_dlmm_pool_readiness(pool, DexPoolReadiness::Ready);
+        assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+        cache.merge_meteora_dlmm_pool_readiness(pool, DexPoolReadiness::Observed);
         assert!(cache.base_mint_has_any_ready_pool(&base_mint));
     }
 

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -2274,6 +2274,59 @@ mod tests {
     }
 
     #[test]
+    fn test_meteora_dlmm_readiness_merge_never_downgrades() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+
+        let mut ready_up = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "meteora_dlmm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1,
+            1,
+            None,
+            1,
+        );
+        ready_up.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+        assert!(apply_pool_cache_update(&cache, &ready_up));
+        assert!(cache.meteora_dlmm_pool_explicitly_ready(&pool));
+        assert_eq!(
+            cache.meteora_dlmm_readiness(&pool),
+            Some(DexPoolReadiness::Ready)
+        );
+
+        let mut weak = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "meteora_dlmm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1,
+            1,
+            None,
+            2,
+        );
+        weak.set_dex_readiness_in_metadata(DexPoolReadiness::Observed);
+        assert!(apply_pool_cache_update(&cache, &weak));
+        assert!(
+            cache.meteora_dlmm_pool_explicitly_ready(&pool),
+            "merge must not downgrade Ready to Observed for Meteora DLMM"
+        );
+        assert_eq!(
+            cache.meteora_dlmm_readiness(&pool),
+            Some(DexPoolReadiness::Ready)
+        );
+    }
+
+    #[test]
     fn test_orca_pool_discovered_jetstream_reconstructs_static_fields() {
         let cache = LivePoolCache::new();
         let pool = Pubkey::new_unique();

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -538,6 +538,12 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 if update.dex == "orca" {
                     cache.merge_orca_pool_readiness(pool_addr, update.effective_dex_readiness());
                 }
+                if update.dex == "meteora_dlmm" {
+                    cache.merge_meteora_dlmm_pool_readiness(
+                        pool_addr,
+                        update.effective_dex_readiness(),
+                    );
+                }
                 // P3 #13: Propagate base_decimals and quote_decimals to SLAVE cache
                 apply_decimals_from_metadata(cache, update);
                 return true;
@@ -940,6 +946,9 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 }
                 if update.dex == "orca" {
                     cache.merge_orca_pool_readiness(addr, update.effective_dex_readiness());
+                }
+                if update.dex == "meteora_dlmm" {
+                    cache.merge_meteora_dlmm_pool_readiness(addr, update.effective_dex_readiness());
                 }
                 // P3 #13: Apply decimals from metadata when present (e.g. BalanceUpdated with metadata)
                 apply_decimals_from_metadata(cache, update);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Kurzbeschreibung

Meteora DLMM nutzt denselben expliziten `DexPoolReadiness`-Pfad wie die anderen DEXe: `market-data` setzt Readiness auf `PoolCacheUpdate`, SLAVE merged monoton über `pool_cache_sync`, Mint-Gate zählt nur explizites `Ready`.

## Vollständigkeitsbegriff (DLMM)

- **Ready:** `reserve_x` und `reserve_y` sind beide ungleich `Pubkey::default()`, und `reserve_x_balance`/`reserve_y_balance` sind bekannt und beide > 0. `active_id`/`bin_step` werden **nicht** für Ready verwendet (legitime Nullen bleiben möglich).
- **Partial:** echte Vault-Pubkeys, aber Reserves noch nicht beidseitig > 0; oder Reserve-Signal nur auf einer Seite / fehlende Balance.
- **Observed:** kein belastbarer Zustand (z. B. Default-Vaults und keine Reserve-Signale).

## Dateien

- `src/execution/live_pool_cache.rs` – Helper, `meteora_dlmm_readiness_by_pool`, Merge, `base_mint_has_explicit_meteora_dlmm_ready_pool`, Tests
- `src/bin/market_data.rs` – Readiness + Merge bei Pool-Discovery- und Vault-`BalanceUpdated`-Pfad
- `src/execution/pool_cache_sync.rs` – Merge für `meteora_dlmm` bei `PoolDiscovered`/`BalanceUpdated`

## Checks

- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` – grün

## Bewusst nicht in diesem Scope

- Kein bounded Bootstrap/Wallet-Verify für Meteora DLMM
- Keine Änderungen an execution_engine/momentum_bot/arb_strategy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37f4bc2b-e52b-4fdd-939c-b800ef545885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37f4bc2b-e52b-4fdd-939c-b800ef545885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

