### PR TITLE
feat(geyser): CompressedAccountFilterSet for tracked accounts (structural churn fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
  "pin-project-lite",
  "serde_core",
  "sync_wrapper",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -2337,6 +2337,7 @@ dependencies = [
  "solana-connection-cache",
  "solana-message 3.0.1",
  "solana-program 3.0.0",
+ "solana-pubkey 4.1.0",
  "solana-quic-client",
  "solana-rpc-client",
  "solana-rpc-client-api",
@@ -3810,7 +3811,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -8435,7 +8436,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -8496,6 +8497,21 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -8531,7 +8547,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -9524,26 +9540,35 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "12.0.0"
-source = "git+https://github.com/rpcpool/yellowstone-grpc.git?branch=master#9d6e1d5234de23e2fada59cdb57b8f8f175e4ee5"
+version = "13.1.0"
+source = "git+https://github.com/rpcpool/yellowstone-grpc.git?rev=486c2102bdf4f2e950dd04d5908388c58d5cc873#486c2102bdf4f2e950dd04d5908388c58d5cc873"
 dependencies = [
+ "arc-swap",
  "bytes",
  "futures",
+ "hyper-util",
+ "log",
+ "pin-project",
  "thiserror 2.0.18",
+ "tokio",
  "tonic",
  "tonic-health",
+ "tower 0.4.13",
  "yellowstone-grpc-proto",
 ]
 
 [[package]]
 name = "yellowstone-grpc-proto"
-version = "12.0.0"
-source = "git+https://github.com/rpcpool/yellowstone-grpc.git?branch=master#9d6e1d5234de23e2fada59cdb57b8f8f175e4ee5"
+version = "12.4.0"
+source = "git+https://github.com/rpcpool/yellowstone-grpc.git?rev=486c2102bdf4f2e950dd04d5908388c58d5cc873#486c2102bdf4f2e950dd04d5908388c58d5cc873"
 dependencies = [
  "anyhow",
  "prost",
  "prost-types",
  "protoc-bin-vendored",
+ "siphasher 1.0.2",
+ "solana-pubkey 4.1.0",
+ "thiserror 2.0.18",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,12 @@ sd-notify = "0.4"
 # TPU Direct Client deps are also non-Windows (same cfg gate).
 # NOTE: These crates are currently unused in Rust code — kept for future TPU sender integration.
 [target.'cfg(not(windows))'.dependencies]
-yellowstone-grpc-client = { git = "https://github.com/rpcpool/yellowstone-grpc.git", branch = "master" }
-yellowstone-grpc-proto = { git = "https://github.com/rpcpool/yellowstone-grpc.git", branch = "master" }
+# Pinned after PR #732 (CompressedAccountFilterSet / cuckoo account filters). `master` head may
+# require Agave 4-only workspace deps; this merge commit carries cuckoo + compatible client/proto API.
+yellowstone-grpc-client = { git = "https://github.com/rpcpool/yellowstone-grpc.git", rev = "486c2102bdf4f2e950dd04d5908388c58d5cc873" }
+yellowstone-grpc-proto = { git = "https://github.com/rpcpool/yellowstone-grpc.git", rev = "486c2102bdf4f2e950dd04d5908388c58d5cc873" }
+# Align with yellowstone-grpc-proto cuckoo helpers (`CompressedAccountFilterSet::insert` takes `solana_pubkey::Pubkey`).
+solana-pubkey = "4.1.0"
 # TPU Direct Client (for low-latency TX submission)
 solana-tpu-client = "=3.0.0"
 solana-connection-cache = "=3.0.0"

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -10293,6 +10293,7 @@ async fn run_geyser_loop(
             program_ids,
             combined_tracked_rx,
             Arc::clone(&ctx.geyser_full_reconnect_threshold_live),
+            ctx.config.read().max_tracked_accounts.max(1),
         );
 
     // Spawn Geyser listener task

--- a/src/execution/cache_geyser.rs
+++ b/src/execution/cache_geyser.rs
@@ -379,6 +379,7 @@ fn build_cache_subscribe_request(
                 owner: vec![program_id.to_string()],
                 filters: vec![],
                 nonempty_txn_signature: None,
+                cuckoo_accounts_filter: None,
             },
         );
     }
@@ -393,6 +394,7 @@ fn build_cache_subscribe_request(
                     owner: vec![],
                     filters: vec![],
                     nonempty_txn_signature: None,
+                    cuckoo_accounts_filter: None,
                 },
             );
         }
