### PR TITLE
fix(market-data): PR163 — watchdog ping on OS thread (timer starvation)

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,12 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### PR163-WATCHDOG-OS-THREAD: systemd-Watchdog-Ping auf dediziertem OS-Thread (Timer-Starvation)
+**Datum**: 2026-05-27  
+**Problem** (Prod post #160/#161): `market-data.service: Watchdog timeout (limit 30s)` → ABRT / Crash-Loop ohne Panic oder Geyser-Fehler. Der Reserve-Ping aus **PR151** lief als `tokio::spawn` + `interval(5s)` auf dem **Haupt-Runtime**; unter Last (Geyser-Ingest, Account-Worker, Publish-Pipeline) **Timer-Starvation** → kein `sd_notify(WATCHDOG)` innerhalb `WatchdogSec=30`. Gleiche Fehlerklasse wie **PR155** (NATS-Publish auf isolierter Runtime).  
+**Fix**: (1) **Dedizierter Thread** `md-watchdog`: `std::thread::sleep(5s)` + `sd_notify(WATCHDOG)` in einer Endlosschleife — unabhängig vom Tokio-Scheduler. (2) **Start** unmittelbar nach `sd_notify(Ready)` (vor langem Geyser-/JetStream-Setup), damit der Watchdog nach Ready nie verhungert. (3) **Entfernt**: Tokio-Watchdog-Task in `run_geyser_loop` sowie redundante `Watchdog`-Pings im `activity_interval`-Arm und im Simulations-`select!` (ein kanonischer Ping-Pfad). **`cfg(test)`**: kein Watchdog-Thread (keine Hintergrund-Threads in Unit-Tests). **Invarianten**: kein RPC (I-7), Geyser/NATS-Pipeline unverändert (Scope nur `market_data` binary).  
+**Dateien**: `src/bin/market_data.rs`, `docs/BUGS_FIXES.md`
+
 ### PR162-GEYSER-INGEST-LIVENESS: eine Geyser-Session + Subscription-Sink aus Read-Loop; Pool-Discovery off Main-`select!`
 **Datum**: 2026-05-27  
 **Problem** (Prod post #160): `head_slot` / `nats_messages_published_total` frieren ~60 s nach Restart; `geyser_listener: heartbeat` fehlt; letztes `subscription updated` beim Startup-Burst; paralleles `GeyserPoolDiscovery` (zweite gRPC-Connection) liefert weiter Meteora-Logs — Haupt-Read-Loop liefert keine Nutzlast mehr (Ingest-Starvation). Publish-Pipeline (#160) war nicht der Blocker.  

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -6627,6 +6627,19 @@ async fn main() -> Result<()> {
         // NOTE: Do NOT unset NOTIFY_SOCKET here; we need it for Watchdog pings.
         let _ = sd_notify::notify(false, &[NotifyState::Ready]);
         debug!("Sent sd_notify READY to systemd");
+
+        // PR163: Watchdog pings on a dedicated OS thread — `tokio::interval` on the main runtime
+        // can starve under Geyser/NATS load (same class as PR155 publish-runtime isolation).
+        #[cfg(not(test))]
+        {
+            std::thread::Builder::new()
+                .name("md-watchdog".to_string())
+                .spawn(|| loop {
+                    std::thread::sleep(std::time::Duration::from_secs(5));
+                    let _ = sd_notify::notify(false, &[NotifyState::Watchdog]);
+                })
+                .expect("spawn md-watchdog thread");
+        }
     }
 
     // Keep readiness fresh even when idle.
@@ -10735,19 +10748,6 @@ async fn run_geyser_loop(
         return Ok(());
     }
 
-    // PR151-NATS-WATCHDOG-FOLLOWUP: systemd WatchdogSec=30 — ping unabhängig vom Geyser-`select!`
-    // und NATS-Backpressure (siehe docs/BUGS_FIXES.md), analog execution_engine `maybe_ping_watchdog`.
-    #[cfg(unix)]
-    {
-        tokio::spawn(async {
-            let mut iv = tokio::time::interval(std::time::Duration::from_secs(5));
-            loop {
-                iv.tick().await;
-                let _ = sd_notify::notify(false, &[NotifyState::Watchdog]);
-            }
-        });
-    }
-
     // Mint metadata fetch pipeline:
     // - We add mints to `tracked_mints` when we see them via tx/pool discovery.
     // - Mint accounts often *never change*, so relying on a future Geyser account update
@@ -11375,10 +11375,6 @@ async fn run_geyser_loop(
                     false
                 };
                 update_readiness_market_data_current(nats_connected, control_sub_active, jetstream_ready);
-
-                // P1 Crash Isolation: Ping systemd watchdog frequently enough.
-                #[cfg(unix)]
-                let _ = sd_notify::notify(false, &[NotifyState::Watchdog]);
             }
 
             // Track wallet ATAs/mints from execution-engine results via JetStream (no RPC).
@@ -11895,12 +11891,6 @@ async fn run_simulation_loop(
                         bytes_written = bytes,
                         "market-data heartbeat (simulation)"
                     );
-                }
-
-                // P1 Crash Isolation: Ping systemd watchdog frequently enough.
-                if slot % 10 == 0 {
-                    #[cfg(unix)]
-                    let _ = sd_notify::notify(false, &[NotifyState::Watchdog]);
                 }
             }
 


### PR DESCRIPTION
## Summary
- systemd watchdog ping on dedicated OS thread (md-watchdog, 5s)
- Removes tokio watchdog spawn and redundant pings in select arms
- Fixes prod crash loop: Watchdog timeout (30s) under runtime starvation

## Deploy with
- PR #162 (Geyser ingest liveness)

## Test plan
- [x] cargo test (agent)
- [ ] CI Eval Level 5
- [ ] Prod: no journalctl watchdog timeout >10min
