### PR TITLE
Momentum Scope B: sticky latest pool/migration state (non-bonding lifecycle)

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -112,7 +112,7 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 ### FIX-SCOPE-B: Momentum „sticky latest state“ (Lifecycle Scope B, non-bonding)
 **Datum**: 2026-05-10
 **Problem**: Neben `BondingCurveProgress` (Scope A) konnten weitere Geyser-/JetStream-Zustände (PumpFun-Migration, reserve-basierte Pool-Marks, `TokenMintInfo`) vor Positionserstellung ankommen und fehlten bei späterem BUY-open, Orphan-Recovery oder Wallet-Reconcile — gleiche Klasse Race wie beim Bonding-Snapshot.
-**Fix**: Slot-/ts-monotone Maps für PumpFun-Migration (`complete`) und reserve-basierte `(mint, pool)`-Preis-Hints aus `PoolCacheUpdate`; `live_cache_pumpfun_complete_evidence` berücksichtigt die Migration-Sticky-Map; gemeinsamer `apply_latest_sticky_state_to_position` nach `open_position`, Reconcile-Pfaden, `TokenMintInfo`, plus bestehende PoolCache- und 6005-Pfade schreiben die Sticky-Maps; I-13 und Scope-1-Slot-Gates beim Apply; `close_position` räumt Sticky (nicht `mint_infos` / nicht Bonding-Duplikat).
+**Fix**: Slot-/ts-monotone Maps für PumpFun-Migration (`complete`) und reserve-basierte `(mint, pool)`-Preis-Hints aus `PoolCacheUpdate`; `live_cache_pumpfun_complete_evidence` berücksichtigt die Migration-Sticky-Map; gemeinsamer `apply_latest_sticky_state_to_position` nach `open_position`, Reconcile-Pfaden, `TokenMintInfo`, plus bestehende PoolCache- und 6005-Pfade schreiben die Sticky-Maps; I-13 und Scope-1-Slot-Gates beim Apply; **`close_position` räumt Sticky nur ohne pending BUY** (analog `latest_bonding_by_mint`). **Reserve-Sticky und Live-PoolCache-Preisupdate nur wenn genau eine Mint-Seite WSOL ist** — keine Marks aus Token/Token-Paaren (I-14 / non-SOL-Quote).
 **Dateien**: `src/bin/momentum_bot.rs`
 
 ### FIX-18: Bug B — Orphaned Buy Recovery

--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -109,6 +109,12 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 **Fix**: `ExecutionResult.confirmed_slot` + Metadata-Spiegel wird beim Confirm gesetzt (Bundle-/Geyser-/RPC-Slot). `PositionTracker` erhält `entry_confirmed_slot` und `last_price_slot`; `update_position_price` akzeptiert nur Updates mit `source_slot > entry_confirmed_slot` und strikt monoton steigend; Pool-Match (I-13) unverändert. Trade- und PoolCache-Pfade reichen Geyser-Slot durch.
 **Dateien**: `src/bin/execution_engine.rs`, `src/bin/momentum_bot.rs`
 
+### FIX-SCOPE-B: Momentum „sticky latest state“ (Lifecycle Scope B, non-bonding)
+**Datum**: 2026-05-10
+**Problem**: Neben `BondingCurveProgress` (Scope A) konnten weitere Geyser-/JetStream-Zustände (PumpFun-Migration, reserve-basierte Pool-Marks, `TokenMintInfo`) vor Positionserstellung ankommen und fehlten bei späterem BUY-open, Orphan-Recovery oder Wallet-Reconcile — gleiche Klasse Race wie beim Bonding-Snapshot.
+**Fix**: Slot-/ts-monotone Maps für PumpFun-Migration (`complete`) und reserve-basierte `(mint, pool)`-Preis-Hints aus `PoolCacheUpdate`; `live_cache_pumpfun_complete_evidence` berücksichtigt die Migration-Sticky-Map; gemeinsamer `apply_latest_sticky_state_to_position` nach `open_position`, Reconcile-Pfaden, `TokenMintInfo`, plus bestehende PoolCache- und 6005-Pfade schreiben die Sticky-Maps; I-13 und Scope-1-Slot-Gates beim Apply; `close_position` räumt Sticky (nicht `mint_infos` / nicht Bonding-Duplikat).
+**Dateien**: `src/bin/momentum_bot.rs`
+
 ### FIX-18: Bug B — Orphaned Buy Recovery
 **Datum**: 2026-02-13
 **Problem**: Race Condition: `cleanup_stale_pending()` entfernte pending intent bevor `ExecutionResult` ankam → Position nie erstellt → kein Sell.

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -2134,6 +2134,26 @@ struct CachedBondingCurveState {
     ts_unix_ms: u64,
 }
 
+/// Scope B: last observed PumpFun bonding-curve **complete** (migration) signal for a mint.
+/// Slot-/timestamp-monotonic merge only; complements LivePoolCache when rows are not yet present.
+#[derive(Debug, Clone)]
+struct CachedPumpfunMigrationCompleteEvidence {
+    slot: u64,
+    ts_unix_ms: u64,
+}
+
+/// Scope B: reserve-derived `tokens_per_sol` hint from `PoolCacheUpdate` for a `(token_mint, pool)`.
+/// Applied only with I-13 pool match and the same slot gates as `update_position_price`.
+#[derive(Debug, Clone)]
+struct CachedPoolReservePriceHint {
+    pool_address: String,
+    #[allow(dead_code)]
+    dex: String,
+    tokens_per_sol: f64,
+    slot: u64,
+    ts_unix_ms: u64,
+}
+
 /// Pending BUY lifecycle (not a wallet position): holds bonding/migration state between
 /// successful intent publish and ExecutionResult / `open_position`.
 #[derive(Debug, Clone)]
