### PR TITLE
Momentum: Cost-Basis Scale-In (Fill-tps) und ExplicitAmount ui_f64

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -1143,3 +1143,15 @@ BUY cost bevorzugt jetzt value_sol (fill_in) — die tatsächlich für den Swap 
 | **Betroffene Module** | momentum-bot, position.rs |
 | **Regression-Prüfung** | PnL und Drawdown nutzen dieselbe Preisquelle (tokens_per_sol), Formeln konsistent. |
 | **Tags** | [momentum, drawdown, ath, fix] |
+
+---
+
+## FIX-46: Momentum Cost Basis / Scale-In `entry_price` und `ExplicitAmount` ohne `ui`
+
+| Symptom | Decision Records: extreme Trailing/TP-Prozente (−80 % from ATH, +300 % TP) bei real nahezu flat/Verlust; Dashboard spiegelt Backend. |
+|---------|----------------------------------------------------------------------------------------------------------------------------------------|
+| **Root Cause** | (1) `PositionTracker::add_investment` gewichtete Scale-In mit `current_price` (Mark) statt Fill-`tokens_per_sol` der neuen Tranche. (2) `ExplicitAmount::as_f64()` lieferte bei deserialisierten Fills ohne `ui` **0** — `entry_price` aus `tok_ui/sol_ui` wurde falsch. |
+| **Fix** | `add_investment(additional_sol, fill_entry_tps)`; `open_position` reicht Fill-`p.entry_price` durch. `ExplicitAmount::ui_f64()` leitet aus `raw`/`decimals` ab; `as_f64()` delegiert dorthin; BUY-Bestätigung und Orphan-Recovery nutzen `ui_f64()` für Fill-UI. |
+| **Betroffene Module** | `src/bin/momentum_bot.rs`, `src/ipc/schema.rs` |
+| **Regression-Prüfung** | Unit-Test: gewichteter Scale-In-Blend nutzt Fill-`tokens_per_sol` statt Marktpreis; `ExplicitAmount` ohne `ui` in JSON. |
+| **Tags** | [momentum, scale-in, entry_price, explicit_amount, i-15] |

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -839,17 +839,24 @@ impl PositionTracker {
         self.highest_price = tokens_per_sol::updated_highest_price(self.highest_price, new_price);
     }
 
