### PR TITLE
I-24d: Orca Whirlpool cold-path Ensure via market-data (Scope 20)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -198,14 +198,15 @@ fn is_orca_structural_sim_error(error_code: Option<&str>) -> bool {
         .unwrap_or(false)
 }
 
-/// Cold Path only: PumpFun bonding-curve recovery (`EnsurePumpfunBondingCurve`) is allowed for
-/// kill-switch/liquidation sells **and** explicit manual sell-all tooling (`sell_all=true`).
+/// Cold Path only: DEX structural sim recovery (e.g. PumpFun bonding-curve, Orca Whirlpool) is
+/// allowed for kill-switch/liquidation sells **and** explicit manual sell-all tooling
+/// (`sell_all=true`).
 ///
 /// Rationale: `sell-all` / keyless tooling may tag `sell_all=true` without `purpose=liquidation`;
 /// that path is still Cold Path (not momentum hot path). PumpSwap recovery stays gated on
 /// `is_liquidation_sell` only.
 #[inline]
-fn is_pumpfun_bonding_curve_cold_path_recovery_sell(intent: &TradeIntent) -> bool {
+fn is_cold_path_recovery_sell(intent: &TradeIntent) -> bool {
     if intent.side != TradeSide::Sell {
         return false;
     }
@@ -8574,7 +8575,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
         // PumpFun bonding curve SELL: stale virtual/real reserves or cashback layout → 6023/6024/Overflow.
         // Cold-path recovery: EnsurePumpfunBondingCurve with force_refresh (RPC in market-data), bounded JetStream wait, one retry.
         if !pumpfun_bonding_recovery_attempted
-            && is_pumpfun_bonding_curve_cold_path_recovery_sell(&intent)
+            && is_cold_path_recovery_sell(&intent)
             && intent.metadata.get("dex").map(|s| s.as_str()) == Some("pumpfun")
             && intent.resources.pools.len() == 1
             && is_pumpfun_bonding_curve_structural_sim_error(sim_result.error_code.as_deref())
@@ -8650,7 +8651,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
         // Orca Whirlpool SELL (liquidation / manual cold path): stale tick or vault evidence →
         // structural sim fail. I-24d: one EnsureOrcaWhirlpoolPoolState + bounded JetStream wait + one retry.
         if !orca_recovery_attempted
-            && is_pumpfun_bonding_curve_cold_path_recovery_sell(&intent)
+            && is_cold_path_recovery_sell(&intent)
             && intent.metadata.get("dex").map(|s| s.as_str()) == Some("orca")
             && intent.resources.pools.len() == 1
             && is_orca_structural_sim_error(sim_result.error_code.as_deref())
@@ -10509,7 +10510,7 @@ async fn spawn_rebroadcast_loop(
 #[cfg(test)]
 mod execution_engine_tests {
     use super::{
-        is_pump_amm_structural_sim_error, is_pumpfun_bonding_curve_cold_path_recovery_sell,
+        is_cold_path_recovery_sell, is_pump_amm_structural_sim_error,
         is_pumpfun_bonding_curve_structural_sim_error, is_regular_momentum_hot_path_sell,
         pump_amm_pool_market_hint_merge, record_pump_amm_hot_path_refresh_after_success,
         select_best_route, try_pump_amm_hot_path_refresh_publish,
@@ -10621,7 +10622,7 @@ mod execution_engine_tests {
         intent
             .metadata
             .insert("dex".to_string(), "pumpfun".to_string());
-        assert!(is_pumpfun_bonding_curve_cold_path_recovery_sell(&intent));
+        assert!(is_cold_path_recovery_sell(&intent));
     }
 
     #[test]
@@ -10645,13 +10646,13 @@ mod execution_engine_tests {
         intent
             .metadata
             .insert("purpose".to_string(), "liquidation".to_string());
-        assert!(is_pumpfun_bonding_curve_cold_path_recovery_sell(&intent));
+        assert!(is_cold_path_recovery_sell(&intent));
 
         intent.metadata.remove("purpose");
         intent
             .metadata
             .insert("kill_switch".to_string(), "true".to_string());
-        assert!(is_pumpfun_bonding_curve_cold_path_recovery_sell(&intent));
+        assert!(is_cold_path_recovery_sell(&intent));
     }
 
     #[test]
@@ -10675,7 +10676,7 @@ mod execution_engine_tests {
         intent
             .metadata
             .insert("dex".to_string(), "pumpfun".to_string());
-        assert!(!is_pumpfun_bonding_curve_cold_path_recovery_sell(&intent));
+        assert!(!is_cold_path_recovery_sell(&intent));
     }
 
     #[test]

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -62,11 +62,11 @@ use ironcrab::execution::tx_builder;
 use ironcrab::execution::wsol_manager::{WsolManager, WsolManagerConfig, WSOL_MINT};
 use ironcrab::ipc::{
     CheckResult, ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, DecisionOutcome,
-    DecisionRecord, ExecutionResult, ExecutionStatus, ExplicitAmount, FairnessPolicy, FeePolicy,
-    FillStatus, FillUnavailableReason, IntentOrigin, IntentTier, KillSwitchContext, MarketEvent,
-    MarketEventKind, PoolCacheUpdate, PriorityFeePercentiles, RecordHeader, RejectReason,
-    SimulationResult, TradeExecutionConstraints, TradeIntent, TradeResources, TradeSide,
-    TradingRegime,
+    DecisionRecord, DexPoolReadiness, ExecutionResult, ExecutionStatus, ExplicitAmount,
+    FairnessPolicy, FeePolicy, FillStatus, FillUnavailableReason, IntentOrigin, IntentTier,
+    KillSwitchContext, MarketEvent, MarketEventKind, PoolCacheUpdate, PriorityFeePercentiles,
+    RecordHeader, RejectReason, SimulationResult, TradeExecutionConstraints, TradeIntent,
+    TradeResources, TradeSide, TradingRegime,
 };
 use ironcrab::ipc::{ControlRequest, ControlRequestKind, ControlResponse, ControlResponseStatus};
 use ironcrab::metrics::{
@@ -180,6 +180,12 @@ fn is_pumpfun_bonding_curve_structural_sim_error(error_code: Option<&str>) -> bo
                 || e.contains("0x1788")
         })
         .unwrap_or(false)
+}
+
+/// Orca Whirlpool: structural sim failure signatures (stale tick/vault layout family).
+#[inline]
+fn is_orca_structural_sim_error(error_code: Option<&str>) -> bool {
+    is_pumpfun_bonding_curve_structural_sim_error(error_code)
 }
 
 /// Cold Path only: PumpFun bonding-curve recovery (`EnsurePumpfunBondingCurve`) is allowed for
@@ -1522,6 +1528,37 @@ async fn wait_for_usable_pump_amm_cache_state(
 ///
 /// Without the snapshot check, an older `Ready` + unchanged reserves could satisfy the wait
 /// immediately after `ControlResponse::Ok` (Bug #34).
+/// Orca Whirlpool cold-path recovery: bounded wait until SLAVE shows explicit JetStream `Ready` and
+/// a **fresh** on-chain evidence tuple vs `before` (Bug #34 / #36 — `ControlResponse::Ok` alone is insufficient).
+async fn wait_for_orca_whirlpool_slave_after_recovery(
+    cache: &LivePoolCache,
+    pool: &Pubkey,
+    before: Option<(i32, u128, u128, u64, u64)>,
+    timeout_ms: u64,
+    poll_interval_ms: u64,
+) -> bool {
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+    while Instant::now() < deadline {
+        if let Some((s, merged)) = cache.orca_whirlpool_slave_readiness_snapshot(pool) {
+            let after = (
+                s.tick_current_index,
+                s.sqrt_price,
+                s.liquidity,
+                s.vault_a_balance.unwrap_or(0),
+                s.vault_b_balance.unwrap_or(0),
+            );
+            if merged == DexPoolReadiness::Ready
+                && cache.orca_pool_explicitly_ready(pool)
+                && Some(after) != before
+            {
+                return true;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
+    }
+    false
+}
+
 async fn wait_for_pumpfun_bonding_cache_refresh(
     cache: &LivePoolCache,
     bonding_curve: &Pubkey,
@@ -2304,6 +2341,113 @@ impl ExecutionContext {
                         base_mint = %base_mint,
                         timeout_secs = DISCOVERY_REQUEST_TIMEOUT_SECS,
                         "PumpFun bonding recovery: timeout (no correlated response)"
+                    );
+                    DiscoveryRequestOutcome::Timeout
+                }
+            };
+
+        let _ = self
+            .pending_discovery_responses
+            .lock()
+            .await
+            .remove(&request_id);
+
+        outcome
+    }
+
+    /// I-24d Scope 20: Orca Whirlpool cold-path recovery — `EnsureOrcaWhirlpoolPoolState` with
+    /// `force_refresh_orca=true`. Does not write SLAVE locally; market-data publishes JetStream.
+    async fn request_orca_whirlpool_recovery_and_wait(
+        &self,
+        base_mint: &str,
+        pool_address_hint: Option<&str>,
+    ) -> DiscoveryRequestOutcome {
+        let Some(ref nats) = self.nats else {
+            warn!(
+                request_id = "n/a",
+                base_mint = %base_mint,
+                "Orca cold-path recovery: NATS not connected"
+            );
+            return DiscoveryRequestOutcome::Error("NATS not connected".to_string());
+        };
+
+        let request_id = Uuid::new_v4().to_string();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        {
+            let mut pending = self.pending_discovery_responses.lock().await;
+            pending.insert(request_id.clone(), tx);
+        }
+
+        let mut req = ControlRequest::new(
+            "execution-engine",
+            BUILD_VERSION,
+            &self.run_id,
+            request_id.clone(),
+            "market-data",
+            ControlRequestKind::EnsureOrcaWhirlpoolPoolState {
+                base_mint: base_mint.to_string(),
+            },
+        );
+        req.pool_address_hint = pool_address_hint.map(String::from);
+        req.force_refresh_orca = true;
+
+        warn!(
+            request_id = %request_id,
+            base_mint = %base_mint,
+            pool_address_hint = ?pool_address_hint,
+            target = "market-data",
+            reason = "orca liquidation/manual sell sim structural fail — requesting authoritative Orca RPC refresh via market-data (I-24d)",
+            "Orca cold-path: publishing EnsureOrcaWhirlpoolPoolState (force_refresh_orca)"
+        );
+
+        if nats.publish(TOPIC_CONTROL_REQUESTS, &req).await.is_err() {
+            let mut pending = self.pending_discovery_responses.lock().await;
+            pending.remove(&request_id);
+            warn!(
+                request_id = %request_id,
+                base_mint = %base_mint,
+                "Orca cold-path recovery: publish failed"
+            );
+            return DiscoveryRequestOutcome::Error("publish failed".to_string());
+        }
+
+        let outcome =
+            match tokio::time::timeout(Duration::from_secs(DISCOVERY_REQUEST_TIMEOUT_SECS), rx)
+                .await
+            {
+                Ok(Ok(resp)) => {
+                    let status_str = format!("{:?}", resp.status);
+                    let pool = resp.pool_address.as_deref();
+                    info!(
+                        request_id = %request_id,
+                        base_mint = %base_mint,
+                        status = %status_str,
+                        pool_address = ?pool,
+                        "Orca cold-path recovery: ControlResponse correlated"
+                    );
+                    match resp.status {
+                        ControlResponseStatus::Ok => DiscoveryRequestOutcome::Ok,
+                        ControlResponseStatus::NotFound => DiscoveryRequestOutcome::NotFound,
+                        ControlResponseStatus::Error => DiscoveryRequestOutcome::Error(
+                            resp.message.unwrap_or_else(|| "unknown error".to_string()),
+                        ),
+                    }
+                }
+                Ok(Err(_)) => {
+                    warn!(
+                        request_id = %request_id,
+                        base_mint = %base_mint,
+                        "Orca cold-path recovery: channel closed before response"
+                    );
+                    DiscoveryRequestOutcome::Error("channel closed".to_string())
+                }
+                Err(_) => {
+                    warn!(
+                        request_id = %request_id,
+                        base_mint = %base_mint,
+                        timeout_secs = DISCOVERY_REQUEST_TIMEOUT_SECS,
+                        "Orca cold-path recovery: timeout waiting for ControlResponse"
                     );
                     DiscoveryRequestOutcome::Timeout
                 }
@@ -7984,6 +8128,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
     let checks_len_before_tx_plan_build = checks.len();
     let mut pump_amm_recovery_attempted = false;
     let mut pumpfun_bonding_recovery_attempted = false;
+    let mut orca_recovery_attempted = false;
     let (
         tx_plan,
         plan_hash_str,
@@ -7993,7 +8138,10 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
         wallet_pubkey,
         bundle_tip_lamports,
     ) = loop {
-        if pump_amm_recovery_attempted || pumpfun_bonding_recovery_attempted {
+        if pump_amm_recovery_attempted
+            || pumpfun_bonding_recovery_attempted
+            || orca_recovery_attempted
+        {
             checks.truncate(checks_len_before_tx_plan_build);
         }
         let (tx_plan, plan_hash_str) = {
@@ -8484,6 +8632,97 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                             continue;
                         }
                     }
+                }
+            }
+        }
+
+        // Orca Whirlpool SELL (liquidation / manual cold path): stale tick or vault evidence →
+        // structural sim fail. I-24d: one EnsureOrcaWhirlpoolPoolState + bounded JetStream wait + one retry.
+        if !orca_recovery_attempted
+            && is_pumpfun_bonding_curve_cold_path_recovery_sell(&intent)
+            && intent.metadata.get("dex").map(|s| s.as_str()) == Some("orca")
+            && intent.resources.pools.len() == 1
+            && is_orca_structural_sim_error(sim_result.error_code.as_deref())
+        {
+            if Pubkey::from_str(&intent.resources.input_mint).is_err() {
+                break (
+                    tx_plan,
+                    plan_hash_str,
+                    sim_result,
+                    requires_bundle,
+                    bundle_tip_ix,
+                    wallet_pubkey,
+                    bundle_tip_lamports,
+                );
+            }
+            let pool_pk = match Pubkey::from_str(intent.resources.pools[0].as_str()) {
+                Ok(p) => p,
+                Err(_) => {
+                    break (
+                        tx_plan,
+                        plan_hash_str,
+                        sim_result,
+                        requires_bundle,
+                        bundle_tip_ix,
+                        wallet_pubkey,
+                        bundle_tip_lamports,
+                    )
+                }
+            };
+            let before_evidence = ctx
+                .live_pool_cache
+                .as_ref()
+                .and_then(|c| c.get(&pool_pk))
+                .and_then(|st| match st {
+                    CachedPoolState::Orca(s) => Some((
+                        s.tick_current_index,
+                        s.sqrt_price,
+                        s.liquidity,
+                        s.vault_a_balance.unwrap_or(0),
+                        s.vault_b_balance.unwrap_or(0),
+                    )),
+                    _ => None,
+                });
+            warn!(
+                intent_id = %intent.intent_id,
+                mint = %intent.resources.input_mint,
+                pool = %pool_pk,
+                sim_error = ?sim_result.error_code,
+                before_evidence = ?before_evidence,
+                "Orca cold-path: simulation structural fail — requesting EnsureOrcaWhirlpoolPoolState from market-data (bounded wait + one tx rebuild retry)"
+            );
+            if let DiscoveryRequestOutcome::Ok = ctx
+                .request_orca_whirlpool_recovery_and_wait(
+                    &intent.resources.input_mint,
+                    Some(&pool_pk.to_string()),
+                )
+                .await
+            {
+                if let Some(cache) = ctx.live_pool_cache.as_ref() {
+                    if wait_for_orca_whirlpool_slave_after_recovery(
+                        cache,
+                        &pool_pk,
+                        before_evidence,
+                        DISCOVERY_CACHE_WAIT_TIMEOUT_MS,
+                        DISCOVERY_CACHE_POLL_INTERVAL_MS,
+                    )
+                    .await
+                    {
+                        orca_recovery_attempted = true;
+                        warn!(
+                            intent_id = %intent.intent_id,
+                            mint = %intent.resources.input_mint,
+                            pool = %pool_pk,
+                            "Orca cold-path: SLAVE shows fresh explicit Ready after recovery — rebuilding tx (one retry)"
+                        );
+                        continue;
+                    }
+                    warn!(
+                        intent_id = %intent.intent_id,
+                        pool = %pool_pk,
+                        timeout_ms = DISCOVERY_CACHE_WAIT_TIMEOUT_MS,
+                        "Orca cold-path: ControlResponse ok but bounded wait for SLAVE explicit Ready + fresh evidence timed out"
+                    );
                 }
             }
         }

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -183,9 +183,19 @@ fn is_pumpfun_bonding_curve_structural_sim_error(error_code: Option<&str>) -> bo
 }
 
 /// Orca Whirlpool: structural sim failure signatures (stale tick/vault layout family).
+/// Cold-path recovery matcher; keep **separate** from PumpFun — same numeric strings today, different
+/// programs (independent evolution).
 #[inline]
 fn is_orca_structural_sim_error(error_code: Option<&str>) -> bool {
-    is_pumpfun_bonding_curve_structural_sim_error(error_code)
+    error_code
+        .map(|e| {
+            e.contains("6023")
+                || e.contains("6024")
+                || e.contains("Overflow")
+                || e.contains("0x1787")
+                || e.contains("0x1788")
+        })
+        .unwrap_or(false)
 }
 
 /// Cold Path only: PumpFun bonding-curve recovery (`EnsurePumpfunBondingCurve`) is allowed for
@@ -1542,10 +1552,7 @@ async fn wait_for_orca_whirlpool_slave_after_recovery(
                 s.vault_a_balance.unwrap_or(0),
                 s.vault_b_balance.unwrap_or(0),
             );
-            if merged == DexPoolReadiness::Ready
-                && cache.orca_pool_explicitly_ready(pool)
-                && Some(after) != before
-            {
+            if merged == DexPoolReadiness::Ready && Some(after) != before {
                 return true;
             }
         }

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -1519,17 +1519,12 @@ async fn wait_for_usable_pump_amm_cache_state(
     false
 }
 
-/// After `EnsurePumpfunBondingCurve` + JetStream merge: wait until SLAVE cache reflects a change
-/// vs the pre-request snapshot (or new entry appears).
+/// After `EnsureOrcaWhirlpoolPoolState` + JetStream merge: bounded wait until the SLAVE cache shows
+/// explicit Orca [`DexPoolReadiness::Ready`] **and** a **fresh** Whirlpool evidence tuple vs `before`.
 ///
-/// When `require_explicit_ready` is true (cold-path recovery after RPC refresh), we require both:
-/// - [`LivePoolCache::pumpfun_bonding_curve_explicitly_ready`] (JetStream carried `Ready`), **and**
-/// - a **fresh** bonding-curve snapshot vs `before` (proves this request’s merge, not a stale Ready).
-///
-/// Without the snapshot check, an older `Ready` + unchanged reserves could satisfy the wait
-/// immediately after `ControlResponse::Ok` (Bug #34).
-/// Orca Whirlpool cold-path recovery: bounded wait until SLAVE shows explicit JetStream `Ready` and
-/// a **fresh** on-chain evidence tuple vs `before` (Bug #34 / #36 — `ControlResponse::Ok` alone is insufficient).
+/// `ControlResponse::Ok` from market-data is correlated only after an Orca-`Ready` JetStream
+/// publish; this wait still requires a changed snapshot so an older `Ready` cannot satisfy
+/// immediately (Bug #34). Does not treat cache rows as ready without explicit merge (Bug #36).
 async fn wait_for_orca_whirlpool_slave_after_recovery(
     cache: &LivePoolCache,
     pool: &Pubkey,
@@ -1559,6 +1554,15 @@ async fn wait_for_orca_whirlpool_slave_after_recovery(
     false
 }
 
+/// After `EnsurePumpfunBondingCurve` + JetStream merge: wait until SLAVE cache reflects a change
+/// vs the pre-request snapshot (or new entry appears).
+///
+/// When `require_explicit_ready` is true (cold-path recovery after RPC refresh), we require both:
+/// - [`LivePoolCache::pumpfun_bonding_curve_explicitly_ready`] (JetStream carried `Ready`), **and**
+/// - a **fresh** bonding-curve snapshot vs `before` (proves this request’s merge, not a stale Ready).
+///
+/// Without the snapshot check, an older `Ready` + unchanged reserves could satisfy the wait
+/// immediately after `ControlResponse::Ok` (Bug #34).
 async fn wait_for_pumpfun_bonding_cache_refresh(
     cache: &LivePoolCache,
     bonding_curve: &Pubkey,

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1684,7 +1684,11 @@ async fn handle_ensure_orca_whirlpool_pool_state(
         "EnsureOrcaWhirlpoolPoolState: starting cache-scoped Orca RPC refresh"
     );
 
-    let mut terminal: Option<(Pubkey, DexPoolReadiness, bool)> = None;
+    // Terminal `ControlResponse::Ok` only when JetStream carried explicit Orca `Ready` (matches
+    // execution-engine `wait_for_orca_whirlpool_slave_after_recovery` — Bug #36: Partial ≠ ready).
+    let mut terminal_ok_pool: Option<Pubkey> = None;
+    // Best-effort: on-chain Ready but JetStream publish failed — report only if no other candidate succeeds.
+    let mut ready_jetstream_failed_pool: Option<Pubkey> = None;
 
     for (pool_addr, state) in candidate_pools {
         if let Some(row) = cold_path_rpc_refresh_orca_whirlpool_pool_row(
@@ -1692,49 +1696,75 @@ async fn handle_ensure_orca_whirlpool_pool_state(
         )
         .await
         {
-            if row.readiness != DexPoolReadiness::Observed && row.jetstream_published {
-                terminal = Some((row.pool_addr, row.readiness, true));
-                break;
-            }
-            if row.readiness != DexPoolReadiness::Observed && !row.jetstream_published {
-                terminal = Some((row.pool_addr, row.readiness, false));
+            match (row.readiness, row.jetstream_published) {
+                (DexPoolReadiness::Ready, true) => {
+                    terminal_ok_pool = Some(row.pool_addr);
+                    break;
+                }
+                (DexPoolReadiness::Ready, false) => {
+                    ready_jetstream_failed_pool = Some(row.pool_addr);
+                }
+                (DexPoolReadiness::Partial, true) => {
+                    debug!(
+                        request_id = %request_id,
+                        pool = %row.pool_addr,
+                        "EnsureOrcaWhirlpoolPoolState: Partial published to JetStream — scan remaining candidates for Ready"
+                    );
+                }
+                (DexPoolReadiness::Partial, false) => {
+                    warn!(
+                        request_id = %request_id,
+                        pool = %row.pool_addr,
+                        "EnsureOrcaWhirlpoolPoolState: Partial row MASTER-updated but JetStream publish failed"
+                    );
+                }
+                (DexPoolReadiness::Observed, _) => {}
             }
         }
     }
 
-    if let Some((pool_pk, readiness, jet_ok)) = terminal {
+    if let Some(pool_pk) = terminal_ok_pool {
         if let Some(ref nats) = ctx.nats {
             let pool_str = pool_pk.to_string();
-            let (status, message) = if jet_ok {
-                info!(
-                    request_id = %request_id,
-                    base_mint = %base_mint_str,
-                    pool = %pool_str,
-                    readiness = ?readiness,
-                    jetstream = "published",
-                    "EnsureOrcaWhirlpoolPoolState: terminal ok (JetStream publish succeeded)"
-                );
-                (ControlResponseStatus::Ok, None)
-            } else {
-                warn!(
-                    request_id = %request_id,
-                    base_mint = %base_mint_str,
-                    pool = %pool_str,
-                    readiness = ?readiness,
-                    "EnsureOrcaWhirlpoolPoolState: terminal error (MASTER updated but JetStream publish failed)"
-                );
-                (
-                    ControlResponseStatus::Error,
-                    Some("JetStream publish failed".to_string()),
-                )
-            };
+            info!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                pool = %pool_str,
+                readiness = ?DexPoolReadiness::Ready,
+                jetstream = "published",
+                "EnsureOrcaWhirlpoolPoolState: terminal ok (Orca Ready + JetStream publish)"
+            );
             publish_control_response(
                 nats,
                 &ctx.run_id,
                 request_id,
-                status,
+                ControlResponseStatus::Ok,
                 Some(pool_str),
-                message,
+                None,
+            )
+            .await;
+        }
+        return;
+    }
+
+    if let Some(pool_pk) = ready_jetstream_failed_pool {
+        if let Some(ref nats) = ctx.nats {
+            let pool_str = pool_pk.to_string();
+            let msg = "JetStream publish failed".to_string();
+            warn!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                pool = %pool_str,
+                error = %msg,
+                "EnsureOrcaWhirlpoolPoolState: terminal error (Orca Ready on MASTER but JetStream publish failed)"
+            );
+            publish_control_response(
+                nats,
+                &ctx.run_id,
+                request_id,
+                ControlResponseStatus::Error,
+                Some(pool_str),
+                Some(msg),
             )
             .await;
         }
@@ -1744,7 +1774,7 @@ async fn handle_ensure_orca_whirlpool_pool_state(
     warn!(
         request_id = %request_id,
         base_mint = %base_mint_str,
-        "EnsureOrcaWhirlpoolPoolState: RPC refresh did not yield publishable Orca state (Error)"
+        "EnsureOrcaWhirlpoolPoolState: RPC refresh did not yield Orca Ready + JetStream publish (Error)"
     );
     if let Some(ref nats) = ctx.nats {
         publish_control_response(

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1260,6 +1260,182 @@ async fn handle_wallet_bootstrap_meteora_cpmm_verify_for_mint(
     }
 }
 
+/// Result of one cache-scoped Orca Whirlpool RPC refresh (pool account + vault balances).
+struct OrcaWhirlpoolRpcRefreshRowResult {
+    pool_addr: Pubkey,
+    readiness: DexPoolReadiness,
+    /// `true` when a non-`Observed` [`DexPoolReadiness`] update was published to JetStream.
+    jetstream_published: bool,
+}
+
+/// Cold-path only: refresh one Orca Whirlpool row already present in MASTER cache — same RPC
+/// pattern as wallet bootstrap (no global scan). Updates MASTER, merges readiness, publishes
+/// JetStream when readiness is not `Observed`.
+///
+/// Returns `None` when this pool row is skipped (fetch/parse/mint mismatch/incomplete vaults).
+async fn cold_path_rpc_refresh_orca_whirlpool_pool_row(
+    ctx: &MarketDataContext,
+    rpc: &Arc<SolanaRpc>,
+    run_id: &str,
+    request_id: &str,
+    base_mint: &Pubkey,
+    pool_addr: Pubkey,
+    mut state: OrcaWhirlpoolState,
+) -> Option<OrcaWhirlpoolRpcRefreshRowResult> {
+    let orca_program = Pubkey::from_str(ORCA_WHIRLPOOL).expect("ORCA_WHIRLPOOL constant");
+
+    let pool_acc = match rpc.get_account_opt_retry(&pool_addr).await {
+        Ok(Some(acc)) => acc,
+        Ok(None) | Err(_) => {
+            debug!(
+                request_id = %request_id,
+                pool = %pool_addr,
+                "Orca Whirlpool RPC refresh: pool account fetch miss, skip"
+            );
+            return None;
+        }
+    };
+
+    let parsed_state = match parse_pool_account(&orca_program, &pool_acc.data) {
+        Some(CachedPoolState::Orca(s)) => s,
+        _ => {
+            debug!(
+                request_id = %request_id,
+                pool = %pool_addr,
+                data_len = pool_acc.data.len(),
+                "Orca Whirlpool RPC refresh: parse pool failed, skip"
+            );
+            return None;
+        }
+    };
+
+    state.token_mint_a = parsed_state.token_mint_a;
+    state.token_mint_b = parsed_state.token_mint_b;
+    state.token_vault_a = parsed_state.token_vault_a;
+    state.token_vault_b = parsed_state.token_vault_b;
+    state.tick_current_index = parsed_state.tick_current_index;
+    state.sqrt_price = parsed_state.sqrt_price;
+    state.liquidity = parsed_state.liquidity;
+    state.fee_rate = parsed_state.fee_rate;
+    state.protocol_fee_rate = parsed_state.protocol_fee_rate;
+    state.tick_spacing = parsed_state.tick_spacing;
+
+    if state.token_mint_a != *base_mint && state.token_mint_b != *base_mint {
+        return None;
+    }
+
+    let vault_a = state.token_vault_a;
+    let vault_b = state.token_vault_b;
+    let bal_a = match rpc.get_account_opt_retry(&vault_a).await {
+        Ok(Some(acc)) => try_parse_token_account_balance(&acc.data),
+        _ => None,
+    };
+    let bal_b = match rpc.get_account_opt_retry(&vault_b).await {
+        Ok(Some(acc)) => try_parse_token_account_balance(&acc.data),
+        _ => None,
+    };
+    let (ba, bb) = match (bal_a, bal_b) {
+        (Some(a), Some(b)) => (a, b),
+        _ => {
+            debug!(
+                request_id = %request_id,
+                pool = %pool_addr,
+                "Orca Whirlpool RPC refresh: vault balance RPC incomplete, skip"
+            );
+            return None;
+        }
+    };
+
+    state.vault_a_balance = Some(ba);
+    state.vault_b_balance = Some(bb);
+
+    ctx.live_pool_cache
+        .upsert(pool_addr, CachedPoolState::Orca(state.clone()), 0);
+
+    let readiness = orca_readiness_for_pool_cache_update(&state);
+    ctx.live_pool_cache
+        .merge_orca_pool_readiness(pool_addr, readiness);
+
+    if readiness == DexPoolReadiness::Observed {
+        debug!(
+            request_id = %request_id,
+            pool = %pool_addr,
+            mint = %base_mint,
+            "Orca Whirlpool RPC refresh: still Observed after RPC, no JetStream publish"
+        );
+        return Some(OrcaWhirlpoolRpcRefreshRowResult {
+            pool_addr,
+            readiness,
+            jetstream_published: false,
+        });
+    }
+
+    let (pub_base_mint, pub_quote_mint, base_r, quote_r) =
+        (state.token_mint_a, state.token_mint_b, ba, bb);
+
+    let jetstream_ok = if let Some(ref nats) = ctx.nats {
+        let mut balance_update = PoolCacheUpdate::new_balance_updated(
+            "market-data",
+            BUILD_VERSION,
+            run_id,
+            pool_addr.to_string(),
+            "orca".to_string(),
+            pub_base_mint.to_string(),
+            pub_quote_mint.to_string(),
+            base_r,
+            quote_r,
+            0,
+        );
+        balance_update.metadata = Some(orca_metadata_for_pool_cache_update(&state));
+        balance_update.set_dex_readiness_in_metadata(readiness);
+        let subject = pool_subject(&pool_addr.to_string());
+        match nats.jetstream_publish(&subject, &balance_update).await {
+            Ok(true) => {
+                info!(
+                    request_id = %request_id,
+                    pool = %pool_addr,
+                    mint = %base_mint,
+                    readiness = ?readiness,
+                    "Orca Whirlpool RPC refresh: published PoolCacheUpdate::BalanceUpdated to JetStream"
+                );
+                true
+            }
+            Ok(false) => {
+                warn!(
+                    request_id = %request_id,
+                    pool = %pool_addr,
+                    "Orca Whirlpool RPC refresh: JetStream publish failed (timeout or drop)"
+                );
+                false
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    request_id = %request_id,
+                    "Orca Whirlpool RPC refresh: Failed to publish PoolCacheUpdate to JetStream"
+                );
+                false
+            }
+        }
+    } else {
+        false
+    };
+
+    if !jetstream_ok {
+        warn!(
+            request_id = %request_id,
+            pool = %pool_addr,
+            "Orca Whirlpool RPC refresh: MASTER cache updated but JetStream publish failed — SSOT drift risk"
+        );
+    }
+
+    Some(OrcaWhirlpoolRpcRefreshRowResult {
+        pool_addr,
+        readiness,
+        jetstream_published: jetstream_ok,
+    })
+}
+
 /// Cold-path only: Orca Whirlpool promotion for one wallet mint. Uses **only** pools already present
 /// in [`LivePoolCache`] (from Geyser); no `getProgramAccounts` / global scan. RPC: per-pool
 /// `get_account` + per-vault balance reads — bounded by the number of matching cache rows.
@@ -1306,9 +1482,7 @@ async fn handle_wallet_bootstrap_orca_whirlpool_verify_for_mint(
         "Wallet bootstrap Orca Whirlpool: verifying cache-scoped pools (cold-path RPC, no global scan)"
     );
 
-    let orca_program = Pubkey::from_str(ORCA_WHIRLPOOL).expect("ORCA_WHIRLPOOL constant");
-
-    for (pool_addr, mut state) in pools {
+    for (pool_addr, state) in pools {
         if ctx.live_pool_cache.base_mint_has_any_ready_pool(base_mint) {
             break;
         }
@@ -1319,146 +1493,269 @@ async fn handle_wallet_bootstrap_orca_whirlpool_verify_for_mint(
             break;
         }
 
-        let pool_acc = match rpc.get_account_opt_retry(&pool_addr).await {
-            Ok(Some(acc)) => acc,
-            Ok(None) | Err(_) => {
-                debug!(
-                    request_id = %request_id,
-                    pool = %pool_addr,
-                    "Wallet bootstrap Orca Whirlpool: pool account fetch miss, skip"
-                );
-                continue;
+        let _ = cold_path_rpc_refresh_orca_whirlpool_pool_row(
+            ctx, rpc, run_id, request_id, base_mint, pool_addr, state,
+        )
+        .await;
+    }
+}
+
+/// I-24d / Scope 20: Cold-path Orca recovery — cache-scoped RPC refresh, JetStream SSOT, ControlResponse.
+async fn handle_ensure_orca_whirlpool_pool_state(
+    ctx: &MarketDataContext,
+    rpc: &Arc<SolanaRpc>,
+    run_id: &str,
+    request_id: &str,
+    base_mint_str: &str,
+    pool_address_hint: Option<&str>,
+    force_refresh: bool,
+) {
+    let base_mint = match Pubkey::from_str(base_mint_str) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(base_mint = %base_mint_str, error = %e, "EnsureOrcaWhirlpoolPoolState: invalid base_mint");
+            if let Some(ref nats) = ctx.nats {
+                publish_control_response(
+                    nats,
+                    &ctx.run_id,
+                    request_id,
+                    ControlResponseStatus::Error,
+                    None,
+                    Some(e.to_string()),
+                )
+                .await;
             }
-        };
-
-        let parsed_state = match parse_pool_account(&orca_program, &pool_acc.data) {
-            Some(CachedPoolState::Orca(s)) => s,
-            _ => {
-                debug!(
-                    request_id = %request_id,
-                    pool = %pool_addr,
-                    data_len = pool_acc.data.len(),
-                    "Wallet bootstrap Orca Whirlpool: parse pool failed, skip"
-                );
-                continue;
-            }
-        };
-
-        state.token_mint_a = parsed_state.token_mint_a;
-        state.token_mint_b = parsed_state.token_mint_b;
-        state.token_vault_a = parsed_state.token_vault_a;
-        state.token_vault_b = parsed_state.token_vault_b;
-        state.tick_current_index = parsed_state.tick_current_index;
-        state.sqrt_price = parsed_state.sqrt_price;
-        state.liquidity = parsed_state.liquidity;
-        state.fee_rate = parsed_state.fee_rate;
-        state.protocol_fee_rate = parsed_state.protocol_fee_rate;
-        state.tick_spacing = parsed_state.tick_spacing;
-
-        if state.token_mint_a != *base_mint && state.token_mint_b != *base_mint {
-            continue;
+            return;
         }
+    };
 
-        let vault_a = state.token_vault_a;
-        let vault_b = state.token_vault_b;
-        let bal_a = match rpc.get_account_opt_retry(&vault_a).await {
-            Ok(Some(acc)) => try_parse_token_account_balance(&acc.data),
-            _ => None,
-        };
-        let bal_b = match rpc.get_account_opt_retry(&vault_b).await {
-            Ok(Some(acc)) => try_parse_token_account_balance(&acc.data),
-            _ => None,
-        };
-        let (ba, bb) = match (bal_a, bal_b) {
-            (Some(a), Some(b)) => (a, b),
-            _ => {
-                debug!(
+    let pool_hint_pk = pool_address_hint.and_then(|s| Pubkey::from_str(s).ok());
+
+    if !force_refresh {
+        if let Some(pool_pk) = pool_hint_pk {
+            if ctx.live_pool_cache.orca_pool_explicitly_ready(&pool_pk) {
+                info!(
                     request_id = %request_id,
-                    pool = %pool_addr,
-                    "Wallet bootstrap Orca Whirlpool: vault balance RPC incomplete, skip"
+                    base_mint = %base_mint_str,
+                    pool = %pool_pk,
+                    "EnsureOrcaWhirlpoolPoolState: cache hit explicit Ready (skip RPC)"
                 );
-                continue;
-            }
-        };
-
-        state.vault_a_balance = Some(ba);
-        state.vault_b_balance = Some(bb);
-
-        ctx.live_pool_cache
-            .upsert(pool_addr, CachedPoolState::Orca(state.clone()), 0);
-
-        let readiness = orca_readiness_for_pool_cache_update(&state);
-        ctx.live_pool_cache
-            .merge_orca_pool_readiness(pool_addr, readiness);
-
-        if readiness == DexPoolReadiness::Observed {
-            debug!(
-                request_id = %request_id,
-                pool = %pool_addr,
-                mint = %base_mint,
-                "Wallet bootstrap Orca Whirlpool: still Observed after RPC, no JetStream publish"
-            );
-            continue;
-        }
-
-        let (pub_base_mint, pub_quote_mint, base_r, quote_r) =
-            (state.token_mint_a, state.token_mint_b, ba, bb);
-
-        let jetstream_ok = if let Some(ref nats) = ctx.nats {
-            let mut balance_update = PoolCacheUpdate::new_balance_updated(
-                "market-data",
-                BUILD_VERSION,
-                run_id,
-                pool_addr.to_string(),
-                "orca".to_string(),
-                pub_base_mint.to_string(),
-                pub_quote_mint.to_string(),
-                base_r,
-                quote_r,
-                0,
-            );
-            balance_update.metadata = Some(orca_metadata_for_pool_cache_update(&state));
-            balance_update.set_dex_readiness_in_metadata(readiness);
-            let subject = pool_subject(&pool_addr.to_string());
-            match nats.jetstream_publish(&subject, &balance_update).await {
-                Ok(true) => {
-                    info!(
-                        request_id = %request_id,
-                        pool = %pool_addr,
-                        mint = %base_mint,
-                        readiness = ?readiness,
-                        "Wallet bootstrap Orca Whirlpool: published PoolCacheUpdate::BalanceUpdated to JetStream"
-                    );
-                    true
+                if let Some(ref nats) = ctx.nats {
+                    publish_control_response(
+                        nats,
+                        &ctx.run_id,
+                        request_id,
+                        ControlResponseStatus::Ok,
+                        Some(pool_pk.to_string()),
+                        None,
+                    )
+                    .await;
                 }
-                Ok(false) => {
+                return;
+            }
+        } else if ctx
+            .live_pool_cache
+            .base_mint_has_explicit_orca_ready_pool(&base_mint)
+        {
+            info!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                "EnsureOrcaWhirlpoolPoolState: mint already has explicit Ready Orca pool (skip RPC)"
+            );
+            if let Some(ref nats) = ctx.nats {
+                publish_control_response(
+                    nats,
+                    &ctx.run_id,
+                    request_id,
+                    ControlResponseStatus::Ok,
+                    None,
+                    None,
+                )
+                .await;
+            }
+            return;
+        }
+    } else {
+        warn!(
+            request_id = %request_id,
+            base_mint = %base_mint_str,
+            pool_address_hint = ?pool_address_hint,
+            "EnsureOrcaWhirlpoolPoolState: force_refresh — always running RPC refresh path (no cache-first short-circuit)"
+        );
+    }
+
+    let mut candidate_pools: Vec<(Pubkey, OrcaWhirlpoolState)> = Vec::new();
+    if let Some(pool_pk) = pool_hint_pk {
+        match ctx.live_pool_cache.get(&pool_pk) {
+            Some(CachedPoolState::Orca(s)) => {
+                if s.token_mint_a != base_mint && s.token_mint_b != base_mint {
                     warn!(
                         request_id = %request_id,
-                        pool = %pool_addr,
-                        "Wallet bootstrap Orca Whirlpool: JetStream publish failed (timeout or drop)"
+                        pool = %pool_pk,
+                        base_mint = %base_mint_str,
+                        "EnsureOrcaWhirlpoolPoolState: pool_address_hint Orca row does not list base_mint"
                     );
-                    false
+                    if let Some(ref nats) = ctx.nats {
+                        publish_control_response(
+                            nats,
+                            &ctx.run_id,
+                            request_id,
+                            ControlResponseStatus::Error,
+                            Some(pool_pk.to_string()),
+                            Some("pool hint mint mismatch".to_string()),
+                        )
+                        .await;
+                    }
+                    return;
                 }
-                Err(e) => {
-                    warn!(
-                        error = %e,
-                        request_id = %request_id,
-                        "Wallet bootstrap Orca Whirlpool: Failed to publish PoolCacheUpdate to JetStream"
-                    );
-                    false
-                }
+                candidate_pools.push((pool_pk, s));
             }
-        } else {
-            false
-        };
-
-        if !jetstream_ok {
-            warn!(
-                request_id = %request_id,
-                pool = %pool_addr,
-                "Wallet bootstrap Orca Whirlpool: MASTER cache updated but JetStream publish failed — SSOT drift risk"
-            );
+            Some(_) => {
+                warn!(
+                    request_id = %request_id,
+                    pool = %pool_pk,
+                    "EnsureOrcaWhirlpoolPoolState: pool_address_hint is not an Orca Whirlpool row"
+                );
+                if let Some(ref nats) = ctx.nats {
+                    publish_control_response(
+                        nats,
+                        &ctx.run_id,
+                        request_id,
+                        ControlResponseStatus::Error,
+                        Some(pool_pk.to_string()),
+                        Some("pool hint is not orca whirlpool in cache".to_string()),
+                    )
+                    .await;
+                }
+                return;
+            }
+            None => {
+                info!(
+                    request_id = %request_id,
+                    pool = %pool_pk,
+                    base_mint = %base_mint_str,
+                    "EnsureOrcaWhirlpoolPoolState: pool hint not in LivePoolCache (NotFound)"
+                );
+                if let Some(ref nats) = ctx.nats {
+                    publish_control_response(
+                        nats,
+                        &ctx.run_id,
+                        request_id,
+                        ControlResponseStatus::NotFound,
+                        Some(pool_pk.to_string()),
+                        None,
+                    )
+                    .await;
+                }
+                return;
+            }
         }
+    } else {
+        candidate_pools = ctx
+            .live_pool_cache
+            .orca_whirlpool_pools_for_mint(&base_mint);
+        if candidate_pools.is_empty() {
+            info!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                "EnsureOrcaWhirlpoolPoolState: no Whirlpool rows in LivePoolCache for mint (NotFound)"
+            );
+            if let Some(ref nats) = ctx.nats {
+                publish_control_response(
+                    nats,
+                    &ctx.run_id,
+                    request_id,
+                    ControlResponseStatus::NotFound,
+                    None,
+                    None,
+                )
+                .await;
+            }
+            return;
+        }
+    }
+
+    info!(
+        request_id = %request_id,
+        base_mint = %base_mint_str,
+        pool_address_hint = ?pool_address_hint,
+        candidates = candidate_pools.len(),
+        force_refresh = %force_refresh,
+        "EnsureOrcaWhirlpoolPoolState: starting cache-scoped Orca RPC refresh"
+    );
+
+    let mut terminal: Option<(Pubkey, DexPoolReadiness, bool)> = None;
+
+    for (pool_addr, state) in candidate_pools {
+        if let Some(row) = cold_path_rpc_refresh_orca_whirlpool_pool_row(
+            ctx, rpc, run_id, request_id, &base_mint, pool_addr, state,
+        )
+        .await
+        {
+            if row.readiness != DexPoolReadiness::Observed && row.jetstream_published {
+                terminal = Some((row.pool_addr, row.readiness, true));
+                break;
+            }
+            if row.readiness != DexPoolReadiness::Observed && !row.jetstream_published {
+                terminal = Some((row.pool_addr, row.readiness, false));
+            }
+        }
+    }
+
+    if let Some((pool_pk, readiness, jet_ok)) = terminal {
+        if let Some(ref nats) = ctx.nats {
+            let pool_str = pool_pk.to_string();
+            let (status, message) = if jet_ok {
+                info!(
+                    request_id = %request_id,
+                    base_mint = %base_mint_str,
+                    pool = %pool_str,
+                    readiness = ?readiness,
+                    jetstream = "published",
+                    "EnsureOrcaWhirlpoolPoolState: terminal ok (JetStream publish succeeded)"
+                );
+                (ControlResponseStatus::Ok, None)
+            } else {
+                warn!(
+                    request_id = %request_id,
+                    base_mint = %base_mint_str,
+                    pool = %pool_str,
+                    readiness = ?readiness,
+                    "EnsureOrcaWhirlpoolPoolState: terminal error (MASTER updated but JetStream publish failed)"
+                );
+                (
+                    ControlResponseStatus::Error,
+                    Some("JetStream publish failed".to_string()),
+                )
+            };
+            publish_control_response(
+                nats,
+                &ctx.run_id,
+                request_id,
+                status,
+                Some(pool_str),
+                message,
+            )
+            .await;
+        }
+        return;
+    }
+
+    warn!(
+        request_id = %request_id,
+        base_mint = %base_mint_str,
+        "EnsureOrcaWhirlpoolPoolState: RPC refresh did not yield publishable Orca state (Error)"
+    );
+    if let Some(ref nats) = ctx.nats {
+        publish_control_response(
+            nats,
+            &ctx.run_id,
+            request_id,
+            ControlResponseStatus::Error,
+            None,
+            Some("orca rpc refresh did not produce jetstream-ready state".to_string()),
+        )
+        .await;
     }
 }
 
@@ -3615,6 +3912,33 @@ async fn run_geyser_loop(
                                                 run_id.as_str(),
                                                 &request_id,
                                                 &base_mint,
+                                                force_refresh,
+                                            )
+                                            .await;
+                                        });
+                                    }
+                                    ControlRequestKind::EnsureOrcaWhirlpoolPoolState { base_mint } => {
+                                        let run_id = ctx.run_id.clone();
+                                        let request_id = req.request_id.clone();
+                                        let pool_hint = req.pool_address_hint.clone();
+                                        let force_refresh = req.force_refresh_orca;
+                                        info!(
+                                            request_id = %request_id,
+                                            base_mint = %base_mint,
+                                            pool_address_hint = ?pool_hint,
+                                            force_refresh_orca = %force_refresh,
+                                            "EnsureOrcaWhirlpoolPoolState received"
+                                        );
+                                        let ctx_clone = ctx.clone();
+                                        let rpc_clone = rpc.clone();
+                                        tokio::spawn(async move {
+                                            handle_ensure_orca_whirlpool_pool_state(
+                                                &ctx_clone,
+                                                &rpc_clone,
+                                                run_id.as_str(),
+                                                &request_id,
+                                                &base_mint,
+                                                pool_hint.as_deref(),
                                                 force_refresh,
                                             )
                                             .await;
@@ -6475,6 +6799,33 @@ async fn run_simulation_loop(
                                                 run_id.as_str(),
                                                 &request_id,
                                                 &base_mint,
+                                                force_refresh,
+                                            )
+                                            .await;
+                                        });
+                                    }
+                                    ControlRequestKind::EnsureOrcaWhirlpoolPoolState { base_mint } => {
+                                        let run_id = ctx.run_id.clone();
+                                        let request_id = req.request_id.clone();
+                                        let pool_hint = req.pool_address_hint.clone();
+                                        let force_refresh = req.force_refresh_orca;
+                                        info!(
+                                            request_id = %request_id,
+                                            base_mint = %base_mint,
+                                            pool_address_hint = ?pool_hint,
+                                            force_refresh_orca = %force_refresh,
+                                            "EnsureOrcaWhirlpoolPoolState received (simulation)"
+                                        );
+                                        let ctx_clone = ctx.clone();
+                                        let rpc_clone = rpc.clone();
+                                        tokio::spawn(async move {
+                                            handle_ensure_orca_whirlpool_pool_state(
+                                                &ctx_clone,
+                                                &rpc_clone,
+                                                run_id.as_str(),
+                                                &request_id,
+                                                &base_mint,
+                                                pool_hint.as_deref(),
                                                 force_refresh,
                                             )
                                             .await;

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -1136,6 +1136,23 @@ impl LivePoolCache {
         self.orca_readiness_by_pool.get(pool).map(|r| *r)
     }
 
+    /// SLAVE-visible Orca Whirlpool row + merged readiness (JetStream path). For cold-path recovery
+    /// waits: compare [`OrcaWhirlpoolState`] evidence vs a pre-request snapshot (Bug #34).
+    #[must_use]
+    pub fn orca_whirlpool_slave_readiness_snapshot(
+        &self,
+        pool: &Pubkey,
+    ) -> Option<(OrcaWhirlpoolState, DexPoolReadiness)> {
+        let state = match self.get(pool)? {
+            CachedPoolState::Orca(s) => s,
+            _ => return None,
+        };
+        let readiness = self
+            .orca_readiness(pool)
+            .unwrap_or(DexPoolReadiness::Observed);
+        Some((state, readiness))
+    }
+
     /// `true` only when JetStream merge recorded [`DexPoolReadiness::Ready`] for this Meteora DLMM pool.
     #[must_use]
     pub fn meteora_dlmm_pool_explicitly_ready(&self, pool: &Pubkey) -> bool {
@@ -2758,6 +2775,22 @@ mod tests {
         assert!(cache.base_mint_has_any_ready_pool(&base_mint));
         cache.merge_orca_pool_readiness(pool, DexPoolReadiness::Observed);
         assert!(cache.base_mint_has_any_ready_pool(&base_mint));
+    }
+
+    #[test]
+    fn test_orca_whirlpool_slave_readiness_snapshot_merges_explicit_ready() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let s = make_orca_state(base_mint, quote_mint, Some(1), Some(2));
+        cache.upsert(pool, CachedPoolState::Orca(s.clone()), 0);
+        cache.merge_orca_pool_readiness(pool, DexPoolReadiness::Ready);
+        let snap = cache
+            .orca_whirlpool_slave_readiness_snapshot(&pool)
+            .expect("snapshot");
+        assert_eq!(snap.1, DexPoolReadiness::Ready);
+        assert_eq!(snap.0.tick_current_index, s.tick_current_index);
     }
 
     #[test]

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -1120,6 +1120,17 @@ pub enum ControlRequestKind {
         /// Token mint (base58) whose bonding curve PDA should be refreshed.
         base_mint: String,
     },
+
+    /// Cold-path recovery: refresh Orca Whirlpool pool state from RPC for pools already present in
+    /// MASTER LivePoolCache (cache-scoped; no global `getProgramAccounts`). Publishes
+    /// `PoolCacheUpdate` to JetStream when readiness promotes to at least Partial / Ready.
+    ///
+    /// Optional whirlpool address: use top-level `pool_address_hint` on [`ControlRequest`] for the
+    /// same backward-compatible fast-path style as PumpSwap.
+    EnsureOrcaWhirlpoolPoolState {
+        /// Base mint (base58) of the token side this recovery is for (intent-relevant mint).
+        base_mint: String,
+    },
 }
 
 fn default_true() -> bool {
@@ -1155,6 +1166,12 @@ pub struct ControlRequest {
     #[serde(default)]
     pub force_refresh_pumpfun: bool,
 
+    /// When true, market-data must **not** short-circuit EnsureOrcaWhirlpoolPoolState from
+    /// existing explicit Ready in LivePoolCache: always run the bounded RPC refresh path and
+    /// republish when readiness allows. Cold-path only (I-5); default false.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub force_refresh_orca: bool,
+
     #[serde(flatten)]
     pub kind: ControlRequestKind,
 }
@@ -1175,6 +1192,7 @@ impl ControlRequest {
             pool_address_hint: None,
             force_refresh: false,
             force_refresh_pumpfun: false,
+            force_refresh_orca: false,
             kind,
         }
     }
@@ -2211,6 +2229,55 @@ mod tests {
             }
             _ => panic!("expected EnsurePumpfunBondingCurve"),
         }
+    }
+
+    #[test]
+    fn test_control_request_ensure_orca_whirlpool_pool_state_serde() {
+        let mut req = ControlRequest::new(
+            "execution-engine",
+            "v0.1.0",
+            "run-123",
+            "req-orca-001".to_string(),
+            "market-data",
+            ControlRequestKind::EnsureOrcaWhirlpoolPoolState {
+                base_mint: "MintOrca11111111111111111111111111111111".to_string(),
+            },
+        );
+        req.pool_address_hint = Some("PoolOrca111111111111111111111111111111".to_string());
+        req.force_refresh_orca = true;
+
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("ensure_orca_whirlpool_pool_state"));
+        assert!(json.contains("MintOrca11111111111111111111111111111111"));
+        assert!(json.contains("pool_address_hint"));
+        assert!(json.contains("PoolOrca111111111111111111111111111111"));
+        assert!(json.contains("\"force_refresh_orca\":true"));
+
+        let parsed: ControlRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.request_id, "req-orca-001");
+        assert!(parsed.force_refresh_orca);
+        match &parsed.kind {
+            ControlRequestKind::EnsureOrcaWhirlpoolPoolState { base_mint } => {
+                assert_eq!(base_mint, "MintOrca11111111111111111111111111111111");
+            }
+            _ => panic!("expected EnsureOrcaWhirlpoolPoolState"),
+        }
+
+        let req_minimal = ControlRequest::new(
+            "execution-engine",
+            "v0.1.0",
+            "run-123",
+            "req-orca-002".to_string(),
+            "market-data",
+            ControlRequestKind::EnsureOrcaWhirlpoolPoolState {
+                base_mint: "MintOrca22222222222222222222222222222222".to_string(),
+            },
+        );
+        let json_min = serde_json::to_string(&req_minimal).unwrap();
+        assert!(!json_min.contains("pool_address_hint"));
+        assert!(!json_min.contains("force_refresh_orca"));
+        let parsed_min: ControlRequest = serde_json::from_str(&json_min).unwrap();
+        assert!(!parsed_min.force_refresh_orca);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Narrow **Orca Whirlpool** cold-path **Request/Reply** (I-24d): `execution-engine` publishes `ControlRequest`; `market-data` does cache-scoped RPC refresh, updates MASTER, publishes `PoolCacheUpdate` to JetStream, and replies with `ControlResponse` (correlation + terminal status).

## Contract

- **`ControlRequestKind::EnsureOrcaWhirlpoolPoolState { base_mint }`**
- Optional whirlpool via top-level **`pool_address_hint`** (PumpSwap-style).
- **`force_refresh_orca`** on `ControlRequest` — `skip_serializing_if` when `false`.

**`ControlResponse::Ok`** only when JetStream publish succeeds **and** Orca row is **`DexPoolReadiness::Ready`** (matches engine wait; **Partial** does not produce Ok). If a candidate reaches Ready but JetStream fails, we keep scanning other cache-scoped pools; if none succeed, **`Error`** with that pool hint.

## Cold-path trigger (execution-engine)

Liquidation / manual sell (`purpose=liquidation`, `kill_switch`, or `sell_all`), `dex=orca`, single pool, structural sim error (6023/6024/Overflow/0x1787/0x1788): one `EnsureOrcaWhirlpoolPoolState` with `force_refresh_orca=true`, then bounded SLAVE wait for explicit Ready + fresh evidence tuple vs pre-request snapshot; at most one tx rebuild retry.

## market-data

Shared helper `cold_path_rpc_refresh_orca_whirlpool_pool_row` (wallet bootstrap + Ensure); no `getProgramAccounts`.

## Review follow-up (merged in branch)

- **Ok / Partial consistency:** terminal Ok only for **Ready** + JetStream (not Partial).
- **Rustdoc:** Orca waiter documented on `wait_for_orca_whirlpool_slave_after_recovery`; PumpFun doc restored above `wait_for_pumpfun_bonding_cache_refresh`.

## Out of scope

Meteora DLMM request/reply, Orca hot-path healing, global Orca scan, quote/builder refactors.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo test --features test_helpers`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b54b0dce-05fb-4a8d-b807-fb52964e0815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b54b0dce-05fb-4a8d-b807-fb52964e0815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

