### PR TITLE
feat(geyser): PR-D momentum active-pool stream + discovery stale cleanup

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -56,22 +56,25 @@ use ironcrab::metrics::{
     record_market_data_account_early_drop_total, record_market_data_account_handler_duration_us,
     record_market_data_bonding_to_trade_slot_delta_slots,
     record_market_data_geyser_to_publish_on_success,
+    record_market_data_momentum_active_pool_messages_total,
     record_market_data_trade_after_bonding_publish_ms, record_market_data_tx_broadcast_lagged,
     record_market_data_tx_channel_lag_ms, serve_metrics,
-    set_market_data_account_broadcast_queue_depth, set_market_data_tx_broadcast_queue_depth,
-    set_readiness_control_sub_active, set_readiness_mode, set_readiness_nats_connected,
-    update_readiness_market_data_current, wall_clock_unix_ms_now, GeyserTrackedEvictKind,
-    MarketDataLatencySegment, MetricsComponent, MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS,
-    MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS, MARKET_EVENTS_MOMENTUM_FANOUT_PUBLISHED_TOTAL,
-    MARKET_EVENTS_PUBLISHED_TOTAL, MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL,
-    NATS_MESSAGES_PUBLISHED_TOTAL, POOLS_TRACKED_GAUGE,
+    set_market_data_account_broadcast_queue_depth, set_market_data_momentum_active_pool_pins_gauge,
+    set_market_data_tx_broadcast_queue_depth, set_readiness_control_sub_active, set_readiness_mode,
+    set_readiness_nats_connected, update_readiness_market_data_current, wall_clock_unix_ms_now,
+    GeyserTrackedEvictKind, MarketDataLatencySegment, MetricsComponent,
+    MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS, MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS,
+    MARKET_EVENTS_MOMENTUM_FANOUT_PUBLISHED_TOTAL, MARKET_EVENTS_PUBLISHED_TOTAL,
+    MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
+    POOLS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
     ensure_pool_cache_stream, ensure_wallet_snapshot_stream, execution_results_consumer_config,
-    pool_subject, wallet_snapshot_consumer_config, wallet_snapshot_subject, NatsClient, NatsConfig,
-    CONFIG_STREAM_NAME, EXECUTION_RESULTS_STREAM_NAME, TOPIC_CONTROL_REQUESTS,
-    TOPIC_CONTROL_RESPONSES, TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS,
+    pool_subject, wallet_snapshot_consumer_config, wallet_snapshot_subject,
+    MomentumActivePoolsUpdate, NatsClient, NatsConfig, CONFIG_STREAM_NAME,
+    EXECUTION_RESULTS_STREAM_NAME, TOPIC_CONTROL_REQUESTS, TOPIC_CONTROL_RESPONSES,
+    TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS, TOPIC_MOMENTUM_ACTIVE_POOLS,
     TOPIC_MOMENTUM_MARKET_EVENTS, TOPIC_PRIORITY_FEE_SAMPLES, WALLET_SNAPSHOT_STREAM_NAME,
 };
 use ironcrab::solana::dex::meteora_bin_array_layout::BinArray;
