### PR TITLE
Scope 52: Grafana „Recent Trades“ – Voll-Mint-Links, Zeit-Modus, Spaltenbreiten

### DIFF
--- a/docs/grafana_multiprocess_dashboard.json
+++ b/docs/grafana_multiprocess_dashboard.json
@@ -2,7 +2,7 @@
   "title": "IronCrab Multi-Process Architecture",
   "description": "Dashboard for the Debuggable-First Multi-Process Architecture",
   "schemaVersion": 39,
-  "version": 5,
+  "version": 6,
   "time": {
     "from": "now-1h",
     "to": "now"
@@ -13,6 +13,34 @@
     "multi-process",
     "trading"
   ],
+  "templating": {
+    "list": [
+      {
+        "name": "time_mode",
+        "type": "custom",
+        "label": "Trades: Zeit (Recent Trades)",
+        "query": "relative,utc",
+        "options": [
+          {
+            "value": "relative",
+            "text": "Relativ (z.B. vor 25 Min.)",
+            "selected": true
+          },
+          {
+            "value": "utc",
+            "text": "UTC"
+          }
+        ],
+        "current": {
+          "value": "relative",
+          "text": "Relativ (z.B. vor 25 Min.)"
+        },
+        "includeAll": false,
+        "multi": false,
+        "hide": 0
+      }
+    ]
+  },
   "panels": [
     {
       "type": "row",
@@ -1906,7 +1934,7 @@
           "type": "json",
           "source": "url",
           "format": "table",
-          "url": "/trades?mode=run",
+          "url": "/trades?mode=run&time_mode=${time_mode}",
           "url_options": {
             "method": "GET",
             "data": ""
@@ -1915,8 +1943,18 @@
           "columns": [
             {
               "selector": "timestamp_ms",
+              "text": "Sort (ms)",
+              "type": "number"
+            },
+            {
+              "selector": "time_display",
               "text": "Time",
-              "type": "timestamp_epoch"
+              "type": "string"
+            },
+            {
+              "selector": "mint_full",
+              "text": "mint_full",
+              "type": "string"
             },
             {
               "selector": "action",
@@ -1972,12 +2010,44 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "Sort (ms)"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "Time"
             },
             "properties": [
               {
-                "id": "unit",
-                "value": "dateTimeFromNow"
+                "id": "custom.width",
+                "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "mint_full"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
               }
             ]
           },
@@ -1987,6 +2057,10 @@
               "options": "Action"
             },
             "properties": [
+              {
+                "id": "custom.width",
+                "value": 70
+              },
               {
                 "id": "custom.cellOptions",
                 "value": {
@@ -2026,14 +2100,14 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 120
+                "value": 130
               },
               {
                 "id": "links",
                 "value": [
                   {
                     "title": "View on Solscan",
-                    "url": "https://solscan.io/token/${__value.text}",
+                    "url": "https://solscan.io/token/${__data.fields.mint_full}",
                     "targetBlank": true
                   }
                 ]
@@ -2048,7 +2122,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 100
+                "value": 110
               },
               {
                 "id": "links",
@@ -2065,9 +2139,25 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "Amount"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "Value (SOL)"
             },
             "properties": [
+              {
+                "id": "custom.width",
+                "value": 115
+              },
               {
                 "id": "decimals",
                 "value": 12
@@ -2080,6 +2170,10 @@
               "options": "PnL (SOL)"
             },
             "properties": [
+              {
+                "id": "custom.width",
+                "value": 95
+              },
               {
                 "id": "decimals",
                 "value": 6
@@ -2114,6 +2208,10 @@
               "options": "PnL %"
             },
             "properties": [
+              {
+                "id": "custom.width",
+                "value": 75
+              },
               {
                 "id": "unit",
                 "value": "percent"
@@ -2154,7 +2252,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 200
+                "value": 160
               },
               {
                 "id": "custom.cellOptions",
@@ -2294,7 +2392,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 300
+                "value": 500
               }
             ]
           }
@@ -2304,7 +2402,7 @@
         "showHeader": true,
         "sortBy": [
           {
-            "displayName": "Time",
+            "displayName": "Sort (ms)",
             "desc": true
           }
         ]

--- a/scripts/trades_server.py
+++ b/scripts/trades_server.py
@@ -7,12 +7,17 @@ Reads from: trade_logs/executions/execution_results-YYYYMMDD.jsonl
 Grafana Infinity data source connects to this for "Recent Trades" table panel.
 
 Usage: python3 trades_server.py [--port 9899]
+
+Query params (GET /trades):
+- mode: limit|run — same as before
+- time_mode: relative|utc — controls `time_display` (default relative); `timestamp_ms` always for sorting
+  Response adds: time_utc, time_age, time_display
 """
 
 import http.server
 import json
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import urlparse, parse_qs
 import argparse
@@ -29,7 +34,8 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
 
         if path == "/trades":
             mode = params.get('mode', ['limit'])[0]
-            self.serve_trades(mode=mode)
+            time_mode = params.get('time_mode', ['relative'])[0]
+            self.serve_trades(mode=mode, time_mode=time_mode)
         elif path == "/decisions":
             self.serve_decisions()
         elif path == "/pnl_24h":
@@ -43,17 +49,63 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
     
-    def serve_trades(self, mode: str = "limit"):
+    def serve_trades(self, mode: str = "limit", time_mode: str = "relative"):
         if mode == "run":
             trades = self.read_trades_by_run()
         else:
             trades = self.read_recent_trades(20)
-        
+
+        self._apply_time_mode_fields(trades, time_mode)
+
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(json.dumps(trades).encode())
+
+    def _format_time_age_german(self, ts_ms: int) -> str:
+        """Relative age in German, e.g. 'vor 25 Minuten' (Grafana table display)."""
+        if not ts_ms:
+            return "—"
+        now = datetime.now(tz=timezone.utc)
+        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+        delta = now - ts
+        total_secs = int(max(0, delta.total_seconds()))
+        if total_secs < 60:
+            s = max(1, total_secs)
+            return f"vor {s} Sekunde{'n' if s != 1 else ''}"
+        if total_secs < 3600:
+            m = max(1, total_secs // 60)
+            if m == 1:
+                return "vor 1 Minute"
+            return f"vor {m} Minuten"
+        if total_secs < 86400:
+            h = max(1, total_secs // 3600)
+            if h == 1:
+                return "vor 1 Stunde"
+            return f"vor {h} Stunden"
+        d = max(1, total_secs // 86400)
+        return f"vor {d} Tagen"
+
+    def _apply_time_mode_fields(self, trades: list, time_mode: str) -> None:
+        """Add time_utc, time_age, and time_display for dashboard toggles (keeps timestamp_ms for sort)."""
+        if time_mode not in ("relative", "utc"):
+            time_mode = "relative"
+        for t in trades:
+            ts_ms = t.get("timestamp_ms") or 0
+            if ts_ms:
+                utc_str = (
+                    datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
+                    + " UTC"
+                )
+            else:
+                utc_str = "—"
+            age_str = self._format_time_age_german(ts_ms)
+            t["time_utc"] = utc_str
+            t["time_age"] = age_str
+            t["time_display"] = age_str if time_mode == "relative" else utc_str
 
     def serve_decisions(self):
         decisions = self.read_recent_decisions(200)
@@ -697,11 +749,39 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
         pass
 
 
+def _self_check():
+    """Quick sanity check for time_mode fields (no server)."""
+    h = TradesHandler.__new__(TradesHandler)
+    ts_ms = 1_700_000_000_000
+    expected_utc = (
+        datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        + " UTC"
+    )
+    row = {"timestamp_ms": ts_ms}
+    TradesHandler._apply_time_mode_fields(h, [row], "relative")
+    assert row.get("time_utc") == expected_utc
+    assert row.get("time_display") == row.get("time_age")
+    TradesHandler._apply_time_mode_fields(h, [row], "utc")
+    assert row.get("time_display") == expected_utc
+    print("trades_server: self-check OK")
+
+
 def main():
     parser = argparse.ArgumentParser(description='Trades history server')
     parser.add_argument('--port', type=int, default=9899, help='Port to listen on (default: 9899)')
+    parser.add_argument(
+        '--self-check',
+        action='store_true',
+        help='Run a quick local check of time_mode fields and exit',
+    )
     args = parser.parse_args()
-    
+
+    if args.self_check:
+        _self_check()
+        return
+
     server = http.server.HTTPServer(('0.0.0.0', args.port), TradesHandler)
     print(f"Trades server running on http://0.0.0.0:{args.port}/trades")
     print(f"Reading from: {EXECUTIONS_DIR}")

--- a/scripts/trades_server.py
+++ b/scripts/trades_server.py
@@ -85,6 +85,8 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
                 return "vor 1 Stunde"
             return f"vor {h} Stunden"
         d = max(1, total_secs // 86400)
+        if d == 1:
+            return "vor 1 Tag"
         return f"vor {d} Tagen"
 
     def _apply_time_mode_fields(self, trades: list, time_mode: str) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Kurz
Behebt drei UX-Punkte am Panel **Recent Trades (Current Run)** (Dashboard-JSON + `trades_server.py` für die Trades-API). **Keine Änderungen** an Trading-Logik, `src/`, oder Execution.

## 1) Solscan Token-Link (volle Mint-Adresse)
- Anzeige bleibt `mint` (gekürzt).
- Data-Link-URL: `https://solscan.io/token/${__data.fields.mint_full}`  
  (Referenz auf verstecktes Feld `mint_full` in derselben Zeile, nicht auf `${__value.text}`.)
- Zusätzliche Infinity-Spalte `mint_full` (Display-Name im Panel: `mint_full`) + Override **Hide in table**, damit das Feld im Link nutzbar bleibt.

## 2) Zeit: Relativ vs. UTC
- **Umsetzung:** Dashboard-Variable `time_mode` mit Werten `relative` | `utc` + Query `GET /trades?mode=run&time_mode=${time_mode}`.
- API liefert weiter `timestamp_ms` (Sortierung) sowie **`time_utc`**, **`time_age`** (deutsch, z. B. „vor 25 Minuten“) und **`time_display`**, abhängig von `time_mode` (Default **relative** = wie bisher lesbar relativ).
- Panel: sichtbare Spalte **Time** zeigt `time_display`; **Sort (ms)** = `timestamp_ms`, versteckt, **Standard-Sortierung absteigend** (neueste zuerst) — Sort-Pfeil bleibt chronologisch sinnvoll, nicht an Relativ- vs. UTC-Text gebunden.
- *Grund kein reiner Doppelspalte:* Eine Umschalt-Variable pro Zeile wäre in der Tabelle doppelt; so bleibt die Tabelle schmal und `Detail` gewinnt Platz.

## 3) Spaltenbreiten
Explizit nachgestellt (u. a. `Detail` 500, schmalere `Action`/`Amount`/PnL-Spalten) damit `Detail` weniger abgeschnitten wird.

## Tests
- `python3 -m py_compile scripts/trades_server.py`
- `python3 scripts/trades_server.py --self-check`
- `python3 -m json.tool docs/grafana_multiprocess_dashboard.json`
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (inkl. `--features test_helpers`)

## Manuelle Verifikation (nach Deploy des Dashboards / laufendem `trades_server`)
- `GET /trades?mode=run&time_mode=relative` und `time_mode=utc` — `time_display` passt, `timestamp_ms` unverändert.
- Token-Klick: Solscan mit vollständiger Mint; TX-Link unverändert.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e866bd1e-fd52-4ef5-882e-28e6b4a0c925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e866bd1e-fd52-4ef5-882e-28e6b4a0c925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

