### PR TITLE
Scope 54: Grafana Recent Trades — Spalten, Value-Decimals, Zeit-Hinweis

### DIFF
--- a/docs/grafana_multiprocess_dashboard.json
+++ b/docs/grafana_multiprocess_dashboard.json
@@ -2,7 +2,7 @@
   "title": "IronCrab Multi-Process Architecture",
   "description": "Dashboard for the Debuggable-First Multi-Process Architecture",
   "schemaVersion": 39,
-  "version": 6,
+  "version": 7,
   "time": {
     "from": "now-1h",
     "to": "now"
@@ -1907,7 +1907,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 59
+        "y": 61
       },
       "fieldConfig": {
         "defaults": {
@@ -1916,13 +1916,28 @@
       }
     },
     {
+      "type": "text",
+      "title": "Recent Trades: Zeit-Modus",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      },
+      "options": {
+        "content": "**Time mode:** Grafana shows dashboard variables in the **top bar**; this JSON model cannot place the `time_mode` control between panels. Use the **Trades: Zeit (Recent Trades)** dropdown at the top to switch Relativ/UTC. The table column arrows **only** control sort order.",
+        "mode": "markdown"
+      },
+      "transparent": true
+    },
+    {
       "type": "table",
       "title": "Recent Trades (Current Run)",
       "gridPos": {
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 67
       },
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
@@ -2058,7 +2073,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 300
+                "value": 110
               },
               {
                 "id": "links",
@@ -2118,7 +2133,7 @@
               },
               {
                 "id": "decimals",
-                "value": 12
+                "value": 9
               }
             ]
           },
@@ -2350,7 +2365,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 520
+                "value": 710
               }
             ]
           }
@@ -2368,7 +2383,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 71
+        "y": 79
       },
       "collapsed": false
     },
@@ -2401,7 +2416,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 72
+        "y": 80
       },
       "fieldConfig": {
         "defaults": {
@@ -2422,7 +2437,7 @@
         "h": 3,
         "w": 4,
         "x": 12,
-        "y": 72
+        "y": 80
       },
       "fieldConfig": {
         "defaults": {
@@ -2462,7 +2477,7 @@
         "h": 3,
         "w": 4,
         "x": 16,
-        "y": 72
+        "y": 80
       },
       "fieldConfig": {
         "defaults": {
@@ -2498,7 +2513,7 @@
         "h": 3,
         "w": 4,
         "x": 20,
-        "y": 72
+        "y": 80
       }
     }
   ]

--- a/docs/grafana_multiprocess_dashboard.json
+++ b/docs/grafana_multiprocess_dashboard.json
@@ -1907,7 +1907,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 61
+        "y": 59
       },
       "fieldConfig": {
         "defaults": {
@@ -1922,7 +1922,7 @@
         "h": 2,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 65
       },
       "options": {
         "content": "**Time mode:** Grafana shows dashboard variables in the **top bar**; this JSON model cannot place the `time_mode` control between panels. Use the **Trades: Zeit (Recent Trades)** dropdown at the top to switch Relativ/UTC. The table column arrows **only** control sort order.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Token (Mint)** und **TX Hash** nutzen jetzt die gleiche Spaltenbreite (110). **`mint_full`**, Solscan-URL und Anzeige der vollständigen Adresse unverändert. Schmalere Minze-Abteilung: mehr Fläche für **Detail** (Breite 520 → 710); bei sehr langen Mint-Strings greift ggf. Tabellen-Truncation, der Klicklink bleibt voll.
- **Value (SOL)**: Anzeigedecimals von 12 auf **9**; **Spaltenbreite 115** wie nach Scope 53.
- **Zeit-Modus**: In diesem Dashboard-JSON-Modell (schemaVersion 39) ist keine native Platzierung des Variablen-Dropdowns zwischen den Panels vorgesehen. Darum **Hinweis-Panel** direkt über *Recent Trades* mit Verweis auf **„Trades: Zeit (Recent Trades)“** in der oberen Grafana-Leiste; Sortierpfeile in der Tabelle = nur Sortierung. **`time_mode`** am Endpoint `/trades?...&time_mode=${time_mode}` unverändert.
- Zusätzlich: **Grid-Layout** korrigiert (Simulation und Recent Trades lagen beide auf `y:59`); **NATS Message Flow**-Abschnitt nach unten gerückt, damit nichts überlappt. Keine sichtbaren Helper-Spalten (`Sort (ms)` / `mint_full` getrennt).

## Trading

Keine Logik, keine `src/`-Änderungen.

## Checks

- `python3 -m json.tool docs/grafana_multiprocess_dashboard.json`
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo test --features test_helpers`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73b60a48-29f9-48bb-83b2-cde26bb46fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73b60a48-29f9-48bb-83b2-cde26bb46fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