-    fn add_investment(&mut self, additional_sol: u64) {
+    /// Scale-in: blend `entry_price` (tokens_per_sol) by SOL weight using the **fill** tps for
+    /// the new tranche — not `current_price` (mark can diverge and blew up TP/ATH decision text).
+    fn add_investment(&mut self, additional_sol: u64, fill_entry_tps: f64) {
         if additional_sol == 0 {
             return;
         }
 
-        // Heuristic: weighted-average entry price based on SOL invested.
-        // Exact fill price/token amount is not available from ExecutionResult today.
+        let leg_tps = if fill_entry_tps > 0.0 && fill_entry_tps.is_finite() {
+            fill_entry_tps
+        } else {
+            // Defensive: missing fill tps — keep prior entry for this leg's weight (avoid 0).
+            self.entry_price
+        };
+
         let old_sol = self.sol_invested.max(1);
         let new_sol = old_sol.saturating_add(additional_sol).max(1);
         let new_entry = ((self.entry_price * (old_sol as f64))
-            + (self.current_price * (additional_sol as f64)))
+            + (leg_tps * (additional_sol as f64)))
             / (new_sol as f64);
 
         self.sol_invested = self.sol_invested.saturating_add(additional_sol);
@@ -3301,7 +3308,7 @@ impl MomentumContext {
             let mut positions = self.positions.write();
             if let Some(pos) = positions.get_mut(p.mint) {
                 pos.token_amount = pos.token_amount.saturating_add(p.token_amount);
-                pos.add_investment(p.sol_invested);
+                pos.add_investment(p.sol_invested, p.entry_price);
                 // Scope 50: Scale-in increases total held — any prior exit intent was sized for
                 // the old total (often probe-only). Reset exit latch so the next exit uses the
                 // combined amount; avoids selling probe while scale-in tokens remain.
@@ -4013,10 +4020,10 @@ impl MomentumContext {
                             let sol_ui = result
                                 .fill_in
                                 .as_ref()
-                                .map(|a| a.as_f64())
+                                .map(|a| a.ui_f64())
                                 .unwrap_or(sol_invested as f64 / 1e9)
                                 .max(0.0);
-                            let tok_ui = fill_out.as_f64().max(0.0);
+                            let tok_ui = fill_out.ui_f64().max(0.0);
                             let entry_price = if sol_ui > 0.0 { tok_ui / sol_ui } else { 1.0 };
 
                             let token_program = result
@@ -4312,10 +4319,10 @@ impl MomentumContext {
                         let sol_ui_for_price = result
                             .fill_in
                             .as_ref()
-                            .map(|a| a.as_f64())
+                            .map(|a| a.ui_f64())
                             .unwrap_or(sol_invested_raw as f64 / 1_000_000_000.0)
                             .max(0.0);
-                        let tok_ui = fill_out.as_f64().max(0.0);
+                        let tok_ui = fill_out.ui_f64().max(0.0);
                         let entry_price = if sol_ui_for_price > 0.0 {
                             tok_ui / sol_ui_for_price
                         } else {
@@ -7222,6 +7229,19 @@ mod tests {
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    /// Scale-in must blend fill `tokens_per_sol` for the new leg, not `current_price` (mark).
+    #[test]
+    fn scale_in_entry_price_blends_fill_tps_not_mark_price() {
+        let mut pos = PositionTracker::new("mint", "pool", "dex", 100.0, 6, 1_000_000, 500_000_000);
+        pos.current_price = 10.0;
+        pos.add_investment(500_000_000, 300.0);
+        assert!(
+            (pos.entry_price - 200.0).abs() < 1e-6,
+            "expected weighted entry ~200 tps, got {}",
+            pos.entry_price
+        );
     }
 
     #[test]

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -123,9 +123,26 @@ impl ExplicitAmount {
         Self::from_ui(Decimal::from_f64_retain(sol).unwrap_or(Decimal::ZERO), 9)
     }
 
+    /// Human-readable amount as `f64` for calculations (I-15).
+    ///
+    /// Prefers explicit `ui` when present and convertible; if missing (e.g. JSON without `ui`),
+    /// derives from `raw` / `decimals` so callers never silently treat a valid fill as zero.
+    pub fn ui_f64(&self) -> f64 {
+        if let Some(ui) = self.ui {
+            if let Some(f) = ui.to_f64() {
+                return f;
+            }
+        }
+        let scale = Decimal::from(10u64.pow(self.decimals as u32));
+        if scale.is_zero() {
+            return 0.0;
+        }
+        (Decimal::from(self.raw) / scale).to_f64().unwrap_or(0.0)
+    }
+
     /// Get UI value as f64 (for calculations)
     pub fn as_f64(&self) -> f64 {
-        self.ui.and_then(|d| d.to_f64()).unwrap_or(0.0)
+        self.ui_f64()
     }
 }
 
@@ -2073,6 +2090,21 @@ mod tests {
         assert_eq!(amt.raw, 1_000_000_000);
         assert_eq!(amt.decimals, 9);
         assert_eq!(amt.ui, Some(Decimal::from(1)));
+    }
+
+    #[test]
+    fn explicit_amount_ui_f64_derives_from_raw_when_ui_missing() {
+        let json = r#"{"raw":500000000,"decimals":9}"#;
+        let amt: ExplicitAmount = serde_json::from_str(json).expect("deserialize");
+        assert!(amt.ui.is_none());
+        assert!((amt.ui_f64() - 0.5).abs() < 1e-9);
+        assert!((amt.as_f64() - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn explicit_amount_ui_f64_matches_constructor_ui() {
+        let amt = ExplicitAmount::new(1_234_567_890, 9);
+        assert!((amt.ui_f64() - amt.as_f64()).abs() < 1e-12);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Kurzbeschreibung

Behebt verzerrte Signal-PnL / TP / ATH-Texte bei Scale-In: die gewichtete `entry_price` (`tokens_per_sol`) wurde mit `current_price` statt mit dem Fill der neuen Tranche gemischt. Zusätzlich liefert `ExplicitAmount::as_f64()` nach Deserialisierung ohne `ui` fälschlich 0 — `entry_price` aus Fill-Ratios war damit kaputt.

## Änderungen

- **`PositionTracker::add_investment(additional_sol, fill_entry_tps)`**: gewichteter Durchschnitt mit Fill-`tokens_per_sol` der neuen Tranche; Fallback bei ungültigem Fill auf bisherige `entry_price`.
- **`open_position`**: bei bestehender Position `pos.add_investment(p.sol_invested, p.entry_price)` — `p.entry_price` ist bereits Fill-basiert wie bei `open_position` neu.
- **`ExplicitAmount::ui_f64()`** in `schema.rs`: bevorzugt `ui`, sonst `raw`/`decimals`; **`as_f64()`** delegiert dorthin (I-15).
- **BUY confirmed & Orphan-Recovery**: `fill_in` / `fill_out` nutzen `ui_f64()` für die Entry-Ratio.
- **Regression**: Unit-Test `scale_in_entry_price_blends_fill_tps_not_mark_price`; Schema-Tests für JSON ohne `ui`.
- **`docs/BUGS_FIXES.md`**: FIX-46.

## STOP-CHECK (kurz)

1. Kein neuer RPC / keine Hot-Path-Änderung außerhalb reiner Accounting-Math.
2. Kein breiter Refactor; nur erlaubte Dateien.
3. Kein Eval-`tests/`-Lesen.

## Prüfungen

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo test --features test_helpers`.

Eval Level 5 nach Merge wie vom Supervisor koordiniert.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa8eb0ba-d5b1-44fb-a54d-ef170833c5ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa8eb0ba-d5b1-44fb-a54d-ef170833c5ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

