### PR TITLE
feat(nats): Momentum-filtered market_events subject

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -55,7 +55,7 @@ use ironcrab::nats::{
     pool_subject, wallet_snapshot_consumer_config, wallet_snapshot_subject, NatsClient, NatsConfig,
     CONFIG_STREAM_NAME, EXECUTION_RESULTS_STREAM_NAME, TOPIC_CONTROL_REQUESTS,
     TOPIC_CONTROL_RESPONSES, TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS,
-    TOPIC_PRIORITY_FEE_SAMPLES, WALLET_SNAPSHOT_STREAM_NAME,
+    TOPIC_MOMENTUM_MARKET_EVENTS, TOPIC_PRIORITY_FEE_SAMPLES, WALLET_SNAPSHOT_STREAM_NAME,
 };
 use ironcrab::solana::dex::meteora_bin_array_layout::BinArray;
 use ironcrab::solana::dex::meteora_dlmm::METEORA_DLMM_PROGRAM;
@@ -109,6 +109,91 @@ const PUMPFUN_PROGRAM: &str = "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P";
 const PUMPFUN_AMM_PROGRAM: &str = "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA";
 const METEORA_DLMM: &str = "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo";
 const METEORA_CPMM: &str = "cpmmpPFsKiR4eeYnGSuXgkhLLgGL1j5FUZoJBJU9t9D";
+
+/// Wrapped SOL mint (same as default quote in many events).
+const WRAPPED_SOL_MINT: &str = "So11111111111111111111111111111111111111112";
+
+/// Subset of [`MarketEventKind`] mirrored to [`TOPIC_MOMENTUM_MARKET_EVENTS`] in addition to core.
+///
+/// Conservative: noise kinds stay core-only. `WalletSnapshotComplete` is included because
+/// momentum-bot reconciles ghost positions from it (JetStream does not replace this signal).
+pub(crate) fn market_event_is_momentum_nats_relevant(kind: &MarketEventKind) -> bool {
+    match kind {
+        MarketEventKind::Trade { .. }
+        | MarketEventKind::PoolCreated { .. }
+        | MarketEventKind::BondingCurveProgress { .. }
+        | MarketEventKind::TokenMintInfo { .. }
+        | MarketEventKind::DexPoolAccounts { .. }
+        | MarketEventKind::DevWalletIdentified { .. }
+        | MarketEventKind::LiquidityRemoved { .. }
+        | MarketEventKind::WalletSnapshotComplete { .. } => true,
+
+        MarketEventKind::PoolStateUpdate {
+            dex, quote_mint, ..
+        } => {
+            let dex_lc = dex.to_ascii_lowercase();
+            let pump_line = matches!(
+                dex_lc.as_str(),
+                "pumpfun" | "pump_amm" | "pumpfunamm" | "pumpfun_amm"
+            );
+            if !pump_line {
+                return false;
+            }
+            let q = quote_mint.as_str();
+            q == NATIVE_SOL_MINT || q == WRAPPED_SOL_MINT
+        }
+
+        MarketEventKind::LatestBlockhash { .. }
+        | MarketEventKind::BinArrayUpdate { .. }
+        | MarketEventKind::SlotUpdate { .. }
+        | MarketEventKind::WalletBalanceSnapshot { .. }
+        | MarketEventKind::PriceUpdate { .. }
+        | MarketEventKind::SwapObserved { .. }
+        | MarketEventKind::AccountUpdate { .. }
+        | MarketEventKind::TransactionDetected { .. }
+        | MarketEventKind::WalletActivity { .. }
+        | MarketEventKind::EarlyBuyerDetected { .. }
+        | MarketEventKind::InsiderAlert { .. } => false,
+    }
+}
+
+/// Publish one logical market event to core NATS and, when [`market_event_is_momentum_nats_relevant`], to momentum subject.
+///
+/// Counts one [`MARKET_EVENTS_PUBLISHED_TOTAL`] per successful core delivery; [`NATS_MESSAGES_PUBLISHED_TOTAL`]
+/// once per successful NATS publish (core plus optional second message).
+pub(crate) async fn publish_market_event_core_and_momentum(
+    nats: &NatsClient,
+    event: &MarketEvent,
+) -> bool {
+    if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, event).await {
+        warn!(
+            error = %e,
+            event_id = %event.event_id,
+            "Failed to publish market event to NATS (core)"
+        );
+        NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
+        return false;
+    }
+
+    NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+    MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+
+    if market_event_is_momentum_nats_relevant(&event.kind) {
+        if let Err(e) = nats.publish(TOPIC_MOMENTUM_MARKET_EVENTS, event).await {
+            warn!(
+                error = %e,
+                event_id = %event.event_id,
+                topic = TOPIC_MOMENTUM_MARKET_EVENTS,
+                "Failed to publish market event to NATS (momentum fan-out)"
+            );
+            NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
+        } else {
+            NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    true
+}
 
 /// Raydium CPMM: `PoolCacheUpdate` uses normalized base/quote (non-SOL first). JetStream vault
 /// metadata must list vault pubkeys in the same order as `base_mint` / `quote_mint` so SLAVE
@@ -4637,9 +4722,7 @@ async fn publish_wallet_snapshot(
     );
 
     if let Some(ref nats) = ctx.nats {
-        if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &complete_event).await {
-            warn!(error = %e, "Failed to publish WalletSnapshotComplete (bootstrap)");
-        }
+        let _ = publish_market_event_core_and_momentum(nats, &complete_event).await;
     }
     if let Err(e) = ctx.jsonl_writer.write(&complete_event) {
         warn!(error = %e, "Failed to write WalletSnapshotComplete (bootstrap) to JSONL");
@@ -6396,13 +6479,7 @@ async fn run_geyser_loop(
 
                 // Publish to NATS
                 if let Some(ref nats) = ctx.nats {
-                    if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &mint_event).await {
-                        warn!(error = %e, "Failed to publish TokenMintInfo event to NATS");
-                        NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                    } else {
-                        NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                        MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                    }
+                    let _ = publish_market_event_core_and_momentum(nats, &mint_event).await;
                 }
             }
 
