### PR TITLE
fix(execution-engine): PumpSwap 6013 triggert force_refresh Recovery-Gate

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -159,7 +159,7 @@ fn pump_amm_pool_market_hint_pk(intent: &TradeIntent, ctx: &ExecutionContext) ->
 }
 
 /// Stale/wrong PumpSwap `pool_accounts` (e.g. creator vault, protocol fee recipient) → simulation
-/// Overflow / Custom(6023) / Custom(6013 InvalidProtocolFeeRecipient) / 0x1787.
+/// Overflow / Custom(6023) / Custom(6013 InvalidProtocolFeeRecipient) / 0x1787 / 0x177D.
 /// Must stay aligned with the PumpSwap cold-path recovery branch (`is_cold_path_recovery_sell` + `dex=pump_amm`).
 #[inline]
 fn is_pump_amm_structural_sim_error(error_code: Option<&str>) -> bool {
@@ -170,6 +170,7 @@ fn is_pump_amm_structural_sim_error(error_code: Option<&str>) -> bool {
                 || e.contains("InvalidProtocolFeeRecipient")
                 || e.contains("Overflow")
                 || e.contains("0x1787")
+                || e.contains("0x177D")
         })
         .unwrap_or(false)
 }
@@ -11191,6 +11192,7 @@ mod execution_engine_tests {
         )));
         assert!(is_pump_amm_structural_sim_error(Some("Overflow")));
         assert!(is_pump_amm_structural_sim_error(Some("0x1787")));
+        assert!(is_pump_amm_structural_sim_error(Some("0x177D")));
         assert!(!is_pump_amm_structural_sim_error(Some("Custom(6005)")));
         assert!(!is_pump_amm_structural_sim_error(None));
     }

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -158,12 +158,19 @@ fn pump_amm_pool_market_hint_pk(intent: &TradeIntent, ctx: &ExecutionContext) ->
     pump_amm_pool_market_hint_merge(intent_pool, cache_pool)
 }
 
-/// Stale/wrong PumpSwap `pool_accounts` (e.g. creator vault) → simulation Overflow / Custom(6023) / 0x1787.
+/// Stale/wrong PumpSwap `pool_accounts` (e.g. creator vault, protocol fee recipient) → simulation
+/// Overflow / Custom(6023) / Custom(6013 InvalidProtocolFeeRecipient) / 0x1787.
 /// Must stay aligned with the PumpSwap cold-path recovery branch (`is_cold_path_recovery_sell` + `dex=pump_amm`).
 #[inline]
 fn is_pump_amm_structural_sim_error(error_code: Option<&str>) -> bool {
     error_code
-        .map(|e| e.contains("6023") || e.contains("Overflow") || e.contains("0x1787"))
+        .map(|e| {
+            e.contains("6023")
+                || e.contains("6013")
+                || e.contains("InvalidProtocolFeeRecipient")
+                || e.contains("Overflow")
+                || e.contains("0x1787")
+        })
         .unwrap_or(false)
 }
 
@@ -9120,7 +9127,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                         mint = %intent.resources.input_mint,
                         pool_hint = ?pool_hint_str,
                         sim_error = ?sim_result.error_code,
-                        "PumpSwap regular SELL: simulation structural error (6023/Overflow family); triggering async non-blocking EnsurePumpAmmPoolAccounts force_refresh to market-data (no wait, no retry this intent)"
+                        "PumpSwap regular SELL: simulation structural error (6013/6023/Overflow family); triggering async non-blocking EnsurePumpAmmPoolAccounts force_refresh to market-data (no wait, no retry this intent)"
                     );
                     if let Some(ref nats) = ctx.nats {
                         ExecutionContext::fire_pump_amm_pool_accounts_refresh_async(
@@ -9156,7 +9163,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
             }
         }
 
-        // PumpSwap SELL: stale/wrong creator-vault accounts in cached pool_accounts → Overflow Custom(6023).
+        // PumpSwap SELL: stale/wrong pool_accounts (creator vault, protocol fee recipient, …) → e.g. Custom(6023), Custom(6013).
         // Cold-path recovery: one EnsurePumpAmmPoolAccounts with force_refresh (RPC market parse).
         // Gate: `is_cold_path_recovery_sell` — liquidation, kill-switch, or explicit `sell_all=true` (not general momentum SELLs).
         if !pump_amm_recovery_attempted
