### PR TITLE
Fix PumpSwap force-refresh extended sell readiness

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -5135,6 +5135,8 @@ async fn handle_ensure_pump_amm_pool_accounts(
                 third_merged,
             );
             ctx.live_pool_cache
+                .set_pump_amm_sell_layout_ready(&pool_address, sell_layout_ready);
+            ctx.live_pool_cache
                 .merge_pump_amm_pool_accounts_readiness(pool_address, dex_readiness);
 
             // Publish JetStream PoolCacheUpdate (authoritative SSOT).

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -252,6 +252,45 @@ fn pump_amm_sell_layout_publish_state(
     (sell_layout_ready, dex_readiness)
 }
 
+/// Resolve PumpSwap SELL-layout state for the EnsurePumpAmmPoolAccounts publish path.
+///
+/// `force_refresh=true` is authoritative and must be able to override stale monotonic cache hints.
+fn pump_amm_sell_layout_state_for_ensure_publish(
+    force_refresh: bool,
+    cached_requires_extended: bool,
+    cached_third_meta: Option<Pubkey>,
+    refresh_requires_extended: bool,
+    refresh_third_meta: Option<Pubkey>,
+    refresh_layout_ready: bool,
+) -> (bool, Option<Pubkey>, bool, DexPoolReadiness) {
+    let (effective_requires_extended, effective_third_meta, base_layout_ready) = if force_refresh {
+        (
+            refresh_requires_extended,
+            refresh_third_meta.filter(|p| *p != Pubkey::default()),
+            refresh_layout_ready,
+        )
+    } else {
+        (
+            cached_requires_extended || refresh_requires_extended,
+            refresh_third_meta
+                .or(cached_third_meta)
+                .filter(|p| *p != Pubkey::default()),
+            refresh_layout_ready,
+        )
+    };
+    let (sell_layout_ready, dex_readiness) = pump_amm_sell_layout_publish_state(
+        effective_requires_extended,
+        effective_third_meta,
+        base_layout_ready,
+    );
+    (
+        effective_requires_extended,
+        effective_third_meta,
+        sell_layout_ready,
+        dex_readiness,
+    )
+}
+
 /// Market data configuration (hot-reloadable via NATS)
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
@@ -5072,15 +5111,15 @@ async fn handle_ensure_pump_amm_pool_accounts(
             let (ext_flag_cache, ext_third_cache) = ctx
                 .live_pool_cache
                 .pump_amm_sell_extended_layout(&pool_address);
-            let sell_flag_merged = ext_flag_cache || sell_cashback_remaining;
-            let third_merged = sell_cashback_third
-                .or(ext_third_cache)
-                .filter(|p| *p != Pubkey::default());
-            let (sell_layout_ready, dex_readiness) = pump_amm_sell_layout_publish_state(
-                sell_flag_merged,
-                third_merged,
-                sell_layout_ready_from_refresh,
-            );
+            let (sell_flag_merged, third_merged, sell_layout_ready, dex_readiness) =
+                pump_amm_sell_layout_state_for_ensure_publish(
+                    force_refresh,
+                    ext_flag_cache,
+                    ext_third_cache,
+                    sell_cashback_remaining,
+                    sell_cashback_third,
+                    sell_layout_ready_from_refresh,
+                );
 
             let (base_reserve, quote_reserve) =
                 match resolve_pump_amm_reserves_for_ensure_discovery(
@@ -5129,11 +5168,19 @@ async fn handle_ensure_pump_amm_pool_accounts(
                 creator: creator_opt,
             });
             ctx.live_pool_cache.upsert(pool_address, state, 0);
-            ctx.live_pool_cache.merge_pump_amm_sell_extended_layout(
-                &pool_address,
-                sell_flag_merged,
-                third_merged,
-            );
+            if force_refresh {
+                ctx.live_pool_cache.set_pump_amm_sell_layout_authoritative(
+                    &pool_address,
+                    sell_flag_merged,
+                    third_merged,
+                );
+            } else {
+                ctx.live_pool_cache.merge_pump_amm_sell_extended_layout(
+                    &pool_address,
+                    sell_flag_merged,
+                    third_merged,
+                );
+            }
             ctx.live_pool_cache
                 .set_pump_amm_sell_layout_ready(&pool_address, sell_layout_ready);
             ctx.live_pool_cache
@@ -5166,6 +5213,12 @@ async fn handle_ensure_pump_amm_pool_accounts(
                     "pump_amm_sell_layout_ready".to_string(),
                     sell_layout_ready.to_string(),
                 );
+                if force_refresh {
+                    meta.insert(
+                        "pump_amm_sell_layout_authoritative".to_string(),
+                        "true".to_string(),
+                    );
+                }
                 if let Some(pk) = third_merged {
                     meta.insert(
                         "pump_amm_sell_cashback_third_meta".to_string(),
@@ -9448,6 +9501,34 @@ mod discovery_tests {
             sell_layout_ready,
             "extended SELL with authoritative third meta must be marked ready"
         );
+        assert_eq!(dex_readiness, DexPoolReadiness::Ready);
+    }
+
+    #[test]
+    fn test_pump_amm_force_refresh_base_overrides_stale_extended_cache_flag() {
+        let stale_third = Pubkey::new_unique();
+        let (
+            effective_requires_extended,
+            effective_third_meta,
+            sell_layout_ready,
+            dex_readiness,
+        ) = pump_amm_sell_layout_state_for_ensure_publish(
+            true,
+            true,
+            Some(stale_third),
+            false,
+            None,
+            true,
+        );
+        assert!(
+            !effective_requires_extended,
+            "authoritative force_refresh base result must override stale extended cache flag"
+        );
+        assert!(
+            effective_third_meta.is_none(),
+            "authoritative base result must discard stale third meta"
+        );
+        assert!(sell_layout_ready, "base layout proven by force_refresh stays ready");
         assert_eq!(dex_readiness, DexPoolReadiness::Ready);
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -228,6 +228,30 @@ fn raydium_cpmm_readiness_for_pool_cache_update(s: &RaydiumCpmmState) -> DexPool
     }
 }
 
+/// PumpSwap SELL-layout contract for JetStream / SLAVE SSOT.
+///
+/// - Base-only SELL stays ready as long as the underlying refresh/observation says the base layout is usable.
+/// - Extended SELL is ready only when the observed third readonly meta is authoritatively known.
+fn pump_amm_sell_layout_publish_state(
+    sell_requires_extended: bool,
+    sell_cashback_third_meta: Option<Pubkey>,
+    base_layout_ready: bool,
+) -> (bool, DexPoolReadiness) {
+    let sell_layout_ready = if sell_requires_extended {
+        sell_cashback_third_meta
+            .filter(|p| *p != Pubkey::default())
+            .is_some()
+    } else {
+        base_layout_ready
+    };
+    let dex_readiness = if sell_layout_ready {
+        DexPoolReadiness::Ready
+    } else {
+        DexPoolReadiness::Partial
+    };
+    (sell_layout_ready, dex_readiness)
+}
+
 /// Market data configuration (hot-reloadable via NATS)
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
@@ -5052,16 +5076,11 @@ async fn handle_ensure_pump_amm_pool_accounts(
             let third_merged = sell_cashback_third
                 .or(ext_third_cache)
                 .filter(|p| *p != Pubkey::default());
-            let sell_layout_ready = if sell_flag_merged {
-                third_merged.is_some()
-            } else {
-                sell_layout_ready_from_refresh
-            };
-            let dex_readiness = if sell_layout_ready {
-                DexPoolReadiness::Ready
-            } else {
-                DexPoolReadiness::Partial
-            };
+            let (sell_layout_ready, dex_readiness) = pump_amm_sell_layout_publish_state(
+                sell_flag_merged,
+                third_merged,
+                sell_layout_ready_from_refresh,
+            );
 
             let (base_reserve, quote_reserve) =
                 match resolve_pump_amm_reserves_for_ensure_discovery(
@@ -8188,25 +8207,31 @@ async fn run_geyser_loop(
                                 ctx.live_pool_cache.pump_amm_sell_extended_layout(pool_address);
                             let merged_flag =
                                 ext_flag || *pump_amm_sell_requires_cashback_remaining;
+                            let merged_third = ext_third
+                                .or(*pump_amm_sell_cashback_third_meta)
+                                .filter(|p| *p != Pubkey::default());
+                            let (sell_layout_ready, dex_readiness) =
+                                pump_amm_sell_layout_publish_state(
+                                    merged_flag,
+                                    merged_third,
+                                    true,
+                                );
                             meta.insert(
                                 "pump_amm_sell_cashback_remaining".to_string(),
                                 merged_flag.to_string(),
                             );
                             meta.insert(
                                 "pump_amm_sell_layout_ready".to_string(),
-                                "true".to_string(),
+                                sell_layout_ready.to_string(),
                             );
-                            if let Some(pk) = ext_third
-                                .or(*pump_amm_sell_cashback_third_meta)
-                                .filter(|p| *p != Pubkey::default())
-                            {
+                            if let Some(pk) = merged_third {
                                 meta.insert(
                                     "pump_amm_sell_cashback_third_meta".to_string(),
                                     pk.to_string(),
                                 );
                             }
                             pool_update.metadata = Some(meta);
-                            pool_update.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+                            pool_update.set_dex_readiness_in_metadata(dex_readiness);
                             let subject = pool_subject(&pool_address.to_string());
                             if let Err(e) = nats.jetstream_publish(&subject, &pool_update).await {
                                 warn!(error = %e, "FIX-33: Failed to publish pump_amm pool_accounts PoolCacheUpdate to JetStream (trade)");
@@ -9399,6 +9424,28 @@ mod discovery_tests {
             raydium_cpmm_readiness_for_pool_cache_update(&s),
             DexPoolReadiness::Observed
         );
+    }
+
+    #[test]
+    fn test_pump_amm_trade_publish_extended_without_third_meta_is_partial() {
+        let (sell_layout_ready, dex_readiness) =
+            pump_amm_sell_layout_publish_state(true, None, true);
+        assert!(
+            !sell_layout_ready,
+            "extended SELL without authoritative third meta must not be marked ready"
+        );
+        assert_eq!(dex_readiness, DexPoolReadiness::Partial);
+    }
+
+    #[test]
+    fn test_pump_amm_trade_publish_extended_with_third_meta_is_ready() {
+        let (sell_layout_ready, dex_readiness) =
+            pump_amm_sell_layout_publish_state(true, Some(Pubkey::new_unique()), true);
+        assert!(
+            sell_layout_ready,
+            "extended SELL with authoritative third meta must be marked ready"
+        );
+        assert_eq!(dex_readiness, DexPoolReadiness::Ready);
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -5297,14 +5297,14 @@ async fn handle_ensure_pump_amm_pool_accounts(
                         );
                     }
                     (true, true, false) => {
-                    warn!(
-                        request_id = %request_id,
-                        base_mint = %base_mint_str,
-                        pool_address = %pool_address_str,
-                        sell_cashback_remaining = sell_flag_merged,
-                        sell_cashback_third_meta = ?third_merged,
-                        "I-24d Discovery: force_refresh result published as Partial (authoritative SELL layout unresolved)"
-                    );
+                        warn!(
+                            request_id = %request_id,
+                            base_mint = %base_mint_str,
+                            pool_address = %pool_address_str,
+                            sell_cashback_remaining = sell_flag_merged,
+                            sell_cashback_third_meta = ?third_merged,
+                            "I-24d Discovery: force_refresh result published as Partial (authoritative SELL layout unresolved)"
+                        );
                     }
                     (true, false, false) => {
                         info!(
@@ -9234,16 +9234,14 @@ mod discovery_tests {
 
     #[test]
     fn test_pump_amm_non_force_refresh_partial_publish_keeps_ok_response() {
-        let (status, message) =
-            pump_amm_control_response_for_ensure_publish(false, true, false);
+        let (status, message) = pump_amm_control_response_for_ensure_publish(false, true, false);
         assert_eq!(status, ControlResponseStatus::Ok);
         assert!(message.is_none());
     }
 
     #[test]
     fn test_pump_amm_force_refresh_partial_publish_returns_authoritative_error() {
-        let (status, message) =
-            pump_amm_control_response_for_ensure_publish(true, true, false);
+        let (status, message) = pump_amm_control_response_for_ensure_publish(true, true, false);
         assert_eq!(status, ControlResponseStatus::Error);
         assert_eq!(
             message.as_deref(),

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -8182,9 +8182,24 @@ async fn run_geyser_loop(
                     // when the parsed Geyser state has empty pool_accounts.
                     if pool_accounts.len() >= 14 {
                         ctx.live_pool_cache.set_pump_amm_pool_accounts(pool_address, pool_accounts.clone());
+                        let (ext_flag, ext_third) =
+                            ctx.live_pool_cache.pump_amm_sell_extended_layout(pool_address);
+                        let merged_flag =
+                            ext_flag || *pump_amm_sell_requires_cashback_remaining;
+                        let merged_third = ext_third
+                            .or(*pump_amm_sell_cashback_third_meta)
+                            .filter(|p| *p != Pubkey::default());
+                        let (sell_layout_ready, dex_readiness) =
+                            pump_amm_sell_layout_publish_state(
+                                merged_flag,
+                                merged_third,
+                                true,
+                            );
+                        ctx.live_pool_cache
+                            .set_pump_amm_sell_layout_ready(pool_address, sell_layout_ready);
                         ctx.live_pool_cache.merge_pump_amm_pool_accounts_readiness(
                             *pool_address,
-                            DexPoolReadiness::Ready,
+                            dex_readiness,
                         );
 
                         // FIX-33: Persist pool_accounts to JetStream so bootstrap recovers them after restart.
@@ -8205,19 +8220,6 @@ async fn run_geyser_loop(
                             let mut meta = std::collections::HashMap::new();
                             let accounts_str: Vec<String> = pool_accounts.iter().map(|p| p.to_string()).collect();
                             meta.insert("pool_accounts".to_string(), accounts_str.join(","));
-                            let (ext_flag, ext_third) =
-                                ctx.live_pool_cache.pump_amm_sell_extended_layout(pool_address);
-                            let merged_flag =
-                                ext_flag || *pump_amm_sell_requires_cashback_remaining;
-                            let merged_third = ext_third
-                                .or(*pump_amm_sell_cashback_third_meta)
-                                .filter(|p| *p != Pubkey::default());
-                            let (sell_layout_ready, dex_readiness) =
-                                pump_amm_sell_layout_publish_state(
-                                    merged_flag,
-                                    merged_third,
-                                    true,
-                                );
                             meta.insert(
                                 "pump_amm_sell_cashback_remaining".to_string(),
                                 merged_flag.to_string(),

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -9507,19 +9507,15 @@ mod discovery_tests {
     #[test]
     fn test_pump_amm_force_refresh_base_overrides_stale_extended_cache_flag() {
         let stale_third = Pubkey::new_unique();
-        let (
-            effective_requires_extended,
-            effective_third_meta,
-            sell_layout_ready,
-            dex_readiness,
-        ) = pump_amm_sell_layout_state_for_ensure_publish(
-            true,
-            true,
-            Some(stale_third),
-            false,
-            None,
-            true,
-        );
+        let (effective_requires_extended, effective_third_meta, sell_layout_ready, dex_readiness) =
+            pump_amm_sell_layout_state_for_ensure_publish(
+                true,
+                true,
+                Some(stale_third),
+                false,
+                None,
+                true,
+            );
         assert!(
             !effective_requires_extended,
             "authoritative force_refresh base result must override stale extended cache flag"
@@ -9528,7 +9524,10 @@ mod discovery_tests {
             effective_third_meta.is_none(),
             "authoritative base result must discard stale third meta"
         );
-        assert!(sell_layout_ready, "base layout proven by force_refresh stays ready");
+        assert!(
+            sell_layout_ready,
+            "base layout proven by force_refresh stays ready"
+        );
         assert_eq!(dex_readiness, DexPoolReadiness::Ready);
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -5137,7 +5137,7 @@ async fn handle_ensure_pump_amm_pool_accounts(
             ctx.live_pool_cache
                 .set_pump_amm_sell_layout_ready(&pool_address, sell_layout_ready);
             ctx.live_pool_cache
-                .merge_pump_amm_pool_accounts_readiness(pool_address, dex_readiness);
+                .set_pump_amm_pool_accounts_readiness_authoritative(pool_address, dex_readiness);
 
             // Publish JetStream PoolCacheUpdate (authoritative SSOT).
             // Reply Ok ONLY when JetStream write succeeds (I-24a).
@@ -8184,23 +8184,22 @@ async fn run_geyser_loop(
                         ctx.live_pool_cache.set_pump_amm_pool_accounts(pool_address, pool_accounts.clone());
                         let (ext_flag, ext_third) =
                             ctx.live_pool_cache.pump_amm_sell_extended_layout(pool_address);
-                        let merged_flag =
-                            ext_flag || *pump_amm_sell_requires_cashback_remaining;
+                        let merged_flag = ext_flag || *pump_amm_sell_requires_cashback_remaining;
                         let merged_third = ext_third
                             .or(*pump_amm_sell_cashback_third_meta)
                             .filter(|p| *p != Pubkey::default());
-                        let (sell_layout_ready, dex_readiness) =
-                            pump_amm_sell_layout_publish_state(
-                                merged_flag,
-                                merged_third,
-                                true,
-                            );
+                        let (sell_layout_ready, dex_readiness) = pump_amm_sell_layout_publish_state(
+                            merged_flag,
+                            merged_third,
+                            true,
+                        );
                         ctx.live_pool_cache
                             .set_pump_amm_sell_layout_ready(pool_address, sell_layout_ready);
-                        ctx.live_pool_cache.merge_pump_amm_pool_accounts_readiness(
-                            *pool_address,
-                            dex_readiness,
-                        );
+                        ctx.live_pool_cache
+                            .set_pump_amm_pool_accounts_readiness_authoritative(
+                                *pool_address,
+                                dex_readiness,
+                            );
 
                         // FIX-33: Persist pool_accounts to JetStream so bootstrap recovers them after restart.
                         if let Some(ref nats) = ctx.nats {

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -291,6 +291,30 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
     )
 }
 
+/// Control-response contract for PumpSwap EnsurePumpAmmPoolAccounts.
+///
+/// Only the authoritative `force_refresh=true` path may turn a successful JetStream publish into an
+/// error when the resolved SELL layout is still not ready.
+fn pump_amm_control_response_for_ensure_publish(
+    force_refresh: bool,
+    jetstream_ok: bool,
+    sell_layout_ready: bool,
+) -> (ControlResponseStatus, Option<String>) {
+    if !jetstream_ok {
+        return (
+            ControlResponseStatus::Error,
+            Some("JetStream publish failed".to_string()),
+        );
+    }
+    if force_refresh && !sell_layout_ready {
+        return (
+            ControlResponseStatus::Error,
+            Some("authoritative PumpSwap SELL layout unresolved after force_refresh".to_string()),
+        );
+    }
+    (ControlResponseStatus::Ok, None)
+}
+
 /// Market data configuration (hot-reloadable via NATS)
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
@@ -5256,17 +5280,23 @@ async fn handle_ensure_pump_amm_pool_accounts(
             };
 
             if let Some(ref nats) = ctx.nats {
-                let (status, message) = if jetstream_ok && sell_layout_ready {
-                    info!(
-                        request_id = %request_id,
-                        base_mint = %base_mint_str,
-                        pool_address = %pool_address_str,
-                        rpc_global_scan = "no",
-                        control_response = "pending_publish",
-                        "I-24d Discovery: terminal outcome ok"
-                    );
-                    (ControlResponseStatus::Ok, None)
-                } else if jetstream_ok {
+                let (status, message) = pump_amm_control_response_for_ensure_publish(
+                    force_refresh,
+                    jetstream_ok,
+                    sell_layout_ready,
+                );
+                match (jetstream_ok, force_refresh, sell_layout_ready) {
+                    (true, _, true) => {
+                        info!(
+                            request_id = %request_id,
+                            base_mint = %base_mint_str,
+                            pool_address = %pool_address_str,
+                            rpc_global_scan = "no",
+                            control_response = "pending_publish",
+                            "I-24d Discovery: terminal outcome ok"
+                        );
+                    }
+                    (true, true, false) => {
                     warn!(
                         request_id = %request_id,
                         base_mint = %base_mint_str,
@@ -5275,24 +5305,25 @@ async fn handle_ensure_pump_amm_pool_accounts(
                         sell_cashback_third_meta = ?third_merged,
                         "I-24d Discovery: force_refresh result published as Partial (authoritative SELL layout unresolved)"
                     );
-                    (
-                        ControlResponseStatus::Error,
-                        Some(
-                            "authoritative PumpSwap SELL layout unresolved after force_refresh"
-                                .to_string(),
-                        ),
-                    )
-                } else {
-                    warn!(
-                        request_id = %request_id,
-                        base_mint = %base_mint_str,
-                        "I-24d Discovery: terminal outcome error (JetStream publish failed)"
-                    );
-                    (
-                        ControlResponseStatus::Error,
-                        Some("JetStream publish failed".to_string()),
-                    )
-                };
+                    }
+                    (true, false, false) => {
+                        info!(
+                            request_id = %request_id,
+                            base_mint = %base_mint_str,
+                            pool_address = %pool_address_str,
+                            sell_cashback_remaining = sell_flag_merged,
+                            sell_cashback_third_meta = ?third_merged,
+                            "I-24d Discovery: terminal outcome ok (non-force-refresh publish may remain Partial)"
+                        );
+                    }
+                    (false, _, _) => {
+                        warn!(
+                            request_id = %request_id,
+                            base_mint = %base_mint_str,
+                            "I-24d Discovery: terminal outcome error (JetStream publish failed)"
+                        );
+                    }
+                }
                 publish_control_response(
                     nats,
                     &ctx.run_id,
@@ -9198,6 +9229,25 @@ mod discovery_tests {
         assert_eq!(
             discovery_response_status_for_jetstream(false),
             ControlResponseStatus::Error
+        );
+    }
+
+    #[test]
+    fn test_pump_amm_non_force_refresh_partial_publish_keeps_ok_response() {
+        let (status, message) =
+            pump_amm_control_response_for_ensure_publish(false, true, false);
+        assert_eq!(status, ControlResponseStatus::Ok);
+        assert!(message.is_none());
+    }
+
+    #[test]
+    fn test_pump_amm_force_refresh_partial_publish_returns_authoritative_error() {
+        let (status, message) =
+            pump_amm_control_response_for_ensure_publish(true, true, false);
+        assert_eq!(status, ControlResponseStatus::Error);
+        assert_eq!(
+            message.as_deref(),
+            Some("authoritative PumpSwap SELL layout unresolved after force_refresh")
         );
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -5017,6 +5017,7 @@ async fn handle_ensure_pump_amm_pool_accounts(
         Ok(Some(wrapped)) if wrapped.accounts.len() >= 14 => {
             let sell_cashback_remaining = wrapped.sell_requires_cashback_remaining;
             let sell_cashback_third = wrapped.sell_cashback_third_meta;
+            let sell_layout_ready_from_refresh = wrapped.sell_layout_ready;
             let accounts = wrapped.accounts;
             let diag = wrapped.diagnostic;
             log_pump_amm_scope44_pool_accounts_diag(
@@ -5051,6 +5052,16 @@ async fn handle_ensure_pump_amm_pool_accounts(
             let third_merged = sell_cashback_third
                 .or(ext_third_cache)
                 .filter(|p| *p != Pubkey::default());
+            let sell_layout_ready = if sell_flag_merged {
+                third_merged.is_some()
+            } else {
+                sell_layout_ready_from_refresh
+            };
+            let dex_readiness = if sell_layout_ready {
+                DexPoolReadiness::Ready
+            } else {
+                DexPoolReadiness::Partial
+            };
 
             let (base_reserve, quote_reserve) =
                 match resolve_pump_amm_reserves_for_ensure_discovery(
@@ -5105,7 +5116,7 @@ async fn handle_ensure_pump_amm_pool_accounts(
                 third_merged,
             );
             ctx.live_pool_cache
-                .merge_pump_amm_pool_accounts_readiness(pool_address, DexPoolReadiness::Ready);
+                .merge_pump_amm_pool_accounts_readiness(pool_address, dex_readiness);
 
             // Publish JetStream PoolCacheUpdate (authoritative SSOT).
             // Reply Ok ONLY when JetStream write succeeds (I-24a).
@@ -5130,6 +5141,10 @@ async fn handle_ensure_pump_amm_pool_accounts(
                     "pump_amm_sell_cashback_remaining".to_string(),
                     sell_flag_merged.to_string(),
                 );
+                meta.insert(
+                    "pump_amm_sell_layout_ready".to_string(),
+                    sell_layout_ready.to_string(),
+                );
                 if let Some(pk) = third_merged {
                     meta.insert(
                         "pump_amm_sell_cashback_third_meta".to_string(),
@@ -5140,7 +5155,7 @@ async fn handle_ensure_pump_amm_pool_accounts(
                     meta.insert("creator".to_string(), creator.to_string());
                 }
                 pool_update.metadata = Some(meta);
-                pool_update.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+                pool_update.set_dex_readiness_in_metadata(dex_readiness);
                 let subject = pool_subject(&pool_address_str);
                 match nats.jetstream_publish(&subject, &pool_update).await {
                     Ok(true) => {
@@ -5167,7 +5182,7 @@ async fn handle_ensure_pump_amm_pool_accounts(
             };
 
             if let Some(ref nats) = ctx.nats {
-                let (status, message) = if jetstream_ok {
+                let (status, message) = if jetstream_ok && sell_layout_ready {
                     info!(
                         request_id = %request_id,
                         base_mint = %base_mint_str,
@@ -5177,6 +5192,22 @@ async fn handle_ensure_pump_amm_pool_accounts(
                         "I-24d Discovery: terminal outcome ok"
                     );
                     (ControlResponseStatus::Ok, None)
+                } else if jetstream_ok {
+                    warn!(
+                        request_id = %request_id,
+                        base_mint = %base_mint_str,
+                        pool_address = %pool_address_str,
+                        sell_cashback_remaining = sell_flag_merged,
+                        sell_cashback_third_meta = ?third_merged,
+                        "I-24d Discovery: force_refresh result published as Partial (authoritative SELL layout unresolved)"
+                    );
+                    (
+                        ControlResponseStatus::Error,
+                        Some(
+                            "authoritative PumpSwap SELL layout unresolved after force_refresh"
+                                .to_string(),
+                        ),
+                    )
                 } else {
                     warn!(
                         request_id = %request_id,
@@ -8160,6 +8191,10 @@ async fn run_geyser_loop(
                             meta.insert(
                                 "pump_amm_sell_cashback_remaining".to_string(),
                                 merged_flag.to_string(),
+                            );
+                            meta.insert(
+                                "pump_amm_sell_layout_ready".to_string(),
+                                "true".to_string(),
                             );
                             if let Some(pk) = ext_third
                                 .or(*pump_amm_sell_cashback_third_meta)

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -1152,19 +1152,6 @@ impl LivePoolCache {
             .insert(pool_market, readiness);
     }
 
-    pub fn merge_pump_amm_sell_layout_ready_from_metadata(
-        &self,
-        pool: &Pubkey,
-        meta: Option<&std::collections::HashMap<String, String>>,
-    ) {
-        let Some(m) = meta else {
-            return;
-        };
-        if let Some(v) = m.get("pump_amm_sell_layout_ready") {
-            self.pump_amm_sell_layout_ready_by_market
-                .insert(*pool, v == "true");
-        }
-    }
     /// Merge PumpFun bonding-curve readiness for `bonding_curve` (monotonic — never downgrade).
     pub fn merge_pumpfun_bonding_readiness(
         &self,

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -1141,20 +1141,6 @@ impl LivePoolCache {
             .or_insert(incoming);
     }
 
-    pub fn merge_pump_amm_sell_layout_ready_from_metadata(
-        &self,
-        pool: &Pubkey,
-        meta: Option<&std::collections::HashMap<String, String>>,
-    ) {
-        let Some(m) = meta else {
-            return;
-        };
-        if let Some(v) = m.get("pump_amm_sell_layout_ready") {
-            self.pump_amm_sell_layout_ready_by_market
-                .insert(*pool, v == "true");
-        }
-    }
-
     /// Merge PumpFun bonding-curve readiness for `bonding_curve` (monotonic — never downgrade).
     pub fn merge_pumpfun_bonding_readiness(
         &self,

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -1141,6 +1141,30 @@ impl LivePoolCache {
             .or_insert(incoming);
     }
 
+    /// Overwrite PumpSwap `pool_accounts` readiness for authoritative updates where `Partial`
+    /// must replace a previously cached `Ready` (e.g. force-refresh / trade-publish SSOT).
+    pub fn set_pump_amm_pool_accounts_readiness_authoritative(
+        &self,
+        pool_market: Pubkey,
+        readiness: DexPoolReadiness,
+    ) {
+        self.pool_accounts_readiness_by_market
+            .insert(pool_market, readiness);
+    }
+
+    pub fn merge_pump_amm_sell_layout_ready_from_metadata(
+        &self,
+        pool: &Pubkey,
+        meta: Option<&std::collections::HashMap<String, String>>,
+    ) {
+        let Some(m) = meta else {
+            return;
+        };
+        if let Some(v) = m.get("pump_amm_sell_layout_ready") {
+            self.pump_amm_sell_layout_ready_by_market
+                .insert(*pool, v == "true");
+        }
+    }
     /// Merge PumpFun bonding-curve readiness for `bonding_curve` (monotonic — never downgrade).
     pub fn merge_pumpfun_bonding_readiness(
         &self,
@@ -2500,6 +2524,34 @@ mod tests {
         assert!(
             !cache.base_mint_has_explicit_pump_amm_ready_pool(&base_mint),
             "mint-level explicit Ready gate must also reject incomplete extended SELL state"
+        );
+    }
+
+    #[test]
+    fn test_pump_amm_authoritative_readiness_overwrites_ready_with_partial() {
+        let cache = LivePoolCache::new();
+        let pool_market = Pubkey::new_unique();
+
+        cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Ready);
+        assert_eq!(
+            cache
+                .pool_accounts_readiness_by_market
+                .get(&pool_market)
+                .map(|r| *r.value()),
+            Some(DexPoolReadiness::Ready)
+        );
+
+        cache.set_pump_amm_pool_accounts_readiness_authoritative(
+            pool_market,
+            DexPoolReadiness::Partial,
+        );
+        assert_eq!(
+            cache
+                .pool_accounts_readiness_by_market
+                .get(&pool_market)
+                .map(|r| *r.value()),
+            Some(DexPoolReadiness::Partial),
+            "authoritative PumpSwap updates must be able to replace stale Ready with Partial"
         );
     }
 

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -438,6 +438,10 @@ pub struct LivePoolCache {
     pump_amm_sell_extended_flag_by_market: DashMap<Pubkey, bool>,
     /// Third trailing readonly meta for extended `sell` (from observed ix); set when authoritatively known.
     pump_amm_sell_extended_third_meta_by_market: DashMap<Pubkey, Pubkey>,
+    /// PumpSwap pool-market -> whether the authoritative source has proven the current SELL layout
+    /// is fully known. `false` means "do not treat this as sell-ready truth yet", even if
+    /// pool_accounts/reserves are otherwise present.
+    pump_amm_sell_layout_ready_by_market: DashMap<Pubkey, bool>,
 }
 
 /// Which vault position (A/B or X/Y or 0/1) this vault represents
@@ -476,6 +480,7 @@ impl LivePoolCache {
             meteora_dlmm_readiness_by_pool: DashMap::new(),
             pump_amm_sell_extended_flag_by_market: DashMap::new(),
             pump_amm_sell_extended_third_meta_by_market: DashMap::new(),
+            pump_amm_sell_layout_ready_by_market: DashMap::new(),
         }
     }
 
@@ -885,6 +890,10 @@ impl LivePoolCache {
         let Some(m) = meta else {
             return;
         };
+        if let Some(v) = m.get("pump_amm_sell_layout_ready") {
+            self.pump_amm_sell_layout_ready_by_market
+                .insert(*pool, v == "true");
+        }
         if m.get("pump_amm_sell_cashback_remaining")
             .is_some_and(|v| v == "true")
         {
@@ -918,6 +927,11 @@ impl LivePoolCache {
         }
     }
 
+    /// Authoritative SELL-layout completeness for PumpSwap.
+    pub fn set_pump_amm_sell_layout_ready(&self, pool: &Pubkey, ready: bool) {
+        self.pump_amm_sell_layout_ready_by_market.insert(*pool, ready);
+    }
+
     /// Extended PumpSwap `sell` layout: flag + third readonly meta (if known).
     #[must_use]
     pub fn pump_amm_sell_extended_layout(&self, pool_market: &Pubkey) -> (bool, Option<Pubkey>) {
@@ -931,6 +945,26 @@ impl LivePoolCache {
             .get(pool_market)
             .map(|e| *e.value());
         (flag, third)
+    }
+
+    #[must_use]
+    pub fn pump_amm_sell_layout_ready(&self, pool_market: &Pubkey) -> bool {
+        self.pump_amm_sell_layout_ready_by_market
+            .get(pool_market)
+            .map(|e| *e.value())
+            .unwrap_or(true)
+    }
+
+    fn pump_amm_sell_layout_complete_for_ready(&self, pool_market: &Pubkey) -> bool {
+        if !self.pump_amm_sell_layout_ready(pool_market) {
+            return false;
+        }
+        let (requires_extended, third) = self.pump_amm_sell_extended_layout(pool_market);
+        if requires_extended {
+            third.filter(|p| *p != Pubkey::default()).is_some()
+        } else {
+            true
+        }
     }
 
     /// Set Raydium AMM Serum/OpenBook accounts (bids, asks, event_queue).
@@ -1104,6 +1138,11 @@ impl LivePoolCache {
             .entry(pool_market)
             .and_modify(|stored| *stored = stored.merge(incoming))
             .or_insert(incoming);
+    }
+
+    fn pump_amm_sell_layout_complete_for_ready(&self, pool_market: &Pubkey) -> bool {
+        let (requires_extended, third_meta) = self.pump_amm_sell_extended_layout(pool_market);
+        !requires_extended || third_meta.filter(|p| *p != Pubkey::default()).is_some()
     }
 
     /// Merge PumpFun bonding-curve readiness for `bonding_curve` (monotonic — never downgrade).
@@ -1466,6 +1505,9 @@ impl LivePoolCache {
         pool_market: &Pubkey,
         state: &PumpAmmState,
     ) -> bool {
+        if !self.pump_amm_sell_layout_complete_for_ready(pool_market) {
+            return false;
+        }
         match self.pool_accounts_readiness_by_market.get(pool_market) {
             Some(r) => *r == DexPoolReadiness::Ready,
             None => {
@@ -1540,7 +1582,11 @@ impl LivePoolCache {
                     .get(pool_market)
                     .map(|r| *r == DexPoolReadiness::Ready)
                     .unwrap_or(false);
-                if explicit_ready && !s.pool_accounts.is_empty() && s.pool_accounts.len() >= 14 {
+                if explicit_ready
+                    && self.pump_amm_sell_layout_complete_for_ready(pool_market)
+                    && !s.pool_accounts.is_empty()
+                    && s.pool_accounts.len() >= 14
+                {
                     return true;
                 }
             }
@@ -2392,6 +2438,73 @@ mod tests {
 
         cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Observed);
         assert!(!cache.pump_amm_swap_accounts_ready_by_base_mint(&base_mint));
+    }
+
+    #[test]
+    fn test_pump_amm_swap_accounts_ready_false_when_extended_layout_missing_third_meta() {
+        let cache = LivePoolCache::new();
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let pool_accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
+
+        cache.upsert(
+            pool_market,
+            make_pump_amm_state(
+                base_mint,
+                quote_mint,
+                Some(1_000_000_000),
+                Some(50_000_000_000),
+                pool_accounts,
+            ),
+            100,
+        );
+        cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Ready);
+        cache.merge_pump_amm_sell_extended_layout(&pool_market, true, None);
+        cache.set_pump_amm_sell_layout_ready(&pool_market, false);
+
+        assert!(
+            !cache.pump_amm_swap_accounts_ready_by_base_mint(&base_mint),
+            "extended layout without third meta must not count as swap-ready"
+        );
+    }
+
+    #[test]
+    fn test_pump_amm_extended_flag_without_third_meta_blocks_ready_gate() {
+        let cache = LivePoolCache::new();
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let pool_accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
+
+        cache.upsert(
+            pool_market,
+            make_pump_amm_state(
+                base_mint,
+                quote_mint,
+                Some(1_000_000_000),
+                Some(50_000_000_000),
+                pool_accounts,
+            ),
+            100,
+        );
+        cache.merge_pump_amm_sell_extended_layout(&pool_market, true, None);
+        cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Ready);
+
+        assert!(
+            cache
+                .get_ready_pump_amm_pool_accounts_by_base_mint(&base_mint)
+                .is_none(),
+            "extended SELL without third meta must not count as ready pool_accounts"
+        );
+        assert!(
+            !cache.pump_amm_swap_accounts_ready_by_base_mint(&base_mint),
+            "execution-engine gate must block extended SELL pools until third meta is present"
+        );
+        assert!(
+            !cache.base_mint_has_explicit_pump_amm_ready_pool(&base_mint),
+            "mint-level explicit Ready gate must also reject incomplete extended SELL state"
+        );
     }
 
     #[test]

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -894,9 +894,9 @@ impl LivePoolCache {
             self.pump_amm_sell_layout_ready_by_market
                 .insert(*pool, v == "true");
         }
-        let authoritative =
-            m.get("pump_amm_sell_layout_authoritative")
-                .is_some_and(|v| v == "true");
+        let authoritative = m
+            .get("pump_amm_sell_layout_authoritative")
+            .is_some_and(|v| v == "true");
         if authoritative {
             let requires_extended = m
                 .get("pump_amm_sell_cashback_remaining")
@@ -962,7 +962,8 @@ impl LivePoolCache {
                     .insert(*pool, pk);
             }
             None => {
-                self.pump_amm_sell_extended_third_meta_by_market.remove(pool);
+                self.pump_amm_sell_extended_third_meta_by_market
+                    .remove(pool);
             }
         }
     }

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -894,17 +894,31 @@ impl LivePoolCache {
             self.pump_amm_sell_layout_ready_by_market
                 .insert(*pool, v == "true");
         }
-        if m.get("pump_amm_sell_cashback_remaining")
-            .is_some_and(|v| v == "true")
-        {
-            self.pump_amm_sell_extended_flag_by_market
-                .insert(*pool, true);
-        }
-        if let Some(s) = m.get("pump_amm_sell_cashback_third_meta") {
-            if let Ok(pk) = Pubkey::from_str(s) {
-                if pk != Pubkey::default() {
-                    self.pump_amm_sell_extended_third_meta_by_market
-                        .insert(*pool, pk);
+        let authoritative =
+            m.get("pump_amm_sell_layout_authoritative")
+                .is_some_and(|v| v == "true");
+        if authoritative {
+            let requires_extended = m
+                .get("pump_amm_sell_cashback_remaining")
+                .is_some_and(|v| v == "true");
+            let third_meta = m
+                .get("pump_amm_sell_cashback_third_meta")
+                .and_then(|s| Pubkey::from_str(s).ok())
+                .filter(|pk| *pk != Pubkey::default());
+            self.set_pump_amm_sell_layout_authoritative(pool, requires_extended, third_meta);
+        } else {
+            if m.get("pump_amm_sell_cashback_remaining")
+                .is_some_and(|v| v == "true")
+            {
+                self.pump_amm_sell_extended_flag_by_market
+                    .insert(*pool, true);
+            }
+            if let Some(s) = m.get("pump_amm_sell_cashback_third_meta") {
+                if let Ok(pk) = Pubkey::from_str(s) {
+                    if pk != Pubkey::default() {
+                        self.pump_amm_sell_extended_third_meta_by_market
+                            .insert(*pool, pk);
+                    }
                 }
             }
         }
@@ -931,6 +945,26 @@ impl LivePoolCache {
     pub fn set_pump_amm_sell_layout_ready(&self, pool: &Pubkey, ready: bool) {
         self.pump_amm_sell_layout_ready_by_market
             .insert(*pool, ready);
+    }
+
+    /// Overwrite PumpSwap SELL-layout shape from an authoritative source (e.g. force-refresh SSOT).
+    pub fn set_pump_amm_sell_layout_authoritative(
+        &self,
+        pool: &Pubkey,
+        requires_extended: bool,
+        third_meta: Option<Pubkey>,
+    ) {
+        self.pump_amm_sell_extended_flag_by_market
+            .insert(*pool, requires_extended);
+        match third_meta.filter(|p| *p != Pubkey::default()) {
+            Some(pk) => {
+                self.pump_amm_sell_extended_third_meta_by_market
+                    .insert(*pool, pk);
+            }
+            None => {
+                self.pump_amm_sell_extended_third_meta_by_market.remove(pool);
+            }
+        }
     }
 
     /// Extended PumpSwap `sell` layout: flag + third readonly meta (if known).
@@ -2539,6 +2573,41 @@ mod tests {
                 .map(|r| *r.value()),
             Some(DexPoolReadiness::Partial),
             "authoritative PumpSwap updates must be able to replace stale Ready with Partial"
+        );
+    }
+
+    #[test]
+    fn test_authoritative_pump_amm_metadata_clears_stale_extended_layout() {
+        let cache = LivePoolCache::new();
+        let pool_market = Pubkey::new_unique();
+        let stale_third = Pubkey::new_unique();
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            "pump_amm_sell_layout_authoritative".to_string(),
+            "true".to_string(),
+        );
+        meta.insert(
+            "pump_amm_sell_cashback_remaining".to_string(),
+            "false".to_string(),
+        );
+        meta.insert("pump_amm_sell_layout_ready".to_string(), "true".to_string());
+
+        cache.merge_pump_amm_sell_extended_layout(&pool_market, true, Some(stale_third));
+        cache.set_pump_amm_sell_layout_ready(&pool_market, false);
+        cache.merge_pump_amm_sell_layout_from_metadata(&pool_market, Some(&meta));
+
+        let (requires_extended, third_meta) = cache.pump_amm_sell_extended_layout(&pool_market);
+        assert!(
+            !requires_extended,
+            "authoritative base metadata must clear stale extended flag"
+        );
+        assert!(
+            third_meta.is_none(),
+            "authoritative base metadata must clear stale third meta"
+        );
+        assert!(
+            cache.pump_amm_sell_layout_ready(&pool_market),
+            "authoritative base metadata keeps SELL layout ready"
         );
     }
 

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -929,7 +929,8 @@ impl LivePoolCache {
 
     /// Authoritative SELL-layout completeness for PumpSwap.
     pub fn set_pump_amm_sell_layout_ready(&self, pool: &Pubkey, ready: bool) {
-        self.pump_amm_sell_layout_ready_by_market.insert(*pool, ready);
+        self.pump_amm_sell_layout_ready_by_market
+            .insert(*pool, ready);
     }
 
     /// Extended PumpSwap `sell` layout: flag + third readonly meta (if known).
@@ -1140,9 +1141,18 @@ impl LivePoolCache {
             .or_insert(incoming);
     }
 
-    fn pump_amm_sell_layout_complete_for_ready(&self, pool_market: &Pubkey) -> bool {
-        let (requires_extended, third_meta) = self.pump_amm_sell_extended_layout(pool_market);
-        !requires_extended || third_meta.filter(|p| *p != Pubkey::default()).is_some()
+    pub fn merge_pump_amm_sell_layout_ready_from_metadata(
+        &self,
+        pool: &Pubkey,
+        meta: Option<&std::collections::HashMap<String, String>>,
+    ) {
+        let Some(m) = meta else {
+            return;
+        };
+        if let Some(v) = m.get("pump_amm_sell_layout_ready") {
+            self.pump_amm_sell_layout_ready_by_market
+                .insert(*pool, v == "true");
+        }
     }
 
     /// Merge PumpFun bonding-curve readiness for `bonding_curve` (monotonic — never downgrade).

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -936,8 +936,10 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 cache.upsert(addr, minimal_state, update.geyser_slot);
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_sell_layout_from_metadata(&addr, update.metadata.as_ref());
-                    cache
-                        .merge_pump_amm_sell_layout_ready_from_metadata(&addr, update.metadata.as_ref());
+                    cache.merge_pump_amm_sell_layout_ready_from_metadata(
+                        &addr,
+                        update.metadata.as_ref(),
+                    );
                     cache.merge_pump_amm_pool_accounts_readiness(
                         addr,
                         update.effective_dex_readiness(),
@@ -1207,9 +1209,8 @@ mod tests {
         update.set_dex_readiness_in_metadata(DexPoolReadiness::Partial);
 
         assert!(apply_pool_cache_update(&cache, &update));
-        assert_eq!(
-            cache.pump_amm_sell_layout_ready(&pool_market),
-            Some(false),
+        assert!(
+            !cache.pump_amm_sell_layout_ready(&pool_market),
             "SLAVE must preserve authoritative 'SELL layout still unknown' signal"
         );
     }

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -510,10 +510,25 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         &pool_addr,
                         update.metadata.as_ref(),
                     );
-                    cache.merge_pump_amm_pool_accounts_readiness(
-                        pool_addr,
-                        update.effective_dex_readiness(),
+                    cache.merge_pump_amm_sell_layout_ready_from_metadata(
+                        &pool_addr,
+                        update.metadata.as_ref(),
                     );
+                    if update
+                        .metadata
+                        .as_ref()
+                        .is_some_and(|m| m.contains_key("pump_amm_sell_layout_ready"))
+                    {
+                        cache.set_pump_amm_pool_accounts_readiness_authoritative(
+                            pool_addr,
+                            update.effective_dex_readiness(),
+                        );
+                    } else {
+                        cache.merge_pump_amm_pool_accounts_readiness(
+                            pool_addr,
+                            update.effective_dex_readiness(),
+                        );
+                    }
                 }
                 if update.dex == "raydium_cpmm" {
                     cache.merge_raydium_cpmm_pool_readiness(
@@ -932,10 +947,25 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 cache.upsert(addr, minimal_state, update.geyser_slot);
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_sell_layout_from_metadata(&addr, update.metadata.as_ref());
-                    cache.merge_pump_amm_pool_accounts_readiness(
-                        addr,
-                        update.effective_dex_readiness(),
+                    cache.merge_pump_amm_sell_layout_ready_from_metadata(
+                        &addr,
+                        update.metadata.as_ref(),
                     );
+                    if update
+                        .metadata
+                        .as_ref()
+                        .is_some_and(|m| m.contains_key("pump_amm_sell_layout_ready"))
+                    {
+                        cache.set_pump_amm_pool_accounts_readiness_authoritative(
+                            addr,
+                            update.effective_dex_readiness(),
+                        );
+                    } else {
+                        cache.merge_pump_amm_pool_accounts_readiness(
+                            addr,
+                            update.effective_dex_readiness(),
+                        );
+                    }
                 }
                 if update.dex == "raydium_cpmm" {
                     cache.merge_raydium_cpmm_pool_readiness(addr, update.effective_dex_readiness());
@@ -1377,6 +1407,84 @@ mod tests {
                 .get_ready_pump_amm_pool_accounts_by_base_mint(&base_mint)
                 .is_some(),
             "merge must not downgrade Ready to Observed"
+        );
+    }
+
+    #[test]
+    fn test_pump_amm_authoritative_partial_overwrites_prior_ready() {
+        let cache = LivePoolCache::new();
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
+
+        let mut ready_meta = std::collections::HashMap::new();
+        ready_meta.insert(
+            "pool_accounts".to_string(),
+            accounts
+                .iter()
+                .map(|p| p.to_string())
+                .collect::<Vec<_>>()
+                .join(","),
+        );
+        ready_meta.insert("pump_amm_sell_layout_ready".to_string(), "true".to_string());
+
+        let mut ready_update = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool_market.to_string(),
+            "pump_amm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1,
+            1,
+            None,
+            1,
+        );
+        ready_update.metadata = Some(ready_meta);
+        ready_update.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+        assert!(apply_pool_cache_update(&cache, &ready_update));
+        assert!(
+            cache.base_mint_has_explicit_pump_amm_ready_pool(&base_mint),
+            "authoritative Ready metadata should mark the pool explicitly ready"
+        );
+
+        let mut partial_meta = std::collections::HashMap::new();
+        partial_meta.insert(
+            "pool_accounts".to_string(),
+            accounts
+                .iter()
+                .map(|p| p.to_string())
+                .collect::<Vec<_>>()
+                .join(","),
+        );
+        partial_meta.insert(
+            "pump_amm_sell_layout_ready".to_string(),
+            "false".to_string(),
+        );
+
+        let mut partial_update = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool_market.to_string(),
+            "pump_amm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1,
+            1,
+            None,
+            2,
+        );
+        partial_update.metadata = Some(partial_meta);
+        partial_update.set_dex_readiness_in_metadata(DexPoolReadiness::Partial);
+        assert!(apply_pool_cache_update(&cache, &partial_update));
+
+        cache.set_pump_amm_sell_layout_ready(&pool_market, true);
+        assert!(
+            !cache.base_mint_has_explicit_pump_amm_ready_pool(&base_mint),
+            "readiness map itself must stay Partial after authoritative overwrite"
         );
     }
 

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -510,10 +510,6 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         &pool_addr,
                         update.metadata.as_ref(),
                     );
-                    cache.merge_pump_amm_sell_layout_ready_from_metadata(
-                        &pool_addr,
-                        update.metadata.as_ref(),
-                    );
                     if update
                         .metadata
                         .as_ref()
@@ -947,10 +943,6 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 cache.upsert(addr, minimal_state, update.geyser_slot);
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_sell_layout_from_metadata(&addr, update.metadata.as_ref());
-                    cache.merge_pump_amm_sell_layout_ready_from_metadata(
-                        &addr,
-                        update.metadata.as_ref(),
-                    );
                     if update
                         .metadata
                         .as_ref()

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -510,6 +510,10 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         &pool_addr,
                         update.metadata.as_ref(),
                     );
+                    cache.merge_pump_amm_sell_layout_ready_from_metadata(
+                        &pool_addr,
+                        update.metadata.as_ref(),
+                    );
                     cache.merge_pump_amm_pool_accounts_readiness(
                         pool_addr,
                         update.effective_dex_readiness(),
@@ -932,6 +936,8 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 cache.upsert(addr, minimal_state, update.geyser_slot);
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_sell_layout_from_metadata(&addr, update.metadata.as_ref());
+                    cache
+                        .merge_pump_amm_sell_layout_ready_from_metadata(&addr, update.metadata.as_ref());
                     cache.merge_pump_amm_pool_accounts_readiness(
                         addr,
                         update.effective_dex_readiness(),
@@ -1161,6 +1167,51 @@ mod tests {
         let (flag, third) = cache.pump_amm_sell_extended_layout(&pool_market);
         assert!(flag);
         assert!(third.is_some());
+    }
+
+    #[test]
+    fn test_jetstream_metadata_propagates_pump_amm_sell_layout_ready_false() {
+        let cache = LivePoolCache::new();
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = "So11111111111111111111111111111111111111112";
+        let accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
+
+        let mut update = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run-456",
+            pool_market.to_string(),
+            "pump_amm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1,
+            1,
+            None,
+            1,
+        );
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            "pool_accounts".to_string(),
+            accounts
+                .iter()
+                .map(|p| p.to_string())
+                .collect::<Vec<_>>()
+                .join(","),
+        );
+        meta.insert(
+            "pump_amm_sell_layout_ready".to_string(),
+            "false".to_string(),
+        );
+        update.metadata = Some(meta);
+        update.set_dex_readiness_in_metadata(DexPoolReadiness::Partial);
+
+        assert!(apply_pool_cache_update(&cache, &update));
+        assert_eq!(
+            cache.pump_amm_sell_layout_ready(&pool_market),
+            Some(false),
+            "SLAVE must preserve authoritative 'SELL layout still unknown' signal"
+        );
     }
 
     #[test]

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -510,10 +510,6 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         &pool_addr,
                         update.metadata.as_ref(),
                     );
-                    cache.merge_pump_amm_sell_layout_ready_from_metadata(
-                        &pool_addr,
-                        update.metadata.as_ref(),
-                    );
                     cache.merge_pump_amm_pool_accounts_readiness(
                         pool_addr,
                         update.effective_dex_readiness(),
@@ -936,10 +932,6 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 cache.upsert(addr, minimal_state, update.geyser_slot);
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_sell_layout_from_metadata(&addr, update.metadata.as_ref());
-                    cache.merge_pump_amm_sell_layout_ready_from_metadata(
-                        &addr,
-                        update.metadata.as_ref(),
-                    );
                     cache.merge_pump_amm_pool_accounts_readiness(
                         addr,
                         update.effective_dex_readiness(),

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -805,7 +805,10 @@ impl PumpFunAmmDex {
                     });
                     return Ok(Some(
                         self.wrap_pool_accounts_v14_with_diagnostic(
-                            base_mint, pool, force_refresh, diagnostic,
+                            base_mint,
+                            pool,
+                            force_refresh,
+                            diagnostic,
                         )
                         .await?,
                     ));
@@ -839,7 +842,10 @@ impl PumpFunAmmDex {
                         });
                         return Ok(Some(
                             self.wrap_pool_accounts_v14_with_diagnostic(
-                                base_mint, pool, force_refresh, diagnostic,
+                                base_mint,
+                                pool,
+                                force_refresh,
+                                diagnostic,
                             )
                             .await?,
                         ));

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -328,6 +328,15 @@ pub struct PoolAccountsV14WithDiagnostic {
     /// Propagate to JetStream / SLAVE: pool needs extended `sell` (24 metas).
     pub sell_requires_cashback_remaining: bool,
     pub sell_cashback_third_meta: Option<Pubkey>,
+    /// `true` only when the cold-path result is authoritative enough for SELL planning.
+    pub sell_layout_ready: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PumpAmmAuthoritativeSellLayout {
+    Unknown,
+    Base,
+    Extended { third_meta: Pubkey },
 }
 
 impl PumpAmmPoolStatic {
@@ -732,6 +741,7 @@ impl PumpFunAmmDex {
                             ),
                             sell_requires_cashback_remaining: sell_requires,
                             sell_cashback_third_meta: sell_third,
+                            sell_layout_ready: true,
                         }));
                     }
                 }
@@ -785,7 +795,6 @@ impl PumpFunAmmDex {
                         pool_market = %pool.pool_market,
                         "pump_amm: PumpAmmPoolStatic from pool_address hint (fast path)"
                     );
-                    let accounts = pool.as_pool_accounts_v14();
                     let diagnostic = pool.last_parse_diagnostics.clone().unwrap_or_else(|| {
                         Self::pump_amm_livepoolcache_diagnostic(
                             "pool_address_hint_fast_path_missing_diag",
@@ -794,12 +803,12 @@ impl PumpFunAmmDex {
                             base_mint,
                         )
                     });
-                    return Ok(Some(PoolAccountsV14WithDiagnostic {
-                        accounts,
-                        diagnostic,
-                        sell_requires_cashback_remaining: pool.sell_requires_cashback_remaining,
-                        sell_cashback_third_meta: pool.sell_cashback_third_meta,
-                    }));
+                    return Ok(Some(
+                        self.wrap_pool_accounts_v14_with_diagnostic(
+                            base_mint, pool, force_refresh, diagnostic,
+                        )
+                        .await?,
+                    ));
                 }
                 PumpAmmMarketParseOutcome::LocalFail(reason) => {
                     warn!(
@@ -819,7 +828,6 @@ impl PumpFunAmmDex {
                         .await?
                     {
                         self.insert_pool_static_cache(pool.clone());
-                        let accounts = pool.as_pool_accounts_v14();
                         let diagnostic = pool.last_parse_diagnostics.clone().unwrap_or_else(|| {
                             Self::pump_amm_tx_history_diagnostic(
                                 "bounded_external_tx_history_pool_address_hint",
@@ -829,12 +837,12 @@ impl PumpFunAmmDex {
                                 None,
                             )
                         });
-                        return Ok(Some(PoolAccountsV14WithDiagnostic {
-                            accounts,
-                            diagnostic,
-                            sell_requires_cashback_remaining: pool.sell_requires_cashback_remaining,
-                            sell_cashback_third_meta: pool.sell_cashback_third_meta,
-                        }));
+                        return Ok(Some(
+                            self.wrap_pool_accounts_v14_with_diagnostic(
+                                base_mint, pool, force_refresh, diagnostic,
+                            )
+                            .await?,
+                        ));
                     }
                     return Err(anyhow!(
                         "pump_amm: pool_address hint parse failed local_parse={} (base_mint={}, pool={}); refusing unbounded getProgramAccounts (I-24d)",
@@ -855,22 +863,6 @@ impl PumpFunAmmDex {
         // CRITICAL: global_volume_accumulator is required for BUY (BuyExactQuoteIn).
         // The PumpSwap program validates it exists and is initialized.
         // Without it: "AccountNotInitialized" error (Custom(3012)).
-        let accounts = vec![
-            pool.pool_market,                  // [0]
-            pool.global_config,                // [1]
-            pool.base_mint,                    // [2]
-            pool.quote_mint,                   // [3]
-            pool.pool_base_vault,              // [4]
-            pool.pool_quote_vault,             // [5]
-            pool.protocol_fee_recipient,       // [6]
-            pool.protocol_fee_recipient_ta,    // [7]
-            pool.event_authority,              // [8]
-            pool.coin_creator_vault_ata,       // [9]
-            pool.coin_creator_vault_authority, // [10]
-            pool.global_volume_accumulator,    // [11] - REQUIRED for BUY!
-            pool.fee_config,                   // [12]
-            pool.fee_program,                  // [13]
-        ];
         let diagnostic = pool.last_parse_diagnostics.clone().unwrap_or_else(|| {
             Self::pump_amm_livepoolcache_diagnostic(
                 "discover_pool_static_missing_diag",
@@ -879,12 +871,10 @@ impl PumpFunAmmDex {
                 base_mint,
             )
         });
-        Ok(Some(PoolAccountsV14WithDiagnostic {
-            accounts,
-            diagnostic,
-            sell_requires_cashback_remaining: pool.sell_requires_cashback_remaining,
-            sell_cashback_third_meta: pool.sell_cashback_third_meta,
-        }))
+        Ok(Some(
+            self.wrap_pool_accounts_v14_with_diagnostic(base_mint, pool, force_refresh, diagnostic)
+                .await?,
+        ))
     }
 
     /// Convenience wrapper: pool_accounts_v1_for_base_mint without hint.
@@ -894,6 +884,245 @@ impl PumpFunAmmDex {
     ) -> Result<Option<Vec<Pubkey>>> {
         self.pool_accounts_v1_for_base_mint_with_hint(base_mint, None, false)
             .await
+    }
+
+    async fn wrap_pool_accounts_v14_with_diagnostic(
+        &self,
+        base_mint: Pubkey,
+        mut pool: PumpAmmPoolStatic,
+        force_refresh: bool,
+        diagnostic: PumpAmmPoolAccountsDiagnostic,
+    ) -> Result<PoolAccountsV14WithDiagnostic> {
+        let sell_layout_ready = if force_refresh {
+            match self
+                .resolve_authoritative_sell_layout_for_force_refresh(&pool, base_mint)
+                .await?
+            {
+                PumpAmmAuthoritativeSellLayout::Unknown => false,
+                PumpAmmAuthoritativeSellLayout::Base => {
+                    pool.sell_requires_cashback_remaining = false;
+                    pool.sell_cashback_third_meta = None;
+                    true
+                }
+                PumpAmmAuthoritativeSellLayout::Extended { third_meta } => {
+                    pool.sell_requires_cashback_remaining = true;
+                    pool.sell_cashback_third_meta = Some(third_meta);
+                    true
+                }
+            }
+        } else {
+            true
+        };
+
+        Ok(PoolAccountsV14WithDiagnostic {
+            accounts: pool.as_pool_accounts_v14(),
+            diagnostic,
+            sell_requires_cashback_remaining: pool.sell_requires_cashback_remaining,
+            sell_cashback_third_meta: pool.sell_cashback_third_meta,
+            sell_layout_ready,
+        })
+    }
+
+    async fn resolve_authoritative_sell_layout_for_force_refresh(
+        &self,
+        pool: &PumpAmmPoolStatic,
+        base_mint: Pubkey,
+    ) -> Result<PumpAmmAuthoritativeSellLayout> {
+        if pool.sell_requires_cashback_remaining {
+            if let Some(third_meta) = pool
+                .sell_cashback_third_meta
+                .filter(|p| *p != Pubkey::default())
+            {
+                return Ok(PumpAmmAuthoritativeSellLayout::Extended { third_meta });
+            }
+        }
+
+        let local_observation = match self
+            .observe_authoritative_sell_layout_from_tx_history_with_rpc(
+                Arc::clone(&self.rpc),
+                pool.pool_market,
+                base_mint,
+                "local_force_refresh_sell_layout",
+            )
+            .await
+        {
+            Ok(layout) => layout,
+            Err(e) => {
+                warn!(
+                    pool = %pool.pool_market,
+                    base_mint = %base_mint,
+                    error = %e,
+                    "pump_amm: local force_refresh SELL-layout observation failed"
+                );
+                PumpAmmAuthoritativeSellLayout::Unknown
+            }
+        };
+        if local_observation != PumpAmmAuthoritativeSellLayout::Unknown {
+            return Ok(local_observation);
+        }
+
+        let Some(ref h_rpc) = self.bounded_tx_fallback_rpc else {
+            return Ok(PumpAmmAuthoritativeSellLayout::Unknown);
+        };
+
+        let local_sigs_empty = match self
+            .rpc
+            .get_signatures_for_address(&pool.pool_market, Some(1))
+            .await
+        {
+            Ok(v) => v.is_empty(),
+            Err(e) => {
+                warn!(
+                    pool = %pool.pool_market,
+                    base_mint = %base_mint,
+                    error = %e,
+                    "pump_amm: local tx index check failed during force_refresh; trying bounded external SELL-layout observation"
+                );
+                true
+            }
+        };
+        if !local_sigs_empty {
+            return Ok(PumpAmmAuthoritativeSellLayout::Unknown);
+        }
+
+        const BOUNDED_EXTERNAL_TX_TIMEOUT: Duration = Duration::from_secs(12);
+        match tokio::time::timeout(
+            BOUNDED_EXTERNAL_TX_TIMEOUT,
+            self.observe_authoritative_sell_layout_from_tx_history_with_rpc(
+                Arc::clone(h_rpc),
+                pool.pool_market,
+                base_mint,
+                "bounded_external_force_refresh_sell_layout",
+            ),
+        )
+        .await
+        {
+            Ok(Ok(layout)) => Ok(layout),
+            Ok(Err(e)) => {
+                warn!(
+                    pool = %pool.pool_market,
+                    base_mint = %base_mint,
+                    error = %e,
+                    "pump_amm: bounded external SELL-layout observation failed"
+                );
+                Ok(PumpAmmAuthoritativeSellLayout::Unknown)
+            }
+            Err(_) => {
+                warn!(
+                    pool = %pool.pool_market,
+                    base_mint = %base_mint,
+                    timeout_secs = BOUNDED_EXTERNAL_TX_TIMEOUT.as_secs(),
+                    "pump_amm: bounded external SELL-layout observation timed out"
+                );
+                Ok(PumpAmmAuthoritativeSellLayout::Unknown)
+            }
+        }
+    }
+
+    async fn observe_authoritative_sell_layout_from_tx_history_with_rpc(
+        &self,
+        tx_rpc: Arc<SolanaRpc>,
+        pool_market: Pubkey,
+        base_mint: Pubkey,
+        log_ctx: &'static str,
+    ) -> Result<PumpAmmAuthoritativeSellLayout> {
+        const MAX_TX_FETCHES: usize = 200;
+        let sigs = tx_rpc
+            .get_signatures_for_address(&pool_market, Some(MAX_TX_FETCHES))
+            .await
+            .map_err(|e| anyhow!("getSignaturesForAddress failed: {e}"))?;
+        if sigs.is_empty() {
+            info!(
+                pool = %pool_market,
+                base_mint = %base_mint,
+                log_ctx,
+                "pump_amm: no signatures available for authoritative SELL-layout observation"
+            );
+            return Ok(PumpAmmAuthoritativeSellLayout::Unknown);
+        }
+
+        let mut fetched = 0usize;
+        for s in &sigs {
+            if fetched >= MAX_TX_FETCHES {
+                break;
+            }
+            if s.err.is_some() {
+                continue;
+            }
+            fetched += 1;
+            let sig = s.signature.to_string();
+            let tx_v = Self::fetch_tx_as_value_with_rpc(tx_rpc.as_ref(), &sig).await?;
+            let msg = match tx_v
+                .get("result")
+                .and_then(|r| r.get("transaction"))
+                .and_then(|t| t.get("message"))
+            {
+                Some(v) => v,
+                None => continue,
+            };
+            let meta = tx_v
+                .get("result")
+                .and_then(|r| r.get("meta"))
+                .unwrap_or(&Value::Null);
+
+            let mut account_keys = match Self::parse_account_keys(msg) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            Self::extend_with_loaded_addresses(&mut account_keys, meta);
+
+            for ix in Self::collect_all_instructions(msg, meta) {
+                let program_id_index = match ix.get("programIdIndex").and_then(|v| v.as_u64()) {
+                    Some(v) => v as usize,
+                    None => continue,
+                };
+                let Some(program_id) = account_keys.get(program_id_index) else {
+                    continue;
+                };
+                if program_id != PUMPFUN_AMM_PROGRAM_ID {
+                    continue;
+                }
+                let accounts: Vec<usize> = match ix.get("accounts").and_then(|v| v.as_array()) {
+                    Some(a) => a
+                        .iter()
+                        .filter_map(|v| v.as_u64().map(|x| x as usize))
+                        .collect(),
+                    None => continue,
+                };
+                let Some(ix_data) = Self::pump_amm_ix_data_from_json(ix) else {
+                    continue;
+                };
+                let Some((observed_pool, observed_base, layout)) =
+                    Self::pump_amm_sell_layout_observation_from_parsed_swap_ix(
+                        &account_keys,
+                        &accounts,
+                        &ix_data,
+                    )
+                else {
+                    continue;
+                };
+                if observed_pool != pool_market || observed_base != base_mint {
+                    continue;
+                }
+                info!(
+                    pool = %pool_market,
+                    base_mint = %base_mint,
+                    log_ctx,
+                    signature = %sig,
+                    layout = ?layout,
+                    "pump_amm: authoritative SELL-layout observed from successful swap tx"
+                );
+                return Ok(layout);
+            }
+        }
+
+        info!(
+            pool = %pool_market,
+            base_mint = %base_mint,
+            log_ctx,
+            "pump_amm: no successful SELL tx observed for authoritative SELL-layout"
+        );
+        Ok(PumpAmmAuthoritativeSellLayout::Unknown)
     }
 
     fn derive_user_volume_accumulator(
@@ -3504,6 +3733,36 @@ impl PumpFunAmmDex {
         None
     }
 
+    fn pump_amm_sell_layout_observation_from_parsed_swap_ix(
+        account_keys: &[String],
+        acc_indices: &[usize],
+        ix_data: &[u8],
+    ) -> Option<(Pubkey, Pubkey, PumpAmmAuthoritativeSellLayout)> {
+        let pool = Self::pump_amm_pool_static_from_parsed_swap_ix(
+            account_keys,
+            acc_indices,
+            ix_data,
+            |_| {
+                Self::pump_amm_livepoolcache_diagnostic(
+                    "sell_layout_observation",
+                    true,
+                    Pubkey::default(),
+                    Pubkey::default(),
+                )
+            },
+        )?;
+        let layout = match acc_indices.len() {
+            21 => PumpAmmAuthoritativeSellLayout::Base,
+            24 => PumpAmmAuthoritativeSellLayout::Extended {
+                third_meta: pool
+                    .sell_cashback_third_meta
+                    .filter(|p| *p != Pubkey::default())?,
+            },
+            _ => return None,
+        };
+        Some((pool.pool_market, pool.base_mint, layout))
+    }
+
     async fn get_vault_amount(&self, ta: Pubkey) -> Result<u64> {
         let acc = self
             .rpc
@@ -4888,6 +5147,63 @@ mod tests {
         let gva = pump_amm_singleton_global_volume_accumulator(&program_id);
         let expected = Pubkey::from_str("C2aFPdENg4A2HQsmrd5rTw5TaYBX5Ku887cWjbFKtZpw").unwrap();
         assert_eq!(gva, expected);
+    }
+
+    #[test]
+    fn test_pump_amm_sell_layout_observation_parses_standard_sell() {
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let mut account_keys: Vec<Pubkey> = (0..21).map(|_| Pubkey::new_unique()).collect();
+        account_keys[0] = pool_market;
+        account_keys[2] = Pubkey::from_str(PUMPFUN_AMM_GLOBAL_CONFIG).unwrap();
+        account_keys[3] = base_mint;
+        account_keys[4] = Pubkey::from_str(WSOL_MINT).unwrap();
+        account_keys[20] = Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).unwrap();
+        let account_keys: Vec<String> = account_keys.iter().map(ToString::to_string).collect();
+        let acc_indices: Vec<usize> = (0..21).collect();
+        let ix_data = pump_amm_sell_ix_discriminator().to_vec();
+
+        let observed = PumpFunAmmDex::pump_amm_sell_layout_observation_from_parsed_swap_ix(
+            &account_keys,
+            &acc_indices,
+            &ix_data,
+        )
+        .expect("standard sell observation");
+
+        assert_eq!(observed.0, pool_market);
+        assert_eq!(observed.1, base_mint);
+        assert_eq!(observed.2, PumpAmmAuthoritativeSellLayout::Base);
+    }
+
+    #[test]
+    fn test_pump_amm_sell_layout_observation_parses_extended_sell() {
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let third_meta = Pubkey::new_unique();
+        let mut account_keys: Vec<Pubkey> = (0..24).map(|_| Pubkey::new_unique()).collect();
+        account_keys[0] = pool_market;
+        account_keys[2] = Pubkey::from_str(PUMPFUN_AMM_GLOBAL_CONFIG).unwrap();
+        account_keys[3] = base_mint;
+        account_keys[4] = Pubkey::from_str(WSOL_MINT).unwrap();
+        account_keys[20] = Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).unwrap();
+        account_keys[23] = third_meta;
+        let account_keys: Vec<String> = account_keys.iter().map(ToString::to_string).collect();
+        let acc_indices: Vec<usize> = (0..24).collect();
+        let ix_data = pump_amm_sell_ix_discriminator().to_vec();
+
+        let observed = PumpFunAmmDex::pump_amm_sell_layout_observation_from_parsed_swap_ix(
+            &account_keys,
+            &acc_indices,
+            &ix_data,
+        )
+        .expect("extended sell observation");
+
+        assert_eq!(observed.0, pool_market);
+        assert_eq!(observed.1, base_mint);
+        assert_eq!(
+            observed.2,
+            PumpAmmAuthoritativeSellLayout::Extended { third_meta }
+        );
     }
 
     /// Mainnet 24-account `sell` (sig `2CCmRDScAErjuBLnVJbGEyV3jsWbuNZpniZ5iTLSwZoE84nmyf285hqJXjRStMHJUaJ9Ex7EvL9fgwAVM83qGd3o`): first two trailing metas are user-derivable; third is observed-only.

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -1057,7 +1057,20 @@ impl PumpFunAmmDex {
             }
             fetched += 1;
             let sig = s.signature.to_string();
-            let tx_v = Self::fetch_tx_as_value_with_rpc(tx_rpc.as_ref(), &sig).await?;
+            let tx_v = match Self::fetch_tx_as_value_with_rpc(tx_rpc.as_ref(), &sig).await {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(
+                        pool = %pool_market,
+                        base_mint = %base_mint,
+                        signature = %sig,
+                        log_ctx,
+                        error = %e,
+                        "pump_amm: getTransaction failed during authoritative SELL-layout scan; skipping signature"
+                    );
+                    continue;
+                }
+            };
             let msg = match tx_v
                 .get("result")
                 .and_then(|r| r.get("transaction"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make PumpSwap `force_refresh` resolve authoritative SELL layout state instead of always returning base-only SELL metadata
- publish SELL-layout completeness through market-data and JetStream so SLAVE cache can distinguish ready vs partial PumpSwap refreshes
- block PumpSwap ready/swap-ready cache hits when extended SELL requires an observed third meta that is still unknown
- align the PumpSwap trade/Geyser PoolCacheUpdate publish path with the same SELL-layout-ready semantics as the EnsurePumpAmmPoolAccounts force-refresh path
- ensure authoritative PumpSwap `Partial` readiness overwrites stale local `Ready` state on the relevant force-refresh / trade-publish paths instead of being trapped by monotonic merge
- remove the reintroduced duplicate `pump_amm_sell_layout_ready` metadata merge while keeping the authoritative PumpSwap readiness-overwrite behavior intact
- ensure authoritative PumpSwap `force_refresh` base-layout results override stale cached extended flags instead of being re-degraded to `Partial`
- keep non-force-refresh PumpSwap Ensure responses on the `Ok` path when JetStream publish succeeds, while preserving the authoritative unresolved error path for `force_refresh=true`

## Testing
- `cargo fmt --check`
- `cargo test --quiet test_pump_amm_trade_publish_extended_without_third_meta_is_partial`
- `cargo test --quiet test_pump_amm_trade_publish_extended_with_third_meta_is_ready`
- `cargo test --quiet test_pump_amm_authoritative_readiness_overwrites_ready_with_partial`
- `cargo test --quiet test_pump_amm_authoritative_partial_overwrites_prior_ready`
- `cargo test --quiet test_pump_amm_force_refresh_base_overrides_stale_extended_cache_flag`
- `cargo test --quiet test_authoritative_pump_amm_metadata_clears_stale_extended_layout`
- `cargo test --quiet test_pump_amm_non_force_refresh_partial_publish_keeps_ok_response`
- `cargo test --quiet test_pump_amm_force_refresh_partial_publish_returns_authoritative_error`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`
- `cargo test --features test_helpers --quiet`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f563cf9-4266-438d-b548-26364a241fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f563cf9-4266-438d-b548-26364a241fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

