### PR TITLE
PumpSwap: Cold-Path-Recovery für manuelles sell_all

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -159,7 +159,7 @@ fn pump_amm_pool_market_hint_pk(intent: &TradeIntent, ctx: &ExecutionContext) ->
 }
 
 /// Stale/wrong PumpSwap `pool_accounts` (e.g. creator vault) → simulation Overflow / Custom(6023) / 0x1787.
-/// Must match the liquidation cold-path recovery matcher.
+/// Must stay aligned with the PumpSwap cold-path recovery branch (`is_cold_path_recovery_sell` + `dex=pump_amm`).
 #[inline]
 fn is_pump_amm_structural_sim_error(error_code: Option<&str>) -> bool {
     error_code
@@ -168,7 +168,7 @@ fn is_pump_amm_structural_sim_error(error_code: Option<&str>) -> bool {
 }
 
 /// PumpFun bonding curve: stale reserves / wrong account count (cashback) → Custom(6023/6024), Overflow.
-/// Cold-path recovery matcher (liquidation / manual); must stay aligned with handler below.
+/// Cold-path structural sim matcher for PumpFun bonding-curve recovery (`is_cold_path_recovery_sell` handlers below).
 #[inline]
 fn is_pumpfun_bonding_curve_structural_sim_error(error_code: Option<&str>) -> bool {
     error_code
@@ -8967,7 +8967,8 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
         }
 
         // Regular PumpSwap SELL hot path: on structural sim failure, trigger async pool_accounts refresh
-        // (no wait, no retry this intent). Liquidation uses synchronous wait+retry below.
+        // (no wait, no retry this intent). Cold-path recovery (`is_cold_path_recovery_sell`: liquidation,
+        // kill-switch, or explicit `sell_all=true`) uses the synchronous wait + one tx rebuild retry below.
         if !ctx.replay_mode
             && !is_liquidation_sell
             && is_regular_momentum_hot_path_sell(&intent)
@@ -9047,7 +9048,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
 
         // PumpSwap SELL: stale/wrong creator-vault accounts in cached pool_accounts → Overflow Custom(6023).
         // Cold-path recovery: one EnsurePumpAmmPoolAccounts with force_refresh (RPC market parse).
-        // Gate: liquidation/kill-switch **or** explicit manual `sell_all=true` (not general strategy SELLs).
+        // Gate: `is_cold_path_recovery_sell` — liquidation, kill-switch, or explicit `sell_all=true` (not general momentum SELLs).
         if !pump_amm_recovery_attempted
             && is_cold_path_recovery_sell(&intent)
             && intent.metadata.get("dex").map(|s| s.as_str()) == Some("pump_amm")
@@ -9175,7 +9176,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
             }
         }
 
-        // Orca Whirlpool SELL (liquidation / manual cold path): stale tick or vault evidence →
+        // Orca Whirlpool SELL (cold-path recovery slice via `is_cold_path_recovery_sell`): stale tick or vault evidence →
         // structural sim fail. I-24d: one EnsureOrcaWhirlpoolPoolState + bounded JetStream wait + one retry.
         if !orca_recovery_attempted
             && is_cold_path_recovery_sell(&intent)
