### PR TITLE
Multi-Pool-Liquidation: nur baubare Routen (Orca Tick-Arrays, PumpSwap, Meteora)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -1653,20 +1653,208 @@ struct RouteCandidate {
     pool_id: String,
     accounts: Vec<String>,
     creator: Option<String>,
+    /// When `Some`, this is already the engine `min_out` in lamports (LivePoolCache quote path)
+    /// and must not be run through slippage scaling again in multi-pool fallback.
+    execution_min_out_lamports: Option<u64>,
 }
 
-fn select_best_route(candidates: Vec<RouteCandidate>) -> Option<RouteCandidate> {
-    let mut best: Option<RouteCandidate> = None;
-    for candidate in candidates {
-        let replace = best
-            .as_ref()
-            .map(|b| candidate.amount_out > b.amount_out)
-            .unwrap_or(true);
-        if replace {
-            best = Some(candidate);
+/// JSON array of additional buildable routes (same shape as [`RouteCandidate`]) for cold-path
+/// multi-pool SELL fallback after `build_tx_plan` Unsupported (liquidation / kill-switch).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MultiPoolFallbackRouteWire {
+    dex: String,
+    pool_id: String,
+    amount_out: u64,
+    accounts: Vec<String>,
+    #[serde(default)]
+    creator: Option<String>,
+    #[serde(default)]
+    execution_min_out_lamports: Option<u64>,
+}
+
+const MULTI_POOL_FALLBACK_ROUTES_JSON_META_KEY: &str = "multi_pool_fallback_routes_json";
+
+fn sort_route_candidates_by_amount_out(mut v: Vec<RouteCandidate>) -> Vec<RouteCandidate> {
+    v.sort_by(|a, b| b.amount_out.cmp(&a.amount_out));
+    v
+}
+
+/// Cold-path liquidation: drop routes that would fail the same structural gates as
+/// `tx_builder::build_tx_plan` (Orca tick-array RPC check, PumpSwap SLAVE ≥12 accounts, Meteora
+/// explicit Ready). Preserves descending `amount_out` order among survivors.
+async fn liquidation_filter_multi_pool_buildable_candidates(
+    live_cache: Option<&LivePoolCache>,
+    orca: &Orca,
+    mint: &Pubkey,
+    sol_mint: &Pubkey,
+    candidates: Vec<RouteCandidate>,
+    quote_attempts: &mut Vec<String>,
+) -> Vec<RouteCandidate> {
+    let ordered = sort_route_candidates_by_amount_out(candidates);
+    let mut out = Vec::new();
+    for c in ordered {
+        match c.dex.as_str() {
+            "orca" => {
+                let Ok(pool_pk) = Pubkey::from_str(&c.pool_id) else {
+                    quote_attempts.push(format!("orca=skip bad_pool_pubkey pool={}", c.pool_id));
+                    continue;
+                };
+                match orca
+                    .cold_path_validate_whirlpool_tick_arrays_for_pool_swap(
+                        &pool_pk, mint, sol_mint,
+                    )
+                    .await
+                {
+                    Ok(()) => out.push(c),
+                    Err(reason) => {
+                        info!(
+                            dex = %c.dex,
+                            pool = %c.pool_id,
+                            reason = %reason,
+                            "routing skipped orca: not buildable; selected next if any"
+                        );
+                        quote_attempts.push(format!(
+                            "orca=skip not_buildable pool={} reason={reason}",
+                            c.pool_id
+                        ));
+                    }
+                }
+            }
+            "pump_amm" => {
+                let Ok(pool_pk) = Pubkey::from_str(&c.pool_id) else {
+                    quote_attempts
+                        .push(format!("pump_amm=skip bad_pool_pubkey pool={}", c.pool_id));
+                    continue;
+                };
+                if !c.accounts.is_empty() {
+                    if let Ok(first) = Pubkey::from_str(&c.accounts[0]) {
+                        if first != pool_pk {
+                            info!(
+                                pool_hint = %c.pool_id,
+                                accounts0 = %first,
+                                "routing skipped pump_amm: not buildable (reason=pool_account_mismatch); selected next if any"
+                            );
+                            quote_attempts.push(format!(
+                                "pump_amm=skip not_buildable pool_mismatch pool={}",
+                                c.pool_id
+                            ));
+                            continue;
+                        }
+                    }
+                }
+                let cache_ok = live_cache.is_some_and(|cache| {
+                    pump_amm_hint_pool_cache_usable_for_tx_plan_builder(cache, &pool_pk)
+                });
+                if !cache_ok {
+                    info!(
+                        pool = %c.pool_id,
+                        "routing skipped pump_amm: not buildable (reason=slave_pool_accounts_not_ready); selected next if any"
+                    );
+                    quote_attempts.push(format!(
+                        "pump_amm=skip not_buildable no_builder_ready_cache pool={}",
+                        c.pool_id
+                    ));
+                    continue;
+                }
+                out.push(c);
+            }
+            "meteora_dlmm" => {
+                let Ok(pool_pk) = Pubkey::from_str(&c.pool_id) else {
+                    quote_attempts.push(format!("meteora=skip bad_pool_pubkey pool={}", c.pool_id));
+                    continue;
+                };
+                let ready = live_cache
+                    .map(|cache| cache.meteora_dlmm_pool_explicitly_ready(&pool_pk))
+                    .unwrap_or(false);
+                if !ready {
+                    info!(
+                        pool = %c.pool_id,
+                        "routing skipped meteora_dlmm: not buildable (reason=no_explicit_ready); selected next if any"
+                    );
+                    quote_attempts.push(format!(
+                        "meteora=skip not_buildable no_explicit_ready pool={}",
+                        c.pool_id
+                    ));
+                    continue;
+                }
+                out.push(c);
+            }
+            _ => out.push(c),
         }
     }
-    best
+    out
+}
+
+fn liquidation_store_multi_pool_fallback_metadata(
+    metadata: &mut HashMap<String, String>,
+    buildable: &[RouteCandidate],
+) {
+    if buildable.len() <= 1 {
+        metadata.remove(MULTI_POOL_FALLBACK_ROUTES_JSON_META_KEY);
+        return;
+    }
+    let tail: Vec<MultiPoolFallbackRouteWire> = buildable
+        .iter()
+        .skip(1)
+        .map(|c| MultiPoolFallbackRouteWire {
+            dex: c.dex.clone(),
+            pool_id: c.pool_id.clone(),
+            amount_out: c.amount_out,
+            accounts: c.accounts.clone(),
+            creator: c.creator.clone(),
+            execution_min_out_lamports: c.execution_min_out_lamports,
+        })
+        .collect();
+    if let Ok(json) = serde_json::to_string(&tail) {
+        metadata.insert(MULTI_POOL_FALLBACK_ROUTES_JSON_META_KEY.to_string(), json);
+    }
+}
+
+/// After `build_tx_plan` returns Unsupported for a cold-path multi-pool sell: apply the next
+/// pre-filtered buildable route (if any). Returns true when `intent` was updated for a retry.
+fn take_next_multi_pool_buildable_fallback_route(intent: &mut TradeIntent) -> bool {
+    if intent.metadata.get("sell_routing").map(|s| s.as_str()) != Some("multi_pool") {
+        return false;
+    }
+    let json = match intent
+        .metadata
+        .get(MULTI_POOL_FALLBACK_ROUTES_JSON_META_KEY)
+    {
+        Some(j) if !j.is_empty() => j.clone(),
+        _ => return false,
+    };
+    let mut routes: Vec<MultiPoolFallbackRouteWire> = match serde_json::from_str(&json) {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    if routes.is_empty() {
+        return false;
+    }
+    let next = routes.remove(0);
+    let rest = serde_json::to_string(&routes).unwrap_or_else(|_| "[]".to_string());
+    intent
+        .metadata
+        .insert(MULTI_POOL_FALLBACK_ROUTES_JSON_META_KEY.to_string(), rest);
+
+    let min_lamports = next.execution_min_out_lamports.unwrap_or_else(|| {
+        let keep_bps = 10_000u64.saturating_sub(intent.max_slippage_bps as u64);
+        ((next.amount_out as u128) * (keep_bps as u128) / 10_000u128) as u64
+    });
+    intent.metadata.insert("dex".to_string(), next.dex.clone());
+    intent.resources.pools = vec![next.pool_id.clone()];
+    intent.resources.accounts = next.accounts.clone();
+    match &next.creator {
+        Some(c) => {
+            intent.metadata.insert("creator".to_string(), c.clone());
+        }
+        None => {
+            intent.metadata.remove("creator");
+        }
+    }
+    intent.execution = Some(TradeExecutionConstraints {
+        min_out: Some(ExplicitAmount::new(min_lamports, 9)),
+    });
+    true
 }
 
 /// Guard timeout for `PumpFunAmmDex::quote_exact_in` in liquidation / 6005-retry.
@@ -3766,6 +3954,7 @@ impl ExecutionContext {
                                 pool_id,
                                 accounts,
                                 creator: None,
+                                execution_min_out_lamports: None,
                             });
                         };
 
@@ -4167,7 +4356,17 @@ impl ExecutionContext {
                         }
                     }
 