@@ -570,7 +573,6 @@ fn pump_amm_control_response_for_ensure_publish(
 
 /// PR-B: explicit Geyser account subscription / LRU (also loaded from `[market_data_geyser]` in config.toml).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)] // MomentumActive wired in PR-D
 enum GeyserPinReason {
     /// Wallet bootstrap / execution-result mint tracking — never LRU-evicted.
     Wallet,
@@ -595,13 +597,12 @@ impl Default for MintTrackInfo {
     }
 }
 
-/// PR-B stub: future NATS-driven active pool pins (PR-D). API is live for unit tests.
+/// PR-B: optional momentum active pool pins (PR-D NATS-driven).
 #[derive(Debug)]
 struct ActivePoolSet {
     pairs: parking_lot::RwLock<std::collections::HashSet<(Pubkey, Pubkey)>>,
 }
 
-#[allow(dead_code)] // pin/unpin used by PR-D and `pr_b_geyser_tracking_tests` (clippy sees bin without tests)
 impl ActivePoolSet {
     fn new() -> Self {
         Self {
@@ -619,6 +620,14 @@ impl ActivePoolSet {
 
     fn is_pinned(&self, mint: Pubkey, pool: Pubkey) -> bool {
         self.pairs.read().contains(&(mint, pool))
+    }
+
+    fn pair_count(&self) -> usize {
+        self.pairs.read().len()
+    }
+
+    fn mint_has_any_pinned_pool(&self, mint: Pubkey) -> bool {
+        self.pairs.read().iter().any(|(m, _)| *m == mint)
     }
 }
 
@@ -996,8 +1005,28 @@ struct BinArrayInfo {
     bin_step: u16,
     last_used_at: Instant,
     pinned: bool,
-    #[allow(dead_code)]
     pin: Option<GeyserPinReason>,
+}
+
+#[derive(Clone, Copy)]
+enum GeyserReserveRegisterFollowUp {
+    None,
+    /// PR-D: promote vault/bin rows for this pool to `MomentumActive` and track pool mints.
+    MomentumUpgrade,
+}
+
+/// Base + quote mint pubkeys for explicit mint-account Geyser tracking (metadata).
+fn pool_mints_for_geyser_explicit_tracking(state: &CachedPoolState) -> Option<(Pubkey, Pubkey)> {
+    let wsol = Pubkey::from_str(NATIVE_SOL_MINT).ok()?;
+    match state {
+        CachedPoolState::RaydiumCpmm(s) => Some((s.token_0_mint, s.token_1_mint)),
+        CachedPoolState::MeteoraCpmm(s) => Some((s.token_0_mint, s.token_1_mint)),
+        CachedPoolState::Meteora(s) => Some((s.token_x_mint, s.token_y_mint)),
+        CachedPoolState::PumpAmm(s) => Some((s.base_mint, s.quote_mint)),
+        CachedPoolState::Orca(s) => Some((s.token_mint_a, s.token_mint_b)),
+        CachedPoolState::RaydiumAmm(s) => Some((s.base_mint, s.quote_mint)),
+        CachedPoolState::PumpFun(s) => Some((s.token_mint, wsol)),
+    }
 }
 
 impl MarketDataContext {
@@ -1274,14 +1303,14 @@ impl MarketDataContext {
         self.broadcast_tracked_geyser_explicit_to_merge();
     }
 
-    /// Track mint pubkey for Geyser `TokenMintInfo` / metadata. Returns `true` if pubkey set changed.
+    /// Track mint pubkey for Geyser `TokenMintInfo` / metadata. Returns `true` if explicit pubkey set changed.
     fn track_mint_for_geyser_metadata(&self, mint: Pubkey, pin: Option<GeyserPinReason>) -> bool {
         let now = Instant::now();
-        let pinned = pin.is_some();
         let mut map = self.tracked_mints.write();
         use std::collections::hash_map::Entry;
         match map.entry(mint) {
             Entry::Vacant(e) => {
+                let pinned = pin.is_some();
                 e.insert(MintTrackInfo {
                     last_used_at: now,
                     pinned,
@@ -1292,11 +1321,24 @@ impl MarketDataContext {
             Entry::Occupied(mut e) => {
                 let v = e.get_mut();
                 v.last_used_at = now;
-                if pinned {
-                    v.pinned = true;
-                    v.pin = pin;
+                match pin {
+                    None => false,
+                    Some(GeyserPinReason::Wallet) => {
+                        let changed = !v.pinned || v.pin != Some(GeyserPinReason::Wallet);
+                        v.pinned = true;
+                        v.pin = Some(GeyserPinReason::Wallet);
+                        changed
+                    }
+                    Some(GeyserPinReason::MomentumActive) => {
+                        if v.pin == Some(GeyserPinReason::Wallet) {
+                            return false;
+                        }
+                        let changed = !v.pinned || v.pin != Some(GeyserPinReason::MomentumActive);
+                        v.pinned = true;
+                        v.pin = Some(GeyserPinReason::MomentumActive);
+                        changed
+                    }
                 }
-                false
             }
         }
     }
@@ -1343,11 +1385,43 @@ impl MarketDataContext {
 
     /// PR-B: after a parsed swap trade, subscribe reserve vaults / DLMM bin arrays from MASTER cache.
     fn register_geyser_reserves_after_trade(&self, pool: Pubkey) {
+        let _ =
+            self.register_geyser_reserves_impl(pool, GeyserReserveRegisterFollowUp::None, false);
+    }
+
+    /// PR-D: explicit vault/bin subscriptions for momentum active `(mint, pool)` when cache has layout.
+    /// Returns whether any tracked set changed. If `suppress_end_sync`, caller must [`Self::sync_geyser_tracked_accounts`].
+    fn register_geyser_reserves_for_momentum_active_pool(
+        &self,
+        pool: Pubkey,
+        suppress_end_sync: bool,
+    ) -> bool {
+        if self.live_pool_cache.get(&pool).is_none() {
+            debug!(
+                run_id = %self.run_id,
+                pool = %pool,
+                "Momentum active pool: LivePoolCache miss — pin may still be recorded; reserve registration deferred"
+            );
+            return false;
+        }
+        self.register_geyser_reserves_impl(
+            pool,
+            GeyserReserveRegisterFollowUp::MomentumUpgrade,
+            suppress_end_sync,
+        )
+    }
+
+    fn register_geyser_reserves_impl(
+        &self,
+        pool: Pubkey,
+        follow_up: GeyserReserveRegisterFollowUp,
+        suppress_end_sync: bool,
+    ) -> bool {
         let now = Instant::now();
         let enable_dlmm = self.config.read().enable_meteora_dlmm;
         let enable_meteora_cpmm = self.config.read().enable_meteora_cpmm;
         let Some(state) = self.live_pool_cache.get(&pool) else {
-            return;
+            return false;
         };
 
         let mut vaults_changed = false;
@@ -1656,9 +1730,132 @@ impl MarketDataContext {
             _ => {}
         }
 
-        if vaults_changed || bins_changed {
+        let mut mints_changed = false;
+        if matches!(follow_up, GeyserReserveRegisterFollowUp::MomentumUpgrade) {
+            {
+                let mut vaults = self.tracked_vaults.write();
+                for v in vaults.values_mut() {
+                    if v.pool_address == pool
+                        && v.pin != Some(GeyserPinReason::Wallet)
+                        && (!v.pinned || v.pin != Some(GeyserPinReason::MomentumActive))
+                    {
+                        v.pinned = true;
+                        v.pin = Some(GeyserPinReason::MomentumActive);
+                        vaults_changed = true;
+                    }
+                }
+            }
+            {
+                let mut bins = self.tracked_bin_arrays.write();
+                for b in bins.values_mut() {
+                    if b.pool_address == pool
+                        && b.pin != Some(GeyserPinReason::Wallet)
+                        && (!b.pinned || b.pin != Some(GeyserPinReason::MomentumActive))
+                    {
+                        b.pinned = true;
+                        b.pin = Some(GeyserPinReason::MomentumActive);
+                        bins_changed = true;
+                    }
+                }
+            }
+            if let Some((a, b)) = pool_mints_for_geyser_explicit_tracking(&state) {
+                if self.track_mint_for_geyser_metadata(a, Some(GeyserPinReason::MomentumActive)) {
+                    mints_changed = true;
+                }
+                if self.track_mint_for_geyser_metadata(b, Some(GeyserPinReason::MomentumActive)) {
+                    mints_changed = true;
+                }
+            }
+        }
+
+        let changed = vaults_changed || bins_changed || mints_changed;
+        if changed && !suppress_end_sync {
             self.sync_geyser_tracked_accounts();
         }
+        changed
+    }
+
+    /// PR-D: apply momentum-bot active pool pin updates (core NATS; immediate `sync_geyser_tracked_accounts`).
+    fn apply_momentum_active_pools_update(&self, update: &MomentumActivePoolsUpdate) {
+        record_market_data_momentum_active_pool_messages_total();
+
+        let mut batch_dirty = false;
+
+        for r in &update.removed {
+            let Ok(mint_pk) = Pubkey::from_str(r.mint.trim()) else {
+                warn!(mint = %r.mint, "MomentumActivePoolsUpdate.removed: invalid mint");
+                continue;
+            };
+            let Ok(pool_pk) = Pubkey::from_str(r.pool.trim()) else {
+                warn!(pool = %r.pool, "MomentumActivePoolsUpdate.removed: invalid pool");
+                continue;
+            };
+            if self.clear_momentum_geyser_reserves_for_active_entry(mint_pk, pool_pk) {
+                batch_dirty = true;
+            }
+        }
+
+        for a in &update.active {
+            let Ok(mint_pk) = Pubkey::from_str(a.mint.trim()) else {
+                warn!(mint = %a.mint, "MomentumActivePoolsUpdate.active: invalid mint");
+                continue;
+            };
+            let Ok(pool_pk) = Pubkey::from_str(a.pool.trim()) else {
+                warn!(pool = %a.pool, "MomentumActivePoolsUpdate.active: invalid pool");
+                continue;
+            };
+            self.active_pool_set.pin_pool(mint_pk, pool_pk);
+            if self.register_geyser_reserves_for_momentum_active_pool(pool_pk, true) {
+                batch_dirty = true;
+            }
+            let _ = &a.pin_reason;
+        }
+
+        if batch_dirty {
+            self.sync_geyser_tracked_accounts();
+        } else {
+            self.refresh_geyser_pins_gauge();
+        }
+        set_market_data_momentum_active_pool_pins_gauge(self.active_pool_set.pair_count());
+    }
+
+    /// Clear `MomentumActive` pins for one `(mint, pool)` side; never demotes [`GeyserPinReason::Wallet`].
+    fn clear_momentum_geyser_reserves_for_active_entry(&self, mint: Pubkey, pool: Pubkey) -> bool {
+        self.active_pool_set.unpin_pool(mint, pool);
+        let mut changed = false;
+        {
+            let mut vaults = self.tracked_vaults.write();
+            for v in vaults.values_mut() {
+                if v.pool_address == pool && v.pin == Some(GeyserPinReason::MomentumActive) {
+                    v.pin = None;
+                    v.pinned = false;
+                    changed = true;
+                }
+            }
+        }
+        {
+            let mut bins = self.tracked_bin_arrays.write();
+            for b in bins.values_mut() {
+                if b.pool_address == pool && b.pin == Some(GeyserPinReason::MomentumActive) {
+                    b.pin = None;
+                    b.pinned = false;
+                    changed = true;
+                }
+            }
+        }
+        if !self.wallet_tracks_mint_for_geyser(&mint)
+            && !self.active_pool_set.mint_has_any_pinned_pool(mint)
+        {
+            let mut m = self.tracked_mints.write();
+            if let Some(info) = m.get_mut(&mint) {
+                if info.pin == Some(GeyserPinReason::MomentumActive) {
+                    info.pinned = false;
+                    info.pin = None;
+                    changed = true;
+                }
+            }
+        }
+        changed
     }
 
     /// P1: Apply config update from control-plane (Runtime Configuration via UI)
@@ -9737,6 +9934,29 @@ async fn run_geyser_loop(
         None
     };
 
+    // PR-D: momentum-bot active pool pin stream (core NATS; fire-and-forget).
+    let mut momentum_active_pools_sub = if let Some(ref nats) = ctx.nats {
+        match nats.subscribe(TOPIC_MOMENTUM_ACTIVE_POOLS).await {
+            Ok(sub) => {
+                info!(
+                    topic = TOPIC_MOMENTUM_ACTIVE_POOLS,
+                    "Subscribed to MomentumActivePools (Geyser pin stream)"
+                );
+                Some(sub)
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    topic = TOPIC_MOMENTUM_ACTIVE_POOLS,
+                    "Failed to subscribe to MomentumActivePools (momentum reserve pins disabled)"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // Option A (MARKET-DATA-TX-INGEST-FAIRNESS): dedizierter Tokio-Task für Geyser-Txs.
     // Verhindert, dass `transaction_rx.recv()` hinter langen Account-`select!`-Armen verhungert
     // (p50 `market_data_tx_channel_lag_ms` war ~1s+ bei gleichzeitig niedrigem Publish-Tail).
@@ -10654,6 +10874,26 @@ async fn run_geyser_loop(
                 }
             }
 
+            // PR-D: Momentum active pool pin stream (core NATS).
+            msg = async {
+                if let Some(ref mut sub) = momentum_active_pools_sub {
+                    sub.next().await
+                } else {
+                    std::future::pending::<Option<ironcrab::nats::NatsMessage>>().await
+                }
+            } => {
+                if let Some(nats_msg) = msg {
+                    match serde_json::from_slice::<MomentumActivePoolsUpdate>(&nats_msg.payload) {
+                        Ok(update) => {
+                            ctx.apply_momentum_active_pools_update(&update);
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "Failed to deserialize MomentumActivePoolsUpdate");
+                        }
+                    }
+                }
+            }
+
             // P1: Handle Config Updates (Runtime Configuration via UI)
             msg = async {
                 if let Some(ref mut sub) = config_subscription {
@@ -10749,6 +10989,28 @@ async fn run_simulation_loop(
             }
             Err(e) => {
                 warn!(error = %e, "Simulation mode: Failed to subscribe to ControlRequests");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let mut momentum_active_pools_sub = if let Some(ref nats) = ctx.nats {
+        match nats.subscribe(TOPIC_MOMENTUM_ACTIVE_POOLS).await {
+            Ok(sub) => {
+                info!(
+                    topic = TOPIC_MOMENTUM_ACTIVE_POOLS,
+                    "Simulation mode: Subscribed to MomentumActivePools"
+                );
+                Some(sub)
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    topic = TOPIC_MOMENTUM_ACTIVE_POOLS,
+                    "Simulation mode: Failed to subscribe to MomentumActivePools"
+                );
                 None
             }
         }
@@ -11050,6 +11312,26 @@ async fn run_simulation_loop(
                         }
                         Err(e) => {
                             warn!(error = %e, "Failed to deserialize ControlRequest");
+                        }
+                    }
+                }
+            }
+
+            // PR-D: Momentum active pool pin stream (simulation / tests).
+            msg = async {
+                if let Some(ref mut sub) = momentum_active_pools_sub {
+                    sub.next().await
+                } else {
+                    std::future::pending::<Option<ironcrab::nats::NatsMessage>>().await
+                }
+            } => {
+                if let Some(nats_msg) = msg {
+                    match serde_json::from_slice::<MomentumActivePoolsUpdate>(&nats_msg.payload) {
+                        Ok(update) => {
+                            ctx.apply_momentum_active_pools_update(&update);
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "Failed to deserialize MomentumActivePoolsUpdate (simulation)");
                         }
                     }
                 }
@@ -12281,5 +12563,170 @@ mod pr_b_geyser_tracking_tests {
         assert!(!MarketDataContext::geyser_pinned_sibling_vault_present(
             &map, pool, true
         ));
+    }
+
+    /// Minimal [`MarketDataContext`] for PR-D active-pool pin tests (no NATS / no Geyser).
+    fn minimal_market_data_context_for_pr_d_tests(jsonl_writer: JsonlWriter) -> MarketDataContext {
+        let (tracked_mints_tx, _tracked_mints_rx) = watch::channel(Vec::<Pubkey>::new());
+        let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
+        let (tracked_bin_arrays_tx, _tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
+        let (tracked_wallet_tx, _tracked_wallet_rx) = watch::channel(Vec::<Pubkey>::new());
+        MarketDataContext {
+            run_id: "run-prd-test".to_string(),
+            config: parking_lot::RwLock::new(MarketDataConfig::default()),
+            geyser_full_reconnect_threshold_live: Arc::new(AtomicUsize::new(0)),
+            nats: None,
+            jsonl_writer,
+            event_counter: std::sync::atomic::AtomicU64::new(0),
+            wallet_tracker: WalletTracker::new(WalletTrackerCfg::default()),
+            priority_fee_tracker: Arc::new(PriorityFeeTracker::new()),
+            tracked_mints: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            tracked_mints_tx,
+            active_pool_set: Arc::new(ActivePoolSet::new()),
+            known_pump_amm_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
+            known_trade_dex_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
+            pumpfun_pool_discovery_mint_info_emitted: parking_lot::RwLock::new(
+                std::collections::HashSet::new(),
+            ),
+            tracked_vaults: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            tracked_vaults_tx,
+            tracked_bin_arrays: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            tracked_bin_arrays_tx,
+            live_pool_cache: Arc::new(LivePoolCache::new()),
+            creator_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            pool_mint_map: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            pool_creator_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            raydium_serum_fetched: parking_lot::RwLock::new(std::collections::HashSet::new()),
+            tracked_wallet: None,
+            tracked_wallet_tx,
+            tracked_wallet_token_accounts: parking_lot::RwLock::new(
+                std::collections::HashSet::new(),
+            ),
+            tracked_wallet_mint_decimals: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            execution_results_deduper: parking_lot::Mutex::new(ExecutionResultDeduper::default()),
+            last_emitted_curve_progress: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            bonding_curve_publish_times: parking_lot::Mutex::new(BondingCurvePublishTimes::new()),
+            pump_amm_dex: parking_lot::RwLock::new(None),
+            helius_rpc: None,
+        }
+    }
+
+    #[test]
+    fn momentum_active_pools_apply_active_sets_momentum_pin_on_vaults() {
+        use ironcrab::nats::{MomentumActivePinReason, MomentumActivePoolEntry};
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = JsonlWriter::new(jsonl_cfg).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: None,
+                reserve_1: None,
+            }),
+            1,
+        );
+
+        let update = MomentumActivePoolsUpdate {
+            version: 1,
+            ts_unix_ms: 1,
+            active: vec![MomentumActivePoolEntry {
+                mint: base_mint.to_string(),
+                pool: pool.to_string(),
+                pin_reason: MomentumActivePinReason::Tracker,
+            }],
+            removed: vec![],
+        };
+        ctx.apply_momentum_active_pools_update(&update);
+
+        let vs = ctx.tracked_vaults.read();
+        assert_eq!(
+            vs.get(&coin_vault).and_then(|v| v.pin),
+            Some(GeyserPinReason::MomentumActive)
+        );
+        assert_eq!(
+            vs.get(&pc_vault).and_then(|v| v.pin),
+            Some(GeyserPinReason::MomentumActive)
+        );
+    }
+
+    #[test]
+    fn momentum_active_pools_removed_clears_momentum_but_keeps_wallet_pin() {
+        use ironcrab::nats::{
+            MomentumActivePinReason, MomentumActivePoolEntry, MomentumRemovedPoolEntry,
+        };
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = JsonlWriter::new(jsonl_cfg).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: None,
+                reserve_1: None,
+            }),
+            1,
+        );
+
+        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
+            version: 1,
+            ts_unix_ms: 1,
+            active: vec![MomentumActivePoolEntry {
+                mint: base_mint.to_string(),
+                pool: pool.to_string(),
+                pin_reason: MomentumActivePinReason::Tracker,
+            }],
+            removed: vec![],
+        });
+
+        {
+            let mut vs = ctx.tracked_vaults.write();
+            if let Some(v) = vs.get_mut(&pc_vault) {
+                v.pin = Some(GeyserPinReason::Wallet);
+                v.pinned = true;
+            }
+        }
+
+        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
+            version: 1,
+            ts_unix_ms: 2,
+            active: vec![],
+            removed: vec![MomentumRemovedPoolEntry {
+                mint: base_mint.to_string(),
+                pool: pool.to_string(),
+                reason: "closed".to_string(),
+            }],
+        });
+
+        let vs = ctx.tracked_vaults.read();
+        assert_eq!(vs.get(&coin_vault).and_then(|v| v.pin), None);
+        assert!(!vs.get(&coin_vault).is_some_and(|v| v.pinned));
+        assert_eq!(
+            vs.get(&pc_vault).and_then(|v| v.pin),
+            Some(GeyserPinReason::Wallet)
+        );
+        assert!(vs.get(&pc_vault).is_some_and(|v| v.pinned));
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -629,6 +629,11 @@ impl ActivePoolSet {
     fn mint_has_any_pinned_pool(&self, mint: Pubkey) -> bool {
         self.pairs.read().iter().any(|(m, _)| *m == mint)
     }
+
+    /// True if any momentum active pin still references this pool (another `(mint, pool)` row).
+    fn pool_has_any_pin(&self, pool: Pubkey) -> bool {
+        self.pairs.read().iter().any(|(_, p)| *p == pool)
+    }
 }
 
 /// Market data configuration (hot-reloadable via NATS)
@@ -1823,23 +1828,27 @@ impl MarketDataContext {
     fn clear_momentum_geyser_reserves_for_active_entry(&self, mint: Pubkey, pool: Pubkey) -> bool {
         self.active_pool_set.unpin_pool(mint, pool);
         let mut changed = false;
-        {
-            let mut vaults = self.tracked_vaults.write();
-            for v in vaults.values_mut() {
-                if v.pool_address == pool && v.pin == Some(GeyserPinReason::MomentumActive) {
-                    v.pin = None;
-                    v.pinned = false;
-                    changed = true;
+        // Pool-level reserve pins are shared: only demote vaults/bin arrays when no `(m, pool)`
+        // row remains after this unpin (PR #147 follow-up).
+        if !self.active_pool_set.pool_has_any_pin(pool) {
+            {
+                let mut vaults = self.tracked_vaults.write();
+                for v in vaults.values_mut() {
+                    if v.pool_address == pool && v.pin == Some(GeyserPinReason::MomentumActive) {
+                        v.pin = None;
+                        v.pinned = false;
+                        changed = true;
+                    }
                 }
             }
-        }
-        {
-            let mut bins = self.tracked_bin_arrays.write();
-            for b in bins.values_mut() {
-                if b.pool_address == pool && b.pin == Some(GeyserPinReason::MomentumActive) {
-                    b.pin = None;
-                    b.pinned = false;
-                    changed = true;
+            {
+                let mut bins = self.tracked_bin_arrays.write();
+                for b in bins.values_mut() {
+                    if b.pool_address == pool && b.pin == Some(GeyserPinReason::MomentumActive) {
+                        b.pin = None;
+                        b.pinned = false;
+                        changed = true;
+                    }
                 }
             }
         }
@@ -12468,6 +12477,23 @@ mod pr_b_geyser_tracking_tests {
         assert!(!s.is_pinned(mint, pool));
     }
 
+    #[test]
+    fn active_pool_set_pool_has_any_pin() {
+        let s = ActivePoolSet::new();
+        let m1 = Pubkey::new_unique();
+        let m2 = Pubkey::new_unique();
+        let pool = Pubkey::new_unique();
+        assert!(!s.pool_has_any_pin(pool));
+        s.pin_pool(m1, pool);
+        assert!(s.pool_has_any_pin(pool));
+        s.pin_pool(m2, pool);
+        assert!(s.pool_has_any_pin(pool));
+        s.unpin_pool(m1, pool);
+        assert!(s.pool_has_any_pin(pool));
+        s.unpin_pool(m2, pool);
+        assert!(!s.pool_has_any_pin(pool));
+    }
+
     /// Bugbot PR-146: paired vault eviction must never pick a pinned sibling for `lru_cap_pair`.
     #[test]
     fn geyser_sibling_evict_helper_skips_pinned_leg() {
@@ -12728,5 +12754,79 @@ mod pr_b_geyser_tracking_tests {
             Some(GeyserPinReason::Wallet)
         );
         assert!(vs.get(&pc_vault).is_some_and(|v| v.pinned));
+    }
+
+    #[test]
+    fn momentum_active_pools_removed_one_mint_keeps_vault_momentum_when_other_mint_pins_pool() {
+        use ironcrab::nats::{
+            MomentumActivePinReason, MomentumActivePoolEntry, MomentumRemovedPoolEntry,
+        };
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = JsonlWriter::new(jsonl_cfg).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let other_tracker_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: None,
+                reserve_1: None,
+            }),
+            1,
+        );
+
+        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
+            version: 1,
+            ts_unix_ms: 1,
+            active: vec![
+                MomentumActivePoolEntry {
+                    mint: base_mint.to_string(),
+                    pool: pool.to_string(),
+                    pin_reason: MomentumActivePinReason::Tracker,
+                },
+                MomentumActivePoolEntry {
+                    mint: other_tracker_mint.to_string(),
+                    pool: pool.to_string(),
+                    pin_reason: MomentumActivePinReason::Tracker,
+                },
+            ],
+            removed: vec![],
+        });
+
+        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
+            version: 1,
+            ts_unix_ms: 2,
+            active: vec![],
+            removed: vec![MomentumRemovedPoolEntry {
+                mint: base_mint.to_string(),
+                pool: pool.to_string(),
+                reason: "stale_discovery".to_string(),
+            }],
+        });
+
+        assert!(
+            ctx.active_pool_set.is_pinned(other_tracker_mint, pool),
+            "second pin row must survive"
+        );
+        let vs = ctx.tracked_vaults.read();
+        assert_eq!(
+            vs.get(&coin_vault).and_then(|v| v.pin),
+            Some(GeyserPinReason::MomentumActive)
+        );
+        assert_eq!(
+            vs.get(&pc_vault).and_then(|v| v.pin),
+            Some(GeyserPinReason::MomentumActive)
+        );
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1856,11 +1856,18 @@ impl MarketDataContext {
     /// PR-D: whether `mint` is still a base/quote leg for any pool that has a momentum active pin row.
     fn momentum_pool_leg_mint_still_required_by_other_pool(&self, mint: Pubkey) -> bool {
         for (_, pool_pk) in self.active_pool_set.snapshot_pairs() {
-            if let Some(state) = self.live_pool_cache.get(&pool_pk) {
-                if let Some((a, b)) = pool_mints_for_geyser_explicit_tracking(&state) {
-                    if a == mint || b == mint {
-                        return true;
+            match self.live_pool_cache.get(&pool_pk) {
+                Some(state) => {
+                    if let Some((a, b)) = pool_mints_for_geyser_explicit_tracking(&state) {
+                        if a == mint || b == mint {
+                            return true;
+                        }
                     }
+                }
+                None => {
+                    // Pinned `(mint, pool)` without cache layout: cannot know pool legs (e.g. WSOL
+                    // quote). Assume this leg may still be required — avoids demoting companion mints.
+                    return true;
                 }
             }
         }
@@ -12895,6 +12902,92 @@ mod pr_b_geyser_tracking_tests {
         assert_eq!(
             vs.get(&pc_vault).and_then(|v| v.pin),
             Some(GeyserPinReason::MomentumActive)
+        );
+    }
+
+    /// PR #147 follow-up: leg mint (WSOL) must stay `MomentumActive` while another pinned pool has
+    /// no `LivePoolCache` row — `momentum_pool_leg_mint_still_required_by_other_pool` is conservative on miss.
+    #[test]
+    fn momentum_leg_mint_pin_kept_when_other_active_pool_has_cache_miss() {
+        use ironcrab::nats::{
+            MomentumActivePinReason, MomentumActivePoolEntry, MomentumRemovedPoolEntry,
+        };
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = JsonlWriter::new(jsonl_cfg).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool_a = Pubkey::new_unique();
+        let pool_b = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let other_tracker_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+
+        ctx.live_pool_cache.upsert(
+            pool_a,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: None,
+                reserve_1: None,
+            }),
+            1,
+        );
+
+        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
+            version: 1,
+            ts_unix_ms: 1,
+            active: vec![
+                MomentumActivePoolEntry {
+                    mint: base_mint.to_string(),
+                    pool: pool_a.to_string(),
+                    pin_reason: MomentumActivePinReason::Tracker,
+                },
+                MomentumActivePoolEntry {
+                    mint: other_tracker_mint.to_string(),
+                    pool: pool_b.to_string(),
+                    pin_reason: MomentumActivePinReason::Tracker,
+                },
+            ],
+            removed: vec![],
+            full_active_snapshot: false,
+        });
+
+        assert!(
+            ctx.tracked_mints
+                .read()
+                .get(&quote)
+                .is_some_and(|m| m.pin == Some(GeyserPinReason::MomentumActive)),
+            "setup: WSOL leg tracked for pool_a"
+        );
+
+        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
+            version: 1,
+            ts_unix_ms: 2,
+            active: vec![],
+            removed: vec![MomentumRemovedPoolEntry {
+                mint: base_mint.to_string(),
+                pool: pool_a.to_string(),
+                reason: "closed".to_string(),
+            }],
+            full_active_snapshot: false,
+        });
+
+        assert!(
+            ctx.active_pool_set.is_pinned(other_tracker_mint, pool_b),
+            "pool_b pin survives pool_a removal"
+        );
+        assert!(
+            ctx.tracked_mints
+                .read()
+                .get(&quote)
+                .is_some_and(|m| m.pin == Some(GeyserPinReason::MomentumActive)),
+            "WSOL must stay pinned while pool_b is active without cache layout"
         );
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -22,7 +22,7 @@ use clap::Parser;
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -633,6 +633,10 @@ impl ActivePoolSet {
     /// True if any momentum active pin still references this pool (another `(mint, pool)` row).
     fn pool_has_any_pin(&self, pool: Pubkey) -> bool {
         self.pairs.read().iter().any(|(_, p)| *p == pool)
+    }
+
+    fn snapshot_pairs(&self) -> HashSet<(Pubkey, Pubkey)> {
+        self.pairs.read().clone()
     }
 }
 
@@ -1390,8 +1394,12 @@ impl MarketDataContext {
 
     /// PR-B: after a parsed swap trade, subscribe reserve vaults / DLMM bin arrays from MASTER cache.
     fn register_geyser_reserves_after_trade(&self, pool: Pubkey) {
-        let _ =
-            self.register_geyser_reserves_impl(pool, GeyserReserveRegisterFollowUp::None, false);
+        let follow_up = if self.active_pool_set.pool_has_any_pin(pool) {
+            GeyserReserveRegisterFollowUp::MomentumUpgrade
+        } else {
+            GeyserReserveRegisterFollowUp::None
+        };
+        let _ = self.register_geyser_reserves_impl(pool, follow_up, false);
     }
 
     /// PR-D: explicit vault/bin subscriptions for momentum active `(mint, pool)` when cache has layout.
@@ -1786,6 +1794,27 @@ impl MarketDataContext {
 
         let mut batch_dirty = false;
 
+        if update.full_active_snapshot {
+            let mut target: HashSet<(Pubkey, Pubkey)> = HashSet::new();
+            for a in &update.active {
+                let Ok(mint_pk) = Pubkey::from_str(a.mint.trim()) else {
+                    warn!(mint = %a.mint, "MomentumActivePoolsUpdate.active (snapshot): invalid mint");
+                    continue;
+                };
+                let Ok(pool_pk) = Pubkey::from_str(a.pool.trim()) else {
+                    warn!(pool = %a.pool, "MomentumActivePoolsUpdate.active (snapshot): invalid pool");
+                    continue;
+                };
+                target.insert((mint_pk, pool_pk));
+            }
+            let before = self.active_pool_set.snapshot_pairs();
+            for (m, p) in before.difference(&target) {
+                if self.clear_momentum_geyser_reserves_for_active_entry(*m, *p) {
+                    batch_dirty = true;
+                }
+            }
+        }
+
         for r in &update.removed {
             let Ok(mint_pk) = Pubkey::from_str(r.mint.trim()) else {
                 warn!(mint = %r.mint, "MomentumActivePoolsUpdate.removed: invalid mint");
@@ -1824,6 +1853,20 @@ impl MarketDataContext {
         set_market_data_momentum_active_pool_pins_gauge(self.active_pool_set.pair_count());
     }
 
+    /// PR-D: whether `mint` is still a base/quote leg for any pool that has a momentum active pin row.
+    fn momentum_pool_leg_mint_still_required_by_other_pool(&self, mint: Pubkey) -> bool {
+        for (_, pool_pk) in self.active_pool_set.snapshot_pairs() {
+            if let Some(state) = self.live_pool_cache.get(&pool_pk) {
+                if let Some((a, b)) = pool_mints_for_geyser_explicit_tracking(&state) {
+                    if a == mint || b == mint {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
     /// Clear `MomentumActive` pins for one `(mint, pool)` side; never demotes [`GeyserPinReason::Wallet`].
     fn clear_momentum_geyser_reserves_for_active_entry(&self, mint: Pubkey, pool: Pubkey) -> bool {
         self.active_pool_set.unpin_pool(mint, pool);
@@ -1848,6 +1891,26 @@ impl MarketDataContext {
                         b.pin = None;
                         b.pinned = false;
                         changed = true;
+                    }
+                }
+            }
+            if let Some(state) = self.live_pool_cache.get(&pool) {
+                if let Some((leg_a, leg_b)) = pool_mints_for_geyser_explicit_tracking(&state) {
+                    for leg in [leg_a, leg_b] {
+                        if self.wallet_tracks_mint_for_geyser(&leg) {
+                            continue;
+                        }
+                        if self.momentum_pool_leg_mint_still_required_by_other_pool(leg) {
+                            continue;
+                        }
+                        let mut m = self.tracked_mints.write();
+                        if let Some(info) = m.get_mut(&leg) {
+                            if info.pin == Some(GeyserPinReason::MomentumActive) {
+                                info.pinned = false;
+                                info.pin = None;
+                                changed = true;
+                            }
+                        }
                     }
                 }
             }
@@ -12673,6 +12736,7 @@ mod pr_b_geyser_tracking_tests {
                 pin_reason: MomentumActivePinReason::Tracker,
             }],
             removed: vec![],
+            full_active_snapshot: false,
         };
         ctx.apply_momentum_active_pools_update(&update);
 
@@ -12725,6 +12789,7 @@ mod pr_b_geyser_tracking_tests {
                 pin_reason: MomentumActivePinReason::Tracker,
             }],
             removed: vec![],
+            full_active_snapshot: false,
         });
 
         {
@@ -12744,6 +12809,7 @@ mod pr_b_geyser_tracking_tests {
                 pool: pool.to_string(),
                 reason: "closed".to_string(),
             }],
+            full_active_snapshot: false,
         });
 
         let vs = ctx.tracked_vaults.read();
@@ -12802,6 +12868,7 @@ mod pr_b_geyser_tracking_tests {
                 },
             ],
             removed: vec![],
+            full_active_snapshot: false,
         });
 
         ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
@@ -12813,6 +12880,7 @@ mod pr_b_geyser_tracking_tests {
                 pool: pool.to_string(),
                 reason: "stale_discovery".to_string(),
             }],
+            full_active_snapshot: false,
         });
 
         assert!(

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -4627,6 +4627,12 @@ impl MomentumContext {
             tracker.set_dev_info(dev_wallet, supply_pct, &config);
             if was_not_rejected && tracker.is_rejected() {
                 self.record_token_blacklisted_once(mint);
+                let reason = tracker.blacklist_reason.as_deref().unwrap_or("rejected");
+                self.queue_momentum_active_pool_removed(
+                    tracker.mint.as_str(),
+                    tracker.pool.as_str(),
+                    reason,
+                );
             }
         }
         self.pumpfun_buy_missing_creator_suppress_clear_for_mint(mint);
@@ -4661,6 +4667,12 @@ impl MomentumContext {
             tracker.record_lp_removal(slot);
             if was_not_rejected && tracker.is_rejected() {
                 self.record_token_blacklisted_once(mint);
+                let reason = tracker.blacklist_reason.as_deref().unwrap_or("rejected");
+                self.queue_momentum_active_pool_removed(
+                    tracker.mint.as_str(),
+                    tracker.pool.as_str(),
+                    reason,
+                );
             }
         }
         self.mark_entry_eval_dirty_for_mint(mint);

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -2874,6 +2874,16 @@ impl MomentumContext {
     }
 
     fn queue_momentum_active_pool_removed(&self, mint: &str, pool: &str, reason: &str) {
+        // Open position on this pool still needs Geyser reserve pins; a Rejected tracker row
+        // (e.g. LP removal, scale-in gate) must not publish `removed` until the position is gone.
+        if self
+            .positions
+            .read()
+            .get(mint)
+            .is_some_and(|p| p.pool.as_str() == pool)
+        {
+            return;
+        }
         let mut g = self.momentum_active_pool_publish_queue.lock();
         g.removed.push(MomentumRemovedPoolEntry {
             mint: mint.to_string(),
@@ -2954,7 +2964,11 @@ impl MomentumContext {
         }
         for (mint, pos) in positions.iter() {
             let key = Self::tracker_storage_key(mint, pos.pool.as_str());
-            if !trackers.contains_key(&key) {
+            let position_fallback = match trackers.get(&key) {
+                None => true,
+                Some(t) => matches!(t.state, TrackerState::Rejected),
+            };
+            if position_fallback {
                 out.push(MomentumActivePoolEntry {
                     mint: mint.clone(),
                     pool: pos.pool.clone(),

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -3042,8 +3042,13 @@ impl MomentumContext {
             return;
         }
         let tk = Self::tracker_storage_key(mint, pool);
-        if self.token_trackers.read().contains_key(&tk) {
-            return;
+        if let Some(t) = self.token_trackers.read().get(&tk) {
+            // `collect_momentum_active_pool_snapshot` skips Rejected rows; a leftover Rejected
+            // line must not block incremental `removed` after the position is gone (pins until
+            // full snapshot otherwise).
+            if !matches!(t.state, TrackerState::Rejected) {
+                return;
+            }
         }
         self.queue_momentum_active_pool_removed(mint, pool, "closed");
     }
@@ -5032,8 +5037,23 @@ impl MomentumContext {
     fn cleanup_old_trackers(&self) {
         let open_mints: std::collections::HashSet<_> =
             self.positions.read().keys().cloned().collect();
-        let mut trackers = self.token_trackers.write();
         let cutoff = Duration::from_secs(300); // 5 minutes
+        let pruned: Vec<(String, String)> = {
+            let trackers = self.token_trackers.read();
+            trackers
+                .values()
+                .filter(|tracker| {
+                    !open_mints.contains(&tracker.mint)
+                        && tracker.first_seen.elapsed() >= cutoff
+                        && tracker.state.is_terminal()
+                })
+                .map(|t| (t.mint.clone(), t.pool.clone()))
+                .collect()
+        };
+        for (mint, pool) in &pruned {
+            self.queue_momentum_active_pool_removed(mint, pool.as_str(), "tracker_cleanup");
+        }
+        let mut trackers = self.token_trackers.write();
         trackers.retain(|_, tracker| {
             open_mints.contains(&tracker.mint)
                 || tracker.first_seen.elapsed() < cutoff

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -46,7 +46,8 @@ use ironcrab::ipc::{
     TradingRegime, NATIVE_SOL_MINT,
 };
 use ironcrab::metrics::{
-    momentum_event_ts_latency_delta_ms, record_momentum_core_market_events_ingest_drain_batch,
+    momentum_event_ts_latency_delta_ms, record_momentum_active_pools_messages_total,
+    record_momentum_core_market_events_ingest_drain_batch,
     record_momentum_core_market_events_processed_kind,
     record_momentum_core_market_events_received_kind, record_momentum_ingest_to_process_us,
     record_momentum_market_events_last_applied_slot,
@@ -68,10 +69,11 @@ use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
     ensure_trade_intents_stream, execution_results_consumer_config,
     pool_cache_live_consumer_config, wallet_snapshot_consumer_config,
-    wallet_snapshot_live_consumer_config, NatsClient, NatsConfig, NatsMessage, CONFIG_STREAM_NAME,
-    EXECUTION_RESULTS_STREAM_NAME, STREAM_NAME, TOPIC_CONTROL_REQUESTS, TOPIC_EXECUTION_RESULTS,
-    TOPIC_MARKET_EVENTS, TOPIC_MOMENTUM_MARKET_EVENTS, TOPIC_TRADE_INTENTS,
-    WALLET_SNAPSHOT_STREAM_NAME,
+    wallet_snapshot_live_consumer_config, MomentumActivePinReason, MomentumActivePoolEntry,
+    MomentumActivePoolsUpdate, MomentumRemovedPoolEntry, NatsClient, NatsConfig, NatsMessage,
+    CONFIG_STREAM_NAME, EXECUTION_RESULTS_STREAM_NAME, STREAM_NAME, TOPIC_CONTROL_REQUESTS,
+    TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS, TOPIC_MOMENTUM_ACTIVE_POOLS,
+    TOPIC_MOMENTUM_MARKET_EVENTS, TOPIC_TRADE_INTENTS, WALLET_SNAPSHOT_STREAM_NAME,
 };
 use ironcrab::solana::dex_parser::SOL_MINT_PUBKEY;
 use ironcrab::storage::{JsonlWriter, JsonlWriterConfig};
@@ -107,6 +109,17 @@ fn is_non_tradeable_momentum_mint(mint: &str) -> bool {
 
 /// JetStream replay dedup for orphaned BUY path — bounded so memory does not grow forever.
 const ORPHANED_RECOVERED_INTENT_IDS_CAP: usize = 50_000;
+
+/// Wire version for [`TOPIC_MOMENTUM_ACTIVE_POOLS`] JSON payloads (PR-D).
+const MOMENTUM_ACTIVE_POOLS_WIRE_VERSION: u32 = 1;
+/// Discovery/Validation trackers without a trade for this long are dropped (PR-D plan #4).
+const MOMENTUM_STALE_DISCOVERY_SECS: u64 = 30 * 60;
+
+#[derive(Debug, Default)]
+struct MomentumActivePoolPublishQueue {
+    active: Vec<MomentumActivePoolEntry>,
+    removed: Vec<MomentumRemovedPoolEntry>,
+}
 
 /// Cooldown between repeated `Ensure*` ControlRequests for the same open-position pool recovery key.
 const OPEN_POSITION_POOL_RECOVERY_COOLDOWN: Duration = Duration::from_secs(60);
@@ -1678,6 +1691,9 @@ struct TokenTracker {
     /// Reason for rejection (only set when state == Rejected)
     blacklist_reason: Option<String>,
 
+    /// PR-D: last time this pool-scoped row observed any market trade (`record_trade`), for stale Discovery cleanup.
+    last_trade_at: Option<Instant>,
+
     /// Last WAIT_* filter class used for metrics/log dedupe (hot path CPU / NATS backpressure).
     last_wait_filter_obs_key: Option<String>,
 }
@@ -1723,6 +1739,7 @@ impl TokenTracker {
             cto_recovery_confirmed: false,
             state: TrackerState::Discovery,
             blacklist_reason: None,
+            last_trade_at: None,
             last_wait_filter_obs_key: None,
         }
     }
@@ -1730,6 +1747,22 @@ impl TokenTracker {
     #[cfg(test)]
     fn last_wait_filter_obs_key_for_test(&self) -> Option<&str> {
         self.last_wait_filter_obs_key.as_deref()
+    }
+
+    /// PR-D tests: Discovery/Validation-Zeile mit simuliertem Alter (`first_seen` / `last_trade_at`).
+    #[cfg(test)]
+    pub(crate) fn test_fixture_stale_discovery(
+        mint: &str,
+        pool: &str,
+        state: TrackerState,
+        first_seen_age: std::time::Duration,
+        last_trade_age: Option<std::time::Duration>,
+    ) -> Self {
+        let mut t = Self::new(mint, pool, "raydium", 1, 10_000_000_000);
+        t.first_seen = Instant::now() - first_seen_age;
+        t.state = state;
+        t.last_trade_at = last_trade_age.map(|d| Instant::now() - d);
+        t
     }
 
     // =========================================================================
@@ -2086,6 +2119,7 @@ impl TokenTracker {
         }
 
         self.trades.push(trade);
+        self.last_trade_at = Some(Instant::now());
     }
 
     fn last_trade_ratio(&self) -> Option<(u64, u64)> {
@@ -2785,6 +2819,8 @@ struct MomentumContext {
     /// K Phase 1: Last event slot/ts for Slot-to-Send Latency propagation
     last_event_slot: std::sync::atomic::AtomicU64,
     last_event_ts_ms: std::sync::atomic::AtomicU64,
+    /// PR-D: coalesced momentum active-pool NATS publishes (flushed on heartbeat / explicit tick).
+    momentum_active_pool_publish_queue: parking_lot::Mutex<MomentumActivePoolPublishQueue>,
 }
 
 /// Merge `lp_removal_observed_at` across sibling pool trackers for the same mint (wallclock LP_REMOVAL path).
@@ -2821,6 +2857,179 @@ impl MomentumContext {
             .intent_counter
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         format!("int-{}-{:06}", &self.run_id[..8], n)
+    }
+
+    fn queue_momentum_active_pool_active(
+        &self,
+        mint: &str,
+        pool: &str,
+        pin_reason: MomentumActivePinReason,
+    ) {
+        let mut g = self.momentum_active_pool_publish_queue.lock();
+        g.active.push(MomentumActivePoolEntry {
+            mint: mint.to_string(),
+            pool: pool.to_string(),
+            pin_reason,
+        });
+    }
+
+    fn queue_momentum_active_pool_removed(&self, mint: &str, pool: &str, reason: &str) {
+        let mut g = self.momentum_active_pool_publish_queue.lock();
+        g.removed.push(MomentumRemovedPoolEntry {
+            mint: mint.to_string(),
+            pool: pool.to_string(),
+            reason: reason.to_string(),
+        });
+    }
+
+    fn flush_momentum_active_pool_publish_queue(self: &Arc<Self>) {
+        if self.nats.is_none() {
+            return;
+        }
+        let (active, removed) = {
+            let mut g = self.momentum_active_pool_publish_queue.lock();
+            if g.active.is_empty() && g.removed.is_empty() {
+                return;
+            }
+            let a = std::mem::take(&mut g.active);
+            let r = std::mem::take(&mut g.removed);
+            (a, r)
+        };
+        self.spawn_publish_momentum_active_pools(active, removed);
+    }
+
+    fn spawn_publish_momentum_active_pools(
+        self: &Arc<Self>,
+        active: Vec<MomentumActivePoolEntry>,
+        removed: Vec<MomentumRemovedPoolEntry>,
+    ) {
+        if active.is_empty() && removed.is_empty() {
+            return;
+        }
+        let Some(nats_src) = self.nats.as_ref() else {
+            return;
+        };
+        let nats = nats_src.clone_for_spawned_publish();
+        let update = MomentumActivePoolsUpdate {
+            version: MOMENTUM_ACTIVE_POOLS_WIRE_VERSION,
+            ts_unix_ms: wall_clock_unix_ms_now(),
+            active,
+            removed,
+        };
+        record_momentum_active_pools_messages_total();
+        tokio::spawn(async move {
+            if let Err(e) = nats.publish(TOPIC_MOMENTUM_ACTIVE_POOLS, &update).await {
+                warn!(
+                    error = %e,
+                    topic = TOPIC_MOMENTUM_ACTIVE_POOLS,
+                    "MomentumActivePools NATS publish failed"
+                );
+            }
+        });
+    }
+
+    fn collect_momentum_active_pool_snapshot(&self) -> Vec<MomentumActivePoolEntry> {
+        let positions = self.positions.read();
+        let trackers = self.token_trackers.read();
+        let mut out = Vec::new();
+        for t in trackers.values() {
+            if matches!(t.state, TrackerState::Rejected) {
+                continue;
+            }
+            let pos_same_pool = positions
+                .get(&t.mint)
+                .is_some_and(|p| p.pool.as_str() == t.pool.as_str());
+            let pin_reason = if pos_same_pool {
+                MomentumActivePinReason::Position
+            } else {
+                MomentumActivePinReason::Tracker
+            };
+            out.push(MomentumActivePoolEntry {
+                mint: t.mint.clone(),
+                pool: t.pool.clone(),
+                pin_reason,
+            });
+        }
+        for (mint, pos) in positions.iter() {
+            let key = Self::tracker_storage_key(mint, pos.pool.as_str());
+            if !trackers.contains_key(&key) {
+                out.push(MomentumActivePoolEntry {
+                    mint: mint.clone(),
+                    pool: pos.pool.clone(),
+                    pin_reason: MomentumActivePinReason::Position,
+                });
+            }
+        }
+        out
+    }
+
+    fn reconcile_momentum_active_pools_snapshot_publish(self: &Arc<Self>) {
+        if self.nats.is_none() {
+            return;
+        }
+        let active = self.collect_momentum_active_pool_snapshot();
+        self.spawn_publish_momentum_active_pools(active, Vec::new());
+    }
+
+    fn prune_stale_discovery_trackers(&self) -> Vec<MomentumRemovedPoolEntry> {
+        let stale = Duration::from_secs(MOMENTUM_STALE_DISCOVERY_SECS);
+        let positions = self.positions.read();
+        let mut trackers = self.token_trackers.write();
+        let keys: Vec<String> = trackers.keys().cloned().collect();
+        let mut removed = Vec::new();
+        for key in keys {
+            let Some(t) = trackers.get(&key) else {
+                continue;
+            };
+            if !matches!(t.state, TrackerState::Discovery | TrackerState::Validation) {
+                continue;
+            }
+            // "Ohne Trade seit 30 min": entweder nie `record_trade` (None) — dann nur prunen wenn
+            // der Tracker schon mindestens `stale` in Discovery/Validation sitzt (`first_seen`);
+            // oder letzter Markt-Trade älter als `stale`.
+            let idle_too_long = match t.last_trade_at {
+                None => t.first_seen.elapsed() > stale,
+                Some(ts) => ts.elapsed() > stale,
+            };
+            if !idle_too_long {
+                continue;
+            }
+            if positions
+                .get(&t.mint)
+                .is_some_and(|p| p.pool.as_str() == t.pool.as_str())
+            {
+                continue;
+            }
+            let mint = t.mint.clone();
+            let pool = t.pool.clone();
+            trackers.remove(&key);
+            removed.push(MomentumRemovedPoolEntry {
+                mint,
+                pool,
+                reason: "stale_discovery".to_string(),
+            });
+        }
+        drop(trackers);
+        drop(positions);
+        let snap = self.token_trackers.read();
+        self.refresh_tracker_keys_by_mint_index_from_map(&snap);
+        let keys_live: std::collections::HashSet<String> = snap.keys().cloned().collect();
+        drop(snap);
+        self.dirty_entry_tracker_keys
+            .write()
+            .retain(|k| keys_live.contains(k));
+        removed
+    }
+
+    fn maybe_queue_removed_after_position_closed(&self, mint: &str, pool: &str) {
+        if self.positions.read().contains_key(mint) {
+            return;
+        }
+        let tk = Self::tracker_storage_key(mint, pool);
+        if self.token_trackers.read().contains_key(&tk) {
+            return;
+        }
+        self.queue_momentum_active_pool_removed(mint, pool, "closed");
     }
 
     /// Same pool filtering as `find_best_sell_pool` (Scope 57 / I-13), shared for exit quotes.
@@ -4332,6 +4541,8 @@ impl MomentumContext {
             );
             if was_not_rejected && tracker.is_rejected() {
                 self.record_token_blacklisted_once(mint);
+                let reason = tracker.blacklist_reason.as_deref().unwrap_or("rejected");
+                self.queue_momentum_active_pool_removed(mint, pool, reason);
             }
             sync_sibling_dev_sell_early =
                 tracker.blacklist_reason.as_deref() == Some("REJECT_DEV_SELL_EARLY");
@@ -4361,6 +4572,11 @@ impl MomentumContext {
                 t.dev_sold = true;
                 t.dev_sold_early = true;
                 t.reject("REJECT_DEV_SELL_EARLY");
+                self.queue_momentum_active_pool_removed(
+                    t.mint.as_str(),
+                    t.pool.as_str(),
+                    "rejected",
+                );
                 self.mark_entry_eval_dirty_key(&sk);
             }
         }
@@ -4605,6 +4821,11 @@ impl MomentumContext {
                             "REJECT_PUMPFUN_BONDING_COMPLETE: skip entry — migrated bonding curve / complete evidence (pump_amm unaffected)"
                         );
                         self.record_token_blacklisted_once(&mint);
+                        self.queue_momentum_active_pool_removed(
+                            &mint,
+                            tracker.pool.as_str(),
+                            "rejected",
+                        );
                     }
                 }
                 continue;
@@ -4638,6 +4859,12 @@ impl MomentumContext {
                     );
                     if was_not_rejected && tracker.is_rejected() {
                         self.record_token_blacklisted_once(&mint);
+                        let rej_reason = tracker.blacklist_reason.as_deref().unwrap_or("rejected");
+                        self.queue_momentum_active_pool_removed(
+                            &mint,
+                            tracker.pool.as_str(),
+                            rej_reason,
+                        );
                     }
 
                     if should_trade {
@@ -4739,6 +4966,12 @@ impl MomentumContext {
                     );
                     if was_not_rejected && tracker.is_rejected() {
                         self.record_token_blacklisted_once(&mint);
+                        let rej_reason = tracker.blacklist_reason.as_deref().unwrap_or("rejected");
+                        self.queue_momentum_active_pool_removed(
+                            &mint,
+                            tracker.pool.as_str(),
+                            rej_reason,
+                        );
                     }
 
                     if should_trade {
@@ -4907,6 +5140,9 @@ impl MomentumContext {
         tokio::spawn(async move {
             ctx.save_position_to_kv(&mint_owned, &tracker).await;
         });
+
+        self.queue_momentum_active_pool_active(p.mint, p.pool, MomentumActivePinReason::Position);
+        self.flush_momentum_active_pool_publish_queue();
     }
 
     /// Update position price from market trade or pool reserves.
@@ -4981,9 +5217,11 @@ impl MomentumContext {
     /// Also removes the position from JetStream KV
     fn close_position(self: &Arc<Self>, mint: &str) {
         let mint_owned = mint.to_string();
-        let removed = {
+        let (removed, closed_pool) = {
             let mut positions = self.positions.write();
-            positions.remove(mint)
+            let pool = positions.get(mint).map(|p| p.pool.clone());
+            let removed = positions.remove(mint);
+            (removed, pool)
         };
 
         if let Some(pos) = removed {
@@ -5003,6 +5241,11 @@ impl MomentumContext {
         if !self.pending_buy_mint_index.read().contains_key(mint) {
             self.latest_bonding_by_mint.write().remove(mint);
             self.clear_scope_b_sticky_state_for_mint(mint);
+        }
+
+        if let Some(ref pool) = closed_pool {
+            self.maybe_queue_removed_after_position_closed(mint, pool.as_str());
+            self.flush_momentum_active_pool_publish_queue();
         }
 
         // Delete from KV asynchronously (fire-and-forget)
@@ -8293,6 +8536,9 @@ async fn main() -> Result<()> {
         exits_generated: std::sync::atomic::AtomicU64::new(0),
         last_event_slot: std::sync::atomic::AtomicU64::new(0),
         last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+        momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+            MomentumActivePoolPublishQueue::default(),
+        ),
     });
 
     // === P0: Wallet snapshot recovery from JetStream ===
@@ -8667,6 +8913,8 @@ async fn main() -> Result<()> {
     strategy_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut activity_interval = tokio::time::interval(std::time::Duration::from_secs(10));
     let mut reconcile_interval = tokio::time::interval(std::time::Duration::from_secs(15));
+    let mut active_pools_snapshot_interval =
+        tokio::time::interval(std::time::Duration::from_secs(30));
     let mut execution_result_scheduled_interval =
         tokio::time::interval(EXECUTION_RESULT_SCHEDULED_POLL_INTERVAL);
     execution_result_scheduled_interval
@@ -8836,6 +9084,7 @@ async fn main() -> Result<()> {
                                         .as_micros()
                                         .min(u128::from(u64::MAX)) as u64,
                                 );
+                                ctx.flush_momentum_active_pool_publish_queue();
                                 let is_trade = matches!(
                                     event.kind,
                                     MarketEventKind::Trade { .. }
@@ -9116,6 +9365,7 @@ async fn main() -> Result<()> {
                                                                     .min(u128::from(u64::MAX))
                                                                     as u64,
                                                             );
+                                                            ctx.flush_momentum_active_pool_publish_queue();
                                                             if need_exit && ctx.position_count() > 0 {
                                                                 ctx.process_exit_signals(None).await;
                                                             }
@@ -9295,6 +9545,12 @@ async fn main() -> Result<()> {
                 ctx.tick_open_position_pool_recovery_retries().await;
             }
 
+            // PR-D: periodic full active-pool snapshot for market-data idempotency.
+            _ = active_pools_snapshot_interval.tick() => {
+                ironcrab::metrics::record_activity();
+                ctx.reconcile_momentum_active_pools_snapshot_publish();
+            }
+
             // Periodic heartbeat
             _ = heartbeat_interval.tick() => {
                 ironcrab::metrics::record_activity();
@@ -9332,6 +9588,16 @@ async fn main() -> Result<()> {
                 // Cleanup old trackers and stale pending intents
                 ctx.cleanup_old_trackers();
                 ctx.cleanup_stale_pending();
+                let stale_removed = ctx.prune_stale_discovery_trackers();
+                if !stale_removed.is_empty() {
+                    if ctx.nats.is_some() {
+                        ctx.spawn_publish_momentum_active_pools(Vec::new(), stale_removed);
+                    } else {
+                        let mut g = ctx.momentum_active_pool_publish_queue.lock();
+                        g.removed.extend(stale_removed);
+                    }
+                }
+                ctx.flush_momentum_active_pool_publish_queue();
             }
         }
     }
@@ -10310,6 +10576,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         }
     }
 
@@ -10456,6 +10725,103 @@ mod tests {
             ctx.token_trackers.read().is_empty(),
             "no pool-scoped rows for quote/native/stable mints"
         );
+    }
+
+    #[test]
+    fn prune_stale_discovery_retains_new_tracker_without_market_trades() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = empty_test_context(jsonl_writer);
+        let mint = "MintPruneNew1111111111111111111111111111";
+        let pool = "poolPruneNew1";
+        let key = MomentumContext::tracker_storage_key(mint, pool);
+        ctx.token_trackers.write().insert(
+            key.clone(),
+            TokenTracker::test_fixture_stale_discovery(
+                mint,
+                pool,
+                TrackerState::Discovery,
+                std::time::Duration::from_secs(120),
+                None,
+            ),
+        );
+        let removed = ctx.prune_stale_discovery_trackers();
+        assert!(
+            removed.is_empty(),
+            "Discovery ohne Markt-Trade darf nicht sofort entfernt werden (first_seen jung)"
+        );
+        assert!(ctx.token_trackers.read().contains_key(&key));
+    }
+
+    #[test]
+    fn prune_stale_discovery_removes_tracker_idle_over_30m_no_position() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = empty_test_context(jsonl_writer);
+        let mint = "MintPruneOld1111111111111111111111111111";
+        let pool = "poolPruneOld1";
+        let key = MomentumContext::tracker_storage_key(mint, pool);
+        ctx.token_trackers.write().insert(
+            key.clone(),
+            TokenTracker::test_fixture_stale_discovery(
+                mint,
+                pool,
+                TrackerState::Validation,
+                std::time::Duration::from_secs(31 * 60),
+                None,
+            ),
+        );
+        let removed = ctx.prune_stale_discovery_trackers();
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].reason, "stale_discovery");
+        assert!(!ctx.token_trackers.read().contains_key(&key));
+    }
+
+    #[test]
+    fn prune_stale_discovery_skips_when_open_position_same_pool() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = empty_test_context(jsonl_writer);
+        let mint = "MintPrunePos1111111111111111111111111111";
+        let pool = "poolPrunePos1";
+        let key = MomentumContext::tracker_storage_key(mint, pool);
+        ctx.token_trackers.write().insert(
+            key.clone(),
+            TokenTracker::test_fixture_stale_discovery(
+                mint,
+                pool,
+                TrackerState::Discovery,
+                std::time::Duration::from_secs(31 * 60),
+                None,
+            ),
+        );
+        ctx.positions.write().insert(
+            mint.to_string(),
+            PositionTracker::new(mint, pool, "raydium", 1.0, 6, 1_000, 1_000_000),
+        );
+        let removed = ctx.prune_stale_discovery_trackers();
+        assert!(removed.is_empty());
+        assert!(ctx.token_trackers.read().contains_key(&key));
+    }
+
+    #[test]
+    fn momentum_active_pool_flush_skipped_without_nats_keeps_queue() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = Arc::new(empty_test_context(jsonl_writer));
+        ctx.queue_momentum_active_pool_active(
+            "MintAct11111111111111111111111111111111",
+            "poolAct11111111111111111111111111111111",
+            MomentumActivePinReason::Tracker,
+        );
+        ctx.flush_momentum_active_pool_publish_queue();
+        let q = ctx.momentum_active_pool_publish_queue.lock();
+        assert_eq!(q.active.len(), 1);
+        assert!(q.removed.is_empty());
     }
 
     #[test]
@@ -11618,6 +11984,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         };
 
         let mint = "So11111111111111111111111111111111111111112";
@@ -11683,6 +12052,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         };
 
         let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
@@ -13296,6 +13668,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         };
 
         // Seed tracker with a last_trade_ratio so intent generation can compute min_out.
@@ -13414,6 +13789,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         };
 
         // Open a position.
@@ -13501,6 +13879,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         };
 
         // Open a position.
@@ -13582,6 +13963,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         };
 
         let now = Instant::now();
@@ -13668,6 +14052,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         });
 
         ctx.register_pool("mintX", "poolX", "raydium", 1);
@@ -13785,6 +14172,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         });
 
         ctx.open_position(OpenPositionParams {
@@ -13895,6 +14285,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         });
 
         ctx.open_position(OpenPositionParams {
@@ -13990,6 +14383,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         };
 
         // Seed pool registry so reconciliation can pick a pool.
@@ -14063,6 +14459,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         };
 
         let mint = "TokenMint1111111111111111111111111111111111";
