### PR TITLE
PR-B: Geyser explicit account cap, LRU eviction, admission (market-data)

### DIFF
--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -248,9 +248,19 @@ Component name: `market-data`
 |-----|------|---------|-------|-------------|
 | `max_events_per_sec` | u32 | 10_000 | 1-1_000_000 | Maximum MarketEvents emitted per second |
 
+### Geyser explicit accounts (PR-B)
+
+Loaded from root TOML section `[market_data_geyser]` in `config.toml` (not the JetStream `market-data` DEX toggles).
+
+| Key | Type | Default | Range | Description |
+|-----|------|---------|-------|-------------|
+| `max_tracked_accounts` | usize | 25000 | 1000-500000 | Max combined explicit Yellowstone accounts (mints + vaults + bin arrays + wallet list). LRU evicts unpinned rows when exceeded. |
+| `geyser_full_reconnect_threshold` | usize | 10000 | 1000-500000 | When combined explicit accounts exceed this, `market-data` forces a full Geyser gRPC reconnect on subscription changes instead of many in-place subscribe updates. |
+
 ### Validation Rules
 - Boolean values must be `true` or `false`
 - `max_events_per_sec` must be between 1 and 1,000,000
+- `max_tracked_accounts` and `geyser_full_reconnect_threshold` must be between 1000 and 500000 (when set via control-plane JSON; TOML should use same bounds)
 
 ---
 

--- a/my_config.server.toml
+++ b/my_config.server.toml
@@ -21,6 +21,11 @@ ws_failover_urls = ["ws://109.230.239.43:8900"]
 # Requires: --geyser-plugin-config flag in validator service
 geyser_grpc_url = "http://127.0.0.1:10000"  # Yellowstone gRPC (http for tonic client)
 
+# market-data: Yellowstone explicit account subscription caps (PR-B)
+[market_data_geyser]
+max_tracked_accounts = 25000
+geyser_full_reconnect_threshold = 10000
+
 # CRITICAL: Helius RPC for mint validation (full transaction index)
 # Local validators do NOT have full transaction history - they return
 # incorrect (too few) signatures for old tokens, causing us to buy them.

--- a/my_config.server.toml
+++ b/my_config.server.toml
@@ -21,11 +21,6 @@ ws_failover_urls = ["ws://109.230.239.43:8900"]
 # Requires: --geyser-plugin-config flag in validator service
 geyser_grpc_url = "http://127.0.0.1:10000"  # Yellowstone gRPC (http for tonic client)
 
-# market-data: Yellowstone explicit account subscription caps (PR-B)
-[market_data_geyser]
-max_tracked_accounts = 25000
-geyser_full_reconnect_threshold = 10000
-
 # CRITICAL: Helius RPC for mint validation (full transaction index)
 # Local validators do NOT have full transaction history - they return
 # incorrect (too few) signatures for old tokens, causing us to buy them.
@@ -43,6 +38,11 @@ rpc_dec_on_rate_limit = 2       # be conservative on backoff
 rpc_timeout_ms = 15000          # 15s timeout (local validator is fast)
 ## Some RPC/Proxies require WS subprotocol header "jsonrpc" for PubSub
 ws_headers = { "Sec-WebSocket-Protocol" = "jsonrpc" }
+
+# market-data: Yellowstone explicit account subscription caps (PR-B)
+[market_data_geyser]
+max_tracked_accounts = 25000
+geyser_full_reconnect_threshold = 10000
 
 # --- Markets (sum must be 100) ---
 [[markets]]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1065,6 +1065,33 @@ impl MarketDataContext {
         geyser_metrics_set_tracked_pinned_accounts(pinned);
     }
 
+    /// Partner vault (opposite base/quote leg) eligible for paired LRU eviction.
+    /// Never returns a pinned sibling — pinned vaults must stay subscribed.
+    pub(crate) fn geyser_unpinned_sibling_vault_pubkey(
+        vaults: &std::collections::HashMap<Pubkey, VaultInfo>,
+        pool: Pubkey,
+        primary_is_base_vault: bool,
+    ) -> Option<Pubkey> {
+        vaults
+            .iter()
+            .find(|(_, vi)| {
+                vi.pool_address == pool && vi.is_base_vault != primary_is_base_vault && !vi.pinned
+            })
+            .map(|(pk, _)| *pk)
+    }
+
+    /// Whether a **pinned** partner vault exists for the same pool (opposite leg).
+    /// Used after evicting an unpinned vault to detect half-pair subscription (documented `warn!`).
+    pub(crate) fn geyser_pinned_sibling_vault_present(
+        vaults: &std::collections::HashMap<Pubkey, VaultInfo>,
+        pool: Pubkey,
+        primary_is_base_vault: bool,
+    ) -> bool {
+        vaults.values().any(|vi| {
+            vi.pool_address == pool && vi.is_base_vault != primary_is_base_vault && vi.pinned
+        })
+    }
+
     /// PR-B: LRU eviction when explicit combined accounts exceed `max_tracked_accounts`.
     /// Never evicts pinned rows; never evicts wallet subscription keys (they are not in these maps).
     fn evict_geyser_unpinned_lru_to_cap(&self) {
@@ -1141,16 +1168,12 @@ impl MarketDataContext {
                             oldest_age_ms = ?oldest_at.elapsed().as_millis(),
                             "geyser_evicted"
                         );
-                        // Evict the paired vault for the same pool so LRU cannot leave half a pair
-                        // tracked (misleading partial reserves when the sibling update path runs).
+                        // Evict the paired vault for the same pool when **both** legs are unpinned, so
+                        // LRU does not leave a misleading half-pair. Never remove a pinned sibling.
                         let pool = v.pool_address;
                         let this_is_base = v.is_base_vault;
-                        let sibling_pk = vaults
-                            .iter()
-                            .find(|(_, vi)| {
-                                vi.pool_address == pool && vi.is_base_vault != this_is_base
-                            })
-                            .map(|(pk, _)| *pk);
+                        let sibling_pk =
+                            Self::geyser_unpinned_sibling_vault_pubkey(&vaults, pool, this_is_base);
                         if let Some(spk) = sibling_pk {
                             if let Some(sv) = vaults.remove(&spk) {
                                 geyser_metrics_inc_tracked_evicted(GeyserTrackedEvictKind::Vault);
@@ -1164,6 +1187,20 @@ impl MarketDataContext {
                                     "geyser_evicted"
                                 );
                             }
+                        } else if Self::geyser_pinned_sibling_vault_present(
+                            &vaults,
+                            pool,
+                            this_is_base,
+                        ) {
+                            // Single warn per eviction step: unpinned leg removed, pinned partner retained
+                            // (intentional — never evict pinned explicit accounts).
+                            warn!(
+                                run_id = %run_id,
+                                pool = %pool,
+                                evicted_vault = %pubkey,
+                                evicted_was_base_vault = this_is_base,
+                                "geyser_evict: removed unpinned vault but pinned sibling vault remains tracked (half-pair subscription)"
+                            );
                         }
                     }
                 }