@@ -2264,6 +2284,13 @@ struct MomentumContext {
     pending_intents: parking_lot::RwLock<HashMap<String, PendingIntent>>,
     /// Latest `BondingCurveProgress` per mint (Geyser slot/ts monotonic).
     latest_bonding_by_mint: parking_lot::RwLock<HashMap<String, CachedBondingCurveState>>,
+    /// Scope B: latest PumpFun migration (`complete`) evidence per mint (Geyser slot/ts monotonic).
+    latest_pumpfun_migration_complete_by_mint:
+        parking_lot::RwLock<HashMap<String, CachedPumpfunMigrationCompleteEvidence>>,
+    /// Scope B: latest reserve-derived mark `tokens_per_sol` per `(token_mint, pool)` from JetStream
+    /// `PoolCacheUpdate` (slot/ts monotonic). Not a wallet or capital truth — only for position marks.
+    latest_pool_reserve_price_hint_by_mint_pool:
+        parking_lot::RwLock<HashMap<(String, String), CachedPoolReservePriceHint>>,
     /// Pending BUY lifecycle entries (intent_id -> entry), after successful JetStream publish.
     pending_buy_entries: parking_lot::RwLock<HashMap<String, PendingBuyEntry>>,
     /// At most one active pending BUY per mint: mint -> intent_id.
@@ -2579,6 +2606,8 @@ impl MomentumContext {
         if let Some((balance_raw, decimals)) = orphan_data {
             if let Some(reconciled) = self.build_reconciled_position(mint, balance_raw, decimals) {
                 let hold_secs = reconciled.entry_time.elapsed().as_secs();
+                let mut reconciled = reconciled;
+                self.apply_latest_sticky_state_to_position(mint, &mut reconciled);
                 self.positions
                     .write()
                     .insert(mint.to_string(), reconciled.clone());
@@ -2651,6 +2680,8 @@ impl MomentumContext {
                 if let Some(reconciled) =
                     self.build_reconciled_position(mint, balance_raw, decimals)
                 {
+                    let mut reconciled = reconciled;
+                    self.apply_latest_sticky_state_to_position(mint, &mut reconciled);
                     self.positions
                         .write()
                         .insert(mint.to_string(), reconciled.clone());
@@ -2680,13 +2711,20 @@ impl MomentumContext {
         }
     }
 
-    /// Scope 57 / I-13: Cache-side PumpFun migration signals (Geyser/JetStream — no RPC).
+    /// Scope 57 / I-13: Cache-side PumpFun migration signals (Geyser/JetStream — no RPC),
+    /// plus Scope B sticky migration evidence when LivePoolCache rows are not yet present.
     fn live_cache_pumpfun_complete_evidence(&self, mint: &str) -> bool {
+        let sticky = self
+            .latest_pumpfun_migration_complete_by_mint
+            .read()
+            .contains_key(mint);
         let Ok(pk) = solana_sdk::pubkey::Pubkey::from_str(mint) else {
-            return false;
+            return sticky;
         };
-        self.live_pool_cache
-            .pumpfun_bonding_curve_complete_for_mint(&pk)
+        sticky
+            || self
+                .live_pool_cache
+                .pumpfun_bonding_curve_complete_for_mint(&pk)
             || self.live_pool_cache.is_pumpfun_complete_for_mint(&pk) == Some(true)
     }
 
@@ -2808,6 +2846,8 @@ impl MomentumContext {
                 .checked_sub(Duration::from_secs(config.max_hold_time_secs))
                 .unwrap_or_else(Instant::now);
         }
+
+        self.apply_latest_sticky_state_to_position(mint, &mut tracker);
 
         Some(tracker)
     }
@@ -3518,7 +3558,6 @@ impl MomentumContext {
                     token_program = ?pos.token_program,
                     "📈 Position scaled in"
                 );
-                pos.clone()
             } else {
                 let mut new_tracker = PositionTracker::new(
                     p.mint,
@@ -3539,7 +3578,7 @@ impl MomentumContext {
                 if let Some(ref snap) = p.initial_bonding {
                     new_tracker.bonding_curve_progress_bps = Some(snap.progress_bps);
                 }
-                positions.insert(p.mint.to_string(), new_tracker.clone());
+                positions.insert(p.mint.to_string(), new_tracker);
                 if p.entry_confirmed_slot == 0 {
                     warn!(
                         mint = %p.mint,
@@ -3553,8 +3592,12 @@ impl MomentumContext {
                     token_program = ?p.token_program,
                     "📈 Position opened"
                 );
-                new_tracker
             }
+            let _ = self.apply_latest_sticky_state_to_position(
+                p.mint,
+                positions.get_mut(p.mint).expect("position"),
+            );
+            positions.get(p.mint).expect("position").clone()
         };
 
         // Persist to KV asynchronously (fire-and-forget)
@@ -3655,6 +3698,8 @@ impl MomentumContext {
         if !self.pending_buy_mint_index.read().contains_key(mint) {
             self.latest_bonding_by_mint.write().remove(mint);
         }
+
+        self.clear_scope_b_sticky_state_for_mint(mint);
 
         // Delete from KV asynchronously (fire-and-forget)
         let ctx = Arc::clone(self);
@@ -4197,6 +4242,9 @@ impl MomentumContext {
 
         if !cache_relevant {
             self.latest_bonding_by_mint.write().remove(mint);
+            if complete {
+                self.merge_pumpfun_migration_complete_evidence(mint, slot, ts_unix_ms);
+            }
             return;
         }
 
@@ -4221,6 +4269,9 @@ impl MomentumContext {
                         ts_unix_ms,
                     },
                 );
+                if complete {
+                    self.merge_pumpfun_migration_complete_evidence(mint, slot, ts_unix_ms);
+                }
             }
         }
 
@@ -4305,6 +4356,215 @@ impl MomentumContext {
 
     fn clone_latest_bonding_snapshot(&self, mint: &str) -> Option<CachedBondingCurveState> {
         self.latest_bonding_by_mint.read().get(mint).cloned()
+    }
+
+    /// Scope B: remove sticky pool hints + migration evidence when a position closes.
+    fn clear_scope_b_sticky_state_for_mint(&self, mint: &str) {
+        self.latest_pumpfun_migration_complete_by_mint
+            .write()
+            .remove(mint);
+        self.latest_pool_reserve_price_hint_by_mint_pool
+            .write()
+            .retain(|key, _| key.0 != mint);
+    }
+
+    /// Scope B: record PumpFun bonding-curve `complete` (migration) with slot-/ts-monotonic merge.
+    pub(crate) fn merge_pumpfun_migration_complete_evidence(
+        &self,
+        mint: &str,
+        slot: u64,
+        ts_unix_ms: u64,
+    ) {
+        let mut map = self.latest_pumpfun_migration_complete_by_mint.write();
+        let accept = match map.get(mint) {
+            None => true,
+            Some(prev) => {
+                bonding_geyser_observation_is_newer(slot, ts_unix_ms, prev.slot, prev.ts_unix_ms)
+            }
+        };
+        if accept {
+            map.insert(
+                mint.to_string(),
+                CachedPumpfunMigrationCompleteEvidence { slot, ts_unix_ms },
+            );
+        }
+    }
+
+    /// Scope B: migration evidence from execution-engine observations (6005, etc.) when Geyser slot
+    /// metadata may be missing — uses `ExecutionResult.confirmed_slot` or last event slot.
+    fn record_pumpfun_migration_complete_evidence_from_execution_observation(
+        &self,
+        mint: &str,
+        result: &ExecutionResult,
+    ) {
+        let slot = result
+            .confirmed_slot
+            .unwrap_or_else(|| {
+                self.last_event_slot
+                    .load(std::sync::atomic::Ordering::Relaxed)
+            })
+            .max(
+                self.last_event_slot
+                    .load(std::sync::atomic::Ordering::Relaxed),
+            );
+        let ts_wall = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let ts = ts_wall.max(
+            self.last_event_ts_ms
+                .load(std::sync::atomic::Ordering::Relaxed),
+        );
+        self.merge_pumpfun_migration_complete_evidence(mint, slot, ts);
+    }
+
+    /// Scope B: merge a `PoolCacheUpdate` into the sticky reserve mark map (same monotonic rules as bonding).
+    pub(crate) fn merge_latest_pool_reserve_price_hint_from_update(
+        &self,
+        update: &ironcrab::ipc::PoolCacheUpdate,
+    ) {
+        if update.base_reserve == 0 || update.quote_reserve == 0 {
+            return;
+        }
+        const SOL_WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
+        let (token_mint, token_reserve, sol_reserve, decimals) =
+            if update.base_mint == SOL_WSOL_MINT {
+                let decimals = self
+                    .mint_infos
+                    .read()
+                    .get(&update.quote_mint)
+                    .map(|m| m.decimals)
+                    .unwrap_or(6);
+                (
+                    update.quote_mint.clone(),
+                    update.quote_reserve,
+                    update.base_reserve,
+                    decimals,
+                )
+            } else {
+                let decimals = self
+                    .mint_infos
+                    .read()
+                    .get(&update.base_mint)
+                    .map(|m| m.decimals)
+                    .unwrap_or(6);
+                (
+                    update.base_mint.clone(),
+                    update.base_reserve,
+                    update.quote_reserve,
+                    decimals,
+                )
+            };
+        let token_ui = token_reserve as f64 / 10f64.powi(decimals as i32);
+        let sol_ui = sol_reserve as f64 / 1_000_000_000.0;
+        if sol_ui <= 0.0 || !sol_ui.is_finite() || token_ui <= 0.0 || !token_ui.is_finite() {
+            return;
+        }
+        let tokens_per_sol = token_ui / sol_ui;
+        if !tokens_per_sol.is_finite() || tokens_per_sol <= 0.0 {
+            return;
+        }
+        let key = (token_mint, update.pool_address.clone());
+        let mut map = self.latest_pool_reserve_price_hint_by_mint_pool.write();
+        let accept = match map.get(&key) {
+            None => true,
+            Some(prev) => bonding_geyser_observation_is_newer(
+                update.geyser_slot,
+                update.header.ts_unix_ms,
+                prev.slot,
+                prev.ts_unix_ms,
+            ),
+        };
+        if accept {
+            map.insert(
+                key,
+                CachedPoolReservePriceHint {
+                    pool_address: update.pool_address.clone(),
+                    dex: update.dex.clone(),
+                    tokens_per_sol,
+                    slot: update.geyser_slot,
+                    ts_unix_ms: update.header.ts_unix_ms,
+                },
+            );
+        }
+    }
+
+    /// Scope B: apply `mint_infos`, cached bonding max-guard, and pool reserve hints to one position.
+    /// Respects I-13 and Scope-1 slot monotonicity. Returns true when bonding or mark price changed
+    /// (caller may trigger `process_exit_signals`).
+    pub(crate) fn apply_latest_sticky_state_to_position(
+        &self,
+        mint: &str,
+        pos: &mut PositionTracker,
+    ) -> bool {
+        let mut exit_maybe = false;
+
+        if let Some(mi) = self.mint_infos.read().get(mint) {
+            if mi.decimals > 0 && pos.token_decimals == 0 {
+                pos.token_decimals = mi.decimals;
+            }
+            if pos
+                .token_program
+                .as_ref()
+                .map(|s| s.is_empty())
+                .unwrap_or(true)
+                && !mi.token_program.is_empty()
+            {
+                pos.token_program = Some(mi.token_program.clone());
+            }
+        }
+
+        if let Some(latest) = self.latest_bonding_by_mint.read().get(mint) {
+            let merged_bps = latest
+                .progress_bps
+                .max(pos.bonding_curve_progress_bps.unwrap_or(0));
+            if pos.bonding_curve_progress_bps != Some(merged_bps) {
+                pos.bonding_curve_progress_bps = Some(merged_bps);
+                exit_maybe = true;
+            }
+        }
+
+        let hint_key = (mint.to_string(), pos.pool.clone());
+        if let Some(hint) = self
+            .latest_pool_reserve_price_hint_by_mint_pool
+            .read()
+            .get(&hint_key)
+            .cloned()
+        {
+            if Self::try_apply_reserve_hint_as_position_price(pos, &hint) {
+                exit_maybe = true;
+            }
+        }
+
+        exit_maybe
+    }
+
+    fn try_apply_reserve_hint_as_position_price(
+        pos: &mut PositionTracker,
+        hint: &CachedPoolReservePriceHint,
+    ) -> bool {
+        if !ironcrab::execution::position_utils::should_apply_position_price_update(
+            &pos.pool,
+            Some(&hint.pool_address),
+        ) {
+            return false;
+        }
+        if pos.entry_confirmed_slot > 0 {
+            if hint.slot <= pos.entry_confirmed_slot {
+                return false;
+            }
+            if hint.slot <= pos.last_price_slot {
+                return false;
+            }
+        }
+        if hint.tokens_per_sol <= 0.0 || !hint.tokens_per_sol.is_finite() {
+            return false;
+        }
+        pos.update_price(hint.tokens_per_sol);
+        if hint.slot > 0 {
+            pos.last_price_slot = pos.last_price_slot.max(hint.slot);
+        }
+        true
     }
 
     /// Handle execution result from execution-engine
@@ -4606,6 +4866,9 @@ impl MomentumContext {
                                 }
                             }
                         }
+                        self.record_pumpfun_migration_complete_evidence_from_execution_observation(
+                            mint, result,
+                        );
                     }
 
                     // FIX-20: Track pool failure for orphaned sell path too.
@@ -4992,6 +5255,10 @@ impl MomentumContext {
                                 }
                             }
                         }
+                        self.record_pumpfun_migration_complete_evidence_from_execution_observation(
+                            &pending.mint,
+                            result,
+                        );
                     }
 
                     // FIX-20: Track pool failure so find_best_sell_pool() prefers alternatives.
