### PR TITLE
Fix momentum PoolCache live-only recovery

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,12 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### FIX-MOM-POOLCACHE-LIVE-ONLY-2026-05-16: Momentum kein globales POOL_CACHE LastPerSubject-Replay
+**Datum**: 2026-05-16  
+**Problem**: `momentum-bot` nutzte `bootstrap_pool_cache_from_jetstream` mit `LastPerSubject` und übernahm denselben Consumer — hunderttausende Snapshot-Messages erzeugten JetStream-Backpressure und blockierten die Core-NATS-Verarbeitung trotz priorisierter Strategy-Fixes.  
+**Fix**: Runtime-Consumer mit `DeliverPolicy::New` und durable `momentum-bot-pool-cache-live` (`pool_cache_live_consumer_config`); kein globaler Bootstrap mehr. Offene Positionen triggern bounded/deduped `Ensure*` ControlRequests an `market-data` (Startup + Retry-Tick wenn keine executable Quote).  
+**Dateien**: `src/bin/momentum_bot.rs`, `src/nats/jetstream.rs`, `docs/BUGS_FIXES.md`
+
 ### FIX-MOM-STRATEGY-INGEST-2026-05-16: Strategy-Tick vs. Core-NATS-Drain (PR111-Follow-up, PR128 erweitert)
 **Datum**: 2026-05-16 (Follow-up: strikt event-/dirty-getrieben, kein periodischer Hot-Path-Scan)  
 **Problem**: Periodischer Entry-Full-/Safety-Scan über viele TokenTracker hielt `token_trackers` unter Write-Lock und band zusammen mit `MissedTickBehavior::Burst` auf dem 500-ms-Strategy-Intervall den Core-NATS-Ingest; Momentum verarbeitete nur noch niedrige zweistellige Events/s trotz schnellem `process_market_event`. Auch ein **budgetierter** periodischer Scan bleibt Hot-Path-Scheduler-Zeit und kann NATS-Drain erneut verdrängen (Regression-Klasse wie PR121).  

--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -9,7 +9,7 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 ### FIX-MOM-POOLCACHE-LIVE-ONLY-2026-05-16: Momentum kein globales POOL_CACHE LastPerSubject-Replay
 **Datum**: 2026-05-16  
 **Problem**: `momentum-bot` nutzte `bootstrap_pool_cache_from_jetstream` mit `LastPerSubject` und übernahm denselben Consumer — hunderttausende Snapshot-Messages erzeugten JetStream-Backpressure und blockierten die Core-NATS-Verarbeitung trotz priorisierter Strategy-Fixes.  
