### PR TITLE
Momentum: Prometheus-Latenzhistogramme für Hot Path und E2E

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -24,6 +24,11 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 **Fix**: Quote-first: bei nutzbarer `ExitExecutableQuote` (pool_sourced, finite `tokens_per_sol`) entscheiden `STOP_LOSS` und `TAKE_PROFIT` nach executable PnL; `current_price` allein triggert sie nicht (keine sekundäre „Stale-Mark“-Suppressionsstufe mehr). **`TRAILING_STOP`:** executable Drawdown nur, wenn `quote_pool == position.pool` (`marks_position_pool`); sonst kein Vergleich gegen Positions-Pool-ATH (I-13). Ohne nutzbare Quote feuern die drei Preis-Exits nicht aus Mark-/Trade-Rauschen. `TIME_EXIT` unverändert; Reporting-PnL nutzt weiter die Quote wenn vorhanden.  
 **Dateien**: `src/bin/momentum_bot.rs`, `docs/MOMENTUM_V2_SPEC.md`, `docs/BUGS_FIXES.md`
 
+### MOM-OBS-LATENCY: Prometheus-Histogramme für Momentum-Hot-Path- und E2E-Latenzen
+**Datum**: 2026-05-15  
+**Zweck** (kein Bugfix): Operative Messbarkeit nach Throughput-Slices — `momentum_event_to_ingest_ms`, `momentum_event_to_intent_publish_ms` (nur wenn auslösendes `MarketEvent.ts_unix_ms` explizit mitgegeben wird), interne µs-Histogramme für `process_market_event`, `record_trade`, Signal-Eval (dirty vs. Full-Scan), NATS-Batch-Deserialize/Flatten; Counter `momentum_latency_event_ts_invalid_total` bei `ts_unix_ms==0` oder Werte in der „Zukunft“ vs. lokaler Wanduhr. Keine Strategie-/RPC-/Topic-Änderungen.  
+**Dateien**: `src/metrics.rs`, `src/bin/momentum_bot.rs`
+
 ### FIX-01: Revert fehlerhafter Commits → `e341c04b`
 **Datum**: 2026-02-09
 **Problem**: 18 Commits (bis `b22bb0a9`) hatten ungewollt die Liquidation zerstört und Architekturprinzipien verletzt (RPC-Calls im Hot Path).

--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -26,7 +26,7 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ### MOM-OBS-LATENCY: Prometheus-Histogramme für Momentum-Hot-Path- und E2E-Latenzen
 **Datum**: 2026-05-15  