@@ -5079,6 +5346,10 @@ impl MomentumContext {
                                 }
                             }
                         }
+                        self.record_pumpfun_migration_complete_evidence_from_execution_observation(
+                            &pending.mint,
+                            result,
+                        );
                     }
 
                     // FIX-20: Track pool failure so find_best_sell_pool() prefers alternatives.
@@ -6072,7 +6343,7 @@ async fn recover_positions_from_jsonl(
 }
 
 /// Bootstrap WalletBalanceSnapshot events from JetStream (race-free recovery)
-async fn bootstrap_wallet_snapshot_from_jetstream(ctx: &MomentumContext) -> Result<usize> {
+async fn bootstrap_wallet_snapshot_from_jetstream(ctx: &Arc<MomentumContext>) -> Result<usize> {
     use async_nats::jetstream;
     use futures::StreamExt;
     use std::collections::HashSet;
@@ -6418,6 +6689,8 @@ async fn main() -> Result<()> {
         positions: parking_lot::RwLock::new(recovered_positions),
         pending_intents: parking_lot::RwLock::new(HashMap::new()),
         latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+        latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+        latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
         pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
         pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
         mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -6794,11 +7067,17 @@ async fn main() -> Result<()> {
                             }
 
                             // Process the event
-                            if let Err(e) = process_market_event(&ctx, &event).await {
-                                warn!(error = %e, event_id = %event.event_id, "Failed to process market event");
-                            } else if matches!(event.kind, MarketEventKind::Trade { .. }) {
-                                // Event-driven: Trade updates position price → check exits immediately (<500ms)
-                                ctx.process_exit_signals().await;
+                            match process_market_event(&ctx, &event).await {
+                                Ok(need_exit) => {
+                                    if need_exit
+                                        || matches!(event.kind, MarketEventKind::Trade { .. })
+                                    {
+                                        ctx.process_exit_signals().await;
+                                    }
+                                }
+                                Err(e) => {
+                                    warn!(error = %e, event_id = %event.event_id, "Failed to process market event");
+                                }
                             }
                         }
                         Err(e) => {
@@ -7021,8 +7300,15 @@ async fn main() -> Result<()> {
                                         match serde_json::from_slice::<MarketEvent>(&msg.payload) {
                                             Ok(event) => {
                                                 if let MarketEventKind::WalletBalanceSnapshot { .. } = &event.kind {
-                                                    if let Err(e) = process_market_event(&ctx, &event).await {
-                                                        warn!(error = %e, "Failed to process WalletBalanceSnapshot from JetStream");
+                                                    match process_market_event(&ctx, &event).await {
+                                                        Ok(need_exit) => {
+                                                            if need_exit {
+                                                                ctx.process_exit_signals().await;
+                                                            }
+                                                        }
+                                                        Err(e) => {
+                                                            warn!(error = %e, "Failed to process WalletBalanceSnapshot from JetStream");
+                                                        }
                                                     }
                                                 }
                                             }
@@ -7082,6 +7368,7 @@ async fn main() -> Result<()> {
                                     Ok(msg) => {
                                         if let Ok(update) = serde_json::from_slice::<ironcrab::ipc::PoolCacheUpdate>(&msg.payload) {
                                             pool_cache_sync::apply_pool_cache_update(&ctx.live_pool_cache, &update);
+                                            ctx.merge_latest_pool_reserve_price_hint_from_update(&update);
                                             // FIX-30a: Update position price from pool reserves
                                             // tokens_per_sol = token_amount / sol_amount (higher = cheaper token)
                                             // Convention: base=token, quote=SOL. If base=SOL (inverted DEX convention),
@@ -7103,6 +7390,20 @@ async fn main() -> Result<()> {
                                                         .unwrap_or(6);
                                                     (update.base_mint.clone(), update.base_reserve, update.quote_reserve, decimals)
                                                 };
+                                                if let Ok(mint_pk) = solana_sdk::pubkey::Pubkey::from_str(&token_mint) {
+                                                    if ctx.live_pool_cache.is_pumpfun_complete_for_mint(&mint_pk)
+                                                        == Some(true)
+                                                        || ctx
+                                                            .live_pool_cache
+                                                            .pumpfun_bonding_curve_complete_for_mint(&mint_pk)
+                                                    {
+                                                        ctx.merge_pumpfun_migration_complete_evidence(
+                                                            &token_mint,
+                                                            update.geyser_slot,
+                                                            update.header.ts_unix_ms,
+                                                        );
+                                                    }
+                                                }
                                                 let token_ui = token_reserve as f64 / 10f64.powi(token_decimals as i32);
                                                 let sol_ui = sol_reserve as f64 / 1_000_000_000.0;
                                                 if sol_ui > 0.0 {
@@ -7640,7 +7941,7 @@ async fn generate_and_publish_buy_intent(
 #[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;
-    use ironcrab::ipc::{FillStatus, RecordHeader};
+    use ironcrab::ipc::{FillStatus, PoolCacheUpdate, PoolCacheUpdateType, RecordHeader};
     use tempfile::TempDir;
 
     fn empty_test_context(jsonl_writer: JsonlWriter) -> MomentumContext {
@@ -7658,6 +7959,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -7674,6 +7977,238 @@ mod tests {
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    const WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
+
+    fn pool_cache_update_stub(
+        mint: &str,
+        pool: &str,
+        token_reserve_raw: u64,
+        sol_lamports: u64,
+        geyser_slot: u64,
+        ts_unix_ms: u64,
+    ) -> PoolCacheUpdate {
+        let mut header = RecordHeader::new("test", BUILD_VERSION, "run");
+        header.ts_unix_ms = ts_unix_ms;
+        PoolCacheUpdate {
+            header,
+            update_type: PoolCacheUpdateType::BalanceUpdated,
+            pool_address: pool.to_string(),
+            dex: "raydium".to_string(),
+            base_mint: mint.to_string(),
+            quote_mint: WSOL_MINT.to_string(),
+            base_reserve: token_reserve_raw,
+            quote_reserve: sol_lamports,
+            liquidity_lamports: None,
+            geyser_slot,
+            metadata: None,
+        }
+    }
+
+    /// Scope B: older-slot `PoolCacheUpdate` must not replace a newer sticky reserve hint.
+    #[tokio::test]
+    async fn sticky_pool_reserve_hint_rejects_stale_slot_merge_by_apply() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = Arc::new(empty_test_context(jsonl_writer));
+        let mint = "MintStickyPool";
+        ctx.record_mint_info(
+            mint,
+            MintInfo {
+                token_program: String::new(),
+                decimals: 6,
+                supply: 0,
+                mint_authority: None,
+                freeze_authority: None,
+                last_updated: Instant::now(),
+            },
+        );
+        ctx.merge_latest_pool_reserve_price_hint_from_update(&pool_cache_update_stub(
+            mint,
+            "poolA",
+            2_000_000,
+            1_000_000_000,
+            300,
+            1,
+        ));
+        ctx.merge_latest_pool_reserve_price_hint_from_update(&pool_cache_update_stub(
+            mint,
+            "poolA",
+            99_000_000,
+            1_000_000_000,
+            100,
+            2,
+        ));
+        ctx.open_position(OpenPositionParams {
+            mint,
+            pool: "poolA",
+            dex: "raydium",
+            entry_price: 50.0,
+            token_decimals: 6,
+            token_amount: 1_000_000,
+            sol_invested: 1_000_000_000,
+            token_program: None,
+            creator: None,
+            entry_confirmed_slot: 200,
+            initial_bonding: None,
+        });
+        let pos = ctx.positions.read().get(mint).unwrap().clone();
+        assert!(
+            (pos.current_price - 2.0).abs() < 0.05,
+            "expected newer-slot sticky tps ~2.0, got {}",
+            pos.current_price
+        );
+        assert_eq!(pos.last_price_slot, 300);
+    }
+
+    /// Scope B: reserve hint merged before BUY open applies on `open_position` when slot ordering allows.
+    #[tokio::test]
+    async fn sticky_pool_reserve_hint_applies_on_open_after_confirm_slot() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = Arc::new(empty_test_context(jsonl_writer));
+        let mint = "MintOpenApply";
+        ctx.record_mint_info(
+            mint,
+            MintInfo {
+                token_program: String::new(),
+                decimals: 6,
+                supply: 0,
+                mint_authority: None,
+                freeze_authority: None,
+                last_updated: Instant::now(),
+            },
+        );
+        ctx.merge_latest_pool_reserve_price_hint_from_update(&pool_cache_update_stub(
+            mint,
+            "poolA",
+            1_000_000,
+            1_000_000_000,
+            600,
+            3,
+        ));
+        ctx.open_position(OpenPositionParams {
+            mint,
+            pool: "poolA",
+            dex: "raydium",
+            entry_price: 50.0,
+            token_decimals: 6,
+            token_amount: 1_000_000,
+            sol_invested: 1_000_000_000,
+            token_program: None,
+            creator: None,
+            entry_confirmed_slot: 500,
+            initial_bonding: None,
+        });
+        let pos = ctx.positions.read().get(mint).unwrap().clone();
+        assert!(
+            (pos.current_price - 1.0).abs() < 0.02,
+            "expected sticky pool mark near 1.0 tps, got {}",
+            pos.current_price
+        );
+        assert_eq!(pos.last_price_slot, 600);
+    }
+
+    /// Scope B: sticky hint for a different pool must not move the position mark (I-13).
+    #[tokio::test]
+    async fn sticky_pool_reserve_hint_wrong_pool_not_applied() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = Arc::new(empty_test_context(jsonl_writer));
+        let mint = "MintOtherPool";
+        ctx.record_mint_info(
+            mint,
+            MintInfo {
+                token_program: String::new(),
+                decimals: 6,
+                supply: 0,
+                mint_authority: None,
+                freeze_authority: None,
+                last_updated: Instant::now(),
+            },
+        );
+        ctx.merge_latest_pool_reserve_price_hint_from_update(&pool_cache_update_stub(
+            mint,
+            "poolB",
+            1_000_000,
+            1_000_000_000,
+            600,
+            1,
+        ));
+        ctx.open_position(OpenPositionParams {
+            mint,
+            pool: "poolA",
+            dex: "raydium",
+            entry_price: 44.0,
+            token_decimals: 6,
+            token_amount: 1_000_000,
+            sol_invested: 1_000_000_000,
+            token_program: None,
+            creator: None,
+            entry_confirmed_slot: 400,
+            initial_bonding: None,
+        });
+        let pos = ctx.positions.read().get(mint).unwrap().clone();
+        assert!(
+            (pos.current_price - 44.0).abs() < 0.001,
+            "wrong-pool hint must not move mark, got {}",
+            pos.current_price
+        );
+    }
+
+    /// Scope B: `TokenMintInfo` cached in `mint_infos` upgrades an open position via apply.
+    #[tokio::test]
+    async fn sticky_mint_info_token_program_applied_when_mint_info_arrives() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = Arc::new(empty_test_context(jsonl_writer));
+        let mint = "MintTP";
+        ctx.open_position(OpenPositionParams {
+            mint,
+            pool: "p1",
+            dex: "raydium",
+            entry_price: 1.0,
+            token_decimals: 6,
+            token_amount: 1,
+            sol_invested: 1,
+            token_program: None,
+            creator: None,
+            entry_confirmed_slot: 0,
+            initial_bonding: None,
+        });
+        ctx.record_mint_info(
+            mint,
+            MintInfo {
+                token_program: "TokenzQdBNbLqP7VEhdkAS6EPFLC1PHnBqCXEpPxuEb".to_string(),
+                decimals: 6,
+                supply: 1,
+                mint_authority: None,
+                freeze_authority: None,
+                last_updated: Instant::now(),
+            },
+        );
+        let mut pos = ctx.positions.read().get(mint).unwrap().clone();
+        ctx.apply_latest_sticky_state_to_position(mint, &mut pos);
+        assert_eq!(
+            pos.token_program.as_deref(),
+            Some("TokenzQdBNbLqP7VEhdkAS6EPFLC1PHnBqCXEpPxuEb")
+        );
+    }
+
+    #[test]
+    fn sticky_pumpfun_migration_complete_surfaces_in_evidence_probe() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = empty_test_context(jsonl_writer);
+        let mint = "NotAValidPubkeyString";
+        ctx.merge_pumpfun_migration_complete_evidence(mint, 10, 20);
+        assert!(ctx.live_cache_pumpfun_complete_evidence(mint));
     }
 
     /// Scope 1: Pre-entry/batched trades must not move `current_price`; slots must be monotonic.
@@ -7861,6 +8396,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -7919,6 +8456,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -8154,6 +8693,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -8411,6 +8952,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -8519,6 +9062,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -8595,6 +9140,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -8659,6 +9206,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -8738,6 +9287,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -8847,6 +9398,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -8950,6 +9503,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -9038,6 +9593,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -9104,6 +9661,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -9161,6 +9720,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -9382,6 +9943,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -9510,6 +10073,8 @@ mod tests {
             positions: parking_lot::RwLock::new(HashMap::new()),
             pending_intents: parking_lot::RwLock::new(HashMap::new()),
             latest_bonding_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pumpfun_migration_complete_by_mint: parking_lot::RwLock::new(HashMap::new()),
+            latest_pool_reserve_price_hint_by_mint_pool: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_entries: parking_lot::RwLock::new(HashMap::new()),
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
@@ -10249,8 +10814,9 @@ async fn generate_and_publish_exit_intent(
     Ok(())
 }
 
-/// Process a MarketEvent and update token trackers
-async fn process_market_event(ctx: &MomentumContext, event: &MarketEvent) -> Result<()> {
+/// Process a MarketEvent and update token trackers.
+/// Returns `Ok(true)` when the caller should run `process_exit_signals()` (bonding/price-relevant sticky apply).
+async fn process_market_event(ctx: &Arc<MomentumContext>, event: &MarketEvent) -> Result<bool> {
     // K Phase 1: Slot-to-Send Latency - store for intent metadata propagation
     if let Some(slot) = event.slot {
         ctx.last_event_slot
@@ -10647,6 +11213,15 @@ async fn process_market_event(ctx: &MomentumContext, event: &MarketEvent) -> Res
                     last_updated: Instant::now(),
                 },
             );
+            let exit_maybe = {
+                let mut positions = ctx.positions.write();
+                if let Some(pos) = positions.get_mut(mint) {
+                    ctx.apply_latest_sticky_state_to_position(mint, pos)
+                } else {
+                    false
+                }
+            };
+            return Ok(exit_maybe);
         }
 
         MarketEventKind::SlotUpdate { current_slot } => {
@@ -10669,7 +11244,7 @@ async fn process_market_event(ctx: &MomentumContext, event: &MarketEvent) -> Res
                 || mint == "11111111111111111111111111111111"
             {
                 debug!(mint = %mint, balance_raw = *balance_raw, "Ignoring SOL/WSOL WalletBalanceSnapshot (not a tradeable position)");
-                return Ok(());
+                return Ok(false);
             }
 
             if *balance_raw == 0 {
@@ -10701,9 +11276,10 @@ async fn process_market_event(ctx: &MomentumContext, event: &MarketEvent) -> Res
                         balance_raw = *balance_raw,
                         "✅ WalletBalanceSnapshot: position verified in wallet"
                     );
-                } else if let Some(reconciled) =
+                } else if let Some(mut reconciled) =
                     ctx.build_reconciled_position(mint, *balance_raw, *decimals)
                 {
+                    ctx.apply_latest_sticky_state_to_position(mint, &mut reconciled);
                     let hold_secs = reconciled.entry_time.elapsed().as_secs();
                     {
                         let mut positions = ctx.positions.write();
@@ -10718,6 +11294,7 @@ async fn process_market_event(ctx: &MomentumContext, event: &MarketEvent) -> Res
                         "🧭 Wallet snapshot reconciled into position (timed exit will apply)"
                     );
                     ctx.save_position_to_kv(mint, &reconciled).await;
+                    return Ok(true);
                 } else {
                     // Wallet has tokens but no pool known yet. Store as orphaned so
                     // we can reconcile later when PoolCreated/DexPoolAccounts arrives.
@@ -10835,6 +11412,9 @@ async fn process_market_event(ctx: &MomentumContext, event: &MarketEvent) -> Res
                 slot,
                 ts_unix_ms,
             );
+            if *complete {
+                ctx.merge_pumpfun_migration_complete_evidence(mint.as_str(), slot, ts_unix_ms);
+            }
 
             // FIX-20: Mark PumpFun pools as migrated when bonding curve completes.
             // This prevents find_best_sell_pool() from selecting a completed PumpFun
@@ -10861,5 +11441,5 @@ async fn process_market_event(ctx: &MomentumContext, event: &MarketEvent) -> Res
         }
     }
 
-    Ok(())
+    Ok(false)
 }

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -2615,8 +2615,6 @@ impl MomentumContext {
         if let Some((balance_raw, decimals)) = orphan_data {
             if let Some(reconciled) = self.build_reconciled_position(mint, balance_raw, decimals) {
                 let hold_secs = reconciled.entry_time.elapsed().as_secs();
-                let mut reconciled = reconciled;
-                self.apply_latest_sticky_state_to_position(mint, &mut reconciled);
                 self.positions
                     .write()
                     .insert(mint.to_string(), reconciled.clone());
@@ -2689,8 +2687,6 @@ impl MomentumContext {
                 if let Some(reconciled) =
                     self.build_reconciled_position(mint, balance_raw, decimals)
                 {
-                    let mut reconciled = reconciled;
-                    self.apply_latest_sticky_state_to_position(mint, &mut reconciled);
                     self.positions
                         .write()
                         .insert(mint.to_string(), reconciled.clone());
@@ -4441,19 +4437,19 @@ impl MomentumContext {
         self.merge_pumpfun_migration_complete_evidence(mint, slot, ts);
     }
 
-    /// Scope B: merge a `PoolCacheUpdate` into the sticky reserve mark map (same monotonic rules as bonding).
-    pub(crate) fn merge_latest_pool_reserve_price_hint_from_update(
+    /// Shared reserve → `tokens_per_sol` pipeline for sticky hints and live position marks (single validation).
+    fn derive_tokens_per_sol_from_pool_cache_update(
         &self,
         update: &ironcrab::ipc::PoolCacheUpdate,
-    ) {
+    ) -> Option<(String, f64, u8, f64, f64)> {
         if update.base_reserve == 0 || update.quote_reserve == 0 {
-            return;
+            return None;
         }
         if !pool_cache_has_exactly_one_wsol_leg(&update.base_mint, &update.quote_mint) {
-            return;
+            return None;
         }
         const SOL_WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
-        let (token_mint, token_reserve, sol_reserve, decimals) =
+        let (token_mint, token_reserve, sol_reserve, token_decimals) =
             if update.base_mint == SOL_WSOL_MINT {
                 let decimals = self
                     .mint_infos
@@ -4481,16 +4477,25 @@ impl MomentumContext {
                     decimals,
                 )
             };
-        let token_ui = token_reserve as f64 / 10f64.powi(decimals as i32);
+        let token_ui = token_reserve as f64 / 10f64.powi(token_decimals as i32);
         let sol_ui = sol_reserve as f64 / 1_000_000_000.0;
         if sol_ui <= 0.0 || !sol_ui.is_finite() || token_ui <= 0.0 || !token_ui.is_finite() {
-            return;
+            return None;
         }
         let tokens_per_sol = token_ui / sol_ui;
         if !tokens_per_sol.is_finite() || tokens_per_sol <= 0.0 {
-            return;
+            return None;
         }
-        let key = (token_mint, update.pool_address.clone());
+        Some((token_mint, tokens_per_sol, token_decimals, token_ui, sol_ui))
+    }
+
+    fn merge_latest_pool_reserve_price_hint_from_derived(
+        &self,
+        update: &ironcrab::ipc::PoolCacheUpdate,
+        token_mint: &str,
+        tokens_per_sol: f64,
+    ) {
+        let key = (token_mint.to_string(), update.pool_address.clone());
         let mut map = self.latest_pool_reserve_price_hint_by_mint_pool.write();
         let accept = match map.get(&key) {
             None => true,
@@ -4513,6 +4518,20 @@ impl MomentumContext {
                 },
             );
         }
+    }
+
+    /// Scope B: merge a `PoolCacheUpdate` into the sticky reserve mark map (same monotonic rules as bonding).
+    #[cfg(test)]
+    pub(crate) fn merge_latest_pool_reserve_price_hint_from_update(
+        &self,
+        update: &ironcrab::ipc::PoolCacheUpdate,
+    ) {
+        let Some((ref token_mint, tokens_per_sol, _, _, _)) =
+            self.derive_tokens_per_sol_from_pool_cache_update(update)
+        else {
+            return;
+        };
+        self.merge_latest_pool_reserve_price_hint_from_derived(update, token_mint, tokens_per_sol);
     }
 
     /// Scope B: apply `mint_infos`, cached bonding max-guard, and pool reserve hints to one position.
@@ -7394,34 +7413,15 @@ async fn main() -> Result<()> {
                                     Ok(msg) => {
                                         if let Ok(update) = serde_json::from_slice::<ironcrab::ipc::PoolCacheUpdate>(&msg.payload) {
                                             pool_cache_sync::apply_pool_cache_update(&ctx.live_pool_cache, &update);
-                                            ctx.merge_latest_pool_reserve_price_hint_from_update(&update);
-                                            // FIX-30a: Update position price from pool reserves
-                                            // tokens_per_sol = token_amount / sol_amount (higher = cheaper token)
-                                            // Convention: base=token, quote=SOL. If base=SOL (inverted DEX convention),
-                                            // swap so we always compute token/sol for the position's token.
-                                            if update.base_reserve > 0
-                                                && update.quote_reserve > 0
-                                                && pool_cache_has_exactly_one_wsol_leg(
-                                                    &update.base_mint,
-                                                    &update.quote_mint,
-                                                )
+                                            // FIX-30a: Single derive for sticky hint + live mark (same validation).
+                                            if let Some((token_mint, tokens_per_sol, _, token_ui, sol_ui)) =
+                                                ctx.derive_tokens_per_sol_from_pool_cache_update(&update)
                                             {
-                                                const SOL_WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
-                                                let (token_mint, token_reserve, sol_reserve, token_decimals) = if update.base_mint == SOL_WSOL_MINT {
-                                                    // Base is SOL → quote is token. tokens_per_sol = quote/base.
-                                                    let decimals = ctx.mint_infos.read()
-                                                        .get(&update.quote_mint)
-                                                        .map(|m| m.decimals)
-                                                        .unwrap_or(6);
-                                                    (update.quote_mint.clone(), update.quote_reserve, update.base_reserve, decimals)
-                                                } else {
-                                                    // Normal: base is token, quote is SOL.
-                                                    let decimals = ctx.mint_infos.read()
-                                                        .get(&update.base_mint)
-                                                        .map(|m| m.decimals)
-                                                        .unwrap_or(6);
-                                                    (update.base_mint.clone(), update.base_reserve, update.quote_reserve, decimals)
-                                                };
+                                                ctx.merge_latest_pool_reserve_price_hint_from_derived(
+                                                    &update,
+                                                    &token_mint,
+                                                    tokens_per_sol,
+                                                );
                                                 if let Ok(mint_pk) = solana_sdk::pubkey::Pubkey::from_str(&token_mint) {
                                                     if ctx.live_pool_cache.is_pumpfun_complete_for_mint(&mint_pk)
                                                         == Some(true)
@@ -7436,36 +7436,31 @@ async fn main() -> Result<()> {
                                                         );
                                                     }
                                                 }
-                                                let token_ui = token_reserve as f64 / 10f64.powi(token_decimals as i32);
-                                                let sol_ui = sol_reserve as f64 / 1_000_000_000.0;
-                                                if sol_ui > 0.0 {
-                                                    let tokens_per_sol = token_ui / sol_ui;
-                                                    // #region agent log
-                                                    dbg_log(
-                                                        "momentum_bot.rs:PoolCache_price_update",
-                                                        "PoolCacheUpdate updating position price",
-                                                        serde_json::json!({
-                                                            "mint": token_mint,
-                                                            "pool": update.pool_address,
-                                                            "dex": update.dex,
-                                                            "base_reserve": update.base_reserve,
-                                                            "quote_reserve": update.quote_reserve,
-                                                            "base_mint": update.base_mint,
-                                                            "token_ui": token_ui,
-                                                            "sol_ui": sol_ui,
-                                                            "tokens_per_sol": tokens_per_sol
-                                                        }),
-                                                        "H-E",
-                                                    );
-                                                    // #endregion
-                                                    ctx.update_position_price(
-                                                        &token_mint,
-                                                        tokens_per_sol,
-                                                        None,
-                                                        Some(&update.pool_address),
-                                                        Some(update.geyser_slot),
-                                                    );
-                                                }
+                                                // #region agent log
+                                                dbg_log(
+                                                    "momentum_bot.rs:PoolCache_price_update",
+                                                    "PoolCacheUpdate updating position price",
+                                                    serde_json::json!({
+                                                        "mint": token_mint,
+                                                        "pool": update.pool_address,
+                                                        "dex": update.dex,
+                                                        "base_reserve": update.base_reserve,
+                                                        "quote_reserve": update.quote_reserve,
+                                                        "base_mint": update.base_mint,
+                                                        "token_ui": token_ui,
+                                                        "sol_ui": sol_ui,
+                                                        "tokens_per_sol": tokens_per_sol
+                                                    }),
+                                                    "H-E",
+                                                );
+                                                // #endregion
+                                                ctx.update_position_price(
+                                                    &token_mint,
+                                                    tokens_per_sol,
+                                                    None,
+                                                    Some(&update.pool_address),
+                                                    Some(update.geyser_slot),
+                                                );
                                             }
                                             msg_count += 1;
                                         }
@@ -11496,10 +11491,9 @@ async fn process_market_event(ctx: &Arc<MomentumContext>, event: &MarketEvent) -
                         balance_raw = *balance_raw,
                         "✅ WalletBalanceSnapshot: position verified in wallet"
                     );
-                } else if let Some(mut reconciled) =
+                } else if let Some(reconciled) =
                     ctx.build_reconciled_position(mint, *balance_raw, *decimals)
                 {
-                    ctx.apply_latest_sticky_state_to_position(mint, &mut reconciled);
                     let hold_secs = reconciled.entry_time.elapsed().as_secs();
                     {
                         let mut positions = ctx.positions.write();

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -4338,6 +4338,7 @@ impl MomentumContext {
             );
             if self.positions.read().get(&e.mint).is_none() {
                 self.latest_bonding_by_mint.write().remove(&e.mint);
+                self.clear_scope_b_sticky_state_for_mint(&e.mint);
             }
         }
     }

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -2185,6 +2185,15 @@ fn bonding_geyser_observation_is_newer(
     }
 }
 
+/// `PoolCacheUpdate` reserve marks require exactly one WSOL leg so reserves map to token vs SOL (I-14).
+#[inline]
+fn pool_cache_has_exactly_one_wsol_leg(base_mint: &str, quote_mint: &str) -> bool {
+    const WSOL: &str = "So11111111111111111111111111111111111111112";
+    let base = base_mint == WSOL;
+    let quote = quote_mint == WSOL;
+    base ^ quote
+}
+
 struct OpenPositionParams<'a> {
     mint: &'a str,
     pool: &'a str,
@@ -3695,11 +3704,11 @@ impl MomentumContext {
 
         // Drop bonding cache for this mint when the position is gone, unless a BUY is already
         // pending again (re-entry lifecycle must keep latest_bonding for confirm/open).
+        // Same for Scope B sticky maps (migration + pool reserve hints).
         if !self.pending_buy_mint_index.read().contains_key(mint) {
             self.latest_bonding_by_mint.write().remove(mint);
+            self.clear_scope_b_sticky_state_for_mint(mint);
         }
-
-        self.clear_scope_b_sticky_state_for_mint(mint);
 
         // Delete from KV asynchronously (fire-and-forget)
         let ctx = Arc::clone(self);
@@ -4368,6 +4377,20 @@ impl MomentumContext {
             .retain(|key, _| key.0 != mint);
     }
 
+    #[cfg(test)]
+    pub(crate) fn test_has_pool_reserve_hint(&self, mint: &str, pool: &str) -> bool {
+        self.latest_pool_reserve_price_hint_by_mint_pool
+            .read()
+            .contains_key(&(mint.to_string(), pool.to_string()))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_has_migration_sticky(&self, mint: &str) -> bool {
+        self.latest_pumpfun_migration_complete_by_mint
+            .read()
+            .contains_key(mint)
+    }
+
     /// Scope B: record PumpFun bonding-curve `complete` (migration) with slot-/ts-monotonic merge.
     pub(crate) fn merge_pumpfun_migration_complete_evidence(
         &self,
@@ -4424,6 +4447,9 @@ impl MomentumContext {
         update: &ironcrab::ipc::PoolCacheUpdate,
     ) {
         if update.base_reserve == 0 || update.quote_reserve == 0 {
+            return;
+        }
+        if !pool_cache_has_exactly_one_wsol_leg(&update.base_mint, &update.quote_mint) {
             return;
         }
         const SOL_WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
@@ -7373,7 +7399,13 @@ async fn main() -> Result<()> {
                                             // tokens_per_sol = token_amount / sol_amount (higher = cheaper token)
                                             // Convention: base=token, quote=SOL. If base=SOL (inverted DEX convention),
                                             // swap so we always compute token/sol for the position's token.
-                                            if update.base_reserve > 0 && update.quote_reserve > 0 {
+                                            if update.base_reserve > 0
+                                                && update.quote_reserve > 0
+                                                && pool_cache_has_exactly_one_wsol_leg(
+                                                    &update.base_mint,
+                                                    &update.quote_mint,
+                                                )
+                                            {
                                                 const SOL_WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
                                                 let (token_mint, token_reserve, sol_reserve, token_decimals) = if update.base_mint == SOL_WSOL_MINT {
                                                     // Base is SOL → quote is token. tokens_per_sol = quote/base.
@@ -8004,6 +8036,105 @@ mod tests {
             geyser_slot,
             metadata: None,
         }
+    }
+
+    fn pool_cache_update_two_tokens_no_wsol(
+        base_mint: &str,
+        quote_mint: &str,
+        pool: &str,
+        base_reserve: u64,
+        quote_reserve: u64,
+        geyser_slot: u64,
+        ts_unix_ms: u64,
+    ) -> PoolCacheUpdate {
+        let mut header = RecordHeader::new("test", BUILD_VERSION, "run");
+        header.ts_unix_ms = ts_unix_ms;
+        PoolCacheUpdate {
+            header,
+            update_type: PoolCacheUpdateType::BalanceUpdated,
+            pool_address: pool.to_string(),
+            dex: "raydium".to_string(),
+            base_mint: base_mint.to_string(),
+            quote_mint: quote_mint.to_string(),
+            base_reserve,
+            quote_reserve,
+            liquidity_lamports: None,
+            geyser_slot,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn sticky_pool_reserve_hint_non_wsol_pair_not_cached() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = empty_test_context(jsonl_writer);
+        ctx.merge_latest_pool_reserve_price_hint_from_update(
+            &pool_cache_update_two_tokens_no_wsol(
+                "MintTokenLegA",
+                "MintTokenLegB",
+                "poolNonSol",
+                1_000_000_000,
+                1_000_000_000,
+                500,
+                1,
+            ),
+        );
+        assert!(!ctx.test_has_pool_reserve_hint("MintTokenLegA", "poolNonSol"));
+        assert!(!ctx.test_has_pool_reserve_hint("MintTokenLegB", "poolNonSol"));
+    }
+
+    /// Non-SOL/WSOL pair must not later move an opened position mark (I-14 / wrong quote leg).
+    #[tokio::test]
+    async fn sticky_pool_reserve_hint_non_wsol_pair_does_not_move_later_position_mark() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = Arc::new(empty_test_context(jsonl_writer));
+        let mint = "MintLaterPos";
+        ctx.record_mint_info(
+            mint,
+            MintInfo {
+                token_program: String::new(),
+                decimals: 6,
+                supply: 0,
+                mint_authority: None,
+                freeze_authority: None,
+                last_updated: Instant::now(),
+            },
+        );
+        ctx.merge_latest_pool_reserve_price_hint_from_update(
+            &pool_cache_update_two_tokens_no_wsol(
+                mint,
+                "OtherMintNoWsol",
+                "poolNonSol",
+                1,
+                1,
+                900,
+                1,
+            ),
+        );
+        assert!(!ctx.test_has_pool_reserve_hint(mint, "poolNonSol"));
+        ctx.open_position(OpenPositionParams {
+            mint,
+            pool: "poolNonSol",
+            dex: "raydium",
+            entry_price: 77.0,
+            token_decimals: 6,
+            token_amount: 1,
+            sol_invested: 1,
+            token_program: None,
+            creator: None,
+            entry_confirmed_slot: 800,
+            initial_bonding: None,
+        });
+        let pos = ctx.positions.read().get(mint).unwrap().clone();
+        assert!(
+            (pos.current_price - 77.0).abs() < 0.001,
+            "non-WSOL PoolCache pair must not seed sticky hint; mark stayed entry, got {}",
+            pos.current_price
+        );
     }
 
     /// Scope B: older-slot `PoolCacheUpdate` must not replace a newer sticky reserve hint.
@@ -10360,8 +10491,33 @@ mod tests {
         });
         ctx.remove_pending_buy_entry_by_intent("int-clr");
 
+        ctx.record_mint_info(
+            mint,
+            MintInfo {
+                token_program: String::new(),
+                decimals: 6,
+                supply: 0,
+                mint_authority: None,
+                freeze_authority: None,
+                last_updated: Instant::now(),
+            },
+        );
+        ctx.merge_pumpfun_migration_complete_evidence(mint, 400, 10);
+        ctx.merge_latest_pool_reserve_price_hint_from_update(&pool_cache_update_stub(
+            mint,
+            "poolClr",
+            1_000_000,
+            1_000_000_000,
+            410,
+            10,
+        ));
+        assert!(ctx.test_has_migration_sticky(mint));
+        assert!(ctx.test_has_pool_reserve_hint(mint, "poolClr"));
+
         Arc::clone(&ctx).close_position(mint);
         assert!(ctx.clone_latest_bonding_snapshot(mint).is_none());
+        assert!(!ctx.test_has_migration_sticky(mint));
+        assert!(!ctx.test_has_pool_reserve_hint(mint, "poolClr"));
     }
 
     #[tokio::test]
@@ -10407,6 +10563,70 @@ mod tests {
             .expect("bonding kept for pending BUY");
         assert_eq!(snap.progress_bps, 9_000);
         assert!(ctx.test_pending_buy_entry_present("int-reentry", mint));
+    }
+
+    #[tokio::test]
+    async fn close_position_keeps_scope_b_sticky_when_pending_buy_exists() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = Arc::new(empty_test_context(jsonl_writer));
+        let mint = "mintScopeBKeep";
+
+        ctx.register_pending_buy_entry_after_publish(PendingBuyPublishMeta {
+            intent_id: "int-scopeb-pend",
+            mint,
+            pool: "poolKeepB",
+            dex: "pumpfun",
+            intended_sol: 1_000_000,
+            entry_kind: Some(EntryKind::Probe),
+            signal_slot: 1,
+            slot_seen_at_ms: 1,
+            creator: None,
+            token_program: None,
+        });
+        ctx.record_mint_info(
+            mint,
+            MintInfo {
+                token_program: String::new(),
+                decimals: 6,
+                supply: 0,
+                mint_authority: None,
+                freeze_authority: None,
+                last_updated: Instant::now(),
+            },
+        );
+        ctx.merge_pumpfun_migration_complete_evidence(mint, 111, 5);
+        ctx.merge_latest_pool_reserve_price_hint_from_update(&pool_cache_update_stub(
+            mint,
+            "poolKeepB",
+            1_000_000,
+            1_000_000_000,
+            220,
+            6,
+        ));
+        assert!(ctx.test_has_migration_sticky(mint));
+        assert!(ctx.test_has_pool_reserve_hint(mint, "poolKeepB"));
+
+        let initial = ctx.clone_latest_bonding_snapshot(mint);
+        ctx.open_position(OpenPositionParams {
+            mint,
+            pool: "poolKeepB",
+            dex: "pumpfun",
+            entry_price: 1.0,
+            token_decimals: 6,
+            token_amount: 1,
+            sol_invested: 1,
+            token_program: None,
+            creator: None,
+            entry_confirmed_slot: 50,
+            initial_bonding: initial,
+        });
+
+        Arc::clone(&ctx).close_position(mint);
+        assert!(ctx.test_has_migration_sticky(mint));
+        assert!(ctx.test_has_pool_reserve_hint(mint, "poolKeepB"));
+        assert!(ctx.test_pending_buy_entry_present("int-scopeb-pend", mint));
     }
 }
 

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -4247,9 +4247,6 @@ impl MomentumContext {
 
         if !cache_relevant {
             self.latest_bonding_by_mint.write().remove(mint);
-            if complete {
-                self.merge_pumpfun_migration_complete_evidence(mint, slot, ts_unix_ms);
-            }
             return;
         }
 
@@ -4274,9 +4271,6 @@ impl MomentumContext {
                         ts_unix_ms,
                     },
                 );
-                if complete {
-                    self.merge_pumpfun_migration_complete_evidence(mint, slot, ts_unix_ms);
-                }
             }
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Scope B** from the momentum event lifecycle plan: sticky, slot-/timestamp-monotonic caches for Geyser/JetStream-derived state **beyond** existing Scope A `latest_bonding_by_mint`, without duplicating bonding logic or changing Scope D quote-gated exits.

### Follow-up (supervisor review)

- **WSOL-only guard**: Sticky pool reserve hints and the JetStream `PoolCacheUpdate` → `update_position_price` path only run when **exactly one** of `base_mint` / `quote_mint` is WSOL (avoids bogus `tokens_per_sol` from token/token pairs; I-14).
- **close_position**: Scope B sticky maps are cleared **only when there is no pending BUY** for the mint (same guard as `latest_bonding_by_mint`).

### Tests

Includes unit tests for stale merge, apply-on-open, wrong pool (I-13), TokenMintInfo, migration probe, **non-WSOL pair ignored**, **close + pending retains sticky**, **close without pending clears sticky**.

### Verification (local)

`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (workspace).

Eval Level 5: run in CI or with sibling `ironcrab-eval` checkout per project workflow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4ca344b-625e-4bd4-bbe3-00df3ba33c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4ca344b-625e-4bd4-bbe3-00df3ba33c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