@@ -408,6 +410,7 @@ fn build_cache_subscribe_request(
                     owner: vec![],
                     filters: vec![],
                     nonempty_txn_signature: None,
+                    cuckoo_accounts_filter: None,
                 },
             );
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -227,6 +227,9 @@ pub static GEYSER_RECONNECT_TOTAL_STREAM_ERROR: Lazy<AtomicU64> = Lazy::new(|| A
 pub static GEYSER_RECONNECT_TOTAL_SINK_GONE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// gRPC stream `Err` deliveries (excludes graceful `None` / stream ended).
 pub static GEYSER_STREAM_ERRORS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// `CompressedAccountFilterSet::insert` failed: capacity below configured explicit-track ceiling.
+pub static GEYSER_TRACKED_CUCKOO_TABLE_FULL_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// 1 while a Geyser gRPC connection is established; 0 while reconnecting.
 pub static GEYSER_CONNECTED: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
@@ -350,6 +353,11 @@ pub fn set_market_data_geyser_sync_pending(pending: u64) {
 
 pub fn geyser_metrics_inc_stream_error() {
     GEYSER_STREAM_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn geyser_metrics_inc_tracked_cuckoo_table_full() {
+    GEYSER_TRACKED_CUCKOO_TABLE_FULL_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 pub fn geyser_metrics_set_connected(connected: bool) {
@@ -2337,6 +2345,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "geyser_stream_errors_total",
         GEYSER_STREAM_ERRORS_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "geyser_tracked_cuckoo_table_full_total",
+        GEYSER_TRACKED_CUCKOO_TABLE_FULL_TOTAL.load(Ordering::Relaxed)
     );
     line!("geyser_connected", GEYSER_CONNECTED.load(Ordering::Relaxed));
     line!(

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -12,6 +12,8 @@ use tokio::sync::watch;
 #[cfg(not(windows))]
 use futures::{SinkExt, StreamExt};
 #[cfg(not(windows))]
+use solana_pubkey::Pubkey as CuckooPubkey;
+#[cfg(not(windows))]
 use solana_sdk::bs58;
 #[cfg(not(windows))]
 use std::collections::HashMap;
@@ -22,6 +24,8 @@ use tracing::{error, info, warn};
 #[cfg(not(windows))]
 use yellowstone_grpc_client::GeyserGrpcClient;
 #[cfg(not(windows))]
+use yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet;
+#[cfg(not(windows))]
 use yellowstone_grpc_proto::prelude::{
     subscribe_update::UpdateOneof, CommitmentLevel, SubscribeRequest,
     SubscribeRequestFilterAccounts, SubscribeRequestFilterBlocksMeta,
@@ -30,7 +34,8 @@ use yellowstone_grpc_proto::prelude::{
 
 #[cfg(not(windows))]
 use crate::metrics::{
-    geyser_metrics_inc_reconnect, geyser_metrics_inc_stream_error, geyser_metrics_set_connected,
+    geyser_metrics_inc_reconnect, geyser_metrics_inc_stream_error,
+    geyser_metrics_inc_tracked_cuckoo_table_full, geyser_metrics_set_connected,
     GeyserReconnectReason,
 };
 #[cfg(not(windows))]
@@ -123,6 +128,10 @@ pub struct GeyserListener {
     /// gRPC reconnect instead of in-place `subscribe_tx.send` (PR-B Yellowstone churn control).
     /// Use `usize::MAX` to always prefer in-place updates. Shared so market-data can hot-reload.
     full_reconnect_tracked_threshold: Arc<AtomicUsize>,
+    /// Max capacity for [`CompressedAccountFilterSet`] (Yellowstone cuckoo wire filter). Must be
+    /// at least the configured `max_tracked_accounts` peak. `0` disables cuckoo (legacy explicit
+    /// chunks — not used when `new_with_tracked_accounts` passes a positive cap from market-data).
+    tracked_cuckoo_max_capacity: usize,
     #[cfg_attr(windows, allow(dead_code))]
     account_tx: broadcast::Sender<GeyserAccountUpdate>,
     #[cfg_attr(windows, allow(dead_code))]
@@ -156,6 +165,7 @@ impl GeyserListener {
                 program_ids,
                 tracked_accounts_rx: None,
                 full_reconnect_tracked_threshold: Arc::new(AtomicUsize::new(usize::MAX)),
+                tracked_cuckoo_max_capacity: 0,
                 account_tx,
                 transaction_tx,
                 blockhash_tx,
@@ -175,6 +185,7 @@ impl GeyserListener {
         program_ids: Vec<Pubkey>,
         tracked_accounts_rx: watch::Receiver<Vec<Pubkey>>,
         full_reconnect_tracked_threshold: Arc<AtomicUsize>,
+        tracked_cuckoo_max_capacity: usize,
     ) -> (
         Self,
         broadcast::Receiver<GeyserAccountUpdate>,
@@ -185,6 +196,7 @@ impl GeyserListener {
             Self::new(endpoint, program_ids);
         listener.tracked_accounts_rx = Some(tracked_accounts_rx);
         listener.full_reconnect_tracked_threshold = full_reconnect_tracked_threshold;
+        listener.tracked_cuckoo_max_capacity = tracked_cuckoo_max_capacity;
         (listener, account_rx, transaction_rx, blockhash_rx)
     }
 
@@ -197,6 +209,7 @@ impl GeyserListener {
                 self.program_ids,
                 self.tracked_accounts_rx,
                 self.full_reconnect_tracked_threshold,
+                self.tracked_cuckoo_max_capacity,
             );
             Err(anyhow!(
                 "Geyser gRPC is not supported on Windows in this repo build. \
@@ -210,15 +223,54 @@ impl GeyserListener {
         }
     }
 
-    /// Build a SubscribeRequest for the given programs and tracked accounts.
+    /// Name of the single Yellowstone `cuckoo_accounts_filter` entry for explicit tracked accounts.
+    #[cfg(not(windows))]
+    const TRACKED_CUCKOO_SUBSCRIBE_NAME: &'static str = "tracked_accounts_cuckoo";
+
+    #[cfg(not(windows))]
+    #[inline]
+    fn cuckoo_pubkey(pk: Pubkey) -> CuckooPubkey {
+        CuckooPubkey::new_from_array(pk.to_bytes())
+    }
+
+    /// Rebuild the persistent cuckoo filter from the full explicit tracked list.
+    ///
+    /// Server-side updates stay compact (single cuckoo blob); rebuilding here is O(n) on the
+    /// client but avoids partial-failure corruption from incremental cuckoo mutations.
+    #[cfg(not(windows))]
+    fn sync_tracked_cuckoo_filter(
+        filter: &mut CompressedAccountFilterSet,
+        max_capacity: usize,
+        new_list: &[Pubkey],
+    ) -> Result<()> {
+        *filter = Self::tracked_cuckoo_from_full_list(max_capacity, new_list)?;
+        Ok(())
+    }
+
+    #[cfg(not(windows))]
+    fn tracked_cuckoo_from_full_list(
+        max_capacity: usize,
+        list: &[Pubkey],
+    ) -> Result<CompressedAccountFilterSet> {
+        let mut f = CompressedAccountFilterSet::with_capacity(max_capacity).map_err(|e| {
+            anyhow!("geyser_listener: CompressedAccountFilterSet with_capacity failed: {e}")
+        })?;
+        for pk in list {
+            f.insert(Self::cuckoo_pubkey(*pk)).map_err(|e| {
+                geyser_metrics_inc_tracked_cuckoo_table_full();
+                anyhow!("geyser_listener: CompressedAccountFilterSet insert / TableFull: {e}")
+            })?;
+        }
+        Ok(f)
+    }
+
+    /// Build a SubscribeRequest for the given programs and optional tracked-account cuckoo filter.
     /// Extracted so it can be reused for initial subscription and incremental updates.
     #[cfg(not(windows))]
-    fn build_subscribe_request(
+    pub(crate) fn build_subscribe_request(
         program_ids: &[Pubkey],
-        tracked_accounts: &[Pubkey],
+        tracked_cuckoo: Option<&mut CompressedAccountFilterSet>,
     ) -> SubscribeRequest {
-        const TRACKED_ACCOUNTS_CHUNK: usize = 1000;
-
         let mut accounts_filter = HashMap::new();
         let mut transactions_filter = HashMap::new();
 
@@ -231,6 +283,7 @@ impl GeyserListener {
                     owner: vec![program_id.to_string()],
                     filters: vec![],
                     nonempty_txn_signature: None,
+                    cuckoo_accounts_filter: None,
                 },
             );
 
@@ -248,26 +301,11 @@ impl GeyserListener {
             );
         }
 
-        // Additional explicit account subscriptions, chunked.
-        if !tracked_accounts.is_empty() {
-            for (chunk_idx, chunk) in tracked_accounts.chunks(TRACKED_ACCOUNTS_CHUNK).enumerate() {
-                accounts_filter.insert(
-                    format!("tracked_accounts_{}", chunk_idx),
-                    SubscribeRequestFilterAccounts {
-                        account: chunk.iter().map(|p| p.to_string()).collect(),
-                        owner: vec![],
-                        filters: vec![],
-                        nonempty_txn_signature: None,
-                    },
-                );
-            }
-        }
-
         // Subscribe to blocks_meta for confirmed blockhash streaming
         let blocks_meta_filter =
             HashMap::from([("blockhash".to_string(), SubscribeRequestFilterBlocksMeta {})]);
 
-        SubscribeRequest {
+        let mut req = SubscribeRequest {
             accounts: accounts_filter,
             slots: HashMap::new(),
             transactions: transactions_filter,
@@ -279,7 +317,13 @@ impl GeyserListener {
             accounts_data_slice: vec![],
             ping: None,
             from_slot: None,
+        };
+
+        if let Some(cuck) = tracked_cuckoo {
+            cuck.insert_into_subscribe_request(&mut req, Self::TRACKED_CUCKOO_SUBSCRIBE_NAME);
         }
+
+        req
     }
 
     /// PR-A: exponential reconnect sleep with small jitter (cold path only).
@@ -314,6 +358,28 @@ impl GeyserListener {
             .as_ref()
             .map(|rx| rx.borrow().clone())
             .unwrap_or_default();
+
+        let mut tracked_cuckoo_filter: Option<CompressedAccountFilterSet> = if tracked_accounts_rx
+            .is_some()
+        {
+            let cap = self.tracked_cuckoo_max_capacity.max(1);
+            match Self::tracked_cuckoo_from_full_list(cap, &tracked_accounts_current) {
+                Ok(f) => Some(f),
+                Err(e) => {
+                    error!(
+                        error = %e,
+                        capacity = cap,
+                        n = tracked_accounts_current.len(),
+                        "geyser_listener: initial CompressedAccountFilterSet build failed"
+                    );
+                    return Err(anyhow!(
+                            "geyser_listener: cannot build CompressedAccountFilterSet: {e}; increase max_tracked_accounts"
+                        ));
+                }
+            }
+        } else {
+            None
+        };
 
         let mut account_update_count = 0u64;
         let mut transaction_count = 0u64;
@@ -355,8 +421,10 @@ impl GeyserListener {
             };
 
             'same_client: loop {
-                let request =
-                    Self::build_subscribe_request(&self.program_ids, &tracked_accounts_current);
+                let request = Self::build_subscribe_request(
+                    &self.program_ids,
+                    tracked_cuckoo_filter.as_mut(),
+                );
 
                 let (mut subscribe_tx, mut stream) =
                     match client.subscribe_with_request(Some(request)).await {
@@ -452,6 +520,15 @@ impl GeyserListener {
                                                 continue;
                                             }
                                         };
+
+                                        if let Some(ref cf) = tracked_cuckoo_filter {
+                                            let passes_owner = self.program_ids.contains(&owner);
+                                            let passes_tracked =
+                                                cf.contains(Self::cuckoo_pubkey(pubkey));
+                                            if !(passes_owner || passes_tracked) {
+                                                continue;
+                                            }
+                                        }
 
                                         let grpc_recv_at = Instant::now();
                                         let event = GeyserAccountUpdate {
@@ -764,7 +841,21 @@ impl GeyserListener {
                         maybe_new = tracked_changed_fut => {
                             if let Some(new_list) = maybe_new {
                                 if new_list != tracked_accounts_current {
-                                    tracked_accounts_current = new_list;
+                                    let _old_list =
+                                        std::mem::replace(&mut tracked_accounts_current, new_list);
+                                    if let Some(ref mut cf) = tracked_cuckoo_filter {
+                                        if let Err(e) = Self::sync_tracked_cuckoo_filter(
+                                            cf,
+                                            self.tracked_cuckoo_max_capacity.max(1),
+                                            &tracked_accounts_current,
+                                        ) {
+                                            error!(
+                                                error = %e,
+                                                "geyser_listener: failed to rebuild CompressedAccountFilterSet"
+                                            );
+                                            return Err(e);
+                                        }
+                                    }
                                     let threshold = self
                                         .full_reconnect_tracked_threshold
                                         .load(Ordering::Relaxed);
@@ -789,7 +880,7 @@ impl GeyserListener {
                                     }
                                     let updated_request = Self::build_subscribe_request(
                                         &self.program_ids,
-                                        &tracked_accounts_current,
+                                        tracked_cuckoo_filter.as_mut(),
                                     );
                                     if let Err(e) = subscribe_tx.send(updated_request).await {
                                         warn!(
@@ -838,6 +929,7 @@ impl GeyserListener {
 #[cfg(all(test, not(windows)))]
 mod geyser_resilience_tests {
     use super::GeyserListener;
+    use yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet;
 
     #[test]
     fn reconnect_sleep_ms_adds_bounded_jitter() {
@@ -845,5 +937,20 @@ mod geyser_resilience_tests {
             let s = GeyserListener::geyser_reconnect_sleep_ms(500);
             assert!((500..=650).contains(&s), "s={s}");
         }
+    }
+
+    #[test]
+    fn subscribe_request_includes_single_tracked_cuckoo_filter() {
+        let mut cuckoo = CompressedAccountFilterSet::with_capacity(16).unwrap();
+        let pk = solana_pubkey::Pubkey::new_from_array([9u8; 32]);
+        cuckoo.insert(pk).unwrap();
+        let req = GeyserListener::build_subscribe_request(&[], Some(&mut cuckoo));
+        let f = req
+            .accounts
+            .get("tracked_accounts_cuckoo")
+            .expect("tracked cuckoo filter");
+        assert!(f.cuckoo_accounts_filter.is_some());
+        assert!(f.account.is_empty());
+        assert!(f.owner.is_empty());
     }
 }

--- a/src/solana/geyser_tx_confirm.rs
+++ b/src/solana/geyser_tx_confirm.rs
@@ -473,6 +473,7 @@ impl GeyserTxConfirm {
                 owner: vec![], // Don't filter by owner - we want specific accounts
                 filters: vec![],
                 nonempty_txn_signature: None,
+                cuckoo_accounts_filter: None,
             },
         );
 


### PR DESCRIPTION
## Summary
- Replace explicit tracked-account pubkey chunks (1000er-Listen) with a single `cuckoo_accounts_filter` via `CompressedAccountFilterSet` (Yellowstone PR #732).
- Persist filter across subscribe updates; rebuild from full list on watch changes (compact wire payload, no incremental half-states on TableFull).
- Drop inbound account updates unless DEX-owner match OR exact tracked membership (client-side false-positive filter).
- Pin yellowstone-grpc to merge `486c2102`; metric `geyser_tracked_cuckoo_table_full_total`.

## Context
Prod validator upgraded to Agave 4.0.0 + yellowstone-grpc-geyser v13.1.0 (CompressedFilterSet server-side). This is the IronCrab client half of the structural Geyser churn fix.

## Test plan
- [ ] CI: fmt, clippy, unit tests
- [ ] Eval (Level 5)
- [ ] Prod smoke after deploy: `market_data_geyser_head_slot` rising, sustained `rate(nats_messages_published_total)>0`, reduced subscription churn logs