@@ -6933,13 +7010,7 @@ async fn run_geyser_loop(
                         }
 
                         if let Some(ref nats) = ctx.nats {
-                            if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &mint_event).await {
-                                warn!(error = %e, "Failed to publish TokenMintInfo event to NATS");
-                                NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                            } else {
-                                NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                            }
+                            let _ = publish_market_event_core_and_momentum(nats, &mint_event).await;
                         }
                     }
                 }
@@ -7135,13 +7206,8 @@ async fn run_geyser_loop(
                                     }
 
                                     if let Some(ref nats) = ctx.nats {
-                                        if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &state_event).await {
-                                            warn!(error = %e, "Failed to publish PoolStateUpdate event to NATS");
-                                            NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                        } else {
-                                            NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                            MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                        }
+                                        let _ =
+                                            publish_market_event_core_and_momentum(nats, &state_event).await;
                                     }
                                 }
                             }
@@ -7192,13 +7258,8 @@ async fn run_geyser_loop(
                                     }
 
                                     if let Some(ref nats) = ctx.nats {
-                                        if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &bin_event).await {
-                                            warn!(error = %e, "Failed to publish BinArrayUpdate event to NATS");
-                                            NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                        } else {
-                                            NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                            MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                        }
+                                        let _ =
+                                            publish_market_event_core_and_momentum(nats, &bin_event).await;
                                     }
                                 }
                             }
@@ -7774,12 +7835,7 @@ async fn run_geyser_loop(
                                         error!(error = %e, "Failed to write BondingCurveProgress event to JSONL");
                                     }
 
-                                    if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &curve_event).await {
-                                        warn!(error = %e, "Failed to publish BondingCurveProgress to NATS");
-                                    } else {
-                                        NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                        MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                    }
+                                    let _ = publish_market_event_core_and_momentum(nats, &curve_event).await;
                                 }
                             }
                             CachedPoolState::PumpAmm(s) => {
@@ -8029,13 +8085,7 @@ async fn run_geyser_loop(
                             }
 
                             if let Some(ref nats) = ctx.nats {
-                                if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &dev_event).await {
-                                    warn!(error = %e, "Failed to publish DevWalletIdentified to NATS");
-                                    NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                } else {
-                                    NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                    MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                }
+                                let _ = publish_market_event_core_and_momentum(nats, &dev_event).await;
                             }
                         }
                     }
@@ -8159,13 +8209,7 @@ async fn run_geyser_loop(
 
                 // Publish to NATS
                 if let Some(ref nats) = ctx.nats {
-                    if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &event).await {
-                        warn!(error = %e, "Failed to publish account event to NATS");
-                        NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                    } else {
-                        NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                        MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                    }
+                    let _ = publish_market_event_core_and_momentum(nats, &event).await;
                 }
             }
 
@@ -8364,13 +8408,7 @@ async fn run_geyser_loop(
                     }
 
                     if let Some(ref nats) = ctx.nats {
-                        if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &dev_event).await {
-                            warn!(error = %e, "Failed to publish dev wallet event to NATS");
-                            NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                        } else {
-                            NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                            MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                        }
+                        let _ = publish_market_event_core_and_momentum(nats, &dev_event).await;
                     }
                 }
 
@@ -8459,13 +8497,8 @@ async fn run_geyser_loop(
                             error!(error = %e, "Failed to write pump_amm PoolCreated (create_pool) to JSONL");
                         }
                         if let Some(ref nats) = ctx.nats {
-                            if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &pool_created_event).await {
-                                warn!(error = %e, "Failed to publish pump_amm PoolCreated (create_pool) to NATS");
-                                NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                            } else {
-                                NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                            }
+                            let _ =
+                                publish_market_event_core_and_momentum(nats, &pool_created_event).await;
                         }
                         ctx.pool_mint_map.write().insert(pool_address.to_string(), base_mint.clone());
                     }
@@ -8550,13 +8583,8 @@ async fn run_geyser_loop(
                         }
 
                         if let Some(ref nats) = ctx.nats {
-                            if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &pool_created_event).await {
-                                warn!(error = %e, "Failed to publish pump_amm PoolCreated event to NATS");
-                                NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                            } else {
-                                NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                            }
+                            let _ =
+                                publish_market_event_core_and_momentum(nats, &pool_created_event).await;
                         }
                     }
 
