### PR TITLE
Ingest-Lag-Metriken: Broadcast-Channel-Lag und Bonding→Trade Slot-Delta

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -76,6 +76,13 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 **Zweck** (Observability only): Kette A–I in `docs/RUNBOOK_PROD.md` — Geyser→Core-Publish (market-data), Momentum-Ingest und Intent-Publish, execution `process_intent` bis Confirm sowie Slot-Lag am Send. Kein Trading-Verhalten, kein Hot-Path-RPC.  
 **Dateien**: `src/metrics.rs`, `src/bin/market_data.rs`, `src/bin/momentum_bot.rs`, `src/bin/execution_engine.rs`, `docs/RUNBOOK_PROD.md`, `docs/BUGS_FIXES.md`
 
+### INGEST-LAG-METRICS: Geyser-Listener vs. market-data Broadcast (2026-05-20)
+**Datum**: 2026-05-20  
+**Zweck** (Observability only): Trennung von (a) Zeit in `tokio::sync::broadcast` + Event-Loop-Scheduling zwischen Geyser-Listener-`send` und market-data-`recv` und (b) Wall-Zeit `market_data_trade_after_bonding_publish_ms` (B★) sowie (c) reiner Ketten-Abstand `market_data_bonding_to_trade_slot_delta_slots` (Geyser-Slots, I-16). **Kein** `getSlot`/`getBlockTime`/`getTransaction` pro Event; nur `Instant` und bestehende `slot`-Felder.  
+**Metriken**: `market_data_tx_channel_lag_ms`, `market_data_account_channel_lag_ms`, `market_data_tx_broadcast_lagged_total`, `market_data_account_broadcast_lagged_total`, `market_data_bonding_to_trade_slot_delta_slots`.  
+**Dateien**: `src/solana/geyser_listener.rs`, `src/bin/market_data.rs`, `src/metrics.rs`, `docs/RUNBOOK_PROD.md`, `docs/BUGS_FIXES.md`  
+**Follow-up**: Fairness-Fix in market-data (`select!`/Priorität) nur wenn Channel-Lag p99 hoch bei kleinem Slot-Delta (separater Handoff).
+
 ### FIX-MOM-EXIT-QUOTE-GUARDS: Frische Reserve-Quotes + getrennte Ingest-Latenzen
 **Datum**: 2026-05-15  
 **Problem**: `momentum_event_to_ingest_ms` wirkte extrem hoch, ohne klare Trennung von JetStream-`PoolCacheUpdate`-Timestamps vs. Core-NATS; price-based Exits konnten theoretisch auf sehr alten Cache-Zeilen oder nicht verifizierten SOL-Paaren basieren.  

--- a/docs/RUNBOOK_PROD.md
+++ b/docs/RUNBOOK_PROD.md
@@ -151,6 +151,21 @@ journalctl -u execution-engine -n 100 --no-pager
 Segmentierte End-to-End-Latenzen über die drei Prozesse **market-data → momentum-bot → execution-engine**.
 Alle Werte nutzen konsistent `RecordHeader.ts_unix_ms` bzw. Geyser-`Instant::now()`-Startpunkte am Publish-Pfad; Details in `docs/BUGS_FIXES.md` (Eintrag **PIPELINE-LATENCY-METRICS**).
 
