### PR TITLE
Follow-up PR #134: lp_removal_observed_at mint merge max

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,11 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### FIX-MOM-LP-OBSERVED-AT-MINT-MERGE-MAX-2026-05-18: LP-Removal Wallclock — Mint-Aggregat `max` statt `min` (PR #134 Follow-up)
+**Datum**: 2026-05-18  
+**Problem**: Beim Merge von `TrackerExitSignals` pro Mint über mehrere Pool-Tracker war `lp_removal_observed_at` mit `min` zusammengeführt — das verschärfte das Wallclock-Fenster künstlich und konnte LP-Hard-Exits still unterdrücken (Bugbot Low auf PR #134).  
+**Fix**: Mint-Aggregat nutzt wieder **`max`** (späteste Sibling-Beobachtung), analog zur Legacy-Logik für `lp_removed_at`; Unit-Test gegen `min`-Regression.
+
 ### FIX-MOM-ENTRY-FILTERS-CHAIN-SLOT-2026-05-17: Momentum Entry-/Filter-Fenster vs. Ingest-Burst (Kettenzeit)
 **Datum**: 2026-05-17  
 **Problem**: `TokenTracker` und Entry-Filter nutzten `Instant::now()` beim Ingest für Fenster (Käufer, Inflow, Velocity, Microbuy/Buyer-Quality). Bei NATS-/Market-Data-Bursts wirkten viele historische Trades gleichzeitig „frisch“ — Filter bestanden, obwohl die Kette schon lange stillstand (Chart vs. Geyser-Slot).  

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -2784,6 +2784,24 @@ struct MomentumContext {
     last_event_ts_ms: std::sync::atomic::AtomicU64,
 }
 
+/// Merge `lp_removal_observed_at` across sibling pool trackers for the same mint (wallclock LP_REMOVAL path).
+///
+/// Per tracker, [`TokenTracker::record_lp_removal`] records the **first** local observation (`get_or_insert_with(Instant::now)`).
+/// For mint-level hard-exit gating we take the **latest** sibling observation (legacy parity with `lp_removed_at` max-merge),
+/// so `obs.elapsed()` vs `lp_removal_window_secs` is not skewed toward “too old” as with `min` (which could suppress exits).
+#[inline]
+fn merge_lp_removal_observed_at_mint_aggregate(
+    existing: Option<Instant>,
+    incoming: Option<Instant>,
+) -> Option<Instant> {
+    match (existing, incoming) {
+        (Some(a), Some(b)) => Some(a.max(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
 impl MomentumContext {
     /// Increment [`Self::tokens_blacklisted`] at most once per mint for this process (metric dedupe).
     /// Tracker rows may still reject independently; this is observability only.
@@ -5169,13 +5187,12 @@ impl MomentumContext {
                             (None, Some(b)) => Some(b),
                             (None, None) => None,
                         };
-                        e.lp_removal_observed_at =
-                            match (e.lp_removal_observed_at, incoming.lp_removal_observed_at) {
-                                (Some(a), Some(b)) => Some(a.min(b)),
-                                (Some(a), None) => Some(a),
-                                (None, Some(b)) => Some(b),
-                                (None, None) => None,
-                            };
+                        // LP wallclock aggregate: latest wins (see [`merge_lp_removal_observed_at_mint_aggregate`]).
+                        e.lp_removal_observed_at = merge_lp_removal_observed_at_mint_aggregate(
+                            e.lp_removal_observed_at,
+                            incoming.lp_removal_observed_at,
+                        );
+                        // dev_sell_observed_at: already “latest wins” (higher slot branch + `in_obs > cur` below).
                         if let Some(b) = incoming.dev_sell_slot {
                             if e.dev_sell_slot.map(|a| b > a).unwrap_or(true) {
                                 e.dev_sell_slot = Some(b);
@@ -10274,6 +10291,29 @@ mod tests {
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    #[test]
+    fn lp_removal_observed_at_mint_merge_uses_max_for_wallclock_recency() {
+        let base = Instant::now();
+        let earlier = base.checked_sub(Duration::from_secs(120)).expect("instant");
+        let later = base.checked_sub(Duration::from_secs(2)).expect("instant");
+        assert_eq!(
+            merge_lp_removal_observed_at_mint_aggregate(Some(earlier), Some(later)),
+            Some(later)
+        );
+        let window_secs = 10u64;
+        let merged = merge_lp_removal_observed_at_mint_aggregate(Some(earlier), Some(later))
+            .expect("merged");
+        assert!(
+            merged.elapsed().as_secs() <= window_secs,
+            "max-merge keeps LP removal observation recent for wallclock window gating"
+        );
+        let min_bug = earlier.min(later);
+        assert!(
+            min_bug.elapsed().as_secs() > window_secs,
+            "min-merge would treat LP removal as outside window and suppress hard exit"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Behebt offenes Bugbot-Finding (Low): Mint-Aggregat von `lp_removal_observed_at` nutzt **`max`** statt `min` — Legacy-Paritaet zu `lp_removed_at`, damit LP-Hard-Exits im Wallclock-Fallback nicht still unterdrueckt werden.
- Hilfsfunktion `merge_lp_removal_observed_at_mint_aggregate` + Unit-Test gegen `min`-Regression.
- Kurzer Eintrag in `docs/BUGS_FIXES.md`.

## Kontext
Follow-up zu PR #134 (Kettenzeit/Slot Entry-Filter). Kein RPC, kein Scope-Creep.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` / `cargo test --features test_helpers` (Agent)
- [ ] CI auf diesem PR (inkl. Eval Level 5 nach Merge in #134)
- [ ] Bugbot auf aktualisiertem #134-Stand nach Merge dieses Follow-ups