@@ -12115,5 +12152,102 @@ mod pr_b_geyser_tracking_tests {
         assert!(s.is_pinned(mint, pool));
         s.unpin_pool(mint, pool);
         assert!(!s.is_pinned(mint, pool));
+    }
+
+    /// Bugbot PR-146: paired vault eviction must never pick a pinned sibling for `lru_cap_pair`.
+    #[test]
+    fn geyser_sibling_evict_helper_skips_pinned_leg() {
+        let pool = Pubkey::new_unique();
+        let base_pk = Pubkey::new_unique();
+        let quote_pk = Pubkey::new_unique();
+        let now = Instant::now();
+        let mut map = std::collections::HashMap::new();
+        map.insert(
+            base_pk,
+            VaultInfo {
+                pool_address: pool,
+                dex: "x".into(),
+                base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::new_unique(),
+                is_base_vault: true,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: now,
+                pinned: false,
+                pin: None,
+                active_id: None,
+                bin_step: None,
+            },
+        );
+        map.insert(
+            quote_pk,
+            VaultInfo {
+                pool_address: pool,
+                dex: "x".into(),
+                base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::new_unique(),
+                is_base_vault: false,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: now,
+                pinned: true,
+                pin: Some(GeyserPinReason::Wallet),
+                active_id: None,
+                bin_step: None,
+            },
+        );
+        assert_eq!(
+            MarketDataContext::geyser_unpinned_sibling_vault_pubkey(&map, pool, true),
+            None
+        );
+        assert!(MarketDataContext::geyser_pinned_sibling_vault_present(
+            &map, pool, true
+        ));
+    }
+
+    #[test]
+    fn geyser_sibling_evict_helper_co_evicts_unpinned_partner() {
+        let pool = Pubkey::new_unique();
+        let base_pk = Pubkey::new_unique();
+        let quote_pk = Pubkey::new_unique();
+        let now = Instant::now();
+        let mut map = std::collections::HashMap::new();
+        map.insert(
+            base_pk,
+            VaultInfo {
+                pool_address: pool,
+                dex: "x".into(),
+                base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::new_unique(),
+                is_base_vault: true,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: now,
+                pinned: false,
+                pin: None,
+                active_id: None,
+                bin_step: None,
+            },
+        );
+        map.insert(
+            quote_pk,
+            VaultInfo {
+                pool_address: pool,
+                dex: "x".into(),
+                base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::new_unique(),
+                is_base_vault: false,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: now,
+                pinned: false,
+                pin: None,
+                active_id: None,
+                bin_step: None,
+            },
+        );
+        assert_eq!(
+            MarketDataContext::geyser_unpinned_sibling_vault_pubkey(&map, pool, true),
+            Some(quote_pk)
+        );
+        assert!(!MarketDataContext::geyser_pinned_sibling_vault_present(
+            &map, pool, true
+        ));
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1129,7 +1129,8 @@ impl MarketDataContext {
 
             match kind {
                 EvKind::Vault => {
-                    if let Some(v) = self.tracked_vaults.write().remove(&pubkey) {
+                    let mut vaults = self.tracked_vaults.write();
+                    if let Some(v) = vaults.remove(&pubkey) {
                         geyser_metrics_inc_tracked_evicted(GeyserTrackedEvictKind::Vault);
                         info!(
                             run_id = %run_id,
@@ -1140,6 +1141,30 @@ impl MarketDataContext {
                             oldest_age_ms = ?oldest_at.elapsed().as_millis(),
                             "geyser_evicted"
                         );
+                        // Evict the paired vault for the same pool so LRU cannot leave half a pair
+                        // tracked (misleading partial reserves when the sibling update path runs).
+                        let pool = v.pool_address;
+                        let this_is_base = v.is_base_vault;
+                        let sibling_pk = vaults
+                            .iter()
+                            .find(|(_, vi)| {
+                                vi.pool_address == pool && vi.is_base_vault != this_is_base
+                            })
+                            .map(|(pk, _)| *pk);
+                        if let Some(spk) = sibling_pk {
+                            if let Some(sv) = vaults.remove(&spk) {
+                                geyser_metrics_inc_tracked_evicted(GeyserTrackedEvictKind::Vault);
+                                info!(
+                                    run_id = %run_id,
+                                    pool = %sv.pool_address,
+                                    mint = %sv.base_mint,
+                                    vault = %spk,
+                                    reason = "lru_cap_pair",
+                                    oldest_age_ms = ?oldest_at.elapsed().as_millis(),
+                                    "geyser_evicted"
+                                );
+                            }
+                        }
                     }
                 }
                 EvKind::Bin => {
@@ -1217,8 +1242,14 @@ impl MarketDataContext {
 
     fn touch_tracked_vault_pubkey(&self, vault: &Pubkey) {
         let now = Instant::now();
-        if let Some(v) = self.tracked_vaults.write().get_mut(vault) {
-            v.last_used_at = now;
+        let mut vs = self.tracked_vaults.write();
+        let pool = vs.get(vault).map(|v| v.pool_address);
+        if let Some(pool) = pool {
+            for v in vs.values_mut() {
+                if v.pool_address == pool {
+                    v.last_used_at = now;
+                }
+            }
         }
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -26,7 +26,7 @@ use std::collections::{HashMap, VecDeque};
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{mpsc, watch};
@@ -766,6 +766,8 @@ struct MarketDataContext {
     run_id: String,
     /// P1: Config in RwLock for runtime hot-reload
     config: parking_lot::RwLock<MarketDataConfig>,
+    /// Same value as `config.geyser_full_reconnect_threshold`, mirrored for `GeyserListener` hot-reload.
+    geyser_full_reconnect_threshold_live: Arc<AtomicUsize>,
     nats: Option<NatsClient>,
     jsonl_writer: JsonlWriter,
     event_counter: std::sync::atomic::AtomicU64,
@@ -1162,25 +1164,32 @@ impl MarketDataContext {
         }
     }
 
+    /// Push current explicit tracked keys to all merge-task channels after eviction.
+    /// Cross-type LRU can evict vaults/bin-arrays/mints from any map; a single `send_tracked_*`
+    /// caller must refresh every channel so the combined Geyser subscription list stays in sync.
+    fn broadcast_tracked_geyser_explicit_to_merge(&self) {
+        let mints: Vec<Pubkey> = self.tracked_mints.read().keys().copied().collect();
+        let vaults: Vec<Pubkey> = self.tracked_vaults.read().keys().copied().collect();
+        let bins: Vec<Pubkey> = self.tracked_bin_arrays.read().keys().copied().collect();
+        let _ = self.tracked_mints_tx.send(mints);
+        let _ = self.tracked_vaults_tx.send(vaults);
+        let _ = self.tracked_bin_arrays_tx.send(bins);
+        self.refresh_geyser_pins_gauge();
+    }
+
     fn send_tracked_mints_geyser(&self) {
         self.evict_geyser_unpinned_lru_to_cap();
-        let keys: Vec<Pubkey> = self.tracked_mints.read().keys().copied().collect();
-        let _ = self.tracked_mints_tx.send(keys);
-        self.refresh_geyser_pins_gauge();
+        self.broadcast_tracked_geyser_explicit_to_merge();
     }
 
     fn send_tracked_vaults_geyser(&self) {
         self.evict_geyser_unpinned_lru_to_cap();
-        let keys: Vec<Pubkey> = self.tracked_vaults.read().keys().copied().collect();
-        let _ = self.tracked_vaults_tx.send(keys);
-        self.refresh_geyser_pins_gauge();
+        self.broadcast_tracked_geyser_explicit_to_merge();
     }
 
     fn send_tracked_bin_arrays_geyser(&self) {
         self.evict_geyser_unpinned_lru_to_cap();
-        let keys: Vec<Pubkey> = self.tracked_bin_arrays.read().keys().copied().collect();
-        let _ = self.tracked_bin_arrays_tx.send(keys);
-        self.refresh_geyser_pins_gauge();
+        self.broadcast_tracked_geyser_explicit_to_merge();
     }
 
     /// Track mint pubkey for Geyser `TokenMintInfo` / metadata. Returns `true` if pubkey set changed.
@@ -1667,7 +1676,10 @@ impl MarketDataContext {
                 "geyser_full_reconnect_threshold" => {
                     if let Some(v) = value.as_u64() {
                         if (1000..=500_000).contains(&v) {
-                            config.geyser_full_reconnect_threshold = v as usize;
+                            let n = v as usize;
+                            config.geyser_full_reconnect_threshold = n;
+                            self.geyser_full_reconnect_threshold_live
+                                .store(n, Ordering::Relaxed);
                             applied.push(key.clone());
                             info!(key = %key, new_value = %v, "Config updated");
                         } else {
@@ -5964,9 +5976,14 @@ async fn main() -> Result<()> {
         None
     };
 
+    let geyser_full_reconnect_threshold_live = Arc::new(AtomicUsize::new(
+        market_data_config.geyser_full_reconnect_threshold,
+    ));
+
     let ctx = Arc::new(MarketDataContext {
         run_id: run_id.clone(),
         config: parking_lot::RwLock::new(market_data_config),
+        geyser_full_reconnect_threshold_live,
         nats,
         jsonl_writer,
         event_counter: std::sync::atomic::AtomicU64::new(0),
@@ -9539,14 +9556,13 @@ async fn run_geyser_loop(
         });
     }
 
-    let full_reconnect_thr = ctx.config.read().geyser_full_reconnect_threshold;
     // Start legacy GeyserListener for transaction parsing (will be phased out in favor of pool discovery)
     let (listener, account_rx, transaction_rx, mut blockhash_rx) =
         GeyserListener::new_with_tracked_accounts(
             geyser_url.to_string(),
             program_ids,
             combined_tracked_rx,
-            full_reconnect_thr,
+            Arc::clone(&ctx.geyser_full_reconnect_threshold_live),
         );
 
     // Spawn Geyser listener task

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1663,121 +1663,129 @@ impl MarketDataContext {
 
     /// P1: Apply config update from control-plane (Runtime Configuration via UI)
     fn apply_config_update(&self, update: &ConfigUpdate) -> ConfigUpdateResponse {
-        let mut config = self.config.write();
         let mut applied = Vec::new();
         let mut rejected = Vec::new();
+        let mut sync_geyser_tracked_after_max_accounts = false;
 
-        for (key, value) in &update.config {
-            match key.as_str() {
-                "enable_raydium" => {
-                    if let Some(v) = value.as_bool() {
-                        config.enable_raydium = v;
-                        applied.push(key.clone());
-                        info!(key = %key, new_value = %v, "Config updated");
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
-                    }
-                }
-                "enable_raydium_cpmm" => {
-                    if let Some(v) = value.as_bool() {
-                        config.enable_raydium_cpmm = v;
-                        applied.push(key.clone());
-                        info!(key = %key, new_value = %v, "Config updated");
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
-                    }
-                }
-                "enable_orca" => {
-                    if let Some(v) = value.as_bool() {
-                        config.enable_orca = v;
-                        applied.push(key.clone());
-                        info!(key = %key, new_value = %v, "Config updated");
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
-                    }
-                }
-                "enable_pumpfun" => {
-                    if let Some(v) = value.as_bool() {
-                        config.enable_pumpfun = v;
-                        applied.push(key.clone());
-                        info!(key = %key, new_value = %v, "Config updated");
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
-                    }
-                }
-                "enable_pumpswap" => {
-                    if let Some(v) = value.as_bool() {
-                        config.enable_pumpswap = v;
-                        applied.push(key.clone());
-                        info!(key = %key, new_value = %v, "Config updated");
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
-                    }
-                }
-                "enable_meteora_dlmm" => {
-                    if let Some(v) = value.as_bool() {
-                        config.enable_meteora_dlmm = v;
-                        applied.push(key.clone());
-                        info!(key = %key, new_value = %v, "Config updated");
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
-                    }
-                }
-                "enable_meteora_cpmm" => {
-                    if let Some(v) = value.as_bool() {
-                        config.enable_meteora_cpmm = v;
-                        applied.push(key.clone());
-                        info!(key = %key, new_value = %v, "Config updated");
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
-                    }
-                }
-                "max_events_per_sec" => {
-                    if let Some(v) = value.as_u64() {
-                        if v > 0 && v <= 1_000_000 {
-                            config.max_events_per_sec = v as u32;
+        {
+            let mut config = self.config.write();
+            for (key, value) in &update.config {
+                match key.as_str() {
+                    "enable_raydium" => {
+                        if let Some(v) = value.as_bool() {
+                            config.enable_raydium = v;
                             applied.push(key.clone());
                             info!(key = %key, new_value = %v, "Config updated");
                         } else {
-                            rejected.push((key.clone(), "Must be 1-1000000".to_string()));
+                            rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
                         }
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
                     }
-                }
-                "max_tracked_accounts" => {
-                    if let Some(v) = value.as_u64() {
-                        if (1000..=500_000).contains(&v) {
-                            config.max_tracked_accounts = v as usize;
+                    "enable_raydium_cpmm" => {
+                        if let Some(v) = value.as_bool() {
+                            config.enable_raydium_cpmm = v;
                             applied.push(key.clone());
                             info!(key = %key, new_value = %v, "Config updated");
                         } else {
-                            rejected.push((key.clone(), "Must be 1000-500000".to_string()));
+                            rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
                         }
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
                     }
-                }
-                "geyser_full_reconnect_threshold" => {
-                    if let Some(v) = value.as_u64() {
-                        if (1000..=500_000).contains(&v) {
-                            let n = v as usize;
-                            config.geyser_full_reconnect_threshold = n;
-                            self.geyser_full_reconnect_threshold_live
-                                .store(n, Ordering::Relaxed);
+                    "enable_orca" => {
+                        if let Some(v) = value.as_bool() {
+                            config.enable_orca = v;
                             applied.push(key.clone());
                             info!(key = %key, new_value = %v, "Config updated");
                         } else {
-                            rejected.push((key.clone(), "Must be 1000-500000".to_string()));
+                            rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
                         }
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
                     }
-                }
-                _ => {
-                    rejected.push((key.clone(), format!("Unknown config key: {}", key)));
+                    "enable_pumpfun" => {
+                        if let Some(v) = value.as_bool() {
+                            config.enable_pumpfun = v;
+                            applied.push(key.clone());
+                            info!(key = %key, new_value = %v, "Config updated");
+                        } else {
+                            rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
+                        }
+                    }
+                    "enable_pumpswap" => {
+                        if let Some(v) = value.as_bool() {
+                            config.enable_pumpswap = v;
+                            applied.push(key.clone());
+                            info!(key = %key, new_value = %v, "Config updated");
+                        } else {
+                            rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
+                        }
+                    }
+                    "enable_meteora_dlmm" => {
+                        if let Some(v) = value.as_bool() {
+                            config.enable_meteora_dlmm = v;
+                            applied.push(key.clone());
+                            info!(key = %key, new_value = %v, "Config updated");
+                        } else {
+                            rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
+                        }
+                    }
+                    "enable_meteora_cpmm" => {
+                        if let Some(v) = value.as_bool() {
+                            config.enable_meteora_cpmm = v;
+                            applied.push(key.clone());
+                            info!(key = %key, new_value = %v, "Config updated");
+                        } else {
+                            rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
+                        }
+                    }
+                    "max_events_per_sec" => {
+                        if let Some(v) = value.as_u64() {
+                            if v > 0 && v <= 1_000_000 {
+                                config.max_events_per_sec = v as u32;
+                                applied.push(key.clone());
+                                info!(key = %key, new_value = %v, "Config updated");
+                            } else {
+                                rejected.push((key.clone(), "Must be 1-1000000".to_string()));
+                            }
+                        } else {
+                            rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
+                        }
+                    }
+                    "max_tracked_accounts" => {
+                        if let Some(v) = value.as_u64() {
+                            if (1000..=500_000).contains(&v) {
+                                config.max_tracked_accounts = v as usize;
+                                applied.push(key.clone());
+                                sync_geyser_tracked_after_max_accounts = true;
+                                info!(key = %key, new_value = %v, "Config updated");
+                            } else {
+                                rejected.push((key.clone(), "Must be 1000-500000".to_string()));
+                            }
+                        } else {
+                            rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
+                        }
+                    }
+                    "geyser_full_reconnect_threshold" => {
+                        if let Some(v) = value.as_u64() {
+                            if (1000..=500_000).contains(&v) {
+                                let n = v as usize;
+                                config.geyser_full_reconnect_threshold = n;
+                                self.geyser_full_reconnect_threshold_live
+                                    .store(n, Ordering::Relaxed);
+                                applied.push(key.clone());
+                                info!(key = %key, new_value = %v, "Config updated");
+                            } else {
+                                rejected.push((key.clone(), "Must be 1000-500000".to_string()));
+                            }
+                        } else {
+                            rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
+                        }
+                    }
+                    _ => {
+                        rejected.push((key.clone(), format!("Unknown config key: {}", key)));
+                    }
                 }
             }
+        }
+
+        if sync_geyser_tracked_after_max_accounts {
+            self.sync_geyser_tracked_accounts();
         }
 
         let status = if rejected.is_empty() {

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -792,6 +792,11 @@ struct MarketDataContext {
     /// Pools for which we've already emitted DexPoolAccounts from trade parsing.
     known_trade_dex_pools: parking_lot::RwLock<std::collections::HashSet<Pubkey>>,
 
+    /// Pump.fun pool discovery: emit `TokenMintInfo` at most once per base mint (Geyser reconnect
+    /// or duplicate discovery must not spam `mint_info_tx`).
+    pumpfun_pool_discovery_mint_info_emitted:
+        parking_lot::RwLock<std::collections::HashSet<Pubkey>>,
+
     /// Vault account tracking for PoolStateUpdate events (Geyser-based reserve balances).
     /// Maps vault_address → VaultInfo (pool context).
     tracked_vaults: parking_lot::RwLock<std::collections::HashMap<Pubkey, VaultInfo>>,
@@ -1165,8 +1170,9 @@ impl MarketDataContext {
     }
 
     /// Push current explicit tracked keys to all merge-task channels after eviction.
-    /// Cross-type LRU can evict vaults/bin-arrays/mints from any map; a single `send_tracked_*`
-    /// caller must refresh every channel so the combined Geyser subscription list stays in sync.
+    /// Cross-type LRU can evict vaults/bin-arrays/mints from any map; callers must run
+    /// [`Self::sync_geyser_tracked_accounts`] so every channel refreshes and the combined Geyser
+    /// subscription list stays in sync.
     fn broadcast_tracked_geyser_explicit_to_merge(&self) {
         let mints: Vec<Pubkey> = self.tracked_mints.read().keys().copied().collect();
         let vaults: Vec<Pubkey> = self.tracked_vaults.read().keys().copied().collect();
@@ -1177,17 +1183,7 @@ impl MarketDataContext {
         self.refresh_geyser_pins_gauge();
     }
 
-    fn send_tracked_mints_geyser(&self) {
-        self.evict_geyser_unpinned_lru_to_cap();
-        self.broadcast_tracked_geyser_explicit_to_merge();
-    }
-
-    fn send_tracked_vaults_geyser(&self) {
-        self.evict_geyser_unpinned_lru_to_cap();
-        self.broadcast_tracked_geyser_explicit_to_merge();
-    }
-
-    fn send_tracked_bin_arrays_geyser(&self) {
+    fn sync_geyser_tracked_accounts(&self) {
         self.evict_geyser_unpinned_lru_to_cap();
         self.broadcast_tracked_geyser_explicit_to_merge();
     }
@@ -1568,11 +1564,8 @@ impl MarketDataContext {
             _ => {}
         }
 
-        if vaults_changed {
-            self.send_tracked_vaults_geyser();
-        }
-        if bins_changed {
-            self.send_tracked_bin_arrays_geyser();
+        if vaults_changed || bins_changed {
+            self.sync_geyser_tracked_accounts();
         }
     }
 
@@ -5386,7 +5379,7 @@ async fn publish_wallet_snapshot(
 
         // Ensure mint is tracked so Geyser can publish TokenMintInfo later (no RPC here).
         if ctx.track_mint_for_geyser_metadata(*mint, Some(GeyserPinReason::Wallet)) {
-            ctx.send_tracked_mints_geyser();
+            ctx.sync_geyser_tracked_accounts();
         }
 
         let mint_str = mint.to_string();
@@ -5994,6 +5987,9 @@ async fn main() -> Result<()> {
         active_pool_set: Arc::new(ActivePoolSet::new()),
         known_pump_amm_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
         known_trade_dex_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
+        pumpfun_pool_discovery_mint_info_emitted: parking_lot::RwLock::new(
+            std::collections::HashSet::new(),
+        ),
         tracked_vaults: parking_lot::RwLock::new(std::collections::HashMap::new()),
         tracked_vaults_tx,
         tracked_bin_arrays: parking_lot::RwLock::new(std::collections::HashMap::new()),
@@ -7800,7 +7796,7 @@ async fn handle_geyser_account(
                 }
             }
             if vaults_changed {
-                ctx.send_tracked_vaults_geyser();
+                ctx.sync_geyser_tracked_accounts();
                 debug!(
                     pool = %account_update.pubkey,
                     coin_vault = %coin_vault,
@@ -7881,7 +7877,7 @@ async fn handle_geyser_account(
                     }
                 }
                 if vaults_changed {
-                    ctx.send_tracked_vaults_geyser();
+                    ctx.sync_geyser_tracked_accounts();
                     debug!(
                         pool = %account_update.pubkey,
                         vault_base = %vault_base,
@@ -7939,7 +7935,7 @@ async fn handle_geyser_account(
                     }
                 }
                 if vaults_changed {
-                    ctx.send_tracked_vaults_geyser();
+                    ctx.sync_geyser_tracked_accounts();
                     debug!(
                         pool = %account_update.pubkey,
                         reserve_x = %s.reserve_x,
@@ -8191,7 +8187,7 @@ async fn handle_geyser_account(
                         }
                     }
                     if vaults_changed {
-                        ctx.send_tracked_vaults_geyser();
+                        ctx.sync_geyser_tracked_accounts();
                         debug!(
                             pool = %account_update.pubkey,
                             base_vault = %s.pool_base_token_account,
@@ -8847,7 +8843,7 @@ async fn handle_geyser_transaction(
         if let Some((mint, dex_opt)) = mint_and_dex {
             let is_new = ctx.track_mint_for_geyser_metadata(mint, None);
             if is_new {
-                ctx.send_tracked_mints_geyser();
+                ctx.sync_geyser_tracked_accounts();
                 debug!(
                     mint = %mint,
                     dex = ?dex_opt,
@@ -10218,7 +10214,7 @@ async fn run_geyser_loop(
                                         let added_mint =
                                             ctx.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::Wallet));
                                         if added_mint {
-                                            ctx.send_tracked_mints_geyser();
+                                            ctx.sync_geyser_tracked_accounts();
                                         }
 
                                         // 4) Recompute tracked wallet accounts and notify listener
@@ -10362,27 +10358,33 @@ async fn run_geyser_loop(
                 // PR-B: discovery-only must not grow explicit Geyser mint/vault/bin subscriptions.
                 // Pump.fun still emits TokenMintInfo with known decimals=6 (no extra mint account filter).
                 if matches!(pool_event.dex_type, PoolDexType::PumpFun) {
-                    let mint_event = MarketEvent::new(
-                        "market-data",
-                        BUILD_VERSION,
-                        run_id,
-                        ctx.next_event_id(),
-                        "geyser_known", // Not RPC - we know pump.fun uses decimals=6
-                        Some(pool_event.slot),
-                        MarketEventKind::TokenMintInfo {
-                            mint: pool_event.base_mint.to_string(),
-                            token_program: spl_token::ID.to_string(), // pump.fun always uses SPL Token
-                            decimals: 6, // pump.fun tokens ALWAYS have 6 decimals
-                            supply: 0,   // Unknown, but not critical for trading
-                            mint_authority: None,
-                            freeze_authority: None,
-                        },
-                    );
-                    let _ = mint_info_tx.send(mint_event);
-                    debug!(
-                        mint = %pool_event.base_mint,
-                        "Emitted TokenMintInfo for pump.fun token (decimals=6, no RPC)"
-                    );
+                    let emit_mint_info = ctx
+                        .pumpfun_pool_discovery_mint_info_emitted
+                        .write()
+                        .insert(pool_event.base_mint);
+                    if emit_mint_info {
+                        let mint_event = MarketEvent::new(
+                            "market-data",
+                            BUILD_VERSION,
+                            run_id,
+                            ctx.next_event_id(),
+                            "geyser_known", // Not RPC - we know pump.fun uses decimals=6
+                            Some(pool_event.slot),
+                            MarketEventKind::TokenMintInfo {
+                                mint: pool_event.base_mint.to_string(),
+                                token_program: spl_token::ID.to_string(), // pump.fun always uses SPL Token
+                                decimals: 6, // pump.fun tokens ALWAYS have 6 decimals
+                                supply: 0,   // Unknown, but not critical for trading
+                                mint_authority: None,
+                                freeze_authority: None,
+                            },
+                        );
+                        let _ = mint_info_tx.send(mint_event);
+                        debug!(
+                            mint = %pool_event.base_mint,
+                            "Emitted TokenMintInfo for pump.fun token (decimals=6, no RPC)"
+                        );
+                    }
                 }
 
                 // Convert to MarketEvent::PoolCreated

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -33,7 +33,7 @@ use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
-use ironcrab::config::{Config, WalletTrackerCfg};
+use ironcrab::config::{Config, MarketDataGeyserCfg, WalletTrackerCfg};
 use ironcrab::ipc::{
     BinData, ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, ControlRequest,
     ControlRequestKind, ControlResponse, ControlResponseStatus, DexPoolReadiness, ExecutionResult,
@@ -49,18 +49,19 @@ use ironcrab::ipc::{
 };
 use ironcrab::metrics::{
     dec_market_data_account_publish_queue_depth, dec_market_data_account_worker_queue_depth,
-    inc_market_data_account_publish_queue_depth, inc_market_data_account_worker_queue_depth,
-    market_data_bump_geyser_head_slot, record_market_data_account_broadcast_lagged,
-    record_market_data_account_channel_lag_ms, record_market_data_account_early_drop_total,
-    record_market_data_account_handler_duration_us,
+    geyser_metrics_inc_tracked_evicted, geyser_metrics_set_subscription_accounts,
+    geyser_metrics_set_tracked_pinned_accounts, inc_market_data_account_publish_queue_depth,
+    inc_market_data_account_worker_queue_depth, market_data_bump_geyser_head_slot,
+    record_market_data_account_broadcast_lagged, record_market_data_account_channel_lag_ms,
+    record_market_data_account_early_drop_total, record_market_data_account_handler_duration_us,
     record_market_data_bonding_to_trade_slot_delta_slots,
     record_market_data_geyser_to_publish_on_success,
     record_market_data_trade_after_bonding_publish_ms, record_market_data_tx_broadcast_lagged,
     record_market_data_tx_channel_lag_ms, serve_metrics,
     set_market_data_account_broadcast_queue_depth, set_market_data_tx_broadcast_queue_depth,
     set_readiness_control_sub_active, set_readiness_mode, set_readiness_nats_connected,
-    update_readiness_market_data_current, wall_clock_unix_ms_now, MarketDataLatencySegment,
-    MetricsComponent, MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS,
+    update_readiness_market_data_current, wall_clock_unix_ms_now, GeyserTrackedEvictKind,
+    MarketDataLatencySegment, MetricsComponent, MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS,
     MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS, MARKET_EVENTS_MOMENTUM_FANOUT_PUBLISHED_TOTAL,
     MARKET_EVENTS_PUBLISHED_TOTAL, MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL,
     NATS_MESSAGES_PUBLISHED_TOTAL, POOLS_TRACKED_GAUGE,
@@ -567,6 +568,60 @@ fn pump_amm_control_response_for_ensure_publish(
     (ControlResponseStatus::Ok, None)
 }
 
+/// PR-B: explicit Geyser account subscription / LRU (also loaded from `[market_data_geyser]` in config.toml).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // MomentumActive wired in PR-D
+enum GeyserPinReason {
+    /// Wallet bootstrap / execution-result mint tracking — never LRU-evicted.
+    Wallet,
+    /// Momentum active pool (PR-D will populate); never LRU-evicted.
+    MomentumActive,
+}
+
+#[derive(Debug, Clone)]
+struct MintTrackInfo {
+    last_used_at: Instant,
+    pinned: bool,
+    pin: Option<GeyserPinReason>,
+}
+
+impl Default for MintTrackInfo {
+    fn default() -> Self {
+        Self {
+            last_used_at: Instant::now(),
+            pinned: false,
+            pin: None,
+        }
+    }
+}
+
+/// PR-B stub: future NATS-driven active pool pins (PR-D). API is live for unit tests.
+#[derive(Debug)]
+struct ActivePoolSet {
+    pairs: parking_lot::RwLock<std::collections::HashSet<(Pubkey, Pubkey)>>,
+}
+
+#[allow(dead_code)] // pin/unpin used by PR-D and `pr_b_geyser_tracking_tests` (clippy sees bin without tests)
+impl ActivePoolSet {
+    fn new() -> Self {
+        Self {
+            pairs: parking_lot::RwLock::new(std::collections::HashSet::new()),
+        }
+    }
+
+    fn pin_pool(&self, mint: Pubkey, pool: Pubkey) {
+        self.pairs.write().insert((mint, pool));
+    }
+
+    fn unpin_pool(&self, mint: Pubkey, pool: Pubkey) {
+        self.pairs.write().remove(&(mint, pool));
+    }
+
+    fn is_pinned(&self, mint: Pubkey, pool: Pubkey) -> bool {
+        self.pairs.read().contains(&(mint, pool))
+    }
+}
+
 /// Market data configuration (hot-reloadable via NATS)
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
@@ -587,10 +642,15 @@ struct MarketDataConfig {
     enable_meteora_cpmm: bool,
     /// Max events per second rate limit. Default: 10000
     max_events_per_sec: u32,
+    /// PR-B: max combined explicit Geyser accounts (mints + vaults + bin arrays + wallet).
+    max_tracked_accounts: usize,
+    /// PR-B: full Geyser reconnect when combined explicit accounts exceed this threshold.
+    geyser_full_reconnect_threshold: usize,
 }
 
 impl Default for MarketDataConfig {
     fn default() -> Self {
+        let g = MarketDataGeyserCfg::default();
         Self {
             enable_raydium: true,
             enable_raydium_cpmm: true,
@@ -600,6 +660,8 @@ impl Default for MarketDataConfig {
             enable_meteora_dlmm: true,
             enable_meteora_cpmm: true,
             max_events_per_sec: 10_000,
+            max_tracked_accounts: g.max_tracked_accounts,
+            geyser_full_reconnect_threshold: g.geyser_full_reconnect_threshold,
         }
     }
 }
@@ -714,8 +776,11 @@ struct MarketDataContext {
     priority_fee_tracker: Arc<PriorityFeeTracker>,
 
     /// Tracked token mints for mint-authority/freeze-authority metadata.
-    tracked_mints: parking_lot::RwLock<std::collections::HashSet<Pubkey>>,
+    tracked_mints: parking_lot::RwLock<std::collections::HashMap<Pubkey, MintTrackInfo>>,
     tracked_mints_tx: watch::Sender<Vec<Pubkey>>,
+
+    /// PR-B: optional momentum active pool pins (empty until PR-D NATS wiring).
+    active_pool_set: Arc<ActivePoolSet>,
 
     /// Known pump_amm pools (already seen first trade).
     /// We emit PoolCreated + DexPoolAccounts on FIRST trade, then just DexPoolAccounts on subsequent trades.
@@ -880,6 +945,11 @@ struct VaultInfo {
     is_base_vault: bool,
     /// Last known balance (for delta detection)
     last_balance: std::sync::atomic::AtomicU64,
+    /// PR-B: LRU ordering for explicit Geyser subscription caps.
+    last_used_at: Instant,
+    /// PR-B: pinned vaults are never evicted from explicit Geyser filters.
+    pinned: bool,
+    pin: Option<GeyserPinReason>,
     // =========================================================================
     // DLMM-specific fields (Option D: Bin Array Traversierung)
     // =========================================================================
@@ -900,6 +970,9 @@ impl Clone for VaultInfo {
             last_balance: std::sync::atomic::AtomicU64::new(
                 self.last_balance.load(std::sync::atomic::Ordering::Relaxed),
             ),
+            last_used_at: self.last_used_at,
+            pinned: self.pinned,
+            pin: self.pin,
             active_id: self.active_id,
             bin_step: self.bin_step,
         }
@@ -914,6 +987,10 @@ struct BinArrayInfo {
     bin_array_index: i64,
     /// Bin step from pool (needed for price calculation)
     bin_step: u16,
+    last_used_at: Instant,
+    pinned: bool,
+    #[allow(dead_code)]
+    pin: Option<GeyserPinReason>,
 }
 
 impl MarketDataContext {
@@ -922,6 +999,572 @@ impl MarketDataContext {
             .event_counter
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         format!("evt-{}-{:06}", &self.run_id[..8], n)
+    }
+
+    fn wallet_tracks_mint_for_geyser(&self, mint: &Pubkey) -> bool {
+        self.tracked_wallet_mint_decimals.read().contains_key(mint)
+    }
+
+    /// PR-B: explicit vault/bin-array/mint Geyser filters — not on cold-path pool-state alone.
+    fn admit_geyser_explicit_pool_assets(
+        &self,
+        pool: Pubkey,
+        base_mint: Pubkey,
+        quote_mint: Pubkey,
+    ) -> bool {
+        self.active_pool_set.is_pinned(base_mint, pool)
+            || self.active_pool_set.is_pinned(quote_mint, pool)
+            || self.wallet_tracks_mint_for_geyser(&base_mint)
+            || self.wallet_tracks_mint_for_geyser(&quote_mint)
+    }
+
+    fn count_geyser_wallet_explicit_accounts(&self) -> usize {
+        if self.tracked_wallet.is_some() {
+            2 + self.tracked_wallet_token_accounts.read().len()
+        } else {
+            0
+        }
+    }
+
+    fn combined_geyser_explicit_accounts(&self) -> usize {
+        self.tracked_vaults.read().len()
+            + self.tracked_bin_arrays.read().len()
+            + self.tracked_mints.read().len()
+            + self.count_geyser_wallet_explicit_accounts()
+    }
+
+    fn refresh_geyser_pins_gauge(&self) {
+        let mut pinned: usize = 0;
+        pinned += self
+            .tracked_mints
+            .read()
+            .values()
+            .filter(|m| m.pinned)
+            .count();
+        pinned += self
+            .tracked_vaults
+            .read()
+            .values()
+            .filter(|v| v.pinned)
+            .count();
+        pinned += self
+            .tracked_bin_arrays
+            .read()
+            .values()
+            .filter(|b| b.pinned)
+            .count();
+        // Wallet ATAs are always subscribed and treated as pinned for ops visibility.
+        pinned += self.count_geyser_wallet_explicit_accounts();
+        geyser_metrics_set_tracked_pinned_accounts(pinned);
+    }
+
+    /// PR-B: LRU eviction when explicit combined accounts exceed `max_tracked_accounts`.
+    /// Never evicts pinned rows; never evicts wallet subscription keys (they are not in these maps).
+    fn evict_geyser_unpinned_lru_to_cap(&self) {
+        let cap = self.config.read().max_tracked_accounts;
+        let run_id = self.run_id.clone();
+        loop {
+            if self.combined_geyser_explicit_accounts() <= cap {
+                break;
+            }
+
+            #[derive(Clone, Copy)]
+            enum EvKind {
+                Vault,
+                Bin,
+                Mint,
+            }
+            let mut best: Option<(Instant, EvKind, Pubkey)> = None;
+
+            for (pk, v) in self.tracked_vaults.read().iter() {
+                if v.pinned {
+                    continue;
+                }
+                let cand = (v.last_used_at, EvKind::Vault, *pk);
+                best = Some(match best {
+                    None => cand,
+                    Some(b) if cand.0 < b.0 => cand,
+                    Some(b) => b,
+                });
+            }
+            for (pk, b) in self.tracked_bin_arrays.read().iter() {
+                if b.pinned {
+                    continue;
+                }
+                let cand = (b.last_used_at, EvKind::Bin, *pk);
+                best = Some(match best {
+                    None => cand,
+                    Some(x) if cand.0 < x.0 => cand,
+                    Some(x) => x,
+                });
+            }
+            for (pk, m) in self.tracked_mints.read().iter() {
+                if m.pinned {
+                    continue;
+                }
+                let cand = (m.last_used_at, EvKind::Mint, *pk);
+                best = Some(match best {
+                    None => cand,
+                    Some(x) if cand.0 < x.0 => cand,
+                    Some(x) => x,
+                });
+            }
+
+            let Some((oldest_at, kind, pubkey)) = best else {
+                error!(
+                    run_id = %run_id,
+                    cap,
+                    combined = self.combined_geyser_explicit_accounts(),
+                    "geyser_evict: cannot reach cap — only pinned explicit accounts remain (no LRU candidates)"
+                );
+                break;
+            };
+
+            match kind {
+                EvKind::Vault => {
+                    if let Some(v) = self.tracked_vaults.write().remove(&pubkey) {
+                        geyser_metrics_inc_tracked_evicted(GeyserTrackedEvictKind::Vault);
+                        info!(
+                            run_id = %run_id,
+                            pool = %v.pool_address,
+                            mint = %v.base_mint,
+                            vault = %pubkey,
+                            reason = "lru_cap",
+                            oldest_age_ms = ?oldest_at.elapsed().as_millis(),
+                            "geyser_evicted"
+                        );
+                    }
+                }
+                EvKind::Bin => {
+                    if let Some(b) = self.tracked_bin_arrays.write().remove(&pubkey) {
+                        geyser_metrics_inc_tracked_evicted(GeyserTrackedEvictKind::BinArray);
+                        info!(
+                            run_id = %run_id,
+                            pool = %b.pool_address,
+                            bin_array = %pubkey,
+                            reason = "lru_cap",
+                            "geyser_evicted"
+                        );
+                    }
+                }
+                EvKind::Mint => {
+                    if self.tracked_mints.write().remove(&pubkey).is_some() {
+                        geyser_metrics_inc_tracked_evicted(GeyserTrackedEvictKind::Mint);
+                        info!(
+                            run_id = %run_id,
+                            mint = %pubkey,
+                            reason = "lru_cap",
+                            "geyser_evicted"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn send_tracked_mints_geyser(&self) {
+        self.evict_geyser_unpinned_lru_to_cap();
+        let keys: Vec<Pubkey> = self.tracked_mints.read().keys().copied().collect();
+        let _ = self.tracked_mints_tx.send(keys);
+        self.refresh_geyser_pins_gauge();
+    }
+
+    fn send_tracked_vaults_geyser(&self) {
+        self.evict_geyser_unpinned_lru_to_cap();
+        let keys: Vec<Pubkey> = self.tracked_vaults.read().keys().copied().collect();
+        let _ = self.tracked_vaults_tx.send(keys);
+        self.refresh_geyser_pins_gauge();
+    }
+
+    fn send_tracked_bin_arrays_geyser(&self) {
+        self.evict_geyser_unpinned_lru_to_cap();
+        let keys: Vec<Pubkey> = self.tracked_bin_arrays.read().keys().copied().collect();
+        let _ = self.tracked_bin_arrays_tx.send(keys);
+        self.refresh_geyser_pins_gauge();
+    }
+
+    /// Track mint pubkey for Geyser `TokenMintInfo` / metadata. Returns `true` if pubkey set changed.
+    fn track_mint_for_geyser_metadata(&self, mint: Pubkey, pin: Option<GeyserPinReason>) -> bool {
+        let now = Instant::now();
+        let pinned = pin.is_some();
+        let mut map = self.tracked_mints.write();
+        use std::collections::hash_map::Entry;
+        match map.entry(mint) {
+            Entry::Vacant(e) => {
+                e.insert(MintTrackInfo {
+                    last_used_at: now,
+                    pinned,
+                    pin,
+                });
+                true
+            }
+            Entry::Occupied(mut e) => {
+                let v = e.get_mut();
+                v.last_used_at = now;
+                if pinned {
+                    v.pinned = true;
+                    v.pin = pin;
+                }
+                false
+            }
+        }
+    }
+
+    fn touch_tracked_vault_pubkey(&self, vault: &Pubkey) {
+        let now = Instant::now();
+        if let Some(v) = self.tracked_vaults.write().get_mut(vault) {
+            v.last_used_at = now;
+        }
+    }
+
+    fn touch_tracked_bin_array_pubkey(&self, pda: &Pubkey) {
+        let now = Instant::now();
+        if let Some(b) = self.tracked_bin_arrays.write().get_mut(pda) {
+            b.last_used_at = now;
+        }
+    }
+
+    fn touch_tracked_pool_vaults_and_bins(&self, pool: Pubkey) {
+        let now = Instant::now();
+        {
+            let mut vs = self.tracked_vaults.write();
+            for v in vs.values_mut() {
+                if v.pool_address == pool {
+                    v.last_used_at = now;
+                }
+            }
+        }
+        {
+            let mut bs = self.tracked_bin_arrays.write();
+            for b in bs.values_mut() {
+                if b.pool_address == pool {
+                    b.last_used_at = now;
+                }
+            }
+        }
+    }
+
+    /// PR-B: after a parsed swap trade, subscribe reserve vaults / DLMM bin arrays from MASTER cache.
+    fn register_geyser_reserves_after_trade(&self, pool: Pubkey) {
+        let now = Instant::now();
+        let enable_dlmm = self.config.read().enable_meteora_dlmm;
+        let enable_meteora_cpmm = self.config.read().enable_meteora_cpmm;
+        let Some(state) = self.live_pool_cache.get(&pool) else {
+            return;
+        };
+
+        let mut vaults_changed = false;
+        let mut bins_changed = false;
+
+        match &state {
+            CachedPoolState::RaydiumCpmm(s) => {
+                let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+                let (base_mint_v, quote_mint_v, coin_vault, pc_vault) = if s.token_1_mint == sol {
+                    (
+                        s.token_0_mint,
+                        s.token_1_mint,
+                        s.token_0_vault,
+                        s.token_1_vault,
+                    )
+                } else if s.token_0_mint == sol {
+                    (
+                        s.token_1_mint,
+                        s.token_0_mint,
+                        s.token_1_vault,
+                        s.token_0_vault,
+                    )
+                } else {
+                    (
+                        s.token_0_mint,
+                        s.token_1_mint,
+                        s.token_0_vault,
+                        s.token_1_vault,
+                    )
+                };
+                let dex_str = "raydium_cpmm".to_string();
+                {
+                    let mut vaults = self.tracked_vaults.write();
+                    vaults.entry(coin_vault).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: pool,
+                            dex: dex_str.clone(),
+                            base_mint: base_mint_v,
+                            quote_mint: quote_mint_v,
+                            is_base_vault: true,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: now,
+                            pinned: false,
+                            pin: None,
+                            active_id: None,
+                            bin_step: None,
+                        }
+                    });
+                    vaults.entry(pc_vault).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: pool,
+                            dex: dex_str,
+                            base_mint: base_mint_v,
+                            quote_mint: quote_mint_v,
+                            is_base_vault: false,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: now,
+                            pinned: false,
+                            pin: None,
+                            active_id: None,
+                            bin_step: None,
+                        }
+                    });
+                }
+            }
+            CachedPoolState::MeteoraCpmm(s) if enable_meteora_cpmm => {
+                let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+                let (base_mint_v, quote_mint_v, vault_base, vault_quote) = if s.token_1_mint == sol
+                {
+                    (
+                        s.token_0_mint,
+                        s.token_1_mint,
+                        s.token_0_vault,
+                        s.token_1_vault,
+                    )
+                } else if s.token_0_mint == sol {
+                    (
+                        s.token_1_mint,
+                        s.token_0_mint,
+                        s.token_1_vault,
+                        s.token_0_vault,
+                    )
+                } else {
+                    (
+                        s.token_0_mint,
+                        s.token_1_mint,
+                        s.token_0_vault,
+                        s.token_1_vault,
+                    )
+                };
+                let dex_str = "meteora_cpmm".to_string();
+                {
+                    let mut vaults = self.tracked_vaults.write();
+                    vaults.entry(vault_base).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: pool,
+                            dex: dex_str.clone(),
+                            base_mint: base_mint_v,
+                            quote_mint: quote_mint_v,
+                            is_base_vault: true,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: now,
+                            pinned: false,
+                            pin: None,
+                            active_id: None,
+                            bin_step: None,
+                        }
+                    });
+                    vaults.entry(vault_quote).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: pool,
+                            dex: dex_str,
+                            base_mint: base_mint_v,
+                            quote_mint: quote_mint_v,
+                            is_base_vault: false,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: now,
+                            pinned: false,
+                            pin: None,
+                            active_id: None,
+                            bin_step: None,
+                        }
+                    });
+                }
+            }
+            CachedPoolState::Meteora(s) if enable_dlmm => {
+                let dex_str = "meteora_dlmm".to_string();
+                {
+                    let mut vaults = self.tracked_vaults.write();
+                    vaults.entry(s.reserve_x).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: pool,
+                            dex: dex_str.clone(),
+                            base_mint: s.token_x_mint,
+                            quote_mint: s.token_y_mint,
+                            is_base_vault: true,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: now,
+                            pinned: false,
+                            pin: None,
+                            active_id: Some(s.active_id),
+                            bin_step: Some(s.bin_step),
+                        }
+                    });
+                    vaults.entry(s.reserve_y).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: pool,
+                            dex: dex_str,
+                            base_mint: s.token_x_mint,
+                            quote_mint: s.token_y_mint,
+                            is_base_vault: false,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: now,
+                            pinned: false,
+                            pin: None,
+                            active_id: Some(s.active_id),
+                            bin_step: Some(s.bin_step),
+                        }
+                    });
+                }
+                let active_id = s.active_id;
+                let active_array_index =
+                    MeteoraDlmmSwapBuilder::bin_id_to_bin_array_index(active_id);
+                let bin_step = s.bin_step;
+                {
+                    let mut bin_arrays = self.tracked_bin_arrays.write();
+                    for offset in -3i64..=3i64 {
+                        let index = active_array_index + offset;
+                        if let Ok(pda) = MeteoraDlmmSwapBuilder::derive_bin_array_pda(&pool, index)
+                        {
+                            bin_arrays.entry(pda).or_insert_with(|| {
+                                bins_changed = true;
+                                BinArrayInfo {
+                                    pool_address: pool,
+                                    bin_array_index: index,
+                                    bin_step,
+                                    last_used_at: now,
+                                    pinned: false,
+                                    pin: None,
+                                }
+                            });
+                        }
+                    }
+                }
+            }
+            CachedPoolState::PumpAmm(s) => {
+                let dex_str = "pump_amm".to_string();
+                {
+                    let mut vaults = self.tracked_vaults.write();
+                    vaults.entry(s.pool_base_token_account).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: pool,
+                            dex: dex_str.clone(),
+                            base_mint: s.base_mint,
+                            quote_mint: s.quote_mint,
+                            is_base_vault: true,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: now,
+                            pinned: false,
+                            pin: None,
+                            active_id: None,
+                            bin_step: None,
+                        }
+                    });
+                    vaults.entry(s.pool_quote_token_account).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: pool,
+                            dex: dex_str,
+                            base_mint: s.base_mint,
+                            quote_mint: s.quote_mint,
+                            is_base_vault: false,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: now,
+                            pinned: false,
+                            pin: None,
+                            active_id: None,
+                            bin_step: None,
+                        }
+                    });
+                }
+            }
+            CachedPoolState::Orca(s) => {
+                let dex_str = "orca".to_string();
+                {
+                    let mut vaults = self.tracked_vaults.write();
+                    vaults.entry(s.token_vault_a).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: pool,
+                            dex: dex_str.clone(),
+                            base_mint: s.token_mint_a,
+                            quote_mint: s.token_mint_b,
+                            is_base_vault: true,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: now,
+                            pinned: false,
+                            pin: None,
+                            active_id: None,
+                            bin_step: None,
+                        }
+                    });
+                    vaults.entry(s.token_vault_b).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: pool,
+                            dex: dex_str,
+                            base_mint: s.token_mint_a,
+                            quote_mint: s.token_mint_b,
+                            is_base_vault: false,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: now,
+                            pinned: false,
+                            pin: None,
+                            active_id: None,
+                            bin_step: None,
+                        }
+                    });
+                }
+            }
+            CachedPoolState::RaydiumAmm(s) => {
+                let dex_str = "raydium".to_string();
+                {
+                    let mut vaults = self.tracked_vaults.write();
+                    vaults.entry(s.coin_vault).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: pool,
+                            dex: dex_str.clone(),
+                            base_mint: s.base_mint,
+                            quote_mint: s.quote_mint,
+                            is_base_vault: true,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: now,
+                            pinned: false,
+                            pin: None,
+                            active_id: None,
+                            bin_step: None,
+                        }
+                    });
+                    vaults.entry(s.pc_vault).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: pool,
+                            dex: dex_str,
+                            base_mint: s.base_mint,
+                            quote_mint: s.quote_mint,
+                            is_base_vault: false,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: now,
+                            pinned: false,
+                            pin: None,
+                            active_id: None,
+                            bin_step: None,
+                        }
+                    });
+                }
+            }
+            _ => {}
+        }
+
+        if vaults_changed {
+            self.send_tracked_vaults_geyser();
+        }
+        if bins_changed {
+            self.send_tracked_bin_arrays_geyser();
+        }
     }
 
     /// P1: Apply config update from control-plane (Runtime Configuration via UI)
@@ -1003,6 +1646,32 @@ impl MarketDataContext {
                             info!(key = %key, new_value = %v, "Config updated");
                         } else {
                             rejected.push((key.clone(), "Must be 1-1000000".to_string()));
+                        }
+                    } else {
+                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
+                    }
+                }
+                "max_tracked_accounts" => {
+                    if let Some(v) = value.as_u64() {
+                        if (1000..=500_000).contains(&v) {
+                            config.max_tracked_accounts = v as usize;
+                            applied.push(key.clone());
+                            info!(key = %key, new_value = %v, "Config updated");
+                        } else {
+                            rejected.push((key.clone(), "Must be 1000-500000".to_string()));
+                        }
+                    } else {
+                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
+                    }
+                }
+                "geyser_full_reconnect_threshold" => {
+                    if let Some(v) = value.as_u64() {
+                        if (1000..=500_000).contains(&v) {
+                            config.geyser_full_reconnect_threshold = v as usize;
+                            applied.push(key.clone());
+                            info!(key = %key, new_value = %v, "Config updated");
+                        } else {
+                            rejected.push((key.clone(), "Must be 1000-500000".to_string()));
                         }
                     } else {
                         rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
@@ -4704,12 +5373,8 @@ async fn publish_wallet_snapshot(
         }
 
         // Ensure mint is tracked so Geyser can publish TokenMintInfo later (no RPC here).
-        {
-            let mut tracked = ctx.tracked_mints.write();
-            if tracked.insert(*mint) {
-                let updated: Vec<Pubkey> = tracked.iter().copied().collect();
-                let _ = ctx.tracked_mints_tx.send(updated);
-            }
+        if ctx.track_mint_for_geyser_metadata(*mint, Some(GeyserPinReason::Wallet)) {
+            ctx.send_tracked_mints_geyser();
         }
 
         let mint_str = mint.to_string();
@@ -5128,29 +5793,41 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let run_id = Uuid::new_v4().to_string();
 
-    let helius_rpc: Option<Arc<SolanaRpc>> = match Config::load(&args.config) {
-        Ok(cfg) => cfg
-            .solana
-            .helius_rpc_url
-            .as_ref()
-            .map(|u| u.trim())
-            .filter(|u| !u.is_empty())
-            .map(|url| {
-                info!(
-                    helius_rpc_host = %url.split('/').nth(2).unwrap_or("?"),
-                    "Loaded solana.helius_rpc_url for bounded PumpSwap TX-history fallback (Cold Path only)"
-                );
-                Arc::new(SolanaRpc::new(url))
-            }),
+    let file_config: Option<Config> = match Config::load(&args.config) {
+        Ok(c) => Some(c),
         Err(e) => {
             warn!(
                 error = %e,
                 config_path = %args.config.display(),
-                "Could not load config.toml; Helius PumpSwap fallback disabled (optional)"
+                "Could not load config.toml; Helius PumpSwap fallback + market_data_geyser defaults (optional)"
             );
             None
         }
     };
+
+    let helius_rpc: Option<Arc<SolanaRpc>> = file_config
+        .as_ref()
+        .and_then(|cfg| {
+            cfg.solana
+                .helius_rpc_url
+                .as_ref()
+                .map(|u| u.trim())
+                .filter(|u| !u.is_empty())
+                .map(|url| {
+                    info!(
+                        helius_rpc_host = %url.split('/').nth(2).unwrap_or("?"),
+                        "Loaded solana.helius_rpc_url for bounded PumpSwap TX-history fallback (Cold Path only)"
+                    );
+                    Arc::new(SolanaRpc::new(url))
+                })
+        });
+
+    let mut market_data_config = MarketDataConfig::default();
+    if let Some(ref c) = file_config {
+        market_data_config.max_tracked_accounts = c.market_data_geyser.max_tracked_accounts;
+        market_data_config.geyser_full_reconnect_threshold =
+            c.market_data_geyser.geyser_full_reconnect_threshold;
+    }
 
     let wallet_env = std::env::var("IRONCRAB_WALLET_PUBKEY").ok();
     info!(
@@ -5289,14 +5966,15 @@ async fn main() -> Result<()> {
 
     let ctx = Arc::new(MarketDataContext {
         run_id: run_id.clone(),
-        config: parking_lot::RwLock::new(MarketDataConfig::default()),
+        config: parking_lot::RwLock::new(market_data_config),
         nats,
         jsonl_writer,
         event_counter: std::sync::atomic::AtomicU64::new(0),
         wallet_tracker,
         priority_fee_tracker: Arc::new(PriorityFeeTracker::new()),
-        tracked_mints: parking_lot::RwLock::new(std::collections::HashSet::new()),
+        tracked_mints: parking_lot::RwLock::new(std::collections::HashMap::new()),
         tracked_mints_tx,
+        active_pool_set: Arc::new(ActivePoolSet::new()),
         known_pump_amm_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
         known_trade_dex_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
         tracked_vaults: parking_lot::RwLock::new(std::collections::HashMap::new()),
@@ -6290,7 +6968,7 @@ fn account_geyser_update_might_be_relevant(
             return true;
         }
     }
-    if ctx.tracked_mints.read().contains(&u.pubkey) {
+    if ctx.tracked_mints.read().contains_key(&u.pubkey) {
         return true;
     }
     if ctx.tracked_vaults.read().contains_key(&u.pubkey) {
@@ -6631,7 +7309,10 @@ async fn handle_geyser_account(
     // Tracked mint updates (Token mint authority/freeze info)
     if (account_update.owner.to_bytes() == spl_token::ID.to_bytes()
         || account_update.owner.to_bytes() == spl_token_2022::ID.to_bytes())
-        && ctx.tracked_mints.read().contains(&account_update.pubkey)
+        && ctx
+            .tracked_mints
+            .read()
+            .contains_key(&account_update.pubkey)
     {
         if let Some((decimals, supply, mint_authority, freeze_authority)) =
             try_parse_mint_account(&account_update.owner, &account_update.data)
@@ -6724,6 +7405,7 @@ async fn handle_geyser_account(
                     .last_balance
                     .swap(balance, std::sync::atomic::Ordering::Relaxed);
                 if balance != prev_balance {
+                    ctx.touch_tracked_vault_pubkey(&account_update.pubkey);
                     // We need both vault balances to emit a complete PoolStateUpdate.
                     // For now, emit partial updates - consumers should merge base+quote.
                     // Future: Track both vaults and emit only when both are known.
@@ -6940,6 +7622,7 @@ async fn handle_geyser_account(
             .get(&account_update.pubkey)
             .cloned();
         if let Some(bin_array_info) = bin_array_info_opt {
+            ctx.touch_tracked_bin_array_pubkey(&account_update.pubkey);
             // Parse bin array to extract liquidity distribution
             match BinArray::parse(&account_update.data, bin_array_info.bin_step) {
                 Ok(parsed_array) => {
@@ -7058,38 +7741,49 @@ async fn handle_geyser_account(
             };
             let dex_str = "raydium_cpmm".to_string();
             let mut vaults_changed = false;
-            {
-                let mut vaults = ctx.tracked_vaults.write();
-                vaults.entry(coin_vault).or_insert_with(|| {
-                    vaults_changed = true;
-                    VaultInfo {
-                        pool_address: account_update.pubkey,
-                        dex: dex_str.clone(),
-                        base_mint: base_mint_v,
-                        quote_mint: quote_mint_v,
-                        is_base_vault: true,
-                        last_balance: std::sync::atomic::AtomicU64::new(0),
-                        active_id: None,
-                        bin_step: None,
-                    }
-                });
-                vaults.entry(pc_vault).or_insert_with(|| {
-                    vaults_changed = true;
-                    VaultInfo {
-                        pool_address: account_update.pubkey,
-                        dex: dex_str,
-                        base_mint: base_mint_v,
-                        quote_mint: quote_mint_v,
-                        is_base_vault: false,
-                        last_balance: std::sync::atomic::AtomicU64::new(0),
-                        active_id: None,
-                        bin_step: None,
-                    }
-                });
+            if ctx.admit_geyser_explicit_pool_assets(
+                account_update.pubkey,
+                base_mint_v,
+                quote_mint_v,
+            ) {
+                {
+                    let mut vaults = ctx.tracked_vaults.write();
+                    vaults.entry(coin_vault).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: account_update.pubkey,
+                            dex: dex_str.clone(),
+                            base_mint: base_mint_v,
+                            quote_mint: quote_mint_v,
+                            is_base_vault: true,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: Instant::now(),
+                            pinned: false,
+                            pin: None,
+                            active_id: None,
+                            bin_step: None,
+                        }
+                    });
+                    vaults.entry(pc_vault).or_insert_with(|| {
+                        vaults_changed = true;
+                        VaultInfo {
+                            pool_address: account_update.pubkey,
+                            dex: dex_str,
+                            base_mint: base_mint_v,
+                            quote_mint: quote_mint_v,
+                            is_base_vault: false,
+                            last_balance: std::sync::atomic::AtomicU64::new(0),
+                            last_used_at: Instant::now(),
+                            pinned: false,
+                            pin: None,
+                            active_id: None,
+                            bin_step: None,
+                        }
+                    });
+                }
             }
             if vaults_changed {
-                let vault_list: Vec<Pubkey> = ctx.tracked_vaults.read().keys().copied().collect();
-                let _ = ctx.tracked_vaults_tx.send(vault_list);
+                ctx.send_tracked_vaults_geyser();
                 debug!(
                     pool = %account_update.pubkey,
                     coin_vault = %coin_vault,
@@ -7128,39 +7822,49 @@ async fn handle_geyser_account(
                 };
                 let dex_str = "meteora_cpmm".to_string();
                 let mut vaults_changed = false;
-                {
-                    let mut vaults = ctx.tracked_vaults.write();
-                    vaults.entry(vault_base).or_insert_with(|| {
-                        vaults_changed = true;
-                        VaultInfo {
-                            pool_address: account_update.pubkey,
-                            dex: dex_str.clone(),
-                            base_mint: base_mint_v,
-                            quote_mint: quote_mint_v,
-                            is_base_vault: true,
-                            last_balance: std::sync::atomic::AtomicU64::new(0),
-                            active_id: None,
-                            bin_step: None,
-                        }
-                    });
-                    vaults.entry(vault_quote).or_insert_with(|| {
-                        vaults_changed = true;
-                        VaultInfo {
-                            pool_address: account_update.pubkey,
-                            dex: dex_str,
-                            base_mint: base_mint_v,
-                            quote_mint: quote_mint_v,
-                            is_base_vault: false,
-                            last_balance: std::sync::atomic::AtomicU64::new(0),
-                            active_id: None,
-                            bin_step: None,
-                        }
-                    });
+                if ctx.admit_geyser_explicit_pool_assets(
+                    account_update.pubkey,
+                    base_mint_v,
+                    quote_mint_v,
+                ) {
+                    {
+                        let mut vaults = ctx.tracked_vaults.write();
+                        vaults.entry(vault_base).or_insert_with(|| {
+                            vaults_changed = true;
+                            VaultInfo {
+                                pool_address: account_update.pubkey,
+                                dex: dex_str.clone(),
+                                base_mint: base_mint_v,
+                                quote_mint: quote_mint_v,
+                                is_base_vault: true,
+                                last_balance: std::sync::atomic::AtomicU64::new(0),
+                                last_used_at: Instant::now(),
+                                pinned: false,
+                                pin: None,
+                                active_id: None,
+                                bin_step: None,
+                            }
+                        });
+                        vaults.entry(vault_quote).or_insert_with(|| {
+                            vaults_changed = true;
+                            VaultInfo {
+                                pool_address: account_update.pubkey,
+                                dex: dex_str,
+                                base_mint: base_mint_v,
+                                quote_mint: quote_mint_v,
+                                is_base_vault: false,
+                                last_balance: std::sync::atomic::AtomicU64::new(0),
+                                last_used_at: Instant::now(),
+                                pinned: false,
+                                pin: None,
+                                active_id: None,
+                                bin_step: None,
+                            }
+                        });
+                    }
                 }
                 if vaults_changed {
-                    let vault_list: Vec<Pubkey> =
-                        ctx.tracked_vaults.read().keys().copied().collect();
-                    let _ = ctx.tracked_vaults_tx.send(vault_list);
+                    ctx.send_tracked_vaults_geyser();
                     debug!(
                         pool = %account_update.pubkey,
                         vault_base = %vault_base,
@@ -7176,39 +7880,49 @@ async fn handle_geyser_account(
             if let CachedPoolState::Meteora(s) = &cached_state {
                 let dex_str = "meteora_dlmm".to_string();
                 let mut vaults_changed = false;
-                {
-                    let mut vaults = ctx.tracked_vaults.write();
-                    vaults.entry(s.reserve_x).or_insert_with(|| {
-                        vaults_changed = true;
-                        VaultInfo {
-                            pool_address: account_update.pubkey,
-                            dex: dex_str.clone(),
-                            base_mint: s.token_x_mint,
-                            quote_mint: s.token_y_mint,
-                            is_base_vault: true,
-                            last_balance: std::sync::atomic::AtomicU64::new(0),
-                            active_id: Some(s.active_id),
-                            bin_step: Some(s.bin_step),
-                        }
-                    });
-                    vaults.entry(s.reserve_y).or_insert_with(|| {
-                        vaults_changed = true;
-                        VaultInfo {
-                            pool_address: account_update.pubkey,
-                            dex: dex_str,
-                            base_mint: s.token_x_mint,
-                            quote_mint: s.token_y_mint,
-                            is_base_vault: false,
-                            last_balance: std::sync::atomic::AtomicU64::new(0),
-                            active_id: Some(s.active_id),
-                            bin_step: Some(s.bin_step),
-                        }
-                    });
+                if ctx.admit_geyser_explicit_pool_assets(
+                    account_update.pubkey,
+                    s.token_x_mint,
+                    s.token_y_mint,
+                ) {
+                    {
+                        let mut vaults = ctx.tracked_vaults.write();
+                        vaults.entry(s.reserve_x).or_insert_with(|| {
+                            vaults_changed = true;
+                            VaultInfo {
+                                pool_address: account_update.pubkey,
+                                dex: dex_str.clone(),
+                                base_mint: s.token_x_mint,
+                                quote_mint: s.token_y_mint,
+                                is_base_vault: true,
+                                last_balance: std::sync::atomic::AtomicU64::new(0),
+                                last_used_at: Instant::now(),
+                                pinned: false,
+                                pin: None,
+                                active_id: Some(s.active_id),
+                                bin_step: Some(s.bin_step),
+                            }
+                        });
+                        vaults.entry(s.reserve_y).or_insert_with(|| {
+                            vaults_changed = true;
+                            VaultInfo {
+                                pool_address: account_update.pubkey,
+                                dex: dex_str,
+                                base_mint: s.token_x_mint,
+                                quote_mint: s.token_y_mint,
+                                is_base_vault: false,
+                                last_balance: std::sync::atomic::AtomicU64::new(0),
+                                last_used_at: Instant::now(),
+                                pinned: false,
+                                pin: None,
+                                active_id: Some(s.active_id),
+                                bin_step: Some(s.bin_step),
+                            }
+                        });
+                    }
                 }
                 if vaults_changed {
-                    let vault_list: Vec<Pubkey> =
-                        ctx.tracked_vaults.read().keys().copied().collect();
-                    let _ = ctx.tracked_vaults_tx.send(vault_list);
+                    ctx.send_tracked_vaults_geyser();
                     debug!(
                         pool = %account_update.pubkey,
                         reserve_x = %s.reserve_x,
@@ -7418,39 +8132,49 @@ async fn handle_geyser_account(
                 {
                     let dex_str = "pump_amm".to_string();
                     let mut vaults_changed = false;
-                    {
-                        let mut vaults = ctx.tracked_vaults.write();
-                        vaults.entry(s.pool_base_token_account).or_insert_with(|| {
-                            vaults_changed = true;
-                            VaultInfo {
-                                pool_address: account_update.pubkey,
-                                dex: dex_str.clone(),
-                                base_mint: s.base_mint,
-                                quote_mint: s.quote_mint,
-                                is_base_vault: true,
-                                last_balance: std::sync::atomic::AtomicU64::new(0),
-                                active_id: None,
-                                bin_step: None,
-                            }
-                        });
-                        vaults.entry(s.pool_quote_token_account).or_insert_with(|| {
-                            vaults_changed = true;
-                            VaultInfo {
-                                pool_address: account_update.pubkey,
-                                dex: dex_str,
-                                base_mint: s.base_mint,
-                                quote_mint: s.quote_mint,
-                                is_base_vault: false,
-                                last_balance: std::sync::atomic::AtomicU64::new(0),
-                                active_id: None,
-                                bin_step: None,
-                            }
-                        });
+                    if ctx.admit_geyser_explicit_pool_assets(
+                        account_update.pubkey,
+                        s.base_mint,
+                        s.quote_mint,
+                    ) {
+                        {
+                            let mut vaults = ctx.tracked_vaults.write();
+                            vaults.entry(s.pool_base_token_account).or_insert_with(|| {
+                                vaults_changed = true;
+                                VaultInfo {
+                                    pool_address: account_update.pubkey,
+                                    dex: dex_str.clone(),
+                                    base_mint: s.base_mint,
+                                    quote_mint: s.quote_mint,
+                                    is_base_vault: true,
+                                    last_balance: std::sync::atomic::AtomicU64::new(0),
+                                    last_used_at: Instant::now(),
+                                    pinned: false,
+                                    pin: None,
+                                    active_id: None,
+                                    bin_step: None,
+                                }
+                            });
+                            vaults.entry(s.pool_quote_token_account).or_insert_with(|| {
+                                vaults_changed = true;
+                                VaultInfo {
+                                    pool_address: account_update.pubkey,
+                                    dex: dex_str,
+                                    base_mint: s.base_mint,
+                                    quote_mint: s.quote_mint,
+                                    is_base_vault: false,
+                                    last_balance: std::sync::atomic::AtomicU64::new(0),
+                                    last_used_at: Instant::now(),
+                                    pinned: false,
+                                    pin: None,
+                                    active_id: None,
+                                    bin_step: None,
+                                }
+                            });
+                        }
                     }
                     if vaults_changed {
-                        let vault_list: Vec<Pubkey> =
-                            ctx.tracked_vaults.read().keys().copied().collect();
-                        let _ = ctx.tracked_vaults_tx.send(vault_list);
+                        ctx.send_tracked_vaults_geyser();
                         debug!(
                             pool = %account_update.pubkey,
                             base_vault = %s.pool_base_token_account,
@@ -8104,18 +8828,13 @@ async fn handle_geyser_transaction(
             ParsedDexEvent::BondingCurveUpdate { .. } => None, // Handled separately in account update
         };
         if let Some((mint, dex_opt)) = mint_and_dex {
-            let mut tracked = ctx.tracked_mints.write();
-            if tracked.insert(mint) {
-                // Push updated list to geyser listener (resubscribe)
-                let updated: Vec<Pubkey> = tracked.iter().copied().collect();
-                let _ = ctx.tracked_mints_tx.send(updated);
-
-                // Geyser delivers mint accounts via AccountsDB snapshot when subscribed.
-                // tracked_mints_tx already sent above → GeyserListener will resubscribe.
+            let is_new = ctx.track_mint_for_geyser_metadata(mint, None);
+            if is_new {
+                ctx.send_tracked_mints_geyser();
                 debug!(
                     mint = %mint,
                     dex = ?dex_opt,
-                    "New mint tracked, waiting for Geyser mint account delivery"
+                    "New mint tracked for Geyser metadata, waiting for mint account delivery"
                 );
             }
         }
@@ -8144,6 +8863,12 @@ async fn handle_geyser_transaction(
             }
             _ => {}
         }
+    }
+
+    // PR-B: qualifying swap trade — refresh LRU timestamps and register reserve vaults / DLMM bins.
+    if let Some(ParsedDexEvent::Trade { pool_address, .. }) = parsed_event.as_ref() {
+        ctx.touch_tracked_pool_vaults_and_bins(*pool_address);
+        ctx.register_geyser_reserves_after_trade(*pool_address);
     }
 
     // Pump.fun: propagate creator/dev wallet so strategy can build deterministic intents.
@@ -8786,6 +9511,7 @@ async fn run_geyser_loop(
         let mut bin_arrays_rx = tracked_bin_arrays_rx;
         let mut wallet_rx = tracked_wallet_rx;
         let combined_tx = combined_tracked_tx;
+        let ctx_merge = Arc::clone(&ctx);
         tokio::spawn(async move {
             loop {
                 tokio::select! {
@@ -8805,17 +9531,22 @@ async fn run_geyser_loop(
                 combined.extend(wallet_accounts);
                 combined.sort();
                 combined.dedup();
+                let n = combined.len();
                 let _ = combined_tx.send(combined);
+                geyser_metrics_set_subscription_accounts(n);
+                ctx_merge.refresh_geyser_pins_gauge();
             }
         });
     }
 
+    let full_reconnect_thr = ctx.config.read().geyser_full_reconnect_threshold;
     // Start legacy GeyserListener for transaction parsing (will be phased out in favor of pool discovery)
     let (listener, account_rx, transaction_rx, mut blockhash_rx) =
         GeyserListener::new_with_tracked_accounts(
             geyser_url.to_string(),
             program_ids,
             combined_tracked_rx,
+            full_reconnect_thr,
         );
 
     // Spawn Geyser listener task
@@ -9467,15 +10198,11 @@ async fn run_geyser_loop(
                                             ctx.live_pool_cache.set_mint_decimals(mint, d);
                                         }
 
-                                        // 3) Track mint so Geyser will deliver the mint account
-                                        let mut added_mint = false;
-                                        {
-                                            let mut tracked = ctx.tracked_mints.write();
-                                            if tracked.insert(mint) {
-                                                added_mint = true;
-                                                let updated: Vec<Pubkey> = tracked.iter().copied().collect();
-                                                let _ = ctx.tracked_mints_tx.send(updated);
-                                            }
+                                        // 3) Track mint so Geyser will deliver the mint account (wallet-pinned).
+                                        let added_mint =
+                                            ctx.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::Wallet));
+                                        if added_mint {
+                                            ctx.send_tracked_mints_geyser();
                                         }
 
                                         // 4) Recompute tracked wallet accounts and notify listener
@@ -9616,37 +10343,30 @@ async fn run_geyser_loop(
                     "Pool discovered via Geyser"
                 );
 
-                // Track base mint for metadata fetching - GEYSER-FIRST: No RPC calls!
-                let mut tracked = ctx.tracked_mints.write();
-                if tracked.insert(pool_event.base_mint) {
-                    let updated: Vec<Pubkey> = tracked.iter().copied().collect();
-                    let _ = ctx.tracked_mints_tx.send(updated);
-
-                    // For Pump.fun/PumpAMM: emit TokenMintInfo immediately with known decimals=6.
-                    // For other DEXes: Geyser will deliver the mint account when subscribed.
-                    // Note: PoolDexType only has PumpFun (legacy bonding), PumpAMM is detected via transaction parsing
-                    let is_pump = matches!(pool_event.dex_type, PoolDexType::PumpFun);
-                    if is_pump {
-                        let mint_event = MarketEvent::new(
-                            "market-data",
-                            BUILD_VERSION,
-                            run_id,
-                            ctx.next_event_id(),
-                            "geyser_known", // Not RPC - we know pump.fun uses decimals=6
-                            Some(pool_event.slot),
-                            MarketEventKind::TokenMintInfo {
-                                mint: pool_event.base_mint.to_string(),
-                                token_program: spl_token::ID.to_string(), // pump.fun always uses SPL Token
-                                decimals: 6, // pump.fun tokens ALWAYS have 6 decimals
-                                supply: 0,   // Unknown, but not critical for trading
-                                mint_authority: None,
-                                freeze_authority: None,
-                            },
-                        );
-                        let _ = mint_info_tx.send(mint_event);
-                        debug!(mint = %pool_event.base_mint, "Emitted TokenMintInfo for pump.fun token (decimals=6, no RPC)");
-                    }
-                    // For other DEXes: Geyser subscription handles it - no RPC call needed.
+                // PR-B: discovery-only must not grow explicit Geyser mint/vault/bin subscriptions.
+                // Pump.fun still emits TokenMintInfo with known decimals=6 (no extra mint account filter).
+                if matches!(pool_event.dex_type, PoolDexType::PumpFun) {
+                    let mint_event = MarketEvent::new(
+                        "market-data",
+                        BUILD_VERSION,
+                        run_id,
+                        ctx.next_event_id(),
+                        "geyser_known", // Not RPC - we know pump.fun uses decimals=6
+                        Some(pool_event.slot),
+                        MarketEventKind::TokenMintInfo {
+                            mint: pool_event.base_mint.to_string(),
+                            token_program: spl_token::ID.to_string(), // pump.fun always uses SPL Token
+                            decimals: 6, // pump.fun tokens ALWAYS have 6 decimals
+                            supply: 0,   // Unknown, but not critical for trading
+                            mint_authority: None,
+                            freeze_authority: None,
+                        },
+                    );
+                    let _ = mint_info_tx.send(mint_event);
+                    debug!(
+                        mint = %pool_event.base_mint,
+                        "Emitted TokenMintInfo for pump.fun token (decimals=6, no RPC)"
+                    );
                 }
 
                 // Convert to MarketEvent::PoolCreated
@@ -9811,101 +10531,8 @@ async fn run_geyser_loop(
                         }
                     }
 
-                    // Track vault accounts for PoolStateUpdate events (Geyser-based reserve balances)
-                    // This enables real-time reserve tracking without RPC calls.
-                    let dex_str = pool_event.dex_type.to_string();
-                    // DLMM-specific: pass active_id/bin_step for Option D (Bin Array Traversierung)
-                    let dlmm_active_id = pool_event.active_id;
-                    let dlmm_bin_step = pool_event.bin_step;
-                    let mut vaults_changed = false;
-                    {
-                        let mut vaults = ctx.tracked_vaults.write();
-                        if let Some(coin_vault) = pool_event.coin_vault {
-                            vaults.entry(coin_vault).or_insert_with(|| {
-                                vaults_changed = true;
-                                VaultInfo {
-                                    pool_address: pool_event.pool_address,
-                                    dex: dex_str.clone(),
-                                    base_mint: pool_event.base_mint,
-                                    quote_mint: pool_event.quote_mint,
-                                    is_base_vault: true,
-                                    last_balance: std::sync::atomic::AtomicU64::new(0),
-                                    active_id: dlmm_active_id,
-                                    bin_step: dlmm_bin_step,
-                                }
-                            });
-                        }
-                        if let Some(pc_vault) = pool_event.pc_vault {
-                            vaults.entry(pc_vault).or_insert_with(|| {
-                                vaults_changed = true;
-                                VaultInfo {
-                                    pool_address: pool_event.pool_address,
-                                    dex: dex_str.clone(),
-                                    base_mint: pool_event.base_mint,
-                                    quote_mint: pool_event.quote_mint,
-                                    is_base_vault: false,
-                                    last_balance: std::sync::atomic::AtomicU64::new(0),
-                                    active_id: dlmm_active_id,
-                                    bin_step: dlmm_bin_step,
-                                }
-                            });
-                        }
-                    }
-                    // Notify GeyserListener to resubscribe with new vault accounts
-                    if vaults_changed {
-                        let vault_list: Vec<Pubkey> = ctx.tracked_vaults.read().keys().copied().collect();
-                        let _ = ctx.tracked_vaults_tx.send(vault_list);
-                        debug!(
-                            pool = %pool_event.pool_address,
-                            coin_vault = ?pool_event.coin_vault,
-                            pc_vault = ?pool_event.pc_vault,
-                            "Registered vault accounts for PoolStateUpdate tracking"
-                        );
-                    }
-
-                    // Track Meteora DLMM Bin Array accounts for BinArrayUpdate events
-                    // This enables real-time liquidity tracking without RPC calls.
-                    if pool_event.dex_type == PoolDexType::MeteoraDlmm {
-                        // For Meteora DLMM, we need to subscribe to bin array accounts.
-                        // We derive PDAs for ±3 arrays around the active bin.
-                        // Use actual active_id/bin_step from pool_event (parsed in geyser_pool_discovery)
-                        let active_id = pool_event.active_id.unwrap_or(0);
-                        let active_array_index = MeteoraDlmmSwapBuilder::bin_id_to_bin_array_index(active_id);
-                        let bin_step = pool_event.bin_step.unwrap_or(1);
-
-                        let mut bin_arrays_changed = false;
-                        {
-                            let mut bin_arrays = ctx.tracked_bin_arrays.write();
-                            // Register ±3 bin arrays around active bin
-                            for offset in -3i64..=3i64 {
-                                let index = active_array_index + offset;
-                                if let Ok(pda) = MeteoraDlmmSwapBuilder::derive_bin_array_pda(
-                                    &pool_event.pool_address,
-                                    index,
-                                ) {
-                                    bin_arrays.entry(pda).or_insert_with(|| {
-                                        bin_arrays_changed = true;
-                                        BinArrayInfo {
-                                            pool_address: pool_event.pool_address,
-                                            bin_array_index: index,
-                                            bin_step,
-                                        }
-                                    });
-                                }
-                            }
-                        }
-                        // Notify GeyserListener to resubscribe with new bin array accounts
-                        if bin_arrays_changed {
-                            let bin_array_list: Vec<Pubkey> = ctx.tracked_bin_arrays.read().keys().copied().collect();
-                            let num_arrays = bin_array_list.len();
-                            let _ = ctx.tracked_bin_arrays_tx.send(bin_array_list);
-                            debug!(
-                                pool = %pool_event.pool_address,
-                                arrays_tracked = num_arrays,
-                                "Registered Meteora DLMM bin array accounts for BinArrayUpdate tracking"
-                            );
-                        }
-                    }
+                    // PR-B: explicit Geyser vault/bin-array subscriptions are deferred until first trade,
+                    // active-pool pin (PR-D), or wallet-held mint admission — not pool_discovery alone.
                 }
             }
 
@@ -11325,5 +11952,119 @@ mod momentum_nats_subject_tests {
             bin_step: None,
         };
         assert!(!market_event_is_momentum_nats_relevant(&ps_pump_usdc));
+    }
+}
+
+#[cfg(test)]
+mod pr_b_geyser_tracking_tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn lru_eviction_prefers_oldest_unpinned_vault() {
+        let a = Pubkey::new_unique();
+        let b = Pubkey::new_unique();
+        let pool = Pubkey::new_unique();
+        let now = Instant::now();
+        let mut map = std::collections::HashMap::new();
+        map.insert(
+            a,
+            VaultInfo {
+                pool_address: pool,
+                dex: "x".into(),
+                base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::new_unique(),
+                is_base_vault: true,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: now - Duration::from_secs(100),
+                pinned: false,
+                pin: None,
+                active_id: None,
+                bin_step: None,
+            },
+        );
+        map.insert(
+            b,
+            VaultInfo {
+                pool_address: pool,
+                dex: "x".into(),
+                base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::new_unique(),
+                is_base_vault: false,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: now - Duration::from_secs(10),
+                pinned: false,
+                pin: None,
+                active_id: None,
+                bin_step: None,
+            },
+        );
+        let oldest = map
+            .iter()
+            .filter(|(_, v)| !v.pinned)
+            .min_by_key(|(_, v)| v.last_used_at)
+            .map(|(k, _)| *k)
+            .expect("candidate");
+        assert_eq!(oldest, a);
+    }
+
+    #[test]
+    fn pinned_vault_not_selected_for_lru() {
+        let a = Pubkey::new_unique();
+        let b = Pubkey::new_unique();
+        let pool = Pubkey::new_unique();
+        let now = Instant::now();
+        let mut map = std::collections::HashMap::new();
+        map.insert(
+            a,
+            VaultInfo {
+                pool_address: pool,
+                dex: "x".into(),
+                base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::new_unique(),
+                is_base_vault: true,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: now - Duration::from_secs(1000),
+                pinned: true,
+                pin: Some(GeyserPinReason::Wallet),
+                active_id: None,
+                bin_step: None,
+            },
+        );
+        map.insert(
+            b,
+            VaultInfo {
+                pool_address: pool,
+                dex: "x".into(),
+                base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::new_unique(),
+                is_base_vault: false,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: now - Duration::from_secs(1),
+                pinned: false,
+                pin: None,
+                active_id: None,
+                bin_step: None,
+            },
+        );
+        let oldest = map
+            .iter()
+            .filter(|(_, v)| !v.pinned)
+            .min_by_key(|(_, v)| v.last_used_at)
+            .map(|(k, _)| *k)
+            .expect("candidate");
+        assert_eq!(oldest, b);
+    }
+
+    #[test]
+    fn active_pool_set_pin_api_roundtrip() {
+        let s = ActivePoolSet::new();
+        let mint = Pubkey::new_unique();
+        let pool = Pubkey::new_unique();
+        assert!(!s.is_pinned(mint, pool));
+        s.pin_pool(mint, pool);
+        assert!(s.is_pinned(mint, pool));
+        s.unpin_pool(mint, pool);
+        assert!(!s.is_pinned(mint, pool));
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1157,6 +1157,12 @@ impl MarketDataContext {
             match kind {
                 EvKind::Vault => {
                     let mut vaults = self.tracked_vaults.write();
+                    // Re-check under write lock: LRU candidate may have been pinned after the read-only scan (TOCTOU).
+                    match vaults.get(&pubkey) {
+                        None => continue,
+                        Some(v) if v.pinned => continue,
+                        Some(_) => {}
+                    }
                     if let Some(v) = vaults.remove(&pubkey) {
                         geyser_metrics_inc_tracked_evicted(GeyserTrackedEvictKind::Vault);
                         info!(
@@ -1175,17 +1181,23 @@ impl MarketDataContext {
                         let sibling_pk =
                             Self::geyser_unpinned_sibling_vault_pubkey(&vaults, pool, this_is_base);
                         if let Some(spk) = sibling_pk {
-                            if let Some(sv) = vaults.remove(&spk) {
-                                geyser_metrics_inc_tracked_evicted(GeyserTrackedEvictKind::Vault);
-                                info!(
-                                    run_id = %run_id,
-                                    pool = %sv.pool_address,
-                                    mint = %sv.base_mint,
-                                    vault = %spk,
-                                    reason = "lru_cap_pair",
-                                    oldest_age_ms = ?oldest_at.elapsed().as_millis(),
-                                    "geyser_evicted"
-                                );
+                            let remove_sibling =
+                                vaults.get(&spk).map(|sv| !sv.pinned).unwrap_or(false);
+                            if remove_sibling {
+                                if let Some(sv) = vaults.remove(&spk) {
+                                    geyser_metrics_inc_tracked_evicted(
+                                        GeyserTrackedEvictKind::Vault,
+                                    );
+                                    info!(
+                                        run_id = %run_id,
+                                        pool = %sv.pool_address,
+                                        mint = %sv.base_mint,
+                                        vault = %spk,
+                                        reason = "lru_cap_pair",
+                                        oldest_age_ms = ?oldest_at.elapsed().as_millis(),
+                                        "geyser_evicted"
+                                    );
+                                }
                             }
                         } else if Self::geyser_pinned_sibling_vault_present(
                             &vaults,
@@ -1205,7 +1217,13 @@ impl MarketDataContext {
                     }
                 }
                 EvKind::Bin => {
-                    if let Some(b) = self.tracked_bin_arrays.write().remove(&pubkey) {
+                    let mut bins = self.tracked_bin_arrays.write();
+                    match bins.get(&pubkey) {
+                        None => continue,
+                        Some(b) if b.pinned => continue,
+                        Some(_) => {}
+                    }
+                    if let Some(b) = bins.remove(&pubkey) {
                         geyser_metrics_inc_tracked_evicted(GeyserTrackedEvictKind::BinArray);
                         info!(
                             run_id = %run_id,
@@ -1217,7 +1235,13 @@ impl MarketDataContext {
                     }
                 }
                 EvKind::Mint => {
-                    if self.tracked_mints.write().remove(&pubkey).is_some() {
+                    let mut mints = self.tracked_mints.write();
+                    match mints.get(&pubkey) {
+                        None => continue,
+                        Some(m) if m.pinned => continue,
+                        Some(_) => {}
+                    }
+                    if mints.remove(&pubkey).is_some() {
                         geyser_metrics_inc_tracked_evicted(GeyserTrackedEvictKind::Mint);
                         info!(
                             run_id = %run_id,

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,6 +136,36 @@ pub struct StrategyDef {
     pub params: toml::Value,
 }
 
+/// market-data Geyser explicit account subscription limits (PR-B).
+/// TOML section: `[market_data_geyser]`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarketDataGeyserCfg {
+    /// Max combined explicit Geyser accounts (mints + vaults + bin arrays + wallet list).
+    #[serde(default = "default_max_tracked_accounts")]
+    pub max_tracked_accounts: usize,
+    /// When `combined_tracked.len()` exceeds this, force a full Geyser gRPC reconnect instead of
+    /// many in-place `subscribe_tx` updates (reduces Yellowstone subscription churn).
+    #[serde(default = "default_geyser_full_reconnect_threshold")]
+    pub geyser_full_reconnect_threshold: usize,
+}
+
+fn default_max_tracked_accounts() -> usize {
+    25_000
+}
+
+fn default_geyser_full_reconnect_threshold() -> usize {
+    10_000
+}
+
+impl Default for MarketDataGeyserCfg {
+    fn default() -> Self {
+        Self {
+            max_tracked_accounts: default_max_tracked_accounts(),
+            geyser_full_reconnect_threshold: default_geyser_full_reconnect_threshold(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub app: AppCfg,
@@ -155,6 +185,8 @@ pub struct Config {
     pub momentum: Option<MomentumCfg>,
     #[serde(default)]
     pub execution_engine: Option<ExecutionEngineCfg>,
+    #[serde(default)]
+    pub market_data_geyser: MarketDataGeyserCfg,
 }
 
 /// Execution Engine Configuration (for execution-engine binary)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -230,12 +230,29 @@ pub static GEYSER_STREAM_ERRORS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64:
 /// 1 while a Geyser gRPC connection is established; 0 while reconnecting.
 pub static GEYSER_CONNECTED: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
+/// Combined explicit Geyser account subscription size (mints + vaults + bin arrays + wallet).
+pub static GEYSER_SUBSCRIPTION_ACCOUNTS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// Pinned explicit accounts (never LRU-evicted).
+pub static GEYSER_TRACKED_PINNED_ACCOUNTS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+pub static GEYSER_TRACKED_ACCOUNTS_EVICTED_VAULT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static GEYSER_TRACKED_ACCOUNTS_EVICTED_BIN_ARRAY: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static GEYSER_TRACKED_ACCOUNTS_EVICTED_MINT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// Reconnect after large explicit subscription set (PR-B: full client reconnect vs in-place churn).
+pub static GEYSER_RECONNECT_TOTAL_SUBSCRIPTION_REBUILD: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 /// Geyser listener reconnect reason (PR-A stream resiliency).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum GeyserReconnectReason {
     StreamEnded,
     StreamError,
     SinkGone,
+    /// PR-B: intentional full reconnect for large `combined_tracked` updates.
+    SubscriptionRebuild,
 }
 
 pub fn geyser_metrics_inc_reconnect(reason: GeyserReconnectReason) {
@@ -249,7 +266,39 @@ pub fn geyser_metrics_inc_reconnect(reason: GeyserReconnectReason) {
         GeyserReconnectReason::SinkGone => {
             GEYSER_RECONNECT_TOTAL_SINK_GONE.fetch_add(1, Ordering::Relaxed);
         }
+        GeyserReconnectReason::SubscriptionRebuild => {
+            GEYSER_RECONNECT_TOTAL_SUBSCRIPTION_REBUILD.fetch_add(1, Ordering::Relaxed);
+        }
     }
+}
+
+pub fn geyser_metrics_set_subscription_accounts(n: usize) {
+    GEYSER_SUBSCRIPTION_ACCOUNTS.store(n as u64, Ordering::Relaxed);
+}
+
+pub fn geyser_metrics_set_tracked_pinned_accounts(n: usize) {
+    GEYSER_TRACKED_PINNED_ACCOUNTS.store(n as u64, Ordering::Relaxed);
+}
+
+pub fn geyser_metrics_inc_tracked_evicted(kind: GeyserTrackedEvictKind) {
+    match kind {
+        GeyserTrackedEvictKind::Vault => {
+            GEYSER_TRACKED_ACCOUNTS_EVICTED_VAULT.fetch_add(1, Ordering::Relaxed);
+        }
+        GeyserTrackedEvictKind::BinArray => {
+            GEYSER_TRACKED_ACCOUNTS_EVICTED_BIN_ARRAY.fetch_add(1, Ordering::Relaxed);
+        }
+        GeyserTrackedEvictKind::Mint => {
+            GEYSER_TRACKED_ACCOUNTS_EVICTED_MINT.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GeyserTrackedEvictKind {
+    Vault,
+    BinArray,
+    Mint,
 }
 
 pub fn geyser_metrics_inc_stream_error() {
@@ -2137,11 +2186,47 @@ async fn metrics_response() -> Response<Body> {
             .to_string(),
     );
     out.push('\n');
+    out.push_str("geyser_reconnect_total{reason=\"subscription_rebuild\"} ");
+    out.push_str(
+        &GEYSER_RECONNECT_TOTAL_SUBSCRIPTION_REBUILD
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
     line!(
         "geyser_stream_errors_total",
         GEYSER_STREAM_ERRORS_TOTAL.load(Ordering::Relaxed)
     );
     line!("geyser_connected", GEYSER_CONNECTED.load(Ordering::Relaxed));
+    line!(
+        "geyser_subscription_accounts",
+        GEYSER_SUBSCRIPTION_ACCOUNTS.load(Ordering::Relaxed)
+    );
+    line!(
+        "geyser_tracked_pinned_accounts",
+        GEYSER_TRACKED_PINNED_ACCOUNTS.load(Ordering::Relaxed)
+    );
+    out.push_str("geyser_tracked_accounts_evicted_total{kind=\"vault\"} ");
+    out.push_str(
+        &GEYSER_TRACKED_ACCOUNTS_EVICTED_VAULT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("geyser_tracked_accounts_evicted_total{kind=\"bin_array\"} ");
+    out.push_str(
+        &GEYSER_TRACKED_ACCOUNTS_EVICTED_BIN_ARRAY
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("geyser_tracked_accounts_evicted_total{kind=\"mint\"} ");
+    out.push_str(
+        &GEYSER_TRACKED_ACCOUNTS_EVICTED_MINT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
     line!(
         "market_data_geyser_head_slot",
         MARKET_DATA_GEYSER_HEAD_SLOT.load(Ordering::Relaxed)

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -117,6 +117,10 @@ pub struct GeyserListener {
     /// This is implemented via explicit `account` filters (not owner-wide token program
     /// subscriptions), so it scales with tracked tokens rather than chain-wide token activity.
     tracked_accounts_rx: Option<watch::Receiver<Vec<Pubkey>>>,
+    /// When `tracked_accounts.len()` exceeds this value, account-list updates use a full outer
+    /// gRPC reconnect instead of in-place `subscribe_tx.send` (PR-B Yellowstone churn control).
+    /// Use `usize::MAX` to always prefer in-place updates.
+    full_reconnect_tracked_threshold: usize,
     #[cfg_attr(windows, allow(dead_code))]
     account_tx: broadcast::Sender<GeyserAccountUpdate>,
     #[cfg_attr(windows, allow(dead_code))]
@@ -149,6 +153,7 @@ impl GeyserListener {
                 endpoint,
                 program_ids,
                 tracked_accounts_rx: None,
+                full_reconnect_tracked_threshold: usize::MAX,
                 account_tx,
                 transaction_tx,
                 blockhash_tx,
@@ -167,6 +172,7 @@ impl GeyserListener {
         endpoint: String,
         program_ids: Vec<Pubkey>,
         tracked_accounts_rx: watch::Receiver<Vec<Pubkey>>,
+        full_reconnect_tracked_threshold: usize,
     ) -> (
         Self,
         broadcast::Receiver<GeyserAccountUpdate>,
@@ -176,6 +182,7 @@ impl GeyserListener {
         let (mut listener, account_rx, transaction_rx, blockhash_rx) =
             Self::new(endpoint, program_ids);
         listener.tracked_accounts_rx = Some(tracked_accounts_rx);
+        listener.full_reconnect_tracked_threshold = full_reconnect_tracked_threshold;
         (listener, account_rx, transaction_rx, blockhash_rx)
     }
 
@@ -183,7 +190,12 @@ impl GeyserListener {
     pub async fn start(self) -> Result<()> {
         #[cfg(windows)]
         {
-            let _ = (self.endpoint, self.program_ids, self.tracked_accounts_rx);
+            let _ = (
+                self.endpoint,
+                self.program_ids,
+                self.tracked_accounts_rx,
+                self.full_reconnect_tracked_threshold,
+            );
             Err(anyhow!(
                 "Geyser gRPC is not supported on Windows in this repo build. \
                  Build on Linux/macOS for Geyser support."
@@ -285,6 +297,8 @@ impl GeyserListener {
         enum SessionExit {
             StreamEnded,
             HardReconnect,
+            /// PR-B: large explicit subscription set — reconnect with a fresh client.
+            SubscriptionRebuild,
         }
 
         info!(
@@ -744,6 +758,16 @@ impl GeyserListener {
                             if let Some(new_list) = maybe_new {
                                 if new_list != tracked_accounts_current {
                                     tracked_accounts_current = new_list;
+                                    if tracked_accounts_current.len()
+                                        > self.full_reconnect_tracked_threshold
+                                    {
+                                        info!(
+                                            tracked_accounts = tracked_accounts_current.len(),
+                                            threshold = self.full_reconnect_tracked_threshold,
+                                            "geyser_listener: large tracked set — forcing full reconnect (skip in-place subscribe update)"
+                                        );
+                                        break 'read SessionExit::SubscriptionRebuild;
+                                    }
                                     let updated_request = Self::build_subscribe_request(
                                         &self.program_ids,
                                         &tracked_accounts_current,
@@ -775,6 +799,12 @@ impl GeyserListener {
                         sleep(Duration::from_millis(sleep_ms)).await;
                         reconnect_backoff_ms =
                             (reconnect_backoff_ms.saturating_mul(2)).min(RECONNECT_BACKOFF_CAP_MS);
+                        continue 'outer;
+                    }
+                    SessionExit::SubscriptionRebuild => {
+                        geyser_metrics_inc_reconnect(GeyserReconnectReason::SubscriptionRebuild);
+                        geyser_metrics_set_connected(false);
+                        // Intentional full reconnect for large subscription churn — no error backoff.
                         continue 'outer;
                     }
                 }

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -807,7 +807,10 @@ impl GeyserListener {
                     SessionExit::SubscriptionRebuild => {
                         geyser_metrics_inc_reconnect(GeyserReconnectReason::SubscriptionRebuild);
                         geyser_metrics_set_connected(false);
-                        // Intentional full reconnect for large subscription churn — no error backoff.
+                        // Intentional full reconnect for large subscription churn — no error backoff sleep
+                        // in this arm. Still reset reconnect jitter so a *prior* HardReconnect cannot leave a
+                        // stale 60s-class backoff applied to the next outer connect attempt.
+                        reconnect_backoff_ms = rand::thread_rng().gen_range(100..=250);
                         continue 'outer;
                     }
                 }

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -3,6 +3,8 @@
 
 use anyhow::{anyhow, Result};
 use solana_sdk::pubkey::Pubkey;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::broadcast;
 use tokio::sync::watch;
@@ -119,8 +121,8 @@ pub struct GeyserListener {
     tracked_accounts_rx: Option<watch::Receiver<Vec<Pubkey>>>,
     /// When `tracked_accounts.len()` exceeds this value, account-list updates use a full outer
     /// gRPC reconnect instead of in-place `subscribe_tx.send` (PR-B Yellowstone churn control).
-    /// Use `usize::MAX` to always prefer in-place updates.
-    full_reconnect_tracked_threshold: usize,
+    /// Use `usize::MAX` to always prefer in-place updates. Shared so market-data can hot-reload.
+    full_reconnect_tracked_threshold: Arc<AtomicUsize>,
     #[cfg_attr(windows, allow(dead_code))]
     account_tx: broadcast::Sender<GeyserAccountUpdate>,
     #[cfg_attr(windows, allow(dead_code))]
@@ -153,7 +155,7 @@ impl GeyserListener {
                 endpoint,
                 program_ids,
                 tracked_accounts_rx: None,
-                full_reconnect_tracked_threshold: usize::MAX,
+                full_reconnect_tracked_threshold: Arc::new(AtomicUsize::new(usize::MAX)),
                 account_tx,
                 transaction_tx,
                 blockhash_tx,
@@ -172,7 +174,7 @@ impl GeyserListener {
         endpoint: String,
         program_ids: Vec<Pubkey>,
         tracked_accounts_rx: watch::Receiver<Vec<Pubkey>>,
-        full_reconnect_tracked_threshold: usize,
+        full_reconnect_tracked_threshold: Arc<AtomicUsize>,
     ) -> (
         Self,
         broadcast::Receiver<GeyserAccountUpdate>,
@@ -758,12 +760,13 @@ impl GeyserListener {
                             if let Some(new_list) = maybe_new {
                                 if new_list != tracked_accounts_current {
                                     tracked_accounts_current = new_list;
-                                    if tracked_accounts_current.len()
-                                        > self.full_reconnect_tracked_threshold
-                                    {
+                                    let threshold = self
+                                        .full_reconnect_tracked_threshold
+                                        .load(Ordering::Relaxed);
+                                    if tracked_accounts_current.len() > threshold {
                                         info!(
                                             tracked_accounts = tracked_accounts_current.len(),
-                                            threshold = self.full_reconnect_tracked_threshold,
+                                            threshold,
                                             "geyser_listener: large tracked set — forcing full reconnect (skip in-place subscribe update)"
                                         );
                                         break 'read SessionExit::SubscriptionRebuild;

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -323,6 +323,11 @@ impl GeyserListener {
         const RECONNECT_BACKOFF_CAP_MS: u64 = 60_000;
         let mut last_stream_ended_log =
             std::time::Instant::now() - std::time::Duration::from_secs(10);
+        // When over `full_reconnect_tracked_threshold`, subscription list deltas used to trigger a
+        // full reconnect on every change — thrashing the stream. Coalesce to at most one such
+        // rebuild per interval; other updates use in-place subscribe (same as small sets).
+        const LARGE_TRACKED_SUBSCRIBE_REBUILD_MIN_INTERVAL: Duration = Duration::from_secs(5);
+        let mut last_large_set_subscription_rebuild: Option<Instant> = None;
 
         geyser_metrics_set_connected(false);
 
@@ -763,7 +768,18 @@ impl GeyserListener {
                                     let threshold = self
                                         .full_reconnect_tracked_threshold
                                         .load(Ordering::Relaxed);
-                                    if tracked_accounts_current.len() > threshold {
+                                    let now = Instant::now();
+                                    let over_threshold =
+                                        tracked_accounts_current.len() > threshold;
+                                    let allow_full_rebuild = over_threshold
+                                        && last_large_set_subscription_rebuild
+                                            .map(|t| {
+                                                now.saturating_duration_since(t)
+                                                    >= LARGE_TRACKED_SUBSCRIBE_REBUILD_MIN_INTERVAL
+                                            })
+                                            .unwrap_or(true);
+                                    if allow_full_rebuild {
+                                        last_large_set_subscription_rebuild = Some(now);
                                         info!(
                                             tracked_accounts = tracked_accounts_current.len(),
                                             threshold,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ziel

`combined_tracked` stabil unter konfigurierbarem Cap halten; **Admission** verschärfen (keine Vaults/Bin-Arrays nur aus Pool-Discovery oder reinem Pool-State-Parse ohne Trade/Pin/Wallet); **LRU-Eviction** für unpinned Einträge; bei großer Subscription **voller Geyser-Reconnect** statt vieler In-Place-Updates.

## Änderungen (Kurz)

- **`[market_data_geyser]`** in `config.toml` / Defaults in `my_config.server.toml`: `max_tracked_accounts` (default 25000), `geyser_full_reconnect_threshold` (default 10000). `Config` + `docs/CONFIG_SCHEMA.md`; Merge beim Start + Hot-Reload-Keys `max_tracked_accounts`, `geyser_full_reconnect_threshold`.
- **`market_data`**: `tracked_mints` → `HashMap` + `MintTrackInfo` (`last_used_at`, `pinned`, `PinReason`); `VaultInfo` / `BinArrayInfo` um LRU/Pin erweitert; **`ActivePoolSet`**-Stub (`pin_pool` / `unpin_pool` / `is_pinned`) für PR-D.
- **Admission**: Vault-Registrierung aus `parse_pool_account` nur bei Wallet-Mint oder Active-Pin; **keine** Vault/Bin-Registrierung mehr aus `pool_discovery`; **Trade-Pfad** registriert Reserves/Bin-Arrays aus `LivePoolCache` nach `ParsedDexEvent::Trade`.
- **LRU**: Eviction über unpinned vault/bin/mint bis `combined <= cap`; Logs `geyser_evicted`; Metriken `geyser_tracked_accounts_evicted_total{kind=...}`.
- **`geyser_listener`**: Wenn `tracked_accounts.len() > threshold` bei Subscription-Änderung → `SessionExit::SubscriptionRebuild` (outer reconnect, kein Backoff); Counter `geyser_reconnect_total{reason="subscription_rebuild"}`.
- **Metriken**: `geyser_subscription_accounts`, `geyser_tracked_pinned_accounts` (inkl. Wallet-Liste als „pinned“ für Ops).

## STOP-Check (I-7 / I-4)

Keine neuen RPC-Calls im Hot Path; Eviction/Subscribe-Signale synchron. Cold-Path-RPC (PumpAmm-Bootstrap etc.) unverändert.

## Tests

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo test --features test_helpers`.

## Minimallösung Mint (`tracked_mints`)

Reine **Pool-Discovery** trägt **keine** Base-Mints mehr in `tracked_mints` ein; Pump.fun sendet weiterhin **TokenMintInfo** (decimals=6) ohne zusätzlichen Mint-Account-Filter. Mints kommen über **Tx** (PoolCreated/Trade/LiquidityRemoved), **Wallet-Bootstrap** (pin `Wallet`) und **ExecutionResults** (pin `Wallet`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c5a96c9-a1e9-499f-90ab-778bdb223674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c5a96c9-a1e9-499f-90ab-778bdb223674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

