### PR TITLE
Scope 48: Amount-aware confirmed SELL state (partial exits)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -383,6 +383,90 @@ fn extract_owner_mint_delta_raw(
     Some((decimals, delta))
 }
 
+/// Hard evidence from confirmed transaction meta: the wallet no longer has any token balance
+/// for `mint` after the tx (typical SPL `close_account` on the wallet ATA).
+///
+/// **Not** inferred from intent metadata (`close_token_ata`) — partial sells can still carry
+/// that flag while the ATA stays open (Scope 48 production case).
+fn tx_meta_wallet_token_balance_absent_after_tx(
+    tx: &EncodedConfirmedTransactionWithStatusMeta,
+    wallet: &Pubkey,
+    mint: &str,
+) -> bool {
+    let Some(meta) = tx.transaction.meta.as_ref() else {
+        return false;
+    };
+    let Some(pre_balances) =
+        Option::<Vec<UiTransactionTokenBalance>>::from(meta.pre_token_balances.clone())
+    else {
+        return false;
+    };
+    let Some(post_balances) =
+        Option::<Vec<UiTransactionTokenBalance>>::from(meta.post_token_balances.clone())
+    else {
+        return false;
+    };
+
+    let owner_str = wallet.to_string();
+    let mut pre_sum: u128 = 0;
+    for b in pre_balances.iter() {
+        let b_owner = Option::<String>::from(b.owner.clone());
+        if b.mint == mint && b_owner.as_deref() == Some(owner_str.as_str()) {
+            if let Ok(v) = u128::from_str(&b.ui_token_amount.amount) {
+                pre_sum = pre_sum.saturating_add(v);
+            }
+        }
+    }
+    if pre_sum == 0 {
+        return false;
+    }
+
+    let mut post_sum: u128 = 0;
+    for b in post_balances.iter() {
+        let b_owner = Option::<String>::from(b.owner.clone());
+        if b.mint == mint && b_owner.as_deref() == Some(owner_str.as_str()) {
+            if let Ok(v) = u128::from_str(&b.ui_token_amount.amount) {
+                post_sum = post_sum.saturating_add(v);
+            }
+        }
+    }
+    post_sum == 0
+}
+
+/// Scope 48: after a confirmed SELL, whether we treat the position as fully closed for
+/// LockManager / `ExecutionResult` metadata.
+///
+/// - **Liquidation / kill-switch**: always full-close (conservative).
+/// - **Regular Momentum / other SELLs**: full-close only when sold amount covers the engine's
+///   pre-release position (`sold_raw >= total_pos`) **or** transaction meta proves the wallet
+///   no longer holds any balance for the mint (actual ATA close / zero balance).
+///
+/// `sell_token_account_closed` metadata is emitted **only** with hard tx-meta evidence, never
+/// from `close_token_ata` intent metadata alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Scope48ConfirmedSellCloseDecision {
+    full_close: bool,
+    sell_token_account_closed: bool,
+    sell_untracked_ata: bool,
+}
+
+fn scope48_confirmed_sell_close_decision(
+    is_liquidation: bool,
+    sold_raw: u64,
+    total_pos: u64,
+    wallet_token_balance_absent_after_tx: bool,
+) -> Scope48ConfirmedSellCloseDecision {
+    let regular_full_close = sold_raw >= total_pos || wallet_token_balance_absent_after_tx;
+    let full_close = is_liquidation || regular_full_close;
+    let sell_token_account_closed = wallet_token_balance_absent_after_tx;
+    let sell_untracked_ata = full_close && !sell_token_account_closed;
+    Scope48ConfirmedSellCloseDecision {
+        full_close,
+        sell_token_account_closed,
+        sell_untracked_ata,
+    }
+}
+
 fn find_message_account_index(
     tx: &EncodedConfirmedTransactionWithStatusMeta,
     pubkey: &Pubkey,
@@ -575,18 +659,24 @@ fn extract_swap_sol_from_inner_instructions(
     (sol_out, sol_in)
 }
 
+/// Best-effort fill accounting from confirmed transaction RPC fetch (cold path after send).
+#[derive(Debug, Clone)]
+struct ComputedIntentFills {
+    fill_in: Option<ExplicitAmount>,
+    fill_out: Option<ExplicitAmount>,
+    fill_status: FillStatus,
+    fill_unavailable_reason: Option<FillUnavailableReason>,
+    wallet_sol_delta: Option<i128>,
+    /// True only from tx meta: wallet had this mint pre-tx and no post-tx token balance for it.
+    wallet_token_balance_absent_after_tx: bool,
+}
+
 async fn compute_intent_fills_best_effort(
     ctx: &ExecutionContext,
     wallet: Pubkey,
     signature: &Signature,
     intent: &TradeIntent,
-) -> (
-    Option<ExplicitAmount>,
-    Option<ExplicitAmount>,
-    FillStatus,
-    Option<FillUnavailableReason>,
-    Option<i128>, // SOL delta in lamports
-) {
+) -> ComputedIntentFills {
     let cfg = RpcTransactionConfig {
         encoding: Some(UiTransactionEncoding::JsonParsed),
         commitment: Some(solana_commitment_config::CommitmentConfig {
@@ -603,24 +693,26 @@ async fn compute_intent_fills_best_effort(
         Ok(tx) => tx,
         Err(e) => {
             debug!(sig = %signature, error = %e, "Failed to fetch tx meta for fills (best-effort)");
-            return (
-                None,
-                None,
-                FillStatus::Unavailable,
-                Some(FillUnavailableReason::RpcTxFetchFailed),
-                None,
-            );
+            return ComputedIntentFills {
+                fill_in: None,
+                fill_out: None,
+                fill_status: FillStatus::Unavailable,
+                fill_unavailable_reason: Some(FillUnavailableReason::RpcTxFetchFailed),
+                wallet_sol_delta: None,
+                wallet_token_balance_absent_after_tx: false,
+            };
         }
     };
 
     if tx.transaction.meta.is_none() {
-        return (
-            None,
-            None,
-            FillStatus::Unavailable,
-            Some(FillUnavailableReason::TxMetaMissing),
-            None,
-        );
+        return ComputedIntentFills {
+            fill_in: None,
+            fill_out: None,
+            fill_status: FillStatus::Unavailable,
+            fill_unavailable_reason: Some(FillUnavailableReason::TxMetaMissing),
+            wallet_sol_delta: None,
+            wallet_token_balance_absent_after_tx: false,
+        };
     }
 
     let input_mint = intent.resources.input_mint.as_str();
@@ -692,13 +784,14 @@ async fn compute_intent_fills_best_effort(
                 wsol_delta // Native delta unavailable, use WSOL delta only
             };
 
-            return (
+            return ComputedIntentFills {
                 fill_in,
                 fill_out,
-                FillStatus::Complete,
-                None,
-                Some(total_sol_delta),
-            );
+                fill_status: FillStatus::Complete,
+                fill_unavailable_reason: None,
+                wallet_sol_delta: Some(total_sol_delta),
+                wallet_token_balance_absent_after_tx: false,
+            };
         }
 
         // Fallback if WSOL token balance not found - use native lamport delta
@@ -711,13 +804,14 @@ async fn compute_intent_fills_best_effort(
                 Some(ExplicitAmount::new(out_raw, 9))
             };
 
-            return (
+            return ComputedIntentFills {
                 fill_in,
                 fill_out,
-                FillStatus::Partial,
-                Some(FillUnavailableReason::TokenBalanceDeltaMissing),
-                Some(payer_delta_lamports),
-            );
+                fill_status: FillStatus::Partial,
+                fill_unavailable_reason: Some(FillUnavailableReason::TokenBalanceDeltaMissing),
+                wallet_sol_delta: Some(payer_delta_lamports),
+                wallet_token_balance_absent_after_tx: false,
+            };
         }
     }
 
@@ -854,6 +948,17 @@ async fn compute_intent_fills_best_effort(
         (false, false) => FillStatus::Unavailable,
     };
 
+    let wallet_token_balance_absent_after_tx =
+        if intent.side == TradeSide::Sell && intent.resources.input_mint != SOL_MINT {
+            tx_meta_wallet_token_balance_absent_after_tx(
+                &tx,
+                &wallet,
+                intent.resources.input_mint.as_str(),
+            )
+        } else {
+            false
+        };
+
     let sol_leg_missing = (input_mint == SOL_MINT && fill_in.is_none())
         || (output_mint == SOL_MINT && fill_out.is_none());
 
@@ -886,13 +991,14 @@ async fn compute_intent_fills_best_effort(
     // (including ATA rent, fees, etc.) which is exactly what PnL needs.
     let wallet_sol_delta = Some(payer_delta_lamports);
 
-    (
+    ComputedIntentFills {
         fill_in,
         fill_out,
         fill_status,
         fill_unavailable_reason,
         wallet_sol_delta,
-    )
+        wallet_token_balance_absent_after_tx,
+    }
 }
 
 /// Extract WSOL flows from arbitrage TX: (amount_spent, amount_received)
@@ -10009,6 +10115,8 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
     // Confirmed SELL: token `fill_in` raw (sold amount), for LockManager + ExecutionResult metadata.
     let mut confirmed_sell_fill_in_raw: Option<u64> = None;
     let mut confirmed_sell_fill_status: Option<FillStatus> = None;
+    // From tx meta only: wallet had input mint pre-tx and zero post-tx token balance rows.
+    let mut confirmed_sell_wallet_balance_absent_after_tx: bool = false;
 
     if config.send_enabled {
         let status = match decision.outcome {
@@ -10173,29 +10281,35 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                     (ctx.wallet_pubkey, exec.signature.as_deref())
                 {
                     if let Ok(sig) = Signature::from_str(sig_str) {
-                        let (fill_in, fill_out, fill_status, fill_reason, wallet_sol_delta) =
+                        let fills =
                             compute_intent_fills_best_effort(ctx, wallet, &sig, &intent).await;
 
                         // Capture fill_out for immediate LockManager update (Fix: SIM_INSUFFICIENT_BALANCE)
                         if intent.side == TradeSide::Buy {
-                            if let Some(ref fo) = fill_out {
+                            if let Some(ref fo) = fills.fill_out {
                                 confirmed_buy_fill_out_raw = Some(fo.raw);
                             }
                         } else if intent.side == TradeSide::Sell {
-                            confirmed_sell_fill_status = Some(fill_status);
-                            if let Some(ref fi) = fill_in {
+                            confirmed_sell_fill_status = Some(fills.fill_status);
+                            confirmed_sell_wallet_balance_absent_after_tx =
+                                fills.wallet_token_balance_absent_after_tx;
+                            if let Some(ref fi) = fills.fill_in {
                                 confirmed_sell_fill_in_raw = Some(fi.raw);
                             }
                         }
 
                         exec = exec
-                            .with_fills(fill_in, fill_out)
-                            .with_fill_diagnostics(fill_status, fill_reason);
-                        if let Some(delta) = wallet_sol_delta {
+                            .with_fills(fills.fill_in, fills.fill_out)
+                            .with_fill_diagnostics(
+                                fills.fill_status,
+                                fills.fill_unavailable_reason,
+                            );
+                        if let Some(delta) = fills.wallet_sol_delta {
                             exec = exec.with_sol_delta(delta);
                         }
 
-                        // Scope 48: metadata for market-data — only untrack ATA / zero snapshot on full close.
+                        // Scope 48: metadata for market-data — full close from amount semantics or hard
+                        // tx-meta evidence (wallet token balance gone). Never from `close_token_ata` alone.
                         if intent.side == TradeSide::Sell
                             && matches!(status, ExecutionStatus::Confirmed)
                         {
@@ -10218,18 +10332,14 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                                     .get("kill_switch")
                                     .map(|v| v == "true")
                                     .unwrap_or(false);
-                            let close_ata_requested = intent
-                                .metadata
-                                .get("close_token_ata")
-                                .map(|v| v == "true")
-                                .unwrap_or(false);
-                            let token_account_closed = close_ata_requested
-                                && fill_status == FillStatus::Complete
-                                && confirmed_sell_fill_in_raw.is_some();
-                            let full_close =
-                                is_liquidation || token_account_closed || sold_raw >= total_pos;
+                            let s48 = scope48_confirmed_sell_close_decision(
+                                is_liquidation,
+                                sold_raw,
+                                total_pos,
+                                fills.wallet_token_balance_absent_after_tx,
+                            );
 
-                            if token_account_closed {
+                            if s48.sell_token_account_closed {
                                 exec.metadata.insert(
                                     "sell_token_account_closed".to_string(),
                                     "true".to_string(),
@@ -10237,13 +10347,13 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                             }
                             exec.metadata.insert(
                                 "sell_position_delta_applied".to_string(),
-                                if full_close {
+                                if s48.full_close {
                                     "full".to_string()
                                 } else {
                                     "partial".to_string()
                                 },
                             );
-                            if full_close && !token_account_closed {
+                            if s48.sell_untracked_ata {
                                 exec.metadata
                                     .insert("sell_untracked_ata".to_string(), "true".to_string());
                             }
@@ -10353,17 +10463,14 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                         .get("kill_switch")
                         .map(|v| v == "true")
                         .unwrap_or(false);
-                let close_ata_requested = intent
-                    .metadata
-                    .get("close_token_ata")
-                    .map(|v| v == "true")
-                    .unwrap_or(false);
-                let fill_complete = confirmed_sell_fill_status == Some(FillStatus::Complete);
-                let token_account_closed =
-                    close_ata_requested && fill_complete && confirmed_sell_fill_in_raw.is_some();
-                let full_close = is_liquidation || token_account_closed || sold_raw >= total_pos;
+                let s48 = scope48_confirmed_sell_close_decision(
+                    is_liquidation,
+                    sold_raw,
+                    total_pos,
+                    confirmed_sell_wallet_balance_absent_after_tx,
+                );
 
-                if full_close {
+                if s48.full_close {
                     ctx.lock_manager
                         .set_available_token_balance(mint_str.clone(), 0);
                     info!(
@@ -10372,7 +10479,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                         sold_raw,
                         total_pos,
                         is_liquidation,
-                        token_account_closed,
+                        sell_token_account_closed = s48.sell_token_account_closed,
                         "LockManager: cleared token balance after confirmed full SELL"
                     );
                 } else {
@@ -10403,7 +10510,14 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
 
         let (fill_in, fill_out, _fill_status, _fill_reason, _wallet_sol_delta) =
             if let (Some(wallet), Ok(sig)) = (ctx.wallet_pubkey, Signature::from_str(&tx_hash)) {
-                compute_intent_fills_best_effort(ctx, wallet, &sig, &intent).await
+                let f = compute_intent_fills_best_effort(ctx, wallet, &sig, &intent).await;
+                (
+                    f.fill_in,
+                    f.fill_out,
+                    f.fill_status,
+                    f.fill_unavailable_reason,
+                    f.wallet_sol_delta,
+                )
             } else {
                 (None, None, FillStatus::Unavailable, None, None)
             };
@@ -11271,8 +11385,9 @@ mod execution_engine_tests {
         is_cold_path_recovery_sell, is_pump_amm_structural_sim_error,
         is_pumpfun_bonding_curve_structural_sim_error, is_regular_momentum_hot_path_sell,
         pump_amm_hint_pool_cache_usable_for_tx_plan_builder, pump_amm_pool_market_hint_merge,
-        record_pump_amm_hot_path_refresh_after_success, select_best_route,
-        try_pump_amm_hot_path_refresh_publish, wait_for_meteora_dlmm_slave_after_recovery,
+        record_pump_amm_hot_path_refresh_after_success, scope48_confirmed_sell_close_decision,
+        select_best_route, try_pump_amm_hot_path_refresh_publish,
+        wait_for_meteora_dlmm_slave_after_recovery,
         wait_for_pump_amm_pool_hint_ready_for_tx_plan_builder,
         wait_for_pumpfun_bonding_cache_refresh, DiscoveryRequestOutcome,
         PumpAmmHotPathRefreshDecision, RouteCandidate, PUMP_AMM_HOT_PATH_REFRESH_COOLDOWN,
@@ -11285,6 +11400,7 @@ mod execution_engine_tests {
         IntentTier, TradeIntent, TradeResources, TradeSide, TradingRegime,
     };
     use ironcrab::solana::dex::pumpfun::PumpFunDex;
+    use ironcrab::storage::locks::{LockHolder, LockManager, LockResult};
     use parking_lot::Mutex as ParkingMutex;
     use solana_sdk::pubkey::Pubkey;
     use std::collections::HashMap;
@@ -11960,5 +12076,102 @@ mod execution_engine_tests {
             !stuck,
             "with before == post-recovery evidence, wait must not succeed (guards Bug #34 ordering)"
         );
+    }
+
+    /// Production Scope 48 failure: `close_token_ata=true` + complete fills + probe-only sold amount
+    /// must NOT be treated as full close for regular Momentum SELL.
+    #[test]
+    fn scope48_regular_momentum_partial_sell_close_token_ata_complete_fills_still_partial() {
+        let probe = 25_313_868_645u64;
+        let scale_in = 56_323_355_801u64;
+        let total_pos = probe.saturating_add(scale_in);
+
+        let s48 = scope48_confirmed_sell_close_decision(
+            false, probe, total_pos,
+            false, // would have been wrongly inferred from close_ata + Complete before fix
+        );
+        assert!(!s48.full_close);
+        assert!(!s48.sell_token_account_closed);
+        assert!(!s48.sell_untracked_ata);
+    }
+
+    #[test]
+    fn scope48_regular_momentum_full_sell_when_sold_covers_position() {
+        let total = 81_637_224_446u64;
+        let s48 = scope48_confirmed_sell_close_decision(false, total, total, false);
+        assert!(s48.full_close);
+        assert!(!s48.sell_token_account_closed);
+        assert!(s48.sell_untracked_ata);
+    }
+
+    #[test]
+    fn scope48_hard_meta_token_balance_gone_sets_sell_token_account_closed() {
+        let s48 = scope48_confirmed_sell_close_decision(false, 1, 1_000_000, true);
+        assert!(s48.full_close);
+        assert!(s48.sell_token_account_closed);
+        assert!(!s48.sell_untracked_ata);
+    }
+
+    #[test]
+    fn scope48_liquidation_conservative_full_close_even_if_amounts_ambiguous() {
+        let s48 = scope48_confirmed_sell_close_decision(true, 1, 10_000_000, false);
+        assert!(s48.full_close);
+        assert!(!s48.sell_token_account_closed);
+        assert!(s48.sell_untracked_ata);
+    }
+
+    /// LockManager: after partial probe sell, residual scale_in remains; Scope 47 release does not resurrect probe.
+    #[test]
+    fn scope48_lockmanager_probe_scale_partial_sell_residual() {
+        const M: &str = "ProdMintScope48";
+        let probe = 25_313_868_645u64;
+        let scale_in = 56_323_355_801u64;
+        let total = probe.saturating_add(scale_in);
+
+        let m = LockManager::new(0);
+        m.update_balances(0, HashMap::from([(M.to_string(), total)]));
+
+        let mut sell = HashMap::new();
+        sell.insert(M.to_string(), probe);
+        assert!(matches!(
+            m.try_lock_capital(LockHolder::new("sell-probe"), 0, sell),
+            LockResult::Acquired
+        ));
+        assert_eq!(m.available_token_balance(M), scale_in);
+
+        let (avail, locked) = m.available_and_locked_tokens_for_intent("sell-probe", M);
+        let total_pos = avail.saturating_add(locked);
+        let sold_raw = probe;
+        let s48 = scope48_confirmed_sell_close_decision(false, sold_raw, total_pos, false);
+        assert!(!s48.full_close);
+
+        m.release_locks_after_confirmed_sell("sell-probe");
+        assert_eq!(m.available_token_balance(M), scale_in);
+        assert_eq!(m.count_non_zero_token_balances(), 1);
+    }
+
+    #[test]
+    fn scope48_lockmanager_full_sell_zeros_balance() {
+        const M: &str = "FullMintScope48";
+        let total = 1_000_000u64;
+        let m = LockManager::new(0);
+        m.update_balances(0, HashMap::from([(M.to_string(), total)]));
+
+        let mut sell = HashMap::new();
+        sell.insert(M.to_string(), total);
+        assert!(matches!(
+            m.try_lock_capital(LockHolder::new("sell-all"), 0, sell),
+            LockResult::Acquired
+        ));
+
+        let (avail, locked) = m.available_and_locked_tokens_for_intent("sell-all", M);
+        let total_pos = avail.saturating_add(locked);
+        let s48 = scope48_confirmed_sell_close_decision(false, total, total_pos, false);
+        assert!(s48.full_close);
+
+        m.set_available_token_balance(M.to_string(), 0);
+        m.release_locks_after_confirmed_sell("sell-all");
+        assert_eq!(m.available_token_balance(M), 0);
+        assert_eq!(m.count_non_zero_token_balances(), 0);
     }
 }

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -10319,19 +10319,13 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                                     &intent.intent_id,
                                     &mint_key,
                                 );
-                            let total_pos = avail.saturating_add(locked);
+                            let total_pos = ctx
+                                .lock_manager
+                                .intent_token_position_total_at_lock(&intent.intent_id, &mint_key)
+                                .unwrap_or_else(|| avail.saturating_add(locked));
                             let sold_raw =
                                 confirmed_sell_fill_in_raw.unwrap_or(intent.required_capital.raw);
-                            let is_liquidation = intent
-                                .metadata
-                                .get("purpose")
-                                .map(|v| v == "liquidation")
-                                .unwrap_or(false)
-                                || intent
-                                    .metadata
-                                    .get("kill_switch")
-                                    .map(|v| v == "true")
-                                    .unwrap_or(false);
+                            let is_liquidation = is_cold_path_recovery_sell(&intent);
                             let s48 = scope48_confirmed_sell_close_decision(
                                 is_liquidation,
                                 sold_raw,
@@ -10360,6 +10354,21 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                         }
                     }
                 }
+            }
+
+            // Confirmed SELL must always carry Scope 48 position metadata for market-data. If the
+            // fill/signature path above was skipped (parse error, missing wallet, etc.), default
+            // to legacy full-close semantics so ATAs are not stuck tracked.
+            if matches!(status, ExecutionStatus::Confirmed)
+                && intent.side == TradeSide::Sell
+                && !exec.metadata.contains_key("sell_position_delta_applied")
+            {
+                exec.metadata.insert(
+                    "sell_position_delta_applied".to_string(),
+                    "full".to_string(),
+                );
+                exec.metadata
+                    .insert("sell_untracked_ata".to_string(), "true".to_string());
             }
 
             exec.status = status;
@@ -10451,18 +10460,12 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                 let (avail, locked) = ctx
                     .lock_manager
                     .available_and_locked_tokens_for_intent(&intent.intent_id, &mint_str);
-                let total_pos = avail.saturating_add(locked);
+                let total_pos = ctx
+                    .lock_manager
+                    .intent_token_position_total_at_lock(&intent.intent_id, &mint_str)
+                    .unwrap_or_else(|| avail.saturating_add(locked));
                 let sold_raw = confirmed_sell_fill_in_raw.unwrap_or(intent.required_capital.raw);
-                let is_liquidation = intent
-                    .metadata
-                    .get("purpose")
-                    .map(|v| v == "liquidation")
-                    .unwrap_or(false)
-                    || intent
-                        .metadata
-                        .get("kill_switch")
-                        .map(|v| v == "true")
-                        .unwrap_or(false);
+                let is_liquidation = is_cold_path_recovery_sell(&intent);
                 let s48 = scope48_confirmed_sell_close_decision(
                     is_liquidation,
                     sold_raw,
@@ -12139,8 +12142,9 @@ mod execution_engine_tests {
         ));
         assert_eq!(m.available_token_balance(M), scale_in);
 
-        let (avail, locked) = m.available_and_locked_tokens_for_intent("sell-probe", M);
-        let total_pos = avail.saturating_add(locked);
+        let total_pos = m
+            .intent_token_position_total_at_lock("sell-probe", M)
+            .expect("snapshot at lock");
         let sold_raw = probe;
         let s48 = scope48_confirmed_sell_close_decision(false, sold_raw, total_pos, false);
         assert!(!s48.full_close);
@@ -12164,8 +12168,9 @@ mod execution_engine_tests {
             LockResult::Acquired
         ));
 
-        let (avail, locked) = m.available_and_locked_tokens_for_intent("sell-all", M);
-        let total_pos = avail.saturating_add(locked);
+        let total_pos = m
+            .intent_token_position_total_at_lock("sell-all", M)
+            .expect("snapshot at lock");
         let s48 = scope48_confirmed_sell_close_decision(false, total, total_pos, false);
         assert!(s48.full_close);
 

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -10006,6 +10006,9 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
     // Capture fill_out for immediate LockManager update after confirmed BUY.
     // Populated inside the should_emit block when fills are available.
     let mut confirmed_buy_fill_out_raw: Option<u64> = None;
+    // Confirmed SELL: token `fill_in` raw (sold amount), for LockManager + ExecutionResult metadata.
+    let mut confirmed_sell_fill_in_raw: Option<u64> = None;
+    let mut confirmed_sell_fill_status: Option<FillStatus> = None;
 
     if config.send_enabled {
         let status = match decision.outcome {
@@ -10178,6 +10181,11 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                             if let Some(ref fo) = fill_out {
                                 confirmed_buy_fill_out_raw = Some(fo.raw);
                             }
+                        } else if intent.side == TradeSide::Sell {
+                            confirmed_sell_fill_status = Some(fill_status);
+                            if let Some(ref fi) = fill_in {
+                                confirmed_sell_fill_in_raw = Some(fi.raw);
+                            }
                         }
 
                         exec = exec
@@ -10185,6 +10193,60 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                             .with_fill_diagnostics(fill_status, fill_reason);
                         if let Some(delta) = wallet_sol_delta {
                             exec = exec.with_sol_delta(delta);
+                        }
+
+                        // Scope 48: metadata for market-data — only untrack ATA / zero snapshot on full close.
+                        if intent.side == TradeSide::Sell
+                            && matches!(status, ExecutionStatus::Confirmed)
+                        {
+                            let mint_key = intent.resources.input_mint.clone();
+                            let (avail, locked) =
+                                ctx.lock_manager.available_and_locked_tokens_for_intent(
+                                    &intent.intent_id,
+                                    &mint_key,
+                                );
+                            let total_pos = avail.saturating_add(locked);
+                            let sold_raw =
+                                confirmed_sell_fill_in_raw.unwrap_or(intent.required_capital.raw);
+                            let is_liquidation = intent
+                                .metadata
+                                .get("purpose")
+                                .map(|v| v == "liquidation")
+                                .unwrap_or(false)
+                                || intent
+                                    .metadata
+                                    .get("kill_switch")
+                                    .map(|v| v == "true")
+                                    .unwrap_or(false);
+                            let close_ata_requested = intent
+                                .metadata
+                                .get("close_token_ata")
+                                .map(|v| v == "true")
+                                .unwrap_or(false);
+                            let token_account_closed = close_ata_requested
+                                && fill_status == FillStatus::Complete
+                                && confirmed_sell_fill_in_raw.is_some();
+                            let full_close =
+                                is_liquidation || token_account_closed || sold_raw >= total_pos;
+
+                            if token_account_closed {
+                                exec.metadata.insert(
+                                    "sell_token_account_closed".to_string(),
+                                    "true".to_string(),
+                                );
+                            }
+                            exec.metadata.insert(
+                                "sell_position_delta_applied".to_string(),
+                                if full_close {
+                                    "full".to_string()
+                                } else {
+                                    "partial".to_string()
+                                },
+                            );
+                            if full_close && !token_account_closed {
+                                exec.metadata
+                                    .insert("sell_untracked_ata".to_string(), "true".to_string());
+                            }
                         }
                     }
                 }
@@ -10273,17 +10335,59 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                 }
             }
             TradeSide::Sell => {
-                // Clear token balance from LockManager after successful SELL.
-                // This prevents stale balances that would pass pre-flight checks
-                // for tokens we no longer hold.
-                let mint_str = &intent.resources.input_mint;
-                ctx.lock_manager
-                    .set_available_token_balance(mint_str.to_string(), 0);
-                info!(
-                    intent_id = %intent.intent_id,
-                    mint = %mint_str,
-                    "LockManager: cleared token balance after confirmed SELL"
-                );
+                // Amount-aware SELL (Scope 48): partial sells must not zero the mint or
+                // double-subtract when `release_locks_after_confirmed_sell` runs (lock still holds sold amount).
+                let mint_str = intent.resources.input_mint.clone();
+                let (avail, locked) = ctx
+                    .lock_manager
+                    .available_and_locked_tokens_for_intent(&intent.intent_id, &mint_str);
+                let total_pos = avail.saturating_add(locked);
+                let sold_raw = confirmed_sell_fill_in_raw.unwrap_or(intent.required_capital.raw);
+                let is_liquidation = intent
+                    .metadata
+                    .get("purpose")
+                    .map(|v| v == "liquidation")
+                    .unwrap_or(false)
+                    || intent
+                        .metadata
+                        .get("kill_switch")
+                        .map(|v| v == "true")
+                        .unwrap_or(false);
+                let close_ata_requested = intent
+                    .metadata
+                    .get("close_token_ata")
+                    .map(|v| v == "true")
+                    .unwrap_or(false);
+                let fill_complete = confirmed_sell_fill_status == Some(FillStatus::Complete);
+                let token_account_closed =
+                    close_ata_requested && fill_complete && confirmed_sell_fill_in_raw.is_some();
+                let full_close = is_liquidation || token_account_closed || sold_raw >= total_pos;
+
+                if full_close {
+                    ctx.lock_manager
+                        .set_available_token_balance(mint_str.clone(), 0);
+                    info!(
+                        intent_id = %intent.intent_id,
+                        mint = %mint_str,
+                        sold_raw,
+                        total_pos,
+                        is_liquidation,
+                        token_account_closed,
+                        "LockManager: cleared token balance after confirmed full SELL"
+                    );
+                } else {
+                    // Partial SELL: `available_tokens` already reflects post-sell unlocked balance
+                    // (total minus lock). Do not `set(..., 0)` or subtract — would double-count vs
+                    // `release_locks_after_confirmed_sell` (Scope 47 + Scope 48).
+                    info!(
+                        intent_id = %intent.intent_id,
+                        mint = %mint_str,
+                        sold_raw,
+                        total_pos,
+                        fill_status = ?confirmed_sell_fill_status,
+                        "LockManager: partial confirmed SELL — leaving token balance unchanged until lock release"
+                    );
+                }
             }
         }
 

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -436,7 +436,8 @@ fn tx_meta_wallet_token_balance_absent_after_tx(
 /// Scope 48: after a confirmed SELL, whether we treat the position as fully closed for
 /// LockManager / `ExecutionResult` metadata.
 ///
-/// - **Liquidation / kill-switch**: always full-close (conservative).
+/// - **Cold-path recovery** ([`is_cold_path_recovery_sell`]: liquidation, kill-switch, sell-all):
+///   always full-close (conservative).
 /// - **Regular Momentum / other SELLs**: full-close only when sold amount covers the engine's
 ///   pre-release position (`sold_raw >= total_pos`) **or** transaction meta proves the wallet
 ///   no longer holds any balance for the mint (actual ATA close / zero balance).
@@ -451,19 +452,68 @@ struct Scope48ConfirmedSellCloseDecision {
 }
 
 fn scope48_confirmed_sell_close_decision(
-    is_liquidation: bool,
+    is_cold_path_recovery: bool,
     sold_raw: u64,
     total_pos: u64,
     wallet_token_balance_absent_after_tx: bool,
 ) -> Scope48ConfirmedSellCloseDecision {
     let regular_full_close = sold_raw >= total_pos || wallet_token_balance_absent_after_tx;
-    let full_close = is_liquidation || regular_full_close;
+    let full_close = is_cold_path_recovery || regular_full_close;
     let sell_token_account_closed = wallet_token_balance_absent_after_tx;
     let sell_untracked_ata = full_close && !sell_token_account_closed;
     Scope48ConfirmedSellCloseDecision {
         full_close,
         sell_token_account_closed,
         sell_untracked_ata,
+    }
+}
+
+/// Scope 48: always set `sell_position_delta_applied` / optional flags on confirmed SELL
+/// `ExecutionResult`s from this engine, using lock snapshot + intent when tx fills are missing.
+fn apply_scope48_confirmed_sell_execution_metadata(
+    exec: &mut ExecutionResult,
+    lock_manager: &LockManager,
+    intent: &TradeIntent,
+    confirmed_sell_fill_in_raw: Option<u64>,
+    wallet_token_balance_absent_after_tx: bool,
+) {
+    if intent.side != TradeSide::Sell || exec.status != ExecutionStatus::Confirmed {
+        return;
+    }
+    let mint_key = intent.resources.input_mint.clone();
+    let (avail, locked) =
+        lock_manager.available_and_locked_tokens_for_intent(&intent.intent_id, &mint_key);
+    let total_pos = lock_manager
+        .intent_token_position_total_at_lock(&intent.intent_id, &mint_key)
+        .unwrap_or_else(|| avail.saturating_add(locked));
+    let sold_raw = confirmed_sell_fill_in_raw.unwrap_or(intent.required_capital.raw);
+    let is_cold_path_recovery = is_cold_path_recovery_sell(intent);
+    let s48 = scope48_confirmed_sell_close_decision(
+        is_cold_path_recovery,
+        sold_raw,
+        total_pos,
+        wallet_token_balance_absent_after_tx,
+    );
+
+    if s48.sell_token_account_closed {
+        exec.metadata
+            .insert("sell_token_account_closed".to_string(), "true".to_string());
+    } else {
+        exec.metadata.remove("sell_token_account_closed");
+    }
+    exec.metadata.insert(
+        "sell_position_delta_applied".to_string(),
+        if s48.full_close {
+            "full".to_string()
+        } else {
+            "partial".to_string()
+        },
+    );
+    if s48.sell_untracked_ata {
+        exec.metadata
+            .insert("sell_untracked_ata".to_string(), "true".to_string());
+    } else {
+        exec.metadata.remove("sell_untracked_ata");
     }
 }
 
@@ -10307,71 +10357,22 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                         if let Some(delta) = fills.wallet_sol_delta {
                             exec = exec.with_sol_delta(delta);
                         }
-
-                        // Scope 48: metadata for market-data — full close from amount semantics or hard
-                        // tx-meta evidence (wallet token balance gone). Never from `close_token_ata` alone.
-                        if intent.side == TradeSide::Sell
-                            && matches!(status, ExecutionStatus::Confirmed)
-                        {
-                            let mint_key = intent.resources.input_mint.clone();
-                            let (avail, locked) =
-                                ctx.lock_manager.available_and_locked_tokens_for_intent(
-                                    &intent.intent_id,
-                                    &mint_key,
-                                );
-                            let total_pos = ctx
-                                .lock_manager
-                                .intent_token_position_total_at_lock(&intent.intent_id, &mint_key)
-                                .unwrap_or_else(|| avail.saturating_add(locked));
-                            let sold_raw =
-                                confirmed_sell_fill_in_raw.unwrap_or(intent.required_capital.raw);
-                            let is_liquidation = is_cold_path_recovery_sell(&intent);
-                            let s48 = scope48_confirmed_sell_close_decision(
-                                is_liquidation,
-                                sold_raw,
-                                total_pos,
-                                fills.wallet_token_balance_absent_after_tx,
-                            );
-
-                            if s48.sell_token_account_closed {
-                                exec.metadata.insert(
-                                    "sell_token_account_closed".to_string(),
-                                    "true".to_string(),
-                                );
-                            }
-                            exec.metadata.insert(
-                                "sell_position_delta_applied".to_string(),
-                                if s48.full_close {
-                                    "full".to_string()
-                                } else {
-                                    "partial".to_string()
-                                },
-                            );
-                            if s48.sell_untracked_ata {
-                                exec.metadata
-                                    .insert("sell_untracked_ata".to_string(), "true".to_string());
-                            }
-                        }
                     }
                 }
             }
 
-            // Confirmed SELL must always carry Scope 48 position metadata for market-data. If the
-            // fill/signature path above was skipped (parse error, missing wallet, etc.), default
-            // to legacy full-close semantics so ATAs are not stuck tracked.
-            if matches!(status, ExecutionStatus::Confirmed)
-                && intent.side == TradeSide::Sell
-                && !exec.metadata.contains_key("sell_position_delta_applied")
-            {
-                exec.metadata.insert(
-                    "sell_position_delta_applied".to_string(),
-                    "full".to_string(),
-                );
-                exec.metadata
-                    .insert("sell_untracked_ata".to_string(), "true".to_string());
-            }
-
             exec.status = status;
+            // Scope 48: always classify confirmed SELL for market-data, even when fill RPC path
+            // was skipped (no signature / parse failure / missing wallet).
+            if intent.side == TradeSide::Sell && exec.status == ExecutionStatus::Confirmed {
+                apply_scope48_confirmed_sell_execution_metadata(
+                    &mut exec,
+                    &ctx.lock_manager,
+                    &intent,
+                    confirmed_sell_fill_in_raw,
+                    confirmed_sell_wallet_balance_absent_after_tx,
+                );
+            }
             if matches!(exec.status, ExecutionStatus::Failed) {
                 exec.error_message = Some("execution_failed".to_string());
                 exec.error_code = decision
@@ -10465,9 +10466,9 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                     .intent_token_position_total_at_lock(&intent.intent_id, &mint_str)
                     .unwrap_or_else(|| avail.saturating_add(locked));
                 let sold_raw = confirmed_sell_fill_in_raw.unwrap_or(intent.required_capital.raw);
-                let is_liquidation = is_cold_path_recovery_sell(&intent);
+                let is_cold_path_recovery = is_cold_path_recovery_sell(&intent);
                 let s48 = scope48_confirmed_sell_close_decision(
-                    is_liquidation,
+                    is_cold_path_recovery,
                     sold_raw,
                     total_pos,
                     confirmed_sell_wallet_balance_absent_after_tx,
@@ -10481,7 +10482,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                         mint = %mint_str,
                         sold_raw,
                         total_pos,
-                        is_liquidation,
+                        is_cold_path_recovery,
                         sell_token_account_closed = s48.sell_token_account_closed,
                         "LockManager: cleared token balance after confirmed full SELL"
                     );
@@ -11385,12 +11386,12 @@ async fn spawn_rebroadcast_loop(
 #[cfg(test)]
 mod execution_engine_tests {
     use super::{
-        is_cold_path_recovery_sell, is_pump_amm_structural_sim_error,
-        is_pumpfun_bonding_curve_structural_sim_error, is_regular_momentum_hot_path_sell,
-        pump_amm_hint_pool_cache_usable_for_tx_plan_builder, pump_amm_pool_market_hint_merge,
-        record_pump_amm_hot_path_refresh_after_success, scope48_confirmed_sell_close_decision,
-        select_best_route, try_pump_amm_hot_path_refresh_publish,
-        wait_for_meteora_dlmm_slave_after_recovery,
+        apply_scope48_confirmed_sell_execution_metadata, is_cold_path_recovery_sell,
+        is_pump_amm_structural_sim_error, is_pumpfun_bonding_curve_structural_sim_error,
+        is_regular_momentum_hot_path_sell, pump_amm_hint_pool_cache_usable_for_tx_plan_builder,
+        pump_amm_pool_market_hint_merge, record_pump_amm_hot_path_refresh_after_success,
+        scope48_confirmed_sell_close_decision, select_best_route,
+        try_pump_amm_hot_path_refresh_publish, wait_for_meteora_dlmm_slave_after_recovery,
         wait_for_pump_amm_pool_hint_ready_for_tx_plan_builder,
         wait_for_pumpfun_bonding_cache_refresh, DiscoveryRequestOutcome,
         PumpAmmHotPathRefreshDecision, RouteCandidate, PUMP_AMM_HOT_PATH_REFRESH_COOLDOWN,
@@ -11399,8 +11400,9 @@ mod execution_engine_tests {
         CachedPoolState, LivePoolCache, MeteoraState, PumpAmmState, PumpFunState,
     };
     use ironcrab::ipc::{
-        ControlResponse, ControlResponseStatus, DexPoolReadiness, ExplicitAmount, IntentOrigin,
-        IntentTier, TradeIntent, TradeResources, TradeSide, TradingRegime,
+        ControlResponse, ControlResponseStatus, DexPoolReadiness, ExecutionResult, ExecutionStatus,
+        ExplicitAmount, IntentOrigin, IntentTier, TradeIntent, TradeResources, TradeSide,
+        TradingRegime,
     };
     use ironcrab::solana::dex::pumpfun::PumpFunDex;
     use ironcrab::storage::locks::{LockHolder, LockManager, LockResult};
@@ -12178,5 +12180,150 @@ mod execution_engine_tests {
         m.release_locks_after_confirmed_sell("sell-all");
         assert_eq!(m.available_token_balance(M), 0);
         assert_eq!(m.count_non_zero_token_balances(), 0);
+    }
+
+    /// No tx-meta fill (`confirmed_sell_fill_in_raw` None): still classify partial from
+    /// `required_capital` + lock snapshot (production RPC/fill gap).
+    #[test]
+    fn scope48_apply_metadata_partial_momentum_sell_without_fill_in_raw() {
+        const MINT: &str = "Scope48MintNoFill";
+        let probe = 25_313_868_645u64;
+        let scale_in = 56_323_355_801u64;
+        let total = probe.saturating_add(scale_in);
+
+        let lm = LockManager::new(0);
+        lm.update_balances(0, HashMap::from([(MINT.to_string(), total)]));
+        let mut sell_map = HashMap::new();
+        sell_map.insert(MINT.to_string(), probe);
+        assert!(matches!(
+            lm.try_lock_capital(LockHolder::new("intent-no-fill"), 0, sell_map),
+            LockResult::Acquired
+        ));
+
+        let mut intent = TradeIntent::new(
+            "momentum-bot",
+            "v0.1.0",
+            "run-1",
+            "intent-no-fill".to_string(),
+            "momentum-bot",
+            IntentTier::Tier1,
+            IntentOrigin::StrategyA,
+            ExplicitAmount::new(probe, 6),
+            TradeResources {
+                input_mint: MINT.to_string(),
+                output_mint: ironcrab::ipc::NATIVE_SOL_MINT.to_string(),
+                pools: vec!["pool".to_string()],
+                accounts: vec![],
+                token_program: None,
+            },
+            0,
+            200,
+            TradeSide::Sell,
+            TradingRegime::Early,
+        );
+        intent
+            .metadata
+            .insert("close_token_ata".to_string(), "true".to_string());
+
+        let mut exec = ExecutionResult::new_sent(
+            "execution-engine",
+            "test",
+            "run",
+            "ex1".to_string(),
+            "d1".to_string(),
+            "intent-no-fill".to_string(),
+            "momentum-bot".to_string(),
+            Some(MINT.to_string()),
+            Some("sig".to_string()),
+            None,
+        );
+        exec.status = ExecutionStatus::Confirmed;
+
+        apply_scope48_confirmed_sell_execution_metadata(&mut exec, &lm, &intent, None, false);
+
+        assert_eq!(
+            exec.metadata
+                .get("sell_position_delta_applied")
+                .map(|s| s.as_str()),
+            Some("partial")
+        );
+        assert!(!exec.metadata.contains_key("sell_untracked_ata"));
+        assert!(!exec.metadata.contains_key("sell_token_account_closed"));
+
+        let sold_raw = intent.required_capital.raw;
+        let total_pos = lm
+            .intent_token_position_total_at_lock(&intent.intent_id, MINT)
+            .expect("snapshot at lock");
+        let s48 = scope48_confirmed_sell_close_decision(false, sold_raw, total_pos, false);
+        assert!(!s48.full_close);
+    }
+
+    #[test]
+    fn scope48_sell_all_conservative_full_close_despite_probe_vs_total() {
+        const MINT: &str = "SellAllMint";
+        let probe = 100u64;
+        let scale = 900u64;
+        let total = probe.saturating_add(scale);
+
+        let lm = LockManager::new(0);
+        lm.update_balances(0, HashMap::from([(MINT.to_string(), total)]));
+        let mut sell_map = HashMap::new();
+        sell_map.insert(MINT.to_string(), probe);
+        assert!(matches!(
+            lm.try_lock_capital(LockHolder::new("sell-all-intent"), 0, sell_map),
+            LockResult::Acquired
+        ));
+
+        let mut intent = TradeIntent::new(
+            "sell-all",
+            "v0.1.0",
+            "run-1",
+            "sell-all-intent".to_string(),
+            "sell-all",
+            IntentTier::Tier1,
+            IntentOrigin::StrategyA,
+            ExplicitAmount::new(probe, 6),
+            TradeResources {
+                input_mint: MINT.to_string(),
+                output_mint: ironcrab::ipc::NATIVE_SOL_MINT.to_string(),
+                pools: vec!["pool".to_string()],
+                accounts: vec![],
+                token_program: None,
+            },
+            0,
+            200,
+            TradeSide::Sell,
+            TradingRegime::Early,
+        );
+        intent
+            .metadata
+            .insert("sell_all".to_string(), "true".to_string());
+        assert!(is_cold_path_recovery_sell(&intent));
+
+        let mut exec = ExecutionResult::new_sent(
+            "execution-engine",
+            "test",
+            "run",
+            "ex-sa".to_string(),
+            "d-sa".to_string(),
+            "sell-all-intent".to_string(),
+            "sell-all".to_string(),
+            Some(MINT.to_string()),
+            None,
+            None,
+        );
+        exec.status = ExecutionStatus::Confirmed;
+
+        apply_scope48_confirmed_sell_execution_metadata(&mut exec, &lm, &intent, None, false);
+        assert_eq!(
+            exec.metadata
+                .get("sell_position_delta_applied")
+                .map(|s| s.as_str()),
+            Some("full")
+        );
+        assert_eq!(
+            exec.metadata.get("sell_untracked_ata").map(|s| s.as_str()),
+            Some("true")
+        );
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3787,6 +3787,96 @@ async fn handle_wallet_bootstrap_meteora_dlmm_verify_for_mint(
     }
 }
 
+/// True when a confirmed SELL [`ExecutionResult`] indicates the wallet no longer holds the
+/// position for this mint (full exit, liquidation, or token ATA closed). Partial sells must
+/// return false so Geyser keeps tracking the ATA until an on-chain balance update arrives.
+fn execution_result_sell_closes_wallet_position(exec: &ExecutionResult) -> bool {
+    if exec.metadata.get("side").map(|s| s.as_str()) != Some("SELL") {
+        return false;
+    }
+    if exec
+        .metadata
+        .get("sell_token_account_closed")
+        .map(|v| v == "true")
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    if exec
+        .metadata
+        .get("sell_untracked_ata")
+        .map(|v| v == "true")
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    matches!(
+        exec.metadata
+            .get("sell_position_delta_applied")
+            .map(|s| s.as_str()),
+        Some("full") | Some("full_no_balance_update")
+    )
+}
+
+#[cfg(test)]
+mod execution_result_sell_close_tests {
+    use super::execution_result_sell_closes_wallet_position;
+    use ironcrab::ipc::{ExecutionResult, ExecutionStatus};
+    use std::collections::HashMap;
+
+    fn base_sell_exec() -> ExecutionResult {
+        let mut exec = ExecutionResult::new_sent(
+            "execution-engine",
+            "test",
+            "run",
+            "ex1".to_string(),
+            "d1".to_string(),
+            "i1".to_string(),
+            "src".to_string(),
+            Some("mint".to_string()),
+            Some("sig".to_string()),
+            None,
+        );
+        exec.status = ExecutionStatus::Confirmed;
+        exec.metadata = HashMap::from([("side".to_string(), "SELL".to_string())]);
+        exec
+    }
+
+    #[test]
+    fn partial_sell_metadata_does_not_close_position() {
+        let mut exec = base_sell_exec();
+        exec.metadata.insert(
+            "sell_position_delta_applied".to_string(),
+            "partial".to_string(),
+        );
+        assert!(!execution_result_sell_closes_wallet_position(&exec));
+    }
+
+    #[test]
+    fn full_sell_metadata_closes_position() {
+        let mut exec = base_sell_exec();
+        exec.metadata.insert(
+            "sell_position_delta_applied".to_string(),
+            "full".to_string(),
+        );
+        exec.metadata
+            .insert("sell_untracked_ata".to_string(), "true".to_string());
+        assert!(execution_result_sell_closes_wallet_position(&exec));
+    }
+
+    #[test]
+    fn token_account_closed_closes_even_if_partial_flag_wrong() {
+        let mut exec = base_sell_exec();
+        exec.metadata.insert(
+            "sell_position_delta_applied".to_string(),
+            "partial".to_string(),
+        );
+        exec.metadata
+            .insert("sell_token_account_closed".to_string(), "true".to_string());
+        assert!(execution_result_sell_closes_wallet_position(&exec));
+    }
+}
+
 /// Publish wallet token balance snapshot for position reconciliation.
 ///
 /// Called at market-data startup to provide momentum-bot with current wallet state.
@@ -6390,8 +6480,9 @@ async fn run_geyser_loop(
                                             "ExecutionResult: tracked wallet ATA/mint"
                                         );
 
-                                        // 5) For confirmed SELLs: write zero-balance snapshot and untrack ATA
-                                        if is_confirmed_sell {
+                                        // 5) Full close / liquidation / ATA-close SELL: zero snapshot + untrack.
+                                        // Partial SELL: keep ATA tracked; residual balance comes from Geyser.
+                                        if is_confirmed_sell && execution_result_sell_closes_wallet_position(&exec) {
                                             let wallet_str = tracked_wallet.wallet.to_string();
                                             let snapshot = MarketEvent::new(
                                                 "market-data",
@@ -6434,6 +6525,13 @@ async fn run_geyser_loop(
                                                     "Untracked ATA after confirmed SELL"
                                                 );
                                             }
+                                        } else if is_confirmed_sell {
+                                            info!(
+                                                mint = %mint_str,
+                                                ata = %ata,
+                                                sell_position_delta = ?exec.metadata.get("sell_position_delta_applied"),
+                                                "Confirmed partial SELL: keeping ATA tracked (no zero snapshot / untrack)"
+                                            );
                                         }
 
                                         if let Err(e) = msg.ack().await {

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3794,6 +3794,11 @@ fn execution_result_sell_closes_wallet_position(exec: &ExecutionResult) -> bool 
     if exec.metadata.get("side").map(|s| s.as_str()) != Some("SELL") {
         return false;
     }
+    // Rolling deploy / skipped Scope 48 block: without an explicit partial marker, keep legacy
+    // "confirmed SELL closes wallet position" semantics (only `partial` keeps the ATA tracked).
+    if !exec.metadata.contains_key("sell_position_delta_applied") {
+        return true;
+    }
     if exec
         .metadata
         .get("sell_token_account_closed")
@@ -3850,6 +3855,12 @@ mod execution_result_sell_close_tests {
             "partial".to_string(),
         );
         assert!(!execution_result_sell_closes_wallet_position(&exec));
+    }
+
+    #[test]
+    fn confirmed_sell_without_scope48_keys_treated_as_full_close() {
+        let exec = base_sell_exec();
+        assert!(execution_result_sell_closes_wallet_position(&exec));
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3823,6 +3823,30 @@ fn execution_result_sell_closes_wallet_position(exec: &ExecutionResult) -> bool 
     )
 }
 
+/// Mixed-deploy / foreign producers may omit Scope 48 fields. Preserve legacy behavior: assume
+/// full close so zero snapshot + untrack still runs for old sell-all tooling, etc.
+/// **Never** backfill `execution-engine` results — that process must emit explicit metadata.
+fn backfill_scope48_metadata_foreign_confirmed_sell(exec: &mut ExecutionResult) {
+    if exec.header.component == "execution-engine" {
+        return;
+    }
+    if exec.status != ExecutionStatus::Confirmed {
+        return;
+    }
+    if exec.metadata.get("side").map(|s| s.as_str()) != Some("SELL") {
+        return;
+    }
+    if exec.metadata.contains_key("sell_position_delta_applied") {
+        return;
+    }
+    exec.metadata.insert(
+        "sell_position_delta_applied".to_string(),
+        "full".to_string(),
+    );
+    exec.metadata
+        .insert("sell_untracked_ata".to_string(), "true".to_string());
+}
+
 #[cfg(test)]
 mod execution_result_sell_close_tests {
     use super::execution_result_sell_closes_wallet_position;
@@ -3885,6 +3909,46 @@ mod execution_result_sell_close_tests {
         exec.metadata
             .insert("sell_token_account_closed".to_string(), "true".to_string());
         assert!(execution_result_sell_closes_wallet_position(&exec));
+    }
+
+    #[test]
+    fn backfill_foreign_confirmed_sell_sets_full_when_scope48_missing() {
+        use super::backfill_scope48_metadata_foreign_confirmed_sell;
+
+        let mut exec = ExecutionResult::new_sent(
+            "legacy-sell-tool",
+            "test",
+            "run",
+            "ex2".to_string(),
+            "d2".to_string(),
+            "i2".to_string(),
+            "src".to_string(),
+            Some("mint".to_string()),
+            Some("sig".to_string()),
+            None,
+        );
+        exec.status = ExecutionStatus::Confirmed;
+        exec.metadata = HashMap::from([("side".to_string(), "SELL".to_string())]);
+        backfill_scope48_metadata_foreign_confirmed_sell(&mut exec);
+        assert_eq!(
+            exec.metadata
+                .get("sell_position_delta_applied")
+                .map(|s| s.as_str()),
+            Some("full")
+        );
+        assert_eq!(
+            exec.metadata.get("sell_untracked_ata").map(|s| s.as_str()),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn backfill_skips_execution_engine_results() {
+        use super::backfill_scope48_metadata_foreign_confirmed_sell;
+
+        let mut exec = base_sell_exec();
+        backfill_scope48_metadata_foreign_confirmed_sell(&mut exec);
+        assert!(!exec.metadata.contains_key("sell_position_delta_applied"));
     }
 }
 
@@ -6323,7 +6387,8 @@ async fn run_geyser_loop(
                             while let Some(msg_result) = messages.next().await {
                                 match msg_result {
                                     Ok(msg) => {
-                                        let exec: ExecutionResult = match serde_json::from_slice(&msg.payload) {
+                                        let mut exec: ExecutionResult =
+                                            match serde_json::from_slice(&msg.payload) {
                                             Ok(e) => e,
                                             Err(e) => {
                                                 debug!(error = %e, "Failed to deserialize ExecutionResult");
@@ -6331,6 +6396,8 @@ async fn run_geyser_loop(
                                                 continue;
                                             }
                                         };
+
+                                        backfill_scope48_metadata_foreign_confirmed_sell(&mut exec);
 
                                         // Dedup on execution_id (fallback: signature)
                                         let dedup_key = if !exec.execution_id.is_empty() {

--- a/src/storage/locks.rs
+++ b/src/storage/locks.rs
@@ -1700,4 +1700,18 @@ mod tests {
             (70, 0)
         );
     }
+
+    #[test]
+    fn test_intent_token_position_total_at_lock_matches_avail_plus_locked() {
+        const M: &str = "TotalAtLockMint";
+        let m = LockManager::new(0);
+        m.update_balances(0, HashMap::from([(M.to_string(), 100u64)]));
+        let mut sell = HashMap::new();
+        sell.insert(M.to_string(), 30u64);
+        assert!(matches!(
+            m.try_lock_capital(LockHolder::new("x"), 0, sell),
+            LockResult::Acquired
+        ));
+        assert_eq!(m.intent_token_position_total_at_lock("x", M), Some(100));
+    }
 }

--- a/src/storage/locks.rs
+++ b/src/storage/locks.rs
@@ -68,6 +68,11 @@ pub struct CapitalLock {
     pub reserves_trading_wsol: bool,
     /// Token amounts locked (mint -> raw amount)
     pub tokens: HashMap<String, u64>,
+    /// At lock acquisition: per mint, `available_tokens[mint]` **before** this lock subtracted
+    /// `amount` (i.e. the engine's notion of total position for that mint at SELL reservation).
+    /// Used for Scope 48 decisions so a concurrent Geyser `set_available_token_balance` cannot
+    /// shrink `avail+locked` mid-flight.
+    pub token_position_total_at_lock: HashMap<String, u64>,
     pub created_at: Instant,
     pub ttl: Duration,
 }
@@ -478,22 +483,6 @@ impl LockManager {
         self.available_tokens.write().insert(mint, new_total);
     }
 
-    /// Subtract sold raw units from the unlocked balance for `mint` (saturating at zero).
-    ///
-    /// Used after a **partial** confirmed SELL: do not call [`Self::set_available_token_balance`]
-    /// to zero while a capital lock still holds sold tokens — that would double-subtract when
-    /// the lock is released ([`Self::release_locks_after_confirmed_sell`]).
-    pub fn subtract_available_token_balance(&self, mint: String, sold_raw: u64) {
-        let current = self
-            .available_tokens
-            .read()
-            .get(&mint)
-            .copied()
-            .unwrap_or(0);
-        let new_total = current.saturating_sub(sold_raw);
-        self.available_tokens.write().insert(mint, new_total);
-    }
-
     /// `(available_unlocked, locked_in_capital_lock)` for `mint` on `intent_id`'s capital lock.
     ///
     /// For a normal in-flight SELL, `available + locked` is the wallet position size the engine
@@ -511,6 +500,18 @@ impl LockManager {
             .unwrap_or(0);
         let available = self.available_token_balance(mint);
         (available, locked)
+    }
+
+    /// Engine position size for `mint` at SELL lock acquisition (`available + locked` before lock),
+    /// if `intent_id` holds a capital lock that includes `mint`.
+    ///
+    /// Stable vs concurrent Geyser updates that call [`Self::set_available_token_balance`] while
+    /// the lock is held (see Scope 48).
+    pub fn intent_token_position_total_at_lock(&self, intent_id: &str, mint: &str) -> Option<u64> {
+        self.capital_locks
+            .read()
+            .get(intent_id)
+            .and_then(|l| l.token_position_total_at_lock.get(mint).copied())
     }
 
     /// Update wallet balances from WalletBalanceUpdate event (SOL + WSOL).
@@ -698,9 +699,12 @@ impl LockManager {
         } else if sol_lamports > 0 {
             *available_sol -= sol_lamports;
         }
+        let mut token_position_total_at_lock = HashMap::with_capacity(tokens.len());
         for (mint, amount) in &tokens {
             if let Some(avail) = available_tokens.get_mut(mint) {
+                let position_total_before = *avail;
                 *avail -= amount;
+                token_position_total_at_lock.insert(mint.clone(), position_total_before);
             }
         }
 
@@ -709,6 +713,7 @@ impl LockManager {
             sol_lamports,
             reserves_trading_wsol: buy_reserves_wsol,
             tokens,
+            token_position_total_at_lock,
             created_at: Instant::now(),
             ttl: self.default_ttl,
         };
@@ -821,9 +826,10 @@ impl LockManager {
     /// Release all locks after an **on-chain confirmed** SELL: restore SOL/WSOL from the
     /// capital lock as in [`Self::release_locks`], but do **not** return locked *input*
     /// token amounts to [`Self::available_tokens`]. After a successful full SELL those
-    /// tokens are no longer held — use [`Self::set_available_token_balance`] to zero **or**
-    /// [`Self::subtract_available_token_balance`] for a partial — and this path must not
-    /// resurrect a ghost `open_positions` count (Invariant A.28, KNOWN_BUG #5).
+    /// tokens are no longer held — use [`Self::set_available_token_balance`] to zero the mint;
+    /// after a partial SELL do not replace balances while the lock is held (avoid double-count vs
+    /// this release path). This path must not resurrect a ghost `open_positions` count (Invariant
+    /// A.28, KNOWN_BUG #5).
     pub fn release_locks_after_confirmed_sell(&self, intent_id: &str) {
         self.release_capital_lock_restore_tokens(intent_id, false);
         self.release_resource_locks_for_intent(intent_id);
@@ -1620,14 +1626,36 @@ mod tests {
     }
 
     #[test]
-    fn test_subtract_available_token_balance_saturating() {
-        const M: &str = "SubMint";
+    fn test_intent_token_position_total_at_lock_stable_across_geyser_mid_flight() {
+        const M: &str = "GeyserRaceMint";
+        let total = 1_000_000u64;
+        let sell_amt = 600_000u64;
         let m = LockManager::new(0);
-        m.update_balances(0, HashMap::from([(M.to_string(), 500u64)]));
-        m.subtract_available_token_balance(M.to_string(), 200);
-        assert_eq!(m.available_token_balance(M), 300);
-        m.subtract_available_token_balance(M.to_string(), 1_000);
-        assert_eq!(m.available_token_balance(M), 0);
+        m.update_balances(0, HashMap::from([(M.to_string(), total)]));
+
+        let mut sell = HashMap::new();
+        sell.insert(M.to_string(), sell_amt);
+        assert!(matches!(
+            m.try_lock_capital(LockHolder::new("sell-race"), 0, sell),
+            LockResult::Acquired
+        ));
+
+        assert_eq!(
+            m.intent_token_position_total_at_lock("sell-race", M),
+            Some(total)
+        );
+
+        // Geyser: wallet already reflects partial sell (T−S) while SELL lock still reserves S.
+        m.set_available_token_balance(M.to_string(), total.saturating_sub(sell_amt));
+        let (avail, locked) = m.available_and_locked_tokens_for_intent("sell-race", M);
+        assert!(
+            avail.saturating_add(locked) < total,
+            "naive avail+locked must not equal pre-lock position under concurrent Geyser replace"
+        );
+        assert_eq!(
+            m.intent_token_position_total_at_lock("sell-race", M),
+            Some(total)
+        );
     }
 
     #[test]

--- a/src/storage/locks.rs
+++ b/src/storage/locks.rs
@@ -478,6 +478,41 @@ impl LockManager {
         self.available_tokens.write().insert(mint, new_total);
     }
 
+    /// Subtract sold raw units from the unlocked balance for `mint` (saturating at zero).
+    ///
+    /// Used after a **partial** confirmed SELL: do not call [`Self::set_available_token_balance`]
+    /// to zero while a capital lock still holds sold tokens — that would double-subtract when
+    /// the lock is released ([`Self::release_locks_after_confirmed_sell`]).
+    pub fn subtract_available_token_balance(&self, mint: String, sold_raw: u64) {
+        let current = self
+            .available_tokens
+            .read()
+            .get(&mint)
+            .copied()
+            .unwrap_or(0);
+        let new_total = current.saturating_sub(sold_raw);
+        self.available_tokens.write().insert(mint, new_total);
+    }
+
+    /// `(available_unlocked, locked_in_capital_lock)` for `mint` on `intent_id`'s capital lock.
+    ///
+    /// For a normal in-flight SELL, `available + locked` is the wallet position size the engine
+    /// believed before lock release.
+    pub fn available_and_locked_tokens_for_intent(
+        &self,
+        intent_id: &str,
+        mint: &str,
+    ) -> (u64, u64) {
+        let locked = self
+            .capital_locks
+            .read()
+            .get(intent_id)
+            .and_then(|l| l.tokens.get(mint).copied())
+            .unwrap_or(0);
+        let available = self.available_token_balance(mint);
+        (available, locked)
+    }
+
     /// Update wallet balances from WalletBalanceUpdate event (SOL + WSOL).
     ///
     /// This is called when market-data publishes balance updates via NATS.
@@ -785,9 +820,10 @@ impl LockManager {
 
     /// Release all locks after an **on-chain confirmed** SELL: restore SOL/WSOL from the
     /// capital lock as in [`Self::release_locks`], but do **not** return locked *input*
-    /// token amounts to [`Self::available_tokens`]. After a successful SELL those tokens
-    /// are no longer held; [`Self::set_available_token_balance`] to zero and this path
-    /// must not resurrect a ghost `open_positions` count (Invariant A.28, KNOWN_BUG #5).
+    /// token amounts to [`Self::available_tokens`]. After a successful full SELL those
+    /// tokens are no longer held — use [`Self::set_available_token_balance`] to zero **or**
+    /// [`Self::subtract_available_token_balance`] for a partial — and this path must not
+    /// resurrect a ghost `open_positions` count (Invariant A.28, KNOWN_BUG #5).
     pub fn release_locks_after_confirmed_sell(&self, intent_id: &str) {
         self.release_capital_lock_restore_tokens(intent_id, false);
         self.release_resource_locks_for_intent(intent_id);
@@ -1547,5 +1583,93 @@ mod tests {
         m.release_locks_after_confirmed_sell("buy-inflight");
 
         assert_eq!(m.available_wsol(), 1_000_000_000);
+    }
+
+    // --- Scope 48: partial confirmed SELL leaves residual balance; full SELL clears ---
+
+    #[test]
+    fn test_partial_confirmed_sell_skip_balance_replace_then_release_keeps_residual() {
+        const M: &str = "ProbeScaleMint";
+        let probe = 25_313_868_645u64;
+        let scale_in = 56_323_355_801u64;
+        let total = probe.saturating_add(scale_in);
+
+        let m = LockManager::new(0);
+        m.update_balances(0, HashMap::from([(M.to_string(), total)]));
+
+        let mut sell = HashMap::new();
+        sell.insert(M.to_string(), probe);
+        assert!(matches!(
+            m.try_lock_capital(LockHolder::new("sell-partial"), 0, sell),
+            LockResult::Acquired
+        ));
+        // In-flight SELL: locked probe is gone from `available_tokens`; residual scale_in remains.
+        assert_eq!(m.available_token_balance(M), scale_in);
+        assert_eq!(m.count_non_zero_token_balances(), 1);
+
+        // Partial confirmed SELL: engine must NOT `set_available_token_balance(..., 0)` here —
+        // balance is already correct until lock release.
+        m.release_locks_after_confirmed_sell("sell-partial");
+
+        assert_eq!(
+            m.available_token_balance(M),
+            scale_in,
+            "must not restore sold probe from lock"
+        );
+        assert_eq!(m.count_non_zero_token_balances(), 1);
+    }
+
+    #[test]
+    fn test_subtract_available_token_balance_saturating() {
+        const M: &str = "SubMint";
+        let m = LockManager::new(0);
+        m.update_balances(0, HashMap::from([(M.to_string(), 500u64)]));
+        m.subtract_available_token_balance(M.to_string(), 200);
+        assert_eq!(m.available_token_balance(M), 300);
+        m.subtract_available_token_balance(M.to_string(), 1_000);
+        assert_eq!(m.available_token_balance(M), 0);
+    }
+
+    #[test]
+    fn test_full_confirmed_sell_zero_then_release_stays_zero() {
+        const M: &str = "FullSellMint";
+        let m = LockManager::new(0);
+        m.update_balances(0, HashMap::from([(M.to_string(), 1_000_000u64)]));
+
+        let mut sell = HashMap::new();
+        sell.insert(M.to_string(), 1_000_000u64);
+        assert!(matches!(
+            m.try_lock_capital(LockHolder::new("sell-full"), 0, sell),
+            LockResult::Acquired
+        ));
+
+        m.set_available_token_balance(M.to_string(), 0);
+        m.release_locks_after_confirmed_sell("sell-full");
+
+        assert_eq!(m.available_token_balance(M), 0);
+        assert_eq!(m.count_non_zero_token_balances(), 0);
+    }
+
+    #[test]
+    fn test_available_and_locked_tokens_for_intent() {
+        const M: &str = "LockViewMint";
+        let m = LockManager::new(0);
+        m.update_balances(0, HashMap::from([(M.to_string(), 100u64)]));
+
+        let mut sell = HashMap::new();
+        sell.insert(M.to_string(), 30u64);
+        assert!(matches!(
+            m.try_lock_capital(LockHolder::new("sell-1"), 0, sell),
+            LockResult::Acquired
+        ));
+
+        assert_eq!(
+            m.available_and_locked_tokens_for_intent("sell-1", M),
+            (70, 30)
+        );
+        assert_eq!(
+            m.available_and_locked_tokens_for_intent("missing", M),
+            (70, 0)
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scope 48: amount-aware confirmed SELL state (partial exits) + review fixes. **Second review:** execution-engine must **never** default `sell_position_delta_applied=full` when fill RPC is skipped — always classify from lock snapshot + `intent.required_capital` (and cold-path recovery for sell-all/liquidation).

## Second review (correctness blocker)

- Removed aggressive default: ~~if Confirmed SELL && missing `sell_position_delta_applied` → full + `sell_untracked_ata`~~.
- **`apply_scope48_confirmed_sell_execution_metadata`** runs after every confirmed SELL emit (independent of `compute_intent_fills_best_effort`).
- **`total_pos`**: `intent_token_position_total_at_lock` (snapshot at lock, stable vs Geyser mid-flight) **or** `available+locked` fallback.
- **`sold_raw`**: `fill_in` when present else `required_capital.raw`.
- **`is_cold_path_recovery_sell`**: conservative full-close (liquidation, kill-switch, **sell_all**).
- **market-data**: `backfill_scope48_metadata_foreign_confirmed_sell` — legacy full only for `header.component != "execution-engine"`.

## Merged with upstream (rebase)

Remote added `CapitalLock.token_position_total_at_lock` + Geyser-race test; this PR keeps `Option<u64>` API and uses `.unwrap_or(avail+locked)` in Scope 48 paths.

## Tests

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo test --features test_helpers`.

## STOP-CHECK

No hot-path RPC; simulation/send unchanged; allowed files only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-462feae4-0af1-4c5a-94a0-f4ba061cfe3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-462feae4-0af1-4c5a-94a0-f4ba061cfe3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

