### PR TITLE
fix(locks): Ghost Open Positions nach bestätigtem SELL (Scope 47)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -10286,7 +10286,6 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                 );
             }
         }
-        OPEN_POSITIONS_GAUGE.store(ctx.get_open_positions() as u64, Ordering::Relaxed);
 
         // Best-effort recent trade record for Grafana (/trades via Infinity datasource).
         // NOTE: If fill accounting is available, use it; otherwise fall back to placeholders.
@@ -10350,7 +10349,20 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
     }
 
     // Release lock (in production: would release after confirmation)
-    ctx.lock_manager.release_locks(&intent.intent_id);
+    if matches!(decision.outcome, DecisionOutcome::Confirmed) && intent.side == TradeSide::Sell {
+        // Do not re-add the sold input tokens to `available_tokens` (ghost open_positions).
+        ctx.lock_manager
+            .release_locks_after_confirmed_sell(&intent.intent_id);
+    } else {
+        ctx.lock_manager.release_locks(&intent.intent_id);
+    }
+
+    if matches!(
+        decision.outcome,
+        DecisionOutcome::Confirmed | DecisionOutcome::FailedConfirmed
+    ) {
+        OPEN_POSITIONS_GAUGE.store(ctx.get_open_positions() as u64, Ordering::Relaxed);
+    }
 
     info!(
         intent_id = %intent.intent_id,

--- a/src/storage/locks.rs
+++ b/src/storage/locks.rs
@@ -779,7 +779,24 @@ impl LockManager {
 
     /// Release all locks for an intent
     pub fn release_locks(&self, intent_id: &str) {
-        // Release capital lock. Same `available_*` order as `try_lock_capital`.
+        self.release_capital_lock_restore_tokens(intent_id, true);
+        self.release_resource_locks_for_intent(intent_id);
+    }
+
+    /// Release all locks after an **on-chain confirmed** SELL: restore SOL/WSOL from the
+    /// capital lock as in [`Self::release_locks`], but do **not** return locked *input*
+    /// token amounts to [`Self::available_tokens`]. After a successful SELL those tokens
+    /// are no longer held; [`Self::set_available_token_balance`] to zero and this path
+    /// must not resurrect a ghost `open_positions` count (Invariant A.28, KNOWN_BUG #5).
+    pub fn release_locks_after_confirmed_sell(&self, intent_id: &str) {
+        self.release_capital_lock_restore_tokens(intent_id, false);
+        self.release_resource_locks_for_intent(intent_id);
+    }
+
+    /// Release the capital lock for `intent_id`. If `restore_tokens` is true, return locked
+    /// token amounts to `available_tokens` (failure / rejection paths). If false, only
+    /// release lamport reservations (e.g. confirmed SELL: tokens are already sold).
+    fn release_capital_lock_restore_tokens(&self, intent_id: &str, restore_tokens: bool) {
         if let Some(lock) = self.capital_locks.write().remove(intent_id) {
             let mut available_sol = self.available_sol.write();
             let mut available_wsol = self.available_wsol.write();
@@ -789,13 +806,16 @@ impl LockManager {
             } else {
                 *available_sol += lock.sol_lamports;
             }
-            for (mint, amount) in lock.tokens {
-                *available_tokens.entry(mint).or_insert(0) += amount;
+            if restore_tokens {
+                for (mint, amount) in lock.tokens {
+                    *available_tokens.entry(mint).or_insert(0) += amount;
+                }
             }
-            debug!(intent_id, "Capital lock released");
+            debug!(intent_id, restore_tokens, "Capital lock released");
         }
+    }
 
-        // Release resource locks
+    fn release_resource_locks_for_intent(&self, intent_id: &str) {
         let mut resource_locks = self.resource_locks.write();
         let to_remove: Vec<_> = resource_locks
             .iter()
@@ -1463,5 +1483,69 @@ mod tests {
             m.available_token_balance("So11111111111111111111111111111111111111112"),
             0
         );
+    }
+
+    // --- Scope 47: confirmed SELL must not resurrect sold token via lock release ---
+
+    #[test]
+    fn test_confirmed_sell_release_does_not_restore_sold_token_to_available() {
+        const M: &str = "GhostMint";
+        let m = LockManager::new(0);
+        m.update_balances(0, HashMap::from([(M.to_string(), 1_000_000u64)]));
+
+        let mut sell = HashMap::new();
+        sell.insert(M.to_string(), 1_000_000u64);
+        assert!(matches!(
+            m.try_lock_capital(LockHolder::new("sell-confirmed"), 0, sell),
+            LockResult::Acquired
+        ));
+
+        m.set_available_token_balance(M.to_string(), 0);
+        assert_eq!(m.available_token_balance(M), 0);
+        assert_eq!(m.count_non_zero_token_balances(), 0);
+
+        m.release_locks_after_confirmed_sell("sell-confirmed");
+
+        assert_eq!(
+            m.available_token_balance(M),
+            0,
+            "must not re-add sold token from released capital lock"
+        );
+        assert_eq!(m.count_non_zero_token_balances(), 0);
+    }
+
+    #[test]
+    fn test_failed_sell_release_restores_locked_tokens() {
+        const M: &str = "FailedSellMint";
+        let m = LockManager::new(0);
+        m.update_balances(0, HashMap::from([(M.to_string(), 1_000_000u64)]));
+
+        let mut sell = HashMap::new();
+        sell.insert(M.to_string(), 800_000u64);
+        assert!(matches!(
+            m.try_lock_capital(LockHolder::new("sell-failed"), 0, sell),
+            LockResult::Acquired
+        ));
+        assert_eq!(m.available_token_balance(M), 200_000);
+
+        m.release_locks("sell-failed");
+
+        assert_eq!(m.available_token_balance(M), 1_000_000);
+        assert_eq!(m.count_non_zero_token_balances(), 1);
+    }
+
+    #[test]
+    fn test_confirmed_sell_release_still_restores_wsol_buy_reservation() {
+        let m = LockManager::new(10_000_000_000);
+        m.update_wallet_balances(5_000_000_000, Some(1_000_000_000));
+        assert!(matches!(
+            m.try_lock_capital(LockHolder::new("buy-inflight"), 300_000_000, HashMap::new()),
+            LockResult::Acquired
+        ));
+        assert_eq!(m.available_wsol(), 700_000_000);
+
+        m.release_locks_after_confirmed_sell("buy-inflight");
+
+        assert_eq!(m.available_wsol(), 1_000_000_000);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zusammenfassung

Nach bestätigter SELL-Transaktion setzte `set_available_token_balance(mint, 0)` die verkaufte Token-Balance korrekt auf 0, aber der anschließende `release_locks` fügte die aus dem Capital Lock freigegebenen Token-Mengen wieder in `available_tokens` ein – damit stieg `count_non_zero_token_balances()` (SSOT für `open_positions`) fälschlich.

## Änderung

- **`LockManager::release_locks_after_confirmed_sell`**: wie `release_locks` für SOL/WSOL-Reserven und Ressourcen-Locks, aber **keine** Rückbuchung der Token-Locks in `available_tokens` (nur sinnvoll, wenn der verkaufte Stand bereits 0 reflektiert, z. B. nach bestätigtem SELL).
- **`execution_engine`**: bei `DecisionOutcome::Confirmed` und `TradeSide::Sell` diese Variante statt `release_locks` verwenden; alle übrigen Pfade unverändert.
- **`OPEN_POSITIONS_GAUGE`**: nach dem **finalen** Lock-Release aktualisieren (nicht mehr davor, wo `release_locks` den Zustand noch korrigieren könnte).

## STOP-CHECKs (I-7, I-9, Isolation, Scope)

- Kein neuer RPC; nur LockManager- und Cleanup-State.
- Keine Simulation/Send-Logik geändert.
- Kein Lesen von `ironcrab-eval` Tests.

## Tests

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo test --features test_helpers`
- **Eval:** `ironcrab-eval` liegt in dieser Cloud-Umgebung nicht als Sibling-Repo; nicht ausgeführt (Vorgabe Scope: kein `Iron_crab-eval` in diesem PR).

## Betroffene Dateien

- `src/storage/locks.rs` (+ gezielte Unit-Tests)
- `src/bin/execution_engine.rs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a228daf-210a-4590-97fe-f206b6d05fbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a228daf-210a-4590-97fe-f206b6d05fbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

