### PR TITLE
Scope 56: Momentum exit quote UI units + orphan scale-in recovery

### DIFF
--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -25,7 +25,7 @@
 
 use anyhow::Result;
 use clap::Parser;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::Ordering;
@@ -74,6 +74,50 @@ use sd_notify::NotifyState;
 
 /// Build version for decision records
 const BUILD_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// JetStream replay dedup for orphaned BUY path — bounded so memory does not grow forever.
+const ORPHANED_RECOVERED_INTENT_IDS_CAP: usize = 50_000;
+
+/// [`HashSet`] insert/remove with LRU eviction when size exceeds `cap` (new inserts only).
+struct BoundedIntentIdCache {
+    set: HashSet<String>,
+    order: VecDeque<String>,
+    cap: usize,
+}
+
+impl BoundedIntentIdCache {
+    fn new(cap: usize) -> Self {
+        Self {
+            set: HashSet::new(),
+            order: VecDeque::new(),
+            cap,
+        }
+    }
+
+    fn insert(&mut self, id: String) -> bool {
+        if self.set.contains(&id) {
+            return false;
+        }
+        self.set.insert(id.clone());
+        self.order.push_back(id);
+        while self.order.len() > self.cap {
+            if let Some(old) = self.order.pop_front() {
+                self.set.remove(&old);
+            }
+        }
+        true
+    }
+
+    fn remove(&mut self, id: &str) -> bool {
+        let removed = self.set.remove(id);
+        if removed {
+            if let Some(pos) = self.order.iter().position(|x| x == id) {
+                self.order.remove(pos);
+            }
+        }
+        removed
+    }
+}
 
 // #region agent log
 fn dbg_log(location: &str, message: &str, data: serde_json::Value, hypothesis_id: &str) {
@@ -2118,7 +2162,7 @@ struct MomentumContext {
     orphaned_mints: parking_lot::RwLock<HashMap<String, (u64, u8)>>,
     /// Scope 56: in-memory idempotency for duplicate JetStream / replayed ExecutionResults
     /// on the orphaned-BUY path (no durable store in this scope).
-    orphaned_recovered_intent_ids: parking_lot::RwLock<HashSet<String>>,
+    orphaned_recovered_intent_ids: parking_lot::RwLock<BoundedIntentIdCache>,
     /// Stats
     tokens_tracked: std::sync::atomic::AtomicU64,
     tokens_blacklisted: std::sync::atomic::AtomicU64,
@@ -5822,7 +5866,9 @@ async fn main() -> Result<()> {
         live_pool_cache,
         position_kv: tokio::sync::OnceCell::new(),
         orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-        orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+        orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+            ORPHANED_RECOVERED_INTENT_IDS_CAP,
+        )),
         tokens_tracked: std::sync::atomic::AtomicU64::new(0),
         tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
         intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7159,7 +7205,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7212,7 +7260,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7290,7 +7340,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7542,7 +7594,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7645,7 +7699,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7716,7 +7772,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7775,7 +7833,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7849,7 +7909,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7949,7 +8011,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -8045,7 +8109,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -8126,7 +8192,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -8187,7 +8255,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -8239,7 +8309,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -8431,7 +8503,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -8552,7 +8626,9 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
-            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
+                ORPHANED_RECOVERED_INTENT_IDS_CAP,
+            )),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -469,8 +469,7 @@ struct PositionTracker {
 /// I-7: from LivePoolCache in-process only — no RPC.
 #[derive(Debug, Clone, Copy)]
 struct ExitExecutableQuote {
-    /// tokens_per_sol implied by selling `position.token_amount` through the position pool
-    /// (raw token / raw lamports, same unit convention as `entry_price`).
+    /// tokens_per_sol (UI): token_ui / sol_ui, matching `entry_price` / `current_price` (I-14).
     tokens_per_sol: f64,
     /// True when `tokens_per_sol` was computed from LivePoolCache for `position.pool`.
     pool_sourced: bool,
@@ -2117,6 +2116,9 @@ struct MomentumContext {
     /// Mints with non-zero wallet balance that could not be reconciled at bootstrap
     /// because no pool was known yet. Checked when new pools are registered.
     orphaned_mints: parking_lot::RwLock<HashMap<String, (u64, u8)>>,
+    /// Scope 56: in-memory idempotency for duplicate JetStream / replayed ExecutionResults
+    /// on the orphaned-BUY path (no durable store in this scope).
+    orphaned_recovered_intent_ids: parking_lot::RwLock<HashSet<String>>,
     /// Stats
     tokens_tracked: std::sync::atomic::AtomicU64,
     tokens_blacklisted: std::sync::atomic::AtomicU64,
@@ -2148,7 +2150,8 @@ impl MomentumContext {
         if sol_out == 0 {
             return None;
         }
-        let tps = (pos.token_amount as f64) / (sol_out as f64);
+        // I-14: same units as `entry_price` (tok_ui/sol_ui), not raw_token/raw_lamports.
+        let tps = tokens_per_sol::ui_tokens_per_sol(pos.token_amount, pos.token_decimals, sol_out);
         if !tps.is_finite() || tps <= 0.0 {
             return None;
         }
@@ -3810,9 +3813,52 @@ impl MomentumContext {
             {
                 if let Some(ref mint) = result.token_mint {
                     if let Some(ref fill_out) = result.fill_out {
-                        // Position may already exist (e.g., scale-in recovered on restart)
-                        let already_has_position = self.positions.read().contains_key(mint);
-                        if !already_has_position {
+                        let idem_inserted = self
+                            .orphaned_recovered_intent_ids
+                            .write()
+                            .insert(result.intent_id.clone());
+                        if !idem_inserted {
+                            debug!(
+                                intent_id = %result.intent_id,
+                                mint = %mint,
+                                "Orphaned BUY: duplicate execution result (already applied) — skip"
+                            );
+                        } else {
+                            let sol_invested = result
+                                .wallet_sol_delta_lamports
+                                .map(|d| d.unsigned_abs() as u64)
+                                .or_else(|| result.fill_in.as_ref().map(|a| a.raw))
+                                .unwrap_or(0);
+
+                            let token_decimals = self
+                                .mint_infos
+                                .read()
+                                .get(mint)
+                                .map(|m| m.decimals)
+                                .unwrap_or(fill_out.decimals);
+
+                            let sol_ui = result
+                                .fill_in
+                                .as_ref()
+                                .map(|a| a.as_f64())
+                                .unwrap_or(sol_invested as f64 / 1e9)
+                                .max(0.0);
+                            let tok_ui = fill_out.as_f64().max(0.0);
+                            let entry_price = if sol_ui > 0.0 { tok_ui / sol_ui } else { 1.0 };
+
+                            let token_program = result
+                                .metadata
+                                .get("token_program")
+                                .cloned()
+                                .filter(|tp| !tp.is_empty())
+                                .or_else(|| {
+                                    self.mint_infos
+                                        .read()
+                                        .get(mint)
+                                        .map(|m| m.token_program.clone())
+                                        .filter(|tp| !tp.is_empty())
+                                });
+
                             // Reconstruct pool/dex/creator from TokenTracker (still alive in memory)
                             let tracker_info: Option<(String, String, Option<String>)> = {
                                 let trackers = self.token_trackers.read();
@@ -3826,42 +3872,44 @@ impl MomentumContext {
                                 })
                             };
 
-                            if let Some((pool, dex, creator)) = tracker_info {
-                                let sol_invested = result
-                                    .wallet_sol_delta_lamports
-                                    .map(|d| d.unsigned_abs() as u64)
-                                    .or_else(|| result.fill_in.as_ref().map(|a| a.raw))
-                                    .unwrap_or(0);
+                            let already_has_position = self.positions.read().contains_key(mint);
 
-                                let token_decimals = self
-                                    .mint_infos
-                                    .read()
-                                    .get(mint)
-                                    .map(|m| m.decimals)
-                                    .unwrap_or(fill_out.decimals);
-
-                                let sol_ui = result
-                                    .fill_in
-                                    .as_ref()
-                                    .map(|a| a.as_f64())
-                                    .unwrap_or(sol_invested as f64 / 1e9)
-                                    .max(0.0);
-                                let tok_ui = fill_out.as_f64().max(0.0);
-                                let entry_price = if sol_ui > 0.0 { tok_ui / sol_ui } else { 1.0 };
-
-                                let token_program = result
-                                    .metadata
-                                    .get("token_program")
-                                    .cloned()
-                                    .filter(|tp| !tp.is_empty())
-                                    .or_else(|| {
-                                        self.mint_infos
-                                            .read()
-                                            .get(mint)
-                                            .map(|m| m.token_program.clone())
-                                            .filter(|tp| !tp.is_empty())
+                            if already_has_position {
+                                if let Some((pool, dex, creator)) = tracker_info {
+                                    info!(
+                                        intent_id = %result.intent_id,
+                                        mint = %mint,
+                                        pool = %pool,
+                                        dex = %dex,
+                                        sol_invested,
+                                        token_amount_raw = fill_out.raw,
+                                        "⚠️ ORPHANED BUY APPLIED TO EXISTING POSITION — scale-in fill \
+                                         recovered after pending intent was dropped"
+                                    );
+                                    self.open_position(OpenPositionParams {
+                                        mint,
+                                        pool: &pool,
+                                        dex: &dex,
+                                        entry_price,
+                                        token_decimals,
+                                        token_amount: fill_out.raw,
+                                        sol_invested,
+                                        token_program,
+                                        creator,
                                     });
-
+                                } else {
+                                    self.orphaned_recovered_intent_ids
+                                        .write()
+                                        .remove(&result.intent_id);
+                                    warn!(
+                                        intent_id = %result.intent_id,
+                                        mint = %mint,
+                                        "Orphaned scale-in BUY: existing Momentum position but no \
+                                         TokenTracker — cannot apply fill (pool/dex unknown). \
+                                         I-12: not silently ignored"
+                                    );
+                                }
+                            } else if let Some((pool, dex, creator)) = tracker_info {
                                 warn!(
                                     intent_id = %result.intent_id,
                                     mint = %mint,
@@ -3885,6 +3933,9 @@ impl MomentumContext {
                                     creator,
                                 });
                             } else {
+                                self.orphaned_recovered_intent_ids
+                                    .write()
+                                    .remove(&result.intent_id);
                                 warn!(
                                     intent_id = %result.intent_id,
                                     mint = %mint,
@@ -5738,6 +5789,7 @@ async fn main() -> Result<()> {
         live_pool_cache,
         position_kv: tokio::sync::OnceCell::new(),
         orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+        orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
         tokens_tracked: std::sync::atomic::AtomicU64::new(0),
         tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
         intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7074,6 +7126,7 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7126,6 +7179,7 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7203,6 +7257,7 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7454,6 +7509,7 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7556,6 +7612,7 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7626,6 +7683,7 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7684,6 +7742,7 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7757,6 +7816,7 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7856,6 +7916,7 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -7951,6 +8012,7 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -8031,6 +8093,7 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -8091,6 +8154,7 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -8142,6 +8206,7 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             intents_generated: std::sync::atomic::AtomicU64::new(0),
@@ -8278,6 +8343,132 @@ mod tests {
         let exec = 3_692_386.0f64; // more valuable (lower tps) than entry
         let p = tokens_per_sol::pnl_pct(entry, exec);
         assert!(p > 0.0, "lower exec tps should be profit, pnl={}", p);
+    }
+
+    /// Scope 56: 9mR7-like numbers — matched UI executable must allow STOP_LOSS (not fake +90k% PnL).
+    #[test]
+    fn scope56_stop_loss_allows_with_ui_matched_executable_quote() {
+        let mut c = make_exit_config();
+        c.hard_stop_loss_pct = 50.0;
+        c.take_profit_pct = 1_000.0;
+
+        let entry = 9_876_538.033_6;
+        let current_stale = 30_000_000.0;
+        let mut pos = PositionTracker::new("m9", "p9", "dex", entry, 6, 12_345_672_542, 0);
+        pos.current_price = current_stale;
+        pos.highest_price = entry;
+        // Pool-correct sell quote (UI): same convention as `entry_price`
+        let sol_out = 418_528u64;
+        let exec_tps = tokens_per_sol::ui_tokens_per_sol(12_345_672_542, 6, sol_out);
+        let ex = ExitExecutableQuote {
+            tokens_per_sol: exec_tps,
+            pool_sourced: true,
+        };
+        let r = pos.should_exit(&c, Some(ex));
+        let (ty, _reason) = r.expect("STOP_LOSS must fire when loss is real");
+        assert_eq!(ty, "STOP_LOSS");
+    }
+
+    /// Orphaned scale-in: existing probe position + confirmed BUY without pending → full total for exits.
+    #[tokio::test]
+    async fn scope56_orphan_scale_in_applies_to_existing_position() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+
+        let ctx = Arc::new(MomentumContext {
+            run_id: "run-test".to_string(),
+            config: parking_lot::RwLock::new(MomentumConfig::default()),
+            nats: None,
+            jsonl_writer,
+            intent_counter: std::sync::atomic::AtomicU64::new(0),
+            pool_first_seen: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            pending_dev_info: parking_lot::RwLock::new(HashMap::new()),
+            pending_pool_accounts: parking_lot::RwLock::new(HashMap::new()),
+            mint_infos: parking_lot::RwLock::new(HashMap::new()),
+            token_trackers: parking_lot::RwLock::new(HashMap::new()),
+            positions: parking_lot::RwLock::new(HashMap::new()),
+            pending_intents: parking_lot::RwLock::new(HashMap::new()),
+            mint_pools: parking_lot::RwLock::new(HashMap::new()),
+            live_pool_cache: LivePoolCache::new(),
+            position_kv: tokio::sync::OnceCell::new(),
+            orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            tokens_tracked: std::sync::atomic::AtomicU64::new(0),
+            tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
+            intents_generated: std::sync::atomic::AtomicU64::new(0),
+            exits_generated: std::sync::atomic::AtomicU64::new(0),
+            last_event_slot: std::sync::atomic::AtomicU64::new(0),
+            last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+        });
+
+        let mint = "9mR7mmX55n1F56rKBBcfMrRzMoJjaZnSRs6fV1GRpump";
+        let pool = "Pool9mR7ttttttttttttttttttttttttttttttttttt";
+        ctx.register_pool(mint, pool, "pump_amm", 1);
+        ctx.token_trackers.write().insert(
+            mint.to_string(),
+            TokenTracker::new(mint, pool, "pump_amm", 1, 0),
+        );
+
+        ctx.open_position(OpenPositionParams {
+            mint,
+            pool,
+            dex: "pump_amm",
+            entry_price: 1.0,
+            token_decimals: 6,
+            token_amount: 12_345_672_542,
+            sol_invested: 1_250_000,
+            token_program: None,
+            creator: None,
+        });
+
+        let scale_fill = 37_843_472_159u64;
+        let sol_spent = 3_750_000u64;
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("side".to_string(), "BUY".to_string());
+        let orphan = ExecutionResult {
+            header: RecordHeader::new("test", BUILD_VERSION, "run-test"),
+            execution_id: "ex-orphan".to_string(),
+            decision_id: "dec-orphan".to_string(),
+            intent_id: "int-orphan-scale-001".to_string(),
+            source: "momentum-bot".to_string(),
+            token_mint: Some(mint.to_string()),
+            signature: Some("sig-orphan".to_string()),
+            bundle_id: None,
+            status: ExecutionStatus::Confirmed,
+            fill_in: Some(ExplicitAmount::new(sol_spent, 9)),
+            fill_out: Some(ExplicitAmount::new(scale_fill, 6)),
+            fill_status: Some(FillStatus::Complete),
+            fill_unavailable_reason: None,
+            confirmed_slot: Some(1),
+            fees: None,
+            pnl: None,
+            wallet_sol_delta_lamports: Some(-(sol_spent as i128)),
+            error_message: None,
+            error_code: None,
+            latency_ms: Some(1),
+            metadata: meta,
+        };
+
+        Arc::clone(&ctx).handle_execution_result(&orphan);
+
+        let expected = 12_345_672_542u64.saturating_add(scale_fill);
+        {
+            let positions = ctx.positions.read();
+            let pos = positions.get(mint).expect("position after orphan scale");
+            assert_eq!(
+                pos.token_amount, expected,
+                "orphan scale-in must add to total"
+            );
+        }
+
+        // Second delivery with same intent_id (JetStream replay) must not double-count
+        Arc::clone(&ctx).handle_execution_result(&orphan);
+        assert_eq!(
+            ctx.positions.read().get(mint).unwrap().token_amount,
+            expected,
+            "duplicate ExecutionResult with same intent_id must not add twice"
+        );
     }
 }
 

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -4224,6 +4224,11 @@ impl MomentumContext {
                         } else {
                             None
                         };
+                        // JetStream replay: same intent_id may be processed on the pending path first,
+                        // then redelivered with pending already consumed — orphan path must idempotently skip.
+                        self.orphaned_recovered_intent_ids
+                            .write()
+                            .insert(result.intent_id.clone());
                         self.open_position(OpenPositionParams {
                             mint: &pending.mint,
                             pool: &pending.pool,

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -3807,7 +3807,8 @@ impl MomentumContext {
             // === Orphaned buy recovery ===
             // If a confirmed BUY arrives after cleanup_stale_pending() removed
             // the pending intent (>2min), recover the position from the
-            // ExecutionResult + TokenTracker data.
+            // ExecutionResult. New positions still need TokenTracker (pool/dex);
+            // existing positions use `PositionTracker` (pool/dex/creator) — I-12.
             else if result.status == ExecutionStatus::Confirmed
                 && result.metadata.get("side").map(|s| s.as_str()) == Some("BUY")
             {
@@ -3859,7 +3860,7 @@ impl MomentumContext {
                                         .filter(|tp| !tp.is_empty())
                                 });
 
-                            // Reconstruct pool/dex/creator from TokenTracker (still alive in memory)
+                            // Optional TokenTracker: upgrade creator for pumpfun, or new-position routing.
                             let tracker_info: Option<(String, String, Option<String>)> = {
                                 let trackers = self.token_trackers.read();
                                 trackers.get(mint).map(|tr| {
@@ -3872,10 +3873,37 @@ impl MomentumContext {
                                 })
                             };
 
-                            let already_has_position = self.positions.read().contains_key(mint);
+                            let already_has_position: bool;
+                            let existing: Option<PositionTracker> = {
+                                let positions = self.positions.read();
+                                let has = positions.contains_key(mint);
+                                let snap = positions.get(mint).cloned();
+                                already_has_position = has;
+                                snap
+                            };
 
                             if already_has_position {
-                                if let Some((pool, dex, creator)) = tracker_info {
+                                // Existing position: pool/dex/creator from `PositionTracker` (restart-safe).
+                                // TokenTracker is optional (e.g. dev_wallet for missing pumpfun creator).
+                                let from_pos: Option<(String, String, Option<String>)> =
+                                    existing.as_ref().and_then(|pos| {
+                                        if pos.pool.is_empty() || pos.dex.is_empty() {
+                                            return None;
+                                        }
+                                        let pool = pos.pool.clone();
+                                        let dex = pos.dex.clone();
+                                        let mut creator = pos.creator.clone();
+                                        if pos.dex == "pumpfun" && creator.is_none() {
+                                            if let Some((_, tr_dex, tr_c)) = tracker_info.as_ref() {
+                                                if tr_dex == "pumpfun" {
+                                                    creator = tr_c.clone();
+                                                }
+                                            }
+                                        }
+                                        Some((pool, dex, creator))
+                                    });
+                                let used_position_routing = from_pos.is_some();
+                                if let Some((pool, dex, creator)) = from_pos.or(tracker_info) {
                                     info!(
                                         intent_id = %result.intent_id,
                                         mint = %mint,
@@ -3883,6 +3911,7 @@ impl MomentumContext {
                                         dex = %dex,
                                         sol_invested,
                                         token_amount_raw = fill_out.raw,
+                                        used_position_routing = used_position_routing,
                                         "⚠️ ORPHANED BUY APPLIED TO EXISTING POSITION — scale-in fill \
                                          recovered after pending intent was dropped"
                                     );
@@ -3904,9 +3933,8 @@ impl MomentumContext {
                                     warn!(
                                         intent_id = %result.intent_id,
                                         mint = %mint,
-                                        "Orphaned scale-in BUY: existing Momentum position but no \
-                                         TokenTracker — cannot apply fill (pool/dex unknown). \
-                                         I-12: not silently ignored"
+                                        "Orphaned scale-in BUY: could not resolve pool/dex (position \
+                                         empty and no TokenTracker). I-12: not silently ignored"
                                     );
                                 }
                             } else if let Some((pool, dex, creator)) = tracker_info {
@@ -8372,13 +8400,18 @@ mod tests {
     /// Orphaned scale-in: existing probe position + confirmed BUY without pending → full total for exits.
     #[tokio::test]
     async fn scope56_orphan_scale_in_applies_to_existing_position() {
+        let mut cfg = MomentumConfig::default();
+        cfg.hard_stop_loss_pct = 1_000.0;
+        cfg.take_profit_pct = 1_000.0;
+        cfg.max_hold_time_secs = 300;
+
         let tmp = TempDir::new().expect("tempdir");
         let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
         let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
 
         let ctx = Arc::new(MomentumContext {
             run_id: "run-test".to_string(),
-            config: parking_lot::RwLock::new(MomentumConfig::default()),
+            config: parking_lot::RwLock::new(cfg),
             nats: None,
             jsonl_writer,
             intent_counter: std::sync::atomic::AtomicU64::new(0),
@@ -8469,6 +8502,127 @@ mod tests {
             expected,
             "duplicate ExecutionResult with same intent_id must not add twice"
         );
+
+        // `check_for_exits` must size to full tracked total (not probe-only)
+        {
+            let mut w = ctx.positions.write();
+            let p = w.get_mut(mint).expect("position for time exit");
+            p.set_entry_time_ago(Duration::from_secs(400));
+        }
+        let exits = ctx.check_for_exits();
+        assert_eq!(exits.len(), 1, "expected one TIME_EXIT");
+        assert_eq!(exits[0].0, mint);
+        assert_eq!(
+            exits[0].5, expected,
+            "exit must use full position after orphan scale-in, not probe size"
+        );
+    }
+
+    /// Orphaned scale-in with no TokenTracker: `PositionTracker` alone supplies pool/dex.
+    #[tokio::test]
+    async fn scope56_orphan_scale_in_without_token_tracker_uses_position_routing() {
+        let mut cfg = MomentumConfig::default();
+        cfg.hard_stop_loss_pct = 1_000.0;
+        cfg.take_profit_pct = 1_000.0;
+        cfg.max_hold_time_secs = 300;
+
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+
+        let ctx = Arc::new(MomentumContext {
+            run_id: "run-test".to_string(),
+            config: parking_lot::RwLock::new(cfg),
+            nats: None,
+            jsonl_writer,
+            intent_counter: std::sync::atomic::AtomicU64::new(0),
+            pool_first_seen: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            pending_dev_info: parking_lot::RwLock::new(HashMap::new()),
+            pending_pool_accounts: parking_lot::RwLock::new(HashMap::new()),
+            mint_infos: parking_lot::RwLock::new(HashMap::new()),
+            token_trackers: parking_lot::RwLock::new(HashMap::new()),
+            positions: parking_lot::RwLock::new(HashMap::new()),
+            pending_intents: parking_lot::RwLock::new(HashMap::new()),
+            mint_pools: parking_lot::RwLock::new(HashMap::new()),
+            live_pool_cache: LivePoolCache::new(),
+            position_kv: tokio::sync::OnceCell::new(),
+            orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
+            orphaned_recovered_intent_ids: parking_lot::RwLock::new(HashSet::new()),
+            tokens_tracked: std::sync::atomic::AtomicU64::new(0),
+            tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
+            intents_generated: std::sync::atomic::AtomicU64::new(0),
+            exits_generated: std::sync::atomic::AtomicU64::new(0),
+            last_event_slot: std::sync::atomic::AtomicU64::new(0),
+            last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+        });
+
+        let mint = "NoTrkMintttttttttttttttttttttttttttttttttttt";
+        let pool = "PoolNoTrktttttttttttttttttttttttttttttttttt";
+        ctx.register_pool(mint, pool, "pump_amm", 1);
+        // Deliberately no `token_trackers` entry
+
+        ctx.open_position(OpenPositionParams {
+            mint,
+            pool,
+            dex: "pump_amm",
+            entry_price: 1.0,
+            token_decimals: 6,
+            token_amount: 12_345_672_542,
+            sol_invested: 1_250_000,
+            token_program: None,
+            creator: None,
+        });
+
+        let scale_fill = 37_843_472_159u64;
+        let sol_spent = 3_750_000u64;
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("side".to_string(), "BUY".to_string());
+        let orphan = ExecutionResult {
+            header: RecordHeader::new("test", BUILD_VERSION, "run-test"),
+            execution_id: "ex-orphan-nt".to_string(),
+            decision_id: "dec-orphan-nt".to_string(),
+            intent_id: "int-orphan-scale-no-trk-001".to_string(),
+            source: "momentum-bot".to_string(),
+            token_mint: Some(mint.to_string()),
+            signature: Some("sig-orphan-nt".to_string()),
+            bundle_id: None,
+            status: ExecutionStatus::Confirmed,
+            fill_in: Some(ExplicitAmount::new(sol_spent, 9)),
+            fill_out: Some(ExplicitAmount::new(scale_fill, 6)),
+            fill_status: Some(FillStatus::Complete),
+            fill_unavailable_reason: None,
+            confirmed_slot: Some(1),
+            fees: None,
+            pnl: None,
+            wallet_sol_delta_lamports: Some(-(sol_spent as i128)),
+            error_message: None,
+            error_code: None,
+            latency_ms: Some(1),
+            metadata: meta,
+        };
+
+        Arc::clone(&ctx).handle_execution_result(&orphan);
+
+        let expected = 12_345_672_542u64.saturating_add(scale_fill);
+        assert_eq!(
+            ctx.positions.read().get(mint).unwrap().token_amount,
+            expected
+        );
+
+        Arc::clone(&ctx).handle_execution_result(&orphan);
+        assert_eq!(
+            ctx.positions.read().get(mint).unwrap().token_amount,
+            expected
+        );
+
+        {
+            let mut w = ctx.positions.write();
+            let p = w.get_mut(mint).expect("pos");
+            p.set_entry_time_ago(Duration::from_secs(400));
+        }
+        let exits = ctx.check_for_exits();
+        assert_eq!(exits.len(), 1);
+        assert_eq!(exits[0].5, expected);
     }
 }
 

--- a/src/execution/tokens_per_sol.rs
+++ b/src/execution/tokens_per_sol.rs
@@ -1,6 +1,35 @@
 //! tokens_per_sol-Konvention (INVARIANTS.md I-14).
 //! LOWER tps = token wertvoller. pnl_pct = (entry/current - 1)*100.
 
+/// `tokens_per_sol` aus UI-Tokenmenge (raw / 10^decimals) und UI-SOL (Lamports / 10^9).
+/// I-15 / I-14: dieselbe Einheit wie Momentum-`entry_price` aus fill_out/fill_in-UI-Amounts.
+/// Kein raw/raw-Mix: nicht `raw_tokens / raw_lamports` verwenden.
+pub fn ui_tokens_per_sol(
+    sell_token_amount_raw: u64,
+    token_decimals: u8,
+    sol_out_lamports: u64,
+) -> f64 {
+    if sol_out_lamports == 0 {
+        return 0.0;
+    }
+    let d = 10f64.powi(i32::from(token_decimals));
+    if d <= 0.0 {
+        return 0.0;
+    }
+    let token_ui = sell_token_amount_raw as f64 / d;
+    const LAMPORTS_PER_SOL: f64 = 1_000_000_000.0;
+    let sol_ui = sol_out_lamports as f64 / LAMPORTS_PER_SOL;
+    if sol_ui <= 0.0 {
+        return 0.0;
+    }
+    let tps = token_ui / sol_ui;
+    if tps.is_finite() && tps > 0.0 {
+        tps
+    } else {
+        0.0
+    }
+}
+
 /// PnL in Prozent. I-14: (entry/current - 1)*100.
 /// Token wird günstiger (current UP) -> negativer PnL.
 pub fn pnl_pct(entry_price: f64, current_price: f64) -> f64 {
@@ -85,5 +114,30 @@ mod tests {
     fn edge_case_zero_drawdown() {
         assert!((drawdown_from_ath_pct(0.0, 100.0) - 0.0).abs() < 1e-10);
         assert!((drawdown_from_ath_pct(100.0, 0.0) - 0.0).abs() < 1e-10);
+    }
+
+    /// Scope 56 / prod: 9mR7...-class – executable tps must match UI convention (not raw/raw).
+    #[test]
+    fn ui_tps_9m_r7_like_sell_matched_entry_and_pnl() {
+        let entry_tps = 9_876_538.033_6;
+        let sell_raw = 12_345_672_542u64;
+        let sol_lamports = 418_528u64;
+        let decimals: u8 = 6;
+        let exec = ui_tokens_per_sol(sell_raw, decimals, sol_lamports);
+        assert!((exec - 29_497_841.343_9).abs() < 0.1, "exec tps {exec}");
+        let pnl = pnl_pct(entry_tps, exec);
+        assert!((pnl - (-66.5)).abs() < 0.2, "pnl {pnl}");
+    }
+
+    #[test]
+    fn lower_exec_tps_than_entry_is_profit() {
+        let p = pnl_pct(1_000.0, 500.0);
+        assert!(p > 0.0, "lower tps = more valuable token = profit");
+    }
+
+    #[test]
+    fn higher_exec_tps_than_entry_is_loss_stop_loss_range() {
+        let p = pnl_pct(1_000.0, 2_000.0);
+        assert!(p < 0.0, "higher tps = loss");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two production regressions from Scope 55:

1. **Executable exit quote units**: `MomentumContext::executable_exit_quote` now computes `tokens_per_sol` as **UI token / UI SOL** (via `tokens_per_sol::ui_tokens_per_sol`), matching `entry_price` / `current_price` (I-14, I-15). Raw-token / raw-lamport division was off by `10^(9 - token_decimals)` and produced nonsensical PnL and exit validation.

2. **Orphaned scale-in BUY recovery**: When a confirmed BUY has no matching pending intent but a position **already exists**, the fill is applied with the same `open_position` path as a normal scale-in. **Pool/dex/creator** come from **`PositionTracker` first** (restart-safe); `TokenTracker` is **optional** (e.g. pumpfun `dev_wallet` when position has no creator). In-memory idempotency on `intent_id` prevents double-application on JetStream replay.

## PR review follow-up (mergeability)

- Existing-position orphan path no longer **requires** TokenTracker.
- New test: no TokenTracker, orphan scale-in still applies; idempotency holds.
- `check_for_exits` assertion after scale-in: exit tuple uses **full** `token_amount` (TIME_EXIT), not probe-only.

## STOP-CHECK (self-review)

- **I-7 / Hot path RPC**: No new RPC; only `LivePoolCache` + in-process fields.
- **I-13 / Pool matching**: Unchanged; still only the position’s pool.
- **I-9 / Simulation**: No changes to execution send/simulation.
- **I-12 / Decision record**: `info!` / `warn!` for paths; `used_position_routing` in log.
- **Level-5**: No reads from `Iron_crab-eval/tests` or `src`.

## Tests

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo test --features test_helpers`

## Files

- `src/execution/tokens_per_sol.rs` — `ui_tokens_per_sol` + tests
- `src/bin/momentum_bot.rs` — quote fix, orphan path, idempotency set, tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac29d67f-625a-4bd8-a47e-2d6432bef261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac29d67f-625a-4bd8-a47e-2d6432bef261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