@@ -14128,6 +14527,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         };
 
         let mint = "TokenMint2222222222222222222222222222222222";
@@ -14679,6 +15081,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         });
 
         let mint = "9mR7mmX55n1F56rKBBcfMrRzMoJjaZnSRs6fV1GRpump";
@@ -14814,6 +15219,9 @@ mod tests {
             exits_generated: std::sync::atomic::AtomicU64::new(0),
             last_event_slot: std::sync::atomic::AtomicU64::new(0),
             last_event_ts_ms: std::sync::atomic::AtomicU64::new(0),
+            momentum_active_pool_publish_queue: parking_lot::Mutex::new(
+                MomentumActivePoolPublishQueue::default(),
+            ),
         });
 
         let mint = "NoTrkMintttttttttttttttttttttttttttttttttttt";
@@ -16124,6 +16532,12 @@ async fn process_market_event(
                         liquidity = liq_sol,
                         "📊 Token tracker initialized"
                     );
+                    ctx.queue_momentum_active_pool_active(
+                        base_mint,
+                        pool_address,
+                        MomentumActivePinReason::Tracker,
+                    );
+                    ctx.flush_momentum_active_pool_publish_queue();
                 }
             } else {
                 debug!(
@@ -16231,6 +16645,12 @@ async fn process_market_event(
                         discovery = "trade",
                         "📊 Token tracker initialized (trade-based discovery)"
                     );
+                    ctx.queue_momentum_active_pool_active(
+                        mint,
+                        pool_address,
+                        MomentumActivePinReason::Tracker,
+                    );
+                    ctx.flush_momentum_active_pool_publish_queue();
                 }
             }
 

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -4508,6 +4508,8 @@ impl MomentumContext {
                     tracker.set_dev_info(&dev_wallet, supply_pct, &config);
                     if was_not_rejected && tracker.is_rejected() {
                         self.record_token_blacklisted_once(mint);
+                        let reason = tracker.blacklist_reason.as_deref().unwrap_or("rejected");
+                        self.queue_momentum_active_pool_removed(mint, pool, reason);
                     }
                 }
 