@@ -9201,7 +9208,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                             warn!(
                                 intent_id = %intent.intent_id,
                                 pool = %pool_pk,
-                                "PumpSwap cold-path recovery: simulation 6023/Overflow — force-refresh pool_accounts (market-data RPC), rebuilding tx (one retry)"
+                                "PumpSwap cold-path recovery: simulation structural (6013/6023/Overflow family) — force-refresh pool_accounts (market-data RPC), rebuilding tx (one retry)"
                             );
                             continue;
                         }
@@ -11175,6 +11182,12 @@ mod execution_engine_tests {
     fn pump_amm_structural_sim_error_matches_cold_path_recovery_pattern() {
         assert!(is_pump_amm_structural_sim_error(Some(
             "Simulation failed: Custom(6023)"
+        )));
+        assert!(is_pump_amm_structural_sim_error(Some(
+            "Simulation failed: Custom(6013)"
+        )));
+        assert!(is_pump_amm_structural_sim_error(Some(
+            "InvalidProtocolFeeRecipient"
         )));
         assert!(is_pump_amm_structural_sim_error(Some("Overflow")));
         assert!(is_pump_amm_structural_sim_error(Some("0x1787")));

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -159,7 +159,7 @@ fn pump_amm_pool_market_hint_pk(intent: &TradeIntent, ctx: &ExecutionContext) ->
 }
 
 /// Stale/wrong PumpSwap `pool_accounts` (e.g. creator vault, protocol fee recipient) → simulation
-/// Overflow / Custom(6023) / Custom(6013 InvalidProtocolFeeRecipient) / 0x1787 / 0x177D.
+/// Overflow / Custom(6023) / Custom(6013 InvalidProtocolFeeRecipient) / 0x1787 / 0x177d.
 /// Must stay aligned with the PumpSwap cold-path recovery branch (`is_cold_path_recovery_sell` + `dex=pump_amm`).
 #[inline]
 fn is_pump_amm_structural_sim_error(error_code: Option<&str>) -> bool {
@@ -170,6 +170,7 @@ fn is_pump_amm_structural_sim_error(error_code: Option<&str>) -> bool {
                 || e.contains("InvalidProtocolFeeRecipient")
                 || e.contains("Overflow")
                 || e.contains("0x1787")
+                || e.contains("0x177d")
                 || e.contains("0x177D")
         })
         .unwrap_or(false)
@@ -11192,6 +11193,7 @@ mod execution_engine_tests {
         )));
         assert!(is_pump_amm_structural_sim_error(Some("Overflow")));
         assert!(is_pump_amm_structural_sim_error(Some("0x1787")));
+        assert!(is_pump_amm_structural_sim_error(Some("0x177d")));
         assert!(is_pump_amm_structural_sim_error(Some("0x177D")));
         assert!(!is_pump_amm_structural_sim_error(Some("Custom(6005)")));
         assert!(!is_pump_amm_structural_sim_error(None));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Kurzbeschreibung

`Custom(6013)` / `InvalidProtocolFeeRecipient` wird im PumpSwap-Recovery-Gate wie die übrigen strukturellen Simulationsfehler behandelt. Dadurch greifen derselbe Hot-Path-Async-Refresh und der Cold-Path-`request_discovery_and_wait(..., force_refresh=true)`-Pfad wie bei 6023/Overflow/0x1787.

## Änderungen

- `is_pump_amm_structural_sim_error`: zusätzlich `6013` und `InvalidProtocolFeeRecipient`
- Kommentare und Log-Texte angepasst (keine irreführende Nennung nur „6023/Overflow“)
- Regressionstest `pump_amm_structural_sim_error_matches_cold_path_recovery_pattern` erweitert

## STOP-CHECK (AGENTS.md)

1. **I-7 Hot-Path RPC:** Keine neuen RPC-Calls; nur String-Matching im bestehenden Gate; Hot-Path bleibt async NATS-Publish.
2. **Pattern:** Gleicher Helper wie zuvor, nur erweiterte Fehlerfamilie.
3. **Scope:** Nur `src/bin/execution_engine.rs`.
4. **I-9 Simulation-Gate:** Unverändert — weiterhin nur Recovery → Rebuild → erneute Simulation.
5. **Eval-Isolation:** Keine Eval-Tests gelesen.

## Tests

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`
- `cargo test --features test_helpers --quiet`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-240c97d7-9bf4-4b58-9086-5e427d19f7fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-240c97d7-9bf4-4b58-9086-5e427d19f7fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

