### PR TITLE
I-24d Scope 21: Meteora DLMM cold-path Ensure via market-data

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -1565,6 +1565,10 @@ async fn wait_for_orca_whirlpool_slave_after_recovery(
 /// After `EnsureMeteoraDlmmPoolState` + JetStream merge: bounded wait until SLAVE shows explicit
 /// Meteora DLMM [`DexPoolReadiness::Ready`] and a **fresh** evidence tuple vs `before`.
 ///
+/// Callers must pass `before` from a snapshot taken **before** publishing the control request
+/// (same contract as [`wait_for_orca_whirlpool_slave_after_recovery`]). Otherwise a fast merge can
+/// make `before` equal the post-recovery state and this wait never observes a change (Bug #34).
+///
 /// `active_id == 0` with unchanged tuple does not satisfy liquidation/build needs (legacy skip);
 /// successful wait requires explicit `Ready` and snapshot change (Bug #34 / #36).
 async fn wait_for_meteora_dlmm_slave_after_recovery(
@@ -2992,6 +2996,21 @@ impl ExecutionContext {
                         reason = "liquidation: Meteora DLMM pools in SLAVE but no explicit Ready — requesting EnsureMeteoraDlmmPoolState from market-data (bounded wait, one attempt per mint)",
                         "Meteora DLMM cold-path: pre-quote recovery request"
                     );
+                    // Bug #34: capture evidence **before** the request (same as Orca cold-path). If we
+                    // snapshot after `ControlResponse::Ok`, a fast JetStream merge can make `before`
+                    // equal the post-recovery tuple and the wait never observes a change.
+                    let hint_pk = pool_hint.as_deref().and_then(|s| Pubkey::from_str(s).ok());
+                    let before_evidence = hint_pk.and_then(|pk| {
+                        cache.get(&pk).and_then(|st| match st {
+                            CachedPoolState::Meteora(s) => Some((
+                                s.active_id,
+                                s.bin_step,
+                                s.reserve_x_balance,
+                                s.reserve_y_balance,
+                            )),
+                            _ => None,
+                        })
+                    });
                     if let DiscoveryRequestOutcome::Ok = ctx
                         .request_meteora_dlmm_recovery_and_wait(
                             mint_str.as_str(),
@@ -2999,18 +3018,6 @@ impl ExecutionContext {
                         )
                         .await
                     {
-                        let hint_pk = pool_hint.as_deref().and_then(|s| Pubkey::from_str(s).ok());
-                        let before_evidence = hint_pk.and_then(|pk| {
-                            cache.get(&pk).and_then(|st| match st {
-                                CachedPoolState::Meteora(s) => Some((
-                                    s.active_id,
-                                    s.bin_step,
-                                    s.reserve_x_balance,
-                                    s.reserve_y_balance,
-                                )),
-                                _ => None,
-                            })
-                        });
                         if let Some(pk) = hint_pk {
                             if wait_for_meteora_dlmm_slave_after_recovery(
                                 cache,
@@ -10714,10 +10721,13 @@ mod execution_engine_tests {
         is_pumpfun_bonding_curve_structural_sim_error, is_regular_momentum_hot_path_sell,
         pump_amm_pool_market_hint_merge, record_pump_amm_hot_path_refresh_after_success,
         select_best_route, try_pump_amm_hot_path_refresh_publish,
-        wait_for_pumpfun_bonding_cache_refresh, DiscoveryRequestOutcome,
-        PumpAmmHotPathRefreshDecision, RouteCandidate, PUMP_AMM_HOT_PATH_REFRESH_COOLDOWN,
+        wait_for_meteora_dlmm_slave_after_recovery, wait_for_pumpfun_bonding_cache_refresh,
+        DiscoveryRequestOutcome, PumpAmmHotPathRefreshDecision, RouteCandidate,
+        PUMP_AMM_HOT_PATH_REFRESH_COOLDOWN,
     };
-    use ironcrab::execution::live_pool_cache::{CachedPoolState, LivePoolCache, PumpFunState};
+    use ironcrab::execution::live_pool_cache::{
+        CachedPoolState, LivePoolCache, MeteoraState, PumpFunState,
+    };
     use ironcrab::ipc::{
         ControlResponse, ControlResponseStatus, DexPoolReadiness, ExplicitAmount, IntentOrigin,
         IntentTier, TradeIntent, TradeResources, TradeSide, TradingRegime,
@@ -11215,5 +11225,70 @@ mod execution_engine_tests {
             try_pump_amm_hot_path_refresh_publish(&map, mint_b, t0),
             PumpAmmHotPathRefreshDecision::Publish
         ));
+    }
+
+    /// Regression: `before` for DLMM recovery wait must be captured **before** awaiting
+    /// `ControlResponse`, or a fast JetStream merge makes `before == after` and the wait times out
+    /// (Bug #34 / #36 — same ordering contract as Orca).
+    #[tokio::test]
+    async fn meteora_dlmm_recovery_wait_needs_pre_request_evidence_snapshot() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(ironcrab::ipc::NATIVE_SOL_MINT).unwrap();
+
+        let initial = MeteoraState {
+            token_x_mint: base_mint,
+            token_y_mint: quote_mint,
+            reserve_x: Pubkey::new_unique(),
+            reserve_y: Pubkey::new_unique(),
+            active_id: 0,
+            bin_step: 10,
+            reserve_x_balance: Some(100),
+            reserve_y_balance: Some(200),
+        };
+        cache.upsert(pool, CachedPoolState::Meteora(initial.clone()), 0);
+        cache.merge_meteora_dlmm_pool_readiness(pool, DexPoolReadiness::Partial);
+
+        let before_evidence = cache.get(&pool).and_then(|st| match st {
+            CachedPoolState::Meteora(s) => Some((
+                s.active_id,
+                s.bin_step,
+                s.reserve_x_balance,
+                s.reserve_y_balance,
+            )),
+            _ => None,
+        });
+        assert_eq!(before_evidence, Some((0, 10, Some(100), Some(200))));
+
+        let mut promoted = initial;
+        promoted.active_id = 42;
+        cache.upsert(pool, CachedPoolState::Meteora(promoted), 0);
+        cache.merge_meteora_dlmm_pool_readiness(pool, DexPoolReadiness::Ready);
+
+        let ok =
+            wait_for_meteora_dlmm_slave_after_recovery(&cache, &pool, before_evidence, 2_000, 5)
+                .await;
+        assert!(
+            ok,
+            "wait should succeed when before is pre-merge and SLAVE shows Ready + changed tuple"
+        );
+
+        // If `before` were wrongly taken after the merge, evidence matches current row → no progress.
+        let stale_before = cache.get(&pool).and_then(|st| match st {
+            CachedPoolState::Meteora(s) => Some((
+                s.active_id,
+                s.bin_step,
+                s.reserve_x_balance,
+                s.reserve_y_balance,
+            )),
+            _ => None,
+        });
+        let stuck =
+            wait_for_meteora_dlmm_slave_after_recovery(&cache, &pool, stale_before, 80, 5).await;
+        assert!(
+            !stuck,
+            "with before == post-recovery evidence, wait must not succeed (guards Bug #34 ordering)"
+        );
     }
 }

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -1562,6 +1562,36 @@ async fn wait_for_orca_whirlpool_slave_after_recovery(
     false
 }
 
+/// After `EnsureMeteoraDlmmPoolState` + JetStream merge: bounded wait until SLAVE shows explicit
+/// Meteora DLMM [`DexPoolReadiness::Ready`] and a **fresh** evidence tuple vs `before`.
+///
+/// `active_id == 0` with unchanged tuple does not satisfy liquidation/build needs (legacy skip);
+/// successful wait requires explicit `Ready` and snapshot change (Bug #34 / #36).
+async fn wait_for_meteora_dlmm_slave_after_recovery(
+    cache: &LivePoolCache,
+    pool: &Pubkey,
+    before: Option<(i32, u16, Option<u64>, Option<u64>)>,
+    timeout_ms: u64,
+    poll_interval_ms: u64,
+) -> bool {
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+    while Instant::now() < deadline {
+        if let Some((s, merged)) = cache.meteora_dlmm_slave_readiness_snapshot(pool) {
+            let after = (
+                s.active_id,
+                s.bin_step,
+                s.reserve_x_balance,
+                s.reserve_y_balance,
+            );
+            if merged == DexPoolReadiness::Ready && Some(after) != before {
+                return true;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
+    }
+    false
+}
+
 /// After `EnsurePumpfunBondingCurve` + JetStream merge: wait until SLAVE cache reflects a change
 /// vs the pre-request snapshot (or new entry appears).
 ///
@@ -2474,6 +2504,113 @@ impl ExecutionContext {
         outcome
     }
 
+    /// I-24d Scope 21: Meteora DLMM cold-path recovery — `EnsureMeteoraDlmmPoolState` with
+    /// `force_refresh_meteora_dlmm=true`. Does not write SLAVE locally; market-data publishes JetStream.
+    async fn request_meteora_dlmm_recovery_and_wait(
+        &self,
+        base_mint: &str,
+        pool_address_hint: Option<&str>,
+    ) -> DiscoveryRequestOutcome {
+        let Some(ref nats) = self.nats else {
+            warn!(
+                request_id = "n/a",
+                base_mint = %base_mint,
+                "Meteora DLMM cold-path recovery: NATS not connected"
+            );
+            return DiscoveryRequestOutcome::Error("NATS not connected".to_string());
+        };
+
+        let request_id = Uuid::new_v4().to_string();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        {
+            let mut pending = self.pending_discovery_responses.lock().await;
+            pending.insert(request_id.clone(), tx);
+        }
+
+        let mut req = ControlRequest::new(
+            "execution-engine",
+            BUILD_VERSION,
+            &self.run_id,
+            request_id.clone(),
+            "market-data",
+            ControlRequestKind::EnsureMeteoraDlmmPoolState {
+                base_mint: base_mint.to_string(),
+            },
+        );
+        req.pool_address_hint = pool_address_hint.map(String::from);
+        req.force_refresh_meteora_dlmm = true;
+
+        warn!(
+            request_id = %request_id,
+            base_mint = %base_mint,
+            pool_address_hint = ?pool_address_hint,
+            target = "market-data",
+            reason = "meteora_dlmm liquidation cold path — SLAVE missing usable DLMM state (active_id/reserves/readiness); requesting authoritative RPC refresh via market-data (I-24d)",
+            "Meteora DLMM cold-path: publishing EnsureMeteoraDlmmPoolState (force_refresh_meteora_dlmm)"
+        );
+
+        if nats.publish(TOPIC_CONTROL_REQUESTS, &req).await.is_err() {
+            let mut pending = self.pending_discovery_responses.lock().await;
+            pending.remove(&request_id);
+            warn!(
+                request_id = %request_id,
+                base_mint = %base_mint,
+                "Meteora DLMM cold-path recovery: publish failed"
+            );
+            return DiscoveryRequestOutcome::Error("publish failed".to_string());
+        }
+
+        let outcome =
+            match tokio::time::timeout(Duration::from_secs(DISCOVERY_REQUEST_TIMEOUT_SECS), rx)
+                .await
+            {
+                Ok(Ok(resp)) => {
+                    let status_str = format!("{:?}", resp.status);
+                    let pool = resp.pool_address.as_deref();
+                    info!(
+                        request_id = %request_id,
+                        base_mint = %base_mint,
+                        status = %status_str,
+                        pool_address = ?pool,
+                        "Meteora DLMM cold-path recovery: ControlResponse correlated"
+                    );
+                    match resp.status {
+                        ControlResponseStatus::Ok => DiscoveryRequestOutcome::Ok,
+                        ControlResponseStatus::NotFound => DiscoveryRequestOutcome::NotFound,
+                        ControlResponseStatus::Error => DiscoveryRequestOutcome::Error(
+                            resp.message.unwrap_or_else(|| "unknown error".to_string()),
+                        ),
+                    }
+                }
+                Ok(Err(_)) => {
+                    warn!(
+                        request_id = %request_id,
+                        base_mint = %base_mint,
+                        "Meteora DLMM cold-path recovery: channel closed before response"
+                    );
+                    DiscoveryRequestOutcome::Error("channel closed".to_string())
+                }
+                Err(_) => {
+                    warn!(
+                        request_id = %request_id,
+                        base_mint = %base_mint,
+                        timeout_secs = DISCOVERY_REQUEST_TIMEOUT_SECS,
+                        "Meteora DLMM cold-path recovery: timeout waiting for ControlResponse"
+                    );
+                    DiscoveryRequestOutcome::Timeout
+                }
+            };
+
+        let _ = self
+            .pending_discovery_responses
+            .lock()
+            .await
+            .remove(&request_id);
+
+        outcome
+    }
+
     /// Hot-path healing: publish `EnsurePumpAmmPoolAccounts` to market-data with `force_refresh=true`
     /// without registering for ControlResponse (no wait, no retry in the same intent).
     /// RPC work happens only in market-data (Cold Path); this path is fire-and-forget NATS publish.
@@ -2612,7 +2749,7 @@ impl ExecutionContext {
         let mut meteora = MeteoraDlmm::new_with_live_cache(
             Arc::clone(&ctx.rpc),
             Some(lpc.clone()),
-            true, // Liquidation = Cold Path — RPC fallback allowed
+            false, // I-24d: no connector RPC fallback — Meteora DLMM cold-path refresh via market-data EnsureMeteoraDlmmPoolState
         );
         meteora.set_user_authority(owner);
         let raydium = Raydium::new_with_live_cache(
@@ -2642,11 +2779,7 @@ impl ExecutionContext {
             for (pool_addr, state) in cache.iter() {
                 match state {
                     CachedPoolState::Meteora(ref ms) => {
-                        // Only inject if we have real Geyser data (active_id != 0)
-                        // Default active_id=0 means no real data, would cause wrong bin array derivation
-                        if ms.active_id != 0
-                            && meteora.inject_cached_meteora_state(&pool_addr, ms).is_ok()
-                        {
+                        if meteora.inject_cached_meteora_state(&pool_addr, ms).is_ok() {
                             meteora_count += 1;
                         }
                     }
@@ -2841,6 +2974,73 @@ impl ExecutionContext {
             //    The PumpFun quoter computes theoretical quotes from cached reserves even for
             //    completed curves, which causes on-chain 6005 (BondingCurveComplete) failures.
             // 3. RPC calls are acceptable here (cold path, safety > speed).
+
+            // I-24d Scope 21: one EnsureMeteoraDlmmPoolState + bounded JetStream wait per liquidation mint
+            // when SLAVE has DLMM rows for this mint but none are explicitly Ready (no connector RPC).
+            if let Some(ref cache) = ctx.live_pool_cache {
+                let rows = cache.meteora_dlmm_pools_for_mint(&mint);
+                if !rows.is_empty() && !cache.base_mint_has_explicit_meteora_dlmm_ready_pool(&mint)
+                {
+                    let pool_hint = rows
+                        .iter()
+                        .find(|(_, s)| s.token_x_mint == mint || s.token_y_mint == mint)
+                        .map(|(pk, _)| pk.to_string());
+                    warn!(
+                        mint = %mint,
+                        dlmm_rows = rows.len(),
+                        pool_address_hint = ?pool_hint,
+                        reason = "liquidation: Meteora DLMM pools in SLAVE but no explicit Ready — requesting EnsureMeteoraDlmmPoolState from market-data (bounded wait, one attempt per mint)",
+                        "Meteora DLMM cold-path: pre-quote recovery request"
+                    );
+                    if let DiscoveryRequestOutcome::Ok = ctx
+                        .request_meteora_dlmm_recovery_and_wait(
+                            mint_str.as_str(),
+                            pool_hint.as_deref(),
+                        )
+                        .await
+                    {
+                        let hint_pk = pool_hint.as_deref().and_then(|s| Pubkey::from_str(s).ok());
+                        let before_evidence = hint_pk.and_then(|pk| {
+                            cache.get(&pk).and_then(|st| match st {
+                                CachedPoolState::Meteora(s) => Some((
+                                    s.active_id,
+                                    s.bin_step,
+                                    s.reserve_x_balance,
+                                    s.reserve_y_balance,
+                                )),
+                                _ => None,
+                            })
+                        });
+                        if let Some(pk) = hint_pk {
+                            if wait_for_meteora_dlmm_slave_after_recovery(
+                                cache,
+                                &pk,
+                                before_evidence,
+                                DISCOVERY_CACHE_WAIT_TIMEOUT_MS,
+                                DISCOVERY_CACHE_POLL_INTERVAL_MS,
+                            )
+                            .await
+                            {
+                                for (pool_addr, ms) in cache.meteora_dlmm_pools_for_mint(&mint) {
+                                    let _ = meteora.inject_cached_meteora_state(&pool_addr, &ms);
+                                }
+                                info!(
+                                    mint = %mint,
+                                    pool = %pk,
+                                    "Meteora DLMM cold-path: SLAVE shows fresh explicit Ready after recovery — continuing liquidation quotes"
+                                );
+                            } else {
+                                warn!(
+                                    mint = %mint,
+                                    pool = %pk,
+                                    timeout_ms = DISCOVERY_CACHE_WAIT_TIMEOUT_MS,
+                                    "Meteora DLMM cold-path: ControlResponse ok but bounded wait for SLAVE explicit Ready + fresh evidence timed out"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
 
             // --- Phase 1: Multi-pool routing (preferred for liquidation) ---
             {
@@ -3125,6 +3325,11 @@ impl ExecutionContext {
 
                         if let Some(pool_id) = q.route.first().cloned() {
                             if let Ok(pool_pk) = Pubkey::from_str(&pool_id) {
+                                let explicit_ready = ctx
+                                    .live_pool_cache
+                                    .as_ref()
+                                    .map(|c| c.meteora_dlmm_pool_explicitly_ready(&pool_pk))
+                                    .unwrap_or(false);
                                 if let Some(pool_accounts) = meteora.get_pool_accounts(&pool_pk) {
                                     let active_id = pool_accounts
                                         .get(5)
@@ -3132,7 +3337,7 @@ impl ExecutionContext {
                                         .and_then(|v| v.parse::<i32>().ok())
                                         .unwrap_or(0);
 
-                                    if active_id != 0 {
+                                    if explicit_ready {
                                         quote_attempts.push(format!(
                                             "meteora=ok amount_out={} pool={} active_id={} accounts_len={}",
                                             q.amount_out,
@@ -3148,8 +3353,8 @@ impl ExecutionContext {
                                         );
                                     } else {
                                         quote_attempts.push(format!(
-                                            "meteora=skip active_id=0 (no Geyser data) pool={}",
-                                            pool_id
+                                            "meteora=skip no_explicit_ready pool={} active_id={}",
+                                            pool_id, active_id
                                         ));
                                     }
                                 } else {
@@ -3358,6 +3563,13 @@ impl ExecutionContext {
                                     Ok(pk) => pk,
                                     Err(_) => continue,
                                 };
+                                if !cache.meteora_dlmm_pool_explicitly_ready(&pool_pk) {
+                                    quote_attempts.push(format!(
+                                        "cache=skip meteora no_explicit_ready pool={}",
+                                        pool_id
+                                    ));
+                                    continue;
+                                }
                                 let Some(pool_accounts) = meteora.get_pool_accounts(&pool_pk)
                                 else {
                                     quote_attempts.push(format!(
@@ -3366,18 +3578,6 @@ impl ExecutionContext {
                                     ));
                                     continue;
                                 };
-                                let active_id = pool_accounts
-                                    .get(5)
-                                    .and_then(|s| s.strip_prefix("active_id:"))
-                                    .and_then(|v| v.parse::<i32>().ok())
-                                    .unwrap_or(0);
-                                if active_id == 0 {
-                                    quote_attempts.push(format!(
-                                        "cache=skip meteora active_id=0 pool={}",
-                                        pool_id
-                                    ));
-                                    continue;
-                                }
                                 pool_accounts
                             }
                             CachedPoolState::Orca(_) => {

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1789,6 +1789,465 @@ async fn handle_ensure_orca_whirlpool_pool_state(
     }
 }
 
+/// Result of one cache-scoped Meteora DLMM RPC refresh (LB pair + vault balances).
+struct MeteoraDlmmRpcRefreshRowResult {
+    pool_addr: Pubkey,
+    readiness: DexPoolReadiness,
+    /// `true` when a non-`Observed` [`DexPoolReadiness`] update was published to JetStream.
+    jetstream_published: bool,
+}
+
+/// Cold-path only: refresh one Meteora DLMM row already present in MASTER cache — same RPC
+/// pattern as wallet bootstrap (no global scan). Updates MASTER, merges readiness, publishes
+/// JetStream when readiness is not `Observed`.
+///
+/// Returns `None` when this pool row is skipped (fetch/parse/mint mismatch/incomplete vaults).
+async fn cold_path_rpc_refresh_meteora_dlmm_pool_row(
+    ctx: &MarketDataContext,
+    rpc: &Arc<SolanaRpc>,
+    run_id: &str,
+    request_id: &str,
+    base_mint: &Pubkey,
+    pool_addr: Pubkey,
+    mut state: MeteoraState,
+) -> Option<MeteoraDlmmRpcRefreshRowResult> {
+    let dlmm_program = Pubkey::from_str(METEORA_DLMM).expect("METEORA_DLMM constant");
+
+    let pool_acc = match rpc.get_account_opt_retry(&pool_addr).await {
+        Ok(Some(acc)) => acc,
+        Ok(None) | Err(_) => {
+            debug!(
+                request_id = %request_id,
+                pool = %pool_addr,
+                "Meteora DLMM RPC refresh: pool account fetch miss, skip"
+            );
+            return None;
+        }
+    };
+
+    let parsed_state = match parse_pool_account(&dlmm_program, &pool_acc.data) {
+        Some(CachedPoolState::Meteora(s)) => s,
+        _ => {
+            debug!(
+                request_id = %request_id,
+                pool = %pool_addr,
+                data_len = pool_acc.data.len(),
+                "Meteora DLMM RPC refresh: parse pool failed, skip"
+            );
+            return None;
+        }
+    };
+
+    state.token_x_mint = parsed_state.token_x_mint;
+    state.token_y_mint = parsed_state.token_y_mint;
+    state.reserve_x = parsed_state.reserve_x;
+    state.reserve_y = parsed_state.reserve_y;
+    state.active_id = parsed_state.active_id;
+    state.bin_step = parsed_state.bin_step;
+
+    if state.token_x_mint != *base_mint && state.token_y_mint != *base_mint {
+        return None;
+    }
+
+    let vx = state.reserve_x;
+    let vy = state.reserve_y;
+    let bal_x = match rpc.get_account_opt_retry(&vx).await {
+        Ok(Some(acc)) => try_parse_token_account_balance(&acc.data),
+        _ => None,
+    };
+    let bal_y = match rpc.get_account_opt_retry(&vy).await {
+        Ok(Some(acc)) => try_parse_token_account_balance(&acc.data),
+        _ => None,
+    };
+    let (bx, by) = match (bal_x, bal_y) {
+        (Some(a), Some(b)) => (a, b),
+        _ => {
+            debug!(
+                request_id = %request_id,
+                pool = %pool_addr,
+                "Meteora DLMM RPC refresh: vault balance RPC incomplete, skip"
+            );
+            return None;
+        }
+    };
+
+    state.reserve_x_balance = Some(bx);
+    state.reserve_y_balance = Some(by);
+
+    ctx.live_pool_cache
+        .upsert(pool_addr, CachedPoolState::Meteora(state.clone()), 0);
+
+    let readiness = meteora_dlmm_readiness_for_pool_cache_update(&state);
+    ctx.live_pool_cache
+        .merge_meteora_dlmm_pool_readiness(pool_addr, readiness);
+
+    if readiness == DexPoolReadiness::Observed {
+        debug!(
+            request_id = %request_id,
+            pool = %pool_addr,
+            mint = %base_mint,
+            "Meteora DLMM RPC refresh: still Observed after RPC, no JetStream publish"
+        );
+        return Some(MeteoraDlmmRpcRefreshRowResult {
+            pool_addr,
+            readiness,
+            jetstream_published: false,
+        });
+    }
+
+    let (pub_base_mint, pub_quote_mint, base_r, quote_r) =
+        (state.token_x_mint, state.token_y_mint, bx, by);
+
+    let jetstream_ok = if let Some(ref nats) = ctx.nats {
+        let mut balance_update = PoolCacheUpdate::new_balance_updated(
+            "market-data",
+            BUILD_VERSION,
+            run_id,
+            pool_addr.to_string(),
+            "meteora_dlmm".to_string(),
+            pub_base_mint.to_string(),
+            pub_quote_mint.to_string(),
+            base_r,
+            quote_r,
+            0,
+        );
+        balance_update.metadata = Some(meteora_dlmm_metadata_for_pool_cache_update(&state));
+        balance_update.set_dex_readiness_in_metadata(readiness);
+        let subject = pool_subject(&pool_addr.to_string());
+        match nats.jetstream_publish(&subject, &balance_update).await {
+            Ok(true) => {
+                info!(
+                    request_id = %request_id,
+                    pool = %pool_addr,
+                    mint = %base_mint,
+                    readiness = ?readiness,
+                    "Meteora DLMM RPC refresh: published PoolCacheUpdate::BalanceUpdated to JetStream"
+                );
+                true
+            }
+            Ok(false) => {
+                warn!(
+                    request_id = %request_id,
+                    pool = %pool_addr,
+                    "Meteora DLMM RPC refresh: JetStream publish failed (timeout or drop)"
+                );
+                false
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    request_id = %request_id,
+                    "Meteora DLMM RPC refresh: Failed to publish PoolCacheUpdate to JetStream"
+                );
+                false
+            }
+        }
+    } else {
+        false
+    };
+
+    if !jetstream_ok {
+        warn!(
+            request_id = %request_id,
+            pool = %pool_addr,
+            "Meteora DLMM RPC refresh: MASTER cache updated but JetStream publish failed — SSOT drift risk"
+        );
+    }
+
+    Some(MeteoraDlmmRpcRefreshRowResult {
+        pool_addr,
+        readiness,
+        jetstream_published: jetstream_ok,
+    })
+}
+
+/// I-24d / Scope 21: Cold-path Meteora DLMM recovery — cache-scoped RPC refresh, JetStream SSOT, ControlResponse.
+async fn handle_ensure_meteora_dlmm_pool_state(
+    ctx: &MarketDataContext,
+    rpc: &Arc<SolanaRpc>,
+    run_id: &str,
+    request_id: &str,
+    base_mint_str: &str,
+    pool_address_hint: Option<&str>,
+    force_refresh: bool,
+) {
+    let base_mint = match Pubkey::from_str(base_mint_str) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(base_mint = %base_mint_str, error = %e, "EnsureMeteoraDlmmPoolState: invalid base_mint");
+            if let Some(ref nats) = ctx.nats {
+                publish_control_response(
+                    nats,
+                    &ctx.run_id,
+                    request_id,
+                    ControlResponseStatus::Error,
+                    None,
+                    Some(e.to_string()),
+                )
+                .await;
+            }
+            return;
+        }
+    };
+
+    let pool_hint_pk = pool_address_hint.and_then(|s| Pubkey::from_str(s).ok());
+
+    if !force_refresh {
+        if let Some(pool_pk) = pool_hint_pk {
+            if ctx
+                .live_pool_cache
+                .meteora_dlmm_pool_explicitly_ready(&pool_pk)
+            {
+                info!(
+                    request_id = %request_id,
+                    base_mint = %base_mint_str,
+                    pool = %pool_pk,
+                    "EnsureMeteoraDlmmPoolState: cache hit explicit Ready (skip RPC)"
+                );
+                if let Some(ref nats) = ctx.nats {
+                    publish_control_response(
+                        nats,
+                        &ctx.run_id,
+                        request_id,
+                        ControlResponseStatus::Ok,
+                        Some(pool_pk.to_string()),
+                        None,
+                    )
+                    .await;
+                }
+                return;
+            }
+        } else if ctx
+            .live_pool_cache
+            .base_mint_has_explicit_meteora_dlmm_ready_pool(&base_mint)
+        {
+            info!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                "EnsureMeteoraDlmmPoolState: mint already has explicit Ready Meteora DLMM pool (skip RPC)"
+            );
+            if let Some(ref nats) = ctx.nats {
+                publish_control_response(
+                    nats,
+                    &ctx.run_id,
+                    request_id,
+                    ControlResponseStatus::Ok,
+                    None,
+                    None,
+                )
+                .await;
+            }
+            return;
+        }
+    } else {
+        warn!(
+            request_id = %request_id,
+            base_mint = %base_mint_str,
+            pool_address_hint = ?pool_address_hint,
+            "EnsureMeteoraDlmmPoolState: force_refresh — always running RPC refresh path (no cache-first short-circuit)"
+        );
+    }
+
+    let mut candidate_pools: Vec<(Pubkey, MeteoraState)> = Vec::new();
+    if let Some(pool_pk) = pool_hint_pk {
+        match ctx.live_pool_cache.get(&pool_pk) {
+            Some(CachedPoolState::Meteora(s)) => {
+                if s.token_x_mint != base_mint && s.token_y_mint != base_mint {
+                    warn!(
+                        request_id = %request_id,
+                        pool = %pool_pk,
+                        base_mint = %base_mint_str,
+                        "EnsureMeteoraDlmmPoolState: pool_address_hint DLMM row does not list base_mint"
+                    );
+                    if let Some(ref nats) = ctx.nats {
+                        publish_control_response(
+                            nats,
+                            &ctx.run_id,
+                            request_id,
+                            ControlResponseStatus::Error,
+                            Some(pool_pk.to_string()),
+                            Some("pool hint mint mismatch".to_string()),
+                        )
+                        .await;
+                    }
+                    return;
+                }
+                candidate_pools.push((pool_pk, s));
+            }
+            Some(_) => {
+                warn!(
+                    request_id = %request_id,
+                    pool = %pool_pk,
+                    "EnsureMeteoraDlmmPoolState: pool_address_hint is not a Meteora DLMM row"
+                );
+                if let Some(ref nats) = ctx.nats {
+                    publish_control_response(
+                        nats,
+                        &ctx.run_id,
+                        request_id,
+                        ControlResponseStatus::Error,
+                        Some(pool_pk.to_string()),
+                        Some("pool hint is not meteora dlmm in cache".to_string()),
+                    )
+                    .await;
+                }
+                return;
+            }
+            None => {
+                info!(
+                    request_id = %request_id,
+                    pool = %pool_pk,
+                    base_mint = %base_mint_str,
+                    "EnsureMeteoraDlmmPoolState: pool hint not in LivePoolCache (NotFound)"
+                );
+                if let Some(ref nats) = ctx.nats {
+                    publish_control_response(
+                        nats,
+                        &ctx.run_id,
+                        request_id,
+                        ControlResponseStatus::NotFound,
+                        Some(pool_pk.to_string()),
+                        None,
+                    )
+                    .await;
+                }
+                return;
+            }
+        }
+    } else {
+        candidate_pools = ctx.live_pool_cache.meteora_dlmm_pools_for_mint(&base_mint);
+        if candidate_pools.is_empty() {
+            info!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                "EnsureMeteoraDlmmPoolState: no Meteora DLMM rows in LivePoolCache for mint (NotFound)"
+            );
+            if let Some(ref nats) = ctx.nats {
+                publish_control_response(
+                    nats,
+                    &ctx.run_id,
+                    request_id,
+                    ControlResponseStatus::NotFound,
+                    None,
+                    None,
+                )
+                .await;
+            }
+            return;
+        }
+    }
+
+    info!(
+        request_id = %request_id,
+        base_mint = %base_mint_str,
+        pool_address_hint = ?pool_address_hint,
+        candidates = candidate_pools.len(),
+        force_refresh = %force_refresh,
+        "EnsureMeteoraDlmmPoolState: starting cache-scoped Meteora DLMM RPC refresh"
+    );
+
+    let mut terminal_ok_pool: Option<Pubkey> = None;
+    let mut ready_jetstream_failed_pool: Option<Pubkey> = None;
+
+    for (pool_addr, state) in candidate_pools {
+        if let Some(row) = cold_path_rpc_refresh_meteora_dlmm_pool_row(
+            ctx, rpc, run_id, request_id, &base_mint, pool_addr, state,
+        )
+        .await
+        {
+            match (row.readiness, row.jetstream_published) {
+                (DexPoolReadiness::Ready, true) => {
+                    terminal_ok_pool = Some(row.pool_addr);
+                    break;
+                }
+                (DexPoolReadiness::Ready, false) => {
+                    ready_jetstream_failed_pool = Some(row.pool_addr);
+                }
+                (DexPoolReadiness::Partial, true) => {
+                    debug!(
+                        request_id = %request_id,
+                        pool = %row.pool_addr,
+                        "EnsureMeteoraDlmmPoolState: Partial published to JetStream — scan remaining candidates for Ready"
+                    );
+                }
+                (DexPoolReadiness::Partial, false) => {
+                    warn!(
+                        request_id = %request_id,
+                        pool = %row.pool_addr,
+                        "EnsureMeteoraDlmmPoolState: Partial row MASTER-updated but JetStream publish failed"
+                    );
+                }
+                (DexPoolReadiness::Observed, _) => {}
+            }
+        }
+    }
+
+    if let Some(pool_pk) = terminal_ok_pool {
+        if let Some(ref nats) = ctx.nats {
+            let pool_str = pool_pk.to_string();
+            info!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                pool = %pool_str,
+                readiness = ?DexPoolReadiness::Ready,
+                jetstream = "published",
+                "EnsureMeteoraDlmmPoolState: terminal ok (Meteora DLMM Ready + JetStream publish)"
+            );
+            publish_control_response(
+                nats,
+                &ctx.run_id,
+                request_id,
+                ControlResponseStatus::Ok,
+                Some(pool_str),
+                None,
+            )
+            .await;
+        }
+        return;
+    }
+
+    if let Some(pool_pk) = ready_jetstream_failed_pool {
+        if let Some(ref nats) = ctx.nats {
+            let pool_str = pool_pk.to_string();
+            let msg = "JetStream publish failed".to_string();
+            warn!(
+                request_id = %request_id,
+                base_mint = %base_mint_str,
+                pool = %pool_str,
+                error = %msg,
+                "EnsureMeteoraDlmmPoolState: terminal error (Ready on MASTER but JetStream publish failed)"
+            );
+            publish_control_response(
+                nats,
+                &ctx.run_id,
+                request_id,
+                ControlResponseStatus::Error,
+                Some(pool_str),
+                Some(msg),
+            )
+            .await;
+        }
+        return;
+    }
+
+    warn!(
+        request_id = %request_id,
+        base_mint = %base_mint_str,
+        "EnsureMeteoraDlmmPoolState: RPC refresh did not yield Meteora DLMM Ready + JetStream publish (Error)"
+    );
+    if let Some(ref nats) = ctx.nats {
+        publish_control_response(
+            nats,
+            &ctx.run_id,
+            request_id,
+            ControlResponseStatus::Error,
+            None,
+            Some("meteora dlmm rpc refresh did not produce jetstream-ready state".to_string()),
+        )
+        .await;
+    }
+}
+
 /// Cold-path only: Meteora DLMM promotion for one wallet mint. Uses **only** pools already present
 /// in [`LivePoolCache`] (from Geyser); no `getProgramAccounts` / global scan. RPC: per-pool
 /// `get_account` (LB pair) + per-reserve-vault balance reads — bounded by matching cache rows.
@@ -1834,9 +2293,7 @@ async fn handle_wallet_bootstrap_meteora_dlmm_verify_for_mint(
         "Wallet bootstrap Meteora DLMM: verifying cache-scoped pools (cold-path RPC, no global scan)"
     );
 
-    let dlmm_program = Pubkey::from_str(METEORA_DLMM).expect("METEORA_DLMM constant");
-
-    for (pool_addr, mut state) in pools {
+    for (pool_addr, state) in pools {
         if ctx.live_pool_cache.base_mint_has_any_ready_pool(base_mint) {
             break;
         }
@@ -1847,142 +2304,10 @@ async fn handle_wallet_bootstrap_meteora_dlmm_verify_for_mint(
             break;
         }
 
-        let pool_acc = match rpc.get_account_opt_retry(&pool_addr).await {
-            Ok(Some(acc)) => acc,
-            Ok(None) | Err(_) => {
-                debug!(
-                    request_id = %request_id,
-                    pool = %pool_addr,
-                    "Wallet bootstrap Meteora DLMM: pool account fetch miss, skip"
-                );
-                continue;
-            }
-        };
-
-        let parsed_state = match parse_pool_account(&dlmm_program, &pool_acc.data) {
-            Some(CachedPoolState::Meteora(s)) => s,
-            _ => {
-                debug!(
-                    request_id = %request_id,
-                    pool = %pool_addr,
-                    data_len = pool_acc.data.len(),
-                    "Wallet bootstrap Meteora DLMM: parse pool failed, skip"
-                );
-                continue;
-            }
-        };
-
-        state.token_x_mint = parsed_state.token_x_mint;
-        state.token_y_mint = parsed_state.token_y_mint;
-        state.reserve_x = parsed_state.reserve_x;
-        state.reserve_y = parsed_state.reserve_y;
-        state.active_id = parsed_state.active_id;
-        state.bin_step = parsed_state.bin_step;
-
-        if state.token_x_mint != *base_mint && state.token_y_mint != *base_mint {
-            continue;
-        }
-
-        let vx = state.reserve_x;
-        let vy = state.reserve_y;
-        let bal_x = match rpc.get_account_opt_retry(&vx).await {
-            Ok(Some(acc)) => try_parse_token_account_balance(&acc.data),
-            _ => None,
-        };
-        let bal_y = match rpc.get_account_opt_retry(&vy).await {
-            Ok(Some(acc)) => try_parse_token_account_balance(&acc.data),
-            _ => None,
-        };
-        let (bx, by) = match (bal_x, bal_y) {
-            (Some(a), Some(b)) => (a, b),
-            _ => {
-                debug!(
-                    request_id = %request_id,
-                    pool = %pool_addr,
-                    "Wallet bootstrap Meteora DLMM: vault balance RPC incomplete, skip"
-                );
-                continue;
-            }
-        };
-
-        state.reserve_x_balance = Some(bx);
-        state.reserve_y_balance = Some(by);
-
-        ctx.live_pool_cache
-            .upsert(pool_addr, CachedPoolState::Meteora(state.clone()), 0);
-
-        let readiness = meteora_dlmm_readiness_for_pool_cache_update(&state);
-        ctx.live_pool_cache
-            .merge_meteora_dlmm_pool_readiness(pool_addr, readiness);
-
-        if readiness == DexPoolReadiness::Observed {
-            debug!(
-                request_id = %request_id,
-                pool = %pool_addr,
-                mint = %base_mint,
-                "Wallet bootstrap Meteora DLMM: still Observed after RPC, no JetStream publish"
-            );
-            continue;
-        }
-
-        let (pub_base_mint, pub_quote_mint, base_r, quote_r) =
-            (state.token_x_mint, state.token_y_mint, bx, by);
-
-        let jetstream_ok = if let Some(ref nats) = ctx.nats {
-            let mut balance_update = PoolCacheUpdate::new_balance_updated(
-                "market-data",
-                BUILD_VERSION,
-                run_id,
-                pool_addr.to_string(),
-                "meteora_dlmm".to_string(),
-                pub_base_mint.to_string(),
-                pub_quote_mint.to_string(),
-                base_r,
-                quote_r,
-                0,
-            );
-            balance_update.metadata = Some(meteora_dlmm_metadata_for_pool_cache_update(&state));
-            balance_update.set_dex_readiness_in_metadata(readiness);
-            let subject = pool_subject(&pool_addr.to_string());
-            match nats.jetstream_publish(&subject, &balance_update).await {
-                Ok(true) => {
-                    info!(
-                        request_id = %request_id,
-                        pool = %pool_addr,
-                        mint = %base_mint,
-                        readiness = ?readiness,
-                        "Wallet bootstrap Meteora DLMM: published PoolCacheUpdate::BalanceUpdated to JetStream"
-                    );
-                    true
-                }
-                Ok(false) => {
-                    warn!(
-                        request_id = %request_id,
-                        pool = %pool_addr,
-                        "Wallet bootstrap Meteora DLMM: JetStream publish failed (timeout or drop)"
-                    );
-                    false
-                }
-                Err(e) => {
-                    warn!(
-                        error = %e,
-                        request_id = %request_id,
-                        "Wallet bootstrap Meteora DLMM: Failed to publish PoolCacheUpdate to JetStream"
-                    );
-                    false
-                }
-            }
-        } else {
-            false
-        };
-
-        if !jetstream_ok {
-            warn!(
-                request_id = %request_id,
-                pool = %pool_addr,
-                "Wallet bootstrap Meteora DLMM: MASTER cache updated but JetStream publish failed — SSOT drift risk"
-            );
-        }
+        let _ = cold_path_rpc_refresh_meteora_dlmm_pool_row(
+            ctx, rpc, run_id, request_id, base_mint, pool_addr, state,
+        )
+        .await;
     }
 }
 
@@ -3963,6 +4288,33 @@ async fn run_geyser_loop(
                                         let rpc_clone = rpc.clone();
                                         tokio::spawn(async move {
                                             handle_ensure_orca_whirlpool_pool_state(
+                                                &ctx_clone,
+                                                &rpc_clone,
+                                                run_id.as_str(),
+                                                &request_id,
+                                                &base_mint,
+                                                pool_hint.as_deref(),
+                                                force_refresh,
+                                            )
+                                            .await;
+                                        });
+                                    }
+                                    ControlRequestKind::EnsureMeteoraDlmmPoolState { base_mint } => {
+                                        let run_id = ctx.run_id.clone();
+                                        let request_id = req.request_id.clone();
+                                        let pool_hint = req.pool_address_hint.clone();
+                                        let force_refresh = req.force_refresh_meteora_dlmm;
+                                        info!(
+                                            request_id = %request_id,
+                                            base_mint = %base_mint,
+                                            pool_address_hint = ?pool_hint,
+                                            force_refresh_meteora_dlmm = %force_refresh,
+                                            "EnsureMeteoraDlmmPoolState received"
+                                        );
+                                        let ctx_clone = ctx.clone();
+                                        let rpc_clone = rpc.clone();
+                                        tokio::spawn(async move {
+                                            handle_ensure_meteora_dlmm_pool_state(
                                                 &ctx_clone,
                                                 &rpc_clone,
                                                 run_id.as_str(),
@@ -6850,6 +7202,33 @@ async fn run_simulation_loop(
                                         let rpc_clone = rpc.clone();
                                         tokio::spawn(async move {
                                             handle_ensure_orca_whirlpool_pool_state(
+                                                &ctx_clone,
+                                                &rpc_clone,
+                                                run_id.as_str(),
+                                                &request_id,
+                                                &base_mint,
+                                                pool_hint.as_deref(),
+                                                force_refresh,
+                                            )
+                                            .await;
+                                        });
+                                    }
+                                    ControlRequestKind::EnsureMeteoraDlmmPoolState { base_mint } => {
+                                        let run_id = ctx.run_id.clone();
+                                        let request_id = req.request_id.clone();
+                                        let pool_hint = req.pool_address_hint.clone();
+                                        let force_refresh = req.force_refresh_meteora_dlmm;
+                                        info!(
+                                            request_id = %request_id,
+                                            base_mint = %base_mint,
+                                            pool_address_hint = ?pool_hint,
+                                            force_refresh_meteora_dlmm = %force_refresh,
+                                            "EnsureMeteoraDlmmPoolState received (simulation)"
+                                        );
+                                        let ctx_clone = ctx.clone();
+                                        let rpc_clone = rpc.clone();
+                                        tokio::spawn(async move {
+                                            handle_ensure_meteora_dlmm_pool_state(
                                                 &ctx_clone,
                                                 &rpc_clone,
                                                 run_id.as_str(),

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -1168,6 +1168,23 @@ impl LivePoolCache {
         self.meteora_dlmm_readiness_by_pool.get(pool).map(|r| *r)
     }
 
+    /// SLAVE-visible Meteora DLMM row + merged readiness (JetStream path). For cold-path recovery
+    /// waits: compare [`MeteoraState`] evidence vs a pre-request snapshot (Bug #34).
+    #[must_use]
+    pub fn meteora_dlmm_slave_readiness_snapshot(
+        &self,
+        pool: &Pubkey,
+    ) -> Option<(MeteoraState, DexPoolReadiness)> {
+        let state = match self.get(pool)? {
+            CachedPoolState::Meteora(s) => s,
+            _ => return None,
+        };
+        let readiness = self
+            .meteora_dlmm_readiness(pool)
+            .unwrap_or(DexPoolReadiness::Observed);
+        Some((state, readiness))
+    }
+
     /// Mint-level helper: Meteora DLMM slice — explicit `Ready` only (no cache-hit heuristic).
     #[must_use]
     pub fn base_mint_has_explicit_meteora_dlmm_ready_pool(&self, base_mint: &Pubkey) -> bool {
@@ -2791,6 +2808,32 @@ mod tests {
             .expect("snapshot");
         assert_eq!(snap.1, DexPoolReadiness::Ready);
         assert_eq!(snap.0.tick_current_index, s.tick_current_index);
+    }
+
+    #[test]
+    fn test_meteora_dlmm_slave_readiness_snapshot_merges_explicit_ready() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let s = make_meteora_dlmm_state(
+            base_mint,
+            quote_mint,
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            -3,
+            10,
+            Some(100),
+            Some(200),
+        );
+        cache.upsert(pool, CachedPoolState::Meteora(s.clone()), 0);
+        cache.merge_meteora_dlmm_pool_readiness(pool, DexPoolReadiness::Ready);
+        let snap = cache
+            .meteora_dlmm_slave_readiness_snapshot(&pool)
+            .expect("snapshot");
+        assert_eq!(snap.1, DexPoolReadiness::Ready);
+        assert_eq!(snap.0.active_id, s.active_id);
+        assert_eq!(snap.0.reserve_x_balance, s.reserve_x_balance);
     }
 
     #[test]

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -1131,6 +1131,17 @@ pub enum ControlRequestKind {
         /// Base mint (base58) of the token side this recovery is for (intent-relevant mint).
         base_mint: String,
     },
+
+    /// Cold-path recovery: refresh Meteora DLMM LB-pair row + vault balances from RPC for pools
+    /// already present in MASTER LivePoolCache (cache-scoped; no global `getProgramAccounts`).
+    /// Publishes `PoolCacheUpdate` to JetStream when readiness promotes to at least Partial / Ready.
+    ///
+    /// Optional LB pair address: use top-level `pool_address_hint` on [`ControlRequest`] for the
+    /// same backward-compatible fast-path style as PumpSwap / Orca.
+    EnsureMeteoraDlmmPoolState {
+        /// Base mint (base58) of the token side this recovery is for (intent-relevant mint).
+        base_mint: String,
+    },
 }
 
 fn default_true() -> bool {
@@ -1172,6 +1183,12 @@ pub struct ControlRequest {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub force_refresh_orca: bool,
 
+    /// When true, market-data must **not** short-circuit EnsureMeteoraDlmmPoolState from
+    /// existing explicit Ready in LivePoolCache: always run the bounded RPC refresh path and
+    /// republish when readiness allows. Cold-path only (I-5); default false.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub force_refresh_meteora_dlmm: bool,
+
     #[serde(flatten)]
     pub kind: ControlRequestKind,
 }
@@ -1193,6 +1210,7 @@ impl ControlRequest {
             force_refresh: false,
             force_refresh_pumpfun: false,
             force_refresh_orca: false,
+            force_refresh_meteora_dlmm: false,
             kind,
         }
     }
@@ -2278,6 +2296,55 @@ mod tests {
         assert!(!json_min.contains("force_refresh_orca"));
         let parsed_min: ControlRequest = serde_json::from_str(&json_min).unwrap();
         assert!(!parsed_min.force_refresh_orca);
+    }
+
+    #[test]
+    fn test_control_request_ensure_meteora_dlmm_pool_state_serde() {
+        let mut req = ControlRequest::new(
+            "execution-engine",
+            "v0.1.0",
+            "run-123",
+            "req-dlmm-001".to_string(),
+            "market-data",
+            ControlRequestKind::EnsureMeteoraDlmmPoolState {
+                base_mint: "MintDlmm111111111111111111111111111111".to_string(),
+            },
+        );
+        req.pool_address_hint = Some("PoolDlmm111111111111111111111111111111".to_string());
+        req.force_refresh_meteora_dlmm = true;
+
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("ensure_meteora_dlmm_pool_state"));
+        assert!(json.contains("MintDlmm111111111111111111111111111111"));
+        assert!(json.contains("pool_address_hint"));
+        assert!(json.contains("PoolDlmm111111111111111111111111111111"));
+        assert!(json.contains("\"force_refresh_meteora_dlmm\":true"));
+
+        let parsed: ControlRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.request_id, "req-dlmm-001");
+        assert!(parsed.force_refresh_meteora_dlmm);
+        match &parsed.kind {
+            ControlRequestKind::EnsureMeteoraDlmmPoolState { base_mint } => {
+                assert_eq!(base_mint, "MintDlmm111111111111111111111111111111");
+            }
+            _ => panic!("expected EnsureMeteoraDlmmPoolState"),
+        }
+
+        let req_minimal = ControlRequest::new(
+            "execution-engine",
+            "v0.1.0",
+            "run-123",
+            "req-dlmm-002".to_string(),
+            "market-data",
+            ControlRequestKind::EnsureMeteoraDlmmPoolState {
+                base_mint: "MintDlmm222222222222222222222222222222".to_string(),
+            },
+        );
+        let json_min = serde_json::to_string(&req_minimal).unwrap();
+        assert!(!json_min.contains("pool_address_hint"));
+        assert!(!json_min.contains("force_refresh_meteora_dlmm"));
+        let parsed_min: ControlRequest = serde_json::from_str(&json_min).unwrap();
+        assert!(!parsed_min.force_refresh_meteora_dlmm);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a narrow **Meteora DLMM** cold-path **Request/Reply** slice aligned with existing PumpSwap / PumpFun / Orca patterns: `execution-engine` publishes `ControlRequest`, `market-data` performs cache-scoped RPC refresh, updates MASTER, publishes `PoolCacheUpdate` to JetStream, and replies with `ControlResponse` (correlation only; JetStream is SSOT).

## Follow-up (supervisor review)

- **Bug #34 ordering:** `before_evidence` for `wait_for_meteora_dlmm_slave_after_recovery` is now captured **before** `request_meteora_dlmm_recovery_and_wait` (same as Orca). Doc comment on the wait helper states the pre-request contract.
- **Regression test:** `meteora_dlmm_recovery_wait_needs_pre_request_evidence_snapshot` — pre-merge `before` succeeds; post-merge `before` does not satisfy the wait.

## Changes

- **`ControlRequestKind::EnsureMeteoraDlmmPoolState { base_mint }`** plus optional top-level `pool_address_hint` and **`force_refresh_meteora_dlmm`** (default false, serde-compatible).
- **`market-data`**: `handle_ensure_meteora_dlmm_pool_state` + shared `cold_path_rpc_refresh_meteora_dlmm_pool_row` (wallet bootstrap DLMM verify reuses the same path).
- **`execution-engine` liquidation**: `MeteoraDlmm::new_with_live_cache(..., allow_rpc_on_miss=false)` — no connector RPC fallback for reserves; when SLAVE has DLMM rows for the mint but **no explicit `Ready`**, one **`EnsureMeteoraDlmmPoolState`** with `force_refresh_meteora_dlmm=true`, then bounded wait on **explicit `Ready` + changed evidence tuple** (`active_id`, `bin_step`, vault balances) vs **pre-request** snapshot. Re-injects DLMM rows from cache after success.
- **`LivePoolCache::meteora_dlmm_slave_readiness_snapshot`** for the wait helper + unit test.
- Liquidation Meteora quote/cache routing: **only** counts as usable when **`meteora_dlmm_pool_explicitly_ready(pool)`** (replaces `active_id != 0` gate for route selection).

## Out of scope (unchanged)

- Orca / Raydium request/reply extensions, Meteora DLMM hot-path healing, global `getProgramAccounts`, quote/builder refactors.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` and `cargo test --features test_helpers`

## STOP-CHECK (post-change)

1. **I-7 Hot-path RPC**: No new RPC in hot path; liquidation + market-data handlers remain cold path.
2. **Pattern**: Matches Orca `EnsureOrcaWhirlpoolPoolState` + `force_refresh_*` + `pool_address_hint`.
3. **Architecture**: No local MASTER/SLAVE discovery writes in execution-engine; authoritative refresh in market-data.
4. **I-9**: Unchanged simulation gating.
5. **Level-5**: No eval test/source reads.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12ec403e-607c-4d57-b760-4432728e359c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12ec403e-607c-4d57-b760-4432728e359c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