@@ -12967,6 +12969,46 @@ mod tests {
             .is_rejected());
     }
 
+    /// PR #147: pending dev applied on vacant insert rejects immediately — queue `removed`, never `active`.
+    #[test]
+    fn get_or_create_tracker_pending_dev_immediate_reject_queues_removed_not_active_for_pin() {
+        let mut cfg = MomentumConfig::default();
+        cfg.max_dev_supply_pct = 50.0;
+
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = empty_test_context(jsonl_writer);
+        *ctx.config.write() = cfg;
+
+        let mint = "MintPendingRejectPin999999999999999999999999";
+        let pool = "poolPendingRejectPin999999999999999999999999";
+
+        ctx.pending_dev_info.write().insert(
+            mint.to_string(),
+            (
+                "DevWallet9999999999999999999999999999999999".to_string(),
+                99.0,
+            ),
+        );
+
+        assert!(ctx.get_or_create_tracker(mint, pool, "raydium", 1, 0));
+
+        let q = ctx.momentum_active_pool_publish_queue.lock();
+        assert!(
+            !q.active
+                .iter()
+                .any(|e| e.mint.as_str() == mint && e.pool.as_str() == pool),
+            "rejected-on-create must not queue active pin"
+        );
+        assert!(
+            q.removed
+                .iter()
+                .any(|r| r.mint.as_str() == mint && r.pool.as_str() == pool),
+            "rejected-on-create must queue removed for market-data"
+        );
+    }
+
     /// `tokens_blacklisted` is mint-level: one LP-removal event rejects two pool rows → +1 not +2.
     #[test]
     fn tokens_blacklisted_once_per_mint_for_record_lp_removal_two_pool_trackers() {
@@ -16573,18 +16615,26 @@ async fn process_market_event(
                     ctx.get_or_create_tracker(base_mint, pool_address, &dex, slot, liq_lamports);
 
                 if created {
-                    info!(
-                        mint = %base_mint,
-                        pool = %pool_address,
-                        dex = %dex,
-                        liquidity = liq_sol,
-                        "📊 Token tracker initialized"
-                    );
-                    ctx.queue_momentum_active_pool_active(
-                        base_mint,
-                        pool_address,
-                        MomentumActivePinReason::Tracker,
-                    );
+                    let tk = MomentumContext::tracker_storage_key(base_mint, pool_address);
+                    let should_pin = ctx
+                        .token_trackers
+                        .read()
+                        .get(&tk)
+                        .is_some_and(|t| !t.is_rejected());
+                    if should_pin {
+                        info!(
+                            mint = %base_mint,
+                            pool = %pool_address,
+                            dex = %dex,
+                            liquidity = liq_sol,
+                            "📊 Token tracker initialized"
+                        );
+                        ctx.queue_momentum_active_pool_active(
+                            base_mint,
+                            pool_address,
+                            MomentumActivePinReason::Tracker,
+                        );
+                    }
                     ctx.flush_momentum_active_pool_publish_queue();
                 }
             } else {
@@ -16686,18 +16736,26 @@ async fn process_market_event(
                 if created {
                     // A.2 Phase 5: Explicitly register pool when discovered via trade
                     ctx.register_pool(mint, pool_address, &dex, slot);
-                    info!(
-                        mint = %mint,
-                        pool = %pool_address,
-                        dex = %dex,
-                        discovery = "trade",
-                        "📊 Token tracker initialized (trade-based discovery)"
-                    );
-                    ctx.queue_momentum_active_pool_active(
-                        mint,
-                        pool_address,
-                        MomentumActivePinReason::Tracker,
-                    );
+                    let tk = MomentumContext::tracker_storage_key(mint, pool_address);
+                    let should_pin = ctx
+                        .token_trackers
+                        .read()
+                        .get(&tk)
+                        .is_some_and(|t| !t.is_rejected());
+                    if should_pin {
+                        info!(
+                            mint = %mint,
+                            pool = %pool_address,
+                            dex = %dex,
+                            discovery = "trade",
+                            "📊 Token tracker initialized (trade-based discovery)"
+                        );
+                        ctx.queue_momentum_active_pool_active(
+                            mint,
+                            pool_address,
+                            MomentumActivePinReason::Tracker,
+                        );
+                    }
                     ctx.flush_momentum_active_pool_publish_queue();
                 }
             }

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -2895,15 +2895,16 @@ impl MomentumContext {
             let r = std::mem::take(&mut g.removed);
             (a, r)
         };
-        self.spawn_publish_momentum_active_pools(active, removed);
+        self.spawn_publish_momentum_active_pools(active, removed, false);
     }
 
     fn spawn_publish_momentum_active_pools(
         self: &Arc<Self>,
         active: Vec<MomentumActivePoolEntry>,
         removed: Vec<MomentumRemovedPoolEntry>,
+        full_active_snapshot: bool,
     ) {
-        if active.is_empty() && removed.is_empty() {
+        if active.is_empty() && removed.is_empty() && !full_active_snapshot {
             return;
         }
         let Some(nats_src) = self.nats.as_ref() else {
@@ -2915,6 +2916,7 @@ impl MomentumContext {
             ts_unix_ms: wall_clock_unix_ms_now(),
             active,
             removed,
+            full_active_snapshot,
         };
         record_momentum_active_pools_messages_total();
         tokio::spawn(async move {
@@ -2968,7 +2970,7 @@ impl MomentumContext {
             return;
         }
         let active = self.collect_momentum_active_pool_snapshot();
-        self.spawn_publish_momentum_active_pools(active, Vec::new());
+        self.spawn_publish_momentum_active_pools(active, Vec::new(), true);
     }
 
     fn prune_stale_discovery_trackers(&self) -> Vec<MomentumRemovedPoolEntry> {
@@ -9591,7 +9593,7 @@ async fn main() -> Result<()> {
                 let stale_removed = ctx.prune_stale_discovery_trackers();
                 if !stale_removed.is_empty() {
                     if ctx.nats.is_some() {
-                        ctx.spawn_publish_momentum_active_pools(Vec::new(), stale_removed);
+                        ctx.spawn_publish_momentum_active_pools(Vec::new(), stale_removed, false);
                     } else {
                         let mut g = ctx.momentum_active_pool_publish_queue.lock();
                         g.removed.extend(stale_removed);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -241,6 +241,15 @@ pub static GEYSER_TRACKED_ACCOUNTS_EVICTED_BIN_ARRAY: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static GEYSER_TRACKED_ACCOUNTS_EVICTED_MINT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
+/// momentum-bot published `MomentumActivePoolsUpdate` payloads (PR-D).
+pub static MOMENTUM_ACTIVE_POOLS_MESSAGES_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// market-data applied `MomentumActivePoolsUpdate` from core NATS (PR-D).
+pub static MARKET_DATA_MOMENTUM_ACTIVE_POOL_MESSAGES_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Count of `(mint, pool)` entries in market-data `ActivePoolSet` (PR-D gauge).
+pub static MARKET_DATA_MOMENTUM_ACTIVE_POOL_PINS_GAUGE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 /// Reconnect after large explicit subscription set (PR-B: full client reconnect vs in-place churn).
 pub static GEYSER_RECONNECT_TOTAL_SUBSCRIPTION_REBUILD: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -280,6 +289,13 @@ pub fn geyser_metrics_set_tracked_pinned_accounts(n: usize) {
     GEYSER_TRACKED_PINNED_ACCOUNTS.store(n as u64, Ordering::Relaxed);
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GeyserTrackedEvictKind {
+    Vault,
+    BinArray,
+    Mint,
+}
+
 pub fn geyser_metrics_inc_tracked_evicted(kind: GeyserTrackedEvictKind) {
     match kind {
         GeyserTrackedEvictKind::Vault => {
@@ -294,11 +310,19 @@ pub fn geyser_metrics_inc_tracked_evicted(kind: GeyserTrackedEvictKind) {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum GeyserTrackedEvictKind {
-    Vault,
-    BinArray,
-    Mint,
+#[inline]
+pub fn record_momentum_active_pools_messages_total() {
+    MOMENTUM_ACTIVE_POOLS_MESSAGES_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_market_data_momentum_active_pool_messages_total() {
+    MARKET_DATA_MOMENTUM_ACTIVE_POOL_MESSAGES_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn set_market_data_momentum_active_pool_pins_gauge(n: usize) {
+    MARKET_DATA_MOMENTUM_ACTIVE_POOL_PINS_GAUGE.store(n as u64, Ordering::Relaxed);
 }
 
 pub fn geyser_metrics_inc_stream_error() {
@@ -2205,6 +2229,18 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "geyser_tracked_pinned_accounts",
         GEYSER_TRACKED_PINNED_ACCOUNTS.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_active_pools_messages_total",
+        MOMENTUM_ACTIVE_POOLS_MESSAGES_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_momentum_active_pool_messages_total",
+        MARKET_DATA_MOMENTUM_ACTIVE_POOL_MESSAGES_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_momentum_active_pool_pins",
+        MARKET_DATA_MOMENTUM_ACTIVE_POOL_PINS_GAUGE.load(Ordering::Relaxed)
     );
     out.push_str("geyser_tracked_accounts_evicted_total{kind=\"vault\"} ");
     out.push_str(

--- a/src/nats/mod.rs
+++ b/src/nats/mod.rs
@@ -11,8 +11,10 @@
 
 pub mod client;
 pub mod jetstream;
+pub mod momentum_active_pools;
 pub mod topics;
 
 pub use client::*;
 pub use jetstream::*;
+pub use momentum_active_pools::*;
 pub use topics::*;

--- a/src/nats/momentum_active_pools.rs
+++ b/src/nats/momentum_active_pools.rs
@@ -1,0 +1,63 @@
+//! Core NATS fire-and-forget messages: momentum-bot → market-data active pool pins (PR-D).
+//!
+//! Spec: `Iron_crab-eval/docs/spec/MOMENTUM_ACTIVE_POOLS.md` (eval repo; wire format stable here).
+
+use serde::{Deserialize, Serialize};
+
+/// Wire payload for `ironcrab.v1.momentum.active_pools` ([`crate::nats::topics::TOPIC_MOMENTUM_ACTIVE_POOLS`]).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MomentumActivePoolsUpdate {
+    pub version: u32,
+    pub ts_unix_ms: u64,
+    pub active: Vec<MomentumActivePoolEntry>,
+    pub removed: Vec<MomentumRemovedPoolEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MomentumActivePoolEntry {
+    pub mint: String,
+    pub pool: String,
+    pub pin_reason: MomentumActivePinReason,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MomentumActivePinReason {
+    Tracker,
+    Position,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MomentumRemovedPoolEntry {
+    pub mint: String,
+    pub pool: String,
+    pub reason: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn momentum_active_pools_update_roundtrip_json() {
+        let u = MomentumActivePoolsUpdate {
+            version: 1,
+            ts_unix_ms: 1_700_000_000,
+            active: vec![MomentumActivePoolEntry {
+                mint: "So11111111111111111111111111111111111111112".to_string(),
+                pool: "Pool111111111111111111111111111111111111111".to_string(),
+                pin_reason: MomentumActivePinReason::Tracker,
+            }],
+            removed: vec![MomentumRemovedPoolEntry {
+                mint: "Mint222222222222222222222222222222222222222".to_string(),
+                pool: "Pool333333333333333333333333333333333333333".to_string(),
+                reason: "stale_discovery".to_string(),
+            }],
+        };
+        let json = serde_json::to_string(&u).expect("serialize");
+        let back: MomentumActivePoolsUpdate = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(u, back);
+        assert!(json.contains("\"pin_reason\":\"tracker\""));
+        assert!(json.contains("\"reason\":\"stale_discovery\""));
+    }
+}

--- a/src/nats/momentum_active_pools.rs
+++ b/src/nats/momentum_active_pools.rs
@@ -11,6 +11,10 @@ pub struct MomentumActivePoolsUpdate {
     pub ts_unix_ms: u64,
     pub active: Vec<MomentumActivePoolEntry>,
     pub removed: Vec<MomentumRemovedPoolEntry>,
+    /// When true, `active` is the authoritative full set: market-data unpins any `(mint, pool)`
+    /// it still holds that is not listed in `active` (reconcile / lost-incremental recovery).
+    #[serde(default)]
+    pub full_active_snapshot: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -53,11 +57,20 @@ mod tests {
                 pool: "Pool333333333333333333333333333333333333333".to_string(),
                 reason: "stale_discovery".to_string(),
             }],
+            full_active_snapshot: false,
         };
         let json = serde_json::to_string(&u).expect("serialize");
         let back: MomentumActivePoolsUpdate = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(u, back);
+        assert!(!back.full_active_snapshot);
         assert!(json.contains("\"pin_reason\":\"tracker\""));
         assert!(json.contains("\"reason\":\"stale_discovery\""));
+    }
+
+    #[test]
+    fn momentum_active_pools_update_deserializes_without_full_snapshot_field() {
+        let json = r#"{"version":1,"ts_unix_ms":1,"active":[],"removed":[]}"#;
+        let u: MomentumActivePoolsUpdate = serde_json::from_str(json).expect("deserialize");
+        assert!(!u.full_active_snapshot);
     }
 }

--- a/src/nats/topics.rs
+++ b/src/nats/topics.rs
@@ -15,6 +15,9 @@ pub const TOPIC_MARKET_EVENTS: &str = "ironcrab.v1.market_events";
 /// Other consumers keep using the core topic; momentum-bot prefers this subject to reduce fan-in.
 pub const TOPIC_MOMENTUM_MARKET_EVENTS: &str = "ironcrab.v1.market_events.momentum";
 
+/// Momentum active pool lifecycle (mint+pool pins for Geyser reserve subscription; PR-D).
+pub const TOPIC_MOMENTUM_ACTIVE_POOLS: &str = "ironcrab.v1.momentum.active_pools";
+
 /// Trade intents from strategy bots
 pub const TOPIC_TRADE_INTENTS: &str = "ironcrab.v1.trade_intents";
 
@@ -119,6 +122,14 @@ mod tests {
         assert!(TOPIC_MOMENTUM_MARKET_EVENTS.contains(TOPIC_VERSION));
         assert!(TOPIC_MOMENTUM_MARKET_EVENTS.starts_with(TOPIC_MARKET_EVENTS));
         assert!(TOPIC_MOMENTUM_MARKET_EVENTS.len() > TOPIC_MARKET_EVENTS.len());
+    }
+
+    #[test]
+    fn test_momentum_active_pools_topic_versioned() {
+        assert!(TOPIC_MOMENTUM_ACTIVE_POOLS.starts_with(TOPIC_PREFIX));
+        assert!(TOPIC_MOMENTUM_ACTIVE_POOLS.contains(TOPIC_VERSION));
+        assert!(TOPIC_MOMENTUM_ACTIVE_POOLS.contains("momentum"));
+        assert!(TOPIC_MOMENTUM_ACTIVE_POOLS.contains("active_pools"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Publishes `ironcrab.v1.momentum.active_pools` from momentum_bot on tracker/position lifecycle (incremental + 30s reconcile).
- market-data subscribes, pins vaults/bins/mints with `GeyserPinReason::MomentumActive`, immediate `sync_geyser_tracked_accounts` (no debounce).
- Discovery/Validation stale cleanup: remove trackers without trade for 30 min (Review decision #4).

Plan: Iron_crab-eval `docs/supervisor/plan_geyser_stream_stability.md` (PR-D). Review decisions **#3** (pin while tracker exists) and **#4** (30 min stale).

## Test plan
- [x] cargo fmt / clippy / test (agent)
- [ ] Eval Level 5 after merge
- [ ] Prod: `geyser_tracked_pinned_accounts` correlates with active trackers; `liq 0.00` rejects should drop for pinned pools

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new cross-service NATS stream that directly affects Geyser explicit subscription pinning/unpinning and eviction behavior; mistakes could increase account load or drop needed subscriptions. Changes are localized but alter runtime lifecycle and synchronization paths in both `momentum_bot` and `market_data`.
> 
> **Overview**
> **Introduces a new NATS topic `ironcrab.v1.momentum.active_pools`** (with `MomentumActivePoolsUpdate` wire types) for momentum-bot to publish *active* and *removed* `(mint, pool)` entries, including periodic full-snapshot reconciliation.
> 
> **Market-data now subscribes to this stream** and uses it to pin/unpin Geyser-tracked reserve vaults, DLMM bin arrays, and related mints under `GeyserPinReason::MomentumActive`, with conservative demotion rules (never override `Wallet` pins; only demote shared pool reserves when no `(mint,pool)` pins remain).
> 
> Momentum-bot additionally **tracks last trade time per tracker and prunes stale Discovery/Validation rows after 30 minutes**, emitting corresponding `removed` updates; multiple new metrics/gauges were added to observe message counts and active pin cardinality, along with targeted unit tests for pin/unpin and stale-prune behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b03e63fd8a7fcc99f85cba2c15d367986ce5214f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->