### PR TITLE
fix(geyser): PR156 — ingest liveness, subscription churn, publish watchdog

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -51,10 +51,12 @@ use ironcrab::ipc::{
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
     dec_market_data_account_low_priority_queue_depth, dec_market_data_account_publish_queue_depth,
-    dec_market_data_account_worker_queue_depth, geyser_metrics_inc_tracked_evicted,
-    geyser_metrics_set_subscription_accounts, geyser_metrics_set_tracked_pinned_accounts,
-    inc_market_data_account_high_priority_queue_depth,
-    inc_market_data_account_low_priority_queue_depth, inc_market_data_account_publish_queue_depth,
+    dec_market_data_account_worker_queue_depth, geyser_ingest_alive_gauge,
+    geyser_metrics_inc_tracked_evicted, geyser_metrics_set_subscription_accounts,
+    geyser_metrics_set_tracked_pinned_accounts, inc_market_data_account_high_priority_queue_depth,
+    inc_market_data_account_low_priority_queue_depth,
+    inc_market_data_account_publish_enqueue_timeouts_total,
+    inc_market_data_account_publish_queue_depth,
     inc_market_data_account_publish_queue_dropped_total,
     inc_market_data_account_publish_worker_liveness_reconnects_total,
     inc_market_data_account_publish_worker_reconnects_total,
@@ -76,8 +78,10 @@ use ironcrab::metrics::{
     set_market_data_momentum_active_pool_pins_gauge, set_market_data_tx_broadcast_queue_depth,
     set_readiness_control_sub_active, set_readiness_mode, set_readiness_nats_connected,
     update_readiness_market_data_current, wall_clock_unix_ms_now, GeyserTrackedEvictKind,
-    MarketDataLatencySegment, MetricsComponent, MARKET_DATA_ACCOUNT_PUBLISH_QUEUE_DEPTH,
+    MarketDataLatencySegment, MetricsComponent, GEYSER_LAST_STREAM_PAYLOAD_UNIX_MS,
+    MARKET_DATA_ACCOUNT_PUBLISH_QUEUE_DEPTH,
     MARKET_DATA_ACCOUNT_PUBLISH_WORKER_LAST_SUCCESS_UNIX_MS,
+    MARKET_DATA_GEYSER_HEAD_SLOT_LAST_BUMP_UNIX_MS,
     MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS, MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS,
     MARKET_EVENTS_MOMENTUM_FANOUT_PUBLISHED_TOTAL, MARKET_EVENTS_PUBLISHED_TOTAL,
     MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
@@ -233,8 +237,8 @@ pub(crate) struct MarketEventCorePublishTrace {
     pub recv_at: Instant,
     pub cold_path: bool,
     pub segment: MarketDataLatencySegment,
-    /// When true, [`record_market_data_geyser_to_publish_on_success`] was already called at `mpsc` enqueue
-    /// (PR153); the worker must not double-count end-to-end latency on successful publish.
+    /// When true, [`record_market_data_geyser_to_publish_on_success`] was already recorded after a
+    /// successful `mpsc` enqueue (PR-156); the worker must not double-count end-to-end latency on successful publish.
     pub skip_geyser_to_publish_histogram: bool,
 }
 
@@ -278,9 +282,8 @@ fn market_data_publish_segment(kind: &MarketEventKind) -> MarketDataLatencySegme
 
 /// Bonding / last-trade side effects after a logical core publish success.
 ///
-/// PR154: called from the inline NATS path after `Ok(true)`, and **optimistically** from
-/// `account_path_enqueue_core_market_event` when using `publish_tx`, so publish workers never take
-/// `bonding_curve_publish_times` (avoids cross-task `parking_lot::Mutex` deadlocks with account handlers).
+/// PR154/PR156: called from the inline NATS path after `Ok(true)`, and after a **successful**
+/// `publish_tx` enqueue (post-`mpsc::send`) so optimistic bonding/trade timestamps match delivered jobs.
 #[inline]
 fn apply_market_event_publish_success_side_effects(ctx: &MarketDataContext, event: &MarketEvent) {
     let now_ms = wall_clock_unix_ms_now();
@@ -7824,9 +7827,14 @@ async fn market_data_publish_liveness_watchdog(nats_handles: Vec<Arc<Mutex<NatsC
         let now = wall_clock_unix_ms_now();
         let last = MARKET_DATA_ACCOUNT_PUBLISH_WORKER_LAST_SUCCESS_UNIX_MS.load(Ordering::Relaxed);
         let depth = MARKET_DATA_ACCOUNT_PUBLISH_QUEUE_DEPTH.load(Ordering::Relaxed);
-        if depth > 0 && now.saturating_sub(last) > STALE_MS {
+        let last_payload = GEYSER_LAST_STREAM_PAYLOAD_UNIX_MS.load(Ordering::Relaxed);
+        let head_bump = MARKET_DATA_GEYSER_HEAD_SLOT_LAST_BUMP_UNIX_MS.load(Ordering::Relaxed);
+        let geyser_alive = geyser_ingest_alive_gauge(now, last_payload, 30_000) == 1
+            || geyser_ingest_alive_gauge(now, head_bump, 30_000) == 1;
+        if now.saturating_sub(last) > STALE_MS && (depth > 0 || geyser_alive) {
             warn!(
                 depth,
+                geyser_alive,
                 last_success_unix_ms = last,
                 stale_ms = now.saturating_sub(last),
                 "account_path: publish liveness watchdog — reconnecting all publish NATS clients"
@@ -7949,20 +7957,32 @@ async fn account_path_enqueue_jetstream<T: Serialize>(
             }
         };
         inc_market_data_account_publish_queue_depth();
-        if tx
-            .send(AccountPathNatsJob::JetStream {
+        match tokio::time::timeout(
+            Duration::from_secs(5),
+            tx.send(AccountPathNatsJob::JetStream {
                 subject,
                 payload,
                 bump_market_events_published_total,
-            })
-            .await
-            .is_err()
+            }),
+        )
+        .await
         {
-            dec_market_data_account_publish_queue_depth();
-            warn!(
-                msg = log_fail,
-                "account_path: publish queue closed (JetStream)"
-            );
+            Ok(Ok(())) => {}
+            Ok(Err(_)) => {
+                dec_market_data_account_publish_queue_depth();
+                warn!(
+                    msg = log_fail,
+                    "account_path: publish queue closed (JetStream)"
+                );
+            }
+            Err(_) => {
+                dec_market_data_account_publish_queue_depth();
+                inc_market_data_account_publish_enqueue_timeouts_total();
+                warn!(
+                    msg = log_fail,
+                    "account_path: publish queue send timed out (JetStream)"
+                );
+            }
         }
     } else if let Some(nats) = nats {
         if let Err(e) = nats.jetstream_publish(&subject, payload).await {
@@ -7987,20 +8007,32 @@ async fn account_path_enqueue_topic_json(
 ) {
     if let Some(tx) = publish_tx {
         inc_market_data_account_publish_queue_depth();
-        if tx
-            .send(AccountPathNatsJob::TopicPublish {
+        match tokio::time::timeout(
+            Duration::from_secs(5),
+            tx.send(AccountPathNatsJob::TopicPublish {
                 topic: topic.to_string(),
                 payload,
                 bump_nats_counter,
-            })
-            .await
-            .is_err()
+            }),
+        )
+        .await
         {
-            dec_market_data_account_publish_queue_depth();
-            warn!(
-                msg = log_fail,
-                "account_path: publish queue closed (topic JSON)"
-            );
+            Ok(Ok(())) => {}
+            Ok(Err(_)) => {
+                dec_market_data_account_publish_queue_depth();
+                warn!(
+                    msg = log_fail,
+                    "account_path: publish queue closed (topic JSON)"
+                );
+            }
+            Err(_) => {
+                dec_market_data_account_publish_queue_depth();
+                inc_market_data_account_publish_enqueue_timeouts_total();
+                warn!(
+                    msg = log_fail,
+                    "account_path: publish queue send timed out (topic JSON)"
+                );
+            }
         }
     } else if let Some(nats) = nats {
         match nats.publish(topic, &payload).await {
@@ -8029,31 +8061,48 @@ async fn account_path_enqueue_core_market_event(
     if let Some(tx) = publish_tx {
         let event_id = event.event_id.clone();
         let event_slot = event.slot;
-        if let Some(t) = trace {
-            record_market_data_geyser_to_publish_on_success(
-                t.recv_at,
-                t.segment,
-                t.cold_path,
-                event_slot,
-            );
-        }
-        apply_market_event_publish_success_side_effects(ctx.as_ref(), &event);
+        let event_for_success_effects = event.clone();
         let trace_for_job =
             trace.map(MarketEventCorePublishTrace::with_skip_geyser_to_publish_histogram);
         inc_market_data_account_publish_queue_depth();
-        if tx
-            .send(AccountPathNatsJob::CoreMarketEvent {
+        match tokio::time::timeout(
+            Duration::from_secs(5),
+            tx.send(AccountPathNatsJob::CoreMarketEvent {
                 event: Box::new(event),
                 trace: trace_for_job,
-            })
-            .await
-            .is_err()
+            }),
+        )
+        .await
         {
-            dec_market_data_account_publish_queue_depth();
-            warn!(
-                event_id = %event_id,
-                "account_path: publish queue closed (core MarketEvent)"
-            );
+            Ok(Ok(())) => {
+                if let Some(t) = trace {
+                    record_market_data_geyser_to_publish_on_success(
+                        t.recv_at,
+                        t.segment,
+                        t.cold_path,
+                        event_slot,
+                    );
+                }
+                apply_market_event_publish_success_side_effects(
+                    ctx.as_ref(),
+                    &event_for_success_effects,
+                );
+            }
+            Ok(Err(_)) => {
+                dec_market_data_account_publish_queue_depth();
+                warn!(
+                    event_id = %event_id,
+                    "account_path: publish queue closed (core MarketEvent)"
+                );
+            }
+            Err(_) => {
+                dec_market_data_account_publish_queue_depth();
+                inc_market_data_account_publish_enqueue_timeouts_total();
+                warn!(
+                    event_id = %event_id,
+                    "account_path: publish queue send timed out (core MarketEvent)"
+                );
+            }
         }
     } else if let Some(nats) = nats {
         let _ = publish_market_event_core_and_momentum_ex(nats, &event, trace, Some(ctx.as_ref()))

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -227,7 +227,8 @@ pub static GEYSER_RECONNECT_TOTAL_STREAM_ERROR: Lazy<AtomicU64> = Lazy::new(|| A
 pub static GEYSER_RECONNECT_TOTAL_SINK_GONE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// gRPC stream `Err` deliveries (excludes graceful `None` / stream ended).
 pub static GEYSER_STREAM_ERRORS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
-/// 1 while a Geyser gRPC connection is established; 0 while reconnecting.
+/// 1 while a Geyser gRPC TCP subscribe handshake succeeded; 0 while reconnecting.
+/// Not ingest health — see `geyser_ingest_alive` / `geyser_last_stream_payload_unix_ms` (PR-156).
 pub static GEYSER_CONNECTED: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
 /// Combined explicit Geyser account subscription size (mints + vaults + bin arrays + wallet).
@@ -254,6 +255,20 @@ pub static MARKET_DATA_MOMENTUM_ACTIVE_POOL_PINS_GAUGE: Lazy<AtomicU64> =
 pub static GEYSER_RECONNECT_TOTAL_SUBSCRIPTION_REBUILD: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
+/// Reconnect after main Geyser stream silent stall (no Account/Tx/BlockMeta payloads; PR-156).
+pub static GEYSER_RECONNECT_TOTAL_INGEST_STALE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// Successful in-place `subscribe_tx.send` updates for tracked-account churn (PR-156).
+pub static GEYSER_SUBSCRIPTION_INPLACE_UPDATES_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Wall-clock ms of last Account/Transaction/BlockMeta payload on main Geyser listener (PR-156).
+pub static GEYSER_LAST_STREAM_PAYLOAD_UNIX_MS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// Wall-clock ms of last [`market_data_bump_geyser_head_slot`] call (PR-156 NATS liveness proxy).
+pub static MARKET_DATA_GEYSER_HEAD_SLOT_LAST_BUMP_UNIX_MS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 /// Geyser listener reconnect reason (PR-A stream resiliency).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum GeyserReconnectReason {
@@ -262,6 +277,8 @@ pub enum GeyserReconnectReason {
     SinkGone,
     /// PR-B: intentional full reconnect for large `combined_tracked` updates.
     SubscriptionRebuild,
+    /// PR-156: no stream payloads for extended period while TCP subscription appears healthy.
+    IngestStale,
 }
 
 pub fn geyser_metrics_inc_reconnect(reason: GeyserReconnectReason) {
@@ -278,6 +295,32 @@ pub fn geyser_metrics_inc_reconnect(reason: GeyserReconnectReason) {
         GeyserReconnectReason::SubscriptionRebuild => {
             GEYSER_RECONNECT_TOTAL_SUBSCRIPTION_REBUILD.fetch_add(1, Ordering::Relaxed);
         }
+        GeyserReconnectReason::IngestStale => {
+            GEYSER_RECONNECT_TOTAL_INGEST_STALE.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Main listener: any Account / Transaction / BlockMeta wire payload (PR-156 ingest liveness).
+#[inline]
+pub fn geyser_metrics_touch_stream_payload_unix_ms() {
+    GEYSER_LAST_STREAM_PAYLOAD_UNIX_MS.store(wall_clock_unix_ms_now(), Ordering::Relaxed);
+}
+
+#[inline]
+pub fn geyser_metrics_inc_subscription_inplace_updates_total() {
+    GEYSER_SUBSCRIPTION_INPLACE_UPDATES_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// PR-156: `1` if last stream payload is within `max_age_ms` of `now_ms`, else `0`. (Gauge semantics.)
+#[inline]
+pub fn geyser_ingest_alive_gauge(now_ms: u64, last_payload_unix_ms: u64, max_age_ms: u64) -> u64 {
+    if last_payload_unix_ms == 0 {
+        0
+    } else if now_ms.saturating_sub(last_payload_unix_ms) < max_age_ms {
+        1
+    } else {
+        0
     }
 }
 
@@ -577,6 +620,10 @@ pub static MARKET_DATA_ACCOUNT_PUBLISH_WORKER_RECONNECTS_TOTAL: Lazy<AtomicU64> 
 pub static MARKET_DATA_ACCOUNT_PUBLISH_WORKER_LIVENESS_RECONNECTS_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
+/// Publish enqueue: `mpsc::send` exceeded timeout (PR-156; avoids blocking account ingest on full queue).
+pub static MARKET_DATA_ACCOUNT_PUBLISH_ENQUEUE_TIMEOUTS_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 /// Account ingest: cheap relevance filter discarded the update before `handle_geyser_account` body.
 pub static MARKET_DATA_ACCOUNT_EARLY_DROP_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
@@ -624,6 +671,8 @@ pub fn market_data_bump_geyser_head_slot(slot: u64) {
         return;
     }
     let _ = MARKET_DATA_GEYSER_HEAD_SLOT.fetch_max(slot, Ordering::Relaxed);
+    MARKET_DATA_GEYSER_HEAD_SLOT_LAST_BUMP_UNIX_MS
+        .store(wall_clock_unix_ms_now(), Ordering::Relaxed);
 }
 
 /// Record wall ms delta for pump.fun trade after last bonding publish (bounded map hit only).
@@ -800,6 +849,11 @@ pub fn inc_market_data_account_publish_worker_stalls_total() {
 #[inline]
 pub fn inc_market_data_account_publish_queue_dropped_total() {
     MARKET_DATA_ACCOUNT_PUBLISH_QUEUE_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_account_publish_enqueue_timeouts_total() {
+    MARKET_DATA_ACCOUNT_PUBLISH_ENQUEUE_TIMEOUTS_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -2398,11 +2452,29 @@ async fn metrics_response() -> Response<Body> {
             .to_string(),
     );
     out.push('\n');
+    out.push_str("geyser_reconnect_total{reason=\"ingest_stale\"} ");
+    out.push_str(
+        &GEYSER_RECONNECT_TOTAL_INGEST_STALE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
     line!(
         "geyser_stream_errors_total",
         GEYSER_STREAM_ERRORS_TOTAL.load(Ordering::Relaxed)
     );
     line!("geyser_connected", GEYSER_CONNECTED.load(Ordering::Relaxed));
+    let now_ms = wall_clock_unix_ms_now();
+    let last_payload_ms = GEYSER_LAST_STREAM_PAYLOAD_UNIX_MS.load(Ordering::Relaxed);
+    line!("geyser_last_stream_payload_unix_ms", last_payload_ms);
+    line!(
+        "geyser_ingest_alive",
+        geyser_ingest_alive_gauge(now_ms, last_payload_ms, 30_000)
+    );
+    line!(
+        "geyser_subscription_inplace_updates_total",
+        GEYSER_SUBSCRIPTION_INPLACE_UPDATES_TOTAL.load(Ordering::Relaxed)
+    );
     line!(
         "geyser_subscription_accounts",
         GEYSER_SUBSCRIPTION_ACCOUNTS.load(Ordering::Relaxed)
@@ -2447,6 +2519,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_geyser_head_slot",
         MARKET_DATA_GEYSER_HEAD_SLOT.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_geyser_head_slot_last_bump_unix_ms",
+        MARKET_DATA_GEYSER_HEAD_SLOT_LAST_BUMP_UNIX_MS.load(Ordering::Relaxed)
     );
     line!(
         "market_data_last_trade_publish_ts_unix_ms",
@@ -2603,6 +2679,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_account_publish_queue_dropped_total",
         MARKET_DATA_ACCOUNT_PUBLISH_QUEUE_DROPPED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_account_publish_enqueue_timeouts_total",
+        MARKET_DATA_ACCOUNT_PUBLISH_ENQUEUE_TIMEOUTS_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_account_publish_workers_active",
@@ -3990,5 +4070,18 @@ mod momentum_latency_metrics_tests {
             MOMENTUM_CORE_MARKET_EVENTS_INGEST_CONSECUTIVE_CAP_HIT_STREAK.load(Ordering::Relaxed),
             0
         );
+    }
+}
+
+#[cfg(test)]
+mod geyser_ingest_liveness_metrics_tests {
+    use super::geyser_ingest_alive_gauge;
+
+    #[test]
+    fn geyser_ingest_alive_gauge_respects_window() {
+        assert_eq!(geyser_ingest_alive_gauge(100_000, 0, 30_000), 0);
+        assert_eq!(geyser_ingest_alive_gauge(100_000, 99_900, 30_000), 1);
+        assert_eq!(geyser_ingest_alive_gauge(130_000, 99_000, 30_000), 0);
+        assert_eq!(geyser_ingest_alive_gauge(129_999, 100_000, 30_000), 1);
     }
 }

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -14,7 +14,9 @@ use futures::{SinkExt, StreamExt};
 #[cfg(not(windows))]
 use solana_sdk::bs58;
 #[cfg(not(windows))]
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+#[cfg(not(windows))]
+use std::pin::Pin;
 #[cfg(not(windows))]
 use tracing::debug;
 #[cfg(not(windows))]
@@ -30,8 +32,9 @@ use yellowstone_grpc_proto::prelude::{
 
 #[cfg(not(windows))]
 use crate::metrics::{
-    geyser_metrics_inc_reconnect, geyser_metrics_inc_stream_error, geyser_metrics_set_connected,
-    GeyserReconnectReason,
+    geyser_metrics_inc_reconnect, geyser_metrics_inc_stream_error,
+    geyser_metrics_inc_subscription_inplace_updates_total, geyser_metrics_set_connected,
+    geyser_metrics_touch_stream_payload_unix_ms, GeyserReconnectReason,
 };
 #[cfg(not(windows))]
 use rand::Rng;
@@ -39,6 +42,8 @@ use rand::Rng;
 use std::time::Duration;
 #[cfg(not(windows))]
 use tokio::time::sleep;
+#[cfg(not(windows))]
+use tokio::time::MissedTickBehavior;
 
 /// Event emitted when an account changes via Geyser
 #[derive(Debug, Clone)]
@@ -384,6 +389,21 @@ impl GeyserListener {
 
                 let mut got_payload_since_subscribe = false;
 
+                const MIN_TRACKED_INPLACE_SUBSCRIBE_INTERVAL: Duration = Duration::from_millis(300);
+                const TRACKED_INPLACE_CHURN_WINDOW: Duration = Duration::from_secs(2);
+                const INGEST_STALE_AFTER: Duration = Duration::from_secs(30);
+                const INGEST_LIVENESS_TICK: Duration = Duration::from_secs(10);
+                const POST_INPLACE_NO_PAYLOAD_WAIT: Duration = Duration::from_secs(10);
+
+                let mut last_stream_payload_at = Instant::now();
+                let mut ingest_liveness_tick = tokio::time::interval(INGEST_LIVENESS_TICK);
+                ingest_liveness_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+                let mut last_tracked_inplace_send_at: Option<Instant> = None;
+                let mut tracked_inplace_churn_times: VecDeque<Instant> = VecDeque::new();
+                let mut pending_tracked_inplace_sleep: Option<Pin<Box<tokio::time::Sleep>>> = None;
+                let mut post_inplace_payload_deadline: Option<Instant> = None;
+
                 let session_exit = 'read: loop {
                     if last_log.elapsed().as_secs() >= 60 {
                         info!(
@@ -432,6 +452,9 @@ impl GeyserListener {
                                     if let Some(update) = msg.update_oneof {
                                         match update {
                                 UpdateOneof::Account(account_update) => {
+                                    last_stream_payload_at = Instant::now();
+                                    post_inplace_payload_deadline = None;
+                                    geyser_metrics_touch_stream_payload_unix_ms();
                                     account_update_count += 1;
 
                                     if let Some(account_info) = account_update.account {
@@ -481,6 +504,9 @@ impl GeyserListener {
                                     }
                                 }
                                 UpdateOneof::Transaction(tx_update) => {
+                                    last_stream_payload_at = Instant::now();
+                                    post_inplace_payload_deadline = None;
+                                    geyser_metrics_touch_stream_payload_unix_ms();
                                     transaction_count += 1;
 
                                     if let Some(tx) = tx_update.transaction {
@@ -736,6 +762,9 @@ impl GeyserListener {
                                     }
                                 }
                                 UpdateOneof::BlockMeta(block_meta) => {
+                                    last_stream_payload_at = Instant::now();
+                                    post_inplace_payload_deadline = None;
+                                    geyser_metrics_touch_stream_payload_unix_ms();
                                     let event = GeyserBlockhashUpdate {
                                         blockhash: block_meta.blockhash,
                                         slot: block_meta.slot,
@@ -756,53 +785,163 @@ impl GeyserListener {
                                 _ => {
                                     // Slots, etc. - ignore
                                 }
+                                        }
+                                    }
+                                }
                             }
-                        }
-                    }
+                        },
+                        _ = ingest_liveness_tick.tick() => {
+                            let now_i = Instant::now();
+                            if let Some(dl) = post_inplace_payload_deadline {
+                                if now_i >= dl {
+                                    warn!(
+                                        tracked_accounts = tracked_accounts_current.len(),
+                                        "geyser_listener: no stream payload within deadline after in-place subscription update — subscription rebuild"
+                                    );
+                                    break 'read SessionExit::SubscriptionRebuild;
+                                }
                             }
+                            if last_stream_payload_at.elapsed() >= INGEST_STALE_AFTER {
+                                let since_ms = last_stream_payload_at
+                                    .elapsed()
+                                    .as_millis()
+                                    .min(u128::from(u64::MAX))
+                                    as u64;
+                                warn!(
+                                    tracked_accounts = tracked_accounts_current.len(),
+                                    since_last_payload_ms = since_ms,
+                                    "geyser_listener: ingest stale (no Account/Tx/BlockMeta payloads) — hard reconnect"
+                                );
+                                geyser_metrics_set_connected(false);
+                                geyser_metrics_inc_reconnect(GeyserReconnectReason::IngestStale);
+                                break 'read SessionExit::HardReconnect;
+                            }
+                        },
+                        _ = async {
+                            match pending_tracked_inplace_sleep.as_mut() {
+                                Some(s) => s.as_mut().await,
+                                None => std::future::pending::<()>().await,
+                            }
+                        }, if pending_tracked_inplace_sleep.is_some() => {
+                            pending_tracked_inplace_sleep = None;
+                            let now = Instant::now();
+                            while let Some(t) = tracked_inplace_churn_times.front().copied() {
+                                if now.saturating_duration_since(t) > TRACKED_INPLACE_CHURN_WINDOW {
+                                    tracked_inplace_churn_times.pop_front();
+                                } else {
+                                    break;
+                                }
+                            }
+                            if tracked_inplace_churn_times.len() >= 3 {
+                                warn!(
+                                    tracked_accounts = tracked_accounts_current.len(),
+                                    "geyser_listener: forcing full reconnect due to subscription churn"
+                                );
+                                break 'read SessionExit::SubscriptionRebuild;
+                            }
+                            let updated_request = Self::build_subscribe_request(
+                                &self.program_ids,
+                                &tracked_accounts_current,
+                            );
+                            if let Err(e) = subscribe_tx.send(updated_request).await {
+                                warn!(
+                                    "geyser_listener: failed to send subscription update: {e}; reconnecting with new client"
+                                );
+                                geyser_metrics_inc_reconnect(GeyserReconnectReason::SinkGone);
+                                break 'read SessionExit::HardReconnect;
+                            }
+                            geyser_metrics_inc_subscription_inplace_updates_total();
+                            last_tracked_inplace_send_at = Some(Instant::now());
+                            tracked_inplace_churn_times.push_back(Instant::now());
+                            post_inplace_payload_deadline =
+                                Some(Instant::now() + POST_INPLACE_NO_PAYLOAD_WAIT);
+                            warn!(
+                                tracked_accounts = tracked_accounts_current.len(),
+                                "geyser_listener: subscription updated (NO reconnect, coalesced)"
+                            );
                         },
                         maybe_new = tracked_changed_fut => {
                             if let Some(new_list) = maybe_new {
-                                if new_list != tracked_accounts_current {
-                                    tracked_accounts_current = new_list;
-                                    let threshold = self
-                                        .full_reconnect_tracked_threshold
-                                        .load(Ordering::Relaxed);
-                                    let now = Instant::now();
-                                    let over_threshold =
-                                        tracked_accounts_current.len() > threshold;
-                                    let allow_full_rebuild = over_threshold
-                                        && last_large_set_subscription_rebuild
-                                            .map(|t| {
-                                                now.saturating_duration_since(t)
-                                                    >= LARGE_TRACKED_SUBSCRIBE_REBUILD_MIN_INTERVAL
-                                            })
-                                            .unwrap_or(true);
-                                    if allow_full_rebuild {
-                                        last_large_set_subscription_rebuild = Some(now);
-                                        info!(
-                                            tracked_accounts = tracked_accounts_current.len(),
-                                            threshold,
-                                            "geyser_listener: large tracked set — forcing full reconnect (skip in-place subscribe update)"
-                                        );
-                                        break 'read SessionExit::SubscriptionRebuild;
-                                    }
-                                    let updated_request = Self::build_subscribe_request(
-                                        &self.program_ids,
-                                        &tracked_accounts_current,
+                                if new_list == tracked_accounts_current {
+                                    continue;
+                                }
+                                tracked_accounts_current = new_list;
+                                let threshold = self
+                                    .full_reconnect_tracked_threshold
+                                    .load(Ordering::Relaxed);
+                                let now = Instant::now();
+                                let over_threshold = tracked_accounts_current.len() > threshold;
+                                let allow_full_rebuild = over_threshold
+                                    && last_large_set_subscription_rebuild
+                                        .map(|t| {
+                                            now.saturating_duration_since(t)
+                                                >= LARGE_TRACKED_SUBSCRIBE_REBUILD_MIN_INTERVAL
+                                        })
+                                        .unwrap_or(true);
+                                if allow_full_rebuild {
+                                    last_large_set_subscription_rebuild = Some(now);
+                                    info!(
+                                        tracked_accounts = tracked_accounts_current.len(),
+                                        threshold,
+                                        "geyser_listener: large tracked set — forcing full reconnect (skip in-place subscribe update)"
                                     );
-                                    if let Err(e) = subscribe_tx.send(updated_request).await {
-                                        warn!(
-                                            "geyser_listener: failed to send subscription update: {e}; reconnecting with new client"
-                                        );
-                                        geyser_metrics_inc_reconnect(GeyserReconnectReason::SinkGone);
-                                        break 'read SessionExit::HardReconnect;
+                                    break 'read SessionExit::SubscriptionRebuild;
+                                }
+
+                                while let Some(t) = tracked_inplace_churn_times.front().copied() {
+                                    if now.saturating_duration_since(t) > TRACKED_INPLACE_CHURN_WINDOW
+                                    {
+                                        tracked_inplace_churn_times.pop_front();
+                                    } else {
+                                        break;
                                     }
+                                }
+                                if tracked_inplace_churn_times.len() >= 3 {
                                     warn!(
                                         tracked_accounts = tracked_accounts_current.len(),
-                                        "geyser_listener: subscription updated (NO reconnect)"
+                                        "geyser_listener: forcing full reconnect due to subscription churn"
                                     );
+                                    break 'read SessionExit::SubscriptionRebuild;
                                 }
+
+                                let can_inplace_send = last_tracked_inplace_send_at
+                                    .map(|t| {
+                                        t.elapsed() >= MIN_TRACKED_INPLACE_SUBSCRIBE_INTERVAL
+                                    })
+                                    .unwrap_or(true);
+                                if !can_inplace_send {
+                                    if pending_tracked_inplace_sleep.is_none() {
+                                        let deadline = last_tracked_inplace_send_at.unwrap()
+                                            + MIN_TRACKED_INPLACE_SUBSCRIBE_INTERVAL;
+                                        pending_tracked_inplace_sleep = Some(Box::pin(
+                                            tokio::time::sleep_until(deadline.into()),
+                                        ));
+                                    }
+                                    continue;
+                                }
+
+                                pending_tracked_inplace_sleep = None;
+
+                                let updated_request = Self::build_subscribe_request(
+                                    &self.program_ids,
+                                    &tracked_accounts_current,
+                                );
+                                if let Err(e) = subscribe_tx.send(updated_request).await {
+                                    warn!(
+                                        "geyser_listener: failed to send subscription update: {e}; reconnecting with new client"
+                                    );
+                                    geyser_metrics_inc_reconnect(GeyserReconnectReason::SinkGone);
+                                    break 'read SessionExit::HardReconnect;
+                                }
+                                geyser_metrics_inc_subscription_inplace_updates_total();
+                                last_tracked_inplace_send_at = Some(Instant::now());
+                                tracked_inplace_churn_times.push_back(Instant::now());
+                                post_inplace_payload_deadline =
+                                    Some(Instant::now() + POST_INPLACE_NO_PAYLOAD_WAIT);
+                                warn!(
+                                    tracked_accounts = tracked_accounts_current.len(),
+                                    "geyser_listener: subscription updated (NO reconnect)"
+                                );
                             }
                         }
                     }
@@ -838,6 +977,42 @@ impl GeyserListener {
 #[cfg(all(test, not(windows)))]
 mod geyser_resilience_tests {
     use super::GeyserListener;
+    use std::collections::VecDeque;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn churn_window_prunes_entries_older_than_two_seconds() {
+        let mut q = VecDeque::new();
+        let now = Instant::now();
+        let old = now - Duration::from_secs(5);
+        q.push_back(old);
+        q.push_back(now);
+        const WINDOW: Duration = Duration::from_secs(2);
+        while let Some(t) = q.front().copied() {
+            if now.saturating_duration_since(t) > WINDOW {
+                q.pop_front();
+            } else {
+                break;
+            }
+        }
+        assert_eq!(q.len(), 1);
+        assert!(now.duration_since(*q.front().unwrap()) <= WINDOW);
+    }
+
+    #[test]
+    fn fourth_inplace_within_window_requires_escalation_check() {
+        let mut q = VecDeque::new();
+        let t = Instant::now();
+        q.push_back(t);
+        q.push_back(t);
+        assert!(q.len() < 3);
+        q.push_back(t);
+        assert_eq!(q.len(), 3);
+        assert!(
+            q.len() >= 3,
+            "with 3 prior in-window sends, the next must use SubscriptionRebuild"
+        );
+    }
 
     #[test]
     fn reconnect_sleep_ms_adds_bounded_jitter() {


### PR DESCRIPTION
## Summary

- **Geyser ingest liveness:** Detect silent main-listener stalls (>30s without Account/Tx/BlockMeta payloads) and force hard reconnect with `geyser_reconnect_total{reason=ingest_stale}`.
- **Subscription churn:** Coalesce tracked-account in-place subscribe updates (300ms min interval); escalate to full reconnect on churn (4 updates in 2s) or missing payloads 10s after in-place update.
- **Metrics:** Add `geyser_ingest_alive`, `geyser_last_stream_payload_unix_ms`, `market_data_geyser_head_slot_last_bump_unix_ms`; clarify `geyser_connected` is TCP/subscribe only.
- **NATS publish liveness:** Reconnect when `last_success` stale and (`queue_depth > 0` OR Geyser ingest alive) — fixes PR155 `depth > 0` blind spot.
- **Enqueue timeout:** 5s timeout on publish `mpsc::send` to unblock account ingest on wedged queue.

Fixes prod incident: `geyser_connected=1` while head_slot/ingest frozen after 15 in-place subscription updates in 3s.

Handoff: `Iron_crab-eval/docs/supervisor/handoff_p156_geyser_ingest_liveness.md`

## Test plan

- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`
- [ ] Prod smoke after deploy: `geyser_ingest_alive=1`, `nats_messages_published_total` rising >10 min
- [ ] Dashboard: use `geyser_ingest_alive` instead of `geyser_connected` alone
