### PR TITLE
fix(market-data): watchdog-safe wallet DEX bootstrap verify (Scope 38)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -384,6 +384,10 @@ struct MarketDataContext {
     /// Only emit when progress changes by >= 50 bps or complete flag changes.
     last_emitted_curve_progress:
         parking_lot::RwLock<std::collections::HashMap<Pubkey, (u32, bool)>>,
+
+    /// PumpSwap / PumpFun AMM cold-path helper; set at Geyser-loop start before wallet snapshot.
+    /// Used for background wallet-bootstrap DEX verification (watchdog-safe).
+    pump_amm_dex: parking_lot::RwLock<Option<Arc<PumpFunAmmDex>>>,
 }
 
 #[derive(Debug, Default)]
@@ -3624,12 +3628,17 @@ async fn handle_wallet_bootstrap_meteora_dlmm_verify_for_mint(
 ///
 /// After startup, live balance updates are handled by Geyser (tracked ATA subscriptions).
 /// No RPC calls are made in the runtime hot-path.
+///
+/// When `dex_verify_blocking` is false (normal startup), bounded wallet DEX verification runs in a
+/// background task so the caller can reach the main loop and systemd watchdog pings before slow
+/// cold-path RPC completes. When true (`wallet_snapshot_only`), verification is awaited so the
+/// one-shot process exits with work finished.
 async fn publish_wallet_snapshot(
-    ctx: &MarketDataContext,
+    ctx: &Arc<MarketDataContext>,
     rpc: &Arc<SolanaRpc>,
-    pump_amm_dex: &PumpFunAmmDex,
     wallet: &Pubkey,
     is_periodic: bool,
+    dex_verify_blocking: bool,
 ) -> Result<()> {
     use async_nats::jetstream;
     use futures::StreamExt;
@@ -4260,15 +4269,64 @@ async fn publish_wallet_snapshot(
     // 4a) Bounded cold-path verification for wallet non-zero mints without explicit Ready
     // (PumpSwap, PumpFun, Raydium CPMM, Meteora CPMM, Orca, Meteora DLMM — cache-scoped where applicable);
     // reuses I-24d handlers + JetStream — no hot-path RPC.
-    run_bounded_wallet_dex_bootstrap_verify(
-        ctx,
-        rpc,
-        pump_amm_dex,
-        &mints_in_wallet,
-        &ctx.run_id,
-        is_periodic,
-    )
-    .await;
+    //
+    // Normal startup: spawn so systemd WatchdogSec is not exceeded while Ensure*/RPC runs serially.
+    // wallet_snapshot_only: block so one-shot mode still completes verification before exit.
+    if !is_periodic {
+        let mints_clone = mints_in_wallet.clone();
+        if dex_verify_blocking {
+            match ctx.pump_amm_dex.read().as_ref() {
+                Some(dex) => {
+                    run_bounded_wallet_dex_bootstrap_verify(
+                        ctx.as_ref(),
+                        rpc,
+                        dex.as_ref(),
+                        &mints_clone,
+                        ctx.run_id.as_str(),
+                        false,
+                    )
+                    .await;
+                }
+                None => {
+                    warn!(
+                        run_id = %ctx.run_id,
+                        "Wallet bootstrap DEX verify skipped: pump_amm_dex not initialized"
+                    );
+                }
+            }
+        } else {
+            let ctx_spawn = Arc::clone(ctx);
+            let rpc_spawn = Arc::clone(rpc);
+            tokio::spawn(async move {
+                let dex_opt = ctx_spawn.pump_amm_dex.read().clone();
+                let Some(dex) = dex_opt else {
+                    warn!(
+                        run_id = %ctx_spawn.run_id,
+                        "Wallet bootstrap DEX verify skipped: pump_amm_dex not initialized (unexpected)"
+                    );
+                    return;
+                };
+                info!(
+                    run_id = %ctx_spawn.run_id,
+                    mints = mints_clone.len(),
+                    "Wallet bootstrap: bounded DEX verification running in background (watchdog-safe)"
+                );
+                run_bounded_wallet_dex_bootstrap_verify(
+                    ctx_spawn.as_ref(),
+                    &rpc_spawn,
+                    dex.as_ref(),
+                    &mints_clone,
+                    ctx_spawn.run_id.as_str(),
+                    false,
+                )
+                .await;
+                info!(
+                    run_id = %ctx_spawn.run_id,
+                    "Wallet bootstrap: bounded DEX verification background task finished"
+                );
+            });
+        }
+    }
 
     // 4b) Cold-path inventory: count wallet-held mints where [`LivePoolCache::base_mint_has_any_ready_pool`]
     // is true (explicit Ready merge per slice: PumpSwap, PumpFun bonding, Raydium CPMM, Meteora CPMM,
@@ -4572,6 +4630,7 @@ async fn main() -> Result<()> {
         tracked_wallet_mint_decimals: parking_lot::RwLock::new(std::collections::HashMap::new()),
         execution_results_deduper: parking_lot::Mutex::new(ExecutionResultDeduper::default()),
         last_emitted_curve_progress: parking_lot::RwLock::new(std::collections::HashMap::new()),
+        pump_amm_dex: parking_lot::RwLock::new(None),
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -5323,6 +5382,7 @@ async fn run_geyser_loop(
         ctx.live_pool_cache.clone(),
         true, // allow_rpc_on_miss: Cold Path Discovery
     ));
+    *ctx.pump_amm_dex.write() = Some(Arc::clone(&pump_amm_dex));
 
     // === P0: Wallet Balance Snapshot (Position Reconciliation) ===
     // Bootstrap wallet state at startup (max 1 RPC roundtrip) using known mints from JetStream.
@@ -5335,7 +5395,7 @@ async fn run_geyser_loop(
         if let Ok(wallet_pubkey) = Pubkey::from_str(&wallet_pubkey_str) {
             info!(wallet = %wallet_pubkey, "📸 Publishing wallet balance snapshot for position reconciliation");
             if let Err(e) =
-                publish_wallet_snapshot(&ctx, &rpc, pump_amm_dex.as_ref(), &wallet_pubkey, false)
+                publish_wallet_snapshot(&ctx, &rpc, &wallet_pubkey, false, wallet_snapshot_only)
                     .await
             {
                 warn!(error = %e, "Failed to publish wallet snapshot (continuing anyway)");

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4275,24 +4275,22 @@ async fn publish_wallet_snapshot(
     if !is_periodic {
         let mints_clone = mints_in_wallet.clone();
         if dex_verify_blocking {
-            match ctx.pump_amm_dex.read().as_ref() {
-                Some(dex) => {
-                    run_bounded_wallet_dex_bootstrap_verify(
-                        ctx.as_ref(),
-                        rpc,
-                        dex.as_ref(),
-                        &mints_clone,
-                        ctx.run_id.as_str(),
-                        false,
-                    )
-                    .await;
-                }
-                None => {
-                    warn!(
-                        run_id = %ctx.run_id,
-                        "Wallet bootstrap DEX verify skipped: pump_amm_dex not initialized"
-                    );
-                }
+            let dex_opt = ctx.pump_amm_dex.read().clone();
+            if let Some(dex) = dex_opt {
+                run_bounded_wallet_dex_bootstrap_verify(
+                    ctx.as_ref(),
+                    rpc,
+                    dex.as_ref(),
+                    &mints_clone,
+                    ctx.run_id.as_str(),
+                    false,
+                )
+                .await;
+            } else {
+                warn!(
+                    run_id = %ctx.run_id,
+                    "Wallet bootstrap DEX verify skipped: pump_amm_dex not initialized"
+                );
             }
         } else {
             let ctx_spawn = Arc::clone(ctx);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`market-data` could exceed `WatchdogSec` during startup because `publish_wallet_snapshot` awaited `run_bounded_wallet_dex_bootstrap_verify` (serial cold-path Ensure*/RPC) before the Geyser main loop ran and `sd_notify(WATCHDOG)` fired on the activity interval.

## Changes

- After `WalletSnapshotComplete` and related snapshot work, **bounded DEX verification** for normal startup runs in a **`tokio::spawn` background task** so the service reaches the main loop quickly.
- **`PumpFunAmmDex`** is stored on `MarketDataContext` (`pump_amm_dex: RwLock<Option<Arc<...>>>`) and set in `run_geyser_loop` before the wallet snapshot so the spawned task uses the same cold-path instance as ControlRequest handlers.
- **`wallet_snapshot_only`**: verification remains **blocking** (`dex_verify_blocking=true`) so one-shot mode still completes work before exit.
- **Logs**: info on background start/finish; warn if `pump_amm_dex` were missing (defensive).

## STOP-CHECK

1. **I-7 Hot Path RPC**: No new RPC; only moved existing cold-path work off the blocking startup path.
2. **Pattern**: Same `allow_rpc_on_miss` PumpFunAmmDex as before; no execution-engine changes.
3. **Architecture**: `market-data` only; keyless unchanged.
4. **I-9 Simulation**: N/A (no TX send).
5. **Eval isolation**: No eval repo access.

## Tests

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`
- `cargo test --features test_helpers --quiet`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c042c6a2-902b-4421-95da-aeafbf7b225b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c042c6a2-902b-4421-95da-aeafbf7b225b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

