### PR TITLE
Default confirm_commitment to confirmed

### DIFF
--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -55,7 +55,7 @@ Component name: `execution-engine`
 |-----|------|---------|-------|-------------|
 | `simulation_timeout_ms` | u64 | 2000 | 100-30000 | Simulation timeout (ms) |
 | `confirmation_timeout_ms` | u64 | 30000 | 500-300000 | Confirmation timeout after send (ms) |
-| `confirm_commitment` | string | "finalized" | finalized, confirmed | Commitment level for TX confirmation. "finalized" (INVARIANTS D.2): Position only from finalized executions. "confirmed": faster but reorg risk. Geyser uses startup value; RPC polling uses hot-reload value. |
+| `confirm_commitment` | string | "confirmed" | finalized, confirmed | Commitment level for TX confirmation. Default `"confirmed"`: lower confirmation latency with **reorg risk** (slot can still reorganize). `"finalized"`: typical ~12–15s extra latency, stronger fork resistance. Geyser subscription uses the value at engine startup (restart to apply a default change consistently); RPC polling uses the hot-reloaded config value. |
 | `send_enabled` | bool | false | true/false | If true, engine signs and submits transactions |
 
 ### Validation Rules

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -1432,7 +1432,7 @@ struct ExecutionConfig {
     // === FIX-32: Geyser TX Confirmation ===
     /// Use Geyser for TX confirmation instead of RPC polling (requires geyser_grpc_url)
     geyser_confirm_enabled: bool,
-    /// Commitment for TX confirmation: "finalized" (default, INVARIANTS D.2) or "confirmed"
+    /// Commitment for TX confirmation: `"confirmed"` (default, lower latency, reorg risk) or `"finalized"` (slower, stricter finality).
     confirm_commitment: String,
     /// Rebroadcast interval during confirmation wait (ms)
     rebroadcast_interval_ms: u64,
@@ -1491,9 +1491,9 @@ impl Default for ExecutionConfig {
             wsol_dry_run: false,
             // FIX-31: Parallel intent processing
             max_concurrent_intents: 4,
-            // FIX-32: Geyser TX confirmation defaults (INVARIANTS D.2: finalized)
+            // FIX-32: Geyser TX confirmation defaults (product default: confirmed — see CONFIG_SCHEMA)
             geyser_confirm_enabled: true,
-            confirm_commitment: "finalized".to_string(),
+            confirm_commitment: "confirmed".to_string(),
             rebroadcast_interval_ms: 2_000,
             max_rebroadcasts: 5,
             // Account Janitor defaults
@@ -6337,10 +6337,10 @@ async fn main() -> Result<()> {
             .and_then(|fp| fp.liquidation_max_priority_fee_micro_lamports),
         liquidation_max_tx_cost_lamports: fee_policy_cfg
             .and_then(|fp| fp.liquidation_max_tx_cost_lamports),
-        // INVARIANTS D.2: confirm_commitment (default finalized)
+        // confirm_commitment: default confirmed (faster confirmation; reorg risk). Use "finalized" in config for stricter finality.
         confirm_commitment: exec_eng_cfg
             .and_then(|e| e.confirm_commitment.clone())
-            .unwrap_or_else(|| "finalized".to_string()),
+            .unwrap_or_else(|| "confirmed".to_string()),
         ..Default::default()
     };
 
@@ -11546,7 +11546,8 @@ async fn confirm_via_geyser(
 }
 
 /// RPC-polling fallback: exponential backoff polling of `get_signature_statuses()`.
-/// INVARIANTS D.2: When confirm_commitment == "finalized", only Finalized status is accepted.
+/// When `confirm_commitment == "finalized"`, only `Finalized` RPC status counts as confirmed;
+/// with default `"confirmed"`, `Confirmed` or `Finalized` is accepted (reorg risk vs latency trade-off).
 async fn confirm_via_rpc_polling(
     ctx: &ExecutionContext,
     signature_base58: &str,

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,8 +128,8 @@ pub struct ExecutionEngineCfg {
     /// Fee Policy Configuration (priority fees, compute limits)
     #[serde(default)]
     pub fee_policy: Option<FeePolicyCfg>,
-    /// Commitment level for TX confirmation: "finalized" (default, safe) or "confirmed" (faster, reorg risk).
-    /// INVARIANTS D.2: Position only from finalized executions when set to "finalized".
+    /// Commitment level for TX confirmation: `"confirmed"` (default, faster, reorg risk) or `"finalized"` (slower, lower reorg risk).
+    /// When set to `"finalized"`, confirmation accepts only finalized on-chain status (stricter than `"confirmed"`).
     #[serde(default)]
     pub confirm_commitment: Option<String>,
 }

--- a/src/solana/geyser_tx_confirm.rs
+++ b/src/solana/geyser_tx_confirm.rs
@@ -123,7 +123,7 @@ impl GeyserTxConfirm {
     /// 1. ATA watcher: subscribes to specific ATA account updates
     /// 2. TX watcher: subscribes to `transactions_status` filtered by `wallet_pubkey`
     ///
-    /// `confirm_commitment`: "finalized" (INVARIANTS D.2, safe) or "confirmed" (faster, reorg risk).
+    /// `confirm_commitment`: `"confirmed"` (engine default, faster, reorg risk) or `"finalized"` (slower, stricter).
     /// Geyser uses startup value; hot-reload does not affect subscription.
     pub fn with_geyser(
         timeout_secs: u64,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Changes the execution engine default for `confirm_commitment` from `finalized` to `confirmed` (struct default and TOML merge when the key is absent). Updates `docs/CONFIG_SCHEMA.md` and Rust comments to describe latency, reorg risk, and Geyser startup vs RPC hot-reload. `geyser_tx_confirm::commitment_from_str` mapping is unchanged (`finalized` → Finalized, else Confirmed).

## STOP-CHECK (pre-change)

1. **I-7**: No new RPC; confirmation path unchanged except default string.
2. **Pattern**: Existing `require_finalized` / Geyser mapping preserved.
3. **Scope**: Only allowed files touched.
4. **I-9**: Unchanged.
5. **Eval isolation**: No Iron_crab-eval access.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet` and `cargo test --features test_helpers --quiet`

**Eval (Level 5):** Not run in this VM (Iron_crab-eval checkout forbidden for this agent). CI job **Eval (Level 5)** on the PR should run after `build-test` passes.

## Supervisor

Spec D.2 update remains in Iron_crab-eval (separate).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fedad4f-a8e6-4e63-8a34-7cc547856f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fedad4f-a8e6-4e63-8a34-7cc547856f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