-**Fix**: Runtime-Consumer mit `DeliverPolicy::New` und durable `momentum-bot-pool-cache-live` (`pool_cache_live_consumer_config`); kein globaler Bootstrap mehr. Offene Positionen triggern bounded/deduped `Ensure*` ControlRequests an `market-data` (Startup + Retry-Tick wenn keine executable Quote).  
+**Fix**: Runtime-Consumer mit `DeliverPolicy::New` und durable `momentum-bot-pool-cache-live` (`pool_cache_live_consumer_config`); kein globaler Bootstrap mehr. Offene Positionen triggern bounded/deduped `Ensure*` ControlRequests an `market-data` (Startup + Retry-Tick wenn keine executable Quote). **PumpFun-Positionen:** parallel `EnsurePumpfunBondingCurve(force_refresh_pumpfun)` und `EnsurePumpAmmPoolAccounts(force_refresh)` **ohne** `pool_address_hint` auf der Bonding-Curve-Adresse (PumpAmm-Discovery für Migration/Exit); reine `pump_amm`-Positionen unverändert mit Pool-Hint.  
 **Dateien**: `src/bin/momentum_bot.rs`, `src/nats/jetstream.rs`, `docs/BUGS_FIXES.md`
 
 ### FIX-MOM-STRATEGY-INGEST-2026-05-16: Strategy-Tick vs. Core-NATS-Drain (PR111-Follow-up, PR128 erweitert)

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -115,7 +115,11 @@ const OPEN_POSITION_POOL_RECOVERY_RETRY_MAX_PER_TICK: usize = 8;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OpenPositionPoolRecoveryKind {
     PumpfunBonding,
+    /// PumpSwap pool_accounts refresh when the position already references the PumpAmm market pool.
     PumpAmmAccounts,
+    /// After migration off bonding curve: discover PumpAmm state without treating the bonding-curve
+    /// pubkey as a PumpAmm `pool_address_hint` (market-data derives/finds the AMM pool from mint).
+    PumpAmmMigrationProbe,
     OrcaWhirlpool,
     MeteoraDlmm,
     RaydiumAmm,
@@ -123,19 +127,39 @@ enum OpenPositionPoolRecoveryKind {
     MeteoraCpmm,
 }
 
-/// Maps [`MomentumContext::normalize_dex_for_execution_engine`] output to a market-data Ensure* path.
-fn open_position_pool_recovery_kind_for_normalized_dex(
+/// Ensure* recovery channels per normalized DEX (see [`MomentumContext::normalize_dex_for_execution_engine`]).
+///
+/// PumpFun positions get **two** bounded channels: bonding-curve refresh plus PumpAmm discovery so
+/// post-migration exits are not stuck on stale curve-only JetStream state.
+const OPEN_POSITION_RECOVERY_PUMPFUN: &[OpenPositionPoolRecoveryKind] = &[
+    OpenPositionPoolRecoveryKind::PumpfunBonding,
+    OpenPositionPoolRecoveryKind::PumpAmmMigrationProbe,
+];
+const OPEN_POSITION_RECOVERY_PUMP_AMM: &[OpenPositionPoolRecoveryKind] =
+    &[OpenPositionPoolRecoveryKind::PumpAmmAccounts];
+const OPEN_POSITION_RECOVERY_ORCA: &[OpenPositionPoolRecoveryKind] =
+    &[OpenPositionPoolRecoveryKind::OrcaWhirlpool];
+const OPEN_POSITION_RECOVERY_METEORA_DLMM: &[OpenPositionPoolRecoveryKind] =
+    &[OpenPositionPoolRecoveryKind::MeteoraDlmm];
+const OPEN_POSITION_RECOVERY_RAYDIUM_AMM: &[OpenPositionPoolRecoveryKind] =
+    &[OpenPositionPoolRecoveryKind::RaydiumAmm];
+const OPEN_POSITION_RECOVERY_RAYDIUM_CPMM: &[OpenPositionPoolRecoveryKind] =
+    &[OpenPositionPoolRecoveryKind::RaydiumCpmm];
+const OPEN_POSITION_RECOVERY_METEORA_CPMM: &[OpenPositionPoolRecoveryKind] =
+    &[OpenPositionPoolRecoveryKind::MeteoraCpmm];
+
+fn open_position_pool_recovery_kinds_for_normalized_dex(
     dex: &str,
-) -> Option<OpenPositionPoolRecoveryKind> {
+) -> &'static [OpenPositionPoolRecoveryKind] {
     match dex {
-        "pumpfun" => Some(OpenPositionPoolRecoveryKind::PumpfunBonding),
-        "pump_amm" => Some(OpenPositionPoolRecoveryKind::PumpAmmAccounts),
-        "orca" => Some(OpenPositionPoolRecoveryKind::OrcaWhirlpool),
-        "meteora_dlmm" => Some(OpenPositionPoolRecoveryKind::MeteoraDlmm),
-        "raydium" => Some(OpenPositionPoolRecoveryKind::RaydiumAmm),
-        "raydium_cpmm" => Some(OpenPositionPoolRecoveryKind::RaydiumCpmm),
-        "meteora_cpmm" => Some(OpenPositionPoolRecoveryKind::MeteoraCpmm),
-        _ => None,
+        "pumpfun" => OPEN_POSITION_RECOVERY_PUMPFUN,
+        "pump_amm" => OPEN_POSITION_RECOVERY_PUMP_AMM,
+        "orca" => OPEN_POSITION_RECOVERY_ORCA,
+        "meteora_dlmm" => OPEN_POSITION_RECOVERY_METEORA_DLMM,
+        "raydium" => OPEN_POSITION_RECOVERY_RAYDIUM_AMM,
+        "raydium_cpmm" => OPEN_POSITION_RECOVERY_RAYDIUM_CPMM,
+        "meteora_cpmm" => OPEN_POSITION_RECOVERY_METEORA_CPMM,
+        _ => &[],
     }
 }
 
@@ -2911,19 +2935,18 @@ impl MomentumContext {
     fn build_open_position_pool_control_request(
         run_id: &str,
         mint: &str,
-        pool: &str,
-        dex_raw: &str,
-    ) -> Option<(ControlRequest, OpenPositionPoolRecoveryKind)> {
-        let dex_norm = Self::normalize_dex_for_execution_engine(dex_raw);
-        let kind = open_position_pool_recovery_kind_for_normalized_dex(dex_norm.as_str())?;
+        position_pool: &str,
+        recovery_kind: OpenPositionPoolRecoveryKind,
+    ) -> (ControlRequest, OpenPositionPoolRecoveryKind) {
         let request_id = format!("mom-pool-rec-{}", Uuid::new_v4());
-        let kind_enum = match kind {
+        let kind_enum = match recovery_kind {
             OpenPositionPoolRecoveryKind::PumpfunBonding => {
                 ControlRequestKind::EnsurePumpfunBondingCurve {
                     base_mint: mint.to_string(),
                 }
             }
-            OpenPositionPoolRecoveryKind::PumpAmmAccounts => {
+            OpenPositionPoolRecoveryKind::PumpAmmAccounts
+            | OpenPositionPoolRecoveryKind::PumpAmmMigrationProbe => {
                 ControlRequestKind::EnsurePumpAmmPoolAccounts {
                     base_mint: mint.to_string(),
                 }
@@ -2962,36 +2985,39 @@ impl MomentumContext {
             "market-data",
             kind_enum,
         );
-        match kind {
+        match recovery_kind {
             OpenPositionPoolRecoveryKind::PumpfunBonding => {
                 req.force_refresh_pumpfun = true;
             }
             OpenPositionPoolRecoveryKind::PumpAmmAccounts => {
-                req.pool_address_hint = Some(pool.to_string());
+                req.pool_address_hint = Some(position_pool.to_string());
+                req.force_refresh = true;
+            }
+            OpenPositionPoolRecoveryKind::PumpAmmMigrationProbe => {
                 req.force_refresh = true;
             }
             OpenPositionPoolRecoveryKind::OrcaWhirlpool => {
-                req.pool_address_hint = Some(pool.to_string());
+                req.pool_address_hint = Some(position_pool.to_string());
                 req.force_refresh_orca = true;
             }
             OpenPositionPoolRecoveryKind::MeteoraDlmm => {
-                req.pool_address_hint = Some(pool.to_string());
+                req.pool_address_hint = Some(position_pool.to_string());
                 req.force_refresh_meteora_dlmm = true;
             }
             OpenPositionPoolRecoveryKind::RaydiumAmm => {
-                req.pool_address_hint = Some(pool.to_string());
+                req.pool_address_hint = Some(position_pool.to_string());
                 req.force_refresh_raydium_amm = true;
             }
             OpenPositionPoolRecoveryKind::RaydiumCpmm => {
-                req.pool_address_hint = Some(pool.to_string());
+                req.pool_address_hint = Some(position_pool.to_string());
                 req.force_refresh_raydium_cpmm = true;
             }
             OpenPositionPoolRecoveryKind::MeteoraCpmm => {
-                req.pool_address_hint = Some(pool.to_string());
+                req.pool_address_hint = Some(position_pool.to_string());
                 req.force_refresh_meteora_cpmm = true;
             }
         }
-        Some((req, kind))
+        (req, recovery_kind)
     }
 
     async fn publish_open_position_pool_recovery_if_allowed(
@@ -3007,9 +3033,9 @@ impl MomentumContext {
         if pool.is_empty() {
             return;
         }
-        let Some((req, kind)) =
-            Self::build_open_position_pool_control_request(self.run_id.as_str(), mint, pool, dex)
-        else {
+        let dex_norm = Self::normalize_dex_for_execution_engine(dex);
+        let kinds = open_position_pool_recovery_kinds_for_normalized_dex(dex_norm.as_str());
+        if kinds.is_empty() {
             info!(
                 mint = %mint,
                 pool = %pool,
@@ -3018,59 +3044,67 @@ impl MomentumContext {
                 "Momentum open-position pool recovery skipped: unsupported dex for Ensure* discovery"
             );
             return;
-        };
-        let key = open_position_pool_recovery_dedupe_key(mint, pool, kind);
-        let now = Instant::now();
-        {
-            let map = self.open_position_pool_recovery_last_sent.read();
-            if let Some(prev) = map.get(&key) {
-                if now.duration_since(*prev) < OPEN_POSITION_POOL_RECOVERY_COOLDOWN {
-                    debug!(
+        }
+        for &recovery_kind in kinds {
+            let (req, kind) = Self::build_open_position_pool_control_request(
+                self.run_id.as_str(),
+                mint,
+                pool,
+                recovery_kind,
+            );
+            let key = open_position_pool_recovery_dedupe_key(mint, pool, kind);
+            let now = Instant::now();
+            {
+                let map = self.open_position_pool_recovery_last_sent.read();
+                if let Some(prev) = map.get(&key) {
+                    if now.duration_since(*prev) < OPEN_POSITION_POOL_RECOVERY_COOLDOWN {
+                        debug!(
+                            mint = %mint,
+                            pool = %pool,
+                            dex = %dex,
+                            reason = reason_tag,
+                            request_kind = ?kind,
+                            "Momentum open-position pool recovery deferred: cooldown"
+                        );
+                        continue;
+                    }
+                }
+            }
+            {
+                self.open_position_pool_recovery_last_sent
+                    .write()
+                    .insert(key, now);
+            }
+            match nats.publish(TOPIC_CONTROL_REQUESTS, &req).await {
+                Ok(true) => {
+                    info!(
                         mint = %mint,
                         pool = %pool,
                         dex = %dex,
-                        reason = reason_tag,
                         request_kind = ?kind,
-                        "Momentum open-position pool recovery deferred: cooldown"
+                        reason = reason_tag,
+                        "Momentum open-position pool recovery requested"
                     );
-                    return;
                 }
-            }
-        }
-        {
-            self.open_position_pool_recovery_last_sent
-                .write()
-                .insert(key, now);
-        }
-        match nats.publish(TOPIC_CONTROL_REQUESTS, &req).await {
-            Ok(true) => {
-                info!(
-                    mint = %mint,
-                    pool = %pool,
-                    dex = %dex,
-                    request_kind = ?kind,
-                    reason = reason_tag,
-                    "Momentum open-position pool recovery requested"
-                );
-            }
-            Ok(false) => {
-                warn!(
-                    mint = %mint,
-                    pool = %pool,
-                    request_kind = ?kind,
-                    reason = reason_tag,
-                    "Momentum open-position pool recovery publish dropped (NATS publish returned false)"
-                );
-            }
-            Err(e) => {
-                warn!(
-                    mint = %mint,
-                    pool = %pool,
-                    request_kind = ?kind,
-                    reason = reason_tag,
-                    error = %e,
-                    "Momentum open-position pool recovery publish failed"
-                );
+                Ok(false) => {
+                    warn!(
+                        mint = %mint,
+                        pool = %pool,
+                        request_kind = ?kind,
+                        reason = reason_tag,
+                        "Momentum open-position pool recovery publish dropped (NATS publish returned false)"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        mint = %mint,
+                        pool = %pool,
+                        request_kind = ?kind,
+                        reason = reason_tag,
+                        error = %e,
+                        "Momentum open-position pool recovery publish failed"
+                    );
+                }
             }
         }
     }
@@ -9934,33 +9968,52 @@ mod tests {
     }
 
     #[test]
-    fn open_position_pool_recovery_kind_mapping() {
+    fn open_position_pool_recovery_kinds_mapping() {
         assert_eq!(
-            open_position_pool_recovery_kind_for_normalized_dex("pumpfun"),
-            Some(OpenPositionPoolRecoveryKind::PumpfunBonding)
+            open_position_pool_recovery_kinds_for_normalized_dex("pumpfun"),
+            &[
+                OpenPositionPoolRecoveryKind::PumpfunBonding,
+                OpenPositionPoolRecoveryKind::PumpAmmMigrationProbe,
+            ]
         );
         assert_eq!(
-            open_position_pool_recovery_kind_for_normalized_dex("pump_amm"),
-            Some(OpenPositionPoolRecoveryKind::PumpAmmAccounts)
+            open_position_pool_recovery_kinds_for_normalized_dex("pump_amm"),
+            &[OpenPositionPoolRecoveryKind::PumpAmmAccounts]
         );
-        assert!(open_position_pool_recovery_kind_for_normalized_dex("unknown_dex").is_none());
+        assert!(open_position_pool_recovery_kinds_for_normalized_dex("unknown_dex").is_empty());
     }
 
     #[test]
-    fn open_position_recovery_control_request_pumpfun_sets_force_refresh_pumpfun() {
+    fn open_position_recovery_pumpfun_emits_bonding_and_pump_amm_migration_probe() {
         use ironcrab::ipc::ControlRequestKind;
-        let (req, k) = MomentumContext::build_open_position_pool_control_request(
+        let bonding = MomentumContext::build_open_position_pool_control_request(
             "runidxxxx",
             "MintMintMintMintMintMintMintMintMintMintMintMint",
             "CrveCrveCrveCrveCrveCrveCrveCrveCrveCrveCrveCrve",
-            "pumpfun",
-        )
-        .expect("pumpfun supported");
-        assert_eq!(k, OpenPositionPoolRecoveryKind::PumpfunBonding);
-        assert!(req.force_refresh_pumpfun);
+            OpenPositionPoolRecoveryKind::PumpfunBonding,
+        );
+        assert_eq!(bonding.1, OpenPositionPoolRecoveryKind::PumpfunBonding);
+        assert!(bonding.0.force_refresh_pumpfun);
         assert!(matches!(
-            req.kind,
+            bonding.0.kind,
             ControlRequestKind::EnsurePumpfunBondingCurve { .. }
+        ));
+
+        let amm_probe = MomentumContext::build_open_position_pool_control_request(
+            "runidxxxx",
+            "MintMintMintMintMintMintMintMintMintMintMintMint",
+            "CrveCrveCrveCrveCrveCrveCrveCrveCrveCrveCrveCrve",
+            OpenPositionPoolRecoveryKind::PumpAmmMigrationProbe,
+        );
+        assert_eq!(
+            amm_probe.1,
+            OpenPositionPoolRecoveryKind::PumpAmmMigrationProbe
+        );
+        assert!(amm_probe.0.force_refresh);
+        assert!(amm_probe.0.pool_address_hint.is_none());
+        assert!(matches!(
+            amm_probe.0.kind,
+            ControlRequestKind::EnsurePumpAmmPoolAccounts { .. }
         ));
     }
 
@@ -9971,9 +10024,8 @@ mod tests {
             "runidxxxx",
             "MintMintMintMintMintMintMintMintMintMintMintMint",
             "PoolPoolPoolPoolPoolPoolPoolPoolPoolPoolPoolPool",
-            "pumpswap",
-        )
-        .expect("pumpswap normalized");
+            OpenPositionPoolRecoveryKind::PumpAmmAccounts,
+        );
         assert_eq!(k, OpenPositionPoolRecoveryKind::PumpAmmAccounts);
         assert!(req.force_refresh);
         assert_eq!(

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -40,10 +40,10 @@ use ironcrab::execution::pool_cache_sync;
 use ironcrab::execution::quote_calculator;
 use ironcrab::execution::tokens_per_sol;
 use ironcrab::ipc::{
-    ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, ExecutionResult, ExecutionStatus,
-    ExplicitAmount, IntentOrigin, IntentTier, MarketEvent, MarketEventKind,
-    TradeExecutionConstraints, TradeIntent, TradeResources, TradeSide, TradingRegime,
-    NATIVE_SOL_MINT,
+    ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, ControlRequest, ControlRequestKind,
+    ExecutionResult, ExecutionStatus, ExplicitAmount, IntentOrigin, IntentTier, MarketEvent,
+    MarketEventKind, TradeExecutionConstraints, TradeIntent, TradeResources, TradeSide,
+    TradingRegime, NATIVE_SOL_MINT,
 };
 use ironcrab::metrics::{
     momentum_event_ts_latency_delta_ms, record_momentum_core_market_events_ingest_drain_batch,
@@ -65,10 +65,11 @@ use ironcrab::metrics::{
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
     ensure_trade_intents_stream, execution_results_consumer_config,
-    wallet_snapshot_consumer_config, wallet_snapshot_live_consumer_config, NatsClient, NatsConfig,
-    NatsMessage, CONFIG_STREAM_NAME, EXECUTION_RESULTS_STREAM_NAME, STREAM_NAME,
-    TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS, TOPIC_MOMENTUM_MARKET_EVENTS,
-    TOPIC_TRADE_INTENTS, WALLET_SNAPSHOT_STREAM_NAME,
+    pool_cache_live_consumer_config, wallet_snapshot_consumer_config,
+    wallet_snapshot_live_consumer_config, NatsClient, NatsConfig, NatsMessage, CONFIG_STREAM_NAME,
+    EXECUTION_RESULTS_STREAM_NAME, STREAM_NAME, TOPIC_CONTROL_REQUESTS, TOPIC_EXECUTION_RESULTS,
+    TOPIC_MARKET_EVENTS, TOPIC_MOMENTUM_MARKET_EVENTS, TOPIC_TRADE_INTENTS,
+    WALLET_SNAPSHOT_STREAM_NAME,
 };
 use ironcrab::solana::dex_parser::SOL_MINT_PUBKEY;
 use ironcrab::storage::{JsonlWriter, JsonlWriterConfig};
@@ -104,6 +105,47 @@ fn is_non_tradeable_momentum_mint(mint: &str) -> bool {
 
 /// JetStream replay dedup for orphaned BUY path — bounded so memory does not grow forever.
 const ORPHANED_RECOVERED_INTENT_IDS_CAP: usize = 50_000;
+
+/// Cooldown between repeated `Ensure*` ControlRequests for the same open-position pool recovery key.
+const OPEN_POSITION_POOL_RECOVERY_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// Max recovery publishes per timed reconcile tick when executable quotes are still missing.
+const OPEN_POSITION_POOL_RECOVERY_RETRY_MAX_PER_TICK: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpenPositionPoolRecoveryKind {
+    PumpfunBonding,
+    PumpAmmAccounts,
+    OrcaWhirlpool,
+    MeteoraDlmm,
+    RaydiumAmm,
+    RaydiumCpmm,
+    MeteoraCpmm,
+}
+
+/// Maps [`MomentumContext::normalize_dex_for_execution_engine`] output to a market-data Ensure* path.
+fn open_position_pool_recovery_kind_for_normalized_dex(
+    dex: &str,
+) -> Option<OpenPositionPoolRecoveryKind> {
+    match dex {
+        "pumpfun" => Some(OpenPositionPoolRecoveryKind::PumpfunBonding),
+        "pump_amm" => Some(OpenPositionPoolRecoveryKind::PumpAmmAccounts),
+        "orca" => Some(OpenPositionPoolRecoveryKind::OrcaWhirlpool),
+        "meteora_dlmm" => Some(OpenPositionPoolRecoveryKind::MeteoraDlmm),
+        "raydium" => Some(OpenPositionPoolRecoveryKind::RaydiumAmm),
+        "raydium_cpmm" => Some(OpenPositionPoolRecoveryKind::RaydiumCpmm),
+        "meteora_cpmm" => Some(OpenPositionPoolRecoveryKind::MeteoraCpmm),
+        _ => None,
+    }
+}
+
+fn open_position_pool_recovery_dedupe_key(
+    mint: &str,
+    pool: &str,
+    kind: OpenPositionPoolRecoveryKind,
+) -> String {
+    format!("{mint}\x1f{pool}\x1f{kind:?}")
+}
 
 /// Core NATS delivers no publisher discovery: subscribing to [`TOPIC_MOMENTUM_MARKET_EVENTS`]
 /// succeeds even when market-data does not publish there yet. If no message arrives within this
@@ -2578,9 +2620,11 @@ struct MomentumContext {
     pending_buy_mint_index: parking_lot::RwLock<HashMap<String, String>>,
     /// Multi-pool registry: All known pools per mint (mint -> Vec<PoolInfo>)
     mint_pools: parking_lot::RwLock<HashMap<String, Vec<PoolInfo>>>,
-    /// SLAVE LivePoolCache — populated from JetStream PoolCacheUpdate events.
+    /// SLAVE LivePoolCache — live `PoolCacheUpdate` from JetStream after start (no global snapshot replay).
     /// Provides reserve-based quoting for multi-pool routing (FIX-21).
     live_pool_cache: LivePoolCache,
+    /// Dedupe / cooldown for startup + retry `Ensure*` ControlRequests to `market-data` for open positions.
+    open_position_pool_recovery_last_sent: parking_lot::RwLock<HashMap<String, Instant>>,
     /// JetStream KV Store for position persistence (initialized lazily)
     position_kv: tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
     /// Mints with non-zero wallet balance that could not be reconciled at bootstrap
@@ -2861,6 +2905,214 @@ impl MomentumContext {
             "pumpswap" | "PumpFunAmm" | "PumpFun AMM" => "pump_amm".to_string(),
             "pumpfun" | "PumpFun" => "pumpfun".to_string(),
             _ => dex.to_string(),
+        }
+    }
+
+    fn build_open_position_pool_control_request(
+        run_id: &str,
+        mint: &str,
+        pool: &str,
+        dex_raw: &str,
+    ) -> Option<(ControlRequest, OpenPositionPoolRecoveryKind)> {
+        let dex_norm = Self::normalize_dex_for_execution_engine(dex_raw);
+        let kind = open_position_pool_recovery_kind_for_normalized_dex(dex_norm.as_str())?;
+        let request_id = format!("mom-pool-rec-{}", Uuid::new_v4());
+        let kind_enum = match kind {
+            OpenPositionPoolRecoveryKind::PumpfunBonding => {
+                ControlRequestKind::EnsurePumpfunBondingCurve {
+                    base_mint: mint.to_string(),
+                }
+            }
+            OpenPositionPoolRecoveryKind::PumpAmmAccounts => {
+                ControlRequestKind::EnsurePumpAmmPoolAccounts {
+                    base_mint: mint.to_string(),
+                }
+            }
+            OpenPositionPoolRecoveryKind::OrcaWhirlpool => {
+                ControlRequestKind::EnsureOrcaWhirlpoolPoolState {
+                    base_mint: mint.to_string(),
+                }
+            }
+            OpenPositionPoolRecoveryKind::MeteoraDlmm => {
+                ControlRequestKind::EnsureMeteoraDlmmPoolState {
+                    base_mint: mint.to_string(),
+                }
+            }
+            OpenPositionPoolRecoveryKind::RaydiumAmm => {
+                ControlRequestKind::EnsureRaydiumAmmPoolState {
+                    base_mint: mint.to_string(),
+                }
+            }
+            OpenPositionPoolRecoveryKind::RaydiumCpmm => {
+                ControlRequestKind::EnsureRaydiumCpmmPoolState {
+                    base_mint: mint.to_string(),
+                }
+            }
+            OpenPositionPoolRecoveryKind::MeteoraCpmm => {
+                ControlRequestKind::EnsureMeteoraCpmmPoolState {
+                    base_mint: mint.to_string(),
+                }
+            }
+        };
+        let mut req = ControlRequest::new(
+            "momentum-bot",
+            BUILD_VERSION,
+            run_id,
+            request_id,
+            "market-data",
+            kind_enum,
+        );
+        match kind {
+            OpenPositionPoolRecoveryKind::PumpfunBonding => {
+                req.force_refresh_pumpfun = true;
+            }
+            OpenPositionPoolRecoveryKind::PumpAmmAccounts => {
+                req.pool_address_hint = Some(pool.to_string());
+                req.force_refresh = true;
+            }
+            OpenPositionPoolRecoveryKind::OrcaWhirlpool => {
+                req.pool_address_hint = Some(pool.to_string());
+                req.force_refresh_orca = true;
+            }
+            OpenPositionPoolRecoveryKind::MeteoraDlmm => {
+                req.pool_address_hint = Some(pool.to_string());
+                req.force_refresh_meteora_dlmm = true;
+            }
+            OpenPositionPoolRecoveryKind::RaydiumAmm => {
+                req.pool_address_hint = Some(pool.to_string());
+                req.force_refresh_raydium_amm = true;
+            }
+            OpenPositionPoolRecoveryKind::RaydiumCpmm => {
+                req.pool_address_hint = Some(pool.to_string());
+                req.force_refresh_raydium_cpmm = true;
+            }
+            OpenPositionPoolRecoveryKind::MeteoraCpmm => {
+                req.pool_address_hint = Some(pool.to_string());
+                req.force_refresh_meteora_cpmm = true;
+            }
+        }
+        Some((req, kind))
+    }
+
+    async fn publish_open_position_pool_recovery_if_allowed(
+        self: &Arc<Self>,
+        mint: &str,
+        pool: &str,
+        dex: &str,
+        reason_tag: &'static str,
+    ) {
+        let Some(nats) = self.nats.as_ref() else {
+            return;
+        };
+        if pool.is_empty() {
+            return;
+        }
+        let Some((req, kind)) =
+            Self::build_open_position_pool_control_request(self.run_id.as_str(), mint, pool, dex)
+        else {
+            info!(
+                mint = %mint,
+                pool = %pool,
+                dex = %dex,
+                reason = reason_tag,
+                "Momentum open-position pool recovery skipped: unsupported dex for Ensure* discovery"
+            );
+            return;
+        };
+        let key = open_position_pool_recovery_dedupe_key(mint, pool, kind);
+        let now = Instant::now();
+        {
+            let map = self.open_position_pool_recovery_last_sent.read();
+            if let Some(prev) = map.get(&key) {
+                if now.duration_since(*prev) < OPEN_POSITION_POOL_RECOVERY_COOLDOWN {
+                    debug!(
+                        mint = %mint,
+                        pool = %pool,
+                        dex = %dex,
+                        reason = reason_tag,
+                        request_kind = ?kind,
+                        "Momentum open-position pool recovery deferred: cooldown"
+                    );
+                    return;
+                }
+            }
+        }
+        {
+            self.open_position_pool_recovery_last_sent
+                .write()
+                .insert(key, now);
+        }
+        match nats.publish(TOPIC_CONTROL_REQUESTS, &req).await {
+            Ok(true) => {
+                info!(
+                    mint = %mint,
+                    pool = %pool,
+                    dex = %dex,
+                    request_kind = ?kind,
+                    reason = reason_tag,
+                    "Momentum open-position pool recovery requested"
+                );
+            }
+            Ok(false) => {
+                warn!(
+                    mint = %mint,
+                    pool = %pool,
+                    request_kind = ?kind,
+                    reason = reason_tag,
+                    "Momentum open-position pool recovery publish dropped (NATS publish returned false)"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    mint = %mint,
+                    pool = %pool,
+                    request_kind = ?kind,
+                    reason = reason_tag,
+                    error = %e,
+                    "Momentum open-position pool recovery publish failed"
+                );
+            }
+        }
+    }
+
+    async fn schedule_open_position_pool_recoveries(self: &Arc<Self>, reason_tag: &'static str) {
+        let rows: Vec<(String, String, String)> = {
+            let g = self.positions.read();
+            g.iter()
+                .map(|(m, p)| (m.clone(), p.pool.clone(), p.dex.clone()))
+                .collect()
+        };
+        for (mint, pool, dex) in rows {
+            self.publish_open_position_pool_recovery_if_allowed(&mint, &pool, &dex, reason_tag)
+                .await;
+        }
+    }
+
+    async fn tick_open_position_pool_recovery_retries(self: &Arc<Self>) {
+        let mut rows: Vec<(String, String, String)> = Vec::new();
+        {
+            let positions = self.positions.read();
+            for (mint, pos) in positions.iter() {
+                if pos.pool.is_empty() || pos.token_amount == 0 {
+                    continue;
+                }
+                if self.executable_exit_quote(pos).is_some() {
+                    continue;
+                }
+                rows.push((mint.clone(), pos.pool.clone(), pos.dex.clone()));
+            }
+        }
+        for (mint, pool, dex) in rows
+            .into_iter()
+            .take(OPEN_POSITION_POOL_RECOVERY_RETRY_MAX_PER_TICK)
+        {
+            self.publish_open_position_pool_recovery_if_allowed(
+                &mint,
+                &pool,
+                &dex,
+                "quote_missing_retry",
+            )
+            .await;
         }
     }
 
@@ -7641,6 +7893,7 @@ async fn main() -> Result<()> {
         pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
         mint_pools: parking_lot::RwLock::new(HashMap::new()),
         live_pool_cache,
+        open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
         position_kv: tokio::sync::OnceCell::new(),
         orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
         orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -7662,55 +7915,8 @@ async fn main() -> Result<()> {
         }
     }
 
-    // === FIX-21: Bootstrap SLAVE LivePoolCache from JetStream (ASYNC) ===
-    // Bootstrap runs in a background task to avoid blocking startup.
-    // With 688k+ pool entries, synchronous bootstrap takes >90s which
-    // exceeds systemd's startup timeout. The service starts immediately;
-    // until bootstrap completes, find_best_*_pool() falls back to last_trade_ratio.
-    let bootstrap_consumer_rx = {
-        let (tx, rx) = tokio::sync::oneshot::channel::<
-            Option<
-                async_nats::jetstream::consumer::Consumer<
-                    async_nats::jetstream::consumer::pull::Config,
-                >,
-            >,
-        >();
-
-        if ctx.nats.is_some() {
-            let ctx_clone = Arc::clone(&ctx);
-            tokio::spawn(async move {
-                let nats = match ctx_clone.nats.as_ref() {
-                    Some(n) => n,
-                    None => {
-                        warn!("NATS cleared before bootstrap started, skipping pool cache sync");
-                        let _ = tx.send(None);
-                        return;
-                    }
-                };
-                match pool_cache_sync::bootstrap_pool_cache_from_jetstream(
-                    nats,
-                    &ctx_clone.live_pool_cache,
-                )
-                .await
-                {
-                    Ok((recovered, consumer)) => {
-                        info!(
-                            pools_recovered = recovered,
-                            "MOMENTUM SLAVE CACHE: bootstrap complete (async)"
-                        );
-                        let _ = tx.send(consumer);
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "MOMENTUM SLAVE CACHE: bootstrap failed");
-                        let _ = tx.send(None);
-                    }
-                }
-            });
-        } else {
-            let _ = tx.send(None);
-        }
-        rx
-    };
+    // Open positions: request authoritative pool rows from market-data (bounded, deduped; no RPC here).
+    ctx.schedule_open_position_pool_recoveries("startup").await;
 
     // === CRITICAL: Check for immediate exits after position recovery ===
     // Recovered positions might already violate max_hold_time or stop-loss
@@ -8007,6 +8213,47 @@ async fn main() -> Result<()> {
         None
     };
 
+    // JetStream consumer for live PoolCacheUpdate only (`DeliverPolicy::New` — no global snapshot replay).
+    let mut pool_cache_consumer_opt = if let Some(ref nats) = ctx.nats {
+        use async_nats::jetstream;
+
+        let jetstream = jetstream::new(nats.client().clone());
+        match jetstream.get_stream(STREAM_NAME).await {
+            Ok(stream) => match stream
+                .create_consumer(pool_cache_live_consumer_config())
+                .await
+            {
+                Ok(consumer) => {
+                    info!(
+                        stream = STREAM_NAME,
+                        deliver_policy = "New",
+                        durable = "momentum-bot-pool-cache-live",
+                        "Momentum PoolCache live consumer created deliver_policy=New"
+                    );
+                    Some(consumer)
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        stream = STREAM_NAME,
+                        "Failed to create JetStream POOL_CACHE live consumer"
+                    );
+                    None
+                }
+            },
+            Err(e) => {
+                debug!(
+                    error = %e,
+                    stream = STREAM_NAME,
+                    "POOL_CACHE JetStream stream not found (market-data may not be running)"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // Subscribe to Control Commands (manual position cleanup, etc.)
     let mut control_subscription = if let Some(ref nats) = ctx.nats {
         match nats.subscribe(TOPIC_CONTROL_COMMANDS).await {
@@ -8025,15 +8272,6 @@ async fn main() -> Result<()> {
     } else {
         None
     };
-
-    // FIX-21: JetStream consumer for incremental PoolCacheUpdates (SLAVE cache sync)
-    // The bootstrap runs asynchronously. We start with no consumer and wait for
-    // the bootstrap to finish, then reuse its consumer for incremental updates.
-    // This avoids replaying all 688k+ messages twice.
-    let mut pool_cache_consumer_opt: Option<
-        async_nats::jetstream::consumer::Consumer<async_nats::jetstream::consumer::pull::Config>,
-    > = None;
-    let mut bootstrap_consumer_rx = Some(bootstrap_consumer_rx);
 
     // Heartbeat and stats tracking
     let mut heartbeat_interval = tokio::time::interval(std::time::Duration::from_secs(60));
@@ -8527,30 +8765,7 @@ async fn main() -> Result<()> {
                 }
             } => {}
 
-            // FIX-21: Receive bootstrap consumer when async bootstrap completes
-            result = async {
-                match bootstrap_consumer_rx.as_mut() {
-                    Some(rx) => rx.await,
-                    None => std::future::pending().await,
-                }
-            } => {
-                // Consume the rx so this arm doesn't fire again
-                bootstrap_consumer_rx = None;
-                match result {
-                    Ok(Some(consumer)) => {
-                        info!(stream = STREAM_NAME, "SLAVE CACHE: bootstrap consumer ready, switching to incremental sync");
-                        pool_cache_consumer_opt = Some(consumer);
-                    }
-                    Ok(None) => {
-                        debug!("SLAVE CACHE: bootstrap completed without consumer");
-                    }
-                    Err(_) => {
-                        warn!("SLAVE CACHE: bootstrap task dropped (sender gone)");
-                    }
-                }
-            }
-
-            // FIX-21: Process incremental PoolCacheUpdates (SLAVE cache sync)
+            // FIX-21: Process incremental PoolCacheUpdates (live JetStream consumer, `DeliverPolicy::New`)
             _ = async {
                 use futures::StreamExt;
                 if let Some(ref mut consumer) = pool_cache_consumer_opt {
@@ -8687,6 +8902,7 @@ async fn main() -> Result<()> {
             _ = reconcile_interval.tick() => {
                 ironcrab::metrics::record_activity();
                 ctx.reconcile_timed_exits().await;
+                ctx.tick_open_position_pool_recovery_retries().await;
             }
 
             // Periodic heartbeat
@@ -9686,6 +9902,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -9699,6 +9916,74 @@ mod tests {
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    #[test]
+    fn momentum_pool_cache_live_consumer_is_new_not_last_per_subject() {
+        use async_nats::jetstream;
+        let live = ironcrab::nats::pool_cache_live_consumer_config();
+        assert!(matches!(
+            live.deliver_policy,
+            jetstream::consumer::DeliverPolicy::New
+        ));
+        let slave = ironcrab::nats::slave_consumer_config();
+        assert!(matches!(
+            slave.deliver_policy,
+            jetstream::consumer::DeliverPolicy::LastPerSubject
+        ));
+    }
+
+    #[test]
+    fn open_position_pool_recovery_kind_mapping() {
+        assert_eq!(
+            open_position_pool_recovery_kind_for_normalized_dex("pumpfun"),
+            Some(OpenPositionPoolRecoveryKind::PumpfunBonding)
+        );
+        assert_eq!(
+            open_position_pool_recovery_kind_for_normalized_dex("pump_amm"),
+            Some(OpenPositionPoolRecoveryKind::PumpAmmAccounts)
+        );
+        assert!(open_position_pool_recovery_kind_for_normalized_dex("unknown_dex").is_none());
+    }
+
+    #[test]
+    fn open_position_recovery_control_request_pumpfun_sets_force_refresh_pumpfun() {
+        use ironcrab::ipc::ControlRequestKind;
+        let (req, k) = MomentumContext::build_open_position_pool_control_request(
+            "runidxxxx",
+            "MintMintMintMintMintMintMintMintMintMintMintMint",
+            "CrveCrveCrveCrveCrveCrveCrveCrveCrveCrveCrveCrve",
+            "pumpfun",
+        )
+        .expect("pumpfun supported");
+        assert_eq!(k, OpenPositionPoolRecoveryKind::PumpfunBonding);
+        assert!(req.force_refresh_pumpfun);
+        assert!(matches!(
+            req.kind,
+            ControlRequestKind::EnsurePumpfunBondingCurve { .. }
+        ));
+    }
+
+    #[test]
+    fn open_position_recovery_control_request_pump_amm_pool_hint_and_force_refresh() {
+        use ironcrab::ipc::ControlRequestKind;
+        let (req, k) = MomentumContext::build_open_position_pool_control_request(
+            "runidxxxx",
+            "MintMintMintMintMintMintMintMintMintMintMintMint",
+            "PoolPoolPoolPoolPoolPoolPoolPoolPoolPoolPoolPool",
+            "pumpswap",
+        )
+        .expect("pumpswap normalized");
+        assert_eq!(k, OpenPositionPoolRecoveryKind::PumpAmmAccounts);
+        assert!(req.force_refresh);
+        assert_eq!(
+            req.pool_address_hint.as_deref(),
+            Some("PoolPoolPoolPoolPoolPoolPoolPoolPoolPoolPoolPool")
+        );
+        assert!(matches!(
+            req.kind,
+            ControlRequestKind::EnsurePumpAmmPoolAccounts { .. }
+        ));
     }
 
     const WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
@@ -10754,6 +11039,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -10818,6 +11104,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -11059,6 +11346,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -12130,6 +12418,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -12247,6 +12536,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -12332,6 +12622,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -12405,6 +12696,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -12490,6 +12782,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -12606,6 +12899,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -12715,6 +13009,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -12809,6 +13104,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -12881,6 +13177,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -12945,6 +13242,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -13473,6 +13771,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
@@ -13607,6 +13906,7 @@ mod tests {
             pending_buy_mint_index: parking_lot::RwLock::new(HashMap::new()),
             mint_pools: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: LivePoolCache::new(),
+            open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(

--- a/src/nats/jetstream.rs
+++ b/src/nats/jetstream.rs
@@ -352,6 +352,23 @@ pub fn slave_consumer_config() -> jetstream::consumer::pull::Config {
     }
 }
 
+/// Consumer config for live `POOL_CACHE` updates only (`DeliverPolicy::New`).
+///
+/// Used by **momentum-bot** so the runtime does not replay the per-subject last snapshot for every
+/// pool in the stream (hundreds of thousands of messages). Cold-path tools (execution-engine,
+/// `sell_all_keyless`, arb-strategy known-pools bootstrap) continue to use
+/// `slave_consumer_config` / `pool_cache_sync::bootstrap_pool_cache_from_jetstream`.
+pub fn pool_cache_live_consumer_config() -> jetstream::consumer::pull::Config {
+    jetstream::consumer::pull::Config {
+        deliver_policy: jetstream::consumer::DeliverPolicy::New,
+        ack_policy: jetstream::consumer::AckPolicy::Explicit,
+        durable_name: Some("momentum-bot-pool-cache-live".to_string()),
+        max_ack_pending: 1000,
+        filter_subject: "ironcrab.pool_cache.>".to_string(),
+        ..Default::default()
+    }
+}
+
 /// Consumer config for wallet snapshot recovery (LastPerSubject)
 pub fn wallet_snapshot_consumer_config() -> jetstream::consumer::pull::Config {
     jetstream::consumer::pull::Config {
@@ -409,5 +426,25 @@ mod tests {
     #[test]
     fn test_stream_name() {
         assert_eq!(STREAM_NAME, "POOL_CACHE");
+    }
+
+    #[test]
+    fn pool_cache_live_consumer_uses_new_deliver_policy() {
+        let live = pool_cache_live_consumer_config();
+        assert!(matches!(
+            live.deliver_policy,
+            jetstream::consumer::DeliverPolicy::New
+        ));
+        assert_eq!(
+            live.durable_name.as_deref(),
+            Some("momentum-bot-pool-cache-live")
+        );
+        assert_eq!(live.filter_subject, "ironcrab.pool_cache.>");
+
+        let slave = slave_consumer_config();
+        assert!(matches!(
+            slave.deliver_policy,
+            jetstream::consumer::DeliverPolicy::LastPerSubject
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- Switch momentum PoolCache runtime consumption to live-only JetStream delivery so startup no longer replays the global LastPerSubject snapshot.
- Add bounded, deduped open-position Ensure recovery requests to market-data for missing executable quote data without adding Momentum hot-path RPC.
- Document the PoolCache replay/backpressure fix in BUGS_FIXES.

## Test plan
- cargo fmt --check / cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
- cargo test --features test_helpers

Note: Eval Level 5 was not run by the Cloud Agent because the eval repo was not present in its workspace; Supervisor CI/Eval review remains required before merge.

Made with [Cursor](https://cursor.com)