### PR TITLE
Scope 55: WSOL close → zero state end-to-end (Geyser + JetStream)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -91,9 +91,9 @@ use ironcrab::metrics::{
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
-    ensure_trade_intents_stream, wallet_snapshot_consumer_config, NatsClient, NatsConfig,
-    CONFIG_STREAM_NAME, STREAM_NAME, TOPIC_CONTROL_REQUESTS, TOPIC_CONTROL_RESPONSES,
-    TOPIC_DECISION_RECORDS, TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS,
+    ensure_trade_intents_stream, wallet_snapshot_consumer_config, wallet_snapshot_subject,
+    NatsClient, NatsConfig, CONFIG_STREAM_NAME, STREAM_NAME, TOPIC_CONTROL_REQUESTS,
+    TOPIC_CONTROL_RESPONSES, TOPIC_DECISION_RECORDS, TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS,
     TOPIC_PRIORITY_FEE_SAMPLES, TOPIC_TRADE_INTENTS, TRADE_INTENTS_STREAM_NAME,
     WALLET_SNAPSHOT_STREAM_NAME,
 };
@@ -4251,16 +4251,62 @@ impl ExecutionContext {
         tokio::time::sleep(Duration::from_secs(15)).await;
         #[cfg(unix)]
         maybe_ping_watchdog();
-        if let Err(e) = Self::cleanup_wallet_after_liquidation(ctx.as_ref(), owner).await {
+        if let Err(e) =
+            Self::cleanup_wallet_after_liquidation(ctx.as_ref(), owner, &ctx.run_id).await
+        {
             warn!(error = %e, "Liquidation cleanup failed (best-effort)");
         }
 
         info!("Liquidation job completed");
     }
 
+    /// After WSOL ATA close (unwrap), push authoritative `WSOL=0` to JetStream and LockManager
+    /// so dashboard/metrics do not retain the last Geyser balance. Cold path only (RPC + cleanup).
+    async fn publish_wsol_zero_snapshot_after_ata_close(ctx: &ExecutionContext, run_id: &str) {
+        let Some(ref nats) = ctx.nats else {
+            return;
+        };
+        let Some(wallet) = ctx.wallet_pubkey else {
+            return;
+        };
+        let wallet_str = wallet.to_string();
+        let event = MarketEvent::new(
+            "execution-engine",
+            BUILD_VERSION,
+            run_id,
+            format!("wsol_ata_close_{}", Uuid::new_v4()),
+            "wsol_ata_close",
+            None,
+            MarketEventKind::WalletBalanceSnapshot {
+                mint: WSOL_MINT.to_string(),
+                balance_raw: 0,
+                decimals: 9,
+                token_program: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string(),
+            },
+        );
+        let subject = wallet_snapshot_subject(&wallet_str, WSOL_MINT);
+        match nats.jetstream_publish(&subject, &event).await {
+            Ok(true) => {
+                info!(wallet = %wallet_str, "Published WSOL=0 WalletBalanceSnapshot after WSOL ATA close");
+            }
+            Ok(false) => {
+                warn!(wallet = %wallet_str, "WSOL=0 snapshot publish dropped (no NATS client or timeout)");
+            }
+            Err(e) => {
+                warn!(error = %e, wallet = %wallet_str, "Failed to publish WSOL=0 snapshot after WSOL ATA close");
+            }
+        }
+        ctx.lock_manager.update_wsol_only(0);
+        if let Some(ref tx) = ctx.wsol_balance_tx {
+            let sol = ctx.lock_manager.total_native_sol();
+            let _ = tx.try_send((sol, Some(0u64)));
+        }
+    }
+
     async fn cleanup_wallet_after_liquidation(
         ctx: &ExecutionContext,
         wallet: Pubkey,
+        run_id: &str,
     ) -> Result<()> {
         let token_program_id = Pubkey::new_from_array(spl_token::id().to_bytes());
         let token_2022_program_id = Pubkey::new_from_array(spl_token_2022::id().to_bytes());
@@ -4316,7 +4362,8 @@ impl ExecutionContext {
                         .await
                         {
                             Ok(sig) => {
-                                info!(wallet = %wallet, wsol_ata = %wsol_ata, signature = %sig, "Unwrapped WSOL (closed ATA)")
+                                info!(wallet = %wallet, wsol_ata = %wsol_ata, signature = %sig, "Unwrapped WSOL (closed ATA)");
+                                Self::publish_wsol_zero_snapshot_after_ata_close(ctx, run_id).await;
                             }
                             Err(e) => {
                                 warn!(wallet = %wallet, wsol_ata = %wsol_ata, error = %e, "Failed to unwrap WSOL (close ATA send failed)")

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -91,9 +91,9 @@ use ironcrab::metrics::{
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
-    ensure_trade_intents_stream, wallet_snapshot_consumer_config, wallet_snapshot_subject,
-    NatsClient, NatsConfig, CONFIG_STREAM_NAME, STREAM_NAME, TOPIC_CONTROL_REQUESTS,
-    TOPIC_CONTROL_RESPONSES, TOPIC_DECISION_RECORDS, TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS,
+    ensure_trade_intents_stream, wallet_snapshot_consumer_config, NatsClient, NatsConfig,
+    CONFIG_STREAM_NAME, STREAM_NAME, TOPIC_CONTROL_REQUESTS, TOPIC_CONTROL_RESPONSES,
+    TOPIC_DECISION_RECORDS, TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS,
     TOPIC_PRIORITY_FEE_SAMPLES, TOPIC_TRADE_INTENTS, TRADE_INTENTS_STREAM_NAME,
     WALLET_SNAPSHOT_STREAM_NAME,
 };
@@ -4251,62 +4251,16 @@ impl ExecutionContext {
         tokio::time::sleep(Duration::from_secs(15)).await;
         #[cfg(unix)]
         maybe_ping_watchdog();
-        if let Err(e) =
-            Self::cleanup_wallet_after_liquidation(ctx.as_ref(), owner, &ctx.run_id).await
-        {
+        if let Err(e) = Self::cleanup_wallet_after_liquidation(ctx.as_ref(), owner).await {
             warn!(error = %e, "Liquidation cleanup failed (best-effort)");
         }
 
         info!("Liquidation job completed");
     }
 
-    /// After WSOL ATA close (unwrap), push authoritative `WSOL=0` to JetStream and LockManager
-    /// so dashboard/metrics do not retain the last Geyser balance. Cold path only (RPC + cleanup).
-    async fn publish_wsol_zero_snapshot_after_ata_close(ctx: &ExecutionContext, run_id: &str) {
-        let Some(ref nats) = ctx.nats else {
-            return;
-        };
-        let Some(wallet) = ctx.wallet_pubkey else {
-            return;
-        };
-        let wallet_str = wallet.to_string();
-        let event = MarketEvent::new(
-            "execution-engine",
-            BUILD_VERSION,
-            run_id,
-            format!("wsol_ata_close_{}", Uuid::new_v4()),
-            "wsol_ata_close",
-            None,
-            MarketEventKind::WalletBalanceSnapshot {
-                mint: WSOL_MINT.to_string(),
-                balance_raw: 0,
-                decimals: 9,
-                token_program: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string(),
-            },
-        );
-        let subject = wallet_snapshot_subject(&wallet_str, WSOL_MINT);
-        match nats.jetstream_publish(&subject, &event).await {
-            Ok(true) => {
-                info!(wallet = %wallet_str, "Published WSOL=0 WalletBalanceSnapshot after WSOL ATA close");
-            }
-            Ok(false) => {
-                warn!(wallet = %wallet_str, "WSOL=0 snapshot publish dropped (no NATS client or timeout)");
-            }
-            Err(e) => {
-                warn!(error = %e, wallet = %wallet_str, "Failed to publish WSOL=0 snapshot after WSOL ATA close");
-            }
-        }
-        ctx.lock_manager.update_wsol_only(0);
-        if let Some(ref tx) = ctx.wsol_balance_tx {
-            let sol = ctx.lock_manager.total_native_sol();
-            let _ = tx.try_send((sol, Some(0u64)));
-        }
-    }
-
     async fn cleanup_wallet_after_liquidation(
         ctx: &ExecutionContext,
         wallet: Pubkey,
-        run_id: &str,
     ) -> Result<()> {
         let token_program_id = Pubkey::new_from_array(spl_token::id().to_bytes());
         let token_2022_program_id = Pubkey::new_from_array(spl_token_2022::id().to_bytes());
@@ -4363,7 +4317,6 @@ impl ExecutionContext {
                         {
                             Ok(sig) => {
                                 info!(wallet = %wallet, wsol_ata = %wsol_ata, signature = %sig, "Unwrapped WSOL (closed ATA)");
-                                Self::publish_wsol_zero_snapshot_after_ata_close(ctx, run_id).await;
                             }
                             Err(e) => {
                                 warn!(wallet = %wallet, wsol_ata = %wsol_ata, error = %e, "Failed to unwrap WSOL (close ATA send failed)")

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -764,6 +764,15 @@ fn try_parse_token_account_balance(data: &[u8]) -> Option<u64> {
     }
 }
 
+/// WSOL wrapped-SOL token account: balance from a Geyser account update, or `None` to skip.
+/// Empty `data` means the account no longer exists as a token account (e.g. ATA closed) → `Some(0)`.
+fn wsol_ata_balance_lamports_from_geyser_data(data: &[u8]) -> Option<u64> {
+    if data.is_empty() {
+        return Some(0);
+    }
+    try_parse_token_account_balance(data)
+}
+
 /// Wallet `mints_in_wallet` are non-zero balances from bootstrap RPC; pick at most `max_mints`
 /// unique pubkeys that still lack explicit Ready for any modeled slice per
 /// [`LivePoolCache::base_mint_has_any_ready_pool`] (PumpSwap, PumpFun, Raydium CPMM, Meteora CPMM, Meteora DLMM,
@@ -6472,15 +6481,18 @@ async fn run_geyser_loop(
                             let wsol_value = if has_wsol { Some(wsol) } else { None };
                             (lamports, wsol_value, lamports != prev)
                         } else {
-                            // WSOL ATA - parse token account balance
-                            if let Some(balance) = try_parse_token_account_balance(&account_update.data) {
-                                let prev = tracked_wallet.last_wsol_balance.swap(balance, Ordering::Relaxed);
-                                tracked_wallet.wsol_seen.store(true, Ordering::Relaxed);
-                                let sol = tracked_wallet.last_sol_balance.load(Ordering::Relaxed);
-                                (sol, Some(balance), balance != prev)
-                            } else {
-                                continue; // Failed to parse, skip
-                            }
+                            // WSOL ATA - parse token account balance.
+                            // When the ATA is closed (unwrap), Geyser often delivers an update with
+                            // `data` empty (account gone) — not parseable as SPL token state.
+                            // That means WSOL=0. Previously we `continue`d and kept a stale balance
+                            // with no zero WalletBalanceSnapshot to JetStream.
+                            let Some(balance) = wsol_ata_balance_lamports_from_geyser_data(&account_update.data) else {
+                                continue;
+                            };
+                            let prev = tracked_wallet.last_wsol_balance.swap(balance, Ordering::Relaxed);
+                            tracked_wallet.wsol_seen.store(true, Ordering::Relaxed);
+                            let sol = tracked_wallet.last_sol_balance.load(Ordering::Relaxed);
+                            (sol, Some(balance), balance != prev)
                         };
 
                         if balance_changed {
@@ -10006,5 +10018,34 @@ mod discovery_tests {
         let mints = vec![base_mint.to_string(), other.to_string()];
         let out = wallet_mints_needing_dex_bootstrap_verify(&cache, &mints, wsol, 8);
         assert_eq!(out, vec![other]);
+    }
+}
+
+/// WSOL ATA balance parsing from Geyser (Scope 55: zero after close)
+#[cfg(test)]
+mod wsol_ata_update_tests {
+    use super::wsol_ata_balance_lamports_from_geyser_data;
+
+    #[test]
+    fn empty_wsol_ata_data_means_zero_balance() {
+        assert_eq!(wsol_ata_balance_lamports_from_geyser_data(&[]), Some(0));
+    }
+
+    #[test]
+    fn short_corrupt_wsol_ata_data_skips_update() {
+        // Not enough bytes for a standard token account; must not be treated as 0
+        // (avoids clobbering state on transient garbage).
+        assert_eq!(wsol_ata_balance_lamports_from_geyser_data(&[1, 2, 3]), None);
+    }
+
+    #[test]
+    fn standard_spl_token_account_parses_amount() {
+        let mut data = vec![0u8; 165];
+        let amt: u64 = 1_000_000_000;
+        data[64..72].copy_from_slice(&amt.to_le_bytes());
+        assert_eq!(
+            wsol_ata_balance_lamports_from_geyser_data(&data),
+            Some(1_000_000_000)
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes stale `available_wsol` / `wallet_total` after a successful **WSOL ATA close** (unwrap).

## Changes

1. **`src/bin/market_data.rs`**
   - `wsol_ata_balance_lamports_from_geyser_data`: empty Geyser `data` on WSOL ATA pubkey → **0** (closed ATA); unparseable short data → skip.
   - Geyser wallet branch uses this so zero propagates to JetStream via the normal `WalletBalanceSnapshot` path.
   - Unit tests for the helper.

2. **`src/bin/execution_engine.rs`**
   - **Follow-up (merge blocker fix):** Removed the earlier `publish_wsol_zero_snapshot_after_ata_close` path that ran on `send_transaction_rpc` → `Ok(sig)` only. That was incorrect because cleanup does **not** wait for confirmation; publishing `WSOL=0` / `update_wsol_only(0)` there could falsify state if the TX never landed. **WSOL=0** is driven solely by **market-data → Geyser → JetStream** after the on-chain close is visible.

## STOP-CHECKs

- **I-7**: No new Hot-Path RPC.
- **I-24a**: Wallet snapshots remain SSOT from market-data (Geyser path).

## Tests

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`
- `cargo test --features test_helpers --quiet`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0974a330-2f82-4a10-b383-9cacedd574ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0974a330-2f82-4a10-b383-9cacedd574ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

