### PR TITLE
ui: min_trades_per_min (trades/min) statt min_trades_per_sec

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -10,7 +10,8 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 **Datum**: 2026-05-20  
 **Problem**: Schwelle als **Trades pro Sekunde** war in Prod (z. B. JetStream `min_trades_per_sec` ≈ 5) extrem streng; viele Pools mit 3–4 Trades/s fielen dauerhaft durch (`filter_passed_total` blieb 0).  
 **Fix**: Kanonische Einheit **`min_trades_per_min`** / Metrik **`trades_per_min`** (gleiche Ketten-Slot-Zeitbasis wie zuvor, nur ×60 für Anzeige/Schwelle). TOML/JetStream-Key **`min_trades_per_sec`** wird weiterhin akzeptiert: Wert ×60 + **warn** (kein stilles 1:1 als „pro Minute“). Default im Code: **30/min** (≈0.5/s).  
-**Dateien**: `src/config.rs`, `src/bin/momentum_bot.rs`, `my_config.server.toml`, `docs/CONFIG_SCHEMA.md`, `docs/BUGS_FIXES.md`, `docs/RUNBOOK_PROD.md`
+**UI-Follow-up** (Control-Plane): `ui/src/pages/ComponentDetail.tsx` zeigt und speichert **`min_trades_per_min`** (Default UI **1.2** wie `my_config.server.toml`); beim Laden wird **`min_trades_per_sec`** aus dem Draft entfernt bzw. einmalig ×60 migriert; Speichern strippt den deprecated Key.  
+**Dateien**: `src/config.rs`, `src/bin/momentum_bot.rs`, `my_config.server.toml`, `docs/CONFIG_SCHEMA.md`, `docs/BUGS_FIXES.md`, `docs/RUNBOOK_PROD.md`, `ui/src/pages/ComponentDetail.tsx`
 
 ### FIX-MOM-LP-OBSERVED-AT-MINT-MERGE-MAX-2026-05-18: LP-Removal Wallclock — Mint-Aggregat `max` statt `min` (PR #134 Follow-up)
 **Datum**: 2026-05-18  

--- a/ui/src/pages/ComponentDetail.tsx
+++ b/ui/src/pages/ComponentDetail.tsx
@@ -41,6 +41,29 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
   return (await response.json()) as T
 }
 