-                    if let Some(best_route) = select_best_route(candidates) {
+                    let buildable = liquidation_filter_multi_pool_buildable_candidates(
+                        ctx.live_pool_cache.as_deref(),
+                        &orca,
+                        &mint,
+                        &sol_mint,
+                        candidates,
+                        &mut quote_attempts,
+                    )
+                    .await;
+                    if let Some(best_route) = buildable.first().cloned() {
+                        liquidation_store_multi_pool_fallback_metadata(&mut metadata, &buildable);
                         metadata.insert("sell_routing".to_string(), "multi_pool".to_string());
                         metadata.insert("dex".to_string(), best_route.dex.clone());
                         if let Some(creator) = best_route.creator.clone() {
@@ -4334,10 +4533,24 @@ impl ExecutionContext {
                                     CachedPoolState::PumpFun(s) => Some(s.creator.to_string()),
                                     _ => None,
                                 },
+                                execution_min_out_lamports: Some(min_out),
                             });
                         }
 
-                        if let Some(best_route) = select_best_route(candidates) {
+                        let buildable = liquidation_filter_multi_pool_buildable_candidates(
+                            ctx.live_pool_cache.as_deref(),
+                            &orca,
+                            &mint,
+                            &sol_mint,
+                            candidates,
+                            &mut quote_attempts,
+                        )
+                        .await;
+                        if let Some(best_route) = buildable.first().cloned() {
+                            liquidation_store_multi_pool_fallback_metadata(
+                                &mut metadata,
+                                &buildable,
+                            );
                             metadata.insert("sell_routing".to_string(), "multi_pool".to_string());
                             metadata.insert("dex".to_string(), best_route.dex.clone());
                             if let Some(creator) = best_route.creator.clone() {
@@ -8403,7 +8616,7 @@ fn max_open_positions_buy_gate(
 }
 
 /// Process a single TradeIntent through the execution pipeline
-async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<()> {
+async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Result<()> {
     ctx.record_intent_received();
 
     // Keep Prometheus counters aligned with persisted decision/intents logs.
@@ -9105,6 +9318,7 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
     let mut pump_amm_recovery_attempted = false;
     let mut pumpfun_bonding_recovery_attempted = false;
     let mut orca_recovery_attempted = false;
+    let mut multi_pool_tx_plan_fallback_attempted = false;
     let (
         tx_plan,
         plan_hash_str,
@@ -9113,11 +9327,12 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
         bundle_tip_ix,
         wallet_pubkey,
         bundle_tip_lamports,
-    ) = loop {
+    ) = 'tx_plan_retry: loop {
         if pump_amm_preplan_discovery_attempted
             || pump_amm_recovery_attempted
             || pumpfun_bonding_recovery_attempted
             || orca_recovery_attempted
+            || multi_pool_tx_plan_fallback_attempted
         {
             checks.truncate(checks_len_before_tx_plan_build);
         }
@@ -9361,6 +9576,22 @@ async fn process_intent(ctx: &ExecutionContext, intent: TradeIntent) -> Result<(
                         (plan, plan_hash_str)
                     }
                     tx_builder::TxPlanOutcome::Unsupported(u) => {
+                        if is_cold_path_recovery_sell(&intent)
+                            && take_next_multi_pool_buildable_fallback_route(&mut intent)
+                        {
+                            multi_pool_tx_plan_fallback_attempted = true;
+                            info!(
+                                intent_id = %intent.intent_id,
+                                details = %u.details,
+                                dex = %intent
+                                    .metadata
+                                    .get("dex")
+                                    .map(|s| s.as_str())
+                                    .unwrap_or("?"),
+                                "multi_pool: tx_plan UnsupportedIntent — switching to next pre-filtered buildable route, retrying plan build"
+                            );
+                            continue 'tx_plan_retry;
+                        }
                         checks.push(CheckResult {
                             check_name: "tx_plan".to_string(),
                             passed: false,
@@ -11688,11 +11919,13 @@ mod execution_engine_tests {
         cold_path_dex_sim_failure_triggers_discovery_recovery, is_cold_path_recovery_sell,
         is_pump_amm_structural_sim_error, is_pumpfun_bonding_curve_structural_sim_error,
         is_regular_momentum_hot_path_sell, liquidation_pumpfun_sell_preference,
-        max_open_positions_buy_gate, pump_amm_hint_pool_cache_usable_for_tx_plan_builder,
+        liquidation_store_multi_pool_fallback_metadata, max_open_positions_buy_gate,
+        pump_amm_hint_pool_cache_usable_for_tx_plan_builder,
         pump_amm_liquidation_quote_timeout_str, pump_amm_pool_market_hint_merge,
         pump_amm_slave_recovery_snapshot, record_pump_amm_hot_path_refresh_after_success,
-        scope48_confirmed_sell_close_decision, select_best_route,
-        try_pump_amm_hot_path_refresh_publish, wait_for_meteora_dlmm_slave_after_recovery,
+        scope48_confirmed_sell_close_decision, sort_route_candidates_by_amount_out,
+        take_next_multi_pool_buildable_fallback_route, try_pump_amm_hot_path_refresh_publish,
+        wait_for_meteora_dlmm_slave_after_recovery,
         wait_for_pump_amm_pool_hint_ready_for_tx_plan_builder,
         wait_for_pump_amm_slave_after_recovery, wait_for_pumpfun_bonding_cache_refresh,
         DiscoveryRequestOutcome, PumpAmmHotPathRefreshDecision, RouteCandidate,
@@ -12542,7 +12775,7 @@ mod execution_engine_tests {
     }
 
     #[test]
-    fn select_best_route_prefers_highest_and_keeps_first_on_tie() {
+    fn sort_route_candidates_prefers_highest_and_keeps_first_on_tie() {
         let candidates = vec![
             RouteCandidate {
                 dex: "raydium".to_string(),
@@ -12550,6 +12783,7 @@ mod execution_engine_tests {
                 pool_id: "pool-1".to_string(),
                 accounts: vec!["a1".to_string()],
                 creator: None,
+                execution_min_out_lamports: None,
             },
             RouteCandidate {
                 dex: "orca".to_string(),
@@ -12557,6 +12791,7 @@ mod execution_engine_tests {
                 pool_id: "pool-2".to_string(),
                 accounts: vec!["a2".to_string()],
                 creator: None,
+                execution_min_out_lamports: None,
             },
             RouteCandidate {
                 dex: "pump_amm".to_string(),
@@ -12564,13 +12799,84 @@ mod execution_engine_tests {
                 pool_id: "pool-3".to_string(),
                 accounts: vec!["a3".to_string()],
                 creator: None,
+                execution_min_out_lamports: None,
             },
         ];
 
-        let best = select_best_route(candidates).expect("expected a best route");
+        let sorted = sort_route_candidates_by_amount_out(candidates);
+        let best = sorted.first().expect("expected a best route");
         assert_eq!(best.dex, "orca");
         assert_eq!(best.pool_id, "pool-2");
         assert_eq!(best.amount_out, 200);
+    }
+
+    #[test]
+    fn multi_pool_fallback_take_next_updates_intent_and_drains_queue() {
+        use super::BUILD_VERSION;
+        use ironcrab::solana::dex_parser::SOL_MINT;
+
+        let mut intent = TradeIntent::new_sell(
+            "execution-engine",
+            BUILD_VERSION,
+            "run",
+            "id-mp-fb".to_string(),
+            "execution-engine",
+            IntentTier::Tier0,
+            IntentOrigin::ExecutionMevB,
+            "mint".to_string(),
+            6,
+            SOL_MINT.to_string(),
+            1_000,
+            0,
+            100,
+            TradingRegime::NotApplicable,
+        );
+        intent
+            .metadata
+            .insert("sell_routing".to_string(), "multi_pool".to_string());
+        intent
+            .metadata
+            .insert("dex".to_string(), "orca".to_string());
+        intent.resources.pools = vec!["orca_pool".to_string()];
+
+        let buildable = vec![
+            RouteCandidate {
+                dex: "orca".to_string(),
+                amount_out: 200,
+                pool_id: "orca_pool".to_string(),
+                accounts: vec![],
+                creator: None,
+                execution_min_out_lamports: None,
+            },
+            RouteCandidate {
+                dex: "pump_amm".to_string(),
+                amount_out: 100,
+                pool_id: "pump_pool".to_string(),
+                accounts: vec!["acct".to_string()],
+                creator: None,
+                execution_min_out_lamports: None,
+            },
+        ];
+        let mut md = std::collections::HashMap::new();
+        liquidation_store_multi_pool_fallback_metadata(&mut md, &buildable);
+        intent.metadata.extend(md);
+
+        assert!(take_next_multi_pool_buildable_fallback_route(&mut intent));
+        assert_eq!(
+            intent.metadata.get("dex").map(String::as_str),
+            Some("pump_amm")
+        );
+        assert_eq!(intent.resources.pools, vec!["pump_pool".to_string()]);
+        assert_eq!(intent.resources.accounts, vec!["acct".to_string()]);
+        let min = intent
+            .execution
+            .as_ref()
+            .and_then(|e| e.min_out.as_ref())
+            .expect("min_out");
+        assert_eq!(min.decimals, 9);
+        assert_eq!(min.raw, 99);
+
+        assert!(!take_next_multi_pool_buildable_fallback_route(&mut intent));
     }
 
     #[test]

--- a/src/solana/dex/orca.rs
+++ b/src/solana/dex/orca.rs
@@ -306,6 +306,70 @@ impl Orca {
         None
     }
 
+    /// Cold-path only: verifies the three Whirlpool tick-array PDAs used by
+    /// [`Self::build_swap_ix_async`] exist on-chain (same derivation when using cached tick data).
+    ///
+    /// Intended for liquidation / kill-switch multi-pool routing — **not** for hot-path callers
+    /// (I-7). May perform one batched `get_multiple_accounts` (same shape as swap build validation).
+    pub async fn cold_path_validate_whirlpool_tick_arrays_for_pool_swap(
+        &self,
+        pool_id: &Pubkey,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+    ) -> Result<(), String> {
+        let pool = self
+            .pools
+            .get(pool_id)
+            .map(|e| e.value().clone())
+            .ok_or_else(|| format!("orca pool {pool_id} not loaded in connector"))?;
+
+        let a_to_b = if pool.base_mint == *input_mint && pool.quote_mint == *output_mint {
+            true
+        } else if pool.base_mint == *output_mint && pool.quote_mint == *input_mint {
+            false
+        } else {
+            return Err("mint pair does not match whirlpool token A/B".to_string());
+        };
+
+        let tick_now = pool
+            .tick_current_index
+            .ok_or_else(|| format!("no tick_current_index for pool {pool_id}"))?;
+        let spacing =
+            pool.tick_spacing
+                .ok_or_else(|| format!("no tick_spacing for pool {pool_id}"))? as i32;
+
+        let (tick_array_0, tick_array_1, tick_array_2, _, _, _) =
+            whirlpool_swap_tick_array_pdas_for_cached_swap(pool_id, tick_now, spacing, a_to_b);
+
+        tracing::debug!(
+            pool = %pool_id,
+            tick_array_0 = %tick_array_0,
+            tick_array_1 = %tick_array_1,
+            tick_array_2 = %tick_array_2,
+            "orca: routing preflight tick array PDAs (cold path)"
+        );
+
+        match self
+            .rpc
+            .rpc
+            .get_multiple_accounts(&[tick_array_0, tick_array_1, tick_array_2])
+            .await
+        {
+            Ok(accounts) => {
+                let missing: Vec<usize> = accounts
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, acct)| if acct.is_none() { Some(idx) } else { None })
+                    .collect();
+                if !missing.is_empty() {
+                    return Err(format!("missing_tick_array_accounts missing={missing:?}"));
+                }
+                Ok(())
+            }
+            Err(e) => Err(format!("tick_array_rpc_validation_failed: {e}")),
+        }
+    }
+
     pub fn insert_mock_pool(
         &self,
         base: Pubkey,
@@ -1320,85 +1384,19 @@ impl Dex for Orca {
             )
         })? as i32;
 
-        let ticks_per_array = spacing * TICK_ARRAY_SIZE;
-
-        let current_array_start = get_tick_array_start_index(tick_now, spacing);
-
-        // Calculate position within current tick array (0 to ticks_per_array-1)
-        let position_in_array = (tick_now - current_array_start).abs();
-        let array_boundary_margin = ticks_per_array / 4; // 25% margin from boundary
+        let (tick_array_0, tick_array_1, tick_array_2, start0, start1, start2) =
+            whirlpool_swap_tick_array_pdas_for_cached_swap(&pool_id, tick_now, spacing, a_to_b);
 
         tracing::debug!(
             pool = %pool_id,
             tick_spacing = spacing,
             tick_current = tick_now,
             cached_tick = ?pool.tick_current_index,
-            current_array_start = current_array_start,
-            position_in_array = position_in_array,
-            a_to_b = a_to_b,
-            "orca: calculating tick arrays with FRESH tick from chain"
-        );
-
-        // IMPROVED: Select tick arrays to handle price movement in EITHER direction.
-        //
-        // Problem: Between fetch_current_tick() and simulation, price may move.
-        // If we only select arrays in the swap direction, we fail with Error 6023.
-        //
-        // Solution: Always include the current array PLUS arrays in BOTH directions.
-        // - tick_array_0: Current array (always contains current tick)
-        // - tick_array_1: Array in swap direction (primary movement)
-        // - tick_array_2: Array in OPPOSITE direction (handle reverse movement)
-        //
-        // This handles ~2 arrays worth of price movement in either direction.
-        let (tick_array_0, tick_array_1, tick_array_2, start0, start1, start2) = {
-            let s0 = current_array_start;
-            // Primary direction based on swap type
-            let s_primary = if a_to_b {
-                s0 - ticks_per_array
-            } else {
-                s0 + ticks_per_array
-            };
-            // Opposite direction to handle price reversal
-            let s_opposite = if a_to_b {
-                s0 + ticks_per_array
-            } else {
-                s0 - ticks_per_array
-            };
-
-            // If tick is near the boundary in primary direction, extend further in that direction
-            let near_low_boundary = position_in_array < array_boundary_margin;
-            let near_high_boundary = position_in_array > (ticks_per_array - array_boundary_margin);
-
-            let (s1, s2) = if a_to_b && near_low_boundary {
-                // A→B swap, tick near low boundary - extend further in decreasing direction
-                (s_primary, s_primary - ticks_per_array)
-            } else if !a_to_b && near_high_boundary {
-                // B→A swap, tick near high boundary - extend further in increasing direction
-                (s_primary, s_primary + ticks_per_array)
-            } else {
-                // Normal case: cover both directions
-                (s_primary, s_opposite)
-            };
-
-            (
-                derive_tick_array_pda(&pool_id, s0),
-                derive_tick_array_pda(&pool_id, s1),
-                derive_tick_array_pda(&pool_id, s2),
-                s0,
-                s1,
-                s2,
-            )
-        };
-
-        tracing::debug!(
-            pool = %pool_id,
-            tick_array_0 = %tick_array_0,
-            tick_array_1 = %tick_array_1,
-            tick_array_2 = %tick_array_2,
             start0 = start0,
             start1 = start1,
             start2 = start2,
-            "orca: derived tick array PDAs (async with fresh tick)"
+            a_to_b = a_to_b,
+            "orca: derived tick array PDAs (async with cached tick)"
         );
 
         // Validate tick arrays exist to avoid InvalidTickArraySequence (6023)
@@ -1656,6 +1654,64 @@ impl Orca {
 /// Orca Whirlpool constants
 const TICK_ARRAY_SIZE: i32 = 88; // Number of ticks per TickArray
 
+/// Tick-array PDAs for a Whirlpool exact-in swap using **cached** tick data — must stay aligned
+/// with [`Orca::build_swap_ix_async`].
+fn whirlpool_swap_tick_array_pdas_for_cached_swap(
+    pool_id: &Pubkey,
+    tick_now: i32,
+    tick_spacing: i32,
+    a_to_b: bool,
+) -> (Pubkey, Pubkey, Pubkey, i32, i32, i32) {
+    let spacing = tick_spacing;
+    let ticks_per_array = spacing * TICK_ARRAY_SIZE;
+    let current_array_start = get_tick_array_start_index(tick_now, spacing);
+    let position_in_array = (tick_now - current_array_start).abs();
+    let array_boundary_margin = ticks_per_array / 4;
+
+    let (tick_array_0, tick_array_1, tick_array_2, start0, start1, start2) = {
+        let s0 = current_array_start;
+        let s_primary = if a_to_b {
+            s0 - ticks_per_array
+        } else {
+            s0 + ticks_per_array
+        };
+        let s_opposite = if a_to_b {
+            s0 + ticks_per_array
+        } else {
+            s0 - ticks_per_array
+        };
+
+        let near_low_boundary = position_in_array < array_boundary_margin;
+        let near_high_boundary = position_in_array > (ticks_per_array - array_boundary_margin);
+
+        let (s1, s2) = if a_to_b && near_low_boundary {
+            (s_primary, s_primary - ticks_per_array)
+        } else if !a_to_b && near_high_boundary {
+            (s_primary, s_primary + ticks_per_array)
+        } else {
+            (s_primary, s_opposite)
+        };
+
+        (
+            derive_tick_array_pda(pool_id, s0),
+            derive_tick_array_pda(pool_id, s1),
+            derive_tick_array_pda(pool_id, s2),
+            s0,
+            s1,
+            s2,
+        )
+    };
+
+    (
+        tick_array_0,
+        tick_array_1,
+        tick_array_2,
+        start0,
+        start1,
+        start2,
+    )
+}
+
 fn derive_tick_array_pda(pool: &Pubkey, start_tick_index: i32) -> Pubkey {
     let seeds: &[&[u8]] = &[
         b"tick_array",
@@ -1778,5 +1834,19 @@ mod tests {
             "expected RPC/fallback/failed in error, got: {}",
             err_msg
         );
+    }
+
+    #[test]
+    fn whirlpool_cached_swap_tick_pdas_stable() {
+        let pool = Pubkey::new_unique();
+        let (a, b, c, _, _, _) =
+            super::whirlpool_swap_tick_array_pdas_for_cached_swap(&pool, 0, 64, true);
+        let (a2, b2, c2, _, _, _) =
+            super::whirlpool_swap_tick_array_pdas_for_cached_swap(&pool, 0, 64, true);
+        assert_eq!(a, a2);
+        assert_eq!(b, b2);
+        assert_eq!(c, c2);
+        assert_ne!(a, b);
+        assert_ne!(b, c);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Kurzbeschreibung

Liquidations-/Kill-Switch-**Multi-Pool-SELL** wählt die beste Route nur noch aus Kandidaten, die dieselben **strukturellen** Voraussetzungen erfüllen wie `build_tx_plan` (Orca: drei Tick-Array-Konten per `get_multiple_accounts` wie im Cold-Path-Swap-Bau; PumpSwap: SLAVE-Cache ≥12 Accounts und Pool-Adresse konsistent mit `resources.accounts[0]`; Meteora DLMM: `explicit_ready`).

## Warum

Prod: Orca hatte die höhere grobe Quote, aber fehlende Tick-Array-Konten → `UNSUPPORTED_INTENT` vor der Simulation, obwohl eine andere DEX-Route noch baubar gewesen wäre.

## Verhalten

- Nach dem Filter: Ranking nach `amount_out` nur unter **buildable** Kandidaten; `quote_attempts` enthält `*_=skip not_buildable …` plus **INFO**-Logs (`routing skipped orca: not buildable; selected next if any` / pump_amm / meteora_dlmm).
- **Fallback**: Weitere baubare Routen werden als JSON in `multi_pool_fallback_routes_json` gespeichert. Liefert `build_tx_plan` trotzdem `UnsupportedIntent`, wechselt der Cold-Path einmal pro Eintrag die Route (dex, pools, accounts, min_out) und baut den Plan erneut (`'tx_plan_retry`-Schleife).
- **Hinweis Orca**: Routing-Preflight und späterer Swap-Bau können jeweils ein batched `get_multiple_accounts` ausführen (Cold Path / Liquidation, kein Hot-Path-`process_intent`-Momentum).

## STOP-CHECK (nach Umsetzung)

1. **I-7**: Keine neuen RPC-Calls im Momentum-Hot-Path; Orca-RPC nur in `cold_path_validate_*` und bestehendem `build_swap_ix_async` bei `allow_rpc_fallback`.
2. **Pattern**: Orca wie bisher `get_multiple_accounts` bei aktiver Tick-Array-Validierung.
3. **Scope**: `orca.rs`, `execution_engine.rs` (Liquidation + `process_intent`).
4. **I-9**: unverändert.
5. **Level 5**: keine Eval-Tests gelesen.

## Tests

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`
- `cargo test`, `cargo test --features test_helpers`
- **Eval (Level 5)**: im Workspace kein Sibling-Checkout von `ironcrab-eval`; bitte CI „Eval (Level 5)“ auf dem PR ausführen.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0146a1c2-0c88-4d3d-8966-6e370e697e6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0146a1c2-0c88-4d3d-8966-6e370e697e6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

