### PR TITLE
fix(pumpswap): preserve authoritative v14 fee_config for extended SELL (Scope 58)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -61,7 +61,9 @@ use ironcrab::solana::dex::meteora_bin_array_layout::BinArray;
 use ironcrab::solana::dex::meteora_dlmm::METEORA_DLMM_PROGRAM;
 use ironcrab::solana::dex::meteora_swap_builder::MeteoraDlmmSwapBuilder;
 use ironcrab::solana::dex::pumpfun::{BondingCurveState, PumpFunDex};
-use ironcrab::solana::dex::pumpfun_amm::{PumpAmmPoolAccountsDiagnostic, PumpFunAmmDex};
+use ironcrab::solana::dex::pumpfun_amm::{
+    pump_amm_authoritative_fee_metas_from_v14, PumpAmmPoolAccountsDiagnostic, PumpFunAmmDex,
+};
 use ironcrab::solana::dex::raydium::Raydium;
 use ironcrab::solana::dex_parser::{
     parse_account_update, parse_transaction_update_with_pool_lookup, DexType, OrcaPoolInfo,
@@ -231,16 +233,26 @@ fn raydium_cpmm_readiness_for_pool_cache_update(s: &RaydiumCpmmState) -> DexPool
 /// PumpSwap SELL-layout contract for JetStream / SLAVE SSOT.
 ///
 /// - Base-only SELL stays ready as long as the underlying refresh/observation says the base layout is usable.
-/// - Extended SELL is ready only when the observed third readonly meta is authoritatively known.
+/// - Extended SELL is ready only when the observed third readonly meta is authoritatively known **and**
+///   v14 `pool_accounts` carry non-default `fee_config` / `fee_program` (Scope 58 / Bug #35).
 fn pump_amm_sell_layout_publish_state(
     sell_requires_extended: bool,
     sell_cashback_third_meta: Option<Pubkey>,
     base_layout_ready: bool,
+    pool_accounts_v14: Option<&[Pubkey]>,
 ) -> (bool, DexPoolReadiness) {
+    let fee_metas_ready = if sell_requires_extended {
+        pool_accounts_v14
+            .and_then(pump_amm_authoritative_fee_metas_from_v14)
+            .is_some()
+    } else {
+        true
+    };
     let sell_layout_ready = if sell_requires_extended {
         sell_cashback_third_meta
             .filter(|p| *p != Pubkey::default())
             .is_some()
+            && fee_metas_ready
     } else {
         base_layout_ready
     };
@@ -262,6 +274,7 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
     refresh_requires_extended: bool,
     refresh_third_meta: Option<Pubkey>,
     refresh_layout_ready: bool,
+    pool_accounts_v14: &[Pubkey],
 ) -> (bool, Option<Pubkey>, bool, DexPoolReadiness) {
     let (effective_requires_extended, effective_third_meta, base_layout_ready) = if force_refresh {
         (
@@ -282,6 +295,7 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
         effective_requires_extended,
         effective_third_meta,
         base_layout_ready,
+        Some(pool_accounts_v14),
     );
     (
         effective_requires_extended,
@@ -5363,6 +5377,7 @@ async fn handle_ensure_pump_amm_pool_accounts(
                     sell_cashback_remaining,
                     sell_cashback_third,
                     sell_layout_ready_from_refresh,
+                    &accounts,
                 );
 
             let (base_reserve, quote_reserve) =
@@ -8518,6 +8533,7 @@ async fn run_geyser_loop(
                             merged_flag,
                             merged_third,
                             true,
+                            Some(pool_accounts.as_slice()),
                         );
                         ctx.live_pool_cache
                             .set_pump_amm_sell_layout_ready(pool_address, sell_layout_ready);
@@ -9774,8 +9790,9 @@ mod discovery_tests {
 
     #[test]
     fn test_pump_amm_trade_publish_extended_without_third_meta_is_partial() {
+        let v14: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
         let (sell_layout_ready, dex_readiness) =
-            pump_amm_sell_layout_publish_state(true, None, true);
+            pump_amm_sell_layout_publish_state(true, None, true, Some(v14.as_slice()));
         assert!(
             !sell_layout_ready,
             "extended SELL without authoritative third meta must not be marked ready"
@@ -9785,8 +9802,15 @@ mod discovery_tests {
 
     #[test]
     fn test_pump_amm_trade_publish_extended_with_third_meta_is_ready() {
-        let (sell_layout_ready, dex_readiness) =
-            pump_amm_sell_layout_publish_state(true, Some(Pubkey::new_unique()), true);
+        let mut v14: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
+        v14[12] = Pubkey::from_str("DcsvhShq8ZaUyU7NtjskVRfKHW7DrSjdu7mkgpzoHyxB").unwrap();
+        v14[13] = Pubkey::from_str("pfeeUxB6jkeY1Hxd7CsFCAjcbHA9rWtchMGdZ6VojVZ").unwrap();
+        let (sell_layout_ready, dex_readiness) = pump_amm_sell_layout_publish_state(
+            true,
+            Some(Pubkey::new_unique()),
+            true,
+            Some(v14.as_slice()),
+        );
         assert!(
             sell_layout_ready,
             "extended SELL with authoritative third meta must be marked ready"
@@ -9797,6 +9821,7 @@ mod discovery_tests {
     #[test]
     fn test_pump_amm_force_refresh_base_overrides_stale_extended_cache_flag() {
         let stale_third = Pubkey::new_unique();
+        let pool_accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
         let (effective_requires_extended, effective_third_meta, sell_layout_ready, dex_readiness) =
             pump_amm_sell_layout_state_for_ensure_publish(
                 true,
@@ -9805,6 +9830,7 @@ mod discovery_tests {
                 false,
                 None,
                 true,
+                &pool_accounts,
             );
         assert!(
             !effective_requires_extended,

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -31,6 +31,7 @@
 //! - PumpFun Bonding: virtual reserves
 //! - PumpFun AMM (PumpSwap): reserves, pool accounts
 
+use crate::solana::dex::pumpfun_amm::pump_amm_authoritative_fee_metas_from_v14;
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use solana_sdk::pubkey::Pubkey;
@@ -997,7 +998,16 @@ impl LivePoolCache {
         }
         let (requires_extended, third) = self.pump_amm_sell_extended_layout(pool_market);
         if requires_extended {
-            third.filter(|p| *p != Pubkey::default()).is_some()
+            if third.filter(|p| *p != Pubkey::default()).is_none() {
+                return false;
+            }
+            let Some(entry) = self.pools.get(pool_market) else {
+                return false;
+            };
+            let CachedPoolState::PumpAmm(s) = &entry.value().state else {
+                return false;
+            };
+            pump_amm_authoritative_fee_metas_from_v14(&s.pool_accounts).is_some()
         } else {
             true
         }
@@ -2592,6 +2602,39 @@ mod tests {
         assert!(
             !cache.base_mint_has_explicit_pump_amm_ready_pool(&base_mint),
             "mint-level explicit Ready gate must also reject incomplete extended SELL state"
+        );
+    }
+
+    #[test]
+    fn test_pump_amm_extended_with_third_but_missing_fee_config_blocks_ready_gate() {
+        let cache = LivePoolCache::new();
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::new_unique();
+        let mut pool_accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
+        pool_accounts[12] = Pubkey::default();
+        pool_accounts[13] = Pubkey::new_unique();
+
+        cache.upsert(
+            pool_market,
+            make_pump_amm_state(
+                base_mint,
+                quote_mint,
+                Some(1_000_000_000),
+                Some(50_000_000_000),
+                pool_accounts,
+            ),
+            100,
+        );
+        cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Ready);
+        cache.merge_pump_amm_sell_extended_layout(&pool_market, true, Some(Pubkey::new_unique()));
+        cache.set_pump_amm_sell_layout_ready(&pool_market, true);
+
+        assert!(
+            cache
+                .get_ready_pump_amm_pool_accounts_by_base_mint(&base_mint)
+                .is_none(),
+            "extended SELL must not be swap-ready until v14 fee_config/fee_program are non-default"
         );
     }
 

--- a/src/execution/tx_builder.rs
+++ b/src/execution/tx_builder.rs
@@ -932,6 +932,16 @@ pub async fn build_tx_plan(
                 Pubkey::from_str(PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR).unwrap_or_default();
             let canonical_fee_prog =
                 Pubkey::from_str(PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR).unwrap_or_default();
+            let v12_fc = pool_accounts[12];
+            let v12_fp = pool_accounts[13];
+            let ix_fc = ixs[0].accounts[19].pubkey;
+            let ix_fp = ixs[0].accounts[20].pubkey;
+            let fee_config_preserved = ix_fc == v12_fc && v12_fc != Pubkey::default();
+            let fee_program_preserved = ix_fp == v12_fp && v12_fp != Pubkey::default();
+            let fee_config_replaced_vs_v14 = ix_fc != v12_fc;
+            let fee_program_replaced_vs_v14 = ix_fp != v12_fp;
+            let pfr_preserved = ixs[0].accounts[9].pubkey == pool_accounts[6];
+            let pfr_ta_preserved = ixs[0].accounts[10].pubkey == pool_accounts[7];
             let sell_csv: String = ixs[0]
                 .accounts
                 .iter()
@@ -943,20 +953,27 @@ pub async fn build_tx_plan(
                 scope = "44",
                 dex = "pump_amm",
                 pool_accounts_source = pool_accounts_build_source,
-                sell_extended = sell_requires_cashback_remaining,
+                sell_extended = sell_requires_cashback_remaining && intent.side == TradeSide::Sell,
                 sell_cashback_third_meta = ?sell_cashback_third_meta,
+                sell_ix_account_count = ixs[0].accounts.len(),
                 pool = %pool_id,
                 input_mint = %intent.resources.input_mint,
                 base_token_program_override = ?token_program_override,
                 v14_csv = %PumpAmmPoolAccountsDiagnostic::format_v14_csv(&pool_accounts[..14]),
                 sell_ix_accounts_csv = %sell_csv,
-                v14_fee_config = %pool_accounts[12],
-                v14_fee_program = %pool_accounts[13],
-                sell_ix_fee_config_meta = %ixs[0].accounts[19].pubkey,
-                sell_ix_fee_program_meta = %ixs[0].accounts[20].pubkey,
-                fee_config_replaced = (pool_accounts[12] != canonical_fee_cfg),
-                fee_program_replaced = (pool_accounts[13] != canonical_fee_prog),
-                "Scope44: pump_amm SELL simulation plan — compare v14_csv + sell_ix_accounts_csv to ref TX; fee_config/fee_program in ix are builder constants"
+                v14_fee_config = %v12_fc,
+                v14_fee_program = %v12_fp,
+                sell_ix_fee_config_meta = %ix_fc,
+                sell_ix_fee_program_meta = %ix_fp,
+                fee_config_preserved_from_v14 = fee_config_preserved,
+                fee_program_preserved_from_v14 = fee_program_preserved,
+                protocol_fee_recipient_preserved_from_v14 = pfr_preserved,
+                protocol_fee_recipient_ta_preserved_from_v14 = pfr_ta_preserved,
+                fee_config_differs_from_mainnet_constant = (v12_fc != canonical_fee_cfg),
+                fee_program_differs_from_expected = (v12_fp != canonical_fee_prog),
+                fee_config_replaced_vs_v14 = fee_config_replaced_vs_v14,
+                fee_program_replaced_vs_v14 = fee_program_replaced_vs_v14,
+                "Scope44: pump_amm SELL plan — ix metas must match authoritative v14; replacements vs v14 are simulation risks (Bug #35)"
             );
         }
 

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -30,8 +30,8 @@ const WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
 const PUMPFUN_AMM_PROGRAM_ID: &str = "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA";
 // Observed on-chain in PumpSwap/Pump.fun AMM swaps: `fee_program` is this program id.
 const PUMPFUN_AMM_FEE_PROGRAM_ID: &str = "pfeeUxB6jkeY1Hxd7CsFCAjcbHA9rWtchMGdZ6VojVZ";
-// Global fee_config account - owned by Fee Program, same for ALL pools.
-// Observed in successful on-chain SELL and BUY transactions.
+// Default `fee_config` pubkey used when v14 `pool_accounts[12]` is missing (fallback only).
+// Successful swaps usually carry an authoritative per-row `fee_config` in DexPoolAccounts (Scope 58).
 const PUMPFUN_AMM_FEE_CONFIG: &str = "5PHirr8joyTMp9JMm6nW7hNDVyEYdkzDqazxPD7RaTjx";
 
 /// Same strings as `build_swap_ix_from_pool_accounts` uses for fee metas (diagnostics / downstream).
@@ -103,6 +103,26 @@ fn pump_amm_resolve_protocol_fee_accounts(
         (true, true) => Err(anyhow!(
             "pump_amm: protocol_fee_recipient and protocol_fee_recipient_ta missing — cannot build swap ix without observed fee accounts"
         )),
+    }
+}
+
+/// Authoritative `fee_config` + `fee_program` from a v14 `DexPoolAccounts` row (indices [12]/[13]).
+///
+/// Used by JetStream readiness: extended SELL must not be marked ready until these are populated,
+/// otherwise the builder would fall back to constants and diverge from on-chain expectations.
+#[must_use]
+pub fn pump_amm_authoritative_fee_metas_from_v14(
+    pool_accounts: &[Pubkey],
+) -> Option<(Pubkey, Pubkey)> {
+    if pool_accounts.len() < 14 {
+        return None;
+    }
+    let fee_config = pool_accounts[12];
+    let fee_program = pool_accounts[13];
+    if fee_config == Pubkey::default() || fee_program == Pubkey::default() {
+        None
+    } else {
+        Some((fee_config, fee_program))
     }
 }
 
@@ -5073,10 +5093,17 @@ impl Dex for PumpFunAmmDex {
                 "pump_amm build_swap_ix: cached pool.event_authority != canonical; using canonical"
             );
         }
-        // SELL position [19] must be the global Fee-Program fee_config (same as
-        // `build_swap_ix_from_pool_accounts`). BUY position [20] is pool-specific (AMM-owned);
-        // pools discovered from BUY tx-history would otherwise store the wrong pubkey for SELL.
-        let sell_fee_config = Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG)?;
+        // SELL meta #19: use the same fee_config as the pool's authoritative market row / v14
+        // `pool_accounts` (Bug #35 / Scope 58). BUY meta #20 remains pool.fee_config (may differ).
+        let sell_fee_config = if pool.fee_config == Pubkey::default() {
+            warn!(
+                pool = %pool.pool_market,
+                "pump_amm build_swap_ix: cached pool.fee_config missing — falling back to PUMPFUN_AMM_FEE_CONFIG constant"
+            );
+            Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG)?
+        } else {
+            pool.fee_config
+        };
         let (protocol_fee_recipient, protocol_fee_recipient_ta) =
             pump_amm_resolve_protocol_fee_accounts(
                 pool.protocol_fee_recipient,
@@ -5250,13 +5277,35 @@ impl PumpFunAmmDex {
         let coin_creator_vault_authority = pool_accounts[10];
         let global_volume_accumulator = pool_accounts[11]; // REQUIRED for BUY!
 
-        // CRITICAL FIX: Use the global fee_config constant instead of trusting pool_accounts.
-        // The fee_config is the SAME for all pools - it's a global account owned by the Fee Program.
-        // Observed from successful on-chain SELL (21 accounts) and BUY (23 accounts) transactions.
-        let fee_config = Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG)?;
-        let fee_program = expected_fee_program; // Always use expected, don't trust intent
-
-        // fee_config and fee_program are now constants, no need for validation
+        // Bug #35 / Scope 58: Preserve authoritative v14 `fee_config` + `fee_program` from
+        // `pool_accounts` (Geyser / market-data / JetStream). Some pools use a pool-specific
+        // `fee_config` pubkey in successful extended SELLs; replacing it with the historical
+        // mainnet constant breaks simulation (Custom 6023).
+        let parsed_fee_config = pool_accounts[12];
+        let parsed_fee_program = pool_accounts[13];
+        let fee_config = if parsed_fee_config == Pubkey::default() {
+            warn!(
+                "pump_amm build_swap_ix_from_pool_accounts: pool_accounts[12] fee_config missing — falling back to PUMPFUN_AMM_FEE_CONFIG constant"
+            );
+            Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG)?
+        } else {
+            parsed_fee_config
+        };
+        let fee_program = if parsed_fee_program == Pubkey::default() {
+            warn!(
+                "pump_amm build_swap_ix_from_pool_accounts: pool_accounts[13] fee_program missing — falling back to expected fee program id"
+            );
+            expected_fee_program
+        } else if parsed_fee_program != expected_fee_program {
+            warn!(
+                from_pool_accounts = %parsed_fee_program,
+                expected = %expected_fee_program,
+                "pump_amm build_swap_ix_from_pool_accounts: pool_accounts[13] fee_program != expected; using pool_accounts value (authoritative)"
+            );
+            parsed_fee_program
+        } else {
+            parsed_fee_program
+        };
 
         let (expected_base, is_buy) = if input_mint == WSOL_MINT {
             (output_mint, true)
@@ -6231,6 +6280,63 @@ mod tests {
         assert_eq!(ixs[0].accounts.len(), 21);
         assert_eq!(ixs[0].accounts[9].pubkey, observed_pfr);
         assert_eq!(ixs[0].accounts[10].pubkey, observed_pfr_ta);
+    }
+
+    /// Scope 58 / Bug #35: extended SELL must preserve v14 `fee_config` when it differs from the historical mainnet constant.
+    #[test]
+    fn test_pumpswap_sell_extended_preserves_authoritative_fee_config_from_v14() {
+        let wsol = Pubkey::from_str(WSOL_MINT).unwrap();
+        let base_mint = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let quote_tp = Pubkey::new_from_array(spl_token::id().to_bytes());
+        let third_meta = Pubkey::new_unique();
+        let pool_specific_fee_config =
+            Pubkey::from_str("DcsvhShq8ZaUyU7NtjskVRfKHW7DrSjdu7mkgpzoHyxB").unwrap();
+        assert_ne!(
+            pool_specific_fee_config,
+            Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG).unwrap()
+        );
+        let fee_program = Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).unwrap();
+        let observed_pfr = Pubkey::new_unique();
+        let observed_pfr_ta = PumpFunAmmDex::derive_ata_with_program(observed_pfr, wsol, quote_tp);
+
+        let pool_accounts: Vec<Pubkey> = vec![
+            Pubkey::new_unique(),
+            Pubkey::from_str(PUMPFUN_AMM_GLOBAL_CONFIG).unwrap(),
+            base_mint,
+            wsol,
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            observed_pfr,
+            observed_pfr_ta,
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            pool_specific_fee_config,
+            fee_program,
+        ];
+        assert_eq!(pool_accounts.len(), 14);
+
+        let ixs = PumpFunAmmDex::build_swap_ix_from_pool_accounts(
+            &base_mint.to_string(),
+            WSOL_MINT,
+            1_000_000,
+            1,
+            user,
+            &pool_accounts,
+            None,
+            true,
+            Some(third_meta),
+        )
+        .expect("extended SELL build");
+
+        assert_eq!(ixs[0].accounts.len(), 24);
+        assert_eq!(
+            ixs[0].accounts[19].pubkey, pool_specific_fee_config,
+            "SELL ix meta #19 must equal authoritative pool_accounts[12], not global constant"
+        );
+        assert_eq!(ixs[0].accounts[20].pubkey, fee_program);
     }
 
     /// SELL path: Token-2022 base mint — ix[11] must be Token-2022 program; user base ATA (ix[5]) must match derivation.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PumpSwap `build_swap_ix_from_pool_accounts` always replaced `pool_accounts[12]` (`fee_config`) with the historical mainnet constant `5PHirr8...`, while authoritative v14 rows (e.g. migrated pools) carry a different `fee_config` (`Dcsvh...`). Extended SELL then logged `fee_config_replaced=true` and could fail simulation with `Custom(6023)`.

## Changes

- **`pumpfun_amm.rs`**: Use authoritative `pool_accounts[12]` / `[13]` for BUY and SELL instruction metas; fall back to constant / expected fee program only when the v14 slot is `default`. `build_swap_ix` (cached path) uses `pool.fee_config` for SELL meta #19 instead of forcing the constant.
- **`tx_builder.rs`**: Scope44 diagnostics now compare ix metas to v14, log preservation vs replacement relative to v14, protocol fee fields, account count, and extended flag.
- **`live_pool_cache.rs`**: For extended SELL, `pump_amm_sell_layout_complete_for_ready` also requires non-default v14 `fee_config` / `fee_program` (via `pump_amm_authoritative_fee_metas_from_v14`).
- **`market_data.rs`**: `pump_amm_sell_layout_publish_state` treats extended layout as JetStream-ready only when third meta **and** v14 fee metas are present; Ensure path passes the resolved account slice.

## Tests

- New: `test_pumpswap_sell_extended_preserves_authoritative_fee_config_from_v14` (non-global fee_config + extended third meta → ix[19] matches v14).
- New: `test_pump_amm_extended_with_third_but_missing_fee_config_blocks_ready_gate`.

## STOP-CHECK (I-7)

No new RPC; builder/cache/market-data paths unchanged regarding RPC classification (cold-path refresh unchanged).

## CI

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo test --features test_helpers`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dac5cef4-3610-4baf-98e0-325a092cbdf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dac5cef4-3610-4baf-98e0-325a092cbdf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

