### PR TITLE
fix(market-data): PR162 — Geyser ingest liveness + unified pool discovery

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,12 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### PR162-GEYSER-INGEST-LIVENESS: eine Geyser-Session + Subscription-Sink aus Read-Loop; Pool-Discovery off Main-`select!`
+**Datum**: 2026-05-27  
+**Problem** (Prod post #160): `head_slot` / `nats_messages_published_total` frieren ~60 s nach Restart; `geyser_listener: heartbeat` fehlt; letztes `subscription updated` beim Startup-Burst; paralleles `GeyserPoolDiscovery` (zweite gRPC-Connection) liefert weiter Meteora-Logs — Haupt-Read-Loop liefert keine Nutzlast mehr (Ingest-Starvation). Publish-Pipeline (#160) war nicht der Blocker.  
+**Fix**: (1) **`GeyserPoolDiscovery` entfernt** — `PoolDiscoveryIngest::spawn_unified` hängt an denselben `GeyserListener`-Broadcasts wie TX/Account (`subscribe_account_updates` / `subscribe_transaction_updates`); genau **eine** `subscribe_with_request`-Session. (2) **`subscribe_tx.send` nicht mehr im Stream-`select!`**: Pending `SubscribeRequest` in `Mutex<Option<_>>` + `Notify`; dedizierter Task awaited nur den Yellowstone-Sink; Read-Loop bleibt auf `stream.next()` fair (Heartbeats, Blockhash, Metrik `geyser_listener_stream_messages_total`). (3) **Pool-Discovery-MarketEvents**: dedizierter Tokio-Task `recv` auf `mpsc` (bounded **10000**) + `handle_pool_discovery_market_event` — kein Arm mehr im Main-`select!` (Fairness wie #151 TX-Ingest). **Invarianten**: kein neuer Hot-Path-RPC (I-7), PR160 Publish-Runtime unangetastet, I-16 kein stilles Droppen zulässig (Enqueue-Drop-Metriken PR160 bleiben).  
+**Dateien**: `src/bin/market_data.rs`, `src/solana/geyser_listener.rs`, `src/solana/geyser_pool_discovery.rs`, `src/metrics.rs`, `src/solana/dex/meteora_dlmm.rs`, `src/solana/dex/raydium_cpmm.rs`, `docs/BUGS_FIXES.md`
+
 ### PR161-GEYSER-MERGE-COALESCING: Merge-Task `combined_tracked` debounced wie TX-Path-Sync
 **Datum**: 2026-05-27  
 **Problem** (Prod post #159): Startup hunderte `subscription updated (NO reconnect)` in wenigen Sekunden — Cuckoo (#159) macht Updates billiger, aber **jeder** Merge feuerte sofort `combined_tracked_tx.send` (bis zu 4× pro `broadcast_tracked_geyser_explicit_to_merge` wegen vier `watch`-Channels) → Read-Loop-Last und NATS-Backpressure-Risiko.  

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -101,7 +101,9 @@ use ironcrab::solana::dex_parser::{
     parse_account_update, parse_transaction_update_with_pool_lookup, DexType, OrcaPoolInfo,
     ParsedDexEvent,
 };
-use ironcrab::solana::geyser_pool_discovery::{DexType as PoolDexType, GeyserPoolDiscovery};
+use ironcrab::solana::geyser_pool_discovery::{
+    DexType as PoolDexType, PoolDiscoveryEvent, PoolDiscoveryIngest,
+};
 use ironcrab::solana::priority_fee_tracker::PriorityFeeTracker;
 use ironcrab::solana::rpc::SolanaRpc;
 use ironcrab::solana::wallet_tracker::WalletTracker;
@@ -8101,6 +8103,216 @@ async fn account_path_enqueue_core_market_event(
     }
 }
 
+/// PR162: pool discovery handler (dedicated task; not in main `select!`).
+/// STOP-CHECK: keine neuen RPC-Calls; Pump.fun TokenMintInfo nutzt bekannte Decimals.
+async fn handle_pool_discovery_market_event(
+    ctx: &Arc<MarketDataContext>,
+    run_id: &str,
+    mint_info_tx: &mpsc::UnboundedSender<MarketEvent>,
+    account_publish_tx: Option<&mpsc::Sender<AccountPathNatsJob>>,
+    pool_event: PoolDiscoveryEvent,
+) {
+    let pool_discovery_recv_at = Instant::now();
+    market_data_bump_geyser_head_slot(pool_event.slot);
+    ironcrab::metrics::record_activity();
+
+    info!(
+        dex = %pool_event.dex_type,
+        pool = %pool_event.pool_address,
+        base = %pool_event.base_mint,
+        quote = %pool_event.quote_mint,
+        liquidity_lamports = pool_event.liquidity_estimate_lamports,
+        "Pool discovered via Geyser"
+    );
+
+    if matches!(pool_event.dex_type, PoolDexType::PumpFun) {
+        let emit_mint_info = ctx
+            .pumpfun_pool_discovery_mint_info_emitted
+            .write()
+            .insert(pool_event.base_mint);
+        if emit_mint_info {
+            let mint_event = MarketEvent::new(
+                "market-data",
+                BUILD_VERSION,
+                run_id,
+                ctx.next_event_id(),
+                "geyser_known",
+                Some(pool_event.slot),
+                MarketEventKind::TokenMintInfo {
+                    mint: pool_event.base_mint.to_string(),
+                    token_program: spl_token::ID.to_string(),
+                    decimals: 6,
+                    supply: 0,
+                    mint_authority: None,
+                    freeze_authority: None,
+                },
+            );
+            let _ = mint_info_tx.send(mint_event);
+            debug!(
+                mint = %pool_event.base_mint,
+                "Emitted TokenMintInfo for pump.fun token (decimals=6, no RPC)"
+            );
+        }
+    }
+
+    let event = MarketEvent::new(
+        "market-data",
+        BUILD_VERSION,
+        run_id,
+        ctx.next_event_id(),
+        "geyser_pool_discovery",
+        Some(pool_event.slot),
+        MarketEventKind::PoolCreated {
+            pool_address: pool_event.pool_address.to_string(),
+            base_mint: pool_event.base_mint.to_string(),
+            quote_mint: pool_event.quote_mint.to_string(),
+            dex: pool_event.dex_type.to_string(),
+            initial_liquidity_sol: Some(
+                rust_decimal::Decimal::from(pool_event.liquidity_estimate_lamports)
+                    / rust_decimal::Decimal::from(1_000_000_000u64),
+            ),
+        },
+    );
+
+    if let Err(e) = ctx.jsonl_writer.write(&event) {
+        error!(error = %e, "Failed to write pool discovery event to JSONL");
+    }
+
+    if ctx.nats.is_some() {
+        let seg = market_data_publish_segment(&event.kind);
+        account_path_enqueue_core_market_event(
+            account_publish_tx,
+            ctx.nats.as_ref(),
+            ctx,
+            event,
+            Some(MarketEventCorePublishTrace {
+                recv_at: pool_discovery_recv_at,
+                cold_path: false,
+                segment: seg,
+            }),
+        )
+        .await;
+    }
+
+    if pool_event.dex_type == PoolDexType::PumpFun {
+        if let Some(creator) = pool_event.creator {
+            let dev_event = MarketEvent::new(
+                "market-data",
+                BUILD_VERSION,
+                run_id,
+                ctx.next_event_id(),
+                "geyser_pool_discovery",
+                Some(pool_event.slot),
+                MarketEventKind::DevWalletIdentified {
+                    mint: pool_event.base_mint.to_string(),
+                    dev_wallet: creator.to_string(),
+                    supply_percentage: 0.0,
+                },
+            );
+
+            if let Err(e) = ctx.jsonl_writer.write(&dev_event) {
+                error!(error = %e, "Failed to write dev wallet event to JSONL");
+            }
+
+            if ctx.nats.is_some() {
+                let seg = market_data_publish_segment(&dev_event.kind);
+                if account_path_enqueue_core_market_event(
+                    account_publish_tx,
+                    ctx.nats.as_ref(),
+                    ctx,
+                    dev_event,
+                    Some(MarketEventCorePublishTrace {
+                        recv_at: pool_discovery_recv_at,
+                        cold_path: false,
+                        segment: seg,
+                    }),
+                )
+                .await
+                {
+                    info!(
+                        mint = %pool_event.base_mint,
+                        creator = %creator,
+                        "✅ DevWalletIdentified enqueued for pump.fun pool"
+                    );
+                }
+            }
+        }
+    }
+
+    if pool_event.coin_vault.is_some() || pool_event.pc_vault.is_some() {
+        let mut accounts = vec![
+            pool_event.pool_address.to_string(),
+            pool_event.base_mint.to_string(),
+            pool_event.quote_mint.to_string(),
+        ];
+
+        if let Some(coin_vault) = pool_event.coin_vault {
+            accounts.push(coin_vault.to_string());
+        }
+        if let Some(pc_vault) = pool_event.pc_vault {
+            accounts.push(pc_vault.to_string());
+        }
+        if let Some(creator) = pool_event.creator {
+            accounts.push(creator.to_string());
+        }
+        if let Some(active_id) = pool_event.active_id {
+            accounts.push(format!("active_id:{}", active_id));
+        }
+        if let Some(bin_step) = pool_event.bin_step {
+            accounts.push(format!("bin_step:{}", bin_step));
+        }
+        if let Some(tick) = pool_event.tick_current_index {
+            accounts.push(format!("tick_current_index:{}", tick));
+        }
+        if let Some(spacing) = pool_event.tick_spacing {
+            accounts.push(format!("tick_spacing:{}", spacing));
+        }
+
+        let accounts_event = MarketEvent::new(
+            "market-data",
+            BUILD_VERSION,
+            run_id,
+            ctx.next_event_id(),
+            "geyser_pool_discovery",
+            Some(pool_event.slot),
+            MarketEventKind::DexPoolAccounts {
+                dex: pool_event.dex_type.to_string(),
+                pool_address: pool_event.pool_address.to_string(),
+                base_mint: pool_event.base_mint.to_string(),
+                quote_mint: pool_event.quote_mint.to_string(),
+                accounts,
+            },
+        );
+
+        if let Err(e) = ctx.jsonl_writer.write(&accounts_event) {
+            error!(error = %e, "Failed to write DexPoolAccounts event to JSONL");
+        }
+
+        if ctx.nats.is_some() {
+            let seg = market_data_publish_segment(&accounts_event.kind);
+            if account_path_enqueue_core_market_event(
+                account_publish_tx,
+                ctx.nats.as_ref(),
+                ctx,
+                accounts_event,
+                Some(MarketEventCorePublishTrace {
+                    recv_at: pool_discovery_recv_at,
+                    cold_path: false,
+                    segment: seg,
+                }),
+            )
+            .await
+            {
+                debug!(
+                    dex = %pool_event.dex_type,
+                    pool = %pool_event.pool_address,
+                    "Enqueued DexPoolAccounts for pool discovery"
+                );
+            }
+        }
+    }
+}
+
 /// Geyser account ingest (dedizierter Task-Fairness, siehe MARKET-DATA-ACCOUNT-INGEST-FAIRNESS).
 /// STOP-CHECK: keine neuen RPC-Calls im Hot-Path; Cold-Path-RPC nur in bestehenden `tokio::spawn`-Pfaden.
 async fn handle_geyser_account(
@@ -10554,17 +10766,6 @@ async fn run_geyser_loop(
         Pubkey::from_str(METEORA_CPMM).expect("valid meteora cpmm pubkey"),
     ];
 
-    // Initialize Geyser-based pool discovery (PRIMARY method for pool discovery)
-    let (pool_discovery, mut pool_discovery_rx) =
-        GeyserPoolDiscovery::new(geyser_url.to_string(), program_ids.clone(), rpc.clone());
-
-    // Spawn pool discovery task
-    let _pool_discovery_handle = tokio::spawn(async move {
-        if let Err(e) = pool_discovery.start().await {
-            error!(error = %e, "GeyserPoolDiscovery crashed");
-        }
-    });
-
     // Merge tracked_mints, tracked_vaults, tracked_bin_arrays, and tracked_wallet into a single combined channel.
     // GeyserListener will subscribe to all accounts in the combined list.
     let (combined_tracked_tx, combined_tracked_rx) = watch::channel(Vec::<Pubkey>::new());
@@ -10588,7 +10789,7 @@ async fn run_geyser_loop(
         });
     }
 
-    // Start legacy GeyserListener for transaction parsing (will be phased out in favor of pool discovery)
+    // Geyser listener + unified pool discovery (single gRPC session; PR162)
     let (listener, account_rx, transaction_rx, mut blockhash_rx) =
         GeyserListener::new_with_tracked_accounts(
             geyser_url.to_string(),
@@ -10598,7 +10799,15 @@ async fn run_geyser_loop(
             ctx.config.read().max_tracked_accounts.max(1),
         );
 
-    // Spawn Geyser listener task
+    let pool_discovery_account_rx = listener.subscribe_account_updates();
+    let pool_discovery_transaction_rx = listener.subscribe_transaction_updates();
+    let pool_discovery_event_rx = PoolDiscoveryIngest::spawn_unified(
+        pool_discovery_account_rx,
+        pool_discovery_transaction_rx,
+        rpc.clone(),
+    );
+
+    // Spawn Geyser listener task (single gRPC session; PR162)
     let listener_handle = tokio::spawn(async move {
         if let Err(e) = listener.start().await {
             error!(error = %e, "Geyser listener crashed");
@@ -10745,6 +10954,26 @@ async fn run_geyser_loop(
                 }
             }
         }
+    });
+
+    // PR162: pool discovery off main `select!` — dedicated consumer (JSONL + enqueue; no sync NATS).
+    let ctx_pool_disc = Arc::clone(&ctx);
+    let run_id_pool_disc = run_id.to_string();
+    let mint_info_tx_pool_disc = mint_info_tx.clone();
+    let account_publish_tx_pool_disc = account_publish_tx.clone();
+    tokio::spawn(async move {
+        let mut pool_discovery_event_rx = pool_discovery_event_rx;
+        while let Some(pool_event) = pool_discovery_event_rx.recv().await {
+            handle_pool_discovery_market_event(
+                &ctx_pool_disc,
+                run_id_pool_disc.as_str(),
+                &mint_info_tx_pool_disc,
+                account_publish_tx_pool_disc.as_ref(),
+                pool_event,
+            )
+            .await;
+        }
+        warn!("pool discovery ingest: event channel closed");
     });
 
     // Option A + MARKET-DATA-ACCOUNT-THROUGHPUT-P0: dedicated recv + worker pool (sharded by pubkey)
@@ -11445,225 +11674,6 @@ async fn run_geyser_loop(
                 }
             }
 
