### PR TITLE
Momentum: quote-first price exits (STOP_LOSS, TAKE_PROFIT, TRAILING_STOP)

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -18,6 +18,12 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 **Fix**: `drain_execution_results` (interleaved) höchstens **einmal** nach vollständiger Verarbeitung eines MarketEvents-Batches, nur wenn das Batch preissensitiv war und Positionen oder ausstehende Execution-Intents existieren; `process_exit_signals` in MarketEvents-, PoolCache- und Wallet-Snapshot-Pfaden nur bei `position_count() > 0`. Geplanter `select!`-Arm für ExecutionResults unverändert.  
 **Dateien**: `src/bin/momentum_bot.rs`
 
+### FIX-MOM-QUOTE-FIRST-PRICE-EXITS: STOP/TP/Trailing aus LivePoolCache-Quote
+**Datum**: 2026-05-14  
+**Problem**: `STOP_LOSS`/`TAKE_PROFIT`/`TRAILING_STOP` trippen nur, wenn `current_price` die Schwelle erreichte; die validierte `ExitExecutableQuote` widersprach oft nicht rechtzeitig. Positions fielen durch zu `TIME_EXIT`, obwohl die ausführbare Reserve-Quote schon weit unter Stop lag (Mark vs. tatsächlicher Sell-Preis).  
+**Fix**: Quote-first: bei nutzbarer `ExitExecutableQuote` (pool_sourced, finite `tokens_per_sol`) entscheiden diese Exits primär nach executable PnL bzw. executable Drawdown; ohne Quote feuern sie nicht aus Trade-/Mark-Rauschen. Stale-Suppression bleibt (aggressiver `current_price` vs. executable). `TIME_EXIT` unverändert; Reporting-PnL nutzt weiter die Quote wenn vorhanden.  
+**Dateien**: `src/bin/momentum_bot.rs`
+
 ### FIX-01: Revert fehlerhafter Commits → `e341c04b`
 **Datum**: 2026-02-09
 **Problem**: 18 Commits (bis `b22bb0a9`) hatten ungewollt die Liquidation zerstört und Architekturprinzipien verletzt (RPC-Calls im Hot Path).

--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -21,8 +21,8 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 ### FIX-MOM-QUOTE-FIRST-PRICE-EXITS: STOP/TP/Trailing aus LivePoolCache-Quote
 **Datum**: 2026-05-14  
 **Problem**: `STOP_LOSS`/`TAKE_PROFIT`/`TRAILING_STOP` trippen nur, wenn `current_price` die Schwelle erreichte; die validierte `ExitExecutableQuote` widersprach oft nicht rechtzeitig. Positions fielen durch zu `TIME_EXIT`, obwohl die ausführbare Reserve-Quote schon weit unter Stop lag (Mark vs. tatsächlicher Sell-Preis).  
-**Fix**: Quote-first: bei nutzbarer `ExitExecutableQuote` (pool_sourced, finite `tokens_per_sol`) entscheiden diese Exits primär nach executable PnL bzw. executable Drawdown; ohne Quote feuern sie nicht aus Trade-/Mark-Rauschen. Stale-Suppression bleibt (aggressiver `current_price` vs. executable). `TIME_EXIT` unverändert; Reporting-PnL nutzt weiter die Quote wenn vorhanden.  
-**Dateien**: `src/bin/momentum_bot.rs`
+**Fix**: Quote-first: bei nutzbarer `ExitExecutableQuote` (pool_sourced, finite `tokens_per_sol`) entscheiden `STOP_LOSS` und `TAKE_PROFIT` nach executable PnL; `current_price` allein triggert sie nicht (keine sekundäre „Stale-Mark“-Suppressionsstufe mehr). **`TRAILING_STOP`:** executable Drawdown nur, wenn `quote_pool == position.pool` (`marks_position_pool`); sonst kein Vergleich gegen Positions-Pool-ATH (I-13). Ohne nutzbare Quote feuern die drei Preis-Exits nicht aus Mark-/Trade-Rauschen. `TIME_EXIT` unverändert; Reporting-PnL nutzt weiter die Quote wenn vorhanden.  
+**Dateien**: `src/bin/momentum_bot.rs`, `docs/MOMENTUM_V2_SPEC.md`, `docs/BUGS_FIXES.md`
 
 ### FIX-01: Revert fehlerhafter Commits → `e341c04b`
 **Datum**: 2026-02-09

--- a/docs/MOMENTUM_V2_SPEC.md
+++ b/docs/MOMENTUM_V2_SPEC.md
@@ -176,7 +176,7 @@ Conditional exits:
 - Trailing stop after activation threshold.
 - Momentum fade (buy ratio below threshold in recent window).
 
-**Quote-first price exits (STOP_LOSS / TAKE_PROFIT / TRAILING_STOP):** these fire only when a usable **executable reserve quote** breaches the configured threshold. **Current-price-only** triggers for those exits are disabled; the trade-ratio mark may diverge for logging but is not the trigger source.
+**Quote-first price exits (STOP_LOSS / TAKE_PROFIT / TRAILING_STOP):** these fire only when a usable **executable reserve quote** breaches the configured threshold. **Current-price-only** triggers for those exits are disabled; the trade-ratio mark may diverge for logging but is not the trigger source. **TRAILING_STOP** additionally requires that the executable quote **marks the position pool** (`quote_pool == position.pool`): an alternate-pool quote may still inform STOP/TAKE per routing policy, but must not be compared to the position-pool ATH for trailing drawdown (I-13).
 
 
 ## 5) Required Signals & Data Sources

--- a/docs/MOMENTUM_V2_SPEC.md
+++ b/docs/MOMENTUM_V2_SPEC.md
@@ -176,7 +176,8 @@ Conditional exits:
 - Trailing stop after activation threshold.
 - Momentum fade (buy ratio below threshold in recent window).
 
