### PR TITLE
fix(dashboard): Scope 53 – Recent Trades (full mint, Time toggle, no helper columns)

### DIFF
--- a/docs/grafana_multiprocess_dashboard.json
+++ b/docs/grafana_multiprocess_dashboard.json
@@ -1942,18 +1942,8 @@
           "root_selector": "",
           "columns": [
             {
-              "selector": "timestamp_ms",
-              "text": "Sort (ms)",
-              "type": "number"
-            },
-            {
               "selector": "time_display",
               "text": "Time",
-              "type": "string"
-            },
-            {
-              "selector": "mint_full",
-              "text": "mint_full",
               "type": "string"
             },
             {
@@ -1962,7 +1952,7 @@
               "type": "string"
             },
             {
-              "selector": "mint",
+              "selector": "mint_full",
               "text": "Token (Mint)",
               "type": "string"
             },
@@ -2010,44 +2000,12 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Sort (ms)"
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
               "options": "Time"
             },
             "properties": [
               {
                 "id": "custom.width",
-                "value": 120
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "mint_full"
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
+                "value": 150
               }
             ]
           },
@@ -2100,14 +2058,14 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 130
+                "value": 300
               },
               {
                 "id": "links",
                 "value": [
                   {
                     "title": "View on Solscan",
-                    "url": "https://solscan.io/token/${__data.fields.mint_full}",
+                    "url": "https://solscan.io/token/${__value.text}",
                     "targetBlank": true
                   }
                 ]
@@ -2392,7 +2350,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 500
+                "value": 520
               }
             ]
           }
@@ -2400,12 +2358,7 @@
       },
       "options": {
         "showHeader": true,
-        "sortBy": [
-          {
-            "displayName": "Sort (ms)",
-            "desc": true
-          }
-        ]
+        "sortBy": []
       }
     },
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zusammenfassung (Scope 53)

Behebt die Dashboard-Regression nach Scope 52: **nur** `docs/grafana_multiprocess_dashboard.json` geändert; `scripts/trades_server.py` unverändert (liefert weiter `time_display` + `time_mode` wie zuvor).

### Token (Mint)
- Eine sichtbare Spalte `Token (Mint)` nutzt den JSON-Selector **`mint_full`**, der vollständige Mint-Adressen anzeigt.
- Solscan-Link wie bei TX: **`https://solscan.io/token/${__value.text}`** (Zelltext = vollständiger Mint).
- Keine zweite Spalte `mint_full` und kein `mint` mehr in der Tabelle (kein abgekürzter Mint).

### Time
- Eine sichtbare Spalte **`Time`** angebunden an **`time_display`**, gesteuert durch Dashboard-Variable `time_mode` (relative/UTC) und `GET /trades?mode=run&time_mode=${time_mode}`.
- **`timestamp_ms`** wird nicht als Tabellenspalte ausgeliefert.

### Entfernt
- Sichtbare Spalte **`Sort (ms)`** entfernt (inkl. `sortBy` auf diese Spalte; Panel-`sortBy` ist leer, damit die **vom `trades_server` gelieferte Reihenfolge** (neueste zuerst) erhalten bleibt).

**Hinweis (Sortierung in Grafana):** Ohne verstecktes numerisches Sortierfeld sortiert die Tabelle ggf. nicht streng chronologisch nach Klick; zuverlässiger chronologischer Klick-Sort wäre nur mit einer unsichtbaren `timestamp_ms`-Spalte in Grafana möglich (bewusst nicht genutzt, damit **keine** sichtbare Hilfsspalte erscheint). Die **API liefert** die Liste weiterhin in sinnvoller zeitlicher Reihenfolge.

### Breiten
- `Action`, `Amount`, `PnL (SOL)`, `PnL %` unverändert schmal; **`Detail` breiter** (520); `Token (Mint)` breit für lange Mints; `Time` etwas breiter für UTC-Zeichenketten.

### Nicht geändert
- Kein Trading-Code, kein `src/`, kein neues Verhalten in `trades_server.py` (nur geprüft: `py_compile` + `--self-check`).

**STOP-CHECK:** Kein RPC/Hot Path; erlaubte Pfade; keine Simulation/Keys.

Tests: `python3 -m py_compile scripts/trades_server.py`, `python3 scripts/trades_server.py --self-check`, `python3 -m json.tool docs/grafana_multiprocess_dashboard.json`; `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo test --features test_helpers`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54b7ef1e-95d2-439d-8f9a-06459f2df438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54b7ef1e-95d2-439d-8f9a-06459f2df438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