-            // Pool Discovery Events (Geyser-based pool creation events)
-            Ok(pool_event) = pool_discovery_rx.recv() => {
-                let pool_discovery_recv_at = Instant::now();
-                market_data_bump_geyser_head_slot(pool_event.slot);
-                ironcrab::metrics::record_activity();
-
-                info!(
-                    dex = %pool_event.dex_type,
-                    pool = %pool_event.pool_address,
-                    base = %pool_event.base_mint,
-                    quote = %pool_event.quote_mint,
-                    liquidity_lamports = pool_event.liquidity_estimate_lamports,
-                    "Pool discovered via Geyser"
-                );
-
-                // PR-B: discovery-only must not grow explicit Geyser mint/vault/bin subscriptions.
-                // Pump.fun still emits TokenMintInfo with known decimals=6 (no extra mint account filter).
-                if matches!(pool_event.dex_type, PoolDexType::PumpFun) {
-                    let emit_mint_info = ctx
-                        .pumpfun_pool_discovery_mint_info_emitted
-                        .write()
-                        .insert(pool_event.base_mint);
-                    if emit_mint_info {
-                        let mint_event = MarketEvent::new(
-                            "market-data",
-                            BUILD_VERSION,
-                            run_id,
-                            ctx.next_event_id(),
-                            "geyser_known", // Not RPC - we know pump.fun uses decimals=6
-                            Some(pool_event.slot),
-                            MarketEventKind::TokenMintInfo {
-                                mint: pool_event.base_mint.to_string(),
-                                token_program: spl_token::ID.to_string(), // pump.fun always uses SPL Token
-                                decimals: 6, // pump.fun tokens ALWAYS have 6 decimals
-                                supply: 0,   // Unknown, but not critical for trading
-                                mint_authority: None,
-                                freeze_authority: None,
-                            },
-                        );
-                        let _ = mint_info_tx.send(mint_event);
-                        debug!(
-                            mint = %pool_event.base_mint,
-                            "Emitted TokenMintInfo for pump.fun token (decimals=6, no RPC)"
-                        );
-                    }
-                }
-
-                // Convert to MarketEvent::PoolCreated
-                let event = MarketEvent::new(
-                    "market-data",
-                    BUILD_VERSION,
-                    run_id,
-                    ctx.next_event_id(),
-                    "geyser_pool_discovery",
-                    Some(pool_event.slot),
-                    MarketEventKind::PoolCreated {
-                        pool_address: pool_event.pool_address.to_string(),
-                        base_mint: pool_event.base_mint.to_string(),
-                        quote_mint: pool_event.quote_mint.to_string(),
-                        dex: pool_event.dex_type.to_string(),
-                        initial_liquidity_sol: Some(
-                            rust_decimal::Decimal::from(pool_event.liquidity_estimate_lamports)
-                                / rust_decimal::Decimal::from(1_000_000_000u64)
-                        ),
-                    },
-                );
-
-                // Write to JSONL
-                if let Err(e) = ctx.jsonl_writer.write(&event) {
-                    error!(error = %e, "Failed to write pool discovery event to JSONL");
-                }
-
-                // Publish to NATS (enqueue-only; PR160)
-                if ctx.nats.is_some() {
-                    let seg = market_data_publish_segment(&event.kind);
-                    account_path_enqueue_core_market_event(
-                        account_publish_tx.as_ref(),
-                        ctx.nats.as_ref(),
-                        &ctx,
-                        event,
-                        Some(MarketEventCorePublishTrace {
-                            recv_at: pool_discovery_recv_at,
-                            cold_path: false,
-                            segment: seg,
-                        }),
-                    )
-                    .await;
-                }
-
-                // Emit DevWalletIdentified for Pump.fun pools where we know the creator
-                // This enables momentum-bot to populate metadata.creator for intent building
-                if pool_event.dex_type == PoolDexType::PumpFun {
-                    if let Some(creator) = pool_event.creator {
-                        let dev_event = MarketEvent::new(
-                            "market-data",
-                            BUILD_VERSION,
-                            run_id,
-                            ctx.next_event_id(),
-                            "geyser_pool_discovery",
-                            Some(pool_event.slot),
-                            MarketEventKind::DevWalletIdentified {
-                                mint: pool_event.base_mint.to_string(),
-                                dev_wallet: creator.to_string(),
-                                // Supply percentage not computed (would need extra on-chain reads)
-                                supply_percentage: 0.0,
-                            },
-                        );
-
-                        if let Err(e) = ctx.jsonl_writer.write(&dev_event) {
-                            error!(error = %e, "Failed to write dev wallet event to JSONL");
-                        }
-
-                        if ctx.nats.is_some() {
-                            let seg = market_data_publish_segment(&dev_event.kind);
-                            if account_path_enqueue_core_market_event(
-                                account_publish_tx.as_ref(),
-                                ctx.nats.as_ref(),
-                                &ctx,
-                                dev_event,
-                                Some(MarketEventCorePublishTrace {
-                                    recv_at: pool_discovery_recv_at,
-                                    cold_path: false,
-                                    segment: seg,
-                                }),
-                            )
-                            .await
-                            {
-                                info!(
-                                    mint = %pool_event.base_mint,
-                                    creator = %creator,
-                                    "✅ DevWalletIdentified enqueued for pump.fun pool"
-                                );
-                            }
-                        }
-                    }
-                }
-
-                // Emit DexPoolAccounts for all DEXes that have vault information
-                // This enables arb-strategy to have pool accounts BEFORE first trade
-                if pool_event.coin_vault.is_some() || pool_event.pc_vault.is_some() {
-                    let mut accounts = vec![
-                        pool_event.pool_address.to_string(),
-                        pool_event.base_mint.to_string(),
-                        pool_event.quote_mint.to_string(),
-                    ];
-
-                    if let Some(coin_vault) = pool_event.coin_vault {
-                        accounts.push(coin_vault.to_string());
-                    }
-                    if let Some(pc_vault) = pool_event.pc_vault {
-                        accounts.push(pc_vault.to_string());
-                    }
-                    if let Some(creator) = pool_event.creator {
-                        accounts.push(creator.to_string());
-                    }
-                    // Meteora DLMM: add active_id and bin_step as tagged values
-                    // Format: "active_id:<value>" and "bin_step:<value>"
-                    if let Some(active_id) = pool_event.active_id {
-                        accounts.push(format!("active_id:{}", active_id));
-                    }
-                    if let Some(bin_step) = pool_event.bin_step {
-                        accounts.push(format!("bin_step:{}", bin_step));
-                    }
-                    // Orca Whirlpool: add tick_current_index and tick_spacing as tagged values
-                    // Format: "tick_current_index:<value>" and "tick_spacing:<value>"
-                    if let Some(tick) = pool_event.tick_current_index {
-                        accounts.push(format!("tick_current_index:{}", tick));
-                    }
-                    if let Some(spacing) = pool_event.tick_spacing {
-                        accounts.push(format!("tick_spacing:{}", spacing));
-                    }
-
-                    let accounts_event = MarketEvent::new(
-                        "market-data",
-                        BUILD_VERSION,
-                        run_id,
-                        ctx.next_event_id(),
-                        "geyser_pool_discovery",
-                        Some(pool_event.slot),
-                        MarketEventKind::DexPoolAccounts {
-                            dex: pool_event.dex_type.to_string(),
-                            pool_address: pool_event.pool_address.to_string(),
-                            base_mint: pool_event.base_mint.to_string(),
-                            quote_mint: pool_event.quote_mint.to_string(),
-                            accounts,
-                        },
-                    );
-
-                    if let Err(e) = ctx.jsonl_writer.write(&accounts_event) {
-                        error!(error = %e, "Failed to write DexPoolAccounts event to JSONL");
-                    }
-
-                    if ctx.nats.is_some() {
-                        let seg = market_data_publish_segment(&accounts_event.kind);
-                        if account_path_enqueue_core_market_event(
-                            account_publish_tx.as_ref(),
-                            ctx.nats.as_ref(),
-                            &ctx,
-                            accounts_event,
-                            Some(MarketEventCorePublishTrace {
-                                recv_at: pool_discovery_recv_at,
-                                cold_path: false,
-                                segment: seg,
-                            }),
-                        )
-                        .await
-                        {
-                            debug!(
-                                dex = %pool_event.dex_type,
-                                pool = %pool_event.pool_address,
-                                "Enqueued DexPoolAccounts for pool discovery"
-                            );
-                        }
-                    }
-
-                    // PR-B: explicit Geyser vault/bin-array subscriptions are deferred until first trade,
-                    // active-pool pin (PR-D), or wallet-held mint admission — not pool_discovery alone.
-                }
-            }
 
             // PR-D: Momentum active pool pin stream (core NATS).
             msg = async {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -225,6 +225,8 @@ pub static GEYSER_RECONNECT_TOTAL_STREAM_ENDED: Lazy<AtomicU64> = Lazy::new(|| A
 pub static GEYSER_RECONNECT_TOTAL_STREAM_ERROR: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// Reconnect after subscription sink closed / send failure (new `connect()`).
 pub static GEYSER_RECONNECT_TOTAL_SINK_GONE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// gRPC stream payloads delivered into the listener (account / transaction / block_meta updates).
+pub static GEYSER_LISTENER_STREAM_MESSAGES_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// gRPC stream `Err` deliveries (excludes graceful `None` / stream ended).
 pub static GEYSER_STREAM_ERRORS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// `CompressedAccountFilterSet::insert` failed: capacity below configured explicit-track ceiling.
@@ -379,6 +381,11 @@ pub fn set_market_data_geyser_merge_pending(pending: u64) {
 
 pub fn geyser_metrics_inc_stream_error() {
     GEYSER_STREAM_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn geyser_metrics_inc_listener_stream_payload() {
+    GEYSER_LISTENER_STREAM_MESSAGES_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -2443,6 +2450,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "geyser_stream_errors_total",
         GEYSER_STREAM_ERRORS_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "geyser_listener_stream_messages_total",
+        GEYSER_LISTENER_STREAM_MESSAGES_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "geyser_tracked_cuckoo_table_full_total",

--- a/src/solana/dex/meteora_dlmm.rs
+++ b/src/solana/dex/meteora_dlmm.rs
@@ -385,7 +385,7 @@ impl Dex for MeteoraDlmm {
     /// - Testing and development
     /// - Fallback when Geyser stream is interrupted
     ///
-    /// In production, pool discovery should happen via `GeyserPoolDiscovery`
+    /// In production, pool discovery should happen via `PoolDiscoveryIngest`
     /// which provides real-time pool updates without expensive RPC scans.
     ///
     /// See: docs/TARGET_ARCHITECTURE.md - "Geyser preferred, RPC only as fallback"

--- a/src/solana/dex/raydium_cpmm.rs
+++ b/src/solana/dex/raydium_cpmm.rs
@@ -349,7 +349,7 @@ impl Dex for RaydiumCpmm {
     /// - Testing and development
     /// - Fallback when Geyser stream is interrupted
     ///
-    /// In production, pool discovery should happen via `GeyserPoolDiscovery`
+    /// In production, pool discovery should happen via `PoolDiscoveryIngest`
     /// which provides real-time pool updates without expensive RPC scans.
     ///
     /// See: docs/TARGET_ARCHITECTURE.md - "Geyser preferred, RPC only as fallback"

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -34,14 +34,18 @@ use yellowstone_grpc_proto::prelude::{
 
 #[cfg(not(windows))]
 use crate::metrics::{
-    geyser_metrics_inc_reconnect, geyser_metrics_inc_stream_error,
-    geyser_metrics_inc_tracked_cuckoo_table_full, geyser_metrics_set_connected,
-    GeyserReconnectReason,
+    geyser_metrics_inc_listener_stream_payload, geyser_metrics_inc_reconnect,
+    geyser_metrics_inc_stream_error, geyser_metrics_inc_tracked_cuckoo_table_full,
+    geyser_metrics_set_connected, GeyserReconnectReason,
 };
 #[cfg(not(windows))]
 use rand::Rng;
 #[cfg(not(windows))]
+use std::sync::Mutex;
+#[cfg(not(windows))]
 use std::time::Duration;
+#[cfg(not(windows))]
+use tokio::sync::Notify;
 #[cfg(not(windows))]
 use tokio::time::sleep;
 
@@ -198,6 +202,18 @@ impl GeyserListener {
         listener.full_reconnect_tracked_threshold = full_reconnect_tracked_threshold;
         listener.tracked_cuckoo_max_capacity = tracked_cuckoo_max_capacity;
         (listener, account_rx, transaction_rx, blockhash_rx)
+    }
+
+    /// Subscribe to account updates (same stream as the primary `account_rx` from [`Self::new`]).
+    ///
+    /// PR162: pool discovery and other auxiliary consumers must not open a second Geyser gRPC session.
+    pub fn subscribe_account_updates(&self) -> broadcast::Receiver<GeyserAccountUpdate> {
+        self.account_tx.subscribe()
+    }
+
+    /// Subscribe to DEX transaction updates (same stream as the primary `transaction_rx`).
+    pub fn subscribe_transaction_updates(&self) -> broadcast::Receiver<GeyserTransactionUpdate> {
+        self.transaction_tx.subscribe()
     }
 
     /// Start listening to Geyser stream
@@ -444,6 +460,33 @@ impl GeyserListener {
                         }
                     };
 
+                // PR162: never `await` Yellowstone `subscribe_tx.send` in the stream read task — a slow
+                // sink starves `stream.next()`, heartbeats, and head_slot. Coalesce bursts into one pending
+                // request; a dedicated task performs the sink send.
+                let pending_subscription_request: Arc<Mutex<Option<SubscribeRequest>>> =
+                    Arc::new(Mutex::new(None));
+                let subscription_notify = Arc::new(Notify::new());
+                let pending_for_updater = Arc::clone(&pending_subscription_request);
+                let notify_for_updater = Arc::clone(&subscription_notify);
+                let subscription_updater_jh = tokio::spawn(async move {
+                    loop {
+                        notify_for_updater.notified().await;
+                        let req = match pending_for_updater.lock() {
+                            Ok(mut g) => g.take(),
+                            Err(_) => continue,
+                        };
+                        let Some(req) = req else { continue };
+                        if let Err(e) = subscribe_tx.send(req).await {
+                            warn!(
+                                error = %e,
+                                "geyser_listener: subscription updater failed to push subscribe request (sink gone)"
+                            );
+                            geyser_metrics_inc_reconnect(GeyserReconnectReason::SinkGone);
+                            break;
+                        }
+                    }
+                });
+
                 info!(
                     programs = ?self.program_ids,
                     tracked_accounts = tracked_accounts_current.len(),
@@ -497,6 +540,7 @@ impl GeyserListener {
                                     break 'read SessionExit::HardReconnect;
                                 }
                                 Some(Ok(msg)) => {
+                                    geyser_metrics_inc_listener_stream_payload();
                                     if let Some(update) = msg.update_oneof {
                                         match update {
                                 UpdateOneof::Account(account_update) => {
@@ -882,22 +926,21 @@ impl GeyserListener {
                                         &self.program_ids,
                                         tracked_cuckoo_filter.as_mut(),
                                     );
-                                    if let Err(e) = subscribe_tx.send(updated_request).await {
-                                        warn!(
-                                            "geyser_listener: failed to send subscription update: {e}; reconnecting with new client"
-                                        );
-                                        geyser_metrics_inc_reconnect(GeyserReconnectReason::SinkGone);
-                                        break 'read SessionExit::HardReconnect;
+                                    if let Ok(mut g) = pending_subscription_request.lock() {
+                                        *g = Some(updated_request);
                                     }
+                                    subscription_notify.notify_one();
                                     warn!(
                                         tracked_accounts = tracked_accounts_current.len(),
-                                        "geyser_listener: subscription updated (NO reconnect)"
+                                        "geyser_listener: subscription updated (NO reconnect; async sink)"
                                     );
                                 }
                             }
                         }
                     }
                 };
+
+                subscription_updater_jh.abort();
 
                 match session_exit {
                     SessionExit::StreamEnded => {

--- a/src/solana/geyser_pool_discovery.rs
+++ b/src/solana/geyser_pool_discovery.rs
@@ -1,102 +1,81 @@
 //! Professional Geyser-based Pool Discovery
 //! Simplified approach: TX-based for Pump.fun, Account-based for Raydium/Orca
+//!
+//! PR162: consumes the **unified** [`crate::solana::geyser_listener::GeyserListener`] broadcast feeds
+//! (no second Geyser gRPC connection).
 
-use crate::solana::geyser_listener::{
-    GeyserAccountUpdate, GeyserListener, GeyserTransactionUpdate,
-};
+use crate::solana::geyser_listener::{GeyserAccountUpdate, GeyserTransactionUpdate};
 use crate::solana::rpc::SolanaRpc;
-use anyhow::Result;
 use solana_sdk::pubkey;
 use solana_sdk::pubkey::Pubkey;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::broadcast;
+use tokio::sync::mpsc;
 use tracing::debug;
 
-/// Pool discovery via Geyser account updates
-pub struct GeyserPoolDiscovery {
-    listener: GeyserListener,
-}
+/// Pool discovery processors attached to the primary Geyser listener (PR162).
+pub struct PoolDiscoveryIngest;
 
-impl GeyserPoolDiscovery {
-    /// Create new Geyser-based pool discovery
+impl PoolDiscoveryIngest {
+    /// Spawn account + transaction processors that emit [`PoolDiscoveryEvent`] on `mpsc`.
     ///
-    /// # Arguments
-    /// * `geyser_endpoint` - Geyser gRPC endpoint (e.g., "http://127.0.0.1:10000")
-    /// * `program_ids` - DEX program IDs to monitor (Raydium, Orca, Pump.fun)
-    /// * `rpc` - RPC client for additional data fetching
-    pub fn new(
-        geyser_endpoint: String,
-        program_ids: Vec<Pubkey>,
+    /// Callers must pass [`GeyserListener::subscribe_account_updates`] /
+    /// [`GeyserListener::subscribe_transaction_updates`] **before** starting the listener so no
+    /// updates are missed.
+    pub fn spawn_unified(
+        mut account_rx: broadcast::Receiver<GeyserAccountUpdate>,
+        mut transaction_rx: broadcast::Receiver<GeyserTransactionUpdate>,
         rpc: Arc<SolanaRpc>,
-    ) -> (Self, broadcast::Receiver<PoolDiscoveryEvent>) {
-        let (listener, account_rx, transaction_rx, _blockhash_rx) =
-            GeyserListener::new(geyser_endpoint, program_ids);
+    ) -> mpsc::Receiver<PoolDiscoveryEvent> {
+        let (event_tx, event_rx) = mpsc::channel(10_000);
 
-        // Create event channel for pool discoveries
-        let (event_tx, event_rx) = broadcast::channel(10000);
-
-        let discovery = Self { listener };
-
-        // Spawn account processor (for Raydium/Orca)
-        let rpc_clone = rpc.clone();
-        let event_tx_clone = event_tx.clone();
+        let rpc_a = rpc.clone();
+        let event_tx_a = event_tx.clone();
         tokio::spawn(async move {
-            let mut rx = account_rx;
             loop {
-                match rx.recv().await {
+                match account_rx.recv().await {
                     Ok(update) => {
-                        if let Some(event) = Self::process_account_update(update, &rpc_clone).await
-                        {
+                        if let Some(event) = Self::process_account_update(update, &rpc_a).await {
                             tracing::debug!(
                                 dex = ?event.dex_type,
                                 pool = %event.pool_address,
                                 "geyser_pool_discovery: sending account-based event"
                             );
-                            let _ = event_tx_clone.send(event);
+                            if event_tx_a.send(event).await.is_err() {
+                                tracing::warn!("geyser_pool_discovery: pool event consumer dropped (account path)");
+                                break;
+                            }
                         }
                     }
                     Err(broadcast::error::RecvError::Lagged(skipped)) => {
                         tracing::warn!(skipped, "geyser_pool_discovery: account processor lagged");
                     }
                     Err(broadcast::error::RecvError::Closed) => {
-                        tracing::warn!("geyser_pool_discovery: account stream closed");
+                        tracing::warn!("geyser_pool_discovery: account broadcast closed");
                         break;
                     }
                 }
             }
         });
 
-        // Spawn transaction processor (for Pump.fun - simplified approach)
-        let rpc_clone2 = rpc;
         tokio::spawn(async move {
-            let mut rx = transaction_rx;
             loop {
-                match rx.recv().await {
+                match transaction_rx.recv().await {
                     Ok(tx_update) => {
-                        if let Some(event) =
-                            Self::process_transaction_update(tx_update, &rpc_clone2).await
+                        if let Some(event) = Self::process_transaction_update(tx_update, &rpc).await
                         {
-                            // Log before sending to verify event is created
                             tracing::info!(
                                 dex = ?event.dex_type,
                                 pool = %event.pool_address,
                                 base_mint = %event.base_mint,
                                 "geyser_pool_discovery: SENDING transaction-based event to sniper"
                             );
-                            match event_tx.send(event) {
-                                Ok(receiver_count) => {
-                                    tracing::info!(
-                                        receiver_count,
-                                        "geyser_pool_discovery: event sent successfully"
-                                    );
-                                }
-                                Err(e) => {
-                                    tracing::error!(
-                                        ?e,
-                                        "geyser_pool_discovery: FAILED to send event - no receivers!"
-                                    );
-                                }
+                            if event_tx.send(event).await.is_err() {
+                                tracing::warn!(
+                                    "geyser_pool_discovery: pool event consumer dropped (tx path)"
+                                );
+                                break;
                             }
                         }
                     }
@@ -107,19 +86,14 @@ impl GeyserPoolDiscovery {
                         );
                     }
                     Err(broadcast::error::RecvError::Closed) => {
-                        tracing::warn!("geyser_pool_discovery: transaction stream closed");
+                        tracing::warn!("geyser_pool_discovery: transaction broadcast closed");
                         break;
                     }
                 }
             }
         });
 
-        (discovery, event_rx)
-    }
-
-    /// Start listening to Geyser updates
-    pub async fn start(self) -> Result<()> {
-        self.listener.start().await
+        event_rx
     }
 
     /// Process account update and determine if it's a new pool
@@ -771,4 +745,62 @@ struct PoolData {
     tick_current_index: Option<i32>,
     /// Orca Whirlpool: tick_spacing
     tick_spacing: Option<u16>,
+}
+
+#[cfg(test)]
+mod pool_discovery_ingest_tests {
+    use super::*;
+    use solana_sdk::pubkey::Pubkey;
+    use std::str::FromStr;
+    use std::time::Instant;
+
+    fn pumpfun_create_tx_update() -> GeyserTransactionUpdate {
+        let pump = Pubkey::from_str("6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P").unwrap();
+        let mint = Pubkey::new_unique();
+        let creator = Pubkey::new_unique();
+        let mut ixs = vec![Pubkey::default(); 8];
+        ixs[0] = mint;
+        ixs[7] = creator;
+        GeyserTransactionUpdate {
+            signature: "testsig".to_string(),
+            slot: 42,
+            account_keys: vec![pump],
+            instruction_accounts: ixs,
+            instruction_data: vec![0x18, 0x1e, 0xc8, 0x28, 0x05, 0x1c, 0x07, 0x77, 0, 0, 0, 0],
+            inner_instructions: vec![],
+            pre_token_balances: vec![],
+            post_token_balances: vec![],
+            pre_balances: vec![],
+            post_balances: vec![],
+            fee_lamports: 0,
+            compute_units_consumed: None,
+            grpc_recv_at: Instant::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_unified_tx_path_emits_pumpfun_pool_event() {
+        let (acc_tx, acc_rx) = broadcast::channel(8);
+        let pool_acc = acc_tx.subscribe();
+        drop(acc_rx);
+
+        let (tx_tx, tx_rx) = broadcast::channel(8);
+        let pool_tx = tx_tx.subscribe();
+        drop(tx_rx);
+
+        let rpc = Arc::new(crate::solana::rpc::SolanaRpc::new("http://127.0.0.1:8899"));
+        let mut out = PoolDiscoveryIngest::spawn_unified(pool_acc, pool_tx, Arc::clone(&rpc));
+
+        let upd = pumpfun_create_tx_update();
+        let expected_mint = upd.instruction_accounts[0];
+        assert!(tx_tx.send(upd).is_ok());
+
+        let ev = tokio::time::timeout(std::time::Duration::from_secs(2), out.recv())
+            .await
+            .expect("timed out waiting for pool discovery event")
+            .expect("pool discovery channel closed");
+
+        assert_eq!(ev.dex_type, DexType::PumpFun);
+        assert_eq!(ev.base_mint, expected_mint);
+    }
 }


### PR DESCRIPTION
## Summary
- Single Geyser connection: PoolDiscoveryIngest via unified listener
- pool_discovery off main select (dedicated task)
- Subscription updates async via dedicated updater task (no subscribe_tx.await in read loop)
- Metric geyser_listener_stream_messages_total

## Prod context
- #161 deployed; crash loop is systemd WatchdogSec=30 timeout (not panic)
- Follow-up PR163: watchdog ping on OS thread

## Test plan
- [x] cargo test (agent)
- [ ] CI Eval Level 5
