### PR TITLE
fix(market-data): PR151 follow-up — async TX DevWallet NATS + watchdog task

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,12 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### PR151-NATS-WATCHDOG-FOLLOWUP: TX DevWallet async NATS + systemd-Watchdog unter Backpressure
+**Datum**: 2026-05-26  
+**Problem** (Prod `ironcrab-prod`): Nach PR #151 (Creator-Latenz korrekt) blieb der TX-Fast-Path `maybe_emit_dev_wallet_after_pool_mint_map` bei **synchronem** `publish_market_event_core_and_momentum_ex().await` im dedizierten Geyser-Tx-Task. Unter NATS-Client-Backpressure (100 ms Publish-Timeout) blockierten viele aufeinanderfolgende Versuche den Tokio-Scheduler; der Main-`select!` kam nicht rechtzeitig zum 10 s-`activity_interval` → **kein** `sd_notify(WATCHDOG)` → systemd `WatchdogSec=30` killte `market-data` in einer Schleife. Symptome: `nats_messages_published_total` friert, Logs `NATS publish timeout (backpressure)` / `Market event publish to NATS (core) dropped or failed`.  
+**Fix**: (1) **TX-Fast-Path** nutzt dieselbe **async**-Queue wie der Account-Pfad: `account_path_enqueue_core_market_event` mit `publish_tx` (kein direktes Await auf Core-Publish im Tx-Ingest-Task wenn Queue existiert). `account_publish_tx`-Worker wird **vor** dem Tx-`tokio::spawn` gestartet und an `handle_geyser_transaction` durchgereicht. (2) **Dedizierter Watchdog-Task** `tokio::time::interval(5 s)` + `sd_notify(WATCHDOG)` (nur unix), unabhängig von Geyser-`select!` und NATS-Last — Reserve zu `WatchdogSec=30`. Idempotenz / `pool_creator_cache` / Metrik `market_data_pool_mint_map_to_devwallet_ms` (Enqueue-/Vorbereitungszeitpunkt) unverändert. **Invarianten**: kein neuer RPC (I-7), keine NATS-Schema-Änderung (I-23), kein Creator aus Swap-Accounts (I-4).  
+**Dateien**: `src/bin/market_data.rs`, `docs/BUGS_FIXES.md`, `docs/RUNBOOK_PROD.md`
+
 ### ACCOUNT-PATH-TX-PARITY-CREATOR: DevWallet/Creator-Latenz — TX-Fast-Path + strategische Account-Queues
 **Datum**: 2026-05-25  
 **Problem** (Prod-Referenz „WONDERBRA“, 2026-05-24): Trade-Discovery ohne `PoolCreated`; `BondingCurveUpdate` füllte `pool_creator_cache`, aber `DevWalletIdentified` wurde nur bei **bekanntem** `pool_mint_map` emittiert — Updates **vor** dem ersten Trade gingen verloren (kein Re-Emit). Zugleich verarbeiteten **8** Account-Worker-FIFO-Shards massenweise PumpFun-Bonding-Curves; strategisch relevante Pools lagen **Minuten** in der Wall-Clock-Warteschlange hinter irrelevanten Updates (`ENTRY_BUY_DEFERRED_MISSING_CREATOR` / BUY-Gate).  

--- a/docs/RUNBOOK_PROD.md
+++ b/docs/RUNBOOK_PROD.md
@@ -168,7 +168,7 @@ curl -s http://localhost:9801/metrics | grep '^geyser_'
 
 **Incident-Debug:** `journalctl -u market-data` (Stream, Reconnects) und im importierten Multi-Process-Dashboard die Zeile **Market Data Service** → Panels **Geyser Connected** / **Geyser Reconnects (5m rate)**.
 
