### PR TITLE
Pipeline-Latenz-Metriken (market-data → momentum → execution)

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -67,8 +67,14 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ### MOM-OBS-LATENCY: Prometheus-Histogramme für Momentum-Hot-Path- und E2E-Latenzen
 **Datum**: 2026-05-15  
-**Zweck** (kein Bugfix): Operative Messbarkeit nach Throughput-Slices — `momentum_event_to_ingest_ms`, `momentum_event_to_intent_publish_ms` (nur mit kausalem `MarketEvent.ts_unix_ms`; aktuell füllt momentum-bot diese Intent-Histogramme nicht, bis Exit-Pfade pro Intent ein explizites Event-Ts führen), interne µs-Histogramme für `process_market_event`, `record_trade`, Signal-Eval (dirty vs. Full-Scan), NATS-Batch-Deserialize/Flatten; Counter `momentum_latency_event_ts_invalid_total` bei `ts_unix_ms==0` oder Werte in der „Zukunft“ vs. lokaler Wanduhr. **`momentum_event_to_ingest_ms`**: nur Live-Ingest aus dem Core-NATS-MarketEvents-Arm — **kein** JetStream-Wallet-Snapshot-Bootstrap (`bootstrap_wallet_snapshot_from_jetstream`), damit historische Replay-Timestamps die SLO nicht verfälschen. Keine Strategie-/RPC-/Topic-Änderungen.  
+**Zweck** (kein Bugfix): Operative Messbarkeit nach Throughput-Slices — `momentum_event_to_ingest_ms`, `momentum_event_to_intent_publish_ms` (nur mit kausalem `MarketEvent.ts_unix_ms`; Exit-Pfade setzen `source_event_ts_unix_ms` explizit), interne µs-Histogramme für `process_market_event`, `record_trade`, Signal-Eval (dirty vs. Full-Scan), NATS-Batch-Deserialize/Flatten; Counter `momentum_latency_event_ts_invalid_total` bei `ts_unix_ms==0` oder Werte in der „Zukunft“ vs. lokaler Wanduhr. **`momentum_event_to_ingest_ms`**: nur Live-Ingest aus dem Core-NATS-MarketEvents-Arm — **kein** JetStream-Wallet-Snapshot-Bootstrap (`bootstrap_wallet_snapshot_from_jetstream`), damit historische Replay-Timestamps die SLO nicht verfälschen. Keine Strategie-/RPC-/Topic-Änderungen.  
+**Follow-up (PIPELINE-LATENCY-METRICS, 2026-05-19)**: Zusätzlich `momentum_intent_header_to_publish_ms_*` und `momentum_publish_to_intent_ms_*` bei erfolgreichem JetStream-Publish von BUY/SELL; segmentierte market-data-/execution-Histogramme siehe **PIPELINE-LATENCY-METRICS**.  
 **Dateien**: `src/metrics.rs`, `src/bin/momentum_bot.rs`
+
+### PIPELINE-LATENCY-METRICS: segmentierte Histogramme market-data → momentum → execution
+**Datum**: 2026-05-19  
+**Zweck** (Observability only): Kette A–I in `docs/RUNBOOK_PROD.md` — Geyser→Core-Publish (market-data), Momentum-Ingest und Intent-Publish, execution `process_intent` bis Confirm sowie Slot-Lag am Send. Kein Trading-Verhalten, kein Hot-Path-RPC.  
+**Dateien**: `src/metrics.rs`, `src/bin/market_data.rs`, `src/bin/momentum_bot.rs`, `src/bin/execution_engine.rs`, `docs/RUNBOOK_PROD.md`, `docs/BUGS_FIXES.md`
 
 ### FIX-MOM-EXIT-QUOTE-GUARDS: Frische Reserve-Quotes + getrennte Ingest-Latenzen
 **Datum**: 2026-05-15  

--- a/docs/RUNBOOK_PROD.md
+++ b/docs/RUNBOOK_PROD.md
@@ -146,6 +146,30 @@ journalctl -u execution-engine -n 100 --no-pager
 | Control Plane API | `http://localhost:8080` | REST API |
 | Trades API | `http://localhost:9899/trades` | Grafana Infinity |
 
+### Pipeline-Latenz (Prometheus-Histogramme, A–I)
+
+Segmentierte End-to-End-Latenzen über die drei Prozesse **market-data → momentum-bot → execution-engine**.
+Alle Werte nutzen konsistent `RecordHeader.ts_unix_ms` bzw. Geyser-`Instant::now()`-Startpunkte am Publish-Pfad; Details in `docs/BUGS_FIXES.md` (Eintrag **PIPELINE-LATENCY-METRICS**).
+
+| Segment | Metrik (Präfix je nach Export) | Kurzinterpretation |
+|--------|--------------------------------|---------------------|
+| A | `market_data_geyser_to_publish_ms_*` (Suffix `_trade`, `_bonding_curve`, …) | Geyser-Eingang bis erfolgreicher Core-NATS-Publish |
+| B | `market_data_slot_lag_at_publish_slots_*` | Slot-Differenz am Publish (market-data) |
+| C | `momentum_event_to_ingest_ms_*` | MarketEvent-Producer-Zeit bis Momentum-Ingest (nur Core NATS) |
+| D | `momentum_intent_header_to_publish_ms_*` | Intent-Header-Zeit bis JetStream-TradeIntent-Publish |
+| E | `momentum_publish_to_intent_ms_*` | Kausales Event-`ts_unix_ms` bis Intent-Header (Momentum-intern) |
+| F | `execution_intent_header_to_receive_ms_*` | Intent-Header bis erster Zeile `process_intent` |
+| G | `execution_process_intent_us_*` | Gesamtdauer `process_intent` (Mikrosekunden) |
+| H | `execution_intent_to_confirm_ms_*` | Intent-Header bis bestätigtes On-Chain-Outcome |
+| I | `execution_slot_lag_at_send_slots_*` | `cached_blockhash.slot` minus Intent-Metadaten-`slot` nach erfolgreichem Send |
+
+Beispiel **rate()** über 5m (Namen an eueren `job`/Labels anpassen):
+
+```promql
+histogram_quantile(0.99, sum(rate(momentum_intent_header_to_publish_ms_bucket[5m])) by (le))
+histogram_quantile(0.99, sum(rate(execution_process_intent_us_bucket[5m])) by (le)) / 1e6
+```
+
 ### PumpSwap Async-Healing Metrics
 
 Im `execution-engine`-Metrics-Endpoint sind fuer den Hot-Path-Healing-Pfad jetzt

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -70,17 +70,20 @@ use ironcrab::ipc::{
 };
 use ironcrab::ipc::{ControlRequest, ControlRequestKind, ControlResponse, ControlResponseStatus};
 use ironcrab::metrics::{
+    record_execution_process_intent_us, record_execution_slot_lag_at_send_slots,
     record_recent_trade, record_tx_slot_to_send_ms, serve_metrics,
     set_readiness_control_response_sub_active, set_readiness_control_sub_active,
     set_readiness_mode, set_readiness_nats_connected, set_readiness_state_paths_initialized,
-    update_readiness_execution_engine_current, MetricsComponent, RecentTrade, ACTIVE_CAPITAL_LOCKS,
-    ACTIVE_RESOURCE_LOCKS, AVAILABLE_SOL_LAMPORTS, CONCURRENT_INTENTS_GAUGE,
-    INTENTS_EXECUTED_TOTAL, INTENTS_RECEIVED_TOTAL, INTENTS_REJECTED_TOTAL,
-    JITO_BUNDLES_LANDED_TOTAL, JITO_BUNDLES_REJECTED_TOTAL, JITO_BUNDLES_SUBMITTED_TOTAL,
-    JITO_BUNDLES_TIMEOUT_TOTAL, JITO_TIP_LAMPORTS_TOTAL, KILL_SWITCH_ACTIVE,
-    NATS_MESSAGES_RECEIVED_TOTAL, OPEN_POSITIONS_GAUGE, POSITION_AUTHORITY_DRIFT_LOCKMANAGER,
-    POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE, POSITION_AUTHORITY_OPEN_GAUGE,
-    POSITION_AUTHORITY_RECONCILE_NEEDED_GAUGE, PUMPSWAP_HOT_PATH_HEALING_ASYNC_PUBLISH_FAIL_TOTAL,
+    try_record_execution_intent_header_to_receive_ms, try_record_execution_intent_to_confirm_ms,
+    update_readiness_execution_engine_current, wall_clock_unix_ms_now, MetricsComponent,
+    RecentTrade, ACTIVE_CAPITAL_LOCKS, ACTIVE_RESOURCE_LOCKS, AVAILABLE_SOL_LAMPORTS,
+    CONCURRENT_INTENTS_GAUGE, INTENTS_EXECUTED_TOTAL, INTENTS_RECEIVED_TOTAL,
+    INTENTS_REJECTED_TOTAL, JITO_BUNDLES_LANDED_TOTAL, JITO_BUNDLES_REJECTED_TOTAL,
+    JITO_BUNDLES_SUBMITTED_TOTAL, JITO_BUNDLES_TIMEOUT_TOTAL, JITO_TIP_LAMPORTS_TOTAL,
+    KILL_SWITCH_ACTIVE, NATS_MESSAGES_RECEIVED_TOTAL, OPEN_POSITIONS_GAUGE,
+    POSITION_AUTHORITY_DRIFT_LOCKMANAGER, POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE,
+    POSITION_AUTHORITY_OPEN_GAUGE, POSITION_AUTHORITY_RECONCILE_NEEDED_GAUGE,
+    PUMPSWAP_HOT_PATH_HEALING_ASYNC_PUBLISH_FAIL_TOTAL,
     PUMPSWAP_HOT_PATH_HEALING_ASYNC_PUBLISH_SUCCESS_TOTAL,
     PUMPSWAP_HOT_PATH_HEALING_COOLDOWN_SUPPRESSED_TOTAL,
     PUMPSWAP_HOT_PATH_HEALING_SKIPPED_NO_NATS_TOTAL, PUMPSWAP_HOT_PATH_HEALING_TRIGGER_TOTAL,
@@ -8615,8 +8618,37 @@ fn max_open_positions_buy_gate(
     (passed, details)
 }
 
+/// After a successful send: `cached_blockhash.slot` minus intent metadata `slot` (Geyser chain position).
+#[inline]
+fn record_execution_slot_lag_at_send_if_applicable(ctx: &ExecutionContext, intent: &TradeIntent) {
+    let Some(intent_slot) = intent
+        .metadata
+        .get("slot")
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|s| *s > 0)
+    else {
+        return;
+    };
+    let Some(cached) = ctx.cached_blockhash.read().clone() else {
+        return;
+    };
+    if cached.slot >= intent_slot {
+        record_execution_slot_lag_at_send_slots(cached.slot - intent_slot);
+    }
+}
+
 /// Process a single TradeIntent through the execution pipeline
 async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Result<()> {
+    try_record_execution_intent_header_to_receive_ms(
+        wall_clock_unix_ms_now(),
+        intent.header.ts_unix_ms,
+    );
+    let process_intent_started = Instant::now();
+    let _process_intent_duration = scopeguard::guard(process_intent_started, |t| {
+        let us = t.elapsed().as_micros().min(u128::from(u64::MAX)) as u64;
+        record_execution_process_intent_us(us);
+    });
+
     ctx.record_intent_received();
 
     // Keep Prometheus counters aligned with persisted decision/intents logs.
@@ -10295,6 +10327,7 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                             .unwrap_or(0);
                         record_tx_slot_to_send_ms(now_ms.saturating_sub(seen));
                     }
