### PR TITLE
PA-2: PositionAuthority runtime metrics (read-only)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -78,8 +78,9 @@ use ironcrab::metrics::{
     INTENTS_EXECUTED_TOTAL, INTENTS_RECEIVED_TOTAL, INTENTS_REJECTED_TOTAL,
     JITO_BUNDLES_LANDED_TOTAL, JITO_BUNDLES_REJECTED_TOTAL, JITO_BUNDLES_SUBMITTED_TOTAL,
     JITO_BUNDLES_TIMEOUT_TOTAL, JITO_TIP_LAMPORTS_TOTAL, KILL_SWITCH_ACTIVE,
-    NATS_MESSAGES_RECEIVED_TOTAL, OPEN_POSITIONS_GAUGE,
-    PUMPSWAP_HOT_PATH_HEALING_ASYNC_PUBLISH_FAIL_TOTAL,
+    NATS_MESSAGES_RECEIVED_TOTAL, OPEN_POSITIONS_GAUGE, POSITION_AUTHORITY_DRIFT_LOCKMANAGER,
+    POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE, POSITION_AUTHORITY_OPEN_GAUGE,
+    POSITION_AUTHORITY_RECONCILE_NEEDED_GAUGE, PUMPSWAP_HOT_PATH_HEALING_ASYNC_PUBLISH_FAIL_TOTAL,
     PUMPSWAP_HOT_PATH_HEALING_ASYNC_PUBLISH_SUCCESS_TOTAL,
     PUMPSWAP_HOT_PATH_HEALING_COOLDOWN_SUPPRESSED_TOTAL,
     PUMPSWAP_HOT_PATH_HEALING_SKIPPED_NO_NATS_TOTAL, PUMPSWAP_HOT_PATH_HEALING_TRIGGER_TOTAL,
@@ -97,6 +98,7 @@ use ironcrab::nats::{
     TOPIC_PRIORITY_FEE_SAMPLES, TOPIC_TRADE_INTENTS, TRADE_INTENTS_STREAM_NAME,
     WALLET_SNAPSHOT_STREAM_NAME,
 };
+use ironcrab::position_authority::{position_authority_drift_lockmanager, PositionAuthority};
 use ironcrab::solana::cross_dex_handler::CrossDexHandler;
 use ironcrab::solana::dex::meteora_dlmm::MeteoraDlmm;
 use ironcrab::solana::dex::orca::Orca;
@@ -1915,6 +1917,8 @@ struct ExecutionContext {
     execution_writer: JsonlWriter,
     burn_writer: JsonlWriter,
     lock_manager: LockManager,
+    /// PA-2: passive PositionAuthority (metrics only; not used for gating or reservations).
+    position_authority: Arc<ParkingMutex<PositionAuthority>>,
     log_base: PathBuf, // P1: For state persistence
     decision_counter: std::sync::atomic::AtomicU64,
     execution_counter: std::sync::atomic::AtomicU64,
@@ -5751,6 +5755,34 @@ impl ExecutionContext {
     fn get_open_positions(&self) -> usize {
         self.lock_manager.count_non_zero_token_balances()
     }
+
+    fn apply_position_authority_from_execution_result(&self, exec: &ExecutionResult) {
+        self.position_authority
+            .lock()
+            .apply_from_confirmed_execution_result(exec);
+        self.refresh_position_authority_metrics();
+    }
+
+    /// Wallet snapshot: same filter as `PositionEvent::try_from_market_event_kind` (ignores SOL/WSOL for authority open count).
+    fn apply_position_authority_from_wallet_event_kind(&self, kind: &MarketEventKind) {
+        self.position_authority
+            .lock()
+            .apply_from_wallet_market_event_kind(kind);
+        self.refresh_position_authority_metrics();
+    }
+
+    fn refresh_position_authority_metrics(&self) {
+        let a = self.position_authority.lock();
+        let auth_open = a.open_positions_count();
+        let reconcile = a.reconcile_needed_positions_count();
+        let lock_open = self.lock_manager.count_non_zero_token_balances();
+        let drift = position_authority_drift_lockmanager(auth_open, lock_open);
+        drop(a);
+        POSITION_AUTHORITY_OPEN_GAUGE.store(auth_open as u64, Ordering::Relaxed);
+        POSITION_AUTHORITY_RECONCILE_NEEDED_GAUGE.store(reconcile as u64, Ordering::Relaxed);
+        POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE.store(lock_open as u64, Ordering::Relaxed);
+        POSITION_AUTHORITY_DRIFT_LOCKMANAGER.store(drift, Ordering::Relaxed);
+    }
 }
 
 #[allow(dead_code)]
@@ -6547,6 +6579,7 @@ async fn main() -> Result<()> {
         execution_writer,
         burn_writer,
         lock_manager,
+        position_authority: Arc::new(ParkingMutex::new(PositionAuthority::new())),
         log_base: log_base.clone(),
         decision_counter: std::sync::atomic::AtomicU64::new(initial_decision_counter),
         execution_counter: std::sync::atomic::AtomicU64::new(initial_execution_counter),
@@ -6674,6 +6707,7 @@ async fn main() -> Result<()> {
 
     // Publish initial gauge values immediately (before the first 30s heartbeat).
     OPEN_POSITIONS_GAUGE.store(ctx.get_open_positions() as u64, Ordering::Relaxed);
+    ctx.refresh_position_authority_metrics();
 
     // Shutdown channel for background tasks (WsolManager, etc.)
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
@@ -7818,6 +7852,8 @@ async fn main() -> Result<()> {
                                                         }
                                                     }
                                                 }
+                                                // PA-2: passive PositionAuthority from same JetStream events (SOL/WSOL ignored for open count)
+                                                ctx.apply_position_authority_from_wallet_event_kind(&event.kind);
                                             }
                                             Err(e) => {
                                                 debug!(error = %e, "Failed to deserialize wallet snapshot MarketEvent");
@@ -7868,6 +7904,7 @@ async fn main() -> Result<()> {
                     INTENTS_REJECTED_TOTAL.store(rejected, Ordering::Relaxed);
                     SIMULATION_FAILURES_TOTAL.store(sim_fail, Ordering::Relaxed);
                     OPEN_POSITIONS_GAUGE.store(ctx.get_open_positions() as u64, Ordering::Relaxed);
+                    ctx.refresh_position_authority_metrics();
                     ACTIVE_CAPITAL_LOCKS.store(cap_locks as u64, Ordering::Relaxed);
                     ACTIVE_RESOURCE_LOCKS.store(res_locks as u64, Ordering::Relaxed);
                     // "Available WSOL" panel: actual WSOL only (0 when no ATA)
@@ -8073,6 +8110,7 @@ async fn build_replay_context(
         execution_writer,
         burn_writer,
         lock_manager,
+        position_authority: Arc::new(ParkingMutex::new(PositionAuthority::new())),
         log_base: log_dir,
         decision_counter: std::sync::atomic::AtomicU64::new(0),
         execution_counter: std::sync::atomic::AtomicU64::new(0),
@@ -10491,6 +10529,9 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
             if let Some(ref nats) = ctx.nats {
                 nats.jetstream_publish(TOPIC_EXECUTION_RESULTS, &exec)
                     .await?;
+            }
+            if exec.status == ExecutionStatus::Confirmed {
+                ctx.apply_position_authority_from_execution_result(&exec);
             }
         }
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -467,6 +467,16 @@ pub static RPC_CONCURRENCY_ADJUSTMENTS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| Ato
 pub static RPC_INFLIGHT_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static RPC_ALLOWED_CONCURRENCY: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static OPEN_POSITIONS_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// PA-2: PositionAuthority model open count (read-only; does not replace `open_positions`).
+pub static POSITION_AUTHORITY_OPEN_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// Count of authority positions in `ReconcileNeeded` with non-zero balance.
+pub static POSITION_AUTHORITY_RECONCILE_NEEDED_GAUGE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// LockManager `count_non_zero_token_balances` mirrored for drift visibility (same instant as authority gauges when refreshed together).
+pub static POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// `authority_open - lockmanager_open` (signed; Prometheus scalar).
+pub static POSITION_AUTHORITY_DRIFT_LOCKMANAGER: Lazy<AtomicI64> = Lazy::new(|| AtomicI64::new(0));
 pub static CONCURRENT_INTENTS_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static DAILY_REALIZED_PNL_SOL_MICRO: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static LIQUIDITY_ESTIMATE_SOL_MICRO: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -1305,6 +1315,22 @@ async fn metrics_response() -> Response<Body> {
         "open_positions",
         OPEN_POSITIONS_GAUGE.load(Ordering::Relaxed)
     );
+    line!(
+        "position_authority_open_positions",
+        POSITION_AUTHORITY_OPEN_GAUGE.load(Ordering::Relaxed)
+    );
+    line!(
+        "position_authority_reconcile_needed_positions",
+        POSITION_AUTHORITY_RECONCILE_NEEDED_GAUGE.load(Ordering::Relaxed)
+    );
+    line!(
+        "position_authority_lockmanager_open_positions",
+        POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE.load(Ordering::Relaxed)
+    );
+    out.push_str(&format!(
+        "position_authority_drift_lockmanager {}\n",
+        POSITION_AUTHORITY_DRIFT_LOCKMANAGER.load(Ordering::Relaxed)
+    ));
     line!(
         "concurrent_intents",
         CONCURRENT_INTENTS_GAUGE.load(Ordering::Relaxed)

--- a/src/position_authority/mod.rs
+++ b/src/position_authority/mod.rs
@@ -4,4 +4,7 @@
 
 mod state;
 
-pub use state::{PositionAuthority, PositionEvent, PositionState, PositionStatus, UpdateSource};
+pub use state::{
+    is_sol_or_wsol_mint, position_authority_drift_lockmanager, PositionAuthority, PositionEvent,
+    PositionState, PositionStatus, UpdateSource,
+};

--- a/src/position_authority/state.rs
+++ b/src/position_authority/state.rs
@@ -329,11 +329,8 @@ impl PositionAuthority {
                 e.token_program = token_program.to_string();
                 e.last_update_source = UpdateSource::WalletSnapshot;
                 if prev == balance_raw {
-                    e.status = if balance_raw > 0 {
-                        PositionStatus::Open
-                    } else {
-                        PositionStatus::Closed
-                    };
+                    // Invariant: balance_raw > 0 (zero balances remove the entry at function start).
+                    e.status = PositionStatus::Open;
                 } else {
                     e.balance_raw = balance_raw;
                     e.status = PositionStatus::ReconcileNeeded;

--- a/src/position_authority/state.rs
+++ b/src/position_authority/state.rs
@@ -5,7 +5,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::ipc::schema::{ExecutionResult, ExecutionStatus, MarketEventKind};
+use crate::ipc::schema::{ExecutionResult, ExecutionStatus, MarketEventKind, NATIVE_SOL_MINT};
 
 // ---------------------------------------------------------------------------
 // Public domain types
@@ -87,6 +87,9 @@ impl PositionEvent {
             return None;
         }
         let mint = result.token_mint.clone()?;
+        if is_sol_or_wsol_mint(&mint) {
+            return None;
+        }
         let side = result.metadata.get("side")?.as_str();
         match side {
             "BUY" => {
@@ -131,12 +134,17 @@ impl PositionEvent {
                 balance_raw,
                 decimals,
                 token_program,
-            } => Some(PositionEvent::WalletBalanceSnapshot {
-                mint: mint.clone(),
-                balance_raw: *balance_raw,
-                decimals: *decimals,
-                token_program: token_program.clone(),
-            }),
+            } => {
+                if is_sol_or_wsol_mint(mint) {
+                    return None;
+                }
+                Some(PositionEvent::WalletBalanceSnapshot {
+                    mint: mint.clone(),
+                    balance_raw: *balance_raw,
+                    decimals: *decimals,
+                    token_program: token_program.clone(),
+                })
+            }
             MarketEventKind::WalletSnapshotComplete {
                 mints_in_wallet,
                 wallet,
@@ -155,6 +163,21 @@ fn default_spl_token_program() -> String {
     "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string()
 }
 
+/// Mints that must not be counted as open **trade** positions in PositionAuthority
+/// (wrapped/native SOL; same canonical mint as [`NATIVE_SOL_MINT`], plus JetStream
+/// `NATIVE_SOL` sentinel for lamports).
+#[inline]
+pub fn is_sol_or_wsol_mint(mint: &str) -> bool {
+    mint == "NATIVE_SOL" || mint == NATIVE_SOL_MINT
+}
+
+/// `authority open count` minus `lock manager open count` (same notion as
+/// `LockManager::count_non_zero_token_balances` in execution-engine).
+#[inline]
+pub fn position_authority_drift_lockmanager(authority_open: usize, lockmanager_open: usize) -> i64 {
+    authority_open as i64 - lockmanager_open as i64
+}
+
 // ---------------------------------------------------------------------------
 // Reducer
 // ---------------------------------------------------------------------------
@@ -168,6 +191,20 @@ pub struct PositionAuthority {
 impl PositionAuthority {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// PA-2: same mapping as execution-engine (confirmed-only; WSOL/SOL execution rows ignored).
+    pub fn apply_from_confirmed_execution_result(&mut self, result: &ExecutionResult) {
+        if let Some(ev) = PositionEvent::try_from_execution_result(result) {
+            self.apply(&ev);
+        }
+    }
+
+    /// PA-2: `MarketEventKind` → same filter as `try_from_market_event_kind` (skips SOL/WSOL for snapshots).
+    pub fn apply_from_wallet_market_event_kind(&mut self, kind: &MarketEventKind) {
+        if let Some(ev) = PositionEvent::try_from_market_event_kind(kind) {
+            self.apply(&ev);
+        }
     }
 
     pub fn apply(&mut self, event: &PositionEvent) {
@@ -311,11 +348,21 @@ impl PositionAuthority {
     pub fn open_positions_count(&self) -> usize {
         self.by_mint.values().filter(|p| p.balance_raw > 0).count()
     }
+
+    /// Mints in [`PositionStatus::ReconcileNeeded`] with non-zero model balance.
+    pub fn reconcile_needed_positions_count(&self) -> usize {
+        self.by_mint
+            .values()
+            .filter(|p| p.balance_raw > 0 && p.status == PositionStatus::ReconcileNeeded)
+            .count()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::ipc::schema::{ExplicitAmount, RecordHeader};
 
     fn mint() -> String {
         "SoMeMint1111111111111111111111111111111111".to_string()
@@ -435,6 +482,216 @@ mod tests {
         assert_eq!(p.balance_raw, 0);
         assert_eq!(p.sold_raw_total, 150);
         assert_eq!(p.status, PositionStatus::ReconcileNeeded);
+    }
+
+    #[test]
+    fn wallet_snapshot_ignores_wsol_mint() {
+        let m = NATIVE_SOL_MINT.to_string();
+        let k = MarketEventKind::WalletBalanceSnapshot {
+            mint: m,
+            balance_raw: 1_000_000,
+            decimals: 9,
+            token_program: default_spl_token_program(),
+        };
+        assert!(PositionEvent::try_from_market_event_kind(&k).is_none());
+    }
+
+    #[test]
+    fn wallet_snapshot_ignores_native_sol_lamport_sentinel() {
+        let k = MarketEventKind::WalletBalanceSnapshot {
+            mint: "NATIVE_SOL".to_string(),
+            balance_raw: 5_000_000_000,
+            decimals: 9,
+            token_program: default_spl_token_program(),
+        };
+        assert!(PositionEvent::try_from_market_event_kind(&k).is_none());
+    }
+
+    #[test]
+    fn reconcile_needed_count_only_reconcile_status() {
+        let m = mint();
+        let mut a = PositionAuthority::new();
+        a.apply(&snap(&m, 250, 6));
+        assert_eq!(a.reconcile_needed_positions_count(), 1);
+        a.apply(&buy(&m, 100, 6));
+        assert_eq!(a.reconcile_needed_positions_count(), 0);
+    }
+
+    #[test]
+    fn drift_helper_matches_lock_manager_style_counts() {
+        use crate::storage::locks::LockManager;
+        let lm = LockManager::new(0);
+        lm.set_available_token_balance("mintA".to_string(), 1);
+        lm.set_available_token_balance("mintB".to_string(), 1);
+        let lock_open = lm.count_non_zero_token_balances();
+        let mut a = PositionAuthority::new();
+        a.apply_from_wallet_market_event_kind(&MarketEventKind::WalletBalanceSnapshot {
+            mint: "mintA".to_string(),
+            balance_raw: 1,
+            decimals: 6,
+            token_program: default_spl_token_program(),
+        });
+        a.apply_from_wallet_market_event_kind(&MarketEventKind::WalletBalanceSnapshot {
+            mint: "mintB".to_string(),
+            balance_raw: 1,
+            decimals: 6,
+            token_program: default_spl_token_program(),
+        });
+        a.apply_from_wallet_market_event_kind(&MarketEventKind::WalletBalanceSnapshot {
+            mint: "mintC".to_string(),
+            balance_raw: 1,
+            decimals: 6,
+            token_program: default_spl_token_program(),
+        });
+        let auth_open = a.open_positions_count();
+        assert_eq!(lock_open, 2);
+        assert_eq!(auth_open, 3);
+        assert_eq!(
+            position_authority_drift_lockmanager(auth_open, lock_open),
+            1
+        );
+    }
+
+    #[test]
+    fn apply_from_confirmed_exec_buy_increments_open() {
+        use std::collections::HashMap;
+
+        let m = mint();
+        let mut meta = HashMap::new();
+        meta.insert("side".to_string(), "BUY".to_string());
+        meta.insert("token_program".to_string(), default_spl_token_program());
+
+        let r = ExecutionResult {
+            header: RecordHeader::new("test", "0", "run"),
+            execution_id: "e1".to_string(),
+            decision_id: "d1".to_string(),
+            intent_id: "i1".to_string(),
+            source: "test".to_string(),
+            token_mint: Some(m.clone()),
+            signature: None,
+            bundle_id: None,
+            status: ExecutionStatus::Confirmed,
+            fill_in: None,
+            fill_out: Some(ExplicitAmount::new(10, 6)),
+            fill_status: None,
+            fill_unavailable_reason: None,
+            confirmed_slot: None,
+            fees: None,
+            pnl: None,
+            wallet_sol_delta_lamports: None,
+            error_message: None,
+            error_code: None,
+            latency_ms: None,
+            metadata: meta,
+        };
+        let mut a = PositionAuthority::new();
+        a.apply_from_confirmed_execution_result(&r);
+        assert_eq!(a.open_positions_count(), 1);
+        assert_eq!(a.get(&m).unwrap().balance_raw, 10);
+    }
+
+    #[test]
+    fn apply_from_confirmed_exec_sell_closes() {
+        use std::collections::HashMap;
+
+        let m = mint();
+        let mut buy_meta = HashMap::new();
+        buy_meta.insert("side".to_string(), "BUY".to_string());
+        buy_meta.insert("token_program".to_string(), default_spl_token_program());
+        let buy = ExecutionResult {
+            header: RecordHeader::new("test", "0", "run"),
+            execution_id: "e0".to_string(),
+            decision_id: "d0".to_string(),
+            intent_id: "i0".to_string(),
+            source: "test".to_string(),
+            token_mint: Some(m.clone()),
+            signature: None,
+            bundle_id: None,
+            status: ExecutionStatus::Confirmed,
+            fill_in: None,
+            fill_out: Some(ExplicitAmount::new(100, 6)),
+            fill_status: None,
+            fill_unavailable_reason: None,
+            confirmed_slot: None,
+            fees: None,
+            pnl: None,
+            wallet_sol_delta_lamports: None,
+            error_message: None,
+            error_code: None,
+            latency_ms: None,
+            metadata: buy_meta,
+        };
+        let mut sell_meta = HashMap::new();
+        sell_meta.insert("side".to_string(), "SELL".to_string());
+        sell_meta.insert("token_program".to_string(), default_spl_token_program());
+        let sell = ExecutionResult {
+            header: RecordHeader::new("test", "0", "run"),
+            execution_id: "e1".to_string(),
+            decision_id: "d1".to_string(),
+            intent_id: "i1".to_string(),
+            source: "test".to_string(),
+            token_mint: Some(m.clone()),
+            signature: None,
+            bundle_id: None,
+            status: ExecutionStatus::Confirmed,
+            fill_in: Some(ExplicitAmount::new(100, 6)),
+            fill_out: None,
+            fill_status: None,
+            fill_unavailable_reason: None,
+            confirmed_slot: None,
+            fees: None,
+            pnl: None,
+            wallet_sol_delta_lamports: None,
+            error_message: None,
+            error_code: None,
+            latency_ms: None,
+            metadata: sell_meta,
+        };
+        let mut a = PositionAuthority::new();
+        a.apply_from_confirmed_execution_result(&buy);
+        a.apply_from_confirmed_execution_result(&sell);
+        assert_eq!(a.open_positions_count(), 0);
+    }
+
+    #[test]
+    fn apply_from_wallet_snapshot_zero_removes() {
+        let m = mint();
+        let mut a = PositionAuthority::new();
+        a.apply_from_confirmed_execution_result(&ExecutionResult {
+            header: RecordHeader::new("t", "0", "r"),
+            execution_id: "e".to_string(),
+            decision_id: "d".to_string(),
+            intent_id: "i".to_string(),
+            source: "s".to_string(),
+            token_mint: Some(m.clone()),
+            signature: None,
+            bundle_id: None,
+            status: ExecutionStatus::Confirmed,
+            fill_in: None,
+            fill_out: Some(ExplicitAmount::new(100, 6)),
+            fill_status: None,
+            fill_unavailable_reason: None,
+            confirmed_slot: None,
+            fees: None,
+            pnl: None,
+            wallet_sol_delta_lamports: None,
+            error_message: None,
+            error_code: None,
+            latency_ms: None,
+            metadata: {
+                let mut h = std::collections::HashMap::new();
+                h.insert("side".to_string(), "BUY".to_string());
+                h.insert("token_program".to_string(), default_spl_token_program());
+                h
+            },
+        });
+        a.apply_from_wallet_market_event_kind(&MarketEventKind::WalletBalanceSnapshot {
+            mint: m,
+            balance_raw: 0,
+            decimals: 6,
+            token_program: default_spl_token_program(),
+        });
+        assert_eq!(a.open_positions_count(), 0);
     }
 
     #[test]

--- a/src/position_authority/state.rs
+++ b/src/position_authority/state.rs
@@ -3,6 +3,7 @@
 //! This module is **not** wired to production. Pure reducer for tests and future
 //! `position-manager` / JetStream consumption.
 
+use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 
 use crate::ipc::schema::{ExecutionResult, ExecutionStatus, MarketEventKind, NATIVE_SOL_MINT};
@@ -319,25 +320,40 @@ impl PositionAuthority {
             self.by_mint.remove(mint);
             return;
         }
-        let e = self
-            .by_mint
-            .entry(mint.to_string())
-            .or_insert_with(|| PositionState {
-                mint: mint.to_string(),
-                balance_raw: 0,
-                decimals,
-                token_program: token_program.to_string(),
-                ata: None,
-                buy_fills: Vec::new(),
-                sold_raw_total: 0,
-                status: PositionStatus::Closed,
-                last_update_source: UpdateSource::WalletSnapshot,
-            });
-        e.decimals = decimals;
-        e.token_program = token_program.to_string();
-        e.balance_raw = balance_raw;
-        e.status = PositionStatus::ReconcileNeeded;
-        e.last_update_source = UpdateSource::WalletSnapshot;
+
+        match self.by_mint.entry(mint.to_string()) {
+            Entry::Occupied(mut occ) => {
+                let e = occ.get_mut();
+                let prev = e.balance_raw;
+                e.decimals = decimals;
+                e.token_program = token_program.to_string();
+                e.last_update_source = UpdateSource::WalletSnapshot;
+                if prev == balance_raw {
+                    e.status = if balance_raw > 0 {
+                        PositionStatus::Open
+                    } else {
+                        PositionStatus::Closed
+                    };
+                } else {
+                    e.balance_raw = balance_raw;
+                    e.status = PositionStatus::ReconcileNeeded;
+                }
+            }
+            Entry::Vacant(v) => {
+                // `balance_raw > 0` here: recovered from wallet with no prior execution state.
+                v.insert(PositionState {
+                    mint: mint.to_string(),
+                    balance_raw,
+                    decimals,
+                    token_program: token_program.to_string(),
+                    ata: None,
+                    buy_fills: Vec::new(),
+                    sold_raw_total: 0,
+                    status: PositionStatus::ReconcileNeeded,
+                    last_update_source: UpdateSource::WalletSnapshot,
+                });
+            }
+        }
     }
 
     pub fn get(&self, mint: &str) -> Option<&PositionState> {
@@ -455,6 +471,30 @@ mod tests {
         assert_eq!(p.balance_raw, 250);
         assert_eq!(p.status, PositionStatus::ReconcileNeeded);
         assert_eq!(p.last_update_source, UpdateSource::WalletSnapshot);
+    }
+
+    #[test]
+    fn wallet_snapshot_matching_existing_position_keeps_open_not_reconcile() {
+        let m = mint();
+        let mut a = PositionAuthority::new();
+        a.apply(&buy(&m, 400, 6));
+        a.apply(&snap(&m, 400, 6));
+        let p = a.get(&m).expect("position");
+        assert_eq!(p.balance_raw, 400);
+        assert_eq!(p.status, PositionStatus::Open);
+        assert_eq!(a.reconcile_needed_positions_count(), 0);
+    }
+
+    #[test]
+    fn wallet_snapshot_different_existing_position_marks_reconcile_needed() {
+        let m = mint();
+        let mut a = PositionAuthority::new();
+        a.apply(&buy(&m, 400, 6));
+        a.apply(&snap(&m, 350, 6));
+        let p = a.get(&m).expect("position");
+        assert_eq!(p.balance_raw, 350);
+        assert_eq!(p.status, PositionStatus::ReconcileNeeded);
+        assert_eq!(a.reconcile_needed_positions_count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change wires **PositionAuthority** into `execution-engine` for **observability only** (PA-2). It does **not** drive risk checks, preflight, reservations, dashboard `open_positions`, Momentum, or routing.

## Review follow-up: reconcile-needed semantics (commit `43fafbe`)

Wallet snapshots no longer mark `ReconcileNeeded` when the snapshot **matches** the authority’s existing `balance_raw` (healthy live sync). `ReconcileNeeded` is set only when the snapshot **diverges** from the prior model balance, or for **unknown** non-zero mints (recovery without execution history).

## What changed

- **`ExecutionContext`**: `position_authority: Arc<ParkingMutex<PositionAuthority>>` — fed from events the engine already processes.
- **Confirmed `ExecutionResult`**: After the result is built, enriched, written, and published to JetStream, `apply_from_confirmed_execution_result` is called only when `status == Confirmed` (maps BUY→`fill_out`, SELL→`fill_in`; ignores canonical SOL/WSOL mint; preserves Token-2022 from metadata).
- **`WalletBalanceSnapshot`**: In the **existing** JetStream consumer, after the existing `LockManager` / WSOL / SOL path, the same `MarketEventKind` is applied to the authority. **No second consumer.**
- **SOL/WSOL**: `NATIVE_SOL`, `NATIVE_SOL_MINT` / WSOL are **not** counted as tradeable authority positions (open count); snapshots for those mints are ignored in the event mapper.
- **New Prometheus series** (existing `open_positions` unchanged):
  - `position_authority_open_positions`
  - `position_authority_reconcile_needed_positions` (from `reconcile_needed_positions_count()` on non-zero + `ReconcileNeeded`)
  - `position_authority_lockmanager_open_positions` (LockManager `count_non_zero_token_balances` for drift context)
  - `position_authority_drift_lockmanager` (signed: `authority_open - lockmanager_open`)

- **PA-1 API**: `reconcile_needed_positions_count()`, `apply_from_confirmed_execution_result`, `apply_from_wallet_market_event_kind`, `is_sol_or_wsol_mint`, `position_authority_drift_lockmanager`.

## Tests

- Unit tests in `src/position_authority/state.rs` for BUY/SELL `ExecutionResult` application, wallet snapshot recovery/clear, SOL/WSOL ignore, drift vs `LockManager` counts, **matching vs divergent wallet snapshot** (`wallet_snapshot_matching_existing_position_keeps_open_not_reconcile`, `wallet_snapshot_different_existing_position_marks_reconcile_needed`).

## STOP-CHECK (AGENTS / ironcrab-core)

- **I-7**: No new RPC; only in-memory / already-consumed events.
- **LockManager / SELL / max_open_positions**: Unchanged; authority is not used for decisions.
- **open_positions** gauge: Unchanged semantics.
- **Level-5**: No reads from `Iron_crab-eval/tests/` or `src/`.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be52478b-b452-418f-9091-936dc8c502fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be52478b-b452-418f-9091-936dc8c502fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

