### PR TITLE
fix(pumpswap): Scope 59 – global SELL fee_config, keep extended v24

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -61,9 +61,7 @@ use ironcrab::solana::dex::meteora_bin_array_layout::BinArray;
 use ironcrab::solana::dex::meteora_dlmm::METEORA_DLMM_PROGRAM;
 use ironcrab::solana::dex::meteora_swap_builder::MeteoraDlmmSwapBuilder;
 use ironcrab::solana::dex::pumpfun::{BondingCurveState, PumpFunDex};
-use ironcrab::solana::dex::pumpfun_amm::{
-    pump_amm_authoritative_fee_metas_from_v14, PumpAmmPoolAccountsDiagnostic, PumpFunAmmDex,
-};
+use ironcrab::solana::dex::pumpfun_amm::{PumpAmmPoolAccountsDiagnostic, PumpFunAmmDex};
 use ironcrab::solana::dex::raydium::Raydium;
 use ironcrab::solana::dex_parser::{
     parse_account_update, parse_transaction_update_with_pool_lookup, DexType, OrcaPoolInfo,
@@ -233,26 +231,18 @@ fn raydium_cpmm_readiness_for_pool_cache_update(s: &RaydiumCpmmState) -> DexPool
 /// PumpSwap SELL-layout contract for JetStream / SLAVE SSOT.
 ///
 /// - Base-only SELL stays ready as long as the underlying refresh/observation says the base layout is usable.
-/// - Extended SELL is ready only when the observed third readonly meta is authoritatively known **and**
-///   v14 `pool_accounts` carry non-default `fee_config` / `fee_program` (Scope 58 / Bug #35).
+/// - Extended SELL is ready when the observed third readonly meta is known and base layout is ready.
+///   SELL ix fee_config uses the global mainnet constant — readiness must not depend on v14[12] (Scope 59).
 fn pump_amm_sell_layout_publish_state(
     sell_requires_extended: bool,
     sell_cashback_third_meta: Option<Pubkey>,
     base_layout_ready: bool,
-    pool_accounts_v14: Option<&[Pubkey]>,
 ) -> (bool, DexPoolReadiness) {
-    let fee_metas_ready = if sell_requires_extended {
-        pool_accounts_v14
-            .and_then(pump_amm_authoritative_fee_metas_from_v14)
-            .is_some()
-    } else {
-        true
-    };
     let sell_layout_ready = if sell_requires_extended {
         sell_cashback_third_meta
             .filter(|p| *p != Pubkey::default())
             .is_some()
-            && fee_metas_ready
+            && base_layout_ready
     } else {
         base_layout_ready
     };
@@ -274,7 +264,6 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
     refresh_requires_extended: bool,
     refresh_third_meta: Option<Pubkey>,
     refresh_layout_ready: bool,
-    pool_accounts_v14: &[Pubkey],
 ) -> (bool, Option<Pubkey>, bool, DexPoolReadiness) {
     let (effective_requires_extended, effective_third_meta, base_layout_ready) = if force_refresh {
         (
@@ -295,7 +284,6 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
         effective_requires_extended,
         effective_third_meta,
         base_layout_ready,
-        Some(pool_accounts_v14),
     );
     (
         effective_requires_extended,
@@ -5238,7 +5226,7 @@ fn log_pump_amm_scope44_pool_accounts_diag(
         fee_prog_cached = %v14.get(13).copied().unwrap_or_default(),
         fee_prog_field = ?diag.fee_program.resolution,
         fee_prog_tag = diag.fee_program.tag,
-        "I-24d Scope44: pump_amm v14 diagnostic — ref_sig=successful swap TX for manual diff; execution-engine SELL overwrites fee_config/fee_program with constants (see tx_builder log)"
+        "I-24d Scope44: pump_amm v14 diagnostic — ref_sig=successful swap TX for manual diff; SELL ix uses global fee_config + fee_program (5PH… / pfee…); v14[12]/[13] may differ (cache row)"
     );
 }
 
@@ -5377,7 +5365,6 @@ async fn handle_ensure_pump_amm_pool_accounts(
                     sell_cashback_remaining,
                     sell_cashback_third,
                     sell_layout_ready_from_refresh,
-                    &accounts,
                 );
 
             let (base_reserve, quote_reserve) =
@@ -8533,7 +8520,6 @@ async fn run_geyser_loop(
                             merged_flag,
                             merged_third,
                             true,
-                            Some(pool_accounts.as_slice()),
                         );
                         ctx.live_pool_cache
                             .set_pump_amm_sell_layout_ready(pool_address, sell_layout_ready);
@@ -9790,9 +9776,8 @@ mod discovery_tests {
 
     #[test]
     fn test_pump_amm_trade_publish_extended_without_third_meta_is_partial() {
-        let v14: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
         let (sell_layout_ready, dex_readiness) =
-            pump_amm_sell_layout_publish_state(true, None, true, Some(v14.as_slice()));
+            pump_amm_sell_layout_publish_state(true, None, true);
         assert!(
             !sell_layout_ready,
             "extended SELL without authoritative third meta must not be marked ready"
@@ -9802,15 +9787,9 @@ mod discovery_tests {
 
     #[test]
     fn test_pump_amm_trade_publish_extended_with_third_meta_is_ready() {
-        let mut v14: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
-        v14[12] = Pubkey::from_str("DcsvhShq8ZaUyU7NtjskVRfKHW7DrSjdu7mkgpzoHyxB").unwrap();
-        v14[13] = Pubkey::from_str("pfeeUxB6jkeY1Hxd7CsFCAjcbHA9rWtchMGdZ6VojVZ").unwrap();
-        let (sell_layout_ready, dex_readiness) = pump_amm_sell_layout_publish_state(
-            true,
-            Some(Pubkey::new_unique()),
-            true,
-            Some(v14.as_slice()),
-        );
+        // v14[12]/[13] may differ from global SELL fee_config — readiness must not depend on them (Scope 59).
+        let (sell_layout_ready, dex_readiness) =
+            pump_amm_sell_layout_publish_state(true, Some(Pubkey::new_unique()), true);
         assert!(
             sell_layout_ready,
             "extended SELL with authoritative third meta must be marked ready"
@@ -9821,7 +9800,6 @@ mod discovery_tests {
     #[test]
     fn test_pump_amm_force_refresh_base_overrides_stale_extended_cache_flag() {
         let stale_third = Pubkey::new_unique();
-        let pool_accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
         let (effective_requires_extended, effective_third_meta, sell_layout_ready, dex_readiness) =
             pump_amm_sell_layout_state_for_ensure_publish(
                 true,
@@ -9830,7 +9808,6 @@ mod discovery_tests {
                 false,
                 None,
                 true,
-                &pool_accounts,
             );
         assert!(
             !effective_requires_extended,

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -31,7 +31,6 @@
 //! - PumpFun Bonding: virtual reserves
 //! - PumpFun AMM (PumpSwap): reserves, pool accounts
 
-use crate::solana::dex::pumpfun_amm::pump_amm_authoritative_fee_metas_from_v14;
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use solana_sdk::pubkey::Pubkey;
@@ -998,16 +997,7 @@ impl LivePoolCache {
         }
         let (requires_extended, third) = self.pump_amm_sell_extended_layout(pool_market);
         if requires_extended {
-            if third.filter(|p| *p != Pubkey::default()).is_none() {
-                return false;
-            }
-            let Some(entry) = self.pools.get(pool_market) else {
-                return false;
-            };
-            let CachedPoolState::PumpAmm(s) = &entry.value().state else {
-                return false;
-            };
-            pump_amm_authoritative_fee_metas_from_v14(&s.pool_accounts).is_some()
+            third.filter(|p| *p != Pubkey::default()).is_some()
         } else {
             true
         }
@@ -2606,7 +2596,8 @@ mod tests {
     }
 
     #[test]
-    fn test_pump_amm_extended_with_third_but_missing_fee_config_blocks_ready_gate() {
+    fn test_pump_amm_extended_sell_readiness_ignores_default_v14_fee_config() {
+        // Scope 59: global SELL fee_config does not use v14[12]; extended readiness must not require it.
         let cache = LivePoolCache::new();
         let pool_market = Pubkey::new_unique();
         let base_mint = Pubkey::new_unique();
@@ -2633,8 +2624,12 @@ mod tests {
         assert!(
             cache
                 .get_ready_pump_amm_pool_accounts_by_base_mint(&base_mint)
-                .is_none(),
-            "extended SELL must not be swap-ready until v14 fee_config/fee_program are non-default"
+                .is_some(),
+            "extended SELL must be swap-ready when third_meta + layout_ready + pool_accounts hold"
+        );
+        assert!(
+            cache.pump_amm_swap_accounts_ready_by_base_mint(&base_mint),
+            "readiness must not block on non-default v14[12] when SELL uses global fee_config"
         );
     }
 

--- a/src/execution/tx_builder.rs
+++ b/src/execution/tx_builder.rs
@@ -936,10 +936,10 @@ pub async fn build_tx_plan(
             let v12_fp = pool_accounts[13];
             let ix_fc = ixs[0].accounts[19].pubkey;
             let ix_fp = ixs[0].accounts[20].pubkey;
-            let fee_config_preserved = ix_fc == v12_fc && v12_fc != Pubkey::default();
-            let fee_program_preserved = ix_fp == v12_fp && v12_fp != Pubkey::default();
-            let fee_config_replaced_vs_v14 = ix_fc != v12_fc;
-            let fee_program_replaced_vs_v14 = ix_fp != v12_fp;
+            let fee_config_uses_global_constant = ix_fc == canonical_fee_cfg;
+            let fee_program_uses_expected = ix_fp == canonical_fee_prog;
+            let fee_config_differs_from_v14_row = v12_fc != ix_fc;
+            let fee_program_differs_from_v14_row = v12_fp != ix_fp;
             let pfr_preserved = ixs[0].accounts[9].pubkey == pool_accounts[6];
             let pfr_ta_preserved = ixs[0].accounts[10].pubkey == pool_accounts[7];
             let sell_csv: String = ixs[0]
@@ -961,19 +961,19 @@ pub async fn build_tx_plan(
                 base_token_program_override = ?token_program_override,
                 v14_csv = %PumpAmmPoolAccountsDiagnostic::format_v14_csv(&pool_accounts[..14]),
                 sell_ix_accounts_csv = %sell_csv,
-                v14_fee_config = %v12_fc,
-                v14_fee_program = %v12_fp,
+                v14_fee_config_row = %v12_fc,
+                v14_fee_program_row = %v12_fp,
                 sell_ix_fee_config_meta = %ix_fc,
                 sell_ix_fee_program_meta = %ix_fp,
-                fee_config_preserved_from_v14 = fee_config_preserved,
-                fee_program_preserved_from_v14 = fee_program_preserved,
+                fee_config_uses_global_constant = fee_config_uses_global_constant,
+                fee_program_matches_expected_fee_program = fee_program_uses_expected,
                 protocol_fee_recipient_preserved_from_v14 = pfr_preserved,
                 protocol_fee_recipient_ta_preserved_from_v14 = pfr_ta_preserved,
-                fee_config_differs_from_mainnet_constant = (v12_fc != canonical_fee_cfg),
-                fee_program_differs_from_expected = (v12_fp != canonical_fee_prog),
-                fee_config_replaced_vs_v14 = fee_config_replaced_vs_v14,
-                fee_program_replaced_vs_v14 = fee_program_replaced_vs_v14,
-                "Scope44: pump_amm SELL plan — ix metas must match authoritative v14; replacements vs v14 are simulation risks (Bug #35)"
+                v14_fee_config_differs_from_global_constant = (v12_fc != canonical_fee_cfg),
+                v14_fee_program_differs_from_expected = (v12_fp != canonical_fee_prog),
+                fee_config_differs_from_v14_row = fee_config_differs_from_v14_row,
+                fee_program_differs_from_v14_row = fee_program_differs_from_v14_row,
+                "Scope44: pump_amm SELL plan — meta #19/#20 must be global FeeConfig + fee_program (v14[12] is informational; wrong type → Custom 3002)"
             );
         }
 

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -30,8 +30,8 @@ const WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
 const PUMPFUN_AMM_PROGRAM_ID: &str = "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA";
 // Observed on-chain in PumpSwap/Pump.fun AMM swaps: `fee_program` is this program id.
 const PUMPFUN_AMM_FEE_PROGRAM_ID: &str = "pfeeUxB6jkeY1Hxd7CsFCAjcbHA9rWtchMGdZ6VojVZ";
-// Default `fee_config` pubkey used when v14 `pool_accounts[12]` is missing (fallback only).
-// Successful swaps usually carry an authoritative per-row `fee_config` in DexPoolAccounts (Scope 58).
+// Global Fee Program fee_config PDA — same for PumpSwap SELL ix meta #19 on successful mainnet txs.
+// v14 `pool_accounts[12]` may carry a different pubkey (cache/market row artifact); SELL must still use this constant (Scope 59).
 const PUMPFUN_AMM_FEE_CONFIG: &str = "5PHirr8joyTMp9JMm6nW7hNDVyEYdkzDqazxPD7RaTjx";
 
 /// Same strings as `build_swap_ix_from_pool_accounts` uses for fee metas (diagnostics / downstream).
@@ -103,26 +103,6 @@ fn pump_amm_resolve_protocol_fee_accounts(
         (true, true) => Err(anyhow!(
             "pump_amm: protocol_fee_recipient and protocol_fee_recipient_ta missing — cannot build swap ix without observed fee accounts"
         )),
-    }
-}
-
-/// Authoritative `fee_config` + `fee_program` from a v14 `DexPoolAccounts` row (indices [12]/[13]).
-///
-/// Used by JetStream readiness: extended SELL must not be marked ready until these are populated,
-/// otherwise the builder would fall back to constants and diverge from on-chain expectations.
-#[must_use]
-pub fn pump_amm_authoritative_fee_metas_from_v14(
-    pool_accounts: &[Pubkey],
-) -> Option<(Pubkey, Pubkey)> {
-    if pool_accounts.len() < 14 {
-        return None;
-    }
-    let fee_config = pool_accounts[12];
-    let fee_program = pool_accounts[13];
-    if fee_config == Pubkey::default() || fee_program == Pubkey::default() {
-        None
-    } else {
-        Some((fee_config, fee_program))
     }
 }
 
@@ -5093,17 +5073,11 @@ impl Dex for PumpFunAmmDex {
                 "pump_amm build_swap_ix: cached pool.event_authority != canonical; using canonical"
             );
         }
-        // SELL meta #19: use the same fee_config as the pool's authoritative market row / v14
-        // `pool_accounts` (Bug #35 / Scope 58). BUY meta #20 remains pool.fee_config (may differ).
-        let sell_fee_config = if pool.fee_config == Pubkey::default() {
-            warn!(
-                pool = %pool.pool_market,
-                "pump_amm build_swap_ix: cached pool.fee_config missing — falling back to PUMPFUN_AMM_FEE_CONFIG constant"
-            );
-            Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG)?
-        } else {
-            pool.fee_config
-        };
+        // SELL meta #19/#20: global Fee Program accounts (mainnet-constant). Cached `pool.fee_config`
+        // may differ from v14/market parse — using it as SELL meta #19 caused Anchor Custom(3002)
+        // (wrong account type vs program expectation); Scope 59 restores global constant semantics.
+        let sell_fee_config = Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG)?;
+        let sell_fee_program = Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID)?;
         let (protocol_fee_recipient, protocol_fee_recipient_ta) =
             pump_amm_resolve_protocol_fee_accounts(
                 pool.protocol_fee_recipient,
@@ -5157,7 +5131,7 @@ impl Dex for PumpFunAmmDex {
                 false,
             )); // 18
             metas.push(AccountMeta::new_readonly(sell_fee_config, false)); // 19
-            metas.push(AccountMeta::new_readonly(pool.fee_program, false)); // 20
+            metas.push(AccountMeta::new_readonly(sell_fee_program, false)); // 20
                                                                             // `pools_by_base` can be stale vs monotonic LivePoolCache (Geyser); prefer DashMap for extended SELL.
             let mut sell_requires_cashback_remaining = pool.sell_requires_cashback_remaining;
             let mut sell_cashback_third_meta = pool.sell_cashback_third_meta;
@@ -5277,13 +5251,12 @@ impl PumpFunAmmDex {
         let coin_creator_vault_authority = pool_accounts[10];
         let global_volume_accumulator = pool_accounts[11]; // REQUIRED for BUY!
 
-        // Bug #35 / Scope 58: Preserve authoritative v14 `fee_config` + `fee_program` from
-        // `pool_accounts` (Geyser / market-data / JetStream). Some pools use a pool-specific
-        // `fee_config` pubkey in successful extended SELLs; replacing it with the historical
-        // mainnet constant breaks simulation (Custom 6023).
+        // BUY uses pool row fee fields from v14 ([12]/[13]); SELL meta #19/#20 must use global
+        // Fee Program accounts (same as successful mainnet reference txs). v14[12] is not always
+        // the SELL fee_config account type — using it caused Custom(3002) (Scope 58 regression).
         let parsed_fee_config = pool_accounts[12];
         let parsed_fee_program = pool_accounts[13];
-        let fee_config = if parsed_fee_config == Pubkey::default() {
+        let buy_fee_config = if parsed_fee_config == Pubkey::default() {
             warn!(
                 "pump_amm build_swap_ix_from_pool_accounts: pool_accounts[12] fee_config missing — falling back to PUMPFUN_AMM_FEE_CONFIG constant"
             );
@@ -5291,7 +5264,7 @@ impl PumpFunAmmDex {
         } else {
             parsed_fee_config
         };
-        let fee_program = if parsed_fee_program == Pubkey::default() {
+        let buy_fee_program = if parsed_fee_program == Pubkey::default() {
             warn!(
                 "pump_amm build_swap_ix_from_pool_accounts: pool_accounts[13] fee_program missing — falling back to expected fee program id"
             );
@@ -5300,12 +5273,15 @@ impl PumpFunAmmDex {
             warn!(
                 from_pool_accounts = %parsed_fee_program,
                 expected = %expected_fee_program,
-                "pump_amm build_swap_ix_from_pool_accounts: pool_accounts[13] fee_program != expected; using pool_accounts value (authoritative)"
+                "pump_amm build_swap_ix_from_pool_accounts: pool_accounts[13] fee_program != expected; using pool_accounts value (authoritative for BUY)"
             );
             parsed_fee_program
         } else {
             parsed_fee_program
         };
+
+        let sell_fee_config = Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG)?;
+        let sell_fee_program = expected_fee_program;
 
         let (expected_base, is_buy) = if input_mint == WSOL_MINT {
             (output_mint, true)
@@ -5384,8 +5360,8 @@ impl PumpFunAmmDex {
                 AccountMeta::new(coin_creator_vault_ata, false), // 17
                 AccountMeta::new_readonly(coin_creator_vault_authority, false), // 18
                 AccountMeta::new(user_vol, false),         // 19 - user volume accumulator
-                AccountMeta::new_readonly(fee_config, false), // 20
-                AccountMeta::new_readonly(fee_program, false), // 21
+                AccountMeta::new_readonly(buy_fee_config, false), // 20
+                AccountMeta::new_readonly(buy_fee_program, false), // 21
                 AccountMeta::new_readonly(program_id, false), // 22
             ]
         } else {
@@ -5416,8 +5392,8 @@ impl PumpFunAmmDex {
                 AccountMeta::new_readonly(program_id, false), // 16
                 AccountMeta::new(coin_creator_vault_ata, false), // 17
                 AccountMeta::new_readonly(coin_creator_vault_authority, false), // 18
-                AccountMeta::new_readonly(fee_config, false), // 19
-                AccountMeta::new_readonly(fee_program, false), // 20
+                AccountMeta::new_readonly(sell_fee_config, false), // 19
+                AccountMeta::new_readonly(sell_fee_program, false), // 20
             ];
             if sell_requires_cashback_remaining {
                 let Some(third) = sell_cashback_third_meta.filter(|p| *p != Pubkey::default())
@@ -6282,18 +6258,19 @@ mod tests {
         assert_eq!(ixs[0].accounts[10].pubkey, observed_pfr_ta);
     }
 
-    /// Scope 58 / Bug #35: extended SELL must preserve v14 `fee_config` when it differs from the historical mainnet constant.
+    /// Extended SELL (24 accounts): meta #19 must be global `PUMPFUN_AMM_FEE_CONFIG` even when v14[12]
+    /// is a different pubkey (SELL expects that account type; v12 alone caused Scope 58 Custom 3002).
     #[test]
-    fn test_pumpswap_sell_extended_preserves_authoritative_fee_config_from_v14() {
+    fn pumpswap_extended_sell_uses_global_fee_config() {
         let wsol = Pubkey::from_str(WSOL_MINT).unwrap();
         let base_mint = Pubkey::new_unique();
         let user = Pubkey::new_unique();
         let quote_tp = Pubkey::new_from_array(spl_token::id().to_bytes());
         let third_meta = Pubkey::new_unique();
-        let pool_specific_fee_config =
+        let row_fee_config =
             Pubkey::from_str("DcsvhShq8ZaUyU7NtjskVRfKHW7DrSjdu7mkgpzoHyxB").unwrap();
         assert_ne!(
-            pool_specific_fee_config,
+            row_fee_config,
             Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG).unwrap()
         );
         let fee_program = Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).unwrap();
@@ -6313,7 +6290,7 @@ mod tests {
             Pubkey::new_unique(),
             Pubkey::new_unique(),
             Pubkey::new_unique(),
-            pool_specific_fee_config,
+            row_fee_config,
             fee_program,
         ];
         assert_eq!(pool_accounts.len(), 14);
@@ -6333,10 +6310,19 @@ mod tests {
 
         assert_eq!(ixs[0].accounts.len(), 24);
         assert_eq!(
-            ixs[0].accounts[19].pubkey, pool_specific_fee_config,
-            "SELL ix meta #19 must equal authoritative pool_accounts[12], not global constant"
+            ixs[0].accounts[19].pubkey,
+            Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG).unwrap(),
+            "SELL ix meta #19 must use global FeeConfig constant, not v14[12]"
         );
         assert_eq!(ixs[0].accounts[20].pubkey, fee_program);
+        assert_eq!(ixs[0].accounts[23].pubkey, third_meta);
+    }
+
+    /// Regression guard (Scope 58): using `pool_accounts[12]` as SELL `fee_config` meta caused
+    /// Anchor `Custom(3002)` (wrong account type vs program). SELL must keep global `5PH…` + `pfee…`.
+    #[test]
+    fn pumpswap_sell_fee_config_scope58_custom3002_regression_guard() {
+        pumpswap_extended_sell_uses_global_fee_config();
     }
 
     /// SELL path: Token-2022 base mint — ix[11] must be Token-2022 program; user base ATA (ix[5]) must match derivation.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Reverts Scope 58’s assumption that SELL must use `v14[12]` as `fee_config` meta. After Scope 58, the same liquidation path failed with Anchor `Custom(3002)` (wrong account type). SELL meta #19/#20 now use the global `PUMPFUN_AMM_FEE_CONFIG` + fee program again; BUY still uses the v14 fee fields.

## What changed
- `build_swap_ix` (cache path): SELL uses global constant fee accounts; extended 24-account layout + `third_meta` unchanged.
- `build_swap_ix_from_pool_accounts`: split BUY (`buy_fee_config` / `buy_fee_program` from v14) vs SELL (global).
- `market_data` + `LivePoolCache`: extended SELL readiness no longer requires non-default `v14[12]`/`[13]`; based on `third_meta` + layout ready + pool state as before Scope 58’s gate.
- Scope44 cold-path logging: `fee_config_uses_global_constant`, row vs ix diffs, full `sell_ix_accounts_csv`.
- Tests: `pumpswap_extended_sell_uses_global_fee_config`, `test_pump_amm_extended_sell_readiness_ignores_default_v14_fee_config`, `pumpswap_sell_fee_config_scope58_custom3002_regression_guard`.

## Verification
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (local).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6fa7b1b-2eee-4524-8d70-b9bebe507bb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6fa7b1b-2eee-4524-8d70-b9bebe507bb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