+                    record_execution_slot_lag_at_send_if_applicable(ctx, &intent);
                     checks.push(CheckResult {
                         check_name: "send".to_string(),
                         passed: true,
@@ -10349,6 +10382,7 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                             .unwrap_or(0);
                         record_tx_slot_to_send_ms(now_ms.saturating_sub(seen));
                     }
+                    record_execution_slot_lag_at_send_if_applicable(ctx, &intent);
                     send_signature = Some(result.signature.clone());
                     send_method_used = Some(result.method.clone());
                     sent_tx = Some(result.tx);
@@ -10867,6 +10901,10 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
 
             exec.status = status;
             if exec.status == ExecutionStatus::Confirmed {
+                try_record_execution_intent_to_confirm_ms(
+                    wall_clock_unix_ms_now(),
+                    intent.header.ts_unix_ms,
+                );
                 if let Some(slot) = tx_landing_slot {
                     exec.confirmed_slot = Some(slot);
                     exec.metadata

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -20,11 +20,12 @@
 use anyhow::Result;
 use clap::Parser;
 use solana_sdk::pubkey::Pubkey;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -44,11 +45,14 @@ use ironcrab::ipc::{
     POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use ironcrab::metrics::{
-    serve_metrics, set_readiness_control_sub_active, set_readiness_mode,
-    set_readiness_nats_connected, update_readiness_market_data_current, MetricsComponent,
-    MARKET_EVENTS_MOMENTUM_FANOUT_PUBLISHED_TOTAL, MARKET_EVENTS_PUBLISHED_TOTAL,
-    MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
-    POOLS_TRACKED_GAUGE,
+    market_data_bump_geyser_head_slot, record_market_data_geyser_to_publish_on_success,
+    record_market_data_trade_after_bonding_publish_ms, serve_metrics,
+    set_readiness_control_sub_active, set_readiness_mode, set_readiness_nats_connected,
+    update_readiness_market_data_current, wall_clock_unix_ms_now, MarketDataLatencySegment,
+    MetricsComponent, MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS,
+    MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS, MARKET_EVENTS_MOMENTUM_FANOUT_PUBLISHED_TOTAL,
+    MARKET_EVENTS_PUBLISHED_TOTAL, MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL,
+    NATS_MESSAGES_PUBLISHED_TOTAL, POOLS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
@@ -155,19 +159,80 @@ pub(crate) fn market_event_is_momentum_nats_relevant(kind: &MarketEventKind) -> 
     }
 }
 
+/// Optional Geyser→core-publish latency trace (same `recv_at` for all publishes from one Geyser message).
+#[derive(Clone, Copy)]
+pub(crate) struct MarketEventCorePublishTrace {
+    pub recv_at: Instant,
+    pub cold_path: bool,
+    pub segment: MarketDataLatencySegment,
+}
+
+#[inline]
+fn market_data_publish_segment(kind: &MarketEventKind) -> MarketDataLatencySegment {
+    match kind {
+        MarketEventKind::Trade { .. } => MarketDataLatencySegment::Trade,
+        MarketEventKind::BondingCurveProgress { .. } => MarketDataLatencySegment::BondingCurve,
+        MarketEventKind::PoolCreated { .. } => MarketDataLatencySegment::PoolCreated,
+        _ => MarketDataLatencySegment::Other,
+    }
+}
+
 /// Publish one logical market event to core NATS and, when [`market_event_is_momentum_nats_relevant`], to momentum subject.
 ///
 /// Counts one [`MARKET_EVENTS_PUBLISHED_TOTAL`] per successful core delivery; [`NATS_MESSAGES_PUBLISHED_TOTAL`]
 /// once per successful NATS publish (core plus optional second message). [`NatsClient::publish`] may return
 /// `Ok(false)` when the message is dropped (no client, NATS error, timeout/backpressure); that is not success.
-pub(crate) async fn publish_market_event_core_and_momentum(
+pub(crate) async fn publish_market_event_core_and_momentum_ex(
     nats: &NatsClient,
     event: &MarketEvent,
+    trace: Option<MarketEventCorePublishTrace>,
+    ctx: Option<&MarketDataContext>,
 ) -> bool {
     match nats.publish(TOPIC_MARKET_EVENTS, event).await {
         Ok(true) => {
             NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
             MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+            if let Some(t) = trace {
+                record_market_data_geyser_to_publish_on_success(
+                    t.recv_at,
+                    t.segment,
+                    t.cold_path,
+                    event.slot,
+                );
+            }
+            if let Some(ctx) = ctx {
+                let now_ms = wall_clock_unix_ms_now();
+                match &event.kind {
+                    MarketEventKind::Trade {
+                        pool_address, dex, ..
+                    } if dex == "pumpfun" => {
+                        MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS.store(now_ms, Ordering::Relaxed);
+                        if let Ok(pk) = Pubkey::from_str(pool_address) {
+                            if let Some(last) = ctx
+                                .bonding_curve_publish_times
+                                .lock()
+                                .last_bonding_wall_ms(&pk)
+                            {
+                                if now_ms >= last {
+                                    record_market_data_trade_after_bonding_publish_ms(
+                                        now_ms.saturating_sub(last),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    MarketEventKind::BondingCurveProgress { bonding_curve, .. } => {
+                        MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS
+                            .store(now_ms, Ordering::Relaxed);
+                        if let Ok(pk) = Pubkey::from_str(bonding_curve) {
+                            ctx.bonding_curve_publish_times
+                                .lock()
+                                .record_bonding_publish(pk, now_ms);
+                        }
+                    }
+                    _ => {}
+                }
+            }
         }
         Ok(false) => {
             warn!(
@@ -536,6 +601,46 @@ struct Args {
     wallet_snapshot_only: bool,
 }
 
+/// Bounded map: bonding-curve pubkey → wall ms of last successful `BondingCurveProgress` core publish.
+const BONDING_CURVE_PUBLISH_MAP_CAP: usize = 10_000;
+
+#[derive(Debug)]
+struct BondingCurvePublishTimes {
+    insert_order: VecDeque<Pubkey>,
+    last_wall_ms: HashMap<Pubkey, u64>,
+}
+
+impl BondingCurvePublishTimes {
+    fn new() -> Self {
+        Self {
+            insert_order: VecDeque::new(),
+            last_wall_ms: HashMap::new(),
+        }
+    }
+
+    fn record_bonding_publish(&mut self, curve: Pubkey, wall_ms: u64) {
+        use std::collections::hash_map::Entry;
+        match self.last_wall_ms.entry(curve) {
+            Entry::Occupied(mut e) => {
+                e.insert(wall_ms);
+            }
+            Entry::Vacant(_) => {
+                while self.insert_order.len() >= BONDING_CURVE_PUBLISH_MAP_CAP {
+                    if let Some(evicted) = self.insert_order.pop_front() {
+                        self.last_wall_ms.remove(&evicted);
+                    }
+                }
+                self.insert_order.push_back(curve);
+                self.last_wall_ms.insert(curve, wall_ms);
+            }
+        }
+    }
+
+    fn last_bonding_wall_ms(&self, curve: &Pubkey) -> Option<u64> {
+        self.last_wall_ms.get(curve).copied()
+    }
+}
+
 /// Runtime context for market-data
 struct MarketDataContext {
     run_id: String,
@@ -618,6 +723,9 @@ struct MarketDataContext {
     /// Only emit when progress changes by >= 50 bps or complete flag changes.
     last_emitted_curve_progress:
         parking_lot::RwLock<std::collections::HashMap<Pubkey, (u32, bool)>>,
+
+    /// Last bonding-curve publish time (wall ms) for `market_data_trade_after_bonding_publish_ms`.
+    bonding_curve_publish_times: parking_lot::Mutex<BondingCurvePublishTimes>,
 
     /// PumpSwap / PumpFun AMM cold-path helper; set at Geyser-loop start before wallet snapshot.
     /// Used for background wallet-bootstrap DEX verification (watchdog-safe).
@@ -4143,6 +4251,7 @@ async fn publish_wallet_snapshot(
         Pubkey::from_str(ASSOCIATED_TOKEN_PROGRAM_ID).expect("valid associated token program");
 
     let wallet_str = wallet.to_string();
+    let wallet_snapshot_bootstrap_started_at = Instant::now();
 
     // 1) Discover known mints from JetStream (LastPerSubject) for this wallet.
     //    This avoids any RPC owner-scan and gives us stable coverage over restarts.
@@ -4745,7 +4854,17 @@ async fn publish_wallet_snapshot(
     );
 
     if let Some(ref nats) = ctx.nats {
-        let _ = publish_market_event_core_and_momentum(nats, &complete_event).await;
+        let _ = publish_market_event_core_and_momentum_ex(
+            nats,
+            &complete_event,
+            Some(MarketEventCorePublishTrace {
+                recv_at: wallet_snapshot_bootstrap_started_at,
+                cold_path: true,
+                segment: MarketDataLatencySegment::Other,
+            }),
+            None,
+        )
+        .await;
     }
     if let Err(e) = ctx.jsonl_writer.write(&complete_event) {
         warn!(error = %e, "Failed to write WalletSnapshotComplete (bootstrap) to JSONL");
@@ -5137,6 +5256,7 @@ async fn main() -> Result<()> {
         tracked_wallet_mint_decimals: parking_lot::RwLock::new(std::collections::HashMap::new()),
         execution_results_deduper: parking_lot::Mutex::new(ExecutionResultDeduper::default()),
         last_emitted_curve_progress: parking_lot::RwLock::new(std::collections::HashMap::new()),
+        bonding_curve_publish_times: parking_lot::Mutex::new(BondingCurvePublishTimes::new()),
         pump_amm_dex: parking_lot::RwLock::new(None),
         helius_rpc,
     });
@@ -6495,6 +6615,7 @@ async fn run_geyser_loop(
 
             // Proactive mint metadata (decimals/supply) fetched via RPC.
             Some(mint_event) = mint_info_rx.recv() => {
+                let mint_geyser_recv_at = Instant::now();
                 // Write to JSONL
                 if let Err(e) = ctx.jsonl_writer.write(&mint_event) {
                     error!(error = %e, "Failed to write TokenMintInfo event to JSONL");
@@ -6502,7 +6623,18 @@ async fn run_geyser_loop(
 
                 // Publish to NATS
                 if let Some(ref nats) = ctx.nats {
-                    let _ = publish_market_event_core_and_momentum(nats, &mint_event).await;
+                    let seg = market_data_publish_segment(&mint_event.kind);
+                    let _ = publish_market_event_core_and_momentum_ex(
+                        nats,
+                        &mint_event,
+                        Some(MarketEventCorePublishTrace {
+                            recv_at: mint_geyser_recv_at,
+                            cold_path: true,
+                            segment: seg,
+                        }),
+                        Some(ctx.as_ref()),
+                    )
+                    .await;
                 }
             }
 
@@ -6798,6 +6930,8 @@ async fn run_geyser_loop(
 
             // Account updates (pool state changes)
             Ok(account_update) = account_rx.recv() => {
+                let account_geyser_recv_at = Instant::now();
+                market_data_bump_geyser_head_slot(account_update.slot);
                 account_count += 1;
                 ironcrab::metrics::record_activity();
 
@@ -7033,7 +7167,17 @@ async fn run_geyser_loop(
                         }
 
                         if let Some(ref nats) = ctx.nats {
-                            let _ = publish_market_event_core_and_momentum(nats, &mint_event).await;
+                            let _ = publish_market_event_core_and_momentum_ex(
+                                nats,
+                                &mint_event,
+                                Some(MarketEventCorePublishTrace {
+                                    recv_at: account_geyser_recv_at,
+                                    cold_path: false,
+                                    segment: MarketDataLatencySegment::Other,
+                                }),
+                                Some(ctx.as_ref()),
+                            )
+                            .await;
                         }
                     }
                 }
@@ -7229,8 +7373,17 @@ async fn run_geyser_loop(
                                     }
 
                                     if let Some(ref nats) = ctx.nats {
-                                        let _ =
-                                            publish_market_event_core_and_momentum(nats, &state_event).await;
+                                        let _ = publish_market_event_core_and_momentum_ex(
+                                            nats,
+                                            &state_event,
+                                            Some(MarketEventCorePublishTrace {
+                                                recv_at: account_geyser_recv_at,
+                                                cold_path: false,
+                                                segment: MarketDataLatencySegment::Other,
+                                            }),
+                                            Some(ctx.as_ref()),
+                                        )
+                                        .await;
                                     }
                                 }
                             }
@@ -7281,8 +7434,17 @@ async fn run_geyser_loop(
                                     }
 
                                     if let Some(ref nats) = ctx.nats {
-                                        let _ =
-                                            publish_market_event_core_and_momentum(nats, &bin_event).await;
+                                        let _ = publish_market_event_core_and_momentum_ex(
+                                            nats,
+                                            &bin_event,
+                                            Some(MarketEventCorePublishTrace {
+                                                recv_at: account_geyser_recv_at,
+                                                cold_path: false,
+                                                segment: MarketDataLatencySegment::Other,
+                                            }),
+                                            Some(ctx.as_ref()),
+                                        )
+                                        .await;
                                     }
                                 }
                             }
@@ -7858,7 +8020,17 @@ async fn run_geyser_loop(
                                         error!(error = %e, "Failed to write BondingCurveProgress event to JSONL");
                                     }
 
-                                    let _ = publish_market_event_core_and_momentum(nats, &curve_event).await;
+                                    let _ = publish_market_event_core_and_momentum_ex(
+                                        nats,
+                                        &curve_event,
+                                        Some(MarketEventCorePublishTrace {
+                                            recv_at: account_geyser_recv_at,
+                                            cold_path: false,
+                                            segment: MarketDataLatencySegment::BondingCurve,
+                                        }),
+                                        Some(ctx.as_ref()),
+                                    )
+                                    .await;
                                 }
                             }
                             CachedPoolState::PumpAmm(s) => {
@@ -8108,7 +8280,17 @@ async fn run_geyser_loop(
                             }
 
                             if let Some(ref nats) = ctx.nats {
-                                let _ = publish_market_event_core_and_momentum(nats, &dev_event).await;
+                                let _ = publish_market_event_core_and_momentum_ex(
+                                    nats,
+                                    &dev_event,
+                                    Some(MarketEventCorePublishTrace {
+                                        recv_at: account_geyser_recv_at,
+                                        cold_path: false,
+                                        segment: MarketDataLatencySegment::Other,
+                                    }),
+                                    Some(ctx.as_ref()),
+                                )
+                                .await;
                             }
                         }
                     }
@@ -8232,12 +8414,24 @@ async fn run_geyser_loop(
 
                 // Publish to NATS
                 if let Some(ref nats) = ctx.nats {
-                    let _ = publish_market_event_core_and_momentum(nats, &event).await;
+                    let seg = market_data_publish_segment(&event.kind);
+                    let _ = publish_market_event_core_and_momentum_ex(
+                        nats,
+                        &event,
+                        Some(MarketEventCorePublishTrace {
+                            recv_at: account_geyser_recv_at,
+                            cold_path: false,
+                            segment: seg,
+                        }),
+                        Some(ctx.as_ref()),
+                    )
+                    .await;
                 }
             }
 
             // Blockhash updates from Geyser blocks_meta
             Ok(bh_update) = blockhash_rx.recv() => {
+                market_data_bump_geyser_head_slot(bh_update.slot);
                 let event = MarketEvent::new(
                     "market-data",
                     BUILD_VERSION,
@@ -8260,6 +8454,8 @@ async fn run_geyser_loop(
 
             // Transaction updates (pool creations, swaps)
             Ok(tx_update) = transaction_rx.recv() => {
+                let tx_geyser_recv_at = Instant::now();
+                market_data_bump_geyser_head_slot(tx_update.slot);
                 tx_count += 1;
                 ironcrab::metrics::record_activity();
 
@@ -8431,7 +8627,17 @@ async fn run_geyser_loop(
                     }
 
                     if let Some(ref nats) = ctx.nats {
-                        let _ = publish_market_event_core_and_momentum(nats, &dev_event).await;
+                        let _ = publish_market_event_core_and_momentum_ex(
+                            nats,
+                            &dev_event,
+                            Some(MarketEventCorePublishTrace {
+                                recv_at: tx_geyser_recv_at,
+                                cold_path: false,
+                                segment: MarketDataLatencySegment::Other,
+                            }),
+                            Some(ctx.as_ref()),
+                        )
+                        .await;
                     }
                 }
 
@@ -8520,8 +8726,17 @@ async fn run_geyser_loop(
                             error!(error = %e, "Failed to write pump_amm PoolCreated (create_pool) to JSONL");
                         }
                         if let Some(ref nats) = ctx.nats {
-                            let _ =
-                                publish_market_event_core_and_momentum(nats, &pool_created_event).await;
+                            let _ = publish_market_event_core_and_momentum_ex(
+                                nats,
+                                &pool_created_event,
+                                Some(MarketEventCorePublishTrace {
+                                    recv_at: tx_geyser_recv_at,
+                                    cold_path: false,
+                                    segment: MarketDataLatencySegment::PoolCreated,
+                                }),
+                                Some(ctx.as_ref()),
+                            )
+                            .await;
                         }
                         ctx.pool_mint_map.write().insert(pool_address.to_string(), base_mint.clone());
                     }
@@ -8606,12 +8821,18 @@ async fn run_geyser_loop(
                         }
 
                         if let Some(ref nats) = ctx.nats {
-                            let _ =
-                                publish_market_event_core_and_momentum(nats, &pool_created_event).await;
+                            let _ = publish_market_event_core_and_momentum_ex(
+                                nats,
+                                &pool_created_event,
+                                Some(MarketEventCorePublishTrace {
+                                    recv_at: tx_geyser_recv_at,
+                                    cold_path: false,
+                                    segment: MarketDataLatencySegment::PoolCreated,
+                                }),
+                                Some(ctx.as_ref()),
+                            )
+                            .await;
                         }
-                    }
-
-                    // Always emit DexPoolAccounts on pump_amm trades
                     let accounts_event = MarketEvent::new(
                         "market-data",
                         BUILD_VERSION,
@@ -8633,10 +8854,18 @@ async fn run_geyser_loop(
                     }
 
                     if let Some(ref nats) = ctx.nats {
-                        let _ = publish_market_event_core_and_momentum(nats, &accounts_event).await;
+                        let _ = publish_market_event_core_and_momentum_ex(
+                            nats,
+                            &accounts_event,
+                            Some(MarketEventCorePublishTrace {
+                                recv_at: tx_geyser_recv_at,
+                                cold_path: false,
+                                segment: MarketDataLatencySegment::Other,
+                            }),
+                            Some(ctx.as_ref()),
+                        )
+                        .await;
                     }
-
-                    // FIX-26: Also populate MASTER LivePoolCache with pool_accounts.
                     // Ensures the Geyser PoolCacheUpdate builder can use these as fallback
                     // when the parsed Geyser state has empty pool_accounts.
                     if pool_accounts.len() >= 14 {
@@ -8718,6 +8947,7 @@ async fn run_geyser_loop(
                         }
                     }
                 }
+                }
 
                 // For non-pump_amm DEXes: emit DexPoolAccounts on first trade if pool_accounts present.
                 if let Some(ParsedDexEvent::Trade {
@@ -8753,7 +8983,18 @@ async fn run_geyser_loop(
                             }
 
                             if let Some(ref nats) = ctx.nats {
-                                if publish_market_event_core_and_momentum(nats, &accounts_event).await {
+                                if publish_market_event_core_and_momentum_ex(
+                                    nats,
+                                    &accounts_event,
+                                    Some(MarketEventCorePublishTrace {
+                                        recv_at: tx_geyser_recv_at,
+                                        cold_path: false,
+                                        segment: MarketDataLatencySegment::Other,
+                                    }),
+                                    None,
+                                )
+                                .await
+                                {
                                     debug!(
                                         dex = %dex,
                                         pool = %pool_address,
@@ -8840,12 +9081,25 @@ async fn run_geyser_loop(
 
                 // Publish to NATS
                 if let Some(ref nats) = ctx.nats {
-                    let _ = publish_market_event_core_and_momentum(nats, &event).await;
+                    let seg = market_data_publish_segment(&event.kind);
+                    let _ = publish_market_event_core_and_momentum_ex(
+                        nats,
+                        &event,
+                        Some(MarketEventCorePublishTrace {
+                            recv_at: tx_geyser_recv_at,
+                            cold_path: false,
+                            segment: seg,
+                        }),
+                        Some(ctx.as_ref()),
+                    )
+                    .await;
                 }
             }
 
             // Pool Discovery Events (Geyser-based pool creation events)
             Ok(pool_event) = pool_discovery_rx.recv() => {
+                let pool_discovery_recv_at = Instant::now();
+                market_data_bump_geyser_head_slot(pool_event.slot);
                 ironcrab::metrics::record_activity();
 
                 info!(
@@ -8917,7 +9171,17 @@ async fn run_geyser_loop(
 
                 // Publish to NATS
                 if let Some(ref nats) = ctx.nats {
-                    let _ = publish_market_event_core_and_momentum(nats, &event).await;
+                    let _ = publish_market_event_core_and_momentum_ex(
+                        nats,
+                        &event,
+                        Some(MarketEventCorePublishTrace {
+                            recv_at: pool_discovery_recv_at,
+                            cold_path: false,
+                            segment: market_data_publish_segment(&event.kind),
+                        }),
+                        Some(ctx.as_ref()),
+                    )
+                    .await;
                 }
 
                 // Emit DevWalletIdentified for Pump.fun pools where we know the creator
@@ -8944,7 +9208,18 @@ async fn run_geyser_loop(
                         }
 
                         if let Some(ref nats) = ctx.nats {
-                            if publish_market_event_core_and_momentum(nats, &dev_event).await {
+                            if publish_market_event_core_and_momentum_ex(
+                                nats,
+                                &dev_event,
+                                Some(MarketEventCorePublishTrace {
+                                    recv_at: pool_discovery_recv_at,
+                                    cold_path: false,
+                                    segment: market_data_publish_segment(&dev_event.kind),
+                                }),
+                                None,
+                            )
+                            .await
+                            {
                                 info!(
                                     mint = %pool_event.base_mint,
                                     creator = %creator,
@@ -9011,7 +9286,18 @@ async fn run_geyser_loop(
                     }
 
                     if let Some(ref nats) = ctx.nats {
-                        if publish_market_event_core_and_momentum(nats, &accounts_event).await {
+                        if publish_market_event_core_and_momentum_ex(
+                            nats,
+                            &accounts_event,
+                            Some(MarketEventCorePublishTrace {
+                                recv_at: pool_discovery_recv_at,
+                                cold_path: false,
+                                segment: market_data_publish_segment(&accounts_event.kind),
+                            }),
+                            None,
+                        )
+                        .await
+                        {
                             debug!(
                                 dex = %pool_event.dex_type,
                                 pool = %pool_event.pool_address,

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -8833,6 +8833,7 @@ async fn run_geyser_loop(
                             )
                             .await;
                         }
+                    }
                     let accounts_event = MarketEvent::new(
                         "market-data",
                         BUILD_VERSION,
@@ -8946,7 +8947,6 @@ async fn run_geyser_loop(
                             }
                         }
                     }
-                }
                 }
 
                 // For non-pump_amm DEXes: emit DexPoolAccounts on first trade if pool_accounts present.

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -623,6 +623,10 @@ impl BondingCurvePublishTimes {
         match self.last_wall_ms.entry(curve) {
             Entry::Occupied(mut e) => {
                 e.insert(wall_ms);
+                // Refresh eviction order: otherwise a still-active curve stays at an old deque
+                // position and can be popped while newer keys retain slots.
+                self.insert_order.retain(|k| *k != curve);
+                self.insert_order.push_back(curve);
             }
             Entry::Vacant(_) => {
                 while self.insert_order.len() >= BONDING_CURVE_PUBLISH_MAP_CAP {

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -55,8 +55,10 @@ use ironcrab::metrics::{
     set_momentum_bot_process_start_unix_sec,
     set_momentum_market_events_ingest_max_wall_lag_ms_last_batch, set_readiness_nats_connected,
     try_record_momentum_event_to_ingest_ms, try_record_momentum_event_to_intent_publish_ms,
-    try_record_momentum_jetstream_poolcache_event_to_ingest_ms, wall_clock_unix_ms_now,
-    MetricsComponent, EXITS_GENERATED_TOTAL, FILTER_PASSED_TOTAL, FILTER_REJECTED_BUYER_QUALITY,
+    try_record_momentum_intent_header_to_publish_ms,
+    try_record_momentum_jetstream_poolcache_event_to_ingest_ms,
+    try_record_momentum_publish_to_intent_ms, wall_clock_unix_ms_now, MetricsComponent,
+    EXITS_GENERATED_TOTAL, FILTER_PASSED_TOTAL, FILTER_REJECTED_BUYER_QUALITY,
     FILTER_REJECTED_DEV_BEHAVIOR, FILTER_REJECTED_INFLOW, FILTER_REJECTED_LIQUIDITY,
     FILTER_REJECTED_TOTAL, FILTER_REJECTED_VELOCITY, INTENTS_GENERATED_TOTAL,
     MARKET_EVENTS_CONSUMED_TOTAL, NATS_ERRORS_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
@@ -8792,6 +8794,9 @@ async fn main() -> Result<()> {
                         // Large values often mean **stale producer timestamps** or clock skew — not
                         // necessarily momentum backlog. JetStream pool-cache lag is tracked separately
                         // via `try_record_momentum_jetstream_poolcache_event_to_ingest_ms`.
+                        // Pipeline note: this is the **market-data → momentum** segment; downstream
+                        // JetStream intent latency uses `try_record_momentum_intent_header_to_publish_ms`
+                        // / `try_record_momentum_publish_to_intent_ms` / `try_record_momentum_event_to_intent_publish_ms`.
                         try_record_momentum_event_to_ingest_ms(now_ms, event.header.ts_unix_ms);
                         if let Some(ms) =
                             momentum_event_ts_latency_delta_ms(now_ms, event.header.ts_unix_ms)
@@ -9664,6 +9669,11 @@ async fn generate_and_publish_buy_intent_inner(
         match nats.jetstream_publish(TOPIC_TRADE_INTENTS, &intent).await {
             Ok(true) => {
                 NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                let now_ms = wall_clock_unix_ms_now();
+                try_record_momentum_intent_header_to_publish_ms(now_ms, intent.header.ts_unix_ms);
+                if ts_ms > 0 && ts_ms <= intent.header.ts_unix_ms {
+                    try_record_momentum_publish_to_intent_ms(intent.header.ts_unix_ms, ts_ms);
+                }
                 publish_ok = true;
             }
             Ok(false) => {
@@ -15936,6 +15946,10 @@ async fn generate_and_publish_exit_intent(
             Ok(true) => {
                 NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
                 let now_ms = wall_clock_unix_ms_now();
+                try_record_momentum_intent_header_to_publish_ms(now_ms, intent.header.ts_unix_ms);
+                if ts_ms > 0 && ts_ms <= intent.header.ts_unix_ms {
+                    try_record_momentum_publish_to_intent_ms(intent.header.ts_unix_ms, ts_ms);
+                }
                 if let Some(ts) = source_event_ts_unix_ms {
                     try_record_momentum_event_to_intent_publish_ms(now_ms, ts);
                 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -581,6 +581,11 @@ pub static MOMENTUM_EVENT_TO_INTENT_PUBLISH_MS_COUNT: Lazy<AtomicU64> =
 const MOMENTUM_INTERNAL_US_BUCKETS: &[u64] = &[
     50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000, 250000,
 ];
+/// Full `process_intent` wall time (µs): includes simulation, send, and confirmation (seconds-scale).
+const EXECUTION_PROCESS_INTENT_US_BUCKETS: &[u64] = &[
+    50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000, 250000, 500_000, 1_000_000,
+    2_000_000, 5_000_000, 10_000_000, 20_000_000, 30_000_000, 45_000_000, 60_000_000,
+];
 pub static MOMENTUM_INGEST_TO_PROCESS_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
     MOMENTUM_INTERNAL_US_BUCKETS
         .iter()
@@ -1127,7 +1132,7 @@ pub static EXECUTION_INTENT_TO_CONFIRM_MS_SUM: Lazy<AtomicU64> = Lazy::new(|| At
 pub static EXECUTION_INTENT_TO_CONFIRM_MS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
 pub static EXECUTION_PROCESS_INTENT_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
-    MOMENTUM_INTERNAL_US_BUCKETS
+    EXECUTION_PROCESS_INTENT_US_BUCKETS
         .iter()
         .map(|_| AtomicU64::new(0))
         .collect()
@@ -1788,7 +1793,7 @@ pub fn try_record_execution_intent_to_confirm_ms(now_ms: u64, intent_header_ts_m
 #[inline]
 pub fn record_execution_process_intent_us(us: u64) {
     record_histogram_u64_into(
-        MOMENTUM_INTERNAL_US_BUCKETS,
+        EXECUTION_PROCESS_INTENT_US_BUCKETS,
         EXECUTION_PROCESS_INTENT_US_BUCKET_COUNTS.as_slice(),
         &EXECUTION_PROCESS_INTENT_US_SUM,
         &EXECUTION_PROCESS_INTENT_US_COUNT,
@@ -2327,7 +2332,7 @@ async fn metrics_response() -> Response<Body> {
     append_momentum_latency_histogram_prometheus(
         &mut out,
         "execution_process_intent_us",
-        MOMENTUM_INTERNAL_US_BUCKETS,
+        EXECUTION_PROCESS_INTENT_US_BUCKETS,
         &EXECUTION_PROCESS_INTENT_US_BUCKET_COUNTS,
         &EXECUTION_PROCESS_INTENT_US_SUM,
         &EXECUTION_PROCESS_INTENT_US_COUNT,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -586,6 +586,12 @@ const EXECUTION_PROCESS_INTENT_US_BUCKETS: &[u64] = &[
     50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000, 250000, 500_000, 1_000_000,
     2_000_000, 5_000_000, 10_000_000, 20_000_000, 30_000_000, 45_000_000, 60_000_000,
 ];
+/// Intent header → on-chain confirm (ms). Upper range matches [`EXECUTION_PROCESS_INTENT_US_BUCKETS`]
+/// (60s) so `histogram_quantile` stays meaningful vs default confirmation timeouts (~15s+).
+const EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS: &[u64] = &[
+    1, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_000, 5_000, 7_500, 10_000, 15_000, 20_000, 30_000,
+    45_000, 60_000,
+];
 pub static MOMENTUM_INGEST_TO_PROCESS_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
     MOMENTUM_INTERNAL_US_BUCKETS
         .iter()
@@ -1123,7 +1129,7 @@ pub static EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_COUNT: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
 pub static EXECUTION_INTENT_TO_CONFIRM_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
-    MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS
+    EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS
         .iter()
         .map(|_| AtomicU64::new(0))
         .collect()
@@ -1779,7 +1785,7 @@ pub fn try_record_execution_intent_header_to_receive_ms(now_ms: u64, intent_head
 pub fn try_record_execution_intent_to_confirm_ms(now_ms: u64, intent_header_ts_ms: u64) {
     if let Some(ms) = momentum_event_ts_latency_delta_ms(now_ms, intent_header_ts_ms) {
         record_histogram_u64_into(
-            MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+            EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS,
             EXECUTION_INTENT_TO_CONFIRM_MS_BUCKET_COUNTS.as_slice(),
             &EXECUTION_INTENT_TO_CONFIRM_MS_SUM,
             &EXECUTION_INTENT_TO_CONFIRM_MS_COUNT,
@@ -2324,7 +2330,7 @@ async fn metrics_response() -> Response<Body> {
     append_momentum_latency_histogram_prometheus(
         &mut out,
         "execution_intent_to_confirm_ms",
-        MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+        EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS,
         &EXECUTION_INTENT_TO_CONFIRM_MS_BUCKET_COUNTS,
         &EXECUTION_INTENT_TO_CONFIRM_MS_SUM,
         &EXECUTION_INTENT_TO_CONFIRM_MS_COUNT,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1118,7 +1118,7 @@ pub static TX_SLOT_TO_SEND_MS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::n
 // --- execution-engine pipeline latency (histograms; complements TX_CONFIRM_LATENCY_MS gauge) ---
 pub static EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
     Lazy::new(|| {
-        MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS
+        EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS
             .iter()
             .map(|_| AtomicU64::new(0))
             .collect()
@@ -1770,7 +1770,7 @@ pub fn record_tx_slot_to_send_ms(ms: u64) {
 pub fn try_record_execution_intent_header_to_receive_ms(now_ms: u64, intent_header_ts_ms: u64) {
     if let Some(ms) = momentum_event_ts_latency_delta_ms(now_ms, intent_header_ts_ms) {
         record_histogram_u64_into(
-            MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+            EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS,
             EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_BUCKET_COUNTS.as_slice(),
             &EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_SUM,
             &EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_COUNT,
@@ -2322,7 +2322,7 @@ async fn metrics_response() -> Response<Body> {
     append_momentum_latency_histogram_prometheus(
         &mut out,
         "execution_intent_header_to_receive_ms",
-        MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+        EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS,
         &EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_BUCKET_COUNTS,
         &EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_SUM,
         &EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_COUNT,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -222,6 +222,307 @@ pub static TOKENS_TRACKED_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0
 pub static GEYSER_RECONNECTS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static GEYSER_ERRORS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
+// --- market-data: Geyser recv → Core NATS publish (hot path observability, no RPC) ---
+/// Monotonic Geyser chain head (max slot seen on market-data ingest paths). I-16: not RPC `getSlot`.
+pub static MARKET_DATA_GEYSER_HEAD_SLOT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+const MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS: &[u64] = &[
+    1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2000, 5000, 10_000, 30_000, 60_000,
+];
+const MARKET_DATA_LATENCY_MS_SUM_CAP: u64 = 600_000;
+
+const MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS: &[u64] = &[0, 1, 2, 3, 5, 10, 20, 50, 100, 200];
+
+/// Segment for `market_data_geyser_to_publish_ms_*` / slot lag histogram families (no dynamic labels).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MarketDataLatencySegment {
+    Trade,
+    BondingCurve,
+    PoolCreated,
+    Other,
+}
+
+static MARKET_DATA_GEYSER_TO_PUBLISH_MS_TRADE_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_GEYSER_TO_PUBLISH_MS_TRADE_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_GEYSER_TO_PUBLISH_MS_TRADE_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+static MARKET_DATA_GEYSER_TO_PUBLISH_MS_BONDING_CURVE_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_GEYSER_TO_PUBLISH_MS_BONDING_CURVE_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_GEYSER_TO_PUBLISH_MS_BONDING_CURVE_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+static MARKET_DATA_GEYSER_TO_PUBLISH_MS_POOL_CREATED_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_GEYSER_TO_PUBLISH_MS_POOL_CREATED_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_GEYSER_TO_PUBLISH_MS_POOL_CREATED_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+static MARKET_DATA_GEYSER_TO_PUBLISH_MS_OTHER_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_GEYSER_TO_PUBLISH_MS_OTHER_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_GEYSER_TO_PUBLISH_MS_OTHER_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+static MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_TRADE_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_TRADE_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_TRADE_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+static MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_BONDING_CURVE_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_BONDING_CURVE_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_BONDING_CURVE_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+static MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_POOL_CREATED_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_POOL_CREATED_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_POOL_CREATED_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+static MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_OTHER_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_OTHER_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_OTHER_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Pump.fun: wall ms between last `BondingCurveProgress` publish and next `Trade` publish (same bonding curve / pool).
+static MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Update monotonic Geyser head slot (max). Safe from any market-data ingest arm.
+#[inline]
+pub fn market_data_bump_geyser_head_slot(slot: u64) {
+    if slot == 0 {
+        return;
+    }
+    let _ = MARKET_DATA_GEYSER_HEAD_SLOT.fetch_max(slot, Ordering::Relaxed);
+}
+
+/// Record wall ms delta for pump.fun trade after last bonding publish (bounded map hit only).
+#[inline]
+pub fn record_market_data_trade_after_bonding_publish_ms(delta_ms: u64) {
+    record_histogram_u64_into(
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+        &MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_BUCKET_COUNTS,
+        &MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_SUM,
+        &MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_COUNT,
+        delta_ms,
+        MARKET_DATA_LATENCY_MS_SUM_CAP,
+    );
+}
+
+/// After successful core `TOPIC_MARKET_EVENTS` publish (`publish_market_event_core_and_momentum_ex` path).
+#[inline]
+pub fn record_market_data_geyser_to_publish_on_success(
+    recv_at: Instant,
+    segment: MarketDataLatencySegment,
+    cold_path: bool,
+    event_slot: Option<u64>,
+) {
+    if cold_path {
+        return;
+    }
+    let elapsed_ms = recv_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+    match segment {
+        MarketDataLatencySegment::Trade => record_histogram_u64_into(
+            MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+            &MARKET_DATA_GEYSER_TO_PUBLISH_MS_TRADE_BUCKET_COUNTS,
+            &MARKET_DATA_GEYSER_TO_PUBLISH_MS_TRADE_SUM,
+            &MARKET_DATA_GEYSER_TO_PUBLISH_MS_TRADE_COUNT,
+            elapsed_ms,
+            MARKET_DATA_LATENCY_MS_SUM_CAP,
+        ),
+        MarketDataLatencySegment::BondingCurve => record_histogram_u64_into(
+            MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+            &MARKET_DATA_GEYSER_TO_PUBLISH_MS_BONDING_CURVE_BUCKET_COUNTS,
+            &MARKET_DATA_GEYSER_TO_PUBLISH_MS_BONDING_CURVE_SUM,
+            &MARKET_DATA_GEYSER_TO_PUBLISH_MS_BONDING_CURVE_COUNT,
+            elapsed_ms,
+            MARKET_DATA_LATENCY_MS_SUM_CAP,
+        ),
+        MarketDataLatencySegment::PoolCreated => record_histogram_u64_into(
+            MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+            &MARKET_DATA_GEYSER_TO_PUBLISH_MS_POOL_CREATED_BUCKET_COUNTS,
+            &MARKET_DATA_GEYSER_TO_PUBLISH_MS_POOL_CREATED_SUM,
+            &MARKET_DATA_GEYSER_TO_PUBLISH_MS_POOL_CREATED_COUNT,
+            elapsed_ms,
+            MARKET_DATA_LATENCY_MS_SUM_CAP,
+        ),
+        MarketDataLatencySegment::Other => record_histogram_u64_into(
+            MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+            &MARKET_DATA_GEYSER_TO_PUBLISH_MS_OTHER_BUCKET_COUNTS,
+            &MARKET_DATA_GEYSER_TO_PUBLISH_MS_OTHER_SUM,
+            &MARKET_DATA_GEYSER_TO_PUBLISH_MS_OTHER_COUNT,
+            elapsed_ms,
+            MARKET_DATA_LATENCY_MS_SUM_CAP,
+        ),
+    };
+    let es = match event_slot {
+        Some(s) if s > 0 => s,
+        _ => return,
+    };
+    let head = MARKET_DATA_GEYSER_HEAD_SLOT.load(Ordering::Relaxed);
+    if head == 0 || head < es {
+        return;
+    }
+    let lag = head.saturating_sub(es);
+    match segment {
+        MarketDataLatencySegment::Trade => record_histogram_u64_into(
+            MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS,
+            &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_TRADE_BUCKET_COUNTS,
+            &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_TRADE_SUM,
+            &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_TRADE_COUNT,
+            lag,
+            u64::MAX,
+        ),
+        MarketDataLatencySegment::BondingCurve => record_histogram_u64_into(
+            MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS,
+            &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_BONDING_CURVE_BUCKET_COUNTS,
+            &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_BONDING_CURVE_SUM,
+            &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_BONDING_CURVE_COUNT,
+            lag,
+            u64::MAX,
+        ),
+        MarketDataLatencySegment::PoolCreated => record_histogram_u64_into(
+            MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS,
+            &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_POOL_CREATED_BUCKET_COUNTS,
+            &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_POOL_CREATED_SUM,
+            &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_POOL_CREATED_COUNT,
+            lag,
+            u64::MAX,
+        ),
+        MarketDataLatencySegment::Other => record_histogram_u64_into(
+            MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS,
+            &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_OTHER_BUCKET_COUNTS,
+            &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_OTHER_SUM,
+            &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_OTHER_COUNT,
+            lag,
+            u64::MAX,
+        ),
+    };
+}
+
+// --- momentum-bot: intent header → JetStream publish (header.ts = TradeIntent::new wall time) ---
+pub static MOMENTUM_INTENT_HEADER_TO_PUBLISH_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+pub static MOMENTUM_INTENT_HEADER_TO_PUBLISH_MS_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_INTENT_HEADER_TO_PUBLISH_MS_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Causal `MarketEvent.header.ts_unix_ms` → `TradeIntent.header.ts_unix_ms` (entry path only).
+pub static MOMENTUM_PUBLISH_TO_INTENT_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static MOMENTUM_PUBLISH_TO_INTENT_MS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_PUBLISH_TO_INTENT_MS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn try_record_momentum_intent_header_to_publish_ms(now_ms: u64, intent_header_ts_ms: u64) {
+    if let Some(ms) = momentum_event_ts_latency_delta_ms(now_ms, intent_header_ts_ms) {
+        record_histogram_u64_into(
+            MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+            MOMENTUM_INTENT_HEADER_TO_PUBLISH_MS_BUCKET_COUNTS.as_slice(),
+            &MOMENTUM_INTENT_HEADER_TO_PUBLISH_MS_SUM,
+            &MOMENTUM_INTENT_HEADER_TO_PUBLISH_MS_COUNT,
+            ms,
+            MOMENTUM_LATENCY_MS_SUM_CAP,
+        );
+    }
+}
+
+/// Wall time from causal market-event publish timestamp to intent `RecordHeader` time.
+#[inline]
+pub fn try_record_momentum_publish_to_intent_ms(intent_header_ts_ms: u64, causal_event_ts_ms: u64) {
+    if causal_event_ts_ms == 0 || causal_event_ts_ms > intent_header_ts_ms {
+        MOMENTUM_LATENCY_EVENT_TS_INVALID_TOTAL.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+    let ms = intent_header_ts_ms.saturating_sub(causal_event_ts_ms);
+    record_histogram_u64_into(
+        MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+        MOMENTUM_PUBLISH_TO_INTENT_MS_BUCKET_COUNTS.as_slice(),
+        &MOMENTUM_PUBLISH_TO_INTENT_MS_SUM,
+        &MOMENTUM_PUBLISH_TO_INTENT_MS_COUNT,
+        ms,
+        MOMENTUM_LATENCY_MS_SUM_CAP,
+    );
+}
+
 // --- momentum-bot service metrics ---
 pub static INTENTS_GENERATED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// Exit/SELL intents generated by momentum-bot (separate from BUY intents)
@@ -802,6 +1103,48 @@ pub static TX_SLOT_TO_SEND_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(||
 });
 pub static TX_SLOT_TO_SEND_MS_SUM_MS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static TX_SLOT_TO_SEND_MS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+// --- execution-engine pipeline latency (histograms; complements TX_CONFIRM_LATENCY_MS gauge) ---
+pub static EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+pub static EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+pub static EXECUTION_INTENT_TO_CONFIRM_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static EXECUTION_INTENT_TO_CONFIRM_MS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static EXECUTION_INTENT_TO_CONFIRM_MS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+pub static EXECUTION_PROCESS_INTENT_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    MOMENTUM_INTERNAL_US_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static EXECUTION_PROCESS_INTENT_US_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static EXECUTION_PROCESS_INTENT_US_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+pub static EXECUTION_SLOT_LAG_AT_SEND_SLOTS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static EXECUTION_SLOT_LAG_AT_SEND_SLOTS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static EXECUTION_SLOT_LAG_AT_SEND_SLOTS_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 pub static TPU_RECONNECT_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static TPU_CACHE_STALE_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static GEYSER_TX_WATCHER_CONNECTED: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
@@ -1411,6 +1754,62 @@ pub fn record_tx_slot_to_send_ms(ms: u64) {
     }
 }
 
+/// `TradeIntent.header.ts_unix_ms` → first line of `process_intent` (JetStream / consumer skew).
+#[inline]
+pub fn try_record_execution_intent_header_to_receive_ms(now_ms: u64, intent_header_ts_ms: u64) {
+    if let Some(ms) = momentum_event_ts_latency_delta_ms(now_ms, intent_header_ts_ms) {
+        record_histogram_u64_into(
+            MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+            EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_BUCKET_COUNTS.as_slice(),
+            &EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_SUM,
+            &EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_COUNT,
+            ms,
+            MOMENTUM_LATENCY_MS_SUM_CAP,
+        );
+    }
+}
+
+/// Intent header time → on-chain confirm observation (wall), histogram for p99 (vs scalar gauge).
+#[inline]
+pub fn try_record_execution_intent_to_confirm_ms(now_ms: u64, intent_header_ts_ms: u64) {
+    if let Some(ms) = momentum_event_ts_latency_delta_ms(now_ms, intent_header_ts_ms) {
+        record_histogram_u64_into(
+            MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+            EXECUTION_INTENT_TO_CONFIRM_MS_BUCKET_COUNTS.as_slice(),
+            &EXECUTION_INTENT_TO_CONFIRM_MS_SUM,
+            &EXECUTION_INTENT_TO_CONFIRM_MS_COUNT,
+            ms,
+            MOMENTUM_LATENCY_MS_SUM_CAP,
+        );
+    }
+}
+
+/// Total `process_intent` wall time (microseconds).
+#[inline]
+pub fn record_execution_process_intent_us(us: u64) {
+    record_histogram_u64_into(
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        EXECUTION_PROCESS_INTENT_US_BUCKET_COUNTS.as_slice(),
+        &EXECUTION_PROCESS_INTENT_US_SUM,
+        &EXECUTION_PROCESS_INTENT_US_COUNT,
+        us,
+        MOMENTUM_LATENCY_US_SUM_CAP,
+    );
+}
+
+/// `cached_blockhash.slot` (Geyser-fed) minus intent metadata `slot` at successful send.
+#[inline]
+pub fn record_execution_slot_lag_at_send_slots(lag_slots: u64) {
+    record_histogram_u64_into(
+        MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS,
+        EXECUTION_SLOT_LAG_AT_SEND_SLOTS_BUCKET_COUNTS.as_slice(),
+        &EXECUTION_SLOT_LAG_AT_SEND_SLOTS_SUM,
+        &EXECUTION_SLOT_LAG_AT_SEND_SLOTS_COUNT,
+        lag_slots,
+        u64::MAX,
+    );
+}
+
 /// Record price impact measurement (basis points)
 pub fn record_price_impact(_price_impact_bps: f64) {
     // For now, we'll just track in the trade success metrics
@@ -1491,6 +1890,90 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "geyser_errors_total",
         GEYSER_ERRORS_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_geyser_head_slot",
+        MARKET_DATA_GEYSER_HEAD_SLOT.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_last_trade_publish_ts_unix_ms",
+        MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_last_bonding_curve_publish_ts_unix_ms",
+        MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS.load(Ordering::Relaxed)
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_geyser_to_publish_ms_trade",
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+        &MARKET_DATA_GEYSER_TO_PUBLISH_MS_TRADE_BUCKET_COUNTS,
+        &MARKET_DATA_GEYSER_TO_PUBLISH_MS_TRADE_SUM,
+        &MARKET_DATA_GEYSER_TO_PUBLISH_MS_TRADE_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_geyser_to_publish_ms_bonding_curve",
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+        &MARKET_DATA_GEYSER_TO_PUBLISH_MS_BONDING_CURVE_BUCKET_COUNTS,
+        &MARKET_DATA_GEYSER_TO_PUBLISH_MS_BONDING_CURVE_SUM,
+        &MARKET_DATA_GEYSER_TO_PUBLISH_MS_BONDING_CURVE_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_geyser_to_publish_ms_pool_created",
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+        &MARKET_DATA_GEYSER_TO_PUBLISH_MS_POOL_CREATED_BUCKET_COUNTS,
+        &MARKET_DATA_GEYSER_TO_PUBLISH_MS_POOL_CREATED_SUM,
+        &MARKET_DATA_GEYSER_TO_PUBLISH_MS_POOL_CREATED_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_geyser_to_publish_ms_other",
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+        &MARKET_DATA_GEYSER_TO_PUBLISH_MS_OTHER_BUCKET_COUNTS,
+        &MARKET_DATA_GEYSER_TO_PUBLISH_MS_OTHER_SUM,
+        &MARKET_DATA_GEYSER_TO_PUBLISH_MS_OTHER_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_slot_lag_at_publish_slots_trade",
+        MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS,
+        &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_TRADE_BUCKET_COUNTS,
+        &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_TRADE_SUM,
+        &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_TRADE_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_slot_lag_at_publish_slots_bonding_curve",
+        MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS,
+        &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_BONDING_CURVE_BUCKET_COUNTS,
+        &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_BONDING_CURVE_SUM,
+        &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_BONDING_CURVE_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_slot_lag_at_publish_slots_pool_created",
+        MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS,
+        &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_POOL_CREATED_BUCKET_COUNTS,
+        &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_POOL_CREATED_SUM,
+        &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_POOL_CREATED_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_slot_lag_at_publish_slots_other",
+        MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS,
+        &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_OTHER_BUCKET_COUNTS,
+        &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_OTHER_SUM,
+        &MARKET_DATA_SLOT_LAG_AT_PUBLISH_SLOTS_OTHER_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_trade_after_bonding_publish_ms",
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+        &MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_BUCKET_COUNTS,
+        &MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_SUM,
+        &MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_COUNT,
     );
 
     // --- momentum-bot service ---
@@ -1691,6 +2174,22 @@ async fn metrics_response() -> Response<Body> {
     );
     append_momentum_latency_histogram_prometheus(
         &mut out,
+        "momentum_intent_header_to_publish_ms",
+        MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+        &MOMENTUM_INTENT_HEADER_TO_PUBLISH_MS_BUCKET_COUNTS,
+        &MOMENTUM_INTENT_HEADER_TO_PUBLISH_MS_SUM,
+        &MOMENTUM_INTENT_HEADER_TO_PUBLISH_MS_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "momentum_publish_to_intent_ms",
+        MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+        &MOMENTUM_PUBLISH_TO_INTENT_MS_BUCKET_COUNTS,
+        &MOMENTUM_PUBLISH_TO_INTENT_MS_SUM,
+        &MOMENTUM_PUBLISH_TO_INTENT_MS_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
         "momentum_ingest_to_process_us",
         MOMENTUM_INTERNAL_US_BUCKETS,
         &MOMENTUM_INGEST_TO_PROCESS_US_BUCKET_COUNTS,
@@ -1809,6 +2308,38 @@ async fn metrics_response() -> Response<Body> {
     ));
     out.push_str(&format!("tx_slot_to_send_ms_sum {}\n", sts_sum));
     out.push_str(&format!("tx_slot_to_send_ms_count {}\n", sts_count));
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "execution_intent_header_to_receive_ms",
+        MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+        &EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_BUCKET_COUNTS,
+        &EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_SUM,
+        &EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "execution_intent_to_confirm_ms",
+        MOMENTUM_EVENT_TO_LATENCY_MS_BUCKETS,
+        &EXECUTION_INTENT_TO_CONFIRM_MS_BUCKET_COUNTS,
+        &EXECUTION_INTENT_TO_CONFIRM_MS_SUM,
+        &EXECUTION_INTENT_TO_CONFIRM_MS_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "execution_process_intent_us",
+        MOMENTUM_INTERNAL_US_BUCKETS,
+        &EXECUTION_PROCESS_INTENT_US_BUCKET_COUNTS,
+        &EXECUTION_PROCESS_INTENT_US_SUM,
+        &EXECUTION_PROCESS_INTENT_US_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "execution_slot_lag_at_send_slots",
+        MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS,
+        &EXECUTION_SLOT_LAG_AT_SEND_SLOTS_BUCKET_COUNTS,
+        &EXECUTION_SLOT_LAG_AT_SEND_SLOTS_SUM,
+        &EXECUTION_SLOT_LAG_AT_SEND_SLOTS_COUNT,
+    );
     line!(
         "tpu_reconnect_total",
         TPU_RECONNECT_TOTAL.load(Ordering::Relaxed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Kurzbeschreibung

Segmentierte Prometheus-Histogramme für die Datenpipeline **Geyser/market-data → momentum-bot (Intent-JetStream) → execution-engine** (Empfang, `process_intent`, Confirm, Slot-Lag beim Send). Rein observability; kein neuer Hot-Path-RPC.

## Änderungen

- **market-data:** Verbleibende Publishes auf `publish_market_event_core_and_momentum_ex` mit `MarketEventCorePublishTrace` (u.a. Wallet-Bootstrap-Complete mit Cold-Path-Startzeit, Pool-Discovery, PumpFunAmm `create_pool`, First-Trade `DexPoolAccounts` für Nicht-AMM). Entfernung des unbenutzten Wrappers `publish_market_event_core_and_momentum`. Fix fehlende `}` bei `is_first_trade` (PumpFunAmm). `BondingCurvePublishTimes::record_bonding_publish` ohne Borrow-Konflikt (Vacant + `remove`).
- **momentum-bot:** Nach erfolgreichem JetStream-Publish von BUY/SELL: `try_record_momentum_intent_header_to_publish_ms`, optional `try_record_momentum_publish_to_intent_ms` (kausales `last_event_ts_ms`). Kommentar zur Einordnung neben `momentum_event_to_ingest_ms`.
- **execution-engine:** `try_record_execution_intent_header_to_receive_ms` am Anfang von `process_intent`, `record_execution_process_intent_us` per `scopeguard` am Funktionsende, `try_record_execution_intent_to_confirm_ms` bei `ExecutionStatus::Confirmed`, `record_execution_slot_lag_at_send_slots` nach erfolgreichem Bundle- bzw. TxSender-Send.
- **Doku:** `docs/RUNBOOK_PROD.md` (Tabelle A–I, PromQL-Beispiele), `docs/BUGS_FIXES.md` (Eintrag **PIPELINE-LATENCY-METRICS**, MOM-OBS aktualisiert).

## Verifikation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` und `cargo test --features test_helpers`
- Eval-Repo-Sibling nicht im Workspace; **Eval (Level 5)** bitte in CI oder mit Checkout gegen diesen Branch ausführen.

## STOP-CHECK (ironcrab-core)

1. Kein neuer RPC im Hot Path.
2. Kein Abweichen von bestehenden Latenz-/Metrik-Patterns ohne Grund.
3. Scope: Observability + Docs.
4. Keine Änderung am Simulation-Gate.
5. Kein Lesen von `Iron_crab-eval/tests/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcfd91cc-48ef-4bc1-9851-a44f7514e9f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcfd91cc-48ef-4bc1-9851-a44f7514e9f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