+function isFiniteConfigNumber(v: ConfigValue): v is number {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+/** Merge-Ergebnis: kein deprecated `min_trades_per_sec` im Draft; Legacy vom Server → ×60. */
+function applyMomentumVelocityUiMigration(
+  merged: ComponentConfig,
+  serverConfig: ComponentConfig,
+): ComponentConfig {
+  const out = { ...merged }
+  delete out['min_trades_per_sec']
+  const serverHasPerMin =
+    'min_trades_per_min' in serverConfig &&
+    isFiniteConfigNumber(serverConfig['min_trades_per_min'])
+  const serverHasPerSec =
+    'min_trades_per_sec' in serverConfig &&
+    isFiniteConfigNumber(serverConfig['min_trades_per_sec'])
+  if (!serverHasPerMin && serverHasPerSec) {
+    out['min_trades_per_min'] = serverConfig['min_trades_per_sec'] as number * 60
+  }
+  return out
+}
+
 function parsePrometheusMetrics(text: string): MetricsData {
   const lines = text.split('\n')
   const result: MetricsData = {}
@@ -139,7 +162,8 @@ const CONFIG_DESCRIPTIONS: Record<string, Record<string, string>> = {
     // Filter 2: Buyer Velocity
     min_unique_buyers: 'FILTER 2: Min unique buyers in window',
     buyer_window_secs: 'FILTER 2: Time window for buyer tracking (seconds)',
-    min_trades_per_sec: 'FILTER 2: Min trades per second for momentum',
+    min_trades_per_min:
+      'FILTER 2: Min trades per minute for momentum (chain-slot window)',
     min_buy_dominance: 'FILTER 2: Min buy ratio (0.0-1.0, 0.45=45%)',
     
     // Filter 3: SOL Inflow
@@ -284,7 +308,7 @@ const CONFIG_GROUPS: Record<string, Record<string, string[]>> = {
     'Filter 2: Buyer Velocity': [
       'min_unique_buyers',
       'buyer_window_secs',
-      'min_trades_per_sec',
+      'min_trades_per_min',
       'min_buy_dominance',
     ],
     'Filter 3: SOL Inflow': [
@@ -425,7 +449,7 @@ const DEFAULT_CONFIGS: Record<string, ComponentConfig> = {
     // Filter 2: Buyer Velocity
     min_unique_buyers: 3,
     buyer_window_secs: 120,
-    min_trades_per_sec: 0.02,
+    min_trades_per_min: 1.2,
     min_buy_dominance: 0.45,
     
     // Filter 3: SOL Inflow
@@ -602,8 +626,11 @@ export function ComponentDetail() {
       // Server values take precedence, defaults fill in missing fields
       const defaults = DEFAULT_CONFIGS[component] || {}
       const serverConfig = data.config || {}
-      const mergedConfig = { ...defaults, ...serverConfig }
-      
+      let mergedConfig: ComponentConfig = { ...defaults, ...serverConfig }
+      if (component === 'momentum-bot') {
+        mergedConfig = applyMomentumVelocityUiMigration(mergedConfig, serverConfig)
+      }
+
       setConfig(mergedConfig)
       setConfigDraft(mergedConfig)
       setLamportsDisplayDraft({})
@@ -632,6 +659,10 @@ export function ComponentDetail() {
       for (const [key, raw] of Object.entries(lamportsDisplayDraft)) {
         if (!isLamportsField(key)) continue
         resolved[key] = solToLamports(raw)
+      }
+
+      if (component === 'momentum-bot') {
+        delete resolved['min_trades_per_sec']
       }
 
       await postJson(`${CONTROL_PLANE}/config`, {
@@ -707,6 +738,12 @@ export function ComponentDetail() {
   // Check if a key represents lamports (for automatic conversion)
   function isLamportsField(key: string): boolean {
     return key.endsWith('_lamports')
+  }
+
+  function getConfigFieldUnit(key: string): string {
+    if (isLamportsField(key)) return ' SOL'
+    if (key === 'min_trades_per_min') return ' trades/min'
+    return ''
   }
 
   // Get display value (converts lamports to SOL if applicable)
@@ -807,7 +844,7 @@ export function ComponentDetail() {
                   if (val === undefined) return null
                   const description = CONFIG_DESCRIPTIONS[component || '']?.[key]
                   const displayValue = getDisplayValue(key, val)
-                  const unit = isLamportsField(key) ? ' SOL' : ''
+                  const unit = getConfigFieldUnit(key)
                   
                   return (
                     <div key={key} className="kvRow" style={{ alignItems: 'center' }}>


### PR DESCRIPTION
## Summary
- Control-Plane UI (`ComponentDetail.tsx`): kanonischer Key **`min_trades_per_min`**, Label **trades/min**, Default **1.2**.
- Beim Laden: Legacy `min_trades_per_sec` vom Server → ×60 nach `min_trades_per_min`, deprecated Key aus Draft entfernt.
- Beim Speichern (`momentum-bot`): `min_trades_per_sec` aus Payload strippen.
- Kurzer Eintrag in `docs/BUGS_FIXES.md` (UI-Follow-up zu #139).

## Test plan
- [x] `cd ui && npm ci && npm run build` (Agent)
- [ ] CI build-test / clippy
- [ ] Manuell: Feld zeigt trades/min, Save sendet `min_trades_per_min`

## Hinweis
Cloud Agent `bc-7ed82b65` — `autoCreatePR` hat keinen PR erstellt; Branch `cursor/ui-min-trades-per-min-ce8e` war gepusht.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that renames a single config field with a small migration/compat layer; main risk is mis-migrating the value (×60) or accidentally dropping the legacy key when it is still needed.
> 
> **Overview**
> Updates the Control-Plane config editor to use **`min_trades_per_min` (trades/min)** instead of the deprecated **`min_trades_per_sec`** for `momentum-bot`, including a load-time one-way migration (server `*_per_sec` → ×60) and stripping the legacy key from drafts and save payloads.
> 
> Also updates UI defaults/labels/grouping and adds a unit suffix (`trades/min`) for the new field, plus a brief docs note in `docs/BUGS_FIXES.md` describing the UI follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4976e35fffa9083ae511ee21e7b38b2f050ee921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->