### PR TITLE
feat(market-data): Geyser stream resilience (PR-A)

### DIFF
--- a/docs/systemd/market-data.service
+++ b/docs/systemd/market-data.service
@@ -27,8 +27,8 @@ Environment=RUST_LOG=info,market_data=info,ironcrab::solana::geyser_listener=war
 
 # P1 Crash Isolation: Watchdog for liveness detection
 WatchdogSec=30
-# Restart on failure
-Restart=on-failure
+# Restart always: transient Geyser stream drops must not leave the unit inactive (exit 0).
+Restart=always
 RestartSec=3
 
 # Resource controls: lower priority than validator

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -219,8 +219,46 @@ pub static MARKET_EVENTS_MOMENTUM_FANOUT_PUBLISHED_TOTAL: Lazy<AtomicU64> =
 pub static POOLS_DISCOVERED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static POOLS_TRACKED_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static TOKENS_TRACKED_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
-pub static GEYSER_RECONNECTS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
-pub static GEYSER_ERRORS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// Reconnect attempts after `stream ended` (same gRPC client, resubscribe).
+pub static GEYSER_RECONNECT_TOTAL_STREAM_ENDED: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// Reconnect after transport/stream error (new `connect()`).
+pub static GEYSER_RECONNECT_TOTAL_STREAM_ERROR: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// Reconnect after subscription sink closed / send failure (new `connect()`).
+pub static GEYSER_RECONNECT_TOTAL_SINK_GONE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// gRPC stream `Err` deliveries (excludes graceful `None` / stream ended).
+pub static GEYSER_STREAM_ERRORS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// 1 while a Geyser gRPC connection is established; 0 while reconnecting.
+pub static GEYSER_CONNECTED: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// Geyser listener reconnect reason (PR-A stream resiliency).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GeyserReconnectReason {
+    StreamEnded,
+    StreamError,
+    SinkGone,
+}
+
+pub fn geyser_metrics_inc_reconnect(reason: GeyserReconnectReason) {
+    match reason {
+        GeyserReconnectReason::StreamEnded => {
+            GEYSER_RECONNECT_TOTAL_STREAM_ENDED.fetch_add(1, Ordering::Relaxed);
+        }
+        GeyserReconnectReason::StreamError => {
+            GEYSER_RECONNECT_TOTAL_STREAM_ERROR.fetch_add(1, Ordering::Relaxed);
+        }
+        GeyserReconnectReason::SinkGone => {
+            GEYSER_RECONNECT_TOTAL_SINK_GONE.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+pub fn geyser_metrics_inc_stream_error() {
+    GEYSER_STREAM_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn geyser_metrics_set_connected(connected: bool) {
+    GEYSER_CONNECTED.store(if connected { 1 } else { 0 }, Ordering::Relaxed);
+}
 
 // --- market-data: Geyser recv → Core NATS publish (hot path observability, no RPC) ---
 /// Monotonic Geyser chain head (max slot seen on market-data ingest paths). I-16: not RPC `getSlot`.
@@ -2078,14 +2116,32 @@ async fn metrics_response() -> Response<Body> {
         "tokens_tracked_total",
         TOKENS_TRACKED_GAUGE.load(Ordering::Relaxed)
     );
-    line!(
-        "geyser_reconnects_total",
-        GEYSER_RECONNECTS_TOTAL.load(Ordering::Relaxed)
+    out.push_str("geyser_reconnect_total{reason=\"stream_ended\"} ");
+    out.push_str(
+        &GEYSER_RECONNECT_TOTAL_STREAM_ENDED
+            .load(Ordering::Relaxed)
+            .to_string(),
     );
-    line!(
-        "geyser_errors_total",
-        GEYSER_ERRORS_TOTAL.load(Ordering::Relaxed)
+    out.push('\n');
+    out.push_str("geyser_reconnect_total{reason=\"stream_error\"} ");
+    out.push_str(
+        &GEYSER_RECONNECT_TOTAL_STREAM_ERROR
+            .load(Ordering::Relaxed)
+            .to_string(),
     );
+    out.push('\n');
+    out.push_str("geyser_reconnect_total{reason=\"sink_gone\"} ");
+    out.push_str(
+        &GEYSER_RECONNECT_TOTAL_SINK_GONE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    line!(
+        "geyser_stream_errors_total",
+        GEYSER_STREAM_ERRORS_TOTAL.load(Ordering::Relaxed)
+    );
+    line!("geyser_connected", GEYSER_CONNECTED.load(Ordering::Relaxed));
     line!(
         "market_data_geyser_head_slot",
         MARKET_DATA_GEYSER_HEAD_SLOT.load(Ordering::Relaxed)

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -26,6 +26,18 @@ use yellowstone_grpc_proto::prelude::{
     SubscribeRequestFilterTransactions,
 };
 
+#[cfg(not(windows))]
+use crate::metrics::{
+    geyser_metrics_inc_reconnect, geyser_metrics_inc_stream_error, geyser_metrics_set_connected,
+    GeyserReconnectReason,
+};
+#[cfg(not(windows))]
+use rand::Rng;
+#[cfg(not(windows))]
+use std::time::Duration;
+#[cfg(not(windows))]
+use tokio::time::sleep;
+
 /// Event emitted when an account changes via Geyser
 #[derive(Debug, Clone)]
 pub struct GeyserAccountUpdate {
@@ -256,22 +268,30 @@ impl GeyserListener {
         }
     }
 
+    /// PR-A: exponential reconnect sleep with small jitter (cold path only).
+    #[cfg(not(windows))]
+    fn geyser_reconnect_sleep_ms(backoff_ms: u64) -> u64 {
+        let jitter_cap = backoff_ms.min(150);
+        let jitter = if jitter_cap == 0 {
+            0u64
+        } else {
+            rand::thread_rng().gen_range(0..=jitter_cap)
+        };
+        backoff_ms.saturating_add(jitter)
+    }
+
     #[cfg(not(windows))]
     async fn start_impl(self) -> Result<()> {
+        enum SessionExit {
+            StreamEnded,
+            HardReconnect,
+        }
+
         info!(
             endpoint = %self.endpoint,
             programs = self.program_ids.len(),
-            "geyser_listener: connecting to Geyser gRPC"
+            "geyser_listener: connecting to Geyser gRPC (resilient mode)"
         );
-
-        // Connect to Geyser gRPC
-        let mut client = GeyserGrpcClient::build_from_shared(self.endpoint.clone())
-            .map_err(|e| anyhow!("Failed to build Geyser client: {}", e))?
-            .connect()
-            .await
-            .map_err(|e| anyhow!("Failed to connect to Geyser: {}", e))?;
-
-        info!("geyser_listener: connected successfully");
 
         let mut tracked_accounts_rx = self.tracked_accounts_rx;
         let mut tracked_accounts_current: Vec<Pubkey> = tracked_accounts_rx
@@ -283,394 +303,497 @@ impl GeyserListener {
         let mut transaction_count = 0u64;
         let mut last_log = std::time::Instant::now();
 
-        loop {
-            let request =
-                Self::build_subscribe_request(&self.program_ids, &tracked_accounts_current);
+        let mut reconnect_backoff_ms: u64 = rand::thread_rng().gen_range(100..=250);
+        const RECONNECT_BACKOFF_CAP_MS: u64 = 60_000;
+        let mut last_stream_ended_log =
+            std::time::Instant::now() - std::time::Duration::from_secs(10);
 
-            // Subscribe with bidirectional channel: Sink for updates, Stream for data
-            let (mut subscribe_tx, mut stream) = client
-                .subscribe_with_request(Some(request))
-                .await
-                .map_err(|e| anyhow!("Failed to subscribe: {}", e))?;
+        geyser_metrics_set_connected(false);
 
-            info!(
-                programs = ?self.program_ids,
-                tracked_accounts = tracked_accounts_current.len(),
-                "geyser_listener: subscribed"
-            );
-
-            loop {
-                if last_log.elapsed().as_secs() >= 60 {
-                    info!(
-                        accounts = account_update_count,
-                        transactions = transaction_count,
-                        tracked_accounts = tracked_accounts_current.len(),
-                        "geyser_listener: heartbeat - still receiving updates"
-                    );
-                    last_log = std::time::Instant::now();
-                }
-
-                let tracked_changed_fut = async {
-                    if let Some(rx) = &mut tracked_accounts_rx {
-                        let _ = rx.changed().await;
-                        Some(rx.borrow().clone())
-                    } else {
-                        std::future::pending::<Option<Vec<Pubkey>>>().await
+        'outer: loop {
+            let mut client = loop {
+                match GeyserGrpcClient::build_from_shared(self.endpoint.clone())
+                    .map_err(|e| anyhow!("Failed to build Geyser client: {}", e))?
+                    .connect()
+                    .await
+                {
+                    Ok(c) => {
+                        info!("geyser_listener: connected successfully");
+                        geyser_metrics_set_connected(true);
+                        break c;
                     }
-                };
+                    Err(e) => {
+                        error!(error = %e, "geyser_listener: connect failed, retrying");
+                        geyser_metrics_set_connected(false);
+                        let sleep_ms = Self::geyser_reconnect_sleep_ms(reconnect_backoff_ms);
+                        sleep(Duration::from_millis(sleep_ms)).await;
+                        reconnect_backoff_ms =
+                            (reconnect_backoff_ms.saturating_mul(2)).min(RECONNECT_BACKOFF_CAP_MS);
+                    }
+                }
+            };
 
-                tokio::select! {
-                    maybe_message = stream.next() => {
-                        let Some(message) = maybe_message else {
-                            warn!("geyser_listener: stream ended; resubscribing");
-                            break;
-                        };
+            'same_client: loop {
+                let request =
+                    Self::build_subscribe_request(&self.program_ids, &tracked_accounts_current);
 
-                        match message {
-                            Ok(msg) => {
-                                if let Some(update) = msg.update_oneof {
-                                    match update {
-                            UpdateOneof::Account(account_update) => {
-                                account_update_count += 1;
+                let (mut subscribe_tx, mut stream) =
+                    match client.subscribe_with_request(Some(request)).await {
+                        Ok(pair) => pair,
+                        Err(e) => {
+                            warn!(
+                                error = %e,
+                                "geyser_listener: subscribe failed; reconnecting with new client"
+                            );
+                            geyser_metrics_inc_stream_error();
+                            geyser_metrics_inc_reconnect(GeyserReconnectReason::StreamError);
+                            geyser_metrics_set_connected(false);
+                            let sleep_ms = Self::geyser_reconnect_sleep_ms(reconnect_backoff_ms);
+                            sleep(Duration::from_millis(sleep_ms)).await;
+                            reconnect_backoff_ms = (reconnect_backoff_ms.saturating_mul(2))
+                                .min(RECONNECT_BACKOFF_CAP_MS);
+                            continue 'outer;
+                        }
+                    };
 
-                                if let Some(account_info) = account_update.account {
-                                    // Parse pubkey
-                                    let pubkey = match account_info.pubkey.as_slice().try_into() {
-                                        Ok(bytes) => Pubkey::new_from_array(bytes),
-                                        Err(_) => {
-                                            warn!("geyser: invalid pubkey length");
-                                            continue;
-                                        }
-                                    };
+                info!(
+                    programs = ?self.program_ids,
+                    tracked_accounts = tracked_accounts_current.len(),
+                    "geyser_listener: subscribed"
+                );
 
-                                    // Parse owner
-                                    let owner = match account_info.owner.as_slice().try_into() {
-                                        Ok(bytes) => Pubkey::new_from_array(bytes),
-                                        Err(_) => {
-                                            warn!("geyser: invalid owner length");
-                                            continue;
-                                        }
-                                    };
+                reconnect_backoff_ms = rand::thread_rng().gen_range(100..=250);
+                let mut got_payload_since_subscribe = false;
 
-                                    let grpc_recv_at = Instant::now();
-                                    let event = GeyserAccountUpdate {
-                                        pubkey,
-                                        slot: account_update.slot,
-                                        owner,
-                                        data: account_info.data,
-                                        lamports: account_info.lamports,
-                                        grpc_recv_at,
-                                    };
+                let session_exit = 'read: loop {
+                    if last_log.elapsed().as_secs() >= 60 {
+                        info!(
+                            accounts = account_update_count,
+                            transactions = transaction_count,
+                            tracked_accounts = tracked_accounts_current.len(),
+                            "geyser_listener: heartbeat - still receiving updates"
+                        );
+                        last_log = std::time::Instant::now();
+                    }
 
-                                    // Broadcast to subscribers
-                                    let _ = self.account_tx.send(event);
+                    let tracked_changed_fut = async {
+                        if let Some(rx) = &mut tracked_accounts_rx {
+                            let _ = rx.changed().await;
+                            Some(rx.borrow().clone())
+                        } else {
+                            std::future::pending::<Option<Vec<Pubkey>>>().await
+                        }
+                    };
 
-                                    if account_update_count % 1000 == 0 {
-                                        info!(
-                                            total_updates = account_update_count,
-                                            slot = account_update.slot,
-                                            "geyser_listener: processing account updates"
+                    tokio::select! {
+                        maybe_message = stream.next() => {
+                            match maybe_message {
+                                None => {
+                                    geyser_metrics_inc_reconnect(GeyserReconnectReason::StreamEnded);
+                                    let now = std::time::Instant::now();
+                                    if now.duration_since(last_stream_ended_log)
+                                        >= Duration::from_secs(1)
+                                    {
+                                        warn!(
+                                            "geyser_listener: stream ended; resubscribing after short backoff"
                                         );
+                                        last_stream_ended_log = now;
+                                    }
+                                    let sleep_ms = rand::thread_rng().gen_range(50..=200);
+                                    sleep(Duration::from_millis(sleep_ms)).await;
+                                    break 'read SessionExit::StreamEnded;
+                                }
+                                Some(Err(e)) => {
+                                    error!(error = %e, "geyser_listener: stream error");
+                                    geyser_metrics_inc_stream_error();
+                                    geyser_metrics_inc_reconnect(GeyserReconnectReason::StreamError);
+                                    break 'read SessionExit::HardReconnect;
+                                }
+                                Some(Ok(msg)) => {
+                                    if let Some(update) = msg.update_oneof {
+                                        match update {
+                                UpdateOneof::Account(account_update) => {
+                                    account_update_count += 1;
+
+                                    if let Some(account_info) = account_update.account {
+                                        // Parse pubkey
+                                        let pubkey = match account_info.pubkey.as_slice().try_into() {
+                                            Ok(bytes) => Pubkey::new_from_array(bytes),
+                                            Err(_) => {
+                                                warn!("geyser: invalid pubkey length");
+                                                continue;
+                                            }
+                                        };
+
+                                        // Parse owner
+                                        let owner = match account_info.owner.as_slice().try_into() {
+                                            Ok(bytes) => Pubkey::new_from_array(bytes),
+                                            Err(_) => {
+                                                warn!("geyser: invalid owner length");
+                                                continue;
+                                            }
+                                        };
+
+                                        let grpc_recv_at = Instant::now();
+                                        let event = GeyserAccountUpdate {
+                                            pubkey,
+                                            slot: account_update.slot,
+                                            owner,
+                                            data: account_info.data,
+                                            lamports: account_info.lamports,
+                                            grpc_recv_at,
+                                        };
+
+                                        // Broadcast to subscribers
+                                        let _ = self.account_tx.send(event);
+                                        if !got_payload_since_subscribe {
+                                            got_payload_since_subscribe = true;
+                                            reconnect_backoff_ms =
+                                                rand::thread_rng().gen_range(100..=250);
+                                        }
+
+                                        if account_update_count % 1000 == 0 {
+                                            info!(
+                                                total_updates = account_update_count,
+                                                slot = account_update.slot,
+                                                "geyser_listener: processing account updates"
+                                            );
+                                        }
                                     }
                                 }
-                            }
-                            UpdateOneof::Transaction(tx_update) => {
-                                transaction_count += 1;
+                                UpdateOneof::Transaction(tx_update) => {
+                                    transaction_count += 1;
 
-                                if let Some(tx) = tx_update.transaction {
-                                    // Extract signature from transaction
-                                    let signature = if !tx.signature.is_empty() {
-                                        bs58::encode(&tx.signature).into_string()
-                                    } else {
-                                        "unknown".to_string()
-                                    };
+                                    if let Some(tx) = tx_update.transaction {
+                                        // Extract signature from transaction
+                                        let signature = if !tx.signature.is_empty() {
+                                            bs58::encode(&tx.signature).into_string()
+                                        } else {
+                                            "unknown".to_string()
+                                        };
 
-                                    // Extract account keys from transaction message
-                                    let mut account_keys = Vec::new();
-                                    let mut instruction_accounts = Vec::new();
-                                    let mut instruction_data = Vec::new();
+                                        // Extract account keys from transaction message
+                                        let mut account_keys = Vec::new();
+                                        let mut instruction_accounts = Vec::new();
+                                        let mut instruction_data = Vec::new();
 
-                                    if let Some(transaction) = &tx.transaction {
-                                        if let Some(message) = &transaction.message {
-                                            // Extract all account keys
-                                            for key in &message.account_keys {
-                                                if key.len() == 32 {
-                                                    if let Ok(bytes) = key.as_slice().try_into() {
-                                                        account_keys
-                                                            .push(Pubkey::new_from_array(bytes));
-                                                    }
-                                                }
-                                            }
-
-                                            // Append loaded addresses from meta (for V0 transactions)
-                                            // Order matters: Static -> Loaded Writable -> Loaded Readonly
-                                            if let Some(meta) = &tx.meta {
-                                                for key in &meta.loaded_writable_addresses {
-                                                    if let Ok(bytes) = key.as_slice().try_into() {
-                                                        account_keys
-                                                            .push(Pubkey::new_from_array(bytes));
-                                                    }
-                                                }
-                                                for key in &meta.loaded_readonly_addresses {
-                                                    if let Ok(bytes) = key.as_slice().try_into() {
-                                                        account_keys
-                                                            .push(Pubkey::new_from_array(bytes));
-                                                    }
-                                                }
-                                            }
-
-                                            // DEBUG: Log instruction extraction attempt
-                                            debug!(
-                                                signature = %signature,
-                                                instruction_count = message.instructions.len(),
-                                                account_keys_len = account_keys.len(),
-                                                "geyser_listener: Processing transaction"
-                                            );
-
-                                            // Find the Pump.fun/Raydium/Orca instruction (not first, could be 2nd or 3rd)
-                                            // Look for instruction that uses our monitored program
-                                            // FIRST: Check top-level instructions
-                                            for (idx, ix) in message.instructions.iter().enumerate()
-                                            {
-                                                if let Some(program_pubkey) =
-                                                    account_keys.get(ix.program_id_index as usize)
-                                                {
-                                                    // DEBUG: Log each instruction
-                                                    debug!(
-                                                        signature = %signature,
-                                                        instruction_idx = idx,
-                                                        program_id = %program_pubkey,
-                                                        accounts_len = ix.accounts.len(),
-                                                        data_len = ix.data.len(),
-                                                        "geyser_listener: Found instruction"
-                                                    );
-
-                                                    // Check if this instruction is for one of our monitored programs
-                                                    if self.program_ids.contains(program_pubkey) {
-                                                        // Extract accounts for this instruction
-                                                        for &account_idx in &ix.accounts {
-                                                            if let Some(pubkey) = account_keys
-                                                                .get(account_idx as usize)
-                                                            {
-                                                                instruction_accounts.push(*pubkey);
-                                                            }
+                                        if let Some(transaction) = &tx.transaction {
+                                            if let Some(message) = &transaction.message {
+                                                // Extract all account keys
+                                                for key in &message.account_keys {
+                                                    if key.len() == 32 {
+                                                        if let Ok(bytes) = key.as_slice().try_into() {
+                                                            account_keys
+                                                                .push(Pubkey::new_from_array(bytes));
                                                         }
-                                                        // Extract instruction data
-                                                        instruction_data = ix.data.clone();
+                                                    }
+                                                }
 
+                                                // Append loaded addresses from meta (for V0 transactions)
+                                                // Order matters: Static -> Loaded Writable -> Loaded Readonly
+                                                if let Some(meta) = &tx.meta {
+                                                    for key in &meta.loaded_writable_addresses {
+                                                        if let Ok(bytes) = key.as_slice().try_into() {
+                                                            account_keys
+                                                                .push(Pubkey::new_from_array(bytes));
+                                                        }
+                                                    }
+                                                    for key in &meta.loaded_readonly_addresses {
+                                                        if let Ok(bytes) = key.as_slice().try_into() {
+                                                            account_keys
+                                                                .push(Pubkey::new_from_array(bytes));
+                                                        }
+                                                    }
+                                                }
+
+                                                // DEBUG: Log instruction extraction attempt
+                                                debug!(
+                                                    signature = %signature,
+                                                    instruction_count = message.instructions.len(),
+                                                    account_keys_len = account_keys.len(),
+                                                    "geyser_listener: Processing transaction"
+                                                );
+
+                                                // Find the Pump.fun/Raydium/Orca instruction (not first, could be 2nd or 3rd)
+                                                // Look for instruction that uses our monitored program
+                                                // FIRST: Check top-level instructions
+                                                for (idx, ix) in message.instructions.iter().enumerate()
+                                                {
+                                                    if let Some(program_pubkey) =
+                                                        account_keys.get(ix.program_id_index as usize)
+                                                    {
+                                                        // DEBUG: Log each instruction
                                                         debug!(
                                                             signature = %signature,
                                                             instruction_idx = idx,
-                                                            "geyser: extracted DEX instruction"
+                                                            program_id = %program_pubkey,
+                                                            accounts_len = ix.accounts.len(),
+                                                            data_len = ix.data.len(),
+                                                            "geyser_listener: Found instruction"
                                                         );
 
-                                                        break; // Found our instruction, stop searching
-                                                    }
-                                                }
-                                            }
-
-                                            // SECOND: If not found in top-level, check inner instructions (CPIs)
-                                            // Pump.fun CREATE is often called via CPI from another program
-                                            if instruction_accounts.is_empty() {
-                                                if let Some(meta) = &tx.meta {
-                                                    for inner_ix_group in &meta.inner_instructions {
-                                                        for inner_ix in &inner_ix_group.instructions
-                                                        {
-                                                            if let Some(program_pubkey) =
-                                                                account_keys.get(
-                                                                    inner_ix.program_id_index
-                                                                        as usize,
-                                                                )
-                                                            {
-                                                                if self
-                                                                    .program_ids
-                                                                    .contains(program_pubkey)
+                                                        // Check if this instruction is for one of our monitored programs
+                                                        if self.program_ids.contains(program_pubkey) {
+                                                            // Extract accounts for this instruction
+                                                            for &account_idx in &ix.accounts {
+                                                                if let Some(pubkey) = account_keys
+                                                                    .get(account_idx as usize)
                                                                 {
-                                                                    // Extract accounts for this inner instruction
-                                                                    for &account_idx in
-                                                                        &inner_ix.accounts
-                                                                    {
-                                                                        if let Some(pubkey) =
-                                                                            account_keys.get(
-                                                                                account_idx
-                                                                                    as usize,
-                                                                            )
-                                                                        {
-                                                                            instruction_accounts
-                                                                                .push(*pubkey);
-                                                                        }
-                                                                    }
-                                                                    // Extract instruction data
-                                                                    instruction_data =
-                                                                        inner_ix.data.clone();
-
-                                                                    debug!(
-                                                                        signature = %signature,
-                                                                        inner_ix_index = inner_ix_group.index,
-                                                                        program_id = %program_pubkey,
-                                                                        "geyser: extracted DEX instruction from INNER instruction (CPI)"
-                                                                    );
-
-                                                                    break; // Found our instruction
+                                                                    instruction_accounts.push(*pubkey);
                                                                 }
                                                             }
+                                                            // Extract instruction data
+                                                            instruction_data = ix.data.clone();
+
+                                                            debug!(
+                                                                signature = %signature,
+                                                                instruction_idx = idx,
+                                                                "geyser: extracted DEX instruction"
+                                                            );
+
+                                                            break; // Found our instruction, stop searching
                                                         }
-                                                        if !instruction_accounts.is_empty() {
-                                                            break; // Already found, exit outer loop
+                                                    }
+                                                }
+
+                                                // SECOND: If not found in top-level, check inner instructions (CPIs)
+                                                // Pump.fun CREATE is often called via CPI from another program
+                                                if instruction_accounts.is_empty() {
+                                                    if let Some(meta) = &tx.meta {
+                                                        for inner_ix_group in &meta.inner_instructions {
+                                                            for inner_ix in &inner_ix_group.instructions
+                                                            {
+                                                                if let Some(program_pubkey) =
+                                                                    account_keys.get(
+                                                                        inner_ix.program_id_index
+                                                                            as usize,
+                                                                    )
+                                                                {
+                                                                    if self
+                                                                        .program_ids
+                                                                        .contains(program_pubkey)
+                                                                    {
+                                                                        // Extract accounts for this inner instruction
+                                                                        for &account_idx in
+                                                                            &inner_ix.accounts
+                                                                        {
+                                                                            if let Some(pubkey) =
+                                                                                account_keys.get(
+                                                                                    account_idx
+                                                                                        as usize,
+                                                                                )
+                                                                            {
+                                                                                instruction_accounts
+                                                                                    .push(*pubkey);
+                                                                            }
+                                                                        }
+                                                                        // Extract instruction data
+                                                                        instruction_data =
+                                                                            inner_ix.data.clone();
+
+                                                                        debug!(
+                                                                            signature = %signature,
+                                                                            inner_ix_index = inner_ix_group.index,
+                                                                            program_id = %program_pubkey,
+                                                                            "geyser: extracted DEX instruction from INNER instruction (CPI)"
+                                                                        );
+
+                                                                        break; // Found our instruction
+                                                                    }
+                                                                }
+                                                            }
+                                                            if !instruction_accounts.is_empty() {
+                                                                break; // Already found, exit outer loop
+                                                            }
                                                         }
                                                     }
                                                 }
                                             }
                                         }
-                                    }
 
-                                    // Extract inner instructions for token transfer parsing
-                                    let mut inner_instructions = Vec::new();
-                                    if let Some(meta) = &tx.meta {
-                                        for inner_ix_group in &meta.inner_instructions {
-                                            for inner_ix in &inner_ix_group.instructions {
-                                                inner_instructions.push(InnerInstruction {
-                                                    program_id_index: inner_ix.program_id_index as u8,
-                                                    accounts: inner_ix.accounts.to_vec(),
-                                                    data: inner_ix.data.clone(),
-                                                });
-                                            }
-                                        }
-                                    }
-
-                                    // Extract token balances for amount calculation
-                                    let mut pre_token_balances = Vec::new();
-                                    let mut post_token_balances = Vec::new();
-                                    let mut pre_balances = Vec::new();
-                                    let mut post_balances = Vec::new();
-                                    let mut fee_lamports = 0u64;
-                                    let mut compute_units_consumed = None;
-
-                                    if let Some(meta) = &tx.meta {
-                                        // Extract fee and compute units for priority fee tracking
-                                        fee_lamports = meta.fee;
-                                        compute_units_consumed = meta.compute_units_consumed;
-
-                                        // Extract native SOL balances (lamports)
-                                        pre_balances = meta.pre_balances.clone();
-                                        post_balances = meta.post_balances.clone();
-                                        for balance in &meta.pre_token_balances {
-                                            if let Some(ui_amount) = &balance.ui_token_amount {
-                                                pre_token_balances.push(TokenBalance {
-                                                    account_index: balance.account_index as u8,
-                                                    mint: balance.mint.clone(),
-                                                    ui_token_amount: TokenAmount {
-                                                        ui_amount: Some(ui_amount.ui_amount),
-                                                        decimals: ui_amount.decimals as u8,
-                                                        amount: ui_amount.amount.clone(),
-                                                    },
-                                                    // Extract program_id (SPL Token or Token-2022)
-                                                    program_id: if balance.program_id.is_empty() {
-                                                        None
-                                                    } else {
-                                                        Some(balance.program_id.clone())
-                                                    },
-                                                });
+                                        // Extract inner instructions for token transfer parsing
+                                        let mut inner_instructions = Vec::new();
+                                        if let Some(meta) = &tx.meta {
+                                            for inner_ix_group in &meta.inner_instructions {
+                                                for inner_ix in &inner_ix_group.instructions {
+                                                    inner_instructions.push(InnerInstruction {
+                                                        program_id_index: inner_ix.program_id_index as u8,
+                                                        accounts: inner_ix.accounts.to_vec(),
+                                                        data: inner_ix.data.clone(),
+                                                    });
+                                                }
                                             }
                                         }
 
-                                        for balance in &meta.post_token_balances {
-                                            if let Some(ui_amount) = &balance.ui_token_amount {
-                                                post_token_balances.push(TokenBalance {
-                                                    account_index: balance.account_index as u8,
-                                                    mint: balance.mint.clone(),
-                                                    ui_token_amount: TokenAmount {
-                                                        ui_amount: Some(ui_amount.ui_amount),
-                                                        decimals: ui_amount.decimals as u8,
-                                                        amount: ui_amount.amount.clone(),
-                                                    },
-                                                    // Extract program_id (SPL Token or Token-2022)
-                                                    program_id: if balance.program_id.is_empty() {
-                                                        None
-                                                    } else {
-                                                        Some(balance.program_id.clone())
-                                                    },
-                                                });
+                                        // Extract token balances for amount calculation
+                                        let mut pre_token_balances = Vec::new();
+                                        let mut post_token_balances = Vec::new();
+                                        let mut pre_balances = Vec::new();
+                                        let mut post_balances = Vec::new();
+                                        let mut fee_lamports = 0u64;
+                                        let mut compute_units_consumed = None;
+
+                                        if let Some(meta) = &tx.meta {
+                                            // Extract fee and compute units for priority fee tracking
+                                            fee_lamports = meta.fee;
+                                            compute_units_consumed = meta.compute_units_consumed;
+
+                                            // Extract native SOL balances (lamports)
+                                            pre_balances = meta.pre_balances.clone();
+                                            post_balances = meta.post_balances.clone();
+                                            for balance in &meta.pre_token_balances {
+                                                if let Some(ui_amount) = &balance.ui_token_amount {
+                                                    pre_token_balances.push(TokenBalance {
+                                                        account_index: balance.account_index as u8,
+                                                        mint: balance.mint.clone(),
+                                                        ui_token_amount: TokenAmount {
+                                                            ui_amount: Some(ui_amount.ui_amount),
+                                                            decimals: ui_amount.decimals as u8,
+                                                            amount: ui_amount.amount.clone(),
+                                                        },
+                                                        // Extract program_id (SPL Token or Token-2022)
+                                                        program_id: if balance.program_id.is_empty() {
+                                                            None
+                                                        } else {
+                                                            Some(balance.program_id.clone())
+                                                        },
+                                                    });
+                                                }
+                                            }
+
+                                            for balance in &meta.post_token_balances {
+                                                if let Some(ui_amount) = &balance.ui_token_amount {
+                                                    post_token_balances.push(TokenBalance {
+                                                        account_index: balance.account_index as u8,
+                                                        mint: balance.mint.clone(),
+                                                        ui_token_amount: TokenAmount {
+                                                            ui_amount: Some(ui_amount.ui_amount),
+                                                            decimals: ui_amount.decimals as u8,
+                                                            amount: ui_amount.amount.clone(),
+                                                        },
+                                                        // Extract program_id (SPL Token or Token-2022)
+                                                        program_id: if balance.program_id.is_empty() {
+                                                            None
+                                                        } else {
+                                                            Some(balance.program_id.clone())
+                                                        },
+                                                    });
+                                                }
                                             }
                                         }
-                                    }
 
-                                    let grpc_recv_at = Instant::now();
-                                    let event = GeyserTransactionUpdate {
-                                        signature,
-                                        slot: tx_update.slot,
-                                        account_keys,
-                                        instruction_accounts,
-                                        instruction_data,
-                                        inner_instructions,
-                                        pre_token_balances,
-                                        post_token_balances,
-                                        pre_balances,
-                                        post_balances,
-                                        fee_lamports,
-                                        compute_units_consumed,
-                                        grpc_recv_at,
+                                        let grpc_recv_at = Instant::now();
+                                        let event = GeyserTransactionUpdate {
+                                            signature,
+                                            slot: tx_update.slot,
+                                            account_keys,
+                                            instruction_accounts,
+                                            instruction_data,
+                                            inner_instructions,
+                                            pre_token_balances,
+                                            post_token_balances,
+                                            pre_balances,
+                                            post_balances,
+                                            fee_lamports,
+                                            compute_units_consumed,
+                                            grpc_recv_at,
+                                        };
+
+                                        // Broadcast to subscribers
+                                        let _ = self.transaction_tx.send(event);
+                                        if !got_payload_since_subscribe {
+                                            got_payload_since_subscribe = true;
+                                            reconnect_backoff_ms =
+                                                rand::thread_rng().gen_range(100..=250);
+                                        }
+
+                                        if transaction_count % 100 == 0 {
+                                            info!(
+                                                total_transactions = transaction_count,
+                                                slot = tx_update.slot,
+                                                "geyser_listener: processing transactions"
+                                            );
+                                        }
+                                    }
+                                }
+                                UpdateOneof::BlockMeta(block_meta) => {
+                                    let event = GeyserBlockhashUpdate {
+                                        blockhash: block_meta.blockhash,
+                                        slot: block_meta.slot,
+                                        block_height: block_meta
+                                            .block_height
+                                            .map(|h| h.block_height)
+                                            .unwrap_or(0),
                                     };
-
-                                    // Broadcast to subscribers
-                                    let _ = self.transaction_tx.send(event);
-
-                                    if transaction_count % 100 == 0 {
-                                        info!(
-                                            total_transactions = transaction_count,
-                                            slot = tx_update.slot,
-                                            "geyser_listener: processing transactions"
-                                        );
+                                    let _ = self.blockhash_tx.send(event);
+                                    if !got_payload_since_subscribe {
+                                        got_payload_since_subscribe = true;
+                                        reconnect_backoff_ms = rand::thread_rng().gen_range(100..=250);
                                     }
                                 }
-                            }
-                            UpdateOneof::BlockMeta(block_meta) => {
-                                let event = GeyserBlockhashUpdate {
-                                    blockhash: block_meta.blockhash,
-                                    slot: block_meta.slot,
-                                    block_height: block_meta
-                                        .block_height
-                                        .map(|h| h.block_height)
-                                        .unwrap_or(0),
-                                };
-                                let _ = self.blockhash_tx.send(event);
-                            }
-                            UpdateOneof::Ping(_) => {
-                                // Keep-alive ping, ignore
-                            }
-                            _ => {
-                                // Slots, etc. - ignore
-                            }
-                                    }
+                                UpdateOneof::Ping(_) => {
+                                    // Keep-alive ping, ignore
                                 }
-                            }
-                            Err(e) => {
-                                error!(error = %e, "geyser_listener: stream error");
-                                return Err(anyhow!("Geyser stream error: {}", e));
+                                _ => {
+                                    // Slots, etc. - ignore
+                                }
                             }
                         }
                     }
-                    maybe_new = tracked_changed_fut => {
-                        if let Some(new_list) = maybe_new {
-                            if new_list != tracked_accounts_current {
-                                tracked_accounts_current = new_list;
-                                let updated_request = Self::build_subscribe_request(
-                                    &self.program_ids,
-                                    &tracked_accounts_current,
-                                );
-                                if let Err(e) = subscribe_tx.send(updated_request).await {
-                                    warn!("geyser_listener: failed to send subscription update: {e}, reconnecting");
-                                    break; // Fallback: reconnect on Sink send error
+                            }
+                        },
+                        maybe_new = tracked_changed_fut => {
+                            if let Some(new_list) = maybe_new {
+                                if new_list != tracked_accounts_current {
+                                    tracked_accounts_current = new_list;
+                                    let updated_request = Self::build_subscribe_request(
+                                        &self.program_ids,
+                                        &tracked_accounts_current,
+                                    );
+                                    if let Err(e) = subscribe_tx.send(updated_request).await {
+                                        warn!(
+                                            "geyser_listener: failed to send subscription update: {e}; reconnecting with new client"
+                                        );
+                                        geyser_metrics_inc_reconnect(GeyserReconnectReason::SinkGone);
+                                        break 'read SessionExit::HardReconnect;
+                                    }
+                                    warn!(
+                                        tracked_accounts = tracked_accounts_current.len(),
+                                        "geyser_listener: subscription updated (NO reconnect)"
+                                    );
                                 }
-                                warn!(
-                                    tracked_accounts = tracked_accounts_current.len(),
-                                    "geyser_listener: subscription updated (NO reconnect)"
-                                );
                             }
                         }
+                    }
+                };
+
+                match session_exit {
+                    SessionExit::StreamEnded => {
+                        continue 'same_client;
+                    }
+                    SessionExit::HardReconnect => {
+                        geyser_metrics_set_connected(false);
+                        let sleep_ms = Self::geyser_reconnect_sleep_ms(reconnect_backoff_ms);
+                        sleep(Duration::from_millis(sleep_ms)).await;
+                        reconnect_backoff_ms =
+                            (reconnect_backoff_ms.saturating_mul(2)).min(RECONNECT_BACKOFF_CAP_MS);
+                        continue 'outer;
                     }
                 }
             }
+        }
+    }
+}
+
+#[cfg(all(test, not(windows)))]
+mod geyser_resilience_tests {
+    use super::GeyserListener;
+
+    #[test]
+    fn reconnect_sleep_ms_adds_bounded_jitter() {
+        for _ in 0..20 {
+            let s = GeyserListener::geyser_reconnect_sleep_ms(500);
+            assert!((500..=650).contains(&s), "s={s}");
         }
     }
 }

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -345,7 +345,6 @@ impl GeyserListener {
                                 error = %e,
                                 "geyser_listener: subscribe failed; reconnecting with new client"
                             );
-                            geyser_metrics_inc_stream_error();
                             geyser_metrics_inc_reconnect(GeyserReconnectReason::StreamError);
                             geyser_metrics_set_connected(false);
                             let sleep_ms = Self::geyser_reconnect_sleep_ms(reconnect_backoff_ms);

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -362,7 +362,6 @@ impl GeyserListener {
                     "geyser_listener: subscribed"
                 );
 
-                reconnect_backoff_ms = rand::thread_rng().gen_range(100..=250);
                 let mut got_payload_since_subscribe = false;
 
                 let session_exit = 'read: loop {


### PR DESCRIPTION
## Summary

- `geyser_listener`: outer reconnect loop with new gRPC connect on hard failures; inner resubscribe on `stream ended` with 50–200 ms jitter (no hot-path delay on healthy stream).
- No fatal `return Err` on stream/sink errors — process stays alive; backoff 100–250 ms → 60 s cap, reset after successful subscribe and first payload.
- Metrics: `geyser_reconnect_total{reason}`, `geyser_stream_errors_total`, `geyser_connected` (replaces legacy `geyser_reconnects_total` / `geyser_errors_total`).
- systemd: `market-data.service` uses `Restart=always` as safety net.

## Context

Prod incident 2026-05-22: reconnect storm → `h2` / BrokenPipe → listener `Err` → market-data exit 0 (no restart with `on-failure`). Subscription size fix is PR-B (separate).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (+ `test_helpers` per agent)
- [ ] CI green on PR
- [ ] Bugbot before merge
- [ ] Staging: brief Geyser interrupt → market-data stays up, `geyser_reconnect_total` increments

## Notes

- Update Grafana if dashboards referenced old metric names (`geyser_reconnects_total`, `geyser_errors_total`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the market-data Geyser ingest reconnection behavior and restart policy, which can affect service availability and load during outages. Risk is mitigated by bounded backoff/jitter and added observability but needs validation under real disconnect scenarios.
> 
> **Overview**
> Improves **market-data Geyser stream resilience** by replacing the single-session listener with a two-level reconnect strategy: *resubscribe on graceful `stream ended`* and *recreate the gRPC client on transport/stream errors or subscription sink failures*, using exponential backoff with jitter and resetting backoff after the first payload.
> 
> Updates observability by replacing legacy Geyser counters with labeled Prometheus metrics (`geyser_reconnect_total{reason=...}`, `geyser_stream_errors_total`) plus a `geyser_connected` gauge, and adds a small unit test for jitter bounds. As an additional safety net, the `market-data` systemd unit switches from `Restart=on-failure` to `Restart=always` so clean exits don’t leave the service down.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 335152579fc198de63227ccebd4740106350b3fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->