-**Zweck** (kein Bugfix): Operative Messbarkeit nach Throughput-Slices — `momentum_event_to_ingest_ms`, `momentum_event_to_intent_publish_ms` (nur wenn auslösendes `MarketEvent.ts_unix_ms` explizit mitgegeben wird), interne µs-Histogramme für `process_market_event`, `record_trade`, Signal-Eval (dirty vs. Full-Scan), NATS-Batch-Deserialize/Flatten; Counter `momentum_latency_event_ts_invalid_total` bei `ts_unix_ms==0` oder Werte in der „Zukunft“ vs. lokaler Wanduhr. Keine Strategie-/RPC-/Topic-Änderungen.  
+**Zweck** (kein Bugfix): Operative Messbarkeit nach Throughput-Slices — `momentum_event_to_ingest_ms`, `momentum_event_to_intent_publish_ms` (nur mit kausalem `MarketEvent.ts_unix_ms`; aktuell füllt momentum-bot diese Intent-Histogramme nicht, bis Exit-Pfade pro Intent ein explizites Event-Ts führen), interne µs-Histogramme für `process_market_event`, `record_trade`, Signal-Eval (dirty vs. Full-Scan), NATS-Batch-Deserialize/Flatten; Counter `momentum_latency_event_ts_invalid_total` bei `ts_unix_ms==0` oder Werte in der „Zukunft“ vs. lokaler Wanduhr. **`momentum_event_to_ingest_ms`**: nur Live-Ingest aus dem Core-NATS-MarketEvents-Arm — **kein** JetStream-Wallet-Snapshot-Bootstrap (`bootstrap_wallet_snapshot_from_jetstream`), damit historische Replay-Timestamps die SLO nicht verfälschen. Keine Strategie-/RPC-/Topic-Änderungen.  
 **Dateien**: `src/metrics.rs`, `src/bin/momentum_bot.rs`
 
 ### FIX-01: Revert fehlerhafter Commits → `e341c04b`

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -46,12 +46,15 @@ use ironcrab::ipc::{
     NATIVE_SOL_MINT,
 };
 use ironcrab::metrics::{
-    serve_metrics, set_readiness_nats_connected, MetricsComponent, EXITS_GENERATED_TOTAL,
-    FILTER_PASSED_TOTAL, FILTER_REJECTED_BUYER_QUALITY, FILTER_REJECTED_DEV_BEHAVIOR,
-    FILTER_REJECTED_INFLOW, FILTER_REJECTED_LIQUIDITY, FILTER_REJECTED_TOTAL,
-    FILTER_REJECTED_VELOCITY, INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL,
-    NATS_ERRORS_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL,
-    POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
+    record_momentum_full_scan_signal_eval_us, record_momentum_ingest_to_process_us,
+    record_momentum_nats_batch_prepare_us, record_momentum_signal_eval_us, serve_metrics,
+    set_readiness_nats_connected, try_record_momentum_event_to_ingest_ms,
+    try_record_momentum_event_to_intent_publish_ms, wall_clock_unix_ms_now, MetricsComponent,
+    EXITS_GENERATED_TOTAL, FILTER_PASSED_TOTAL, FILTER_REJECTED_BUYER_QUALITY,
+    FILTER_REJECTED_DEV_BEHAVIOR, FILTER_REJECTED_INFLOW, FILTER_REJECTED_LIQUIDITY,
+    FILTER_REJECTED_TOTAL, FILTER_REJECTED_VELOCITY, INTENTS_GENERATED_TOTAL,
+    MARKET_EVENTS_CONSUMED_TOTAL, NATS_ERRORS_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
+    NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
@@ -198,6 +201,23 @@ fn dbg_log(location: &str, message: &str, data: serde_json::Value, hypothesis_id
 }
 // #endregion
 
+/// Drop guard: records `momentum_process_market_event_us` (full async scope of `process_market_event`).
+struct MomentumProcessMarketEventTimer(std::time::Instant);
+impl Drop for MomentumProcessMarketEventTimer {
+    fn drop(&mut self) {
+        let us = self.0.elapsed().as_micros().min(u128::from(u64::MAX)) as u64;
+        ironcrab::metrics::record_momentum_process_market_event_us(us);
+    }
+}
+
+/// Drop guard: records `momentum_record_trade_us` for hot-path `MomentumContext::record_trade`.
+struct MomentumRecordTradeTimer(std::time::Instant);
+impl Drop for MomentumRecordTradeTimer {
+    fn drop(&mut self) {
+        let us = self.0.elapsed().as_micros().min(u128::from(u64::MAX)) as u64;
+        ironcrab::metrics::record_momentum_record_trade_us(us);
+    }
+}
 #[derive(Parser, Debug)]
 #[command(name = "momentum-bot")]
 #[command(about = "IronCrab Strategy Plane – Momentum policy and TradeIntent generation")]
@@ -3530,6 +3550,7 @@ impl MomentumContext {
         token_amount: u64,
         signature: &str,
     ) {
+        let _rt = MomentumRecordTradeTimer(Instant::now());
         let config = self.config.read().clone();
         let mut trackers = self.token_trackers.write();
         let key = Self::tracker_storage_key(mint, pool);
@@ -3677,7 +3698,8 @@ impl MomentumContext {
             self.refresh_tracker_keys_by_mint_index_from_map(&trackers);
             let mut tracker_keys: Vec<String> = trackers.keys().cloned().collect();
             tracker_keys.sort_unstable();
-            return self.check_for_signals_eval_sorted_tracker_keys(
+            let eval_t0 = Instant::now();
+            let signals = self.check_for_signals_eval_sorted_tracker_keys(
                 &config,
                 &mint_infos,
                 &positions,
@@ -3686,6 +3708,10 @@ impl MomentumContext {
                 &mut trackers,
                 &tracker_keys,
             );
+            record_momentum_full_scan_signal_eval_us(
+                eval_t0.elapsed().as_micros().min(u128::from(u64::MAX)) as u64,
+            );
+            return signals;
         }
 
         let mut dirty_keys: Vec<String> = {
@@ -3702,7 +3728,8 @@ impl MomentumContext {
             return Vec::new();
         }
 
-        self.check_for_signals_eval_sorted_tracker_keys(
+        let eval_t0 = Instant::now();
+        let signals = self.check_for_signals_eval_sorted_tracker_keys(
             &config,
             &mint_infos,
             &positions,
@@ -3710,7 +3737,11 @@ impl MomentumContext {
             &pending_buy_entries,
             &mut trackers,
             &dirty_keys,
-        )
+        );
+        record_momentum_signal_eval_us(
+            eval_t0.elapsed().as_micros().min(u128::from(u64::MAX)) as u64
+        );
+        signals
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -4514,7 +4545,9 @@ impl MomentumContext {
 
     /// Check for exit signals and publish intents. Call on every price-updating event
     /// (PoolCacheUpdate, Trade) for sub-500ms reaction; strategy_interval is fallback.
-    async fn process_exit_signals(self: &Arc<Self>) {
+    /// `source_event_ts_unix_ms`: producer `MarketEvent` header time when this run is triggered
+    /// directly from that event chain; `None` for timer/reconcile/bootstrap paths (no E2E intent metric).
+    async fn process_exit_signals(self: &Arc<Self>, source_event_ts_unix_ms: Option<u64>) {
         let exits = self.check_for_exits();
         for (mint, pool, dex, exit_type, reason, token_amount) in exits {
             info!(
@@ -4534,6 +4567,7 @@ impl MomentumContext {
                 &exit_type,
                 &reason,
                 token_amount,
+                source_event_ts_unix_ms,
             )
             .await
             {
@@ -4612,6 +4646,7 @@ impl MomentumContext {
                 &exit_type,
                 &reason,
                 candidate.token_amount,
+                None,
             )
             .await
             {
@@ -5311,7 +5346,7 @@ impl MomentumContext {
                                     });
                                     let ctx_exit = Arc::clone(self);
                                     tokio::spawn(async move {
-                                        ctx_exit.process_exit_signals().await;
+                                        ctx_exit.process_exit_signals(None).await;
                                     });
                                 } else {
                                     self.remove_pending_buy_entry_by_intent(&result.intent_id);
@@ -5356,7 +5391,7 @@ impl MomentumContext {
                                 });
                                 let ctx_exit = Arc::clone(self);
                                 tokio::spawn(async move {
-                                    ctx_exit.process_exit_signals().await;
+                                    ctx_exit.process_exit_signals(None).await;
                                 });
                             } else {
                                 self.remove_pending_buy_entry_by_intent(&result.intent_id);
@@ -5655,7 +5690,7 @@ impl MomentumContext {
                         });
                         let ctx_exit = Arc::clone(self);
                         tokio::spawn(async move {
-                            ctx_exit.process_exit_signals().await;
+                            ctx_exit.process_exit_signals(None).await;
                         });
                     }
                     TradeSide::Sell => {
@@ -6981,10 +7016,20 @@ async fn bootstrap_wallet_snapshot_from_jetstream(ctx: &Arc<MomentumContext>) ->
 
             if let MarketEventKind::WalletBalanceSnapshot { mint, .. } = &event.kind {
                 snapshot_mints.insert(mint.clone());
-                if let Err(e) = process_market_event(ctx, &event).await {
-                    warn!(error = %e, "Failed to apply WalletBalanceSnapshot");
-                } else {
-                    recovered += 1;
+                let now_ms = wall_clock_unix_ms_now();
+                try_record_momentum_event_to_ingest_ms(now_ms, event.header.ts_unix_ms);
+                let ingest_t0 = Instant::now();
+                let apply_res = process_market_event(ctx, &event).await;
+                record_momentum_ingest_to_process_us(
+                    ingest_t0.elapsed().as_micros().min(u128::from(u64::MAX)) as u64,
+                );
+                match apply_res {
+                    Err(e) => {
+                        warn!(error = %e, "Failed to apply WalletBalanceSnapshot");
+                    }
+                    Ok(_) => {
+                        recovered += 1;
+                    }
                 }
             }
 
@@ -7375,6 +7420,7 @@ async fn main() -> Result<()> {
                 &exit_type,
                 &reason,
                 token_amount,
+                None,
             )
             .await
             {
@@ -7755,6 +7801,7 @@ async fn main() -> Result<()> {
                         );
                     }
 
+                    let batch_prep_t0 = Instant::now();
                     let mut deserialized: Vec<MarketEvent> = Vec::new();
                     for pl in raw_chunks {
                         match serde_json::from_slice::<MarketEvent>(&pl) {
@@ -7767,6 +7814,13 @@ async fn main() -> Result<()> {
 
                     let events_to_run =
                         flatten_market_events_for_ingest_ordered_batch(deserialized);
+
+                    record_momentum_nats_batch_prepare_us(
+                        batch_prep_t0
+                            .elapsed()
+                            .as_micros()
+                            .min(u128::from(u64::MAX)) as u64,
+                    );
 
                     let mut batch_had_price_sensitive_market_event = false;
                     for event in events_to_run {
@@ -7788,6 +7842,9 @@ async fn main() -> Result<()> {
                                 (None, 0u64)
                             };
 
+                        let now_ms = wall_clock_unix_ms_now();
+                        try_record_momentum_event_to_ingest_ms(now_ms, event.header.ts_unix_ms);
+                        let ingest_t0 = Instant::now();
                         match process_market_event(&ctx, &event).await {
                             Ok(need_exit) => {
                                 let is_trade = matches!(
@@ -7799,7 +7856,8 @@ async fn main() -> Result<()> {
                                     is_trade,
                                     ctx.position_count(),
                                 ) {
-                                    ctx.process_exit_signals().await;
+                                    ctx.process_exit_signals(Some(event.header.ts_unix_ms))
+                                        .await;
                                 }
                             }
                             Err(e) => {
@@ -7810,6 +7868,12 @@ async fn main() -> Result<()> {
                                 );
                             }
                         }
+                        record_momentum_ingest_to_process_us(
+                            ingest_t0
+                                .elapsed()
+                                .as_micros()
+                                .min(u128::from(u64::MAX)) as u64,
+                        );
 
                         if let Some(t0) = scope_c_latency_t0 {
                             let duration_ms = t0.elapsed().as_millis() as u64;
@@ -8042,13 +8106,36 @@ async fn main() -> Result<()> {
                                         match serde_json::from_slice::<MarketEvent>(&msg.payload) {
                                             Ok(event) => {
                                                 if let MarketEventKind::WalletBalanceSnapshot { .. } = &event.kind {
+                                                    let now_ms = wall_clock_unix_ms_now();
+                                                    try_record_momentum_event_to_ingest_ms(
+                                                        now_ms,
+                                                        event.header.ts_unix_ms,
+                                                    );
+                                                    let ingest_t0 = Instant::now();
                                                     match process_market_event(&ctx, &event).await {
                                                         Ok(need_exit) => {
+                                                            record_momentum_ingest_to_process_us(
+                                                                ingest_t0
+                                                                    .elapsed()
+                                                                    .as_micros()
+                                                                    .min(u128::from(u64::MAX))
+                                                                    as u64,
+                                                            );
                                                             if need_exit && ctx.position_count() > 0 {
-                                                                ctx.process_exit_signals().await;
+                                                                ctx.process_exit_signals(Some(
+                                                                    event.header.ts_unix_ms,
+                                                                ))
+                                                                .await;
                                                             }
                                                         }
                                                         Err(e) => {
+                                                            record_momentum_ingest_to_process_us(
+                                                                ingest_t0
+                                                                    .elapsed()
+                                                                    .as_micros()
+                                                                    .min(u128::from(u64::MAX))
+                                                                    as u64,
+                                                            );
                                                             warn!(error = %e, "Failed to process WalletBalanceSnapshot from JetStream");
                                                         }
                                                     }
@@ -8249,7 +8336,7 @@ async fn main() -> Result<()> {
                                 trace!(updates = msg_count, "SLAVE CACHE: processed PoolCacheUpdates");
                                 // Event-driven: check exits immediately after price update (<500ms reaction)
                                 if ctx.position_count() > 0 {
-                                    ctx.process_exit_signals().await;
+                                    ctx.process_exit_signals(None).await;
                                 }
                                 // Scope C: yield a bounded ExecutionResult drain after heavy pool-cache work.
                                 if let Some(ref er_consumer) = execution_js_consumer {
@@ -8339,7 +8426,7 @@ async fn main() -> Result<()> {
 
                 // === Check for EXIT signals (fallback; primary = event-driven on PoolCacheUpdate/Trade) ===
                 if ctx.position_count() > 0 {
-                    ctx.process_exit_signals().await;
+                    ctx.process_exit_signals(None).await;
                 }
             }
 
@@ -11984,6 +12071,7 @@ mod tests {
             "TIME_EXIT",
             "test",
             14_099_749_285,
+            None,
         )
         .await
         .expect("exit intent");
@@ -13708,6 +13796,7 @@ mod tests {
 }
 
 /// Generate and publish a SELL intent for position exit
+#[allow(clippy::too_many_arguments)]
 async fn generate_and_publish_exit_intent(
     ctx: &MomentumContext,
     mint: &str,
@@ -13716,6 +13805,9 @@ async fn generate_and_publish_exit_intent(
     exit_type: &str,
     reason: &str,
     token_amount: u64,
+    // When `Some`, successful publish records `momentum_event_to_intent_publish_ms`.
+    // Use `None` for timer/reconcile/bootstrap paths (no E2E sample).
+    source_event_ts_unix_ms: Option<u64>,
 ) -> Result<()> {
     // Authoritative sell size: open position total at publish time (handles probe+scale-in
     // and races where the caller still had a stale hint amount).
@@ -14094,6 +14186,10 @@ async fn generate_and_publish_exit_intent(
         match nats.jetstream_publish(TOPIC_TRADE_INTENTS, &intent).await {
             Ok(true) => {
                 NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                let now_ms = wall_clock_unix_ms_now();
+                if let Some(ts) = source_event_ts_unix_ms {
+                    try_record_momentum_event_to_intent_publish_ms(now_ms, ts);
+                }
             }
             Ok(false) => {
                 NATS_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
@@ -14115,6 +14211,7 @@ async fn generate_and_publish_exit_intent(
 /// Process a MarketEvent and update token trackers.
 /// Returns `Ok(true)` when the caller should run `process_exit_signals()` (bonding/price-relevant sticky apply).
 async fn process_market_event(ctx: &Arc<MomentumContext>, event: &MarketEvent) -> Result<bool> {
+    let _mt = MomentumProcessMarketEventTimer(Instant::now());
     // K Phase 1: Slot-to-Send Latency - store for intent metadata propagation
     if let Some(slot) = event.slot {
         ctx.last_event_slot

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -8116,11 +8116,6 @@ async fn main() -> Result<()> {
                                         match serde_json::from_slice::<MarketEvent>(&msg.payload) {
                                             Ok(event) => {
                                                 if let MarketEventKind::WalletBalanceSnapshot { .. } = &event.kind {
-                                                    let now_ms = wall_clock_unix_ms_now();
-                                                    try_record_momentum_event_to_ingest_ms(
-                                                        now_ms,
-                                                        event.header.ts_unix_ms,
-                                                    );
                                                     let ingest_t0 = Instant::now();
                                                     match process_market_event(&ctx, &event).await {
                                                         Ok(need_exit) => {

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -4545,8 +4545,10 @@ impl MomentumContext {
 
     /// Check for exit signals and publish intents. Call on every price-updating event
     /// (PoolCacheUpdate, Trade) for sub-500ms reaction; strategy_interval is fallback.
-    /// `source_event_ts_unix_ms`: producer `MarketEvent` header time when this run is triggered
-    /// directly from that event chain; `None` for timer/reconcile/bootstrap paths (no E2E intent metric).
+    /// `source_event_ts_unix_ms`: reserved for a future path where each published exit intent is
+    /// provably tied to one `MarketEvent` header (per-mint causality). **Broad** `check_for_exits()`
+    /// runs must pass `None` so `momentum_event_to_intent_publish_ms` is not filled with a
+    /// non-causal timestamp. Today all call sites use `None`.
     async fn process_exit_signals(self: &Arc<Self>, source_event_ts_unix_ms: Option<u64>) {
         let exits = self.check_for_exits();
         for (mint, pool, dex, exit_type, reason, token_amount) in exits {
@@ -7016,8 +7018,8 @@ async fn bootstrap_wallet_snapshot_from_jetstream(ctx: &Arc<MomentumContext>) ->
 
             if let MarketEventKind::WalletBalanceSnapshot { mint, .. } = &event.kind {
                 snapshot_mints.insert(mint.clone());
-                let now_ms = wall_clock_unix_ms_now();
-                try_record_momentum_event_to_ingest_ms(now_ms, event.header.ts_unix_ms);
+                // JetStream bootstrap/replay: do not mix historical `ts_unix_ms` into
+                // `momentum_event_to_ingest_ms` (live Core NATS ingest SLO only).
                 let ingest_t0 = Instant::now();
                 let apply_res = process_market_event(ctx, &event).await;
                 record_momentum_ingest_to_process_us(
@@ -7856,8 +7858,10 @@ async fn main() -> Result<()> {
                                     is_trade,
                                     ctx.position_count(),
                                 ) {
-                                    ctx.process_exit_signals(Some(event.header.ts_unix_ms))
-                                        .await;
+                                    // `check_for_exits()` scans all positions — one MarketEvent ts is not
+                                    // causal per mint/pool. Omit `momentum_event_to_intent_publish_ms` here
+                                    // until per-exit causality is threaded (PR-124 follow-up).
+                                    ctx.process_exit_signals(None).await;
                                 }
                             }
                             Err(e) => {
@@ -8122,10 +8126,7 @@ async fn main() -> Result<()> {
                                                                     as u64,
                                                             );
                                                             if need_exit && ctx.position_count() > 0 {
-                                                                ctx.process_exit_signals(Some(
-                                                                    event.header.ts_unix_ms,
-                                                                ))
-                                                                .await;
+                                                                ctx.process_exit_signals(None).await;
                                                             }
                                                         }
                                                         Err(e) => {
@@ -13805,8 +13806,9 @@ async fn generate_and_publish_exit_intent(
     exit_type: &str,
     reason: &str,
     token_amount: u64,
-    // When `Some`, successful publish records `momentum_event_to_intent_publish_ms`.
-    // Use `None` for timer/reconcile/bootstrap paths (no E2E sample).
+    // When `Some`, successful publish records `momentum_event_to_intent_publish_ms` only if this
+    // timestamp is causal for this intent (same decision chain). Use `None` for timer/reconcile,
+    // bootstrap, and any `check_for_exits()`-driven scan where one event is not tied to each exit.
     source_event_ts_unix_ms: Option<u64>,
 ) -> Result<()> {
     // Authoritative sell size: open position total at publish time (handles probe+scale-in

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -7849,6 +7849,12 @@ async fn main() -> Result<()> {
                         let ingest_t0 = Instant::now();
                         match process_market_event(&ctx, &event).await {
                             Ok(need_exit) => {
+                                record_momentum_ingest_to_process_us(
+                                    ingest_t0
+                                        .elapsed()
+                                        .as_micros()
+                                        .min(u128::from(u64::MAX)) as u64,
+                                );
                                 let is_trade = matches!(
                                     event.kind,
                                     MarketEventKind::Trade { .. }
@@ -7865,6 +7871,12 @@ async fn main() -> Result<()> {
                                 }
                             }
                             Err(e) => {
+                                record_momentum_ingest_to_process_us(
+                                    ingest_t0
+                                        .elapsed()
+                                        .as_micros()
+                                        .min(u128::from(u64::MAX)) as u64,
+                                );
                                 warn!(
                                     error = %e,
                                     event_id = %event.event_id,
@@ -7872,12 +7884,6 @@ async fn main() -> Result<()> {
                                 );
                             }
                         }
-                        record_momentum_ingest_to_process_us(
-                            ingest_t0
-                                .elapsed()
-                                .as_micros()
-                                .min(u128::from(u64::MAX)) as u64,
-                        );
 
                         if let Some(t0) = scope_c_latency_t0 {
                             let duration_ms = t0.elapsed().as_millis() as u64;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -357,6 +357,8 @@ pub fn momentum_event_ts_latency_delta_ms(now_ms: u64, event_ts_ms: u64) -> Opti
     Some(now_ms.saturating_sub(event_ts_ms))
 }
 
+/// Records producer→momentum wall latency for **live** Core NATS MarketEvent ingest.
+/// Do **not** call from JetStream bootstrap/replay recovery (historical `ts_unix_ms` would skew p95/p99).
 #[inline]
 pub fn try_record_momentum_event_to_ingest_ms(now_ms: u64, event_ts_ms: u64) {
     if let Some(ms) = momentum_event_ts_latency_delta_ms(now_ms, event_ts_ms) {
@@ -371,8 +373,10 @@ pub fn try_record_momentum_event_to_ingest_ms(now_ms: u64, event_ts_ms: u64) {
     }
 }
 
-/// Call only after a successful JetStream publish when `event_ts_ms` is the producer time of the
-/// triggering `MarketEvent` (never from a timer / global latch).
+/// Call only after a successful JetStream publish when `event_ts_ms` is the **causal**
+/// `MarketEvent.header.ts_unix_ms` for that intent (same mint/pool decision chain). Never pass a
+/// timestamp from an unrelated event or a broad multi-position scan — use `None` at the call site
+/// instead of calling this helper.
 #[inline]
 pub fn try_record_momentum_event_to_intent_publish_ms(now_ms: u64, event_ts_ms: u64) {
     if let Some(ms) = momentum_event_ts_latency_delta_ms(now_ms, event_ts_ms) {
@@ -2287,6 +2291,24 @@ mod momentum_latency_metrics_tests {
         assert_eq!(
             MOMENTUM_LATENCY_EVENT_TS_INVALID_TOTAL.load(Ordering::Relaxed),
             2
+        );
+    }
+
+    #[test]
+    fn event_to_intent_publish_records_when_explicit_causal_ts_used() {
+        reset_momentum_latency_metrics_for_test();
+        try_record_momentum_event_to_intent_publish_ms(5_000, 4_000);
+        assert_eq!(
+            MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_COUNT.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_SUM.load(Ordering::Relaxed),
+            1_000
+        );
+        assert_eq!(
+            MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_BUCKET_COUNTS[8].load(Ordering::Relaxed),
+            1
         );
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -341,7 +341,6 @@ fn record_histogram_u64_into(
     for (i, b) in buckets.iter().enumerate() {
         if v <= *b {
             bucket_counts[i].fetch_add(1, Ordering::Relaxed);
-            break;
         }
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -232,6 +232,287 @@ pub static FILTER_REJECTED_INFLOW: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new
 pub static FILTER_REJECTED_DEV_BEHAVIOR: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static MARKET_EVENTS_CONSUMED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
+// --- momentum-bot hot-path latency (Prometheus histograms; momentum-bot process only) ---
+/// Producer `RecordHeader.ts_unix_ms` → momentum ingest (`now_ms`), milliseconds.
+const MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS: &[u64] =
+    &[1, 5, 10, 25, 50, 100, 250, 500, 1000, 2000, 5000];
+pub static MOMENTUM_EVENT_TO_INGEST_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static MOMENTUM_EVENT_TO_INGEST_MS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_EVENT_TO_INGEST_MS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// Same buckets: wall-clock from event `ts_unix_ms` to successful TradeIntent publish (only when
+/// the causative `MarketEvent` timestamp is passed explicitly — no global `last_event_ts` guess).
+pub static MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+pub static MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+const MOMENTUM_INTERNAL_US_BUCKETS: &[u64] = &[
+    50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000, 250000,
+];
+pub static MOMENTUM_INGEST_TO_PROCESS_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    MOMENTUM_INTERNAL_US_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static MOMENTUM_INGEST_TO_PROCESS_US_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_INGEST_TO_PROCESS_US_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+pub static MOMENTUM_PROCESS_MARKET_EVENT_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    MOMENTUM_INTERNAL_US_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static MOMENTUM_PROCESS_MARKET_EVENT_US_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_PROCESS_MARKET_EVENT_US_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+pub static MOMENTUM_RECORD_TRADE_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    MOMENTUM_INTERNAL_US_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static MOMENTUM_RECORD_TRADE_US_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_RECORD_TRADE_US_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+pub static MOMENTUM_SIGNAL_EVAL_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    MOMENTUM_INTERNAL_US_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static MOMENTUM_SIGNAL_EVAL_US_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_SIGNAL_EVAL_US_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+pub static MOMENTUM_FULL_SCAN_SIGNAL_EVAL_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MOMENTUM_INTERNAL_US_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+pub static MOMENTUM_FULL_SCAN_SIGNAL_EVAL_US_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_FULL_SCAN_SIGNAL_EVAL_US_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Deserialize + `flatten_market_events_for_ingest_ordered_batch` for one Core NATS activation.
+pub static MOMENTUM_NATS_BATCH_PREPARE_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    MOMENTUM_INTERNAL_US_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static MOMENTUM_NATS_BATCH_PREPARE_US_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_NATS_BATCH_PREPARE_US_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+pub static MOMENTUM_LATENCY_EVENT_TS_INVALID_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+const MOMENTUM_LATENCY_MS_SUM_CAP: u64 = 1_000_000;
+const MOMENTUM_LATENCY_US_SUM_CAP: u64 = 60_000_000;
+
+#[inline]
+fn record_histogram_u64_into(
+    buckets: &[u64],
+    bucket_counts: &[AtomicU64],
+    sum: &AtomicU64,
+    count: &AtomicU64,
+    value: u64,
+    sum_cap: u64,
+) {
+    let v = value.min(sum_cap);
+    sum.fetch_add(v, Ordering::Relaxed);
+    count.fetch_add(1, Ordering::Relaxed);
+    for (i, b) in buckets.iter().enumerate() {
+        if v <= *b {
+            bucket_counts[i].fetch_add(1, Ordering::Relaxed);
+            break;
+        }
+    }
+}
+
+/// `event_ts_ms` must be from the causative `MarketEvent` header. Returns `now_ms - event_ts_ms`
+/// when the timestamp is usable (non-zero, not after `now_ms`). Otherwise increments
+/// [`MOMENTUM_LATENCY_EVENT_TS_INVALID_TOTAL`] and returns `None` (no histogram sample).
+pub fn momentum_event_ts_latency_delta_ms(now_ms: u64, event_ts_ms: u64) -> Option<u64> {
+    if event_ts_ms == 0 || event_ts_ms > now_ms {
+        MOMENTUM_LATENCY_EVENT_TS_INVALID_TOTAL.fetch_add(1, Ordering::Relaxed);
+        return None;
+    }
+    Some(now_ms.saturating_sub(event_ts_ms))
+}
+
+#[inline]
+pub fn try_record_momentum_event_to_ingest_ms(now_ms: u64, event_ts_ms: u64) {
+    if let Some(ms) = momentum_event_ts_latency_delta_ms(now_ms, event_ts_ms) {
+        record_histogram_u64_into(
+            MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+            &MOMENTUM_EVENT_TO_INGEST_MS_BUCKET_COUNTS,
+            &MOMENTUM_EVENT_TO_INGEST_MS_SUM,
+            &MOMENTUM_EVENT_TO_INGEST_MS_COUNT,
+            ms,
+            MOMENTUM_LATENCY_MS_SUM_CAP,
+        );
+    }
+}
+
+/// Call only after a successful JetStream publish when `event_ts_ms` is the producer time of the
+/// triggering `MarketEvent` (never from a timer / global latch).
+#[inline]
+pub fn try_record_momentum_event_to_intent_publish_ms(now_ms: u64, event_ts_ms: u64) {
+    if let Some(ms) = momentum_event_ts_latency_delta_ms(now_ms, event_ts_ms) {
+        record_histogram_u64_into(
+            MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+            &MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_BUCKET_COUNTS,
+            &MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_SUM,
+            &MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_COUNT,
+            ms,
+            MOMENTUM_LATENCY_MS_SUM_CAP,
+        );
+    }
+}
+
+#[inline]
+pub fn record_momentum_ingest_to_process_us(us: u64) {
+    record_histogram_u64_into(
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        &MOMENTUM_INGEST_TO_PROCESS_US_BUCKET_COUNTS,
+        &MOMENTUM_INGEST_TO_PROCESS_US_SUM,
+        &MOMENTUM_INGEST_TO_PROCESS_US_COUNT,
+        us,
+        MOMENTUM_LATENCY_US_SUM_CAP,
+    );
+}
+
+#[inline]
+pub fn record_momentum_process_market_event_us(us: u64) {
+    record_histogram_u64_into(
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        &MOMENTUM_PROCESS_MARKET_EVENT_US_BUCKET_COUNTS,
+        &MOMENTUM_PROCESS_MARKET_EVENT_US_SUM,
+        &MOMENTUM_PROCESS_MARKET_EVENT_US_COUNT,
+        us,
+        MOMENTUM_LATENCY_US_SUM_CAP,
+    );
+}
+
+#[inline]
+pub fn record_momentum_record_trade_us(us: u64) {
+    record_histogram_u64_into(
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        &MOMENTUM_RECORD_TRADE_US_BUCKET_COUNTS,
+        &MOMENTUM_RECORD_TRADE_US_SUM,
+        &MOMENTUM_RECORD_TRADE_US_COUNT,
+        us,
+        MOMENTUM_LATENCY_US_SUM_CAP,
+    );
+}
+
+#[inline]
+pub fn record_momentum_signal_eval_us(us: u64) {
+    record_histogram_u64_into(
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        &MOMENTUM_SIGNAL_EVAL_US_BUCKET_COUNTS,
+        &MOMENTUM_SIGNAL_EVAL_US_SUM,
+        &MOMENTUM_SIGNAL_EVAL_US_COUNT,
+        us,
+        MOMENTUM_LATENCY_US_SUM_CAP,
+    );
+}
+
+#[inline]
+pub fn record_momentum_full_scan_signal_eval_us(us: u64) {
+    record_histogram_u64_into(
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        &MOMENTUM_FULL_SCAN_SIGNAL_EVAL_US_BUCKET_COUNTS,
+        &MOMENTUM_FULL_SCAN_SIGNAL_EVAL_US_SUM,
+        &MOMENTUM_FULL_SCAN_SIGNAL_EVAL_US_COUNT,
+        us,
+        MOMENTUM_LATENCY_US_SUM_CAP,
+    );
+}
+
+#[inline]
+pub fn record_momentum_nats_batch_prepare_us(us: u64) {
+    record_histogram_u64_into(
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        &MOMENTUM_NATS_BATCH_PREPARE_US_BUCKET_COUNTS,
+        &MOMENTUM_NATS_BATCH_PREPARE_US_SUM,
+        &MOMENTUM_NATS_BATCH_PREPARE_US_COUNT,
+        us,
+        MOMENTUM_LATENCY_US_SUM_CAP,
+    );
+}
+
+/// Wall-clock milliseconds since UNIX epoch (for momentum E2E latency vs `RecordHeader.ts_unix_ms`).
+#[inline]
+pub fn wall_clock_unix_ms_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+fn reset_momentum_latency_metrics_for_test() {
+    for c in MOMENTUM_EVENT_TO_INGEST_MS_BUCKET_COUNTS.iter() {
+        c.store(0, Ordering::Relaxed);
+    }
+    MOMENTUM_EVENT_TO_INGEST_MS_SUM.store(0, Ordering::Relaxed);
+    MOMENTUM_EVENT_TO_INGEST_MS_COUNT.store(0, Ordering::Relaxed);
+    for c in MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_BUCKET_COUNTS.iter() {
+        c.store(0, Ordering::Relaxed);
+    }
+    MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_SUM.store(0, Ordering::Relaxed);
+    MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_COUNT.store(0, Ordering::Relaxed);
+    for c in MOMENTUM_INGEST_TO_PROCESS_US_BUCKET_COUNTS.iter() {
+        c.store(0, Ordering::Relaxed);
+    }
+    MOMENTUM_INGEST_TO_PROCESS_US_SUM.store(0, Ordering::Relaxed);
+    MOMENTUM_INGEST_TO_PROCESS_US_COUNT.store(0, Ordering::Relaxed);
+    for c in MOMENTUM_PROCESS_MARKET_EVENT_US_BUCKET_COUNTS.iter() {
+        c.store(0, Ordering::Relaxed);
+    }
+    MOMENTUM_PROCESS_MARKET_EVENT_US_SUM.store(0, Ordering::Relaxed);
+    MOMENTUM_PROCESS_MARKET_EVENT_US_COUNT.store(0, Ordering::Relaxed);
+    for c in MOMENTUM_RECORD_TRADE_US_BUCKET_COUNTS.iter() {
+        c.store(0, Ordering::Relaxed);
+    }
+    MOMENTUM_RECORD_TRADE_US_SUM.store(0, Ordering::Relaxed);
+    MOMENTUM_RECORD_TRADE_US_COUNT.store(0, Ordering::Relaxed);
+    for c in MOMENTUM_SIGNAL_EVAL_US_BUCKET_COUNTS.iter() {
+        c.store(0, Ordering::Relaxed);
+    }
+    MOMENTUM_SIGNAL_EVAL_US_SUM.store(0, Ordering::Relaxed);
+    MOMENTUM_SIGNAL_EVAL_US_COUNT.store(0, Ordering::Relaxed);
+    for c in MOMENTUM_FULL_SCAN_SIGNAL_EVAL_US_BUCKET_COUNTS.iter() {
+        c.store(0, Ordering::Relaxed);
+    }
+    MOMENTUM_FULL_SCAN_SIGNAL_EVAL_US_SUM.store(0, Ordering::Relaxed);
+    MOMENTUM_FULL_SCAN_SIGNAL_EVAL_US_COUNT.store(0, Ordering::Relaxed);
+    for c in MOMENTUM_NATS_BATCH_PREPARE_US_BUCKET_COUNTS.iter() {
+        c.store(0, Ordering::Relaxed);
+    }
+    MOMENTUM_NATS_BATCH_PREPARE_US_SUM.store(0, Ordering::Relaxed);
+    MOMENTUM_NATS_BATCH_PREPARE_US_COUNT.store(0, Ordering::Relaxed);
+    MOMENTUM_LATENCY_EVENT_TS_INVALID_TOTAL.store(0, Ordering::Relaxed);
+}
+
 // --- execution-engine service metrics ---
 pub static INTENTS_RECEIVED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static INTENTS_EXECUTED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -881,6 +1162,26 @@ pub fn record_slippage(_slippage_bps: f64) {
     // Could add a separate histogram for slippage if needed
 }
 
+/// Append `_bucket{le=...}`, `_sum`, `_count` lines (same layout as `tx_slot_to_send_ms`).
+fn append_momentum_latency_histogram_prometheus(
+    out: &mut String,
+    metric: &str,
+    buckets: &[u64],
+    counts: &[AtomicU64],
+    sum: &AtomicU64,
+    count: &AtomicU64,
+) {
+    let c = count.load(Ordering::Relaxed);
+    let s = sum.load(Ordering::Relaxed);
+    for (i, b) in buckets.iter().enumerate() {
+        let v = counts[i].load(Ordering::Relaxed);
+        out.push_str(&format!("{}_bucket{{le=\"{}\"}} {}\n", metric, b, v));
+    }
+    out.push_str(&format!("{}_bucket{{le=\"+Inf\"}} {}\n", metric, c));
+    out.push_str(&format!("{}_sum {}\n", metric, s));
+    out.push_str(&format!("{}_count {}\n", metric, c));
+}
+
 async fn metrics_response() -> Response<Body> {
     // Build Prometheus exposition text
     let mut out = String::with_capacity(8192);
@@ -975,6 +1276,74 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_events_consumed_total",
         MARKET_EVENTS_CONSUMED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_latency_event_ts_invalid_total",
+        MOMENTUM_LATENCY_EVENT_TS_INVALID_TOTAL.load(Ordering::Relaxed)
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "momentum_event_to_ingest_ms",
+        MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+        &MOMENTUM_EVENT_TO_INGEST_MS_BUCKET_COUNTS,
+        &MOMENTUM_EVENT_TO_INGEST_MS_SUM,
+        &MOMENTUM_EVENT_TO_INGEST_MS_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "momentum_event_to_intent_publish_ms",
+        MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+        &MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_BUCKET_COUNTS,
+        &MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_SUM,
+        &MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "momentum_ingest_to_process_us",
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        &MOMENTUM_INGEST_TO_PROCESS_US_BUCKET_COUNTS,
+        &MOMENTUM_INGEST_TO_PROCESS_US_SUM,
+        &MOMENTUM_INGEST_TO_PROCESS_US_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "momentum_process_market_event_us",
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        &MOMENTUM_PROCESS_MARKET_EVENT_US_BUCKET_COUNTS,
+        &MOMENTUM_PROCESS_MARKET_EVENT_US_SUM,
+        &MOMENTUM_PROCESS_MARKET_EVENT_US_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "momentum_record_trade_us",
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        &MOMENTUM_RECORD_TRADE_US_BUCKET_COUNTS,
+        &MOMENTUM_RECORD_TRADE_US_SUM,
+        &MOMENTUM_RECORD_TRADE_US_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "momentum_signal_eval_us",
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        &MOMENTUM_SIGNAL_EVAL_US_BUCKET_COUNTS,
+        &MOMENTUM_SIGNAL_EVAL_US_SUM,
+        &MOMENTUM_SIGNAL_EVAL_US_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "momentum_full_scan_signal_eval_us",
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        &MOMENTUM_FULL_SCAN_SIGNAL_EVAL_US_BUCKET_COUNTS,
+        &MOMENTUM_FULL_SCAN_SIGNAL_EVAL_US_SUM,
+        &MOMENTUM_FULL_SCAN_SIGNAL_EVAL_US_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "momentum_nats_batch_prepare_us",
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        &MOMENTUM_NATS_BATCH_PREPARE_US_BUCKET_COUNTS,
+        &MOMENTUM_NATS_BATCH_PREPARE_US_SUM,
+        &MOMENTUM_NATS_BATCH_PREPARE_US_COUNT,
     );
 
     // --- execution-engine service ---
@@ -1890,4 +2259,46 @@ pub fn record_activity() {
         .unwrap()
         .as_secs();
     LAST_ACTIVITY_TS.store(now, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod momentum_latency_metrics_tests {
+    use super::*;
+
+    #[test]
+    fn event_to_ingest_places_sample_in_expected_bucket() {
+        reset_momentum_latency_metrics_for_test();
+        try_record_momentum_event_to_ingest_ms(100, 40);
+        assert_eq!(MOMENTUM_EVENT_TO_INGEST_MS_COUNT.load(Ordering::Relaxed), 1);
+        assert_eq!(MOMENTUM_EVENT_TO_INGEST_MS_SUM.load(Ordering::Relaxed), 60);
+        // 60 ms → first bucket with le >= 60 is 100 (index 5 in [1,5,10,25,50,100,...])
+        assert_eq!(
+            MOMENTUM_EVENT_TO_INGEST_MS_BUCKET_COUNTS[5].load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[test]
+    fn invalid_event_ts_does_not_record_histogram_but_bumps_invalid() {
+        reset_momentum_latency_metrics_for_test();
+        try_record_momentum_event_to_ingest_ms(1_000, 0);
+        try_record_momentum_event_to_ingest_ms(500, 600);
+        assert_eq!(MOMENTUM_EVENT_TO_INGEST_MS_COUNT.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            MOMENTUM_LATENCY_EVENT_TS_INVALID_TOTAL.load(Ordering::Relaxed),
+            2
+        );
+    }
+
+    #[test]
+    fn internal_us_histogram_records_sum_and_bucket() {
+        reset_momentum_latency_metrics_for_test();
+        record_momentum_signal_eval_us(800);
+        assert_eq!(MOMENTUM_SIGNAL_EVAL_US_COUNT.load(Ordering::Relaxed), 1);
+        assert_eq!(MOMENTUM_SIGNAL_EVAL_US_SUM.load(Ordering::Relaxed), 800);
+        assert_eq!(
+            MOMENTUM_SIGNAL_EVAL_US_BUCKET_COUNTS[4].load(Ordering::Relaxed),
+            1
+        );
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up (Supervisor-Review): `momentum_event_to_ingest_ms` nur noch aus dem **live** Core-NATS-Ingest (kein JetStream-Wallet-Bootstrap-Replay); `process_exit_signals` übergibt für breite `check_for_exits()`-Scans durchgehend **`None`**, damit `momentum_event_to_intent_publish_ms` nicht mit nicht-kausalem Event-`ts_unix_ms` gefüllt wird. Doku/Kommentare + Unit-Test für Intent-Histogramm bei explizit kausalem Ts.

## STOP-CHECK
Keine RPC-, Strategie-, Simulations- oder Topic-Änderungen.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31b362e7-fc54-4de6-b578-353a113db205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31b362e7-fc54-4de6-b578-353a113db205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