+**Ingest-Lag (Geyser vs. market-data Broadcast)** — siehe `docs/BUGS_FIXES.md` (**INGEST-LAG-METRICS**):
+
+| Signal | Metrik | Kurzinterpretation |
+|--------|--------|-------------------|
+| Channel-Queue | `market_data_tx_channel_lag_ms`, `market_data_account_channel_lag_ms` | Zeit zwischen Listener-`send` und market-data-`recv` (Broadcast + Tokio-Scheduling), **kein** Netzwerk danach |
+| Drops | `market_data_tx_broadcast_lagged_total`, `market_data_account_broadcast_lagged_total` | Summe der übersprungenen Nachrichten bei `RecvError::Lagged` |
+| Ketten vs. Wall | `market_data_bonding_to_trade_slot_delta_slots` | Slot-Delta letztes `BondingCurveProgress` → nächstes Pump.fun-`Trade` (I-16: Geyser-Slots) |
+
+**Entscheidungsbaum (nach Metrik-Deploy):**
+
+- `market_data_tx_channel_lag_ms` / `market_data_account_channel_lag_ms` **p99 hoch** → Backlog/Fairness eher in market-data (Broadcast/Loop), nicht „langsamer Publish“ allein.
+- Channel-Lag **niedrig**, aber `market_data_trade_after_bonding_publish_ms` (**B★**) weiter hoch → eher Geyser/Subscription/Vor market-data.
+- `market_data_bonding_to_trade_slot_delta_slots` **hoch** → kettenbedingte Lücke zwischen Bonding- und Trade-Sicht.
+- Slot-Delta **klein**, B★ **groß** → Wall-Lag ohne Slot-Erklärung (MATRIX-Muster: Scheduling/Stream).
+
 | Segment | Metrik (Präfix je nach Export) | Kurzinterpretation |
 |--------|--------------------------------|---------------------|
 | A | `market_data_geyser_to_publish_ms_*` (Suffix `_trade`, `_bonding_curve`, …) | Geyser-Eingang bis erfolgreicher Core-NATS-Publish |

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -45,14 +45,18 @@ use ironcrab::ipc::{
     POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use ironcrab::metrics::{
-    market_data_bump_geyser_head_slot, record_market_data_geyser_to_publish_on_success,
-    record_market_data_trade_after_bonding_publish_ms, serve_metrics,
-    set_readiness_control_sub_active, set_readiness_mode, set_readiness_nats_connected,
-    update_readiness_market_data_current, wall_clock_unix_ms_now, MarketDataLatencySegment,
-    MetricsComponent, MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS,
-    MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS, MARKET_EVENTS_MOMENTUM_FANOUT_PUBLISHED_TOTAL,
-    MARKET_EVENTS_PUBLISHED_TOTAL, MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL,
-    NATS_MESSAGES_PUBLISHED_TOTAL, POOLS_TRACKED_GAUGE,
+    market_data_bump_geyser_head_slot, record_market_data_account_broadcast_lagged,
+    record_market_data_account_channel_lag_ms,
+    record_market_data_bonding_to_trade_slot_delta_slots,
+    record_market_data_geyser_to_publish_on_success,
+    record_market_data_trade_after_bonding_publish_ms, record_market_data_tx_broadcast_lagged,
+    record_market_data_tx_channel_lag_ms, serve_metrics, set_readiness_control_sub_active,
+    set_readiness_mode, set_readiness_nats_connected, update_readiness_market_data_current,
+    wall_clock_unix_ms_now, MarketDataLatencySegment, MetricsComponent,
+    MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS, MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS,
+    MARKET_EVENTS_MOMENTUM_FANOUT_PUBLISHED_TOTAL, MARKET_EVENTS_PUBLISHED_TOTAL,
+    MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
+    POOLS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
@@ -208,16 +212,20 @@ pub(crate) async fn publish_market_event_core_and_momentum_ex(
                     } if dex == "pumpfun" => {
                         MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS.store(now_ms, Ordering::Relaxed);
                         if let Ok(pk) = Pubkey::from_str(pool_address) {
-                            if let Some(last) = ctx
-                                .bonding_curve_publish_times
-                                .lock()
-                                .last_bonding_wall_ms(&pk)
-                            {
+                            let bonding_times = ctx.bonding_curve_publish_times.lock();
+                            if let Some(last) = bonding_times.last_bonding_wall_ms(&pk) {
                                 if now_ms >= last {
                                     record_market_data_trade_after_bonding_publish_ms(
                                         now_ms.saturating_sub(last),
                                     );
                                 }
+                            }
+                            if let (Some(bond_slot), Some(trade_slot)) = (
+                                bonding_times.last_bonding_slot(&pk),
+                                event.slot.filter(|&s| s > 0),
+                            ) {
+                                let delta = trade_slot.saturating_sub(bond_slot);
+                                record_market_data_bonding_to_trade_slot_delta_slots(delta);
                             }
                         }
                     }
@@ -227,7 +235,7 @@ pub(crate) async fn publish_market_event_core_and_momentum_ex(
                         if let Ok(pk) = Pubkey::from_str(bonding_curve) {
                             ctx.bonding_curve_publish_times
                                 .lock()
-                                .record_bonding_publish(pk, now_ms);
+                                .record_bonding_publish(pk, now_ms, event.slot);
                         }
                     }
                     _ => {}
@@ -608,6 +616,8 @@ const BONDING_CURVE_PUBLISH_MAP_CAP: usize = 10_000;
 struct BondingCurvePublishTimes {
     insert_order: VecDeque<Pubkey>,
     last_wall_ms: HashMap<Pubkey, u64>,
+    /// Geyser slot from the last successfully published `BondingCurveProgress` for this curve (I-16).
+    last_bonding_slot: HashMap<Pubkey, u64>,
 }
 
 impl BondingCurvePublishTimes {
@@ -615,14 +625,18 @@ impl BondingCurvePublishTimes {
         Self {
             insert_order: VecDeque::new(),
             last_wall_ms: HashMap::new(),
+            last_bonding_slot: HashMap::new(),
         }
     }
 
-    fn record_bonding_publish(&mut self, curve: Pubkey, wall_ms: u64) {
+    fn record_bonding_publish(&mut self, curve: Pubkey, wall_ms: u64, bonding_slot: Option<u64>) {
         use std::collections::hash_map::Entry;
         match self.last_wall_ms.entry(curve) {
             Entry::Occupied(mut e) => {
                 e.insert(wall_ms);
+                if let Some(s) = bonding_slot.filter(|&s| s > 0) {
+                    self.last_bonding_slot.insert(curve, s);
+                }
                 // Refresh eviction order: otherwise a still-active curve stays at an old deque
                 // position and can be popped while newer keys retain slots.
                 self.insert_order.retain(|k| *k != curve);
@@ -632,16 +646,24 @@ impl BondingCurvePublishTimes {
                 while self.insert_order.len() >= BONDING_CURVE_PUBLISH_MAP_CAP {
                     if let Some(evicted) = self.insert_order.pop_front() {
                         self.last_wall_ms.remove(&evicted);
+                        self.last_bonding_slot.remove(&evicted);
                     }
                 }
                 self.insert_order.push_back(curve);
                 self.last_wall_ms.insert(curve, wall_ms);
+                if let Some(s) = bonding_slot.filter(|&s| s > 0) {
+                    self.last_bonding_slot.insert(curve, s);
+                }
             }
         }
     }
 
     fn last_bonding_wall_ms(&self, curve: &Pubkey) -> Option<u64> {
         self.last_wall_ms.get(curve).copied()
+    }
+
+    fn last_bonding_slot(&self, curve: &Pubkey) -> Option<u64> {
+        self.last_bonding_slot.get(curve).copied()
     }
 }
 
@@ -6933,8 +6955,15 @@ async fn run_geyser_loop(
             } => {}
 
             // Account updates (pool state changes)
-            Ok(account_update) = account_rx.recv() => {
-                let account_geyser_recv_at = Instant::now();
+            account_rx_res = account_rx.recv() => {
+                match account_rx_res {
+                    Ok(account_update) => {
+                let recv_at = Instant::now();
+                record_market_data_account_channel_lag_ms(
+                    account_update.grpc_recv_at,
+                    recv_at,
+                );
+                let account_geyser_recv_at = recv_at;
                 market_data_bump_geyser_head_slot(account_update.slot);
                 account_count += 1;
                 ironcrab::metrics::record_activity();
@@ -8431,6 +8460,15 @@ async fn run_geyser_loop(
                     )
                     .await;
                 }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        record_market_data_account_broadcast_lagged(n);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        warn!("Geyser account broadcast channel closed");
+                        break;
+                    }
+                }
             }
 
             // Blockhash updates from Geyser blocks_meta
@@ -8457,8 +8495,12 @@ async fn run_geyser_loop(
             }
 
             // Transaction updates (pool creations, swaps)
-            Ok(tx_update) = transaction_rx.recv() => {
-                let tx_geyser_recv_at = Instant::now();
+            transaction_rx_res = transaction_rx.recv() => {
+                match transaction_rx_res {
+                    Ok(tx_update) => {
+                let recv_at = Instant::now();
+                record_market_data_tx_channel_lag_ms(tx_update.grpc_recv_at, recv_at);
+                let tx_geyser_recv_at = recv_at;
                 market_data_bump_geyser_head_slot(tx_update.slot);
                 tx_count += 1;
                 ironcrab::metrics::record_activity();
@@ -9097,6 +9139,15 @@ async fn run_geyser_loop(
                         Some(ctx.as_ref()),
                     )
                     .await;
+                }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        record_market_data_tx_broadcast_lagged(n);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        warn!("Geyser transaction broadcast channel closed");
+                        break;
+                    }
                 }
             }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -355,6 +355,43 @@ static MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_SUM: Lazy<AtomicU64> =
 static MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_COUNT: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
+/// Geyser listener `broadcast::send` → market-data `recv()` (queue + scheduling), milliseconds.
+static MARKET_DATA_TX_CHANNEL_LAG_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+static MARKET_DATA_TX_CHANNEL_LAG_MS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_TX_CHANNEL_LAG_MS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+static MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+static MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// Pump.fun: slot delta from last published `BondingCurveProgress` (Geyser slot) to successful `Trade` publish (same pool/bonding curve).
+static MARKET_DATA_BONDING_TO_TRADE_SLOT_DELTA_SLOTS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_BONDING_TO_TRADE_SLOT_DELTA_SLOTS_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_BONDING_TO_TRADE_SLOT_DELTA_SLOTS_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// `broadcast::RecvError::Lagged(n)` — skipped messages (cumulative `n` added per occurrence).
+pub static MARKET_DATA_TX_BROADCAST_LAGGED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_ACCOUNT_BROADCAST_LAGGED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 /// Update monotonic Geyser head slot (max). Safe from any market-data ingest arm.
 #[inline]
 pub fn market_data_bump_geyser_head_slot(slot: u64) {
@@ -375,6 +412,67 @@ pub fn record_market_data_trade_after_bonding_publish_ms(delta_ms: u64) {
         delta_ms,
         MARKET_DATA_LATENCY_MS_SUM_CAP,
     );
+}
+
+/// Wall ms from `grpc_recv_at` (set in Geyser listener before `broadcast::send`) to market-data `recv()` return.
+#[inline]
+pub fn record_market_data_tx_channel_lag_ms(grpc_recv_at: Instant, recv_at: Instant) {
+    let ms = recv_at
+        .saturating_duration_since(grpc_recv_at)
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64;
+    record_histogram_u64_into(
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+        &MARKET_DATA_TX_CHANNEL_LAG_MS_BUCKET_COUNTS,
+        &MARKET_DATA_TX_CHANNEL_LAG_MS_SUM,
+        &MARKET_DATA_TX_CHANNEL_LAG_MS_COUNT,
+        ms,
+        MARKET_DATA_LATENCY_MS_SUM_CAP,
+    );
+}
+
+/// Same as [`record_market_data_tx_channel_lag_ms`] for account updates.
+#[inline]
+pub fn record_market_data_account_channel_lag_ms(grpc_recv_at: Instant, recv_at: Instant) {
+    let ms = recv_at
+        .saturating_duration_since(grpc_recv_at)
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64;
+    record_histogram_u64_into(
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+        &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_BUCKET_COUNTS,
+        &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_SUM,
+        &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_COUNT,
+        ms,
+        MARKET_DATA_LATENCY_MS_SUM_CAP,
+    );
+}
+
+/// Pump.fun trade publish: chain slots since last bonding-curve progress publish for the same pool key.
+#[inline]
+pub fn record_market_data_bonding_to_trade_slot_delta_slots(delta_slots: u64) {
+    record_histogram_u64_into(
+        MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS,
+        &MARKET_DATA_BONDING_TO_TRADE_SLOT_DELTA_SLOTS_BUCKET_COUNTS,
+        &MARKET_DATA_BONDING_TO_TRADE_SLOT_DELTA_SLOTS_SUM,
+        &MARKET_DATA_BONDING_TO_TRADE_SLOT_DELTA_SLOTS_COUNT,
+        delta_slots,
+        u64::MAX,
+    );
+}
+
+#[inline]
+pub fn record_market_data_tx_broadcast_lagged(skipped_messages: u64) {
+    if skipped_messages > 0 {
+        MARKET_DATA_TX_BROADCAST_LAGGED_TOTAL.fetch_add(skipped_messages, Ordering::Relaxed);
+    }
+}
+
+#[inline]
+pub fn record_market_data_account_broadcast_lagged(skipped_messages: u64) {
+    if skipped_messages > 0 {
+        MARKET_DATA_ACCOUNT_BROADCAST_LAGGED_TOTAL.fetch_add(skipped_messages, Ordering::Relaxed);
+    }
 }
 
 /// After successful core `TOPIC_MARKET_EVENTS` publish (`publish_market_event_core_and_momentum_ex` path).
@@ -1985,6 +2083,38 @@ async fn metrics_response() -> Response<Body> {
         &MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_BUCKET_COUNTS,
         &MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_SUM,
         &MARKET_DATA_TRADE_AFTER_BONDING_PUBLISH_MS_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_tx_channel_lag_ms",
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+        &MARKET_DATA_TX_CHANNEL_LAG_MS_BUCKET_COUNTS,
+        &MARKET_DATA_TX_CHANNEL_LAG_MS_SUM,
+        &MARKET_DATA_TX_CHANNEL_LAG_MS_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_account_channel_lag_ms",
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+        &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_BUCKET_COUNTS,
+        &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_SUM,
+        &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_bonding_to_trade_slot_delta_slots",
+        MARKET_DATA_SLOT_LAG_AT_PUBLISH_BUCKETS,
+        &MARKET_DATA_BONDING_TO_TRADE_SLOT_DELTA_SLOTS_BUCKET_COUNTS,
+        &MARKET_DATA_BONDING_TO_TRADE_SLOT_DELTA_SLOTS_SUM,
+        &MARKET_DATA_BONDING_TO_TRADE_SLOT_DELTA_SLOTS_COUNT,
+    );
+    line!(
+        "market_data_tx_broadcast_lagged_total",
+        MARKET_DATA_TX_BROADCAST_LAGGED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_account_broadcast_lagged_total",
+        MARKET_DATA_ACCOUNT_BROADCAST_LAGGED_TOTAL.load(Ordering::Relaxed)
     );
 
     // --- momentum-bot service ---

--- a/src/solana/dex_parser.rs
+++ b/src/solana/dex_parser.rs
@@ -1766,6 +1766,7 @@ fn parse_raydium_cpmm_transaction(update: &GeyserTransactionUpdate) -> Option<Pa
 mod tests {
     use super::*;
     use crate::solana::geyser_listener::{GeyserTransactionUpdate, TokenAmount, TokenBalance};
+    use std::time::Instant;
 
     #[test]
     fn test_dex_type_display() {
@@ -1807,6 +1808,7 @@ mod tests {
             post_balances: vec![],
             fee_lamports: 5000,
             compute_units_consumed: None,
+            grpc_recv_at: Instant::now(),
         };
 
         let parsed = parse_transaction_update(&update);
@@ -1932,6 +1934,7 @@ mod tests {
             post_balances,
             fee_lamports: 5000,
             compute_units_consumed: None,
+            grpc_recv_at: Instant::now(),
         };
 
         let parsed = parse_transaction_update(&update);
@@ -2057,6 +2060,7 @@ mod tests {
             post_balances,
             fee_lamports: 5000,
             compute_units_consumed: None,
+            grpc_recv_at: Instant::now(),
         };
 
         let event = parse_transaction_update(&update).expect("extended sell parse");

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{anyhow, Result};
 use solana_sdk::pubkey::Pubkey;
+use std::time::Instant;
 use tokio::sync::broadcast;
 use tokio::sync::watch;
 
@@ -33,6 +34,8 @@ pub struct GeyserAccountUpdate {
     pub owner: Pubkey,
     pub data: Vec<u8>,
     pub lamports: u64,
+    /// Wall-clock instant when the gRPC stream delivered this update into the listener (immediately before broadcast send).
+    pub grpc_recv_at: Instant,
 }
 
 /// Inner instruction from transaction meta (for parsing token transfers)
@@ -82,6 +85,8 @@ pub struct GeyserTransactionUpdate {
     pub fee_lamports: u64,
     /// Compute units consumed (for priority fee calculation)
     pub compute_units_consumed: Option<u64>,
+    /// Wall-clock instant when the gRPC stream delivered this update into the listener (immediately before broadcast send).
+    pub grpc_recv_at: Instant,
 }
 
 /// Event emitted when a new confirmed block is produced (from blocks_meta)
@@ -347,12 +352,14 @@ impl GeyserListener {
                                         }
                                     };
 
+                                    let grpc_recv_at = Instant::now();
                                     let event = GeyserAccountUpdate {
                                         pubkey,
                                         slot: account_update.slot,
                                         owner,
                                         data: account_info.data,
                                         lamports: account_info.lamports,
+                                        grpc_recv_at,
                                     };
 
                                     // Broadcast to subscribers
@@ -588,6 +595,7 @@ impl GeyserListener {
                                         }
                                     }
 
+                                    let grpc_recv_at = Instant::now();
                                     let event = GeyserTransactionUpdate {
                                         signature,
                                         slot: tx_update.slot,
@@ -601,6 +609,7 @@ impl GeyserListener {
                                         post_balances,
                                         fee_lamports,
                                         compute_units_consumed,
+                                        grpc_recv_at,
                                     };
 
                                     // Broadcast to subscribers

--- a/tests/dex_parser_orca.rs
+++ b/tests/dex_parser_orca.rs
@@ -4,6 +4,7 @@ use ironcrab::solana::dex_parser::{
 use ironcrab::solana::geyser_listener::{GeyserTransactionUpdate, TokenAmount, TokenBalance};
 use solana_sdk::pubkey::Pubkey;
 use std::str::FromStr;
+use std::time::Instant;
 
 const ORCA_WHIRLPOOL: &str = "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc";
 const ORCA_SWAP: [u8; 8] = [0xf8, 0xc6, 0x9e, 0x91, 0xe1, 0x75, 0x87, 0xc8];
@@ -55,6 +56,7 @@ fn parse_orca_buy_from_sol_uses_pool_mints_and_offsets() {
         post_balances: vec![5_000],
         fee_lamports: 0,
         compute_units_consumed: None,
+        grpc_recv_at: Instant::now(),
     };
 
     let lookup = |pool_key: &Pubkey| {
@@ -119,6 +121,7 @@ fn parse_orca_sell_to_sol_uses_pool_mints_and_offsets() {
         post_balances: vec![12_000],
         fee_lamports: 0,
         compute_units_consumed: None,
+        grpc_recv_at: Instant::now(),
     };
 
     let lookup = |pool_key: &Pubkey| {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Kurzbeschreibung
Ergänzt die in PR #136 begonnene Observability um zwei Messstufen: (1) **Wall-Zeit im `tokio::sync::broadcast`** zwischen Geyser-Listener-`send` und market-data-`recv`, (2) **Slot-Delta** vom letzten erfolgreichen `BondingCurveProgress`-Publish zum nächsten Pump.fun-`Trade` (Geyser-Slots, I-16). Optional **Lagged-Counter** für gedroppte Broadcast-Nachrichten.

## Änderungen
- `GeyserAccountUpdate` / `GeyserTransactionUpdate`: neues Feld `grpc_recv_at: Instant`, gesetzt unmittelbar vor `account_tx` / `transaction_tx.send` in `geyser_listener.rs`.
- `market_data.rs`: nach erfolgreichem `recv` Histogramme `market_data_tx_channel_lag_ms` / `market_data_account_channel_lag_ms`; `RecvError::Lagged(n)` → `market_data_*_broadcast_lagged_total` (+`n`); `BondingCurvePublishTimes` um `last_bonding_slot` erweitert; bei Pump.fun-`Trade`-Publish `market_data_bonding_to_trade_slot_delta_slots`.
- `metrics.rs`: Histogramm-/Counter-Implementierung und Prometheus-Export.
- Doku: `RUNBOOK_PROD.md` (Tabelle + Entscheidungsbaum), `BUGS_FIXES.md` (**INGEST-LAG-METRICS**).
- Tests/Mocks: `grpc_recv_at: Instant::now()` an allen Konstruktoren.

## Verifikation
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` und `cargo test --features test_helpers`

## Smoke nach Deploy
`curl -s localhost:9801/metrics | grep -E 'channel_lag|bonding_to_trade_slot|broadcast_lagged'`

## Nicht im Scope
Kein `select!`/Fairness-Tuning, kein RPC für Metriken, keine Eval-Repo-Änderungen.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb980803-63aa-424b-af5c-4e3b0f995172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb980803-63aa-424b-af5c-4e3b0f995172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