@@ -11060,7 +11061,7 @@ mod execution_engine_tests {
     use std::time::Instant;
 
     #[test]
-    fn pump_amm_structural_sim_error_matches_liquidation_pattern() {
+    fn pump_amm_structural_sim_error_matches_cold_path_recovery_pattern() {
         assert!(is_pump_amm_structural_sim_error(Some(
             "Simulation failed: Custom(6023)"
         )));

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -203,8 +203,8 @@ fn is_orca_structural_sim_error(error_code: Option<&str>) -> bool {
 /// (`sell_all=true`).
 ///
 /// Rationale: `sell-all` / keyless tooling may tag `sell_all=true` without `purpose=liquidation`;
-/// that path is still Cold Path (not momentum hot path). PumpSwap recovery stays gated on
-/// `is_liquidation_sell` only.
+/// that path is still Cold Path (not momentum hot path). PumpSwap structural sim recovery uses
+/// the same gate as other cold-path DEX recovery ([`is_cold_path_recovery_sell`]).
 #[inline]
 fn is_cold_path_recovery_sell(intent: &TradeIntent) -> bool {
     if intent.side != TradeSide::Sell {
@@ -9047,8 +9047,9 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
 
         // PumpSwap SELL: stale/wrong creator-vault accounts in cached pool_accounts → Overflow Custom(6023).
         // Cold-path recovery: one EnsurePumpAmmPoolAccounts with force_refresh (RPC market parse).
+        // Gate: liquidation/kill-switch **or** explicit manual `sell_all=true` (not general strategy SELLs).
         if !pump_amm_recovery_attempted
-            && is_liquidation_sell
+            && is_cold_path_recovery_sell(&intent)
             && intent.metadata.get("dex").map(|s| s.as_str()) == Some("pump_amm")
             && is_pump_amm_structural_sim_error(sim_result.error_code.as_deref())
         {
@@ -9089,7 +9090,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                             warn!(
                                 intent_id = %intent.intent_id,
                                 pool = %pool_pk,
-                                "PumpSwap liquidation: simulation 6023/Overflow — force-refresh pool_accounts (market-data RPC), rebuilding tx (one retry)"
+                                "PumpSwap cold-path recovery: simulation 6023/Overflow — force-refresh pool_accounts (market-data RPC), rebuilding tx (one retry)"
                             );
                             continue;
                         }
@@ -11151,6 +11152,33 @@ mod execution_engine_tests {
         intent
             .metadata
             .insert("dex".to_string(), "pumpfun".to_string());
+        assert!(is_cold_path_recovery_sell(&intent));
+    }
+
+    #[test]
+    fn pumpswap_recovery_cold_path_includes_sell_all_without_purpose_liquidation() {
+        let mut intent = TradeIntent::new_sell(
+            "sell-all",
+            "v0.1.0",
+            "run-1",
+            "id-sa-pamm".to_string(),
+            "sell-all",
+            IntentTier::Tier0,
+            IntentOrigin::StrategyA,
+            "Mint111111111111111111111111111111111111111".to_string(),
+            6,
+            ironcrab::ipc::NATIVE_SOL_MINT.to_string(),
+            1_000_000,
+            0,
+            200,
+            TradingRegime::NotApplicable,
+        );
+        intent
+            .metadata
+            .insert("sell_all".to_string(), "true".to_string());
+        intent
+            .metadata
+            .insert("dex".to_string(), "pump_amm".to_string());
         assert!(is_cold_path_recovery_sell(&intent));
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zusammenfassung

Der synchrone PumpSwap-Recovery-Pfad nach strukturellem Sim-Fail (`6023` / `Overflow` / `0x1787`) war nur bei Liquidation/Kill-Switch aktiv (`is_liquidation_sell`). Manuelle Cold-Path-SELLs mit `sell_all=true` fallen zwar unter `is_cold_path_recovery_sell`, hatten aber keinen `EnsurePumpAmmPoolAccounts`-Wait+Retry.

## Änderung

- Gate des bestehenden Blocks auf `is_cold_path_recovery_sell(&intent)` erweitert (enthält weiterhin Liquidation/Kill-Switch **und** explizites `sell_all=true`).
- Unverändert: nur `dex=pump_amm`, nur strukturelle PumpSwap-Sim-Fehler, `pump_amm_pool_market_hint_pk`, ein `request_discovery_and_wait` + bounded Cache-Wait + ein Rebuild-Retry (`pump_amm_recovery_attempted`).
- Kommentare/Docstrings/Testname an den Cold-Path-Recovery-Scope angeglichen (keine Logikänderung im Follow-up-Commit).

## STOP-CHECK (AGENTS.md)

1. **I-7 Hot-Path-RPC:** Nein — kein neuer RPC; Recovery bleibt hinter dem bestehenden Cold-Path-Control-Flow.
2. **Pattern:** Entspricht PumpFun/Orca (Cold-Path-Gate + ein Retry).
3. **Scope:** Nur `src/bin/execution_engine.rs`.
4. **I-9 Simulation:** Unverändert simulate-gated; kein Send ohne erfolgreiche Sim.
5. **Level-5:** Keine Eval-Tests gelesen.

## Checks

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea197ba7-7d0a-4e0f-a79d-bb4d69ab216e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea197ba7-7d0a-4e0f-a79d-bb4d69ab216e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