@@ -8582,13 +8610,7 @@ async fn run_geyser_loop(
                     }
 
                     if let Some(ref nats) = ctx.nats {
-                        if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &accounts_event).await {
-                            warn!(error = %e, "Failed to publish DexPoolAccounts event to NATS");
-                            NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                        } else {
-                            NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                            MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                        }
+                        let _ = publish_market_event_core_and_momentum(nats, &accounts_event).await;
                     }
 
                     // FIX-26: Also populate MASTER LivePoolCache with pool_accounts.
@@ -8708,13 +8730,7 @@ async fn run_geyser_loop(
                             }
 
                             if let Some(ref nats) = ctx.nats {
-                                if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &accounts_event).await
-                                {
-                                    warn!(error = %e, "Failed to publish DexPoolAccounts event to NATS");
-                                    NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                } else {
-                                    NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                    MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                                if publish_market_event_core_and_momentum(nats, &accounts_event).await {
                                     debug!(
                                         dex = %dex,
                                         pool = %pool_address,
@@ -8801,13 +8817,7 @@ async fn run_geyser_loop(
 
                 // Publish to NATS
                 if let Some(ref nats) = ctx.nats {
-                    if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &event).await {
-                        warn!(error = %e, "Failed to publish tx event to NATS");
-                        NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                    } else {
-                        NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                        MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                    }
+                    let _ = publish_market_event_core_and_momentum(nats, &event).await;
                 }
             }
 
@@ -8884,13 +8894,7 @@ async fn run_geyser_loop(
 
                 // Publish to NATS
                 if let Some(ref nats) = ctx.nats {
-                    if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &event).await {
-                        warn!(error = %e, "Failed to publish pool discovery event to NATS");
-                        NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                    } else {
-                        NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                        MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                    }
+                    let _ = publish_market_event_core_and_momentum(nats, &event).await;
                 }
 
                 // Emit DevWalletIdentified for Pump.fun pools where we know the creator
@@ -8917,12 +8921,7 @@ async fn run_geyser_loop(
                         }
 
                         if let Some(ref nats) = ctx.nats {
-                            if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &dev_event).await {
-                                warn!(error = %e, "Failed to publish dev wallet event to NATS");
-                                NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                            } else {
-                                NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                            if publish_market_event_core_and_momentum(nats, &dev_event).await {
                                 info!(
                                     mint = %pool_event.base_mint,
                                     creator = %creator,
@@ -8989,12 +8988,7 @@ async fn run_geyser_loop(
                     }
 
                     if let Some(ref nats) = ctx.nats {
-                        if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, &accounts_event).await {
-                            warn!(error = %e, "Failed to publish DexPoolAccounts event to NATS");
-                            NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-                        } else {
-                            NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                            MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                        if publish_market_event_core_and_momentum(nats, &accounts_event).await {
                             debug!(
                                 dex = %pool_event.dex_type,
                                 pool = %pool_event.pool_address,
@@ -10355,5 +10349,165 @@ mod wsol_ata_update_tests {
             wsol_ata_balance_lamports_from_geyser_data(&data),
             Some(1_000_000_000)
         );
+    }
+}
+
+/// Momentum NATS subject fan-out classification (see `TOPIC_MOMENTUM_MARKET_EVENTS`).
+#[cfg(test)]
+mod momentum_nats_subject_tests {
+    use super::market_event_is_momentum_nats_relevant;
+    use ironcrab::ipc::{MarketEventKind, NATIVE_SOL_MINT};
+
+    fn sample_trade() -> MarketEventKind {
+        MarketEventKind::Trade {
+            pool_address: "pool1".into(),
+            mint: "mint1".into(),
+            quote_mint: NATIVE_SOL_MINT.into(),
+            trader: "trader1".into(),
+            is_buy: true,
+            sol_amount: 1,
+            token_amount: 1,
+            token_decimals: 6,
+            signature: None,
+            dex: "pumpfun".into(),
+            creator: None,
+            token_program: None,
+        }
+    }
+
+    #[test]
+    fn momentum_relevance_always_true_for_core_entry_exit_kinds() {
+        assert!(market_event_is_momentum_nats_relevant(&sample_trade()));
+        assert!(market_event_is_momentum_nats_relevant(
+            &MarketEventKind::PoolCreated {
+                pool_address: "p".into(),
+                base_mint: "m".into(),
+                quote_mint: NATIVE_SOL_MINT.into(),
+                dex: "raydium".into(),
+                initial_liquidity_sol: None,
+            }
+        ));
+        assert!(market_event_is_momentum_nats_relevant(
+            &MarketEventKind::BondingCurveProgress {
+                mint: "m".into(),
+                bonding_curve: "bc".into(),
+                progress_bps: 100,
+                complete: false,
+            }
+        ));
+        assert!(market_event_is_momentum_nats_relevant(
+            &MarketEventKind::TokenMintInfo {
+                mint: "m".into(),
+                token_program: "tp".into(),
+                decimals: 6,
+                supply: 0,
+                mint_authority: None,
+                freeze_authority: None,
+            }
+        ));
+        assert!(market_event_is_momentum_nats_relevant(
+            &MarketEventKind::DexPoolAccounts {
+                dex: "orca".into(),
+                pool_address: "p".into(),
+                base_mint: "m".into(),
+                quote_mint: NATIVE_SOL_MINT.into(),
+                accounts: vec![],
+            }
+        ));
+        assert!(market_event_is_momentum_nats_relevant(
+            &MarketEventKind::DevWalletIdentified {
+                mint: "m".into(),
+                dev_wallet: "d".into(),
+                supply_percentage: 0.0,
+            }
+        ));
+        assert!(market_event_is_momentum_nats_relevant(
+            &MarketEventKind::LiquidityRemoved {
+                pool_address: "p".into(),
+                mint: "m".into(),
+                sol_amount: 0,
+                token_amount: 0,
+                signature: None,
+            }
+        ));
+        assert!(market_event_is_momentum_nats_relevant(
+            &MarketEventKind::WalletSnapshotComplete {
+                mints_in_wallet: vec![],
+                wallet: "w".into(),
+                is_periodic: false,
+            }
+        ));
+    }
+
+    #[test]
+    fn momentum_relevance_false_for_explicit_noise_kinds() {
+        assert!(!market_event_is_momentum_nats_relevant(
+            &MarketEventKind::LatestBlockhash {
+                blockhash: "h".into(),
+                slot: 1,
+                block_height: 1,
+            }
+        ));
+        assert!(!market_event_is_momentum_nats_relevant(
+            &MarketEventKind::BinArrayUpdate {
+                pool_address: "p".into(),
+                bin_array_index: 0,
+                bins: vec![],
+                update_slot: 1,
+            }
+        ));
+        assert!(!market_event_is_momentum_nats_relevant(
+            &MarketEventKind::SlotUpdate { current_slot: 1 }
+        ));
+        assert!(!market_event_is_momentum_nats_relevant(
+            &MarketEventKind::WalletBalanceSnapshot {
+                mint: "m".into(),
+                balance_raw: 0,
+                decimals: 6,
+                token_program: "tp".into(),
+            }
+        ));
+    }
+
+    #[test]
+    fn pool_state_update_only_pump_line_sol_quoted() {
+        let ps_pump_sol = MarketEventKind::PoolStateUpdate {
+            pool_address: "p".into(),
+            dex: "pumpfun".into(),
+            reserve_base: 1,
+            reserve_quote: 1,
+            base_mint: "m".into(),
+            quote_mint: NATIVE_SOL_MINT.into(),
+            update_slot: 1,
+            active_id: None,
+            bin_step: None,
+        };
+        assert!(market_event_is_momentum_nats_relevant(&ps_pump_sol));
+
+        let ps_ray = MarketEventKind::PoolStateUpdate {
+            pool_address: "p".into(),
+            dex: "raydium".into(),
+            reserve_base: 1,
+            reserve_quote: 1,
+            base_mint: "m".into(),
+            quote_mint: NATIVE_SOL_MINT.into(),
+            update_slot: 1,
+            active_id: None,
+            bin_step: None,
+        };
+        assert!(!market_event_is_momentum_nats_relevant(&ps_ray));
+
+        let ps_pump_usdc = MarketEventKind::PoolStateUpdate {
+            pool_address: "p".into(),
+            dex: "pump_amm".into(),
+            reserve_base: 1,
+            reserve_quote: 1,
+            base_mint: "m".into(),
+            quote_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".into(),
+            update_slot: 1,
+            active_id: None,
+            bin_step: None,
+        };
+        assert!(!market_event_is_momentum_nats_relevant(&ps_pump_usdc));
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -110,9 +110,6 @@ const PUMPFUN_AMM_PROGRAM: &str = "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA";
 const METEORA_DLMM: &str = "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo";
 const METEORA_CPMM: &str = "cpmmpPFsKiR4eeYnGSuXgkhLLgGL1j5FUZoJBJU9t9D";
 
-/// Wrapped SOL mint (same as default quote in many events).
-const WRAPPED_SOL_MINT: &str = "So11111111111111111111111111111111111111112";
-
 /// Subset of [`MarketEventKind`] mirrored to [`TOPIC_MOMENTUM_MARKET_EVENTS`] in addition to core.
 ///
 /// Conservative: noise kinds stay core-only. `WalletSnapshotComplete` is included because
@@ -140,7 +137,7 @@ pub(crate) fn market_event_is_momentum_nats_relevant(kind: &MarketEventKind) -> 
                 return false;
             }
             let q = quote_mint.as_str();
-            q == NATIVE_SOL_MINT || q == WRAPPED_SOL_MINT
+            q == NATIVE_SOL_MINT
         }
 
         MarketEventKind::LatestBlockhash { .. }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -157,35 +157,59 @@ pub(crate) fn market_event_is_momentum_nats_relevant(kind: &MarketEventKind) -> 
 /// Publish one logical market event to core NATS and, when [`market_event_is_momentum_nats_relevant`], to momentum subject.
 ///
 /// Counts one [`MARKET_EVENTS_PUBLISHED_TOTAL`] per successful core delivery; [`NATS_MESSAGES_PUBLISHED_TOTAL`]
-/// once per successful NATS publish (core plus optional second message).
+/// once per successful NATS publish (core plus optional second message). [`NatsClient::publish`] may return
+/// `Ok(false)` when the message is dropped (no client, NATS error, timeout/backpressure); that is not success.
 pub(crate) async fn publish_market_event_core_and_momentum(
     nats: &NatsClient,
     event: &MarketEvent,
 ) -> bool {
-    if let Err(e) = nats.publish(TOPIC_MARKET_EVENTS, event).await {
-        warn!(
-            error = %e,
-            event_id = %event.event_id,
-            "Failed to publish market event to NATS (core)"
-        );
-        NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-        return false;
-    }
-
-    NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-    MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-
-    if market_event_is_momentum_nats_relevant(&event.kind) {
-        if let Err(e) = nats.publish(TOPIC_MOMENTUM_MARKET_EVENTS, event).await {
+    match nats.publish(TOPIC_MARKET_EVENTS, event).await {
+        Ok(true) => {
+            NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+            MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(false) => {
+            warn!(
+                event_id = %event.event_id,
+                topic = TOPIC_MARKET_EVENTS,
+                "Market event publish to NATS (core) dropped or failed"
+            );
+            NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
+            return false;
+        }
+        Err(e) => {
             warn!(
                 error = %e,
                 event_id = %event.event_id,
-                topic = TOPIC_MOMENTUM_MARKET_EVENTS,
-                "Failed to publish market event to NATS (momentum fan-out)"
+                "Failed to publish market event to NATS (core)"
             );
             NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
-        } else {
-            NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+            return false;
+        }
+    }
+
+    if market_event_is_momentum_nats_relevant(&event.kind) {
+        match nats.publish(TOPIC_MOMENTUM_MARKET_EVENTS, event).await {
+            Ok(true) => {
+                NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+            }
+            Ok(false) => {
+                warn!(
+                    event_id = %event.event_id,
+                    topic = TOPIC_MOMENTUM_MARKET_EVENTS,
+                    "Market event publish to NATS (momentum fan-out) dropped or failed"
+                );
+                NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    event_id = %event.event_id,
+                    topic = TOPIC_MOMENTUM_MARKET_EVENTS,
+                    "Failed to publish market event to NATS (momentum fan-out)"
+                );
+                NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
+            }
         }
     }
 

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -7536,6 +7536,7 @@ async fn main() -> Result<()> {
                             fallback_topic = TOPIC_MARKET_EVENTS,
                             "Momentum MarketEvents subscription ended before first message; falling back to core MarketEvents topic"
                         );
+                        drop(sub);
                         match nats.subscribe(TOPIC_MARKET_EVENTS).await {
                             Ok(sub) => {
                                 info!(
@@ -7557,6 +7558,7 @@ async fn main() -> Result<()> {
                             wait_secs = MOMENTUM_MARKET_EVENTS_FIRST_MSG_FALLBACK.as_secs(),
                             "No message on momentum MarketEvents topic within wait window (likely no publisher or version skew); falling back to core MarketEvents topic"
                         );
+                        drop(sub);
                         match nats.subscribe(TOPIC_MARKET_EVENTS).await {
                             Ok(sub) => {
                                 info!(

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -99,6 +99,9 @@ const ORPHANED_RECOVERED_INTENT_IDS_CAP: usize = 50_000;
 /// Core NATS delivers no publisher discovery: subscribing to [`TOPIC_MOMENTUM_MARKET_EVENTS`]
 /// succeeds even when market-data does not publish there yet. If no message arrives within this
 /// window, subscribe to [`TOPIC_MARKET_EVENTS`] so rolling deploys do not starve silently.
+///
+/// `sd_notify(READY)` is sent only after this probe (see main loop startup) so systemd
+/// `WatchdogSec` in `docs/systemd/momentum-bot.service` does not elapse during the wait.
 const MOMENTUM_MARKET_EVENTS_FIRST_MSG_FALLBACK: Duration = Duration::from_secs(30);
 
 // --- Scope C (momentum event lifecycle): bounded ExecutionResult drains + observability ---
@@ -7505,17 +7508,6 @@ async fn main() -> Result<()> {
     // === Main Loop: Process MarketEvents from NATS ===
     info!("Entering main event loop");
 
-    // P1 Crash Isolation: Signal systemd that we're ready
-    #[cfg(unix)]
-    {
-        // NOTE: Do NOT unset NOTIFY_SOCKET here; we need it for Watchdog pings.
-        let _ = sd_notify::notify(false, &[NotifyState::Ready]);
-        debug!("Sent sd_notify READY to systemd");
-    }
-
-    // Keep readiness fresh even when idle.
-    ironcrab::metrics::record_activity();
-
     let mut pending_market_nats_message: Option<NatsMessage> = None;
 
     // Subscribe to Momentum-filtered MarketEvents (reduces Core NATS fan-in vs full stream).
@@ -7809,6 +7801,17 @@ async fn main() -> Result<()> {
     // Graceful shutdown handling
     let shutdown = tokio::signal::ctrl_c();
     tokio::pin!(shutdown);
+
+    // Defer READY until after NATS setup (including momentum first-message probe). With
+    // Type=notify + WatchdogSec, READY starts the watchdog; the probe can block ~30s without
+    // the main loop's periodic WATCHDOG pings yet.
+    ironcrab::metrics::record_activity();
+    #[cfg(unix)]
+    {
+        // NOTIFY_SOCKET must stay set for Watchdog pings in the main loop.
+        let _ = sd_notify::notify(false, &[NotifyState::Ready]);
+        debug!("Sent sd_notify READY to systemd");
+    }
 
     loop {
         tokio::select! {

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -57,9 +57,9 @@ use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
     ensure_trade_intents_stream, execution_results_consumer_config,
     wallet_snapshot_consumer_config, wallet_snapshot_live_consumer_config, NatsClient, NatsConfig,
-    CONFIG_STREAM_NAME, EXECUTION_RESULTS_STREAM_NAME, STREAM_NAME, TOPIC_EXECUTION_RESULTS,
-    TOPIC_MARKET_EVENTS, TOPIC_MOMENTUM_MARKET_EVENTS, TOPIC_TRADE_INTENTS,
-    WALLET_SNAPSHOT_STREAM_NAME,
+    NatsMessage, CONFIG_STREAM_NAME, EXECUTION_RESULTS_STREAM_NAME, STREAM_NAME,
+    TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS, TOPIC_MOMENTUM_MARKET_EVENTS,
+    TOPIC_TRADE_INTENTS, WALLET_SNAPSHOT_STREAM_NAME,
 };
 use ironcrab::solana::dex_parser::SOL_MINT_PUBKEY;
 use ironcrab::storage::{JsonlWriter, JsonlWriterConfig};
@@ -95,6 +95,11 @@ fn is_non_tradeable_momentum_mint(mint: &str) -> bool {
 
 /// JetStream replay dedup for orphaned BUY path — bounded so memory does not grow forever.
 const ORPHANED_RECOVERED_INTENT_IDS_CAP: usize = 50_000;
+
+/// Core NATS delivers no publisher discovery: subscribing to [`TOPIC_MOMENTUM_MARKET_EVENTS`]
+/// succeeds even when market-data does not publish there yet. If no message arrives within this
+/// window, subscribe to [`TOPIC_MARKET_EVENTS`] so rolling deploys do not starve silently.
+const MOMENTUM_MARKET_EVENTS_FIRST_MSG_FALLBACK: Duration = Duration::from_secs(30);
 
 // --- Scope C (momentum event lifecycle): bounded ExecutionResult drains + observability ---
 /// Max `ExecutionResult` messages per `tokio::select!` activation (fairness vs MarketEvent / PoolCache).
@@ -7511,15 +7516,70 @@ async fn main() -> Result<()> {
     // Keep readiness fresh even when idle.
     ironcrab::metrics::record_activity();
 
+    let mut pending_market_nats_message: Option<NatsMessage> = None;
+
     // Subscribe to Momentum-filtered MarketEvents (reduces Core NATS fan-in vs full stream).
     let mut subscription = if let Some(ref nats) = ctx.nats {
         match nats.subscribe(TOPIC_MOMENTUM_MARKET_EVENTS).await {
-            Ok(sub) => {
+            Ok(mut sub) => {
                 info!(
                     topic = TOPIC_MOMENTUM_MARKET_EVENTS,
-                    "Subscribed to Momentum-filtered MarketEvents"
+                    wait_secs = MOMENTUM_MARKET_EVENTS_FIRST_MSG_FALLBACK.as_secs(),
+                    "Subscribed to Momentum-filtered MarketEvents; waiting for first message"
                 );
-                Some(sub)
+                match tokio::time::timeout(MOMENTUM_MARKET_EVENTS_FIRST_MSG_FALLBACK, sub.next())
+                    .await
+                {
+                    Ok(Some(first)) => {
+                        info!(
+                            topic = TOPIC_MOMENTUM_MARKET_EVENTS,
+                            "Momentum-filtered MarketEvents topic is active"
+                        );
+                        pending_market_nats_message = Some(first);
+                        Some(sub)
+                    }
+                    Ok(None) => {
+                        warn!(
+                            momentum_topic = TOPIC_MOMENTUM_MARKET_EVENTS,
+                            fallback_topic = TOPIC_MARKET_EVENTS,
+                            "Momentum MarketEvents subscription ended before first message; falling back to core MarketEvents topic"
+                        );
+                        match nats.subscribe(TOPIC_MARKET_EVENTS).await {
+                            Ok(sub) => {
+                                info!(
+                                    topic = TOPIC_MARKET_EVENTS,
+                                    "Subscribed to MarketEvents (fallback)"
+                                );
+                                Some(sub)
+                            }
+                            Err(e2) => {
+                                warn!(error = %e2, "Failed to subscribe to NATS, running in offline mode");
+                                None
+                            }
+                        }
+                    }
+                    Err(_elapsed) => {
+                        warn!(
+                            momentum_topic = TOPIC_MOMENTUM_MARKET_EVENTS,
+                            fallback_topic = TOPIC_MARKET_EVENTS,
+                            wait_secs = MOMENTUM_MARKET_EVENTS_FIRST_MSG_FALLBACK.as_secs(),
+                            "No message on momentum MarketEvents topic within wait window (likely no publisher or version skew); falling back to core MarketEvents topic"
+                        );
+                        match nats.subscribe(TOPIC_MARKET_EVENTS).await {
+                            Ok(sub) => {
+                                info!(
+                                    topic = TOPIC_MARKET_EVENTS,
+                                    "Subscribed to MarketEvents (fallback)"
+                                );
+                                Some(sub)
+                            }
+                            Err(e2) => {
+                                warn!(error = %e2, "Failed to subscribe to NATS, running in offline mode");
+                                None
+                            }
+                        }
+                    }
+                }
             }
             Err(e) => {
                 warn!(
@@ -7765,11 +7825,13 @@ async fn main() -> Result<()> {
             // typically MarketEvents; `async_nats` "slow consumers for subscription N" correlates
             // with this high-volume path when JetStream arms monopolize the runtime).
             msg = async {
-                if let Some(ref mut sub) = subscription {
+                if let Some(pending) = pending_market_nats_message.take() {
+                    Some(pending)
+                } else if let Some(ref mut sub) = subscription {
                     sub.next().await
                 } else {
                     // No subscription - just wait forever (heartbeat will still fire)
-                    std::future::pending::<Option<ironcrab::nats::NatsMessage>>().await
+                    std::future::pending::<Option<NatsMessage>>().await
                 }
             } => {
                 if let Some(nats_msg) = msg {

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -58,7 +58,8 @@ use ironcrab::nats::{
     ensure_trade_intents_stream, execution_results_consumer_config,
     wallet_snapshot_consumer_config, wallet_snapshot_live_consumer_config, NatsClient, NatsConfig,
     CONFIG_STREAM_NAME, EXECUTION_RESULTS_STREAM_NAME, STREAM_NAME, TOPIC_EXECUTION_RESULTS,
-    TOPIC_MARKET_EVENTS, TOPIC_TRADE_INTENTS, WALLET_SNAPSHOT_STREAM_NAME,
+    TOPIC_MARKET_EVENTS, TOPIC_MOMENTUM_MARKET_EVENTS, TOPIC_TRADE_INTENTS,
+    WALLET_SNAPSHOT_STREAM_NAME,
 };
 use ironcrab::solana::dex_parser::SOL_MINT_PUBKEY;
 use ironcrab::storage::{JsonlWriter, JsonlWriterConfig};
@@ -107,8 +108,9 @@ const EXECUTION_RESULT_INTERLEAVED_FETCH_EXPIRES: Duration = Duration::from_mill
 /// Smaller batches reduce single-arm starvation of other `tokio::select!` branches.
 const POOL_CACHE_UPDATE_FETCH_MAX: usize = 32;
 const POOL_CACHE_UPDATE_FETCH_EXPIRES: Duration = Duration::from_millis(50);
-/// Core NATS `TOPIC_MARKET_EVENTS`: drain immediately queued messages per select activation
-/// so JetStream arms cannot starve the high-volume MarketEvents subscriber (slow-consumer stall).
+/// Core NATS market-events subject (full fan-out). Momentum-bot prefers [`TOPIC_MOMENTUM_MARKET_EVENTS`].
+/// Drain immediately queued messages per select activation so JetStream arms cannot starve the
+/// high-volume MarketEvents subscriber (slow-consumer stall).
 const CORE_MARKET_EVENTS_INGEST_DRAIN_MAX: usize = 48;
 /// Wallet snapshot JetStream pull cap per `select!` activation (fairness vs Core MarketEvents).
 const WALLET_SNAPSHOT_FETCH_MAX: usize = 16;
@@ -7509,16 +7511,36 @@ async fn main() -> Result<()> {
     // Keep readiness fresh even when idle.
     ironcrab::metrics::record_activity();
 
-    // Subscribe to MarketEvents from NATS
+    // Subscribe to Momentum-filtered MarketEvents (reduces Core NATS fan-in vs full stream).
     let mut subscription = if let Some(ref nats) = ctx.nats {
-        match nats.subscribe(TOPIC_MARKET_EVENTS).await {
+        match nats.subscribe(TOPIC_MOMENTUM_MARKET_EVENTS).await {
             Ok(sub) => {
-                info!(topic = TOPIC_MARKET_EVENTS, "Subscribed to MarketEvents");
+                info!(
+                    topic = TOPIC_MOMENTUM_MARKET_EVENTS,
+                    "Subscribed to Momentum-filtered MarketEvents"
+                );
                 Some(sub)
             }
             Err(e) => {
-                warn!(error = %e, "Failed to subscribe to NATS, running in offline mode");
-                None
+                warn!(
+                    error = %e,
+                    momentum_topic = TOPIC_MOMENTUM_MARKET_EVENTS,
+                    fallback_topic = TOPIC_MARKET_EVENTS,
+                    "Failed to subscribe to momentum MarketEvents topic; falling back to core MarketEvents topic"
+                );
+                match nats.subscribe(TOPIC_MARKET_EVENTS).await {
+                    Ok(sub) => {
+                        info!(
+                            topic = TOPIC_MARKET_EVENTS,
+                            "Subscribed to MarketEvents (fallback)"
+                        );
+                        Some(sub)
+                    }
+                    Err(e2) => {
+                        warn!(error = %e2, "Failed to subscribe to NATS, running in offline mode");
+                        None
+                    }
+                }
             }
         }
     } else {

--- a/src/nats/topics.rs
+++ b/src/nats/topics.rs
@@ -11,6 +11,10 @@ pub const TOPIC_VERSION: &str = "v1";
 /// Market events from market-data service
 pub const TOPIC_MARKET_EVENTS: &str = "ironcrab.v1.market_events";
 
+/// Momentum-filtered market events (subset of [`TOPIC_MARKET_EVENTS`] payloads).
+/// Other consumers keep using the core topic; momentum-bot prefers this subject to reduce fan-in.
+pub const TOPIC_MOMENTUM_MARKET_EVENTS: &str = "ironcrab.v1.market_events.momentum";
+
 /// Trade intents from strategy bots
 pub const TOPIC_TRADE_INTENTS: &str = "ironcrab.v1.trade_intents";
 
@@ -79,6 +83,7 @@ pub fn config_topic(component: &str) -> String {
 pub fn all_topics() -> Vec<&'static str> {
     vec![
         TOPIC_MARKET_EVENTS,
+        TOPIC_MOMENTUM_MARKET_EVENTS,
         TOPIC_TRADE_INTENTS,
         TOPIC_EXECUTION_RESULTS,
         TOPIC_CONTROL_REQUESTS,
@@ -106,6 +111,14 @@ mod tests {
     fn test_topic_format() {
         assert!(TOPIC_MARKET_EVENTS.starts_with(TOPIC_PREFIX));
         assert!(TOPIC_MARKET_EVENTS.contains(TOPIC_VERSION));
+    }
+
+    #[test]
+    fn test_momentum_market_events_topic_versioned() {
+        assert!(TOPIC_MOMENTUM_MARKET_EVENTS.starts_with(TOPIC_PREFIX));
+        assert!(TOPIC_MOMENTUM_MARKET_EVENTS.contains(TOPIC_VERSION));
+        assert!(TOPIC_MOMENTUM_MARKET_EVENTS.starts_with(TOPIC_MARKET_EVENTS));
+        assert!(TOPIC_MOMENTUM_MARKET_EVENTS.len() > TOPIC_MARKET_EVENTS.len());
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the next scope from the Momentum throughput plan: `market-data` publishes a **subset** of Core `MarketEvent`s to a dedicated NATS subject `ironcrab.v1.market_events.momentum`, and `momentum-bot` subscribes there first (with fallback to the full core topic).

## Why

After Scope 1, Momentum no longer stalls as a slow consumer, but still ingests the full Core market-events fan-out. This change reduces NATS fan-in for Momentum without changing strategy, filters, execution, or pool-matching semantics.

## Changes

- **`src/nats/topics.rs`**: `TOPIC_MOMENTUM_MARKET_EVENTS`, included in `all_topics()`, version/prefix tests.
- **`src/bin/market_data.rs`**: `market_event_is_momentum_nats_relevant()` + `publish_market_event_core_and_momentum()`; all instrumented Core publishes route through the helper.
  - **Always** mirrored: `Trade`, `PoolCreated`, `BondingCurveProgress`, `TokenMintInfo`, `DexPoolAccounts`, `DevWalletIdentified`, `LiquidityRemoved`, `WalletSnapshotComplete` (needed for ghost-position reconciliation on the NATS path).
  - **Conditional** `PoolStateUpdate`: only `pumpfun` / `pump_amm` (case-insensitive) with SOL quote mint.
  - **Not** mirrored: `LatestBlockhash`, `BinArrayUpdate`, generic `AccountUpdate` / `TransactionDetected`, wallet-activity noise, etc. (unchanged on Core only).
  - **Metrics**: `MARKET_EVENTS_PUBLISHED_TOTAL` +1 per logical event on successful Core delivery; `NATS_MESSAGES_PUBLISHED_TOTAL` +1 per successful NATS message (Core + optional second publish). Momentum publish failure increments `NATS_ERRORS_TOTAL`.
- **`src/bin/momentum_bot.rs`**: Subscribe to `TOPIC_MOMENTUM_MARKET_EVENTS` with warn + fallback to `TOPIC_MARKET_EVENTS` if subscribe fails.

## STOP-CHECK (self-review)

1. **I-7 Hot-path RPC**: No RPC changes; NATS-only routing.
2. **Pattern**: Mirrors core publish first; optional second subject.
3. **Scope**: Only allowed files.
4. **I-9 Simulation**: Untouched.
5. **Level-5**: No eval test sources read.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test --bin market-data momentum_nats`

Eval sibling repo not present in this workspace; Level-5 eval run via CI as usual.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f3dd75d-430d-4641-9d6f-76ddf3ba6455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f3dd75d-430d-4641-9d6f-76ddf3ba6455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