-**Betrieb:** `docs/systemd/market-data.service` setzt `Restart=always` (transiente Stream-Abbrüche sollen die Unit nicht dauerhaft inaktiv lassen). Nach Deploy in Grafana Dashboard JSON neu importieren bzw. Refresh; Explore: `geyser_connected{job="market-data"}`.
+**Betrieb:** `docs/systemd/market-data.service` setzt `Restart=always` (transiente Stream-Abbrüche sollen die Unit nicht dauerhaft inaktiv lassen). Nach Deploy in Grafana Dashboard JSON neu importieren bzw. Refresh; Explore: `geyser_connected{job="market-data"}`. **systemd-Watchdog:** Zusätzlich zum bestehenden Ping im Haupt-`select!` pingt ein **dedizierter Task alle 5 s** (`sd_notify(WATCHDOG)`), damit `WatchdogSec=30` nicht verfehlt wird, wenn NATS-Backpressure oder Geyser-Arbeit den Main-Loop verzögert (**PR151-NATS-WATCHDOG-FOLLOWUP** in `docs/BUGS_FIXES.md`).
 
 **Prometheus / `rate()`:** Der Text-Export der Metriken kann je nach Prometheus-Konfiguration abweichen — nach Deploy in Explore verifizieren, z. B. `rate(geyser_reconnect_total{job="market-data"}[5m])` und `rate(geyser_stream_errors_total{job="market-data"}[5m])` liefern sinnvolle Zeitreihen.
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -7490,13 +7490,18 @@ async fn account_worker_recv_next(
 
 /// After `pool_mint_map` insert on the TX path: emit `DevWalletIdentified` if bonding-curve cache
 /// already holds authoritative creator (no Swap parsing; I-4 / BUG-D).
+///
+/// NATS: when `publish_tx` is set (same channel as `account_path_publish_worker`), enqueue only —
+/// avoids blocking the TX ingest task on Core NATS backpressure (PR151 follow-up).
+#[allow(clippy::too_many_arguments)]
 async fn maybe_emit_dev_wallet_after_pool_mint_map(
-    ctx: &MarketDataContext,
+    ctx: &Arc<MarketDataContext>,
     run_id: &str,
     pool: &Pubkey,
     mint: &str,
     slot: Option<u64>,
     tx_grpc_recv_at: Instant,
+    publish_tx: Option<&mpsc::Sender<AccountPathNatsJob>>,
     nats: Option<&NatsClient>,
 ) -> bool {
     let pool_str = pool.to_string();
@@ -7552,16 +7557,17 @@ async fn maybe_emit_dev_wallet_after_pool_mint_map(
     if let Err(e) = ctx.jsonl_writer.write(&dev_event) {
         error!(error = %e, "Failed to write DevWalletIdentified (TX fast-path) to JSONL");
     }
-    if let Some(nats_client) = nats {
-        let _ = publish_market_event_core_and_momentum_ex(
-            nats_client,
-            &dev_event,
+    if publish_tx.is_some() || ctx.nats.is_some() {
+        account_path_enqueue_core_market_event(
+            publish_tx,
+            nats,
+            ctx,
+            dev_event,
             Some(MarketEventCorePublishTrace {
                 recv_at: tx_grpc_recv_at,
                 cold_path: false,
                 segment: MarketDataLatencySegment::Other,
             }),
-            Some(ctx),
         )
         .await;
     }
@@ -9334,6 +9340,7 @@ async fn handle_geyser_transaction(
     run_id: &str,
     tx_update: GeyserTransactionUpdate,
     tx_count: &AtomicU64,
+    account_publish_tx: Option<&mpsc::Sender<AccountPathNatsJob>>,
 ) {
     let recv_at = Instant::now();
     record_market_data_tx_channel_lag_ms(tx_update.grpc_recv_at, recv_at);
@@ -9442,12 +9449,13 @@ async fn handle_geyser_transaction(
                     .write()
                     .insert(*pool_address);
                 maybe_emit_dev_wallet_after_pool_mint_map(
-                    ctx.as_ref(),
+                    &ctx,
                     run_id,
                     pool_address,
                     &base_mint.to_string(),
                     Some(tx_update.slot),
                     tx_update.grpc_recv_at,
+                    account_publish_tx,
                     ctx.nats.as_ref(),
                 )
                 .await;
@@ -9465,12 +9473,13 @@ async fn handle_geyser_transaction(
                     .write()
                     .insert(*pool_address);
                 maybe_emit_dev_wallet_after_pool_mint_map(
-                    ctx.as_ref(),
+                    &ctx,
                     run_id,
                     pool_address,
                     &mint.to_string(),
                     Some(tx_update.slot),
                     tx_update.grpc_recv_at,
+                    account_publish_tx,
                     ctx.nats.as_ref(),
                 )
                 .await;
@@ -10087,6 +10096,19 @@ async fn run_geyser_loop(
         return Ok(());
     }
 
+    // PR151-NATS-WATCHDOG-FOLLOWUP: systemd WatchdogSec=30 — ping unabhängig vom Geyser-`select!`
+    // und NATS-Backpressure (siehe docs/BUGS_FIXES.md), analog execution_engine `maybe_ping_watchdog`.
+    #[cfg(unix)]
+    {
+        tokio::spawn(async {
+            let mut iv = tokio::time::interval(std::time::Duration::from_secs(5));
+            loop {
+                iv.tick().await;
+                let _ = sd_notify::notify(false, &[NotifyState::Watchdog]);
+            }
+        });
+    }
+
     // Mint metadata fetch pipeline:
     // - We add mints to `tracked_mints` when we see them via tx/pool discovery.
     // - Mint accounts often *never change*, so relying on a future Geyser account update
@@ -10261,6 +10283,19 @@ async fn run_geyser_loop(
         None
     };
 
+    // Async NATS publish queue (shared by account workers and TX fast-path DevWallet enqueue).
+    // Must exist before the Geyser-Tx task starts so `handle_geyser_transaction` can enqueue.
+    let account_publish_tx: Option<mpsc::Sender<AccountPathNatsJob>> =
+        ctx.nats.as_ref().map(|nats| {
+            let (tx, rx) = mpsc::channel(MARKET_DATA_ACCOUNT_PUBLISH_QUEUE_CAP);
+            let ctx_pub = Arc::clone(&ctx);
+            let nats_pub = nats.clone_for_spawned_publish();
+            tokio::spawn(async move {
+                account_path_publish_worker(rx, ctx_pub, nats_pub).await;
+            });
+            tx
+        });
+
     // Option A (MARKET-DATA-TX-INGEST-FAIRNESS): dedizierter Tokio-Task für Geyser-Txs.
     // Verhindert, dass `transaction_rx.recv()` hinter langen Account-`select!`-Armen verhungert
     // (p50 `market_data_tx_channel_lag_ms` war ~1s+ bei gleichzeitig niedrigem Publish-Tail).
@@ -10268,6 +10303,7 @@ async fn run_geyser_loop(
     let ctx_geyser_tx = Arc::clone(&ctx);
     let run_id_geyser_tx = run_id.to_string();
     let tx_count_geyser_tx = Arc::clone(&tx_count);
+    let account_publish_tx_geyser_tx = account_publish_tx.clone();
     let mut transaction_rx_geyser = transaction_rx;
     tokio::spawn(async move {
         loop {
@@ -10279,6 +10315,7 @@ async fn run_geyser_loop(
                         run_id_geyser_tx.as_str(),
                         tx_update,
                         tx_count_geyser_tx.as_ref(),
+                        account_publish_tx_geyser_tx.as_ref(),
                     )
                     .await;
                 }
@@ -10303,17 +10340,6 @@ async fn run_geyser_loop(
     let account_count_geyser_acc = Arc::clone(&account_count);
     let rpc_geyser_acc = Arc::clone(&rpc);
     let mut account_rx_geyser = account_rx;
-
-    let account_publish_tx: Option<mpsc::Sender<AccountPathNatsJob>> =
-        ctx_geyser_acc.nats.as_ref().map(|nats| {
-            let (tx, rx) = mpsc::channel(MARKET_DATA_ACCOUNT_PUBLISH_QUEUE_CAP);
-            let ctx_pub = Arc::clone(&ctx_geyser_acc);
-            let nats_pub = nats.clone_for_spawned_publish();
-            tokio::spawn(async move {
-                account_path_publish_worker(rx, ctx_pub, nats_pub).await;
-            });
-            tx
-        });
 
     let mut worker_high_tx_list: Vec<mpsc::Sender<AccountWorkItem>> =
         Vec::with_capacity(MARKET_DATA_ACCOUNT_WORKER_COUNT);
@@ -13247,7 +13273,8 @@ mod pr_b_geyser_tracking_tests {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = JsonlWriter::new(jsonl_cfg).expect("jsonl");
-        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let ctx = Arc::new(minimal_market_data_context_for_pr_d_tests(jsonl));
+        let (publish_tx, mut publish_rx) = mpsc::channel::<AccountPathNatsJob>(8);
         let pool = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
         let creator = Pubkey::new_unique();
@@ -13263,10 +13290,24 @@ mod pr_b_geyser_tracking_tests {
                 &mint.to_string(),
                 Some(1),
                 grpc_at,
+                Some(&publish_tx),
                 None,
             )
             .await
         );
+        let job = tokio::time::timeout(std::time::Duration::from_secs(2), publish_rx.recv())
+            .await
+            .expect("timeout waiting for publish job")
+            .expect("enqueue expected");
+        match job {
+            AccountPathNatsJob::CoreMarketEvent { event, .. } => {
+                assert!(matches!(
+                    event.kind,
+                    MarketEventKind::DevWalletIdentified { .. }
+                ));
+            }
+            _ => panic!("expected CoreMarketEvent job"),
+        }
         assert!(
             !maybe_emit_dev_wallet_after_pool_mint_map(
                 &ctx,
@@ -13275,10 +13316,15 @@ mod pr_b_geyser_tracking_tests {
                 &mint.to_string(),
                 Some(2),
                 grpc_at,
+                Some(&publish_tx),
                 None,
             )
             .await,
             "second call with same creator must not re-emit"
+        );
+        assert!(
+            publish_rx.try_recv().is_err(),
+            "idempotent second call must not enqueue another NATS job"
         );
         let date = chrono::Utc::now().format("%Y%m%d");
         let log = tmp.path().join(format!("market_events-{date}.jsonl"));


### PR DESCRIPTION
## Summary

Follow-up to PR #151.

- TX DevWallet via async account_path_enqueue_core_market_event
- Dedicated 5s watchdog ping task

## Test plan

- [ ] CI green
- [ ] Prod watchdog + NATS rate OK after deploy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot-path Geyser transaction ingest and NATS publish behavior for DevWallet events; incorrect enqueue or watchdog wiring could drop events or still fail liveness checks under load.
> 
> **Overview**
> Follow-up to PR #151: under NATS publish backpressure, the Geyser **TX** path was still **awaiting** core `DevWalletIdentified` publishes, which could stall the dedicated tx-ingest task and starve the main loop’s watchdog pings—leading to **systemd** killing `market-data` on `WatchdogSec=30`.
> 
> **TX DevWallet** now enqueues through the same **async** `account_path_enqueue_core_market_event` / `account_publish_tx` worker used on the account path (no direct core publish await in the tx task when the queue exists). The publish worker is **started before** the Geyser transaction `tokio::spawn`, and `handle_geyser_transaction` receives the sender for Pump.fun `pool_mint_map` fast-path calls.
> 
> A **unix-only** background task pings **`sd_notify(WATCHDOG)` every 5s**, independent of the Geyser `select!` loop and NATS load. Ops notes were added in **`docs/BUGS_FIXES.md`** and **`docs/RUNBOOK_PROD.md`**. The unit test asserts enqueue + idempotency via the publish channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2dcc239faefca659a6513f2104ff41bbf9072f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->