----
+**Quote-first price exits (STOP_LOSS / TAKE_PROFIT / TRAILING_STOP):** these fire only when a usable **executable reserve quote** breaches the configured threshold. **Current-price-only** triggers for those exits are disabled; the trade-ratio mark may diverge for logging but is not the trigger source.
+
 
 ## 5) Required Signals & Data Sources
 

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -568,6 +568,8 @@ struct PositionTracker {
 /// I-7: from LivePoolCache in-process only — no RPC.
 /// I-13: If `marks_position_pool` is false (e.g. PumpSwap quote while position.pool is still PumpFun BC),
 /// this quote is only for exit decisions — never apply `tokens_per_sol` as `current_price` on the position.
+/// Price exits (`STOP_LOSS` / `TAKE_PROFIT` / `TRAILING_STOP`) are **quote-first**: they trigger from a
+/// usable executable quote when present; they do not use `current_price` alone (see `should_exit`).
 #[derive(Debug, Clone)]
 struct ExitExecutableQuote {
     /// tokens_per_sol (UI): token_ui / sol_ui, matching `entry_price` / `current_price` (I-14).
@@ -584,109 +586,38 @@ struct ExitExecutableQuote {
     cache_age_ms: Option<u64>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ExitPriceValidationAction {
-    /// Use `current_price`-based PnL for this exit.
-    Allow,
-    /// Do not emit this price-based exit this tick (stale/wrong `current_price` vs executable).
-    Suppress,
+/// Reserve-based quote is usable for quote-first price exits (I-14, I-15, I-16).
+#[inline]
+fn exit_executable_quote_is_usable(q: &ExitExecutableQuote) -> bool {
+    q.pool_sourced && q.tokens_per_sol > 0.0 && q.tokens_per_sol.is_finite()
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ExitRejectionReason {
-    StaleOrWrongPrice,
-    /// No valid reserve quote for this position size — price-based exit must not fire (I-16).
-    NoExecutableQuote,
-}
-
-/// Pure helper: decide whether a price-based exit should be suppressed when a pool-correct
-/// executable quote exists. I-14: `pnl_pct` / drawdown use `tokens_per_sol`.
-///
-/// Scope D: `TAKE_PROFIT`, `STOP_LOSS`, and `TRAILING_STOP` require a valid executable quote;
-/// they never fire on `current_price` / trade-ratio noise alone.
-fn exit_action_for_price_signal(
+/// When a **valid** executable quote exists: suppress firing because `current_price` is more
+/// aggressive than the executable (trade spike / stale mark), but the pool quote disagrees.
+/// Quote-first triggers call this only after the executable condition for that exit is met.
+fn suppress_price_exit_stale_aggressive_current(
+    exit_type: &str,
     entry_price: f64,
     highest_price: f64,
     current_price: f64,
-    exit_type: &str,
     config: &MomentumConfig,
-    exit_quote: Option<&ExitExecutableQuote>,
-) -> (
-    ExitPriceValidationAction,
-    f64,
-    f64,
-    Option<ExitRejectionReason>,
-) {
+    exec_pnl: f64,
+    exec_tokens_per_sol: f64,
+) -> bool {
     let current_pnl = tokens_per_sol::pnl_pct(entry_price, current_price);
-    let q = match exit_quote {
-        None => {
-            return (
-                ExitPriceValidationAction::Suppress,
-                current_pnl,
-                current_pnl,
-                Some(ExitRejectionReason::NoExecutableQuote),
-            );
-        }
-        Some(q) => q,
-    };
-    if !q.pool_sourced || q.tokens_per_sol <= 0.0 {
-        return (
-            ExitPriceValidationAction::Suppress,
-            current_pnl,
-            current_pnl,
-            Some(ExitRejectionReason::NoExecutableQuote),
-        );
-    }
-
-    let executable_pnl_val = tokens_per_sol::pnl_pct(entry_price, q.tokens_per_sol);
     let current_dd = tokens_per_sol::drawdown_from_ath_pct(highest_price, current_price);
-    let exec_dd = tokens_per_sol::drawdown_from_ath_pct(highest_price, q.tokens_per_sol);
+    let exec_dd = tokens_per_sol::drawdown_from_ath_pct(highest_price, exec_tokens_per_sol);
 
-    // STOP_LOSS: `current` says at/beyond hard stop, but executable says we are not — suppress
-    if exit_type == "STOP_LOSS"
-        && current_pnl <= -config.hard_stop_loss_pct
-        && executable_pnl_val > -config.hard_stop_loss_pct
-    {
-        return (
-            ExitPriceValidationAction::Suppress,
-            current_pnl,
-            executable_pnl_val,
-            Some(ExitRejectionReason::StaleOrWrongPrice),
-        );
+    match exit_type {
+        "STOP_LOSS" => {
+            current_pnl <= -config.hard_stop_loss_pct && exec_pnl > -config.hard_stop_loss_pct
+        }
+        "TAKE_PROFIT" => current_pnl >= config.take_profit_pct && exec_pnl < config.take_profit_pct,
+        "TRAILING_STOP" => {
+            current_dd >= config.trailing_stop_pct && exec_dd < config.trailing_stop_pct
+        }
+        _ => false,
     }
-
-    // TAKE_PROFIT: require executable to confirm the gain target
-    if exit_type == "TAKE_PROFIT"
-        && current_pnl >= config.take_profit_pct
-        && executable_pnl_val < config.take_profit_pct
-    {
-        return (
-            ExitPriceValidationAction::Suppress,
-            current_pnl,
-            executable_pnl_val,
-            Some(ExitRejectionReason::StaleOrWrongPrice),
-        );
-    }
-
-    // TRAILING_STOP: `current` says drawdown limit hit, executable disagrees
-    if exit_type == "TRAILING_STOP"
-        && current_dd >= config.trailing_stop_pct
-        && exec_dd < config.trailing_stop_pct
-    {
-        return (
-            ExitPriceValidationAction::Suppress,
-            current_pnl,
-            executable_pnl_val,
-            Some(ExitRejectionReason::StaleOrWrongPrice),
-        );
-    }
-
-    (
-        ExitPriceValidationAction::Allow,
-        current_pnl,
-        executable_pnl_val,
-        None,
-    )
 }
 
 #[derive(Clone, Debug)]
@@ -971,6 +902,9 @@ impl PositionTracker {
 
     /// Check if we should exit this position. `exit_quote` is a reserve-based quote for selling
     /// `token_amount` from `LivePoolCache` (I-7: no RPC).
+    ///
+    /// Quote-first (price exits): `STOP_LOSS`, `TAKE_PROFIT`, and `TRAILING_STOP` trigger from a
+    /// **usable** executable reserve quote when present; `current_price` alone never trips these.
     fn should_exit(
         &mut self,
         config: &MomentumConfig,
@@ -978,157 +912,172 @@ impl PositionTracker {
     ) -> Option<(String, String)> {
         // Returns: Some((exit_type, reason)) or None
 
-        // Mut: refreshed after `update_price` in validation suppress paths so trailing/activation
-        // do not use stale pnl/drawdown vs updated self.current_price (see f7477a89).
+        let valid_q = exit_quote.filter(|q| exit_executable_quote_is_usable(q));
         let mut pnl = self.pnl_pct();
-        let mut drawdown = self.drawdown_from_ath_pct();
         let hold_secs = self.entry_time.elapsed().as_secs();
 
-        let pnl_for_reporting = match exit_quote {
-            Some(q) if q.pool_sourced && q.tokens_per_sol > 0.0 => {
-                tokens_per_sol::pnl_pct(self.entry_price, q.tokens_per_sol)
-            }
-            _ => pnl,
-        };
+        let pnl_for_reporting = valid_q
+            .map(|q| tokens_per_sol::pnl_pct(self.entry_price, q.tokens_per_sol))
+            .unwrap_or(pnl);
 
-        // 1. Hard Stop Loss - validate against executable quote when available (stale `current_price`)
-        if pnl <= -config.hard_stop_loss_pct {
-            let (action, current_pnl, exec_pnl, rejection) = exit_action_for_price_signal(
-                self.entry_price,
-                self.highest_price,
-                self.current_price,
-                "STOP_LOSS",
-                config,
-                exit_quote,
-            );
-            if action == ExitPriceValidationAction::Suppress {
-                if let Some(q) = exit_quote
-                    .as_ref()
-                    .filter(|q| q.pool_sourced && q.tokens_per_sol > 0.0 && q.marks_position_pool)
-                {
-                    self.update_price(q.tokens_per_sol);
-                    pnl = self.pnl_pct();
-                    drawdown = self.drawdown_from_ath_pct();
+        // 1. Hard stop — quote-first: executable PnL must breach threshold (I-14, I-16).
+        if let Some(q) = valid_q {
+            let exec_pnl = tokens_per_sol::pnl_pct(self.entry_price, q.tokens_per_sol);
+            if exec_pnl <= -config.hard_stop_loss_pct {
+                let current_pnl = pnl;
+                if suppress_price_exit_stale_aggressive_current(
+                    "STOP_LOSS",
+                    self.entry_price,
+                    self.highest_price,
+                    self.current_price,
+                    config,
+                    exec_pnl,
+                    q.tokens_per_sol,
+                ) {
+                    if q.marks_position_pool {
+                        self.update_price(q.tokens_per_sol);
+                        pnl = self.pnl_pct();
+                    }
+                    debug!(
+                        mint = %self.mint,
+                        position_pool = %self.pool,
+                        quote_pool = %q.quote_pool,
+                        quote_dex = %q.quote_dex,
+                        entry_price = self.entry_price,
+                        current_price = self.current_price,
+                        executable_tokens_per_sol = q.tokens_per_sol,
+                        current_pnl_pct = %format!("{:.4}", current_pnl),
+                        executable_pnl_pct = %format!("{:.4}", exec_pnl),
+                        exit_type = "STOP_LOSS",
+                        decision = "suppress",
+                        reason = "STALE_AGGRESSIVE_CURRENT_VS_EXECUTABLE",
+                        "exit_signal_suppressed_stale_price"
+                    );
+                } else {
+                    info!(
+                        mint = %self.mint,
+                        position_pool = %self.pool,
+                        quote_pool = %q.quote_pool,
+                        quote_dex = %q.quote_dex,
+                        entry_price = self.entry_price,
+                        current_price = self.current_price,
+                        executable_tokens_per_sol = q.tokens_per_sol,
+                        current_pnl_pct = %format!("{:.4}", current_pnl),
+                        executable_pnl_pct = %format!("{:.4}", exec_pnl),
+                        exit_type = "STOP_LOSS",
+                        "STOP_LOSS trigger (quote-first executable reserve PnL)"
+                    );
+                    return Some((
+                        "STOP_LOSS".to_string(),
+                        format!(
+                            "Hard stop hit: {:.1}% executable loss (limit: -{:.1}%)",
+                            exec_pnl, config.hard_stop_loss_pct
+                        ),
+                    ));
                 }
-                warn!(
+            }
+        } else if pnl <= -config.hard_stop_loss_pct {
+            debug!(
+                mint = %self.mint,
+                position_pool = %self.pool,
+                reason = "NO_EXECUTABLE_QUOTE",
+                current_pnl_pct = %format!("{:.4}", pnl),
+                "price_exit_skipped_no_executable_quote"
+            );
+        } else if let Some(q) = exit_quote {
+            if !exit_executable_quote_is_usable(q) {
+                debug!(
                     mint = %self.mint,
                     position_pool = %self.pool,
-                    entry_price = self.entry_price,
-                    current_price = self.current_price,
-                    executable_tokens_per_sol = ?exit_quote.map(|q| q.tokens_per_sol),
-                    current_pnl_pct = %format!("{:.4}", current_pnl),
-                    executable_pnl_pct = %format!("{:.4}", exec_pnl),
-                    exit_type_original = "STOP_LOSS",
-                    decision = "suppress",
-                    ?rejection,
-                    "exit_signal_suppressed_stale_price"
+                    reason = "UNUSABLE_EXECUTABLE_QUOTE",
+                    pool_sourced = q.pool_sourced,
+                    tokens_per_sol = q.tokens_per_sol,
+                    "price_exit_skipped_unusable_executable_quote"
                 );
-            } else {
-                info!(
-                    mint = %self.mint,
-                    position_pool = %self.pool,
-                    entry_price = self.entry_price,
-                    current_price = self.current_price,
-                    executable_tokens_per_sol = ?exit_quote.map(|q| q.tokens_per_sol),
-                    current_pnl_pct = %format!("{:.4}", current_pnl),
-                    executable_pnl_pct = %format!("{:.4}", exec_pnl),
-                    exit_type_original = "STOP_LOSS",
-                    decision = "allow",
-                    "STOP_LOSS trigger (exit price validated against pool quote when available)"
-                );
-                return Some((
-                    "STOP_LOSS".to_string(),
-                    format!(
-                        "Hard stop hit: {:.1}% executable loss (limit: -{:.1}%)",
-                        exec_pnl, config.hard_stop_loss_pct
-                    ),
-                ));
             }
         }
 
-        // 2. Take Profit - lock in gains (only after min hold to avoid wrong-pool price spike)
-        if hold_secs >= config.take_profit_min_hold_secs && pnl >= config.take_profit_pct {
-            let (action, current_pnl, exec_pnl, rejection) = exit_action_for_price_signal(
-                self.entry_price,
-                self.highest_price,
-                self.current_price,
-                "TAKE_PROFIT",
-                config,
-                exit_quote,
-            );
-            if action == ExitPriceValidationAction::Suppress {
-                if let Some(q) = exit_quote
-                    .as_ref()
-                    .filter(|q| q.pool_sourced && q.tokens_per_sol > 0.0 && q.marks_position_pool)
-                {
-                    self.update_price(q.tokens_per_sol);
-                    pnl = self.pnl_pct();
-                    drawdown = self.drawdown_from_ath_pct();
-                }
-                if let Some(q) = exit_quote
-                    .as_ref()
-                    .filter(|q| q.pool_sourced && q.tokens_per_sol > 0.0)
-                {
-                    let ep = tokens_per_sol::pnl_pct(self.entry_price, q.tokens_per_sol);
-                    if ep <= -config.hard_stop_loss_pct {
+        // 2. Take profit — quote-first: executable gain must meet target after min hold.
+        if hold_secs >= config.take_profit_min_hold_secs {
+            if let Some(q) = valid_q {
+                let exec_pnl = tokens_per_sol::pnl_pct(self.entry_price, q.tokens_per_sol);
+                if exec_pnl >= config.take_profit_pct {
+                    let current_pnl = pnl;
+                    if suppress_price_exit_stale_aggressive_current(
+                        "TAKE_PROFIT",
+                        self.entry_price,
+                        self.highest_price,
+                        self.current_price,
+                        config,
+                        exec_pnl,
+                        q.tokens_per_sol,
+                    ) {
+                        if q.marks_position_pool {
+                            self.update_price(q.tokens_per_sol);
+                            pnl = self.pnl_pct();
+                        }
+                        debug!(
+                            mint = %self.mint,
+                            position_pool = %self.pool,
+                            quote_pool = %q.quote_pool,
+                            quote_dex = %q.quote_dex,
+                            entry_price = self.entry_price,
+                            current_price = self.current_price,
+                            executable_tokens_per_sol = q.tokens_per_sol,
+                            current_pnl_pct = %format!("{:.4}", current_pnl),
+                            executable_pnl_pct = %format!("{:.4}", exec_pnl),
+                            exit_type = "TAKE_PROFIT",
+                            decision = "suppress",
+                            reason = "STALE_AGGRESSIVE_CURRENT_VS_EXECUTABLE",
+                            "exit_signal_suppressed_stale_price"
+                        );
+                    } else {
+                        // #region agent log
+                        dbg_log(
+                            "momentum_bot.rs:should_exit_TAKE_PROFIT",
+                            "TAKE_PROFIT trigger - capturing pnl inputs",
+                            serde_json::json!({
+                                "mint": self.mint,
+                                "entry_price": self.entry_price,
+                                "current_price": self.current_price,
+                                "highest_price": self.highest_price,
+                                "pnl_pct": pnl,
+                                "take_profit_pct": config.take_profit_pct,
+                                "ratio_entry_over_current": self.entry_price / self.current_price
+                            }),
+                            "H-ALL",
+                        );
+                        // #endregion
+                        info!(
+                            mint = %self.mint,
+                            position_pool = %self.pool,
+                            quote_pool = %q.quote_pool,
+                            quote_dex = %q.quote_dex,
+                            entry_price = self.entry_price,
+                            current_price = self.current_price,
+                            executable_tokens_per_sol = q.tokens_per_sol,
+                            current_pnl_pct = %format!("{:.4}", current_pnl),
+                            executable_pnl_pct = %format!("{:.4}", exec_pnl),
+                            exit_type = "TAKE_PROFIT",
+                            "TAKE_PROFIT trigger (quote-first executable reserve PnL)"
+                        );
                         return Some((
-                            "STOP_LOSS".to_string(),
+                            "TAKE_PROFIT".to_string(),
                             format!(
-                                "Hard stop hit: {:.1}% executable loss (limit: -{:.1}%)",
-                                ep, config.hard_stop_loss_pct
+                                "Take profit hit: +{:.1}% executable gain (target: +{:.1}%)",
+                                exec_pnl, config.take_profit_pct
                             ),
                         ));
                     }
                 }
-                warn!(
+            } else if pnl >= config.take_profit_pct {
+                debug!(
                     mint = %self.mint,
                     position_pool = %self.pool,
-                    entry_price = self.entry_price,
-                    current_price = self.current_price,
-                    executable_tokens_per_sol = ?exit_quote.map(|q| q.tokens_per_sol),
-                    current_pnl_pct = %format!("{:.4}", current_pnl),
-                    executable_pnl_pct = %format!("{:.4}", exec_pnl),
-                    exit_type_original = "TAKE_PROFIT",
-                    decision = "suppress",
-                    ?rejection,
-                    "exit_signal_suppressed_stale_price"
+                    reason = "NO_EXECUTABLE_QUOTE",
+                    current_pnl_pct = %format!("{:.4}", pnl),
+                    "price_exit_skipped_no_executable_quote"
                 );
-            } else {
-                // #region agent log
-                dbg_log(
-                    "momentum_bot.rs:should_exit_TAKE_PROFIT",
-                    "TAKE_PROFIT trigger - capturing pnl inputs",
-                    serde_json::json!({
-                        "mint": self.mint,
-                        "entry_price": self.entry_price,
-                        "current_price": self.current_price,
-                        "highest_price": self.highest_price,
-                        "pnl_pct": pnl,
-                        "take_profit_pct": config.take_profit_pct,
-                        "ratio_entry_over_current": self.entry_price / self.current_price
-                    }),
-                    "H-ALL",
-                );
-                // #endregion
-                info!(
-                    mint = %self.mint,
-                    position_pool = %self.pool,
-                    entry_price = self.entry_price,
-                    current_price = self.current_price,
-                    executable_tokens_per_sol = ?exit_quote.map(|q| q.tokens_per_sol),
-                    current_pnl_pct = %format!("{:.4}", current_pnl),
-                    executable_pnl_pct = %format!("{:.4}", exec_pnl),
-                    exit_type_original = "TAKE_PROFIT",
-                    decision = "allow",
-                    "TAKE_PROFIT trigger (exit price validated against pool quote when available)"
-                );
-                return Some((
-                    "TAKE_PROFIT".to_string(),
-                    format!(
-                        "Take profit hit: +{:.1}% executable gain (target: +{:.1}%)",
-                        exec_pnl, config.take_profit_pct
-                    ),
-                ));
             }
         }
 
@@ -1155,71 +1104,90 @@ impl PositionTracker {
             }
         }
 
-        // 3. Trailing Stop - activate after profit threshold
-        if pnl >= config.trailing_activation_pct {
+        // 3. Trailing stop — quote-first drawdown vs ATH when a usable executable exists (I-13, I-14).
+        if let Some(q) = valid_q {
+            if q.marks_position_pool {
+                self.highest_price =
+                    tokens_per_sol::updated_highest_price(self.highest_price, q.tokens_per_sol);
+            }
+        }
+
+        let activation_pnl = valid_q
+            .map(|q| tokens_per_sol::pnl_pct(self.entry_price, q.tokens_per_sol))
+            .unwrap_or(pnl);
+        if activation_pnl >= config.trailing_activation_pct {
             self.trailing_active = true;
         }
 
-        if self.trailing_active && drawdown >= config.trailing_stop_pct {
-            let (action, current_pnl, exec_pnl, rejection) = exit_action_for_price_signal(
-                self.entry_price,
-                self.highest_price,
-                self.current_price,
-                "TRAILING_STOP",
-                config,
-                exit_quote,
-            );
-            if action == ExitPriceValidationAction::Suppress {
-                if let Some(q) = exit_quote
-                    .as_ref()
-                    .filter(|q| q.pool_sourced && q.tokens_per_sol > 0.0 && q.marks_position_pool)
-                {
-                    self.update_price(q.tokens_per_sol);
-                    pnl = self.pnl_pct();
-                    drawdown = self.drawdown_from_ath_pct();
-                    let _ = drawdown;
+        if self.trailing_active {
+            if let Some(q) = valid_q {
+                let exec_dd =
+                    tokens_per_sol::drawdown_from_ath_pct(self.highest_price, q.tokens_per_sol);
+                if exec_dd >= config.trailing_stop_pct {
+                    let exec_pnl = tokens_per_sol::pnl_pct(self.entry_price, q.tokens_per_sol);
+                    let current_pnl = pnl;
+                    if suppress_price_exit_stale_aggressive_current(
+                        "TRAILING_STOP",
+                        self.entry_price,
+                        self.highest_price,
+                        self.current_price,
+                        config,
+                        exec_pnl,
+                        q.tokens_per_sol,
+                    ) {
+                        if q.marks_position_pool {
+                            self.update_price(q.tokens_per_sol);
+                            pnl = self.pnl_pct();
+                        }
+                        debug!(
+                            mint = %self.mint,
+                            position_pool = %self.pool,
+                            quote_pool = %q.quote_pool,
+                            quote_dex = %q.quote_dex,
+                            entry_price = self.entry_price,
+                            current_price = self.current_price,
+                            executable_tokens_per_sol = q.tokens_per_sol,
+                            current_pnl_pct = %format!("{:.4}", current_pnl),
+                            executable_pnl_pct = %format!("{:.4}", exec_pnl),
+                            exit_type = "TRAILING_STOP",
+                            decision = "suppress",
+                            reason = "STALE_AGGRESSIVE_CURRENT_VS_EXECUTABLE",
+                            "exit_signal_suppressed_stale_price"
+                        );
+                    } else {
+                        info!(
+                            mint = %self.mint,
+                            position_pool = %self.pool,
+                            quote_pool = %q.quote_pool,
+                            quote_dex = %q.quote_dex,
+                            entry_price = self.entry_price,
+                            current_price = self.current_price,
+                            executable_tokens_per_sol = q.tokens_per_sol,
+                            current_pnl_pct = %format!("{:.4}", current_pnl),
+                            executable_pnl_pct = %format!("{:.4}", exec_pnl),
+                            exit_type = "TRAILING_STOP",
+                            "TRAILING_STOP trigger (quote-first executable drawdown)"
+                        );
+                        return Some((
+                            "TRAILING_STOP".to_string(),
+                            format!(
+                                "Trailing stop hit: -{:.1}% executable drawdown from ATH (limit: -{:.1}%), executable P&L: {:.1}%",
+                                exec_dd, config.trailing_stop_pct, exec_pnl
+                            ),
+                        ));
+                    }
                 }
-                warn!(
-                    mint = %self.mint,
-                    position_pool = %self.pool,
-                    entry_price = self.entry_price,
-                    current_price = self.current_price,
-                    executable_tokens_per_sol = ?exit_quote.map(|q| q.tokens_per_sol),
-                    current_pnl_pct = %format!("{:.4}", current_pnl),
-                    executable_pnl_pct = %format!("{:.4}", exec_pnl),
-                    exit_type_original = "TRAILING_STOP",
-                    decision = "suppress",
-                    ?rejection,
-                    "exit_signal_suppressed_stale_price"
-                );
             } else {
-                info!(
-                    mint = %self.mint,
-                    position_pool = %self.pool,
-                    entry_price = self.entry_price,
-                    current_price = self.current_price,
-                    executable_tokens_per_sol = ?exit_quote.map(|q| q.tokens_per_sol),
-                    current_pnl_pct = %format!("{:.4}", current_pnl),
-                    executable_pnl_pct = %format!("{:.4}", exec_pnl),
-                    exit_type_original = "TRAILING_STOP",
-                    decision = "allow",
-                    "TRAILING_STOP trigger (exit price validated against pool quote when available)"
-                );
-                let q_exec = exit_quote
-                    .as_ref()
-                    .expect("TRAILING_STOP allow implies executable quote");
-                let exec_dd = tokens_per_sol::drawdown_from_ath_pct(
-                    self.highest_price,
-                    q_exec.tokens_per_sol,
-                );
-                let exec_pnl_tr = tokens_per_sol::pnl_pct(self.entry_price, q_exec.tokens_per_sol);
-                return Some((
-                    "TRAILING_STOP".to_string(),
-                    format!(
-                        "Trailing stop hit: -{:.1}% executable drawdown from ATH (limit: -{:.1}%), executable P&L: {:.1}%",
-                        exec_dd, config.trailing_stop_pct, exec_pnl_tr
-                    ),
-                ));
+                let drawdown = self.drawdown_from_ath_pct();
+                if drawdown >= config.trailing_stop_pct {
+                    debug!(
+                        mint = %self.mint,
+                        position_pool = %self.pool,
+                        reason = "NO_EXECUTABLE_QUOTE",
+                        current_drawdown_pct = %format!("{:.4}", drawdown),
+                        "trailing_stop_skipped_no_executable_quote"
+                    );
+                }
             }
         }
 
@@ -12598,6 +12566,57 @@ mod tests {
         );
     }
 
+    /// Quote-first: executable reserve shows deep loss while `current_price` mark is only mildly off.
+    #[test]
+    fn stop_loss_quote_first_fires_on_executable_even_if_current_pnl_mild() {
+        let mut c = make_exit_config();
+        c.hard_stop_loss_pct = 20.0;
+        c.take_profit_pct = 1_000.0;
+        let entry = 100.0;
+        let mut pos = PositionTracker::new("m", "p", "dex", entry, 6, 1_000_000, 0);
+        pos.current_price = 110.0; // ~-9.1% PnL vs entry
+        pos.highest_price = entry;
+        let ex = sample_exit_quote(250.0); // executable ~-150% loss
+        let (ty, _) = pos.should_exit(&c, Some(&ex)).expect("STOP_LOSS");
+        assert_eq!(ty, "STOP_LOSS");
+    }
+
+    /// Quote-first: `current_price` looks past hard stop but executable is better — do not exit.
+    #[test]
+    fn stop_loss_not_fired_when_only_current_pnl_past_stop_executable_disagrees() {
+        let mut c = make_exit_config();
+        c.hard_stop_loss_pct = 20.0;
+        c.take_profit_pct = 1_000.0;
+        let entry = 100.0;
+        let mut pos = PositionTracker::new("m", "p", "dex", entry, 6, 1_000_000, 0);
+        pos.current_price = 300.0; // mark looks like huge loss
+        pos.highest_price = entry;
+        let ex = sample_exit_quote(105.0); // executable only mild loss vs -20% threshold
+        assert!(pos.should_exit(&c, Some(&ex)).is_none());
+    }
+
+    /// Wrong-pool executable may still drive STOP decision but must not overwrite `current_price` (I-13).
+    #[test]
+    fn stop_loss_wrong_pool_executable_does_not_update_current_price() {
+        let mut c = make_exit_config();
+        c.hard_stop_loss_pct = 20.0;
+        c.take_profit_pct = 1_000.0;
+        let entry = 100.0;
+        let mut pos = PositionTracker::new("m", "pos_pool", "dex", entry, 6, 1_000_000, 0);
+        pos.current_price = 110.0;
+        pos.highest_price = entry;
+        let mut ex = sample_exit_quote(250.0);
+        ex.marks_position_pool = false;
+        ex.quote_pool = "other_pool".to_string();
+        let before = pos.current_price;
+        let (ty, _) = pos.should_exit(&c, Some(&ex)).expect("STOP_LOSS");
+        assert_eq!(ty, "STOP_LOSS");
+        assert_eq!(
+            pos.current_price, before,
+            "alternate-pool quote must not refresh mark"
+        );
+    }
+
     /// TP: `current` shows gain but no pool quote to confirm (or would disagree) → no TP
     #[test]
     fn take_profit_not_allowed_from_stale_or_unvalidated_quote() {
@@ -12623,6 +12642,27 @@ mod tests {
         assert!(r1.is_none(), "expected TP suppression, got {:?}", r1);
     }
 
+    /// Quote-first: executable shows take-profit even when `current_price` has not crossed.
+    #[test]
+    fn take_profit_fires_from_executable_quote_when_hold_met() {
+        let mut c = make_exit_config();
+        c.take_profit_pct = 20.0;
+        c.take_profit_min_hold_secs = 0;
+        c.hard_stop_loss_pct = 200.0;
+        let entry = 100.0;
+        let mut pos = PositionTracker::new("m", "p", "dex", entry, 6, 1_000_000, 0);
+        pos.current_price = 130.0; // mark-only loss vs entry
+        pos.highest_price = entry;
+        let ex = sample_exit_quote(40.0); // executable large gain vs entry
+        let (ty, reason) = pos.should_exit(&c, Some(&ex)).expect("TAKE_PROFIT");
+        assert_eq!(ty, "TAKE_PROFIT");
+        assert!(
+            reason.contains("executable"),
+            "reason should reflect executable: {}",
+            reason
+        );
+    }
+
     #[test]
     fn time_exit_still_allowed_without_price_validation() {
         let c = make_exit_config();
@@ -12638,6 +12678,22 @@ mod tests {
             reason.contains("Max hold time exceeded")
                 && !reason.to_lowercase().contains("hard stop"),
             "TIME_EXIT should not be framed as hard stop: {}",
+            reason
+        );
+    }
+
+    #[test]
+    fn time_exit_reporting_pnl_uses_executable_when_quote_valid() {
+        let c = make_exit_config();
+        let entry = 100.0;
+        let mut pos = PositionTracker::new("m", "p", "dex", entry, 6, 1_000_000, 0);
+        pos.set_entry_time_ago(Duration::from_secs(c.max_hold_time_secs + 1));
+        pos.current_price = entry;
+        let ex = sample_exit_quote(80.0);
+        let (_, reason) = pos.should_exit(&c, Some(&ex)).expect("time exit");
+        assert!(
+            reason.contains("25.0%") || reason.contains("25.0"),
+            "expected executable-backed reporting PnL in reason: {}",
             reason
         );
     }

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -592,9 +592,11 @@ fn exit_executable_quote_is_usable(q: &ExitExecutableQuote) -> bool {
     q.pool_sourced && q.tokens_per_sol > 0.0 && q.tokens_per_sol.is_finite()
 }
 
-/// When a **valid** executable quote exists: suppress firing because `current_price` is more
-/// aggressive than the executable (trade spike / stale mark), but the pool quote disagrees.
-/// Quote-first triggers call this only after the executable condition for that exit is met.
+/// When a **valid** executable quote exists and the caller already determined the executable
+/// exit threshold is met (quote-first): suppress only when **both** mark and executable breach
+/// the same band, and the executable is **more extreme** than the mark (reserve looks worse /
+/// more aggressive than mark-to-market). If the mark is still inside the band, quote-first
+/// intentionally still exits on the executable alone (see tests).
 fn suppress_price_exit_stale_aggressive_current(
     exit_type: &str,
     entry_price: f64,
@@ -610,11 +612,19 @@ fn suppress_price_exit_stale_aggressive_current(
 
     match exit_type {
         "STOP_LOSS" => {
-            current_pnl <= -config.hard_stop_loss_pct && exec_pnl > -config.hard_stop_loss_pct
+            current_pnl <= -config.hard_stop_loss_pct
+                && exec_pnl <= -config.hard_stop_loss_pct
+                && exec_pnl < current_pnl
         }
-        "TAKE_PROFIT" => current_pnl >= config.take_profit_pct && exec_pnl < config.take_profit_pct,
+        "TAKE_PROFIT" => {
+            current_pnl >= config.take_profit_pct
+                && exec_pnl >= config.take_profit_pct
+                && exec_pnl > current_pnl
+        }
         "TRAILING_STOP" => {
-            current_dd >= config.trailing_stop_pct && exec_dd < config.trailing_stop_pct
+            current_dd >= config.trailing_stop_pct
+                && exec_dd >= config.trailing_stop_pct
+                && exec_dd > current_dd
         }
         _ => false,
     }

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -920,24 +920,26 @@ impl PositionTracker {
                     ),
                 ));
             }
-        } else if let Some(q) = exit_quote {
-            // `valid_q` is None but a quote exists → not pool-sourced / non-finite / otherwise unusable.
-            debug!(
-                mint = %self.mint,
-                position_pool = %self.pool,
-                reason = "UNUSABLE_EXECUTABLE_QUOTE",
-                pool_sourced = q.pool_sourced,
-                tokens_per_sol = q.tokens_per_sol,
-                "price_exit_skipped_unusable_executable_quote"
-            );
         } else if pnl <= -config.hard_stop_loss_pct {
-            debug!(
-                mint = %self.mint,
-                position_pool = %self.pool,
-                reason = "NO_EXECUTABLE_QUOTE",
-                current_pnl_pct = %format!("{:.4}", pnl),
-                "price_exit_skipped_no_executable_quote"
-            );
+            if let Some(q) = exit_quote {
+                // `valid_q` is None but a quote exists → not pool-sourced / non-finite / otherwise unusable.
+                debug!(
+                    mint = %self.mint,
+                    position_pool = %self.pool,
+                    reason = "UNUSABLE_EXECUTABLE_QUOTE",
+                    pool_sourced = q.pool_sourced,
+                    tokens_per_sol = q.tokens_per_sol,
+                    "price_exit_skipped_unusable_executable_quote"
+                );
+            } else {
+                debug!(
+                    mint = %self.mint,
+                    position_pool = %self.pool,
+                    reason = "NO_EXECUTABLE_QUOTE",
+                    current_pnl_pct = %format!("{:.4}", pnl),
+                    "price_exit_skipped_no_executable_quote"
+                );
+            }
         }
 
         // 2. Take profit — quote-first: executable gain must meet target after min hold.

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -880,6 +880,7 @@ impl PositionTracker {
     /// Quote-first (price exits): `STOP_LOSS`, `TAKE_PROFIT`, and `TRAILING_STOP` trigger from a
     /// **usable** executable reserve quote when present. `current_price` alone never trips these;
     /// there is no secondary “stale mark” suppression on those quote-first paths.
+    /// `TRAILING_STOP` evaluates executable drawdown only when `marks_position_pool` (I-13).
     fn should_exit(
         &mut self,
         config: &MomentumConfig,
@@ -1038,7 +1039,9 @@ impl PositionTracker {
             }
         }
 
+        // Trailing activation: executable PnL only when quote marks position pool (I-13).
         let activation_pnl = valid_q
+            .filter(|q| q.marks_position_pool)
             .map(|q| tokens_per_sol::pnl_pct(self.entry_price, q.tokens_per_sol))
             .unwrap_or(pnl);
         if activation_pnl >= config.trailing_activation_pct {
@@ -1047,30 +1050,47 @@ impl PositionTracker {
 
         if self.trailing_active {
             if let Some(q) = valid_q {
-                let exec_dd =
-                    tokens_per_sol::drawdown_from_ath_pct(self.highest_price, q.tokens_per_sol);
-                if exec_dd >= config.trailing_stop_pct {
-                    let exec_pnl = tokens_per_sol::pnl_pct(self.entry_price, q.tokens_per_sol);
-                    info!(
-                        mint = %self.mint,
-                        position_pool = %self.pool,
-                        quote_pool = %q.quote_pool,
-                        quote_dex = %q.quote_dex,
-                        entry_price = self.entry_price,
-                        current_price = self.current_price,
-                        executable_tokens_per_sol = q.tokens_per_sol,
-                        current_pnl_pct = %format!("{:.4}", pnl),
-                        executable_pnl_pct = %format!("{:.4}", exec_pnl),
-                        exit_type = "TRAILING_STOP",
-                        "TRAILING_STOP trigger (quote-first executable drawdown)"
-                    );
-                    return Some((
-                        "TRAILING_STOP".to_string(),
-                        format!(
-                            "Trailing stop hit: -{:.1}% executable drawdown from ATH (limit: -{:.1}%), executable P&L: {:.1}%",
-                            exec_dd, config.trailing_stop_pct, exec_pnl
-                        ),
-                    ));
+                if !q.marks_position_pool {
+                    let exec_dd =
+                        tokens_per_sol::drawdown_from_ath_pct(self.highest_price, q.tokens_per_sol);
+                    if exec_dd >= config.trailing_stop_pct {
+                        debug!(
+                            mint = %self.mint,
+                            position_pool = %self.pool,
+                            quote_pool = %q.quote_pool,
+                            quote_dex = %q.quote_dex,
+                            reason = "TRAILING_STOP_SKIPPED_QUOTE_NOT_POSITION_POOL",
+                            executable_drawdown_pct = %format!("{:.4}", exec_dd),
+                            trailing_stop_pct = config.trailing_stop_pct,
+                            "trailing_stop_skipped_alternate_pool_quote"
+                        );
+                    }
+                } else {
+                    let exec_dd =
+                        tokens_per_sol::drawdown_from_ath_pct(self.highest_price, q.tokens_per_sol);
+                    if exec_dd >= config.trailing_stop_pct {
+                        let exec_pnl = tokens_per_sol::pnl_pct(self.entry_price, q.tokens_per_sol);
+                        info!(
+                            mint = %self.mint,
+                            position_pool = %self.pool,
+                            quote_pool = %q.quote_pool,
+                            quote_dex = %q.quote_dex,
+                            entry_price = self.entry_price,
+                            current_price = self.current_price,
+                            executable_tokens_per_sol = q.tokens_per_sol,
+                            current_pnl_pct = %format!("{:.4}", pnl),
+                            executable_pnl_pct = %format!("{:.4}", exec_pnl),
+                            exit_type = "TRAILING_STOP",
+                            "TRAILING_STOP trigger (quote-first executable drawdown)"
+                        );
+                        return Some((
+                            "TRAILING_STOP".to_string(),
+                            format!(
+                                "Trailing stop hit: -{:.1}% executable drawdown from ATH (limit: -{:.1}%), executable P&L: {:.1}%",
+                                exec_dd, config.trailing_stop_pct, exec_pnl
+                            ),
+                        ));
+                    }
                 }
             } else {
                 let drawdown = self.drawdown_from_ath_pct();
@@ -12386,7 +12406,7 @@ mod tests {
         assert_eq!(got[0], pool);
     }
 
-    // --- Exit price validation (stale `current_price` vs pool executable quote) ---
+    // --- Quote-first price exits (ExitExecutableQuote, I-13 pool context) ---
 
     fn make_exit_config() -> MomentumConfig {
         let mut c = MomentumConfig::default();
@@ -12411,9 +12431,9 @@ mod tests {
         }
     }
 
-    /// Production-like: stale tps would trip hard stop, executable tps is profitable.
+    /// Production-like: bad mark would look stopped out; executable shows gain — no STOP (quote-first).
     #[test]
-    fn hard_stop_suppressed_when_executable_quote_profitable() {
+    fn hard_stop_not_fired_when_executable_profitable_despite_bad_mark() {
         let mut c = make_exit_config();
         c.hard_stop_loss_pct = 50.0; // "Hard stop" threshold includes -50.3% class
 
@@ -12425,7 +12445,11 @@ mod tests {
         // Exec ~3,692,386 tps → pnl = (5.7M/3.7M-1)*100 = +~55% (I-14)
         let ex = sample_exit_quote(3_692_386.0);
         let r = pos.should_exit(&c, Some(&ex));
-        assert!(r.is_none(), "expected STOP_LOSS suppression, got {:?}", r);
+        assert!(
+            r.is_none(),
+            "expected no STOP_LOSS when executable is not past threshold, got {:?}",
+            r
+        );
     }
 
     #[test]
@@ -12510,6 +12534,49 @@ mod tests {
             pos.current_price, before,
             "alternate-pool quote must not refresh mark"
         );
+    }
+
+    /// I-13: alternate-pool executable must not drive TRAILING_STOP vs position-pool ATH.
+    #[test]
+    fn trailing_stop_skipped_when_executable_quote_not_position_pool() {
+        let mut c = make_exit_config();
+        c.trailing_stop_pct = 15.0;
+        c.trailing_activation_pct = 1.0;
+        c.hard_stop_loss_pct = 99.0;
+        c.take_profit_pct = 1_000.0;
+        let entry = 100.0;
+        let mut pos = PositionTracker::new("m", "pos_pool", "dex", entry, 6, 1_000_000, 0);
+        pos.trailing_active = true;
+        pos.highest_price = entry;
+        pos.current_price = 102.0;
+        let mut ex = sample_exit_quote(250.0);
+        ex.marks_position_pool = false;
+        ex.quote_pool = "other_pool".to_string();
+        assert!(
+            pos.should_exit(&c, Some(&ex)).is_none(),
+            "wrong-pool executable must not trip TRAILING vs position ATH"
+        );
+    }
+
+    #[test]
+    fn trailing_stop_fires_when_position_pool_executable_drawdown_exceeds_limit() {
+        let mut c = make_exit_config();
+        c.trailing_stop_pct = 15.0;
+        c.trailing_activation_pct = 1.0;
+        c.hard_stop_loss_pct = 99.0;
+        c.take_profit_pct = 1_000.0;
+        let entry = 100.0;
+        let mut pos = PositionTracker::new("m", "pos_pool", "dex", entry, 6, 1_000_000, 0);
+        pos.trailing_active = true;
+        pos.highest_price = entry;
+        pos.current_price = 102.0;
+        let mut ex = sample_exit_quote(250.0);
+        ex.marks_position_pool = true;
+        ex.quote_pool = "pos_pool".to_string();
+        let (ty, _) = pos
+            .should_exit(&c, Some(&ex))
+            .expect("TRAILING_STOP from position-pool quote");
+        assert_eq!(ty, "TRAILING_STOP");
     }
 
     /// TP: `current` shows gain but no pool quote to confirm (or would disagree) → no TP

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -920,6 +920,16 @@ impl PositionTracker {
                     ),
                 ));
             }
+        } else if let Some(q) = exit_quote {
+            // `valid_q` is None but a quote exists → not pool-sourced / non-finite / otherwise unusable.
+            debug!(
+                mint = %self.mint,
+                position_pool = %self.pool,
+                reason = "UNUSABLE_EXECUTABLE_QUOTE",
+                pool_sourced = q.pool_sourced,
+                tokens_per_sol = q.tokens_per_sol,
+                "price_exit_skipped_unusable_executable_quote"
+            );
         } else if pnl <= -config.hard_stop_loss_pct {
             debug!(
                 mint = %self.mint,
@@ -928,17 +938,6 @@ impl PositionTracker {
                 current_pnl_pct = %format!("{:.4}", pnl),
                 "price_exit_skipped_no_executable_quote"
             );
-        } else if let Some(q) = exit_quote {
-            if !exit_executable_quote_is_usable(q) {
-                debug!(
-                    mint = %self.mint,
-                    position_pool = %self.pool,
-                    reason = "UNUSABLE_EXECUTABLE_QUOTE",
-                    pool_sourced = q.pool_sourced,
-                    tokens_per_sol = q.tokens_per_sol,
-                    "price_exit_skipped_unusable_executable_quote"
-                );
-            }
         }
 
         // 2. Take profit — quote-first: executable gain must meet target after min hold.
@@ -984,13 +983,25 @@ impl PositionTracker {
                     ));
                 }
             } else if pnl >= config.take_profit_pct {
-                debug!(
-                    mint = %self.mint,
-                    position_pool = %self.pool,
-                    reason = "NO_EXECUTABLE_QUOTE",
-                    current_pnl_pct = %format!("{:.4}", pnl),
-                    "price_exit_skipped_no_executable_quote"
-                );
+                if let Some(q) = exit_quote {
+                    // Mark at target but no usable executable quote — distinguish missing vs unusable.
+                    debug!(
+                        mint = %self.mint,
+                        position_pool = %self.pool,
+                        reason = "UNUSABLE_EXECUTABLE_QUOTE",
+                        pool_sourced = q.pool_sourced,
+                        tokens_per_sol = q.tokens_per_sol,
+                        "price_exit_skipped_unusable_executable_quote"
+                    );
+                } else {
+                    debug!(
+                        mint = %self.mint,
+                        position_pool = %self.pool,
+                        reason = "NO_EXECUTABLE_QUOTE",
+                        current_pnl_pct = %format!("{:.4}", pnl),
+                        "price_exit_skipped_no_executable_quote"
+                    );
+                }
             }
         }
 

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -568,8 +568,10 @@ struct PositionTracker {
 /// I-7: from LivePoolCache in-process only — no RPC.
 /// I-13: If `marks_position_pool` is false (e.g. PumpSwap quote while position.pool is still PumpFun BC),
 /// this quote is only for exit decisions — never apply `tokens_per_sol` as `current_price` on the position.
-/// Price exits (`STOP_LOSS` / `TAKE_PROFIT` / `TRAILING_STOP`) are **quote-first**: they trigger from a
-/// usable executable quote when present; they do not use `current_price` alone (see `should_exit`).
+/// Price exits (`STOP_LOSS` / `TAKE_PROFIT` / `TRAILING_STOP`) are **quote-first**: they trigger only
+/// from a usable executable reserve quote when present. **Current-price-only** triggers for these
+/// exits are disabled — `current_price` may diverge from the executable for logging and reporting,
+/// but it is not a trigger source (see `should_exit`).
 #[derive(Debug, Clone)]
 struct ExitExecutableQuote {
     /// tokens_per_sol (UI): token_ui / sol_ui, matching `entry_price` / `current_price` (I-14).
@@ -590,44 +592,6 @@ struct ExitExecutableQuote {
 #[inline]
 fn exit_executable_quote_is_usable(q: &ExitExecutableQuote) -> bool {
     q.pool_sourced && q.tokens_per_sol > 0.0 && q.tokens_per_sol.is_finite()
-}
-
-/// When a **valid** executable quote exists and the caller already determined the executable
-/// exit threshold is met (quote-first): suppress only when **both** mark and executable breach
-/// the same band, and the executable is **more extreme** than the mark (reserve looks worse /
-/// more aggressive than mark-to-market). If the mark is still inside the band, quote-first
-/// intentionally still exits on the executable alone (see tests).
-fn suppress_price_exit_stale_aggressive_current(
-    exit_type: &str,
-    entry_price: f64,
-    highest_price: f64,
-    current_price: f64,
-    config: &MomentumConfig,
-    exec_pnl: f64,
-    exec_tokens_per_sol: f64,
-) -> bool {
-    let current_pnl = tokens_per_sol::pnl_pct(entry_price, current_price);
-    let current_dd = tokens_per_sol::drawdown_from_ath_pct(highest_price, current_price);
-    let exec_dd = tokens_per_sol::drawdown_from_ath_pct(highest_price, exec_tokens_per_sol);
-
-    match exit_type {
-        "STOP_LOSS" => {
-            current_pnl <= -config.hard_stop_loss_pct
-                && exec_pnl <= -config.hard_stop_loss_pct
-                && exec_pnl < current_pnl
-        }
-        "TAKE_PROFIT" => {
-            current_pnl >= config.take_profit_pct
-                && exec_pnl >= config.take_profit_pct
-                && exec_pnl > current_pnl
-        }
-        "TRAILING_STOP" => {
-            current_dd >= config.trailing_stop_pct
-                && exec_dd >= config.trailing_stop_pct
-                && exec_dd > current_dd
-        }
-        _ => false,
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -914,7 +878,8 @@ impl PositionTracker {
     /// `token_amount` from `LivePoolCache` (I-7: no RPC).
     ///
     /// Quote-first (price exits): `STOP_LOSS`, `TAKE_PROFIT`, and `TRAILING_STOP` trigger from a
-    /// **usable** executable reserve quote when present; `current_price` alone never trips these.
+    /// **usable** executable reserve quote when present. `current_price` alone never trips these;
+    /// there is no secondary “stale mark” suppression on those quote-first paths.
     fn should_exit(
         &mut self,
         config: &MomentumConfig,
@@ -923,7 +888,7 @@ impl PositionTracker {
         // Returns: Some((exit_type, reason)) or None
 
         let valid_q = exit_quote.filter(|q| exit_executable_quote_is_usable(q));
-        let mut pnl = self.pnl_pct();
+        let pnl = self.pnl_pct();
         let hold_secs = self.entry_time.elapsed().as_secs();
 
         let pnl_for_reporting = valid_q
@@ -934,57 +899,26 @@ impl PositionTracker {
         if let Some(q) = valid_q {
             let exec_pnl = tokens_per_sol::pnl_pct(self.entry_price, q.tokens_per_sol);
             if exec_pnl <= -config.hard_stop_loss_pct {
-                let current_pnl = pnl;
-                if suppress_price_exit_stale_aggressive_current(
-                    "STOP_LOSS",
-                    self.entry_price,
-                    self.highest_price,
-                    self.current_price,
-                    config,
-                    exec_pnl,
-                    q.tokens_per_sol,
-                ) {
-                    if q.marks_position_pool {
-                        self.update_price(q.tokens_per_sol);
-                        pnl = self.pnl_pct();
-                    }
-                    debug!(
-                        mint = %self.mint,
-                        position_pool = %self.pool,
-                        quote_pool = %q.quote_pool,
-                        quote_dex = %q.quote_dex,
-                        entry_price = self.entry_price,
-                        current_price = self.current_price,
-                        executable_tokens_per_sol = q.tokens_per_sol,
-                        current_pnl_pct = %format!("{:.4}", current_pnl),
-                        executable_pnl_pct = %format!("{:.4}", exec_pnl),
-                        exit_type = "STOP_LOSS",
-                        decision = "suppress",
-                        reason = "STALE_AGGRESSIVE_CURRENT_VS_EXECUTABLE",
-                        "exit_signal_suppressed_stale_price"
-                    );
-                } else {
-                    info!(
-                        mint = %self.mint,
-                        position_pool = %self.pool,
-                        quote_pool = %q.quote_pool,
-                        quote_dex = %q.quote_dex,
-                        entry_price = self.entry_price,
-                        current_price = self.current_price,
-                        executable_tokens_per_sol = q.tokens_per_sol,
-                        current_pnl_pct = %format!("{:.4}", current_pnl),
-                        executable_pnl_pct = %format!("{:.4}", exec_pnl),
-                        exit_type = "STOP_LOSS",
-                        "STOP_LOSS trigger (quote-first executable reserve PnL)"
-                    );
-                    return Some((
-                        "STOP_LOSS".to_string(),
-                        format!(
-                            "Hard stop hit: {:.1}% executable loss (limit: -{:.1}%)",
-                            exec_pnl, config.hard_stop_loss_pct
-                        ),
-                    ));
-                }
+                info!(
+                    mint = %self.mint,
+                    position_pool = %self.pool,
+                    quote_pool = %q.quote_pool,
+                    quote_dex = %q.quote_dex,
+                    entry_price = self.entry_price,
+                    current_price = self.current_price,
+                    executable_tokens_per_sol = q.tokens_per_sol,
+                    current_pnl_pct = %format!("{:.4}", pnl),
+                    executable_pnl_pct = %format!("{:.4}", exec_pnl),
+                    exit_type = "STOP_LOSS",
+                    "STOP_LOSS trigger (quote-first executable reserve PnL)"
+                );
+                return Some((
+                    "STOP_LOSS".to_string(),
+                    format!(
+                        "Hard stop hit: {:.1}% executable loss (limit: -{:.1}%)",
+                        exec_pnl, config.hard_stop_loss_pct
+                    ),
+                ));
             }
         } else if pnl <= -config.hard_stop_loss_pct {
             debug!(
@@ -1012,73 +946,42 @@ impl PositionTracker {
             if let Some(q) = valid_q {
                 let exec_pnl = tokens_per_sol::pnl_pct(self.entry_price, q.tokens_per_sol);
                 if exec_pnl >= config.take_profit_pct {
-                    let current_pnl = pnl;
-                    if suppress_price_exit_stale_aggressive_current(
-                        "TAKE_PROFIT",
-                        self.entry_price,
-                        self.highest_price,
-                        self.current_price,
-                        config,
-                        exec_pnl,
-                        q.tokens_per_sol,
-                    ) {
-                        if q.marks_position_pool {
-                            self.update_price(q.tokens_per_sol);
-                            pnl = self.pnl_pct();
-                        }
-                        debug!(
-                            mint = %self.mint,
-                            position_pool = %self.pool,
-                            quote_pool = %q.quote_pool,
-                            quote_dex = %q.quote_dex,
-                            entry_price = self.entry_price,
-                            current_price = self.current_price,
-                            executable_tokens_per_sol = q.tokens_per_sol,
-                            current_pnl_pct = %format!("{:.4}", current_pnl),
-                            executable_pnl_pct = %format!("{:.4}", exec_pnl),
-                            exit_type = "TAKE_PROFIT",
-                            decision = "suppress",
-                            reason = "STALE_AGGRESSIVE_CURRENT_VS_EXECUTABLE",
-                            "exit_signal_suppressed_stale_price"
-                        );
-                    } else {
-                        // #region agent log
-                        dbg_log(
-                            "momentum_bot.rs:should_exit_TAKE_PROFIT",
-                            "TAKE_PROFIT trigger - capturing pnl inputs",
-                            serde_json::json!({
-                                "mint": self.mint,
-                                "entry_price": self.entry_price,
-                                "current_price": self.current_price,
-                                "highest_price": self.highest_price,
-                                "pnl_pct": pnl,
-                                "take_profit_pct": config.take_profit_pct,
-                                "ratio_entry_over_current": self.entry_price / self.current_price
-                            }),
-                            "H-ALL",
-                        );
-                        // #endregion
-                        info!(
-                            mint = %self.mint,
-                            position_pool = %self.pool,
-                            quote_pool = %q.quote_pool,
-                            quote_dex = %q.quote_dex,
-                            entry_price = self.entry_price,
-                            current_price = self.current_price,
-                            executable_tokens_per_sol = q.tokens_per_sol,
-                            current_pnl_pct = %format!("{:.4}", current_pnl),
-                            executable_pnl_pct = %format!("{:.4}", exec_pnl),
-                            exit_type = "TAKE_PROFIT",
-                            "TAKE_PROFIT trigger (quote-first executable reserve PnL)"
-                        );
-                        return Some((
-                            "TAKE_PROFIT".to_string(),
-                            format!(
-                                "Take profit hit: +{:.1}% executable gain (target: +{:.1}%)",
-                                exec_pnl, config.take_profit_pct
-                            ),
-                        ));
-                    }
+                    // #region agent log
+                    dbg_log(
+                        "momentum_bot.rs:should_exit_TAKE_PROFIT",
+                        "TAKE_PROFIT trigger - capturing pnl inputs",
+                        serde_json::json!({
+                            "mint": self.mint,
+                            "entry_price": self.entry_price,
+                            "current_price": self.current_price,
+                            "highest_price": self.highest_price,
+                            "pnl_pct": pnl,
+                            "take_profit_pct": config.take_profit_pct,
+                            "ratio_entry_over_current": self.entry_price / self.current_price
+                        }),
+                        "H-ALL",
+                    );
+                    // #endregion
+                    info!(
+                        mint = %self.mint,
+                        position_pool = %self.pool,
+                        quote_pool = %q.quote_pool,
+                        quote_dex = %q.quote_dex,
+                        entry_price = self.entry_price,
+                        current_price = self.current_price,
+                        executable_tokens_per_sol = q.tokens_per_sol,
+                        current_pnl_pct = %format!("{:.4}", pnl),
+                        executable_pnl_pct = %format!("{:.4}", exec_pnl),
+                        exit_type = "TAKE_PROFIT",
+                        "TAKE_PROFIT trigger (quote-first executable reserve PnL)"
+                    );
+                    return Some((
+                        "TAKE_PROFIT".to_string(),
+                        format!(
+                            "Take profit hit: +{:.1}% executable gain (target: +{:.1}%)",
+                            exec_pnl, config.take_profit_pct
+                        ),
+                    ));
                 }
             } else if pnl >= config.take_profit_pct {
                 debug!(
@@ -1135,57 +1038,26 @@ impl PositionTracker {
                     tokens_per_sol::drawdown_from_ath_pct(self.highest_price, q.tokens_per_sol);
                 if exec_dd >= config.trailing_stop_pct {
                     let exec_pnl = tokens_per_sol::pnl_pct(self.entry_price, q.tokens_per_sol);
-                    let current_pnl = pnl;
-                    if suppress_price_exit_stale_aggressive_current(
-                        "TRAILING_STOP",
-                        self.entry_price,
-                        self.highest_price,
-                        self.current_price,
-                        config,
-                        exec_pnl,
-                        q.tokens_per_sol,
-                    ) {
-                        if q.marks_position_pool {
-                            self.update_price(q.tokens_per_sol);
-                            pnl = self.pnl_pct();
-                        }
-                        debug!(
-                            mint = %self.mint,
-                            position_pool = %self.pool,
-                            quote_pool = %q.quote_pool,
-                            quote_dex = %q.quote_dex,
-                            entry_price = self.entry_price,
-                            current_price = self.current_price,
-                            executable_tokens_per_sol = q.tokens_per_sol,
-                            current_pnl_pct = %format!("{:.4}", current_pnl),
-                            executable_pnl_pct = %format!("{:.4}", exec_pnl),
-                            exit_type = "TRAILING_STOP",
-                            decision = "suppress",
-                            reason = "STALE_AGGRESSIVE_CURRENT_VS_EXECUTABLE",
-                            "exit_signal_suppressed_stale_price"
-                        );
-                    } else {
-                        info!(
-                            mint = %self.mint,
-                            position_pool = %self.pool,
-                            quote_pool = %q.quote_pool,
-                            quote_dex = %q.quote_dex,
-                            entry_price = self.entry_price,
-                            current_price = self.current_price,
-                            executable_tokens_per_sol = q.tokens_per_sol,
-                            current_pnl_pct = %format!("{:.4}", current_pnl),
-                            executable_pnl_pct = %format!("{:.4}", exec_pnl),
-                            exit_type = "TRAILING_STOP",
-                            "TRAILING_STOP trigger (quote-first executable drawdown)"
-                        );
-                        return Some((
-                            "TRAILING_STOP".to_string(),
-                            format!(
-                                "Trailing stop hit: -{:.1}% executable drawdown from ATH (limit: -{:.1}%), executable P&L: {:.1}%",
-                                exec_dd, config.trailing_stop_pct, exec_pnl
-                            ),
-                        ));
-                    }
+                    info!(
+                        mint = %self.mint,
+                        position_pool = %self.pool,
+                        quote_pool = %q.quote_pool,
+                        quote_dex = %q.quote_dex,
+                        entry_price = self.entry_price,
+                        current_price = self.current_price,
+                        executable_tokens_per_sol = q.tokens_per_sol,
+                        current_pnl_pct = %format!("{:.4}", pnl),
+                        executable_pnl_pct = %format!("{:.4}", exec_pnl),
+                        exit_type = "TRAILING_STOP",
+                        "TRAILING_STOP trigger (quote-first executable drawdown)"
+                    );
+                    return Some((
+                        "TRAILING_STOP".to_string(),
+                        format!(
+                            "Trailing stop hit: -{:.1}% executable drawdown from ATH (limit: -{:.1}%), executable P&L: {:.1}%",
+                            exec_dd, config.trailing_stop_pct, exec_pnl
+                        ),
+                    ));
                 }
             } else {
                 let drawdown = self.drawdown_from_ath_pct();
@@ -12671,6 +12543,98 @@ mod tests {
             "reason should reflect executable: {}",
             reason
         );
+    }
+
+    /// Quote-first: STOP_LOSS fires when executable is past stop even if mark is only ~-30%.
+    #[test]
+    fn stop_loss_fires_when_executable_deeper_loss_than_current_mark() {
+        let mut c = make_exit_config();
+        c.hard_stop_loss_pct = 20.0;
+        c.take_profit_pct = 1_000.0;
+        let entry = 100.0;
+        let current_tps = entry / 0.7; // ~-30% PnL (I-14)
+        let exec_tps = entry / 0.5; // ~-50% PnL
+        let mut pos = PositionTracker::new("m", "p", "dex", entry, 6, 1_000_000, 0);
+        pos.current_price = current_tps;
+        pos.highest_price = entry;
+        let ex = sample_exit_quote(exec_tps);
+        let cur_pnl = tokens_per_sol::pnl_pct(entry, current_tps);
+        let exe_pnl = tokens_per_sol::pnl_pct(entry, exec_tps);
+        assert!(
+            cur_pnl < -28.0 && cur_pnl > -32.0,
+            "expected ~-30% mark pnl, got {}",
+            cur_pnl
+        );
+        assert!(
+            exe_pnl < -45.0 && exe_pnl > -55.0,
+            "expected ~-50% exec pnl, got {}",
+            exe_pnl
+        );
+        let (ty, _) = pos.should_exit(&c, Some(&ex)).expect("STOP_LOSS");
+        assert_eq!(ty, "STOP_LOSS");
+    }
+
+    /// Quote-first: TAKE_PROFIT fires on executable even when mark gain is lower than executable.
+    #[test]
+    fn take_profit_fires_when_executable_more_profitable_than_current_mark() {
+        let mut c = make_exit_config();
+        c.take_profit_pct = 20.0;
+        c.take_profit_min_hold_secs = 0;
+        c.hard_stop_loss_pct = 200.0;
+        let entry = 100.0;
+        let current_tps = entry / 1.3; // ~+30% PnL
+        let exec_tps = entry / 1.6; // ~+60% PnL
+        let mut pos = PositionTracker::new("m", "p", "dex", entry, 6, 1_000_000, 0);
+        pos.current_price = current_tps;
+        pos.highest_price = entry;
+        let ex = sample_exit_quote(exec_tps);
+        let cur_pnl = tokens_per_sol::pnl_pct(entry, current_tps);
+        let exe_pnl = tokens_per_sol::pnl_pct(entry, exec_tps);
+        assert!(
+            cur_pnl > 25.0 && cur_pnl < 35.0,
+            "expected ~+30% mark pnl, got {}",
+            cur_pnl
+        );
+        assert!(
+            exe_pnl > 55.0 && exe_pnl < 65.0,
+            "expected ~+60% exec pnl, got {}",
+            exe_pnl
+        );
+        let (ty, _) = pos.should_exit(&c, Some(&ex)).expect("TAKE_PROFIT");
+        assert_eq!(ty, "TAKE_PROFIT");
+    }
+
+    /// Quote-first: TRAILING_STOP fires when mark is past trailing threshold and executable DD is worse.
+    #[test]
+    fn trailing_stop_fires_when_executable_drawdown_exceeds_current() {
+        let mut c = make_exit_config();
+        c.trailing_stop_pct = 20.0;
+        c.trailing_activation_pct = 5.0;
+        c.hard_stop_loss_pct = 200.0;
+        c.take_profit_pct = 1_000.0;
+        let entry = 100.0;
+        let ath = 70.0_f64; // best (lowest) tps seen
+        let current_tps = 90.0;
+        let exec_tps = 95.0;
+        let mut pos = PositionTracker::new("m", "p", "dex", entry, 6, 1_000_000, 0);
+        pos.highest_price = ath;
+        pos.current_price = current_tps;
+        let current_dd = tokens_per_sol::drawdown_from_ath_pct(ath, current_tps);
+        let exec_dd = tokens_per_sol::drawdown_from_ath_pct(ath, exec_tps);
+        assert!(
+            current_dd >= c.trailing_stop_pct - 1e-6,
+            "mark drawdown should breach threshold: {}",
+            current_dd
+        );
+        assert!(
+            exec_dd > current_dd,
+            "executable drawdown should exceed mark: exec={} current={}",
+            exec_dd,
+            current_dd
+        );
+        let ex = sample_exit_quote(exec_tps);
+        let (ty, _) = pos.should_exit(&c, Some(&ex)).expect("TRAILING_STOP");
+        assert_eq!(ty, "TRAILING_STOP");
     }
 
     #[test]


### PR DESCRIPTION
﻿## Summary

Price-based exits in `momentum_bot` now use a **usable** `ExitExecutableQuote` from `LivePoolCache` as the primary trigger (executable PnL / executable drawdown), not `current_price` first. This matches real sell sizing and avoids `TIME_EXIT` with mild reporting PnL while the reserve quote was already far past stop.

## Behaviour

- **STOP_LOSS**: fires when `executable_pnl <= -hard_stop_loss_pct` with a usable quote; never from trade/mark alone without a quote.
- **TAKE_PROFIT**: after min hold, fires when `executable_pnl >= take_profit_pct` with a usable quote.
- **TRAILING_STOP**: activation uses `executable_pnl` when a usable quote exists, else mark PnL; fire only on executable drawdown vs ATH when a usable quote exists. It merges executable into `highest_price` only when `marks_position_pool` (I-13).
- **No current-price-only suppression path**: quote-first paths do not suppress an exit because the executable quote is more extreme than the mark. If the executable quote breaches the threshold, the price exit fires.
- **TIME_EXIT / bonding / momentum / dev-LP** unchanged in intent.
- **Observability**: `info` on real triggers includes `quote_pool` / `quote_dex`; `debug` logs cover `NO_EXECUTABLE_QUOTE` and `UNUSABLE_EXECUTABLE_QUOTE`.

## Invariants / STOP-check

- I-7: no new RPC; only existing in-process LivePoolCache quote path.
- I-13: alternate-pool quote does not update `current_price` (tests assert).
- I-14: quote PnL uses `tokens_per_sol` convention.
- I-9: no execution/simulation changes.

## Tests

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`.
- CI Eval Level 5 is green.

## Docs

- `docs/BUGS_FIXES.md`: `FIX-MOM-QUOTE-FIRST-PRICE-EXITS`.
- `docs/MOMENTUM_V2_SPEC.md`: quote-first price-exit policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core exit-decision logic for `STOP_LOSS`/`TAKE_PROFIT`/`TRAILING_STOP` to rely on executable reserve quotes instead of mark price, which can materially alter live trading behavior. Risk is mitigated by added unit tests and the fact that non-price exits and `TIME_EXIT` behavior remain unchanged.
> 
> **Overview**
> Updates `momentum_bot` so price-based exits (`STOP_LOSS`, `TAKE_PROFIT`, `TRAILING_STOP`) are **quote-first**: they now trigger only from a *usable* `ExitExecutableQuote` (pool-sourced, finite `tokens_per_sol`) rather than `current_price` marks.
> 
> Removes the prior “stale mark suppression/validation” helper and replaces it with explicit quote usability checks, adds guardrails for `TRAILING_STOP` to only compare drawdown when the quote marks the position pool (`marks_position_pool`), and improves observability via `info` trigger logs including `quote_pool`/`quote_dex` plus `debug` reasons when exits are skipped due to missing/unusable quotes.
> 
> Extends unit tests around `PositionTracker::should_exit` to cover quote-first triggers, wrong-pool behavior, and `TIME_EXIT` reporting PnL, and updates `docs/BUGS_FIXES.md` and `docs/MOMENTUM_V2_SPEC.md` to document the new quote-first exit policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ceb3215e27151c32b6888961ee91490bd434ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->