### PR TITLE
docs(grafana): Geyser-Gesundheit für market-data (PR #143 Metriken)

### DIFF
--- a/docs/RUNBOOK_PROD.md
+++ b/docs/RUNBOOK_PROD.md
@@ -146,6 +146,32 @@ journalctl -u execution-engine -n 100 --no-pager
 | Control Plane API | `http://localhost:8080` | REST API |
 | Trades API | `http://localhost:9899/trades` | Grafana Infinity |
 
+### Geyser / market-data Metriken (PR #143)
+
+Nach dem Geyser-Stream-Resilienz-Deploy ersetzen **neue** Prometheus-Namen die bisherigen Legacy-Zähler. Manuelle Grafana-Panels oder Alerts, die noch die alten Namen nutzen, zeigen dann keine Daten mehr.
+
+| Alt (entfernt) | Neu | Typ | Kurzbedeutung |
+|----------------|-----|-----|----------------|
+| `geyser_reconnects_total` | `geyser_reconnect_total{reason="stream_ended"}` | counter (Text-Export) | Resubscribe nach Stream-Ende |
+| — | `geyser_reconnect_total{reason="stream_error"}` | counter | harter Fehler → neuer Connect |
+| — | `geyser_reconnect_total{reason="sink_gone"}` | counter | Subscription-Sink weg |
+| `geyser_errors_total` | `geyser_stream_errors_total` | counter | gRPC-`Err` auf dem Stream |
+| — | `geyser_connected` | gauge 0/1 | 1 = verbunden |
+
+**Job-Label:** Prometheus scraped `market-data` typischerweise als `job="market-data"` (siehe `prometheus_multiprocess.yml`). In PromQL und Dashboards immer `{job="market-data"}` verwenden.
+
+**Schnellcheck auf dem Server:**
+
+```bash
+curl -s http://localhost:9801/metrics | grep '^geyser_'
+```
+
+**Incident-Debug:** `journalctl -u market-data` (Stream, Reconnects) und im importierten Multi-Process-Dashboard die Zeile **Market Data Service** → Panels **Geyser Connected** / **Geyser Reconnects (5m rate)**.
+
+**Betrieb:** `docs/systemd/market-data.service` setzt `Restart=always` (transiente Stream-Abbrüche sollen die Unit nicht dauerhaft inaktiv lassen). Nach Deploy in Grafana Dashboard JSON neu importieren bzw. Refresh; Explore: `geyser_connected{job="market-data"}`.
+
+**Prometheus / `rate()`:** Der Text-Export der Metriken kann je nach Prometheus-Konfiguration abweichen — nach Deploy in Explore verifizieren, z. B. `rate(geyser_reconnect_total{job="market-data"}[5m])` und `rate(geyser_stream_errors_total{job="market-data"}[5m])` liefern sinnvolle Zeitreihen.
+
 ### Pipeline-Latenz (Prometheus-Histogramme, A–I)
 
 Segmentierte End-to-End-Latenzen über die drei Prozesse **market-data → momentum-bot → execution-engine**.

--- a/docs/grafana_alert_rules.json
+++ b/docs/grafana_alert_rules.json
@@ -1094,6 +1094,118 @@
     },
     {
       "orgId": 1,
+      "name": "IronCrab Market Data",
+      "folder": "IronCrab Alerts",
+      "interval": "30s",
+      "rules": [
+        {
+          "uid": "ironcrab-marketdata-geyser-disconnected",
+          "title": "MarketDataGeyserDisconnected",
+          "condition": "C",
+          "data": [
+            {
+              "refId": "A",
+              "relativeTimeRange": { "from": 300, "to": 0 },
+              "datasourceUid": "bf5zln2g4x5vka",
+              "model": {
+                "expr": "geyser_connected{job=\"market-data\"}",
+                "refId": "A"
+              }
+            },
+            {
+              "refId": "B",
+              "datasourceUid": "__expr__",
+              "model": {
+                "expression": "A",
+                "reducer": "last",
+                "refId": "B",
+                "type": "reduce"
+              }
+            },
+            {
+              "refId": "C",
+              "datasourceUid": "__expr__",
+              "model": {
+                "conditions": [
+                  {
+                    "evaluator": { "params": [1], "type": "lt" }
+                  }
+                ],
+                "expression": "B",
+                "refId": "C",
+                "type": "threshold"
+              }
+            }
+          ],
+          "noDataState": "Alerting",
+          "execErrState": "Alerting",
+          "for": "2m",
+          "annotations": {
+            "summary": "market-data meldet keinen Geyser-Stream (geyser_connected=0)",
+            "description": "Mind. 2 Minuten lang geyser_connected{job=\"market-data\"} < 1. Hot-Path ohne frische Geyser-Daten. journalctl -u market-data pruefen; Validator-Geyser-Plugin und gRPC-Netzwerk verifizieren."
+          },
+          "labels": {
+            "severity": "critical",
+            "component": "market-data",
+            "type": "geyser"
+          }
+        },
+        {
+          "uid": "ironcrab-marketdata-geyser-reconnect-storm",
+          "title": "MarketDataGeyserReconnectStorm",
+          "condition": "C",
+          "data": [
+            {
+              "refId": "A",
+              "relativeTimeRange": { "from": 300, "to": 0 },
+              "datasourceUid": "bf5zln2g4x5vka",
+              "model": {
+                "expr": "sum(rate(geyser_reconnect_total{job=\"market-data\"}[1m]))",
+                "refId": "A"
+              }
+            },
+            {
+              "refId": "B",
+              "datasourceUid": "__expr__",
+              "model": {
+                "expression": "A",
+                "reducer": "last",
+                "refId": "B",
+                "type": "reduce"
+              }
+            },
+            {
+              "refId": "C",
+              "datasourceUid": "__expr__",
+              "model": {
+                "conditions": [
+                  {
+                    "evaluator": { "params": [0.5], "type": "gt" }
+                  }
+                ],
+                "expression": "B",
+                "refId": "C",
+                "type": "threshold"
+              }
+            }
+          ],
+          "noDataState": "OK",
+          "execErrState": "OK",
+          "for": "3m",
+          "annotations": {
+            "summary": "Geyser-Reconnect-Rate bei market-data erhoeht",
+            "description": "sum(rate(geyser_reconnect_total{job=\"market-data\"}[1m])) > 0.5 fuer 3m. Auf Reconnect-Sturm pruefen (Grafana: Panel Geyser Reconnects 5m rate; PR #143 Metriken)."
+          },
+          "labels": {
+            "severity": "warning",
+            "component": "market-data",
+            "type": "geyser"
+          }
+        }
+      ]
+    },
+    {
+      "orgId": 1,
       "name": "Validator Health",
       "folder": "IronCrab Alerts",
       "interval": "30s",

--- a/docs/grafana_multiprocess_dashboard.json
+++ b/docs/grafana_multiprocess_dashboard.json
@@ -2,7 +2,7 @@
   "title": "IronCrab Multi-Process Architecture",
   "description": "Dashboard for the Debuggable-First Multi-Process Architecture",
   "schemaVersion": 39,
-  "version": 7,
+  "version": 8,
   "time": {
     "from": "now-1h",
     "to": "now"
@@ -1050,13 +1050,148 @@
       }
     },
     {
+      "type": "stat",
+      "title": "Geyser Connected",
+      "description": "1 = gRPC-Stream verbunden, 0 = disconnected / Reconnect. Metriken aus PR #143.",
+      "targets": [
+        {
+          "expr": "geyser_connected{job=\"market-data\"}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "1": {
+                  "text": "CONNECTED",
+                  "color": "green"
+                }
+              }
+            },
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DISCONNECTED",
+                  "color": "red"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Geyser Reconnects (1h)",
+      "description": "Summe der Reconnect-Zuw\u00e4chse \u00fcber alle reason-Labels (1h-Fenster).",
+      "targets": [
+        {
+          "expr": "sum(increase(geyser_reconnect_total{job=\"market-data\"}[1h]))",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Geyser Reconnects (5m rate)",
+      "description": "rate() nach reason \u2014 Reconnect-Sturm (Incident: ~50/s gesamt). Summe >1/s in Explore pr\u00fcfen.",
+      "targets": [
+        {
+          "expr": "sum(rate(geyser_reconnect_total{job=\"market-data\"}[5m])) by (reason)",
+          "refId": "A",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 8,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Geyser Stream Errors (5m rate)",
+      "description": "gRPC-Stream-Fehler (z. B. BrokenPipe, h2).",
+      "targets": [
+        {
+          "expr": "rate(geyser_stream_errors_total{job=\"market-data\"}[5m])",
+          "refId": "A",
+          "legendFormat": "errors/s"
+        }
+      ],
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      }
+    },
+    {
       "type": "row",
       "title": "Momentum Bot (Port 9802) - 4-Filter Policy",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 44
       },
       "collapsed": false
     },
@@ -1074,7 +1209,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 31
+        "y": 45
       },
       "fieldConfig": {
         "defaults": {
@@ -1099,7 +1234,7 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 31
+        "y": 45
       },
       "fieldConfig": {
         "defaults": {
@@ -1123,7 +1258,7 @@
         "h": 4,
         "w": 2,
         "x": 8,
-        "y": 31
+        "y": 45
       },
       "fieldConfig": {
         "defaults": {
@@ -1147,7 +1282,7 @@
         "h": 4,
         "w": 2,
         "x": 10,
-        "y": 31
+        "y": 45
       },
       "fieldConfig": {
         "defaults": {
@@ -1171,7 +1306,7 @@
         "h": 4,
         "w": 2,
         "x": 12,
-        "y": 31
+        "y": 45
       },
       "fieldConfig": {
         "defaults": {
@@ -1195,7 +1330,7 @@
         "h": 4,
         "w": 2,
         "x": 14,
-        "y": 31
+        "y": 45
       },
       "fieldConfig": {
         "defaults": {
@@ -1219,7 +1354,7 @@
         "h": 4,
         "w": 2,
         "x": 16,
-        "y": 31
+        "y": 45
       },
       "fieldConfig": {
         "defaults": {
@@ -1244,7 +1379,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 31
+        "y": 45
       },
       "options": {
         "legend": {
@@ -1272,7 +1407,7 @@
         "h": 4,
         "w": 18,
         "x": 0,
-        "y": 35
+        "y": 49
       },
       "fieldConfig": {
         "defaults": {
@@ -1290,7 +1425,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 53
       },
       "collapsed": false
     },
@@ -1307,7 +1442,7 @@
         "h": 4,
         "w": 6,
         "x": 0,
-        "y": 40
+        "y": 54
       },
       "fieldConfig": {
         "defaults": {
@@ -1331,7 +1466,7 @@
         "h": 4,
         "w": 6,
         "x": 6,
-        "y": 40
+        "y": 54
       },
       "fieldConfig": {
         "defaults": {
@@ -1367,7 +1502,7 @@
         "h": 4,
         "w": 6,
         "x": 12,
-        "y": 40
+        "y": 54
       },
       "fieldConfig": {
         "defaults": {
@@ -1412,7 +1547,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 58
       },
       "collapsed": false
     },
@@ -1429,7 +1564,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 45
+        "y": 59
       },
       "fieldConfig": {
         "defaults": {
@@ -1453,7 +1588,7 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 45
+        "y": 59
       },
       "fieldConfig": {
         "defaults": {
@@ -1477,7 +1612,7 @@
         "h": 4,
         "w": 4,
         "x": 8,
-        "y": 45
+        "y": 59
       },
       "fieldConfig": {
         "defaults": {
@@ -1501,7 +1636,7 @@
         "h": 4,
         "w": 4,
         "x": 12,
-        "y": 45
+        "y": 59
       },
       "fieldConfig": {
         "defaults": {
@@ -1525,7 +1660,7 @@
         "h": 4,
         "w": 4,
         "x": 16,
-        "y": 45
+        "y": 59
       },
       "fieldConfig": {
         "defaults": {
@@ -1547,7 +1682,7 @@
         "h": 4,
         "w": 4,
         "x": 20,
-        "y": 45
+        "y": 59
       }
     },
     {
@@ -1563,7 +1698,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 49
+        "y": 63
       },
       "fieldConfig": {
         "defaults": {
@@ -1604,7 +1739,7 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 49
+        "y": 63
       },
       "fieldConfig": {
         "defaults": {
@@ -1627,7 +1762,7 @@
         "h": 4,
         "w": 4,
         "x": 8,
-        "y": 49
+        "y": 63
       },
       "fieldConfig": {
         "defaults": {
@@ -1683,7 +1818,7 @@
         "h": 4,
         "w": 4,
         "x": 12,
-        "y": 49
+        "y": 63
       },
       "fieldConfig": {
         "defaults": {
@@ -1756,7 +1891,7 @@
         "h": 4,
         "w": 4,
         "x": 16,
-        "y": 49
+        "y": 63
       },
       "fieldConfig": {
         "defaults": {
@@ -1778,7 +1913,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 53
+        "y": 67
       },
       "options": {
         "legend": {
@@ -1806,7 +1941,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 53
+        "y": 67
       },
       "fieldConfig": {
         "defaults": {
@@ -1838,7 +1973,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 53
+        "y": 67
       },
       "fieldConfig": {
         "defaults": {
@@ -1907,7 +2042,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 59
+        "y": 73
       },
       "fieldConfig": {
         "defaults": {
@@ -1922,7 +2057,7 @@
         "h": 2,
         "w": 24,
         "x": 0,
-        "y": 65
+        "y": 79
       },
       "options": {
         "content": "**Time mode:** Grafana shows dashboard variables in the **top bar**; this JSON model cannot place the `time_mode` control between panels. Use the **Trades: Zeit (Recent Trades)** dropdown at the top to switch Relativ/UTC. The table column arrows **only** control sort order.",
@@ -1937,7 +2072,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 81
       },
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
@@ -2383,7 +2518,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 79
+        "y": 93
       },
       "collapsed": false
     },
@@ -2416,7 +2551,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 80
+        "y": 94
       },
       "fieldConfig": {
         "defaults": {
@@ -2437,7 +2572,7 @@
         "h": 3,
         "w": 4,
         "x": 12,
-        "y": 80
+        "y": 94
       },
       "fieldConfig": {
         "defaults": {
@@ -2477,7 +2612,7 @@
         "h": 3,
         "w": 4,
         "x": 16,
-        "y": 80
+        "y": 94
       },
       "fieldConfig": {
         "defaults": {
@@ -2513,7 +2648,7 @@
         "h": 3,
         "w": 4,
         "x": 20,
-        "y": 80
+        "y": 94
       }
     }
   ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ziel

Dashboard, Alert-Vorlagen und Runbook an die **neuen** Geyser-Metriken aus dem Stream-Resilienz-Work (PR #143 / Branch `cursor/geyser-stream-resilienz-d8b6`) anbinden, damit Stream-Abbruch und Reconnect-Sturm in Grafana sichtbar werden.

## Änderungen

- **`docs/grafana_multiprocess_dashboard.json`**: Unter der Row **Market Data Service (Port 9801)** vier neue Panels (`geyser_connected`, `geyser_reconnect_total` mit `rate`/`increase`, `geyser_stream_errors_total`); alle Panels mit `gridPos.y >= 30` um 14 Zeilen nach unten verschoben (Dashboard-Version 8).
- **`docs/grafana_alert_rules.json`**: Neue Gruppe **IronCrab Market Data** — `MarketDataGeyserDisconnected` (2m, critical), `MarketDataGeyserReconnectStorm` (3m, warning); `datasourceUid` wie bestehende Rules (`bf5zln2g4x5vka`).
- **`docs/RUNBOOK_PROD.md`**: Abschnitt **Geyser / market-data Metriken (PR #143)** mit Alt→Neu-Tabelle, `curl`-Check, Debug-Hinweisen, `rate()`-Verifikation nach Deploy.

## Testplan

- [x] `python3 -c "import json; …"` — beide JSON-Dateien parsebar
- [x] Keine PromQL-Queries im Repo auf die alten Counter-Namen (Legacy nur in der Migrations-Tabelle im Runbook)
- [ ] Nach Merge: Grafana Dashboard neu importieren; Explore `geyser_connected{job="market-data"}`

## Basis-Branch

Dieser Branch basiert auf `cursor/geyser-stream-resilienz-d8b6` (ein Commit **nach** dem Geyser-Resilienz-Feature). Als Merge-Ziel eignet sich zuerst derselbe Branch bzw. nach Merge von #143 `architecture-rebuild`.

## STOP-CHECK (Agent)

- I-7 / Hot Path: keine Änderung an Rust oder RPC.
- Scope: nur erlaubte `docs/`-Dateien.
- Kein Lesen von `Iron_crab-eval/tests/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b522439-e09d-48a0-ab3e-a2634e0360ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b522439-e09d-48a0-ab3e-a2634e0360ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

