### PR TITLE
fix(geyser): PR164 — sacred TX stream + split account/cuckoo connection

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,12 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### PR164-GEYSER-SPLIT-TX-SACRED: zwei gRPC-Sessions (TX heilig + Account/Cuckoo); TX-Liveness-Reconnect
+**Datum**: 2026-05-27  
+**Problem** (Prod nach PR #162): Nach Startup-Burst in-place `SubscribeRequest`-Updates liefert Yellowstone weiter **Account**-Updates, aber **keine** DEX-`Transaction`-Updates mehr (`Parsed DEX transaction` stoppt; `market_data_geyser_to_publish_ms_trade_count` friert) — **ohne** Stream-Error/Reconnect-Metrik. Ursache: eine Session teilte sich TX-Filter und Cuckoo-Pin-Updates über denselben `subscribe_tx`-Sink; der letzte Full-Replace tötet den TX-Teil still.  
+**Fix**: (1) **`GeyserTxListener`**: nur `build_tx_subscribe_request` (DEX-`transactions` + `blocks_meta`), **kein** `subscribe_tx.send` nach Init, **keine** tracked-Pins. (2) **`GeyserAccountListener`**: nur `build_account_subscribe_request` (Owner-`accounts` + Cuckoo; **leere** `transactions`); Merge→`combined_tracked` + async Sink (#162) nur hier. (3) **Metriken**: `geyser_tx_listener_transactions_total`, `geyser_account_listener_account_updates_total`, `geyser_tx_listener_subscribe_updates_total` (0 nach Init), `geyser_account_listener_subscribe_updates_total`, `geyser_tx_listener_liveness_reconnects_total`; `geyser_connected` nur wenn **beide** Sessions up. (4) **TX-Liveness**: wenn 60 s keine TX-Updates **und** `market_data_geyser_head_slot` steigt → nur TX-Session outer reconnect + Log. (5) **Optional**: `PoolCreated`-Dedup pro `pool_address` vor Publish. **Invarianten**: kein RPC (I-7), Geyser-first (I-4/I-16), PR160/#161 unangetastet.  
+**Dateien**: `src/solana/geyser_listener.rs`, `src/bin/market_data.rs`, `src/metrics.rs`, `src/solana/geyser_pool_discovery.rs`, `docs/BUGS_FIXES.md`
+
 ### PR163-WATCHDOG-OS-THREAD: systemd-Watchdog-Ping auf dediziertem OS-Thread (Timer-Starvation)
 **Datum**: 2026-05-27  
 **Problem** (Prod post #160/#161): `market-data.service: Watchdog timeout (limit 30s)` → ABRT / Crash-Loop ohne Panic oder Geyser-Fehler. Der Reserve-Ping aus **PR151** lief als `tokio::spawn` + `interval(5s)` auf dem **Haupt-Runtime**; unter Last (Geyser-Ingest, Account-Worker, Publish-Pipeline) **Timer-Starvation** → kein `sd_notify(WATCHDOG)` innerhalb `WatchdogSec=30`. Gleiche Fehlerklasse wie **PR155** (NATS-Publish auf isolierter Runtime).  

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -114,7 +114,7 @@ use spl_token_2022::extension::StateWithExtensions;
 /// NATS topic for config reload (P1: Runtime Configuration via UI)
 const TOPIC_CONFIG_RELOAD: &str = "ironcrab.control.config.reload";
 use ironcrab::solana::geyser_listener::{
-    GeyserAccountUpdate, GeyserListener, GeyserTransactionUpdate,
+    GeyserAccountListener, GeyserAccountUpdate, GeyserTransactionUpdate, GeyserTxListener,
 };
 use ironcrab::storage::{JsonlWriter, JsonlWriterConfig};
 
@@ -694,7 +694,7 @@ struct MarketDataConfig {
     max_tracked_accounts: usize,
     /// PR-B: full Geyser reconnect when combined explicit accounts exceed this threshold.
     geyser_full_reconnect_threshold: usize,
-    /// Coalesce TX-path Geyser subscription sync **and** merge-task `combined_tracked`→GeyserListener
+    /// Coalesce TX-path Geyser subscription sync **and** merge-task `combined_tracked`→GeyserAccountListener
     /// updates (PR161); same debounce window for both (ms). Clamped 10–100 at use sites.
     geyser_sync_batch_ms: u64,
 }
@@ -818,7 +818,7 @@ struct MarketDataContext {
     run_id: String,
     /// P1: Config in RwLock for runtime hot-reload
     config: parking_lot::RwLock<MarketDataConfig>,
-    /// Same value as `config.geyser_full_reconnect_threshold`, mirrored for `GeyserListener` hot-reload.
+    /// Same value as `config.geyser_full_reconnect_threshold`, mirrored for `GeyserAccountListener` hot-reload.
     geyser_full_reconnect_threshold_live: Arc<AtomicUsize>,
     nats: Option<NatsClient>,
     jsonl_writer: JsonlWriter,
@@ -852,13 +852,13 @@ struct MarketDataContext {
     /// Vault account tracking for PoolStateUpdate events (Geyser-based reserve balances).
     /// Maps vault_address → VaultInfo (pool context).
     tracked_vaults: parking_lot::RwLock<std::collections::HashMap<Pubkey, VaultInfo>>,
-    /// Channel to notify GeyserListener when tracked vaults change (triggers resubscribe).
+    /// Channel to notify GeyserAccountListener when tracked vaults change (triggers resubscribe).
     tracked_vaults_tx: watch::Sender<Vec<Pubkey>>,
 
     /// Meteora DLMM Bin Array tracking for BinArrayUpdate events (Geyser-based liquidity).
     /// Maps bin_array_pda → BinArrayInfo (pool context).
     tracked_bin_arrays: parking_lot::RwLock<std::collections::HashMap<Pubkey, BinArrayInfo>>,
-    /// Channel to notify GeyserListener when tracked bin arrays change (triggers resubscribe).
+    /// Channel to notify GeyserAccountListener when tracked bin arrays change (triggers resubscribe).
     tracked_bin_arrays_tx: watch::Sender<Vec<Pubkey>>,
 
     /// MASTER LivePoolCache - Single Source of Truth for all pool state.
@@ -891,7 +891,7 @@ struct MarketDataContext {
     /// Wallet pubkey to track for balance updates (for WsolManager in execution-engine).
     /// Set via IRONCRAB_WALLET_PUBKEY env var.
     tracked_wallet: Option<TrackedWallet>,
-    /// Channel to notify GeyserListener when tracked wallet accounts change.
+    /// Channel to notify GeyserAccountListener when tracked wallet accounts change.
     /// NOTE: We keep the Sender alive even though we don't use it after initial send,
     /// because dropping it would close the Receiver used by the merge task.
     #[allow(dead_code)]
@@ -922,6 +922,9 @@ struct MarketDataContext {
 
     /// Debounced flush of explicit Geyser subscription maps after TX-path reserve registration.
     geyser_sync_batch_timer: parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>,
+
+    /// PR164: dedupe `PoolCreated` NATS/JSONL for the same pool (account-path vault spam).
+    pool_discovery_poolcreated_emitted: parking_lot::RwLock<std::collections::HashSet<Pubkey>>,
 }
 
 #[derive(Debug, Default)]
@@ -6617,6 +6620,9 @@ async fn main() -> Result<()> {
         pump_amm_dex: parking_lot::RwLock::new(None),
         helius_rpc,
         geyser_sync_batch_timer: parking_lot::Mutex::new(None),
+        pool_discovery_poolcreated_emitted: parking_lot::RwLock::new(
+            std::collections::HashSet::new(),
+        ),
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -8128,6 +8134,14 @@ async fn handle_pool_discovery_market_event(
     let pool_discovery_recv_at = Instant::now();
     market_data_bump_geyser_head_slot(pool_event.slot);
     ironcrab::metrics::record_activity();
+
+    if !ctx
+        .pool_discovery_poolcreated_emitted
+        .write()
+        .insert(pool_event.pool_address)
+    {
+        return;
+    }
 
     info!(
         dex = %pool_event.dex_type,
@@ -10767,7 +10781,7 @@ async fn run_geyser_loop(
     ];
 
     // Merge tracked_mints, tracked_vaults, tracked_bin_arrays, and tracked_wallet into a single combined channel.
-    // GeyserListener will subscribe to all accounts in the combined list.
+    // GeyserAccountListener subscribes to all accounts in the combined list (TX path: GeyserTxListener).
     let (combined_tracked_tx, combined_tracked_rx) = watch::channel(Vec::<Pubkey>::new());
     {
         let mints_rx = tracked_mints_rx;
@@ -10789,28 +10803,35 @@ async fn run_geyser_loop(
         });
     }
 
-    // Geyser listener + unified pool discovery (single gRPC session; PR162)
-    let (listener, account_rx, transaction_rx, mut blockhash_rx) =
-        GeyserListener::new_with_tracked_accounts(
-            geyser_url.to_string(),
-            program_ids,
-            combined_tracked_rx,
-            Arc::clone(&ctx.geyser_full_reconnect_threshold_live),
-            ctx.config.read().max_tracked_accounts.max(1),
-        );
+    // PR164: two Geyser gRPC sessions — TX+blockhash (sacred, no pin subscribe updates) and
+    // accounts+cuckoo (in-place subscribe updates). Merge → account session only.
+    let (tx_listener, transaction_rx, mut blockhash_rx) =
+        GeyserTxListener::new(geyser_url.to_string(), program_ids.clone());
+    let (account_listener, account_rx) = GeyserAccountListener::new_with_tracked_accounts(
+        geyser_url.to_string(),
+        program_ids,
+        combined_tracked_rx,
+        Arc::clone(&ctx.geyser_full_reconnect_threshold_live),
+        ctx.config.read().max_tracked_accounts.max(1),
+    );
 
-    let pool_discovery_account_rx = listener.subscribe_account_updates();
-    let pool_discovery_transaction_rx = listener.subscribe_transaction_updates();
+    let pool_discovery_account_rx = account_listener.subscribe_account_updates();
+    let pool_discovery_transaction_rx = tx_listener.subscribe_transaction_updates();
     let pool_discovery_event_rx = PoolDiscoveryIngest::spawn_unified(
         pool_discovery_account_rx,
         pool_discovery_transaction_rx,
         rpc.clone(),
     );
 
-    // Spawn Geyser listener task (single gRPC session; PR162)
-    let listener_handle = tokio::spawn(async move {
-        if let Err(e) = listener.start().await {
-            error!(error = %e, "Geyser listener crashed");
+    let tx_listener_handle = tokio::spawn(async move {
+        if let Err(e) = tx_listener.start().await {
+            error!(error = %e, "Geyser TX listener crashed");
+        }
+    });
+
+    let account_listener_handle = tokio::spawn(async move {
+        if let Err(e) = account_listener.start().await {
+            error!(error = %e, "Geyser account listener crashed");
         }
     });
 
@@ -11098,7 +11119,8 @@ async fn run_geyser_loop(
             _ = geyser_tx_stream_stopped_rx.changed() => {
                 if *geyser_tx_stream_stopped_rx.borrow() {
                     warn!("Geyser transaction stream ended; stopping market-data Geyser loop");
-                    listener_handle.abort();
+                    tx_listener_handle.abort();
+                    account_listener_handle.abort();
                     break;
                 }
             }
@@ -11106,7 +11128,8 @@ async fn run_geyser_loop(
             _ = geyser_account_stream_stopped_rx.changed() => {
                 if *geyser_account_stream_stopped_rx.borrow() {
                     warn!("Geyser account stream ended; stopping market-data Geyser loop");
-                    listener_handle.abort();
+                    tx_listener_handle.abort();
+                    account_listener_handle.abort();
                     break;
                 }
             }
@@ -11752,7 +11775,8 @@ async fn run_geyser_loop(
 
             _ = &mut shutdown => {
                 info!("Shutdown signal received");
-                listener_handle.abort();
+                tx_listener_handle.abort();
+                account_listener_handle.abort();
                 break;
             }
         }
@@ -13421,6 +13445,9 @@ mod pr_b_geyser_tracking_tests {
             pump_amm_dex: parking_lot::RwLock::new(None),
             helius_rpc: None,
             geyser_sync_batch_timer: parking_lot::Mutex::new(None),
+            pool_discovery_poolcreated_emitted: parking_lot::RwLock::new(
+                std::collections::HashSet::new(),
+            ),
         })
     }
 
@@ -13478,6 +13505,9 @@ mod pr_b_geyser_tracking_tests {
             pump_amm_dex: parking_lot::RwLock::new(None),
             helius_rpc: None,
             geyser_sync_batch_timer: parking_lot::Mutex::new(None),
+            pool_discovery_poolcreated_emitted: parking_lot::RwLock::new(
+                std::collections::HashSet::new(),
+            ),
         });
         (
             ctx,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -233,7 +233,27 @@ pub static GEYSER_STREAM_ERRORS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64:
 pub static GEYSER_TRACKED_CUCKOO_TABLE_FULL_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 /// 1 while a Geyser gRPC connection is established; 0 while reconnecting.
+/// PR164: `1` only when **both** TX and account Geyser sessions are connected.
 pub static GEYSER_CONNECTED: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// PR164: TX-only Geyser gRPC session (transactions + blocks_meta).
+pub static GEYSER_TX_SESSION_CONNECTED: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// PR164: Account-only Geyser gRPC session (owner filters + cuckoo pins; no transaction filters).
+pub static GEYSER_ACCOUNT_SESSION_CONNECTED: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// PR164: `UpdateOneof::Transaction` received on the TX-only session.
+pub static GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// PR164: Account updates received on the account-only session.
+pub static GEYSER_ACCOUNT_LISTENER_ACCOUNT_UPDATES_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// PR164: In-place subscribe updates after initial connect (must stay **0** on TX session).
+pub static GEYSER_TX_LISTENER_SUBSCRIBE_UPDATES_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// PR164: In-place subscribe updates (cuckoo / pin rebuild) on account session.
+pub static GEYSER_ACCOUNT_LISTENER_SUBSCRIBE_UPDATES_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// PR164: Forced outer reconnect of TX session because transaction ingest stalled while chain advanced.
+pub static GEYSER_TX_LISTENER_LIVENESS_RECONNECTS_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 /// Combined explicit Geyser account subscription size (mints + vaults + bin arrays + wallet).
 pub static GEYSER_SUBSCRIPTION_ACCOUNTS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -393,8 +413,49 @@ pub fn geyser_metrics_inc_tracked_cuckoo_table_full() {
     GEYSER_TRACKED_CUCKOO_TABLE_FULL_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn geyser_metrics_set_connected(connected: bool) {
-    GEYSER_CONNECTED.store(if connected { 1 } else { 0 }, Ordering::Relaxed);
+#[inline]
+fn geyser_metrics_refresh_aggregate_connected() {
+    let both = GEYSER_TX_SESSION_CONNECTED.load(Ordering::Relaxed) == 1
+        && GEYSER_ACCOUNT_SESSION_CONNECTED.load(Ordering::Relaxed) == 1;
+    GEYSER_CONNECTED.store(if both { 1 } else { 0 }, Ordering::Relaxed);
+}
+
+/// PR164: TX Geyser session connected state (also refreshes aggregate `geyser_connected`).
+pub fn geyser_metrics_set_tx_session_connected(connected: bool) {
+    GEYSER_TX_SESSION_CONNECTED.store(if connected { 1 } else { 0 }, Ordering::Relaxed);
+    geyser_metrics_refresh_aggregate_connected();
+}
+
+/// PR164: Account Geyser session connected state (also refreshes aggregate `geyser_connected`).
+pub fn geyser_metrics_set_account_session_connected(connected: bool) {
+    GEYSER_ACCOUNT_SESSION_CONNECTED.store(if connected { 1 } else { 0 }, Ordering::Relaxed);
+    geyser_metrics_refresh_aggregate_connected();
+}
+
+#[inline]
+pub fn geyser_metrics_inc_tx_listener_transactions_total() {
+    GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn geyser_metrics_inc_account_listener_account_updates_total() {
+    GEYSER_ACCOUNT_LISTENER_ACCOUNT_UPDATES_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn geyser_metrics_inc_account_listener_subscribe_updates_total() {
+    GEYSER_ACCOUNT_LISTENER_SUBSCRIBE_UPDATES_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn geyser_metrics_inc_tx_listener_liveness_reconnect_total() {
+    GEYSER_TX_LISTENER_LIVENESS_RECONNECTS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Monotonic Geyser head slot (read-only). Used by TX liveness gate (PR164).
+#[inline]
+pub fn market_data_geyser_head_slot_value() -> u64 {
+    MARKET_DATA_GEYSER_HEAD_SLOT.load(Ordering::Relaxed)
 }
 
 // --- market-data: Geyser recv → Core NATS publish (hot path observability, no RPC) ---
@@ -751,13 +812,13 @@ pub fn record_market_data_tx_broadcast_lagged(skipped_messages: u64) {
     }
 }
 
-/// Update gauge: pending tx updates in the `broadcast` receiver (see `GeyserListener` tx channel).
+/// Update gauge: pending tx updates in the `broadcast` receiver (see `GeyserTxListener` tx channel).
 #[inline]
 pub fn set_market_data_tx_broadcast_queue_depth(depth: usize) {
     MARKET_DATA_TX_BROADCAST_QUEUE_DEPTH.store(depth as u64, Ordering::Relaxed);
 }
 
-/// Update gauge: pending account updates in the `broadcast` receiver (see `GeyserListener` account channel).
+/// Update gauge: pending account updates in the `broadcast` receiver (see `GeyserAccountListener` account channel).
 #[inline]
 pub fn set_market_data_account_broadcast_queue_depth(depth: usize) {
     MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH.store(depth as u64, Ordering::Relaxed);
@@ -2460,6 +2521,34 @@ async fn metrics_response() -> Response<Body> {
         GEYSER_TRACKED_CUCKOO_TABLE_FULL_TOTAL.load(Ordering::Relaxed)
     );
     line!("geyser_connected", GEYSER_CONNECTED.load(Ordering::Relaxed));
+    line!(
+        "geyser_tx_session_connected",
+        GEYSER_TX_SESSION_CONNECTED.load(Ordering::Relaxed)
+    );
+    line!(
+        "geyser_account_session_connected",
+        GEYSER_ACCOUNT_SESSION_CONNECTED.load(Ordering::Relaxed)
+    );
+    line!(
+        "geyser_tx_listener_transactions_total",
+        GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "geyser_account_listener_account_updates_total",
+        GEYSER_ACCOUNT_LISTENER_ACCOUNT_UPDATES_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "geyser_tx_listener_subscribe_updates_total",
+        GEYSER_TX_LISTENER_SUBSCRIBE_UPDATES_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "geyser_account_listener_subscribe_updates_total",
+        GEYSER_ACCOUNT_LISTENER_SUBSCRIBE_UPDATES_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "geyser_tx_listener_liveness_reconnects_total",
+        GEYSER_TX_LISTENER_LIVENESS_RECONNECTS_TOTAL.load(Ordering::Relaxed)
+    );
     line!(
         "geyser_subscription_accounts",
         GEYSER_SUBSCRIPTION_ACCOUNTS.load(Ordering::Relaxed)

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -34,9 +34,14 @@ use yellowstone_grpc_proto::prelude::{
 
 #[cfg(not(windows))]
 use crate::metrics::{
+    geyser_metrics_inc_account_listener_account_updates_total,
+    geyser_metrics_inc_account_listener_subscribe_updates_total,
     geyser_metrics_inc_listener_stream_payload, geyser_metrics_inc_reconnect,
     geyser_metrics_inc_stream_error, geyser_metrics_inc_tracked_cuckoo_table_full,
-    geyser_metrics_set_connected, GeyserReconnectReason,
+    geyser_metrics_inc_tx_listener_liveness_reconnect_total,
+    geyser_metrics_inc_tx_listener_transactions_total,
+    geyser_metrics_set_account_session_connected, geyser_metrics_set_tx_session_connected,
+    market_data_geyser_head_slot_value, GeyserReconnectReason,
 };
 #[cfg(not(windows))]
 use rand::Rng;
@@ -120,103 +125,580 @@ pub struct GeyserBlockhashUpdate {
     pub block_height: u64,
 }
 
-pub struct GeyserListener {
+/// PR-A: exponential reconnect sleep with small jitter (cold path only).
+#[cfg(not(windows))]
+fn geyser_reconnect_sleep_ms(backoff_ms: u64) -> u64 {
+    let jitter_cap = backoff_ms.min(150);
+    let jitter = if jitter_cap == 0 {
+        0u64
+    } else {
+        rand::thread_rng().gen_range(0..=jitter_cap)
+    };
+    backoff_ms.saturating_add(jitter)
+}
+
+/// Yellowstone `cuckoo_accounts_filter` entry name for explicit tracked accounts.
+#[cfg(not(windows))]
+pub(crate) const TRACKED_CUCKOO_SUBSCRIBE_NAME: &str = "tracked_accounts_cuckoo";
+
+#[cfg(not(windows))]
+pub(crate) fn build_tx_subscribe_request(program_ids: &[Pubkey]) -> SubscribeRequest {
+    let mut transactions_filter = HashMap::new();
+    for (idx, program_id) in program_ids.iter().enumerate() {
+        transactions_filter.insert(
+            format!("dex_transactions_{}", idx),
+            SubscribeRequestFilterTransactions {
+                vote: Some(false),
+                failed: Some(false),
+                signature: None,
+                account_include: vec![program_id.to_string()],
+                account_exclude: vec![],
+                account_required: vec![],
+            },
+        );
+    }
+    let blocks_meta_filter =
+        HashMap::from([("blockhash".to_string(), SubscribeRequestFilterBlocksMeta {})]);
+    SubscribeRequest {
+        accounts: HashMap::new(),
+        slots: HashMap::new(),
+        transactions: transactions_filter,
+        transactions_status: HashMap::new(),
+        blocks: HashMap::new(),
+        blocks_meta: blocks_meta_filter,
+        entry: HashMap::new(),
+        commitment: Some(CommitmentLevel::Confirmed as i32),
+        accounts_data_slice: vec![],
+        ping: None,
+        from_slot: None,
+    }
+}
+
+#[cfg(not(windows))]
+pub(crate) fn build_account_subscribe_request(
+    program_ids: &[Pubkey],
+    tracked_cuckoo: Option<&mut CompressedAccountFilterSet>,
+) -> SubscribeRequest {
+    let mut accounts_filter = HashMap::new();
+
+    for (idx, program_id) in program_ids.iter().enumerate() {
+        accounts_filter.insert(
+            format!("dex_accounts_{}", idx),
+            SubscribeRequestFilterAccounts {
+                account: vec![],
+                owner: vec![program_id.to_string()],
+                filters: vec![],
+                nonempty_txn_signature: None,
+                cuckoo_accounts_filter: None,
+            },
+        );
+    }
+
+    let mut req = SubscribeRequest {
+        accounts: accounts_filter,
+        slots: HashMap::new(),
+        transactions: HashMap::new(),
+        transactions_status: HashMap::new(),
+        blocks: HashMap::new(),
+        blocks_meta: HashMap::new(),
+        entry: HashMap::new(),
+        commitment: Some(CommitmentLevel::Confirmed as i32),
+        accounts_data_slice: vec![],
+        ping: None,
+        from_slot: None,
+    };
+
+    if let Some(cuck) = tracked_cuckoo {
+        cuck.insert_into_subscribe_request(&mut req, TRACKED_CUCKOO_SUBSCRIBE_NAME);
+    }
+
+    req
+}
+
+/// PR164: TX-only Geyser gRPC session — one `SubscribeRequest` at connect, **no** in-place
+/// subscription updates (sacred TX stream + `blocks_meta` blockhash).
+pub struct GeyserTxListener {
     endpoint: String,
     program_ids: Vec<Pubkey>,
-    /// Optional dynamic list of additional accounts (e.g. SPL mint pubkeys) to subscribe to.
-    ///
-    /// This is implemented via explicit `account` filters (not owner-wide token program
-    /// subscriptions), so it scales with tracked tokens rather than chain-wide token activity.
-    tracked_accounts_rx: Option<watch::Receiver<Vec<Pubkey>>>,
-    /// When `tracked_accounts.len()` exceeds this value, account-list updates use a full outer
-    /// gRPC reconnect instead of in-place `subscribe_tx.send` (PR-B Yellowstone churn control).
-    /// Use `usize::MAX` to always prefer in-place updates. Shared so market-data can hot-reload.
-    full_reconnect_tracked_threshold: Arc<AtomicUsize>,
-    /// Max capacity for [`CompressedAccountFilterSet`] (Yellowstone cuckoo wire filter). Must be
-    /// at least the configured `max_tracked_accounts` peak. `0` disables cuckoo (legacy explicit
-    /// chunks — not used when `new_with_tracked_accounts` passes a positive cap from market-data).
-    tracked_cuckoo_max_capacity: usize,
-    #[cfg_attr(windows, allow(dead_code))]
-    account_tx: broadcast::Sender<GeyserAccountUpdate>,
     #[cfg_attr(windows, allow(dead_code))]
     transaction_tx: broadcast::Sender<GeyserTransactionUpdate>,
     #[cfg_attr(windows, allow(dead_code))]
     blockhash_tx: broadcast::Sender<GeyserBlockhashUpdate>,
 }
 
-impl GeyserListener {
-    /// Create new Geyser listener
-    ///
-    /// `endpoint`: Geyser gRPC endpoint (e.g., "http://127.0.0.1:10000")
-    /// `program_ids`: DEX program IDs to monitor (Raydium, Orca, Pump.fun)
+/// PR164: Account + cuckoo Geyser session — owner filters + dynamic pins; **no** transaction filters.
+pub struct GeyserAccountListener {
+    endpoint: String,
+    program_ids: Vec<Pubkey>,
+    tracked_accounts_rx: watch::Receiver<Vec<Pubkey>>,
+    full_reconnect_tracked_threshold: Arc<AtomicUsize>,
+    tracked_cuckoo_max_capacity: usize,
+    #[cfg_attr(windows, allow(dead_code))]
+    account_tx: broadcast::Sender<GeyserAccountUpdate>,
+}
+
+impl GeyserTxListener {
     pub fn new(
         endpoint: String,
         program_ids: Vec<Pubkey>,
     ) -> (
         Self,
-        broadcast::Receiver<GeyserAccountUpdate>,
         broadcast::Receiver<GeyserTransactionUpdate>,
         broadcast::Receiver<GeyserBlockhashUpdate>,
     ) {
-        // Large buffer for high-frequency updates
-        let (account_tx, account_rx) = broadcast::channel(200000);
         let (transaction_tx, transaction_rx) = broadcast::channel(50000);
         let (blockhash_tx, blockhash_rx) = broadcast::channel(100);
-
         (
             Self {
                 endpoint,
                 program_ids,
-                tracked_accounts_rx: None,
-                full_reconnect_tracked_threshold: Arc::new(AtomicUsize::new(usize::MAX)),
-                tracked_cuckoo_max_capacity: 0,
-                account_tx,
                 transaction_tx,
                 blockhash_tx,
             },
-            account_rx,
             transaction_rx,
             blockhash_rx,
         )
     }
 
-    /// Create a new Geyser listener with an additional dynamic tracked-account subscription.
-    ///
-    /// When the provided watch channel updates, the listener will resubscribe to include the
-    /// new account list.
+    pub fn subscribe_transaction_updates(&self) -> broadcast::Receiver<GeyserTransactionUpdate> {
+        self.transaction_tx.subscribe()
+    }
+
+    pub fn subscribe_blockhash_updates(&self) -> broadcast::Receiver<GeyserBlockhashUpdate> {
+        self.blockhash_tx.subscribe()
+    }
+
+    pub async fn start(self) -> Result<()> {
+        #[cfg(windows)]
+        {
+            let _ = (self.endpoint, self.program_ids);
+            Err(anyhow!(
+                "Geyser gRPC is not supported on Windows in this repo build. \
+                 Build on Linux/macOS for Geyser support."
+            ))
+        }
+
+        #[cfg(not(windows))]
+        {
+            self.start_tx_impl().await
+        }
+    }
+
+    #[cfg(not(windows))]
+    async fn start_tx_impl(self) -> Result<()> {
+        use crate::metrics::GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL;
+        use std::sync::atomic::Ordering as AtomicOrdering;
+
+        enum SessionExit {
+            StreamEnded,
+            HardReconnect,
+            TxLivenessStale,
+        }
+
+        info!(
+            endpoint = %self.endpoint,
+            programs = self.program_ids.len(),
+            "geyser_tx_listener: connecting to Geyser gRPC (TX + blocks_meta only; PR164)"
+        );
+
+        let Self {
+            endpoint,
+            program_ids,
+            transaction_tx,
+            blockhash_tx,
+        } = self;
+
+        let mut reconnect_backoff_ms: u64 = rand::thread_rng().gen_range(100..=250);
+        const RECONNECT_BACKOFF_CAP_MS: u64 = 60_000;
+        let mut last_stream_ended_log =
+            std::time::Instant::now() - std::time::Duration::from_secs(10);
+        let mut last_log = std::time::Instant::now();
+        let mut transaction_count: u64 = 0;
+        let mut seen_tx_since_connect = false;
+        let mut last_liveness_tx_total: u64 = 0;
+        let mut last_liveness_head_slot: u64 = 0;
+        let mut first_liveness_window = true;
+
+        'outer: loop {
+            let mut client = loop {
+                match GeyserGrpcClient::build_from_shared(endpoint.clone())
+                    .map_err(|e| anyhow!("Failed to build Geyser client: {}", e))?
+                    .connect()
+                    .await
+                {
+                    Ok(c) => {
+                        info!("geyser_tx_listener: connected successfully");
+                        geyser_metrics_set_tx_session_connected(true);
+                        break c;
+                    }
+                    Err(e) => {
+                        error!(error = %e, "geyser_tx_listener: connect failed, retrying");
+                        geyser_metrics_set_tx_session_connected(false);
+                        let sleep_ms = geyser_reconnect_sleep_ms(reconnect_backoff_ms);
+                        sleep(Duration::from_millis(sleep_ms)).await;
+                        reconnect_backoff_ms =
+                            (reconnect_backoff_ms.saturating_mul(2)).min(RECONNECT_BACKOFF_CAP_MS);
+                    }
+                }
+            };
+
+            'same_client: loop {
+                let request = build_tx_subscribe_request(&program_ids);
+                let (mut _subscribe_tx, mut stream) =
+                    match client.subscribe_with_request(Some(request)).await {
+                        Ok(pair) => pair,
+                        Err(e) => {
+                            warn!(
+                                error = %e,
+                                "geyser_tx_listener: subscribe failed; reconnecting with new client"
+                            );
+                            geyser_metrics_inc_reconnect(GeyserReconnectReason::StreamError);
+                            geyser_metrics_set_tx_session_connected(false);
+                            let sleep_ms = geyser_reconnect_sleep_ms(reconnect_backoff_ms);
+                            sleep(Duration::from_millis(sleep_ms)).await;
+                            reconnect_backoff_ms = (reconnect_backoff_ms.saturating_mul(2))
+                                .min(RECONNECT_BACKOFF_CAP_MS);
+                            continue 'outer;
+                        }
+                    };
+
+                info!(
+                    programs = ?program_ids,
+                    "geyser_tx_listener: subscribed (TX sacred — no further subscribe updates)"
+                );
+
+                let mut got_payload_since_subscribe = false;
+                let mut liveness = tokio::time::interval(Duration::from_secs(60));
+                liveness.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+                let session_exit = 'read: loop {
+                    if last_log.elapsed().as_secs() >= 60 {
+                        info!(
+                            transactions = transaction_count,
+                            "geyser_tx_listener: heartbeat - still receiving updates"
+                        );
+                        last_log = std::time::Instant::now();
+                    }
+
+                    tokio::select! {
+                        biased;
+                        _ = liveness.tick() => {
+                            let head = market_data_geyser_head_slot_value();
+                            let tx_total = GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL.load(AtomicOrdering::Relaxed);
+                            if first_liveness_window {
+                                last_liveness_head_slot = head;
+                                last_liveness_tx_total = tx_total;
+                                first_liveness_window = false;
+                                continue;
+                            }
+                            if seen_tx_since_connect
+                                && tx_total == last_liveness_tx_total
+                                && head > last_liveness_head_slot
+                            {
+                                warn!(
+                                    tx_total,
+                                    head_slot = head,
+                                    prev_head_slot = last_liveness_head_slot,
+                                    "geyser_tx_listener: TX stream stale — forcing reconnect"
+                                );
+                                geyser_metrics_inc_tx_listener_liveness_reconnect_total();
+                                break 'read SessionExit::TxLivenessStale;
+                            }
+                            last_liveness_head_slot = head;
+                            last_liveness_tx_total = tx_total;
+                        }
+                        maybe_message = stream.next() => {
+                            match maybe_message {
+                                None => {
+                                    geyser_metrics_inc_reconnect(GeyserReconnectReason::StreamEnded);
+                                    let now = std::time::Instant::now();
+                                    if now.duration_since(last_stream_ended_log)
+                                        >= Duration::from_secs(1)
+                                    {
+                                        warn!(
+                                            "geyser_tx_listener: stream ended; resubscribing after short backoff"
+                                        );
+                                        last_stream_ended_log = now;
+                                    }
+                                    let sleep_ms = rand::thread_rng().gen_range(50..=200);
+                                    sleep(Duration::from_millis(sleep_ms)).await;
+                                    break 'read SessionExit::StreamEnded;
+                                }
+                                Some(Err(e)) => {
+                                    error!(error = %e, "geyser_tx_listener: stream error");
+                                    geyser_metrics_inc_stream_error();
+                                    geyser_metrics_inc_reconnect(GeyserReconnectReason::StreamError);
+                                    break 'read SessionExit::HardReconnect;
+                                }
+                                Some(Ok(msg)) => {
+                                    geyser_metrics_inc_listener_stream_payload();
+                                    if let Some(update) = msg.update_oneof {
+                                        match update {
+                                            UpdateOneof::Transaction(tx_update) => {
+                                                geyser_metrics_inc_tx_listener_transactions_total();
+                                                transaction_count = transaction_count.saturating_add(1);
+                                                if let Some(tx) = tx_update.transaction {
+                                                    seen_tx_since_connect = true;
+                                                    let signature = if !tx.signature.is_empty() {
+                                                        bs58::encode(&tx.signature).into_string()
+                                                    } else {
+                                                        "unknown".to_string()
+                                                    };
+                                                    let mut account_keys = Vec::new();
+                                                    let mut instruction_accounts = Vec::new();
+                                                    let mut instruction_data = Vec::new();
+                                                    if let Some(transaction) = &tx.transaction {
+                                                        if let Some(message) = &transaction.message {
+                                                            for key in &message.account_keys {
+                                                                if key.len() == 32 {
+                                                                    if let Ok(bytes) = key.as_slice().try_into() {
+                                                                        account_keys.push(Pubkey::new_from_array(bytes));
+                                                                    }
+                                                                }
+                                                            }
+                                                            if let Some(meta) = &tx.meta {
+                                                                for key in &meta.loaded_writable_addresses {
+                                                                    if let Ok(bytes) = key.as_slice().try_into() {
+                                                                        account_keys.push(Pubkey::new_from_array(bytes));
+                                                                    }
+                                                                }
+                                                                for key in &meta.loaded_readonly_addresses {
+                                                                    if let Ok(bytes) = key.as_slice().try_into() {
+                                                                        account_keys.push(Pubkey::new_from_array(bytes));
+                                                                    }
+                                                                }
+                                                            }
+                                                            debug!(
+                                                                signature = %signature,
+                                                                instruction_count = message.instructions.len(),
+                                                                account_keys_len = account_keys.len(),
+                                                                "geyser_tx_listener: Processing transaction"
+                                                            );
+                                                            for (idx, ix) in message.instructions.iter().enumerate() {
+                                                                if let Some(program_pubkey) =
+                                                                    account_keys.get(ix.program_id_index as usize)
+                                                                {
+                                                                    debug!(
+                                                                        signature = %signature,
+                                                                        instruction_idx = idx,
+                                                                        program_id = %program_pubkey,
+                                                                        accounts_len = ix.accounts.len(),
+                                                                        data_len = ix.data.len(),
+                                                                        "geyser_tx_listener: Found instruction"
+                                                                    );
+                                                                    if program_ids.contains(program_pubkey) {
+                                                                        for &account_idx in &ix.accounts {
+                                                                            if let Some(pubkey) =
+                                                                                account_keys.get(account_idx as usize)
+                                                                            {
+                                                                                instruction_accounts.push(*pubkey);
+                                                                            }
+                                                                        }
+                                                                        instruction_data = ix.data.clone();
+                                                                        debug!(
+                                                                            signature = %signature,
+                                                                            instruction_idx = idx,
+                                                                            "geyser: extracted DEX instruction"
+                                                                        );
+                                                                        break;
+                                                                    }
+                                                                }
+                                                            }
+                                                            if instruction_accounts.is_empty() {
+                                                                if let Some(meta) = &tx.meta {
+                                                                    for inner_ix_group in &meta.inner_instructions {
+                                                                        for inner_ix in &inner_ix_group.instructions {
+                                                                            if let Some(program_pubkey) = account_keys.get(
+                                                                                inner_ix.program_id_index as usize,
+                                                                            ) {
+                                                                                if program_ids.contains(program_pubkey) {
+                                                                                    for &account_idx in &inner_ix.accounts {
+                                                                                        if let Some(pubkey) = account_keys.get(
+                                                                                            account_idx as usize,
+                                                                                        ) {
+                                                                                            instruction_accounts.push(*pubkey);
+                                                                                        }
+                                                                                    }
+                                                                                    instruction_data = inner_ix.data.clone();
+                                                                                    debug!(
+                                                                                        signature = %signature,
+                                                                                        inner_ix_index = inner_ix_group.index,
+                                                                                        program_id = %program_pubkey,
+                                                                                        "geyser: extracted DEX instruction from INNER instruction (CPI)"
+                                                                                    );
+                                                                                    break;
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                        if !instruction_accounts.is_empty() {
+                                                                            break;
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                    let mut inner_instructions = Vec::new();
+                                                    if let Some(meta) = &tx.meta {
+                                                        for inner_ix_group in &meta.inner_instructions {
+                                                            for inner_ix in &inner_ix_group.instructions {
+                                                                inner_instructions.push(InnerInstruction {
+                                                                    program_id_index: inner_ix.program_id_index as u8,
+                                                                    accounts: inner_ix.accounts.to_vec(),
+                                                                    data: inner_ix.data.clone(),
+                                                                });
+                                                            }
+                                                        }
+                                                    }
+                                                    let mut pre_token_balances = Vec::new();
+                                                    let mut post_token_balances = Vec::new();
+                                                    let mut pre_balances = Vec::new();
+                                                    let mut post_balances = Vec::new();
+                                                    let mut fee_lamports = 0u64;
+                                                    let mut compute_units_consumed = None;
+                                                    if let Some(meta) = &tx.meta {
+                                                        fee_lamports = meta.fee;
+                                                        compute_units_consumed = meta.compute_units_consumed;
+                                                        pre_balances = meta.pre_balances.clone();
+                                                        post_balances = meta.post_balances.clone();
+                                                        for balance in &meta.pre_token_balances {
+                                                            if let Some(ui_amount) = &balance.ui_token_amount {
+                                                                pre_token_balances.push(TokenBalance {
+                                                                    account_index: balance.account_index as u8,
+                                                                    mint: balance.mint.clone(),
+                                                                    ui_token_amount: TokenAmount {
+                                                                        ui_amount: Some(ui_amount.ui_amount),
+                                                                        decimals: ui_amount.decimals as u8,
+                                                                        amount: ui_amount.amount.clone(),
+                                                                    },
+                                                                    program_id: if balance.program_id.is_empty() {
+                                                                        None
+                                                                    } else {
+                                                                        Some(balance.program_id.clone())
+                                                                    },
+                                                                });
+                                                            }
+                                                        }
+                                                        for balance in &meta.post_token_balances {
+                                                            if let Some(ui_amount) = &balance.ui_token_amount {
+                                                                post_token_balances.push(TokenBalance {
+                                                                    account_index: balance.account_index as u8,
+                                                                    mint: balance.mint.clone(),
+                                                                    ui_token_amount: TokenAmount {
+                                                                        ui_amount: Some(ui_amount.ui_amount),
+                                                                        decimals: ui_amount.decimals as u8,
+                                                                        amount: ui_amount.amount.clone(),
+                                                                    },
+                                                                    program_id: if balance.program_id.is_empty() {
+                                                                        None
+                                                                    } else {
+                                                                        Some(balance.program_id.clone())
+                                                                    },
+                                                                });
+                                                            }
+                                                        }
+                                                    }
+                                                    let grpc_recv_at = Instant::now();
+                                                    let event = GeyserTransactionUpdate {
+                                                        signature,
+                                                        slot: tx_update.slot,
+                                                        account_keys,
+                                                        instruction_accounts,
+                                                        instruction_data,
+                                                        inner_instructions,
+                                                        pre_token_balances,
+                                                        post_token_balances,
+                                                        pre_balances,
+                                                        post_balances,
+                                                        fee_lamports,
+                                                        compute_units_consumed,
+                                                        grpc_recv_at,
+                                                    };
+                                                    let _ = transaction_tx.send(event);
+                                                    if !got_payload_since_subscribe {
+                                                        got_payload_since_subscribe = true;
+                                                        reconnect_backoff_ms =
+                                                            rand::thread_rng().gen_range(100..=250);
+                                                    }
+                                                    if transaction_count % 100 == 0 {
+                                                        info!(
+                                                            total_transactions = transaction_count,
+                                                            slot = tx_update.slot,
+                                                            "geyser_tx_listener: processing transactions"
+                                                        );
+                                                    }
+                                                }
+                                            }
+                                            UpdateOneof::BlockMeta(block_meta) => {
+                                                let event = GeyserBlockhashUpdate {
+                                                    blockhash: block_meta.blockhash,
+                                                    slot: block_meta.slot,
+                                                    block_height: block_meta
+                                                        .block_height
+                                                        .map(|h| h.block_height)
+                                                        .unwrap_or(0),
+                                                };
+                                                let _ = blockhash_tx.send(event);
+                                                if !got_payload_since_subscribe {
+                                                    got_payload_since_subscribe = true;
+                                                    reconnect_backoff_ms =
+                                                        rand::thread_rng().gen_range(100..=250);
+                                                }
+                                            }
+                                            UpdateOneof::Ping(_) => {}
+                                            _ => {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                match session_exit {
+                    SessionExit::StreamEnded => {
+                        continue 'same_client;
+                    }
+                    SessionExit::HardReconnect | SessionExit::TxLivenessStale => {
+                        geyser_metrics_set_tx_session_connected(false);
+                        let sleep_ms = geyser_reconnect_sleep_ms(reconnect_backoff_ms);
+                        sleep(Duration::from_millis(sleep_ms)).await;
+                        reconnect_backoff_ms =
+                            (reconnect_backoff_ms.saturating_mul(2)).min(RECONNECT_BACKOFF_CAP_MS);
+                        continue 'outer;
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl GeyserAccountListener {
     pub fn new_with_tracked_accounts(
         endpoint: String,
         program_ids: Vec<Pubkey>,
         tracked_accounts_rx: watch::Receiver<Vec<Pubkey>>,
         full_reconnect_tracked_threshold: Arc<AtomicUsize>,
         tracked_cuckoo_max_capacity: usize,
-    ) -> (
-        Self,
-        broadcast::Receiver<GeyserAccountUpdate>,
-        broadcast::Receiver<GeyserTransactionUpdate>,
-        broadcast::Receiver<GeyserBlockhashUpdate>,
-    ) {
-        let (mut listener, account_rx, transaction_rx, blockhash_rx) =
-            Self::new(endpoint, program_ids);
-        listener.tracked_accounts_rx = Some(tracked_accounts_rx);
-        listener.full_reconnect_tracked_threshold = full_reconnect_tracked_threshold;
-        listener.tracked_cuckoo_max_capacity = tracked_cuckoo_max_capacity;
-        (listener, account_rx, transaction_rx, blockhash_rx)
+    ) -> (Self, broadcast::Receiver<GeyserAccountUpdate>) {
+        let (account_tx, account_rx) = broadcast::channel(200000);
+        (
+            Self {
+                endpoint,
+                program_ids,
+                tracked_accounts_rx,
+                full_reconnect_tracked_threshold,
+                tracked_cuckoo_max_capacity,
+                account_tx,
+            },
+            account_rx,
+        )
     }
 
-    /// Subscribe to account updates (same stream as the primary `account_rx` from [`Self::new`]).
-    ///
-    /// PR162: pool discovery and other auxiliary consumers must not open a second Geyser gRPC session.
     pub fn subscribe_account_updates(&self) -> broadcast::Receiver<GeyserAccountUpdate> {
         self.account_tx.subscribe()
     }
 
-    /// Subscribe to DEX transaction updates (same stream as the primary `transaction_rx`).
-    pub fn subscribe_transaction_updates(&self) -> broadcast::Receiver<GeyserTransactionUpdate> {
-        self.transaction_tx.subscribe()
-    }
-
-    /// Start listening to Geyser stream
     pub async fn start(self) -> Result<()> {
         #[cfg(windows)]
         {
@@ -235,13 +717,9 @@ impl GeyserListener {
 
         #[cfg(not(windows))]
         {
-            self.start_impl().await
+            self.start_account_impl().await
         }
     }
-
-    /// Name of the single Yellowstone `cuckoo_accounts_filter` entry for explicit tracked accounts.
-    #[cfg(not(windows))]
-    const TRACKED_CUCKOO_SUBSCRIBE_NAME: &'static str = "tracked_accounts_cuckoo";
 
     #[cfg(not(windows))]
     #[inline]
@@ -250,9 +728,6 @@ impl GeyserListener {
     }
 
     /// Rebuild the persistent cuckoo filter from the full explicit tracked list.
-    ///
-    /// Server-side updates stay compact (single cuckoo blob); rebuilding here is O(n) on the
-    /// client but avoids partial-failure corruption from incremental cuckoo mutations.
     #[cfg(not(windows))]
     fn sync_tracked_cuckoo_filter(
         filter: &mut CompressedAccountFilterSet,
@@ -280,82 +755,8 @@ impl GeyserListener {
         Ok(f)
     }
 
-    /// Build a SubscribeRequest for the given programs and optional tracked-account cuckoo filter.
-    /// Extracted so it can be reused for initial subscription and incremental updates.
     #[cfg(not(windows))]
-    pub(crate) fn build_subscribe_request(
-        program_ids: &[Pubkey],
-        tracked_cuckoo: Option<&mut CompressedAccountFilterSet>,
-    ) -> SubscribeRequest {
-        let mut accounts_filter = HashMap::new();
-        let mut transactions_filter = HashMap::new();
-
-        for (idx, program_id) in program_ids.iter().enumerate() {
-            // Account updates for pool state changes
-            accounts_filter.insert(
-                format!("dex_accounts_{}", idx),
-                SubscribeRequestFilterAccounts {
-                    account: vec![],
-                    owner: vec![program_id.to_string()],
-                    filters: vec![],
-                    nonempty_txn_signature: None,
-                    cuckoo_accounts_filter: None,
-                },
-            );
-
-            // Transactions for swaps / pool creation
-            transactions_filter.insert(
-                format!("dex_transactions_{}", idx),
-                SubscribeRequestFilterTransactions {
-                    vote: Some(false),
-                    failed: Some(false),
-                    signature: None,
-                    account_include: vec![program_id.to_string()],
-                    account_exclude: vec![],
-                    account_required: vec![],
-                },
-            );
-        }
-
-        // Subscribe to blocks_meta for confirmed blockhash streaming
-        let blocks_meta_filter =
-            HashMap::from([("blockhash".to_string(), SubscribeRequestFilterBlocksMeta {})]);
-
-        let mut req = SubscribeRequest {
-            accounts: accounts_filter,
-            slots: HashMap::new(),
-            transactions: transactions_filter,
-            transactions_status: HashMap::new(),
-            blocks: HashMap::new(),
-            blocks_meta: blocks_meta_filter,
-            entry: HashMap::new(),
-            commitment: Some(CommitmentLevel::Confirmed as i32),
-            accounts_data_slice: vec![],
-            ping: None,
-            from_slot: None,
-        };
-
-        if let Some(cuck) = tracked_cuckoo {
-            cuck.insert_into_subscribe_request(&mut req, Self::TRACKED_CUCKOO_SUBSCRIBE_NAME);
-        }
-
-        req
-    }
-
-    /// PR-A: exponential reconnect sleep with small jitter (cold path only).
-    #[cfg(not(windows))]
-    fn geyser_reconnect_sleep_ms(backoff_ms: u64) -> u64 {
-        let jitter_cap = backoff_ms.min(150);
-        let jitter = if jitter_cap == 0 {
-            0u64
-        } else {
-            rand::thread_rng().gen_range(0..=jitter_cap)
-        };
-        backoff_ms.saturating_add(jitter)
-    }
-
-    #[cfg(not(windows))]
-    async fn start_impl(self) -> Result<()> {
+    async fn start_account_impl(self) -> Result<()> {
         enum SessionExit {
             StreamEnded,
             HardReconnect,
@@ -363,22 +764,26 @@ impl GeyserListener {
             SubscriptionRebuild,
         }
 
+        let Self {
+            endpoint,
+            program_ids,
+            tracked_accounts_rx,
+            full_reconnect_tracked_threshold,
+            tracked_cuckoo_max_capacity,
+            account_tx,
+        } = self;
+
         info!(
-            endpoint = %self.endpoint,
-            programs = self.program_ids.len(),
-            "geyser_listener: connecting to Geyser gRPC (resilient mode)"
+            endpoint = %endpoint,
+            programs = program_ids.len(),
+            "geyser_account_listener: connecting to Geyser gRPC (accounts + cuckoo; PR164)"
         );
 
-        let mut tracked_accounts_rx = self.tracked_accounts_rx;
-        let mut tracked_accounts_current: Vec<Pubkey> = tracked_accounts_rx
-            .as_ref()
-            .map(|rx| rx.borrow().clone())
-            .unwrap_or_default();
+        let mut tracked_accounts_rx = tracked_accounts_rx;
+        let mut tracked_accounts_current: Vec<Pubkey> = tracked_accounts_rx.borrow().clone();
 
-        let mut tracked_cuckoo_filter: Option<CompressedAccountFilterSet> = if tracked_accounts_rx
-            .is_some()
-        {
-            let cap = self.tracked_cuckoo_max_capacity.max(1);
+        let cap = tracked_cuckoo_max_capacity.max(1);
+        let mut tracked_cuckoo_filter: Option<CompressedAccountFilterSet> =
             match Self::tracked_cuckoo_from_full_list(cap, &tracked_accounts_current) {
                 Ok(f) => Some(f),
                 Err(e) => {
@@ -386,19 +791,15 @@ impl GeyserListener {
                         error = %e,
                         capacity = cap,
                         n = tracked_accounts_current.len(),
-                        "geyser_listener: initial CompressedAccountFilterSet build failed"
+                        "geyser_account_listener: initial CompressedAccountFilterSet build failed"
                     );
                     return Err(anyhow!(
-                            "geyser_listener: cannot build CompressedAccountFilterSet: {e}; increase max_tracked_accounts"
+                            "geyser_account_listener: cannot build CompressedAccountFilterSet: {e}; increase max_tracked_accounts"
                         ));
                 }
-            }
-        } else {
-            None
-        };
+            };
 
         let mut account_update_count = 0u64;
-        let mut transaction_count = 0u64;
         let mut last_log = std::time::Instant::now();
 
         let mut reconnect_backoff_ms: u64 = rand::thread_rng().gen_range(100..=250);
@@ -411,24 +812,24 @@ impl GeyserListener {
         const LARGE_TRACKED_SUBSCRIBE_REBUILD_MIN_INTERVAL: Duration = Duration::from_secs(5);
         let mut last_large_set_subscription_rebuild: Option<Instant> = None;
 
-        geyser_metrics_set_connected(false);
+        geyser_metrics_set_account_session_connected(false);
 
         'outer: loop {
             let mut client = loop {
-                match GeyserGrpcClient::build_from_shared(self.endpoint.clone())
+                match GeyserGrpcClient::build_from_shared(endpoint.clone())
                     .map_err(|e| anyhow!("Failed to build Geyser client: {}", e))?
                     .connect()
                     .await
                 {
                     Ok(c) => {
                         info!("geyser_listener: connected successfully");
-                        geyser_metrics_set_connected(true);
+                        geyser_metrics_set_account_session_connected(true);
                         break c;
                     }
                     Err(e) => {
                         error!(error = %e, "geyser_listener: connect failed, retrying");
-                        geyser_metrics_set_connected(false);
-                        let sleep_ms = Self::geyser_reconnect_sleep_ms(reconnect_backoff_ms);
+                        geyser_metrics_set_account_session_connected(false);
+                        let sleep_ms = geyser_reconnect_sleep_ms(reconnect_backoff_ms);
                         sleep(Duration::from_millis(sleep_ms)).await;
                         reconnect_backoff_ms =
                             (reconnect_backoff_ms.saturating_mul(2)).min(RECONNECT_BACKOFF_CAP_MS);
@@ -437,10 +838,8 @@ impl GeyserListener {
             };
 
             'same_client: loop {
-                let request = Self::build_subscribe_request(
-                    &self.program_ids,
-                    tracked_cuckoo_filter.as_mut(),
-                );
+                let request =
+                    build_account_subscribe_request(&program_ids, tracked_cuckoo_filter.as_mut());
 
                 let (mut subscribe_tx, mut stream) =
                     match client.subscribe_with_request(Some(request)).await {
@@ -451,8 +850,8 @@ impl GeyserListener {
                                 "geyser_listener: subscribe failed; reconnecting with new client"
                             );
                             geyser_metrics_inc_reconnect(GeyserReconnectReason::StreamError);
-                            geyser_metrics_set_connected(false);
-                            let sleep_ms = Self::geyser_reconnect_sleep_ms(reconnect_backoff_ms);
+                            geyser_metrics_set_account_session_connected(false);
+                            let sleep_ms = geyser_reconnect_sleep_ms(reconnect_backoff_ms);
                             sleep(Duration::from_millis(sleep_ms)).await;
                             reconnect_backoff_ms = (reconnect_backoff_ms.saturating_mul(2))
                                 .min(RECONNECT_BACKOFF_CAP_MS);
@@ -488,9 +887,9 @@ impl GeyserListener {
                 });
 
                 info!(
-                    programs = ?self.program_ids,
+                    programs = ?program_ids,
                     tracked_accounts = tracked_accounts_current.len(),
-                    "geyser_listener: subscribed"
+                    "geyser_account_listener: subscribed"
                 );
 
                 let mut got_payload_since_subscribe = false;
@@ -499,20 +898,15 @@ impl GeyserListener {
                     if last_log.elapsed().as_secs() >= 60 {
                         info!(
                             accounts = account_update_count,
-                            transactions = transaction_count,
                             tracked_accounts = tracked_accounts_current.len(),
-                            "geyser_listener: heartbeat - still receiving updates"
+                            "geyser_account_listener: heartbeat - still receiving updates"
                         );
                         last_log = std::time::Instant::now();
                     }
 
                     let tracked_changed_fut = async {
-                        if let Some(rx) = &mut tracked_accounts_rx {
-                            let _ = rx.changed().await;
-                            Some(rx.borrow().clone())
-                        } else {
-                            std::future::pending::<Option<Vec<Pubkey>>>().await
-                        }
+                        let _ = tracked_accounts_rx.changed().await;
+                        tracked_accounts_rx.borrow().clone()
                     };
 
                     tokio::select! {
@@ -545,6 +939,7 @@ impl GeyserListener {
                                         match update {
                                 UpdateOneof::Account(account_update) => {
                                     account_update_count += 1;
+                                    geyser_metrics_inc_account_listener_account_updates_total();
 
                                     if let Some(account_info) = account_update.account {
                                         // Parse pubkey
@@ -566,7 +961,7 @@ impl GeyserListener {
                                         };
 
                                         if let Some(ref cf) = tracked_cuckoo_filter {
-                                            let passes_owner = self.program_ids.contains(&owner);
+                                            let passes_owner = program_ids.contains(&owner);
                                             let passes_tracked =
                                                 cf.contains(Self::cuckoo_pubkey(pubkey));
                                             if !(passes_owner || passes_tracked) {
@@ -585,7 +980,7 @@ impl GeyserListener {
                                         };
 
                                         // Broadcast to subscribers
-                                        let _ = self.account_tx.send(event);
+                                        let _ = account_tx.send(event);
                                         if !got_payload_since_subscribe {
                                             got_payload_since_subscribe = true;
                                             reconnect_backoff_ms =
@@ -601,296 +996,25 @@ impl GeyserListener {
                                         }
                                     }
                                 }
-                                UpdateOneof::Transaction(tx_update) => {
-                                    transaction_count += 1;
-
-                                    if let Some(tx) = tx_update.transaction {
-                                        // Extract signature from transaction
-                                        let signature = if !tx.signature.is_empty() {
-                                            bs58::encode(&tx.signature).into_string()
-                                        } else {
-                                            "unknown".to_string()
-                                        };
-
-                                        // Extract account keys from transaction message
-                                        let mut account_keys = Vec::new();
-                                        let mut instruction_accounts = Vec::new();
-                                        let mut instruction_data = Vec::new();
-
-                                        if let Some(transaction) = &tx.transaction {
-                                            if let Some(message) = &transaction.message {
-                                                // Extract all account keys
-                                                for key in &message.account_keys {
-                                                    if key.len() == 32 {
-                                                        if let Ok(bytes) = key.as_slice().try_into() {
-                                                            account_keys
-                                                                .push(Pubkey::new_from_array(bytes));
-                                                        }
-                                                    }
-                                                }
-
-                                                // Append loaded addresses from meta (for V0 transactions)
-                                                // Order matters: Static -> Loaded Writable -> Loaded Readonly
-                                                if let Some(meta) = &tx.meta {
-                                                    for key in &meta.loaded_writable_addresses {
-                                                        if let Ok(bytes) = key.as_slice().try_into() {
-                                                            account_keys
-                                                                .push(Pubkey::new_from_array(bytes));
-                                                        }
-                                                    }
-                                                    for key in &meta.loaded_readonly_addresses {
-                                                        if let Ok(bytes) = key.as_slice().try_into() {
-                                                            account_keys
-                                                                .push(Pubkey::new_from_array(bytes));
-                                                        }
-                                                    }
-                                                }
-
-                                                // DEBUG: Log instruction extraction attempt
-                                                debug!(
-                                                    signature = %signature,
-                                                    instruction_count = message.instructions.len(),
-                                                    account_keys_len = account_keys.len(),
-                                                    "geyser_listener: Processing transaction"
-                                                );
-
-                                                // Find the Pump.fun/Raydium/Orca instruction (not first, could be 2nd or 3rd)
-                                                // Look for instruction that uses our monitored program
-                                                // FIRST: Check top-level instructions
-                                                for (idx, ix) in message.instructions.iter().enumerate()
-                                                {
-                                                    if let Some(program_pubkey) =
-                                                        account_keys.get(ix.program_id_index as usize)
-                                                    {
-                                                        // DEBUG: Log each instruction
-                                                        debug!(
-                                                            signature = %signature,
-                                                            instruction_idx = idx,
-                                                            program_id = %program_pubkey,
-                                                            accounts_len = ix.accounts.len(),
-                                                            data_len = ix.data.len(),
-                                                            "geyser_listener: Found instruction"
-                                                        );
-
-                                                        // Check if this instruction is for one of our monitored programs
-                                                        if self.program_ids.contains(program_pubkey) {
-                                                            // Extract accounts for this instruction
-                                                            for &account_idx in &ix.accounts {
-                                                                if let Some(pubkey) = account_keys
-                                                                    .get(account_idx as usize)
-                                                                {
-                                                                    instruction_accounts.push(*pubkey);
-                                                                }
-                                                            }
-                                                            // Extract instruction data
-                                                            instruction_data = ix.data.clone();
-
-                                                            debug!(
-                                                                signature = %signature,
-                                                                instruction_idx = idx,
-                                                                "geyser: extracted DEX instruction"
-                                                            );
-
-                                                            break; // Found our instruction, stop searching
-                                                        }
-                                                    }
-                                                }
-
-                                                // SECOND: If not found in top-level, check inner instructions (CPIs)
-                                                // Pump.fun CREATE is often called via CPI from another program
-                                                if instruction_accounts.is_empty() {
-                                                    if let Some(meta) = &tx.meta {
-                                                        for inner_ix_group in &meta.inner_instructions {
-                                                            for inner_ix in &inner_ix_group.instructions
-                                                            {
-                                                                if let Some(program_pubkey) =
-                                                                    account_keys.get(
-                                                                        inner_ix.program_id_index
-                                                                            as usize,
-                                                                    )
-                                                                {
-                                                                    if self
-                                                                        .program_ids
-                                                                        .contains(program_pubkey)
-                                                                    {
-                                                                        // Extract accounts for this inner instruction
-                                                                        for &account_idx in
-                                                                            &inner_ix.accounts
-                                                                        {
-                                                                            if let Some(pubkey) =
-                                                                                account_keys.get(
-                                                                                    account_idx
-                                                                                        as usize,
-                                                                                )
-                                                                            {
-                                                                                instruction_accounts
-                                                                                    .push(*pubkey);
-                                                                            }
-                                                                        }
-                                                                        // Extract instruction data
-                                                                        instruction_data =
-                                                                            inner_ix.data.clone();
-
-                                                                        debug!(
-                                                                            signature = %signature,
-                                                                            inner_ix_index = inner_ix_group.index,
-                                                                            program_id = %program_pubkey,
-                                                                            "geyser: extracted DEX instruction from INNER instruction (CPI)"
-                                                                        );
-
-                                                                        break; // Found our instruction
-                                                                    }
-                                                                }
-                                                            }
-                                                            if !instruction_accounts.is_empty() {
-                                                                break; // Already found, exit outer loop
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-
-                                        // Extract inner instructions for token transfer parsing
-                                        let mut inner_instructions = Vec::new();
-                                        if let Some(meta) = &tx.meta {
-                                            for inner_ix_group in &meta.inner_instructions {
-                                                for inner_ix in &inner_ix_group.instructions {
-                                                    inner_instructions.push(InnerInstruction {
-                                                        program_id_index: inner_ix.program_id_index as u8,
-                                                        accounts: inner_ix.accounts.to_vec(),
-                                                        data: inner_ix.data.clone(),
-                                                    });
-                                                }
-                                            }
-                                        }
-
-                                        // Extract token balances for amount calculation
-                                        let mut pre_token_balances = Vec::new();
-                                        let mut post_token_balances = Vec::new();
-                                        let mut pre_balances = Vec::new();
-                                        let mut post_balances = Vec::new();
-                                        let mut fee_lamports = 0u64;
-                                        let mut compute_units_consumed = None;
-
-                                        if let Some(meta) = &tx.meta {
-                                            // Extract fee and compute units for priority fee tracking
-                                            fee_lamports = meta.fee;
-                                            compute_units_consumed = meta.compute_units_consumed;
-
-                                            // Extract native SOL balances (lamports)
-                                            pre_balances = meta.pre_balances.clone();
-                                            post_balances = meta.post_balances.clone();
-                                            for balance in &meta.pre_token_balances {
-                                                if let Some(ui_amount) = &balance.ui_token_amount {
-                                                    pre_token_balances.push(TokenBalance {
-                                                        account_index: balance.account_index as u8,
-                                                        mint: balance.mint.clone(),
-                                                        ui_token_amount: TokenAmount {
-                                                            ui_amount: Some(ui_amount.ui_amount),
-                                                            decimals: ui_amount.decimals as u8,
-                                                            amount: ui_amount.amount.clone(),
-                                                        },
-                                                        // Extract program_id (SPL Token or Token-2022)
-                                                        program_id: if balance.program_id.is_empty() {
-                                                            None
-                                                        } else {
-                                                            Some(balance.program_id.clone())
-                                                        },
-                                                    });
-                                                }
-                                            }
-
-                                            for balance in &meta.post_token_balances {
-                                                if let Some(ui_amount) = &balance.ui_token_amount {
-                                                    post_token_balances.push(TokenBalance {
-                                                        account_index: balance.account_index as u8,
-                                                        mint: balance.mint.clone(),
-                                                        ui_token_amount: TokenAmount {
-                                                            ui_amount: Some(ui_amount.ui_amount),
-                                                            decimals: ui_amount.decimals as u8,
-                                                            amount: ui_amount.amount.clone(),
-                                                        },
-                                                        // Extract program_id (SPL Token or Token-2022)
-                                                        program_id: if balance.program_id.is_empty() {
-                                                            None
-                                                        } else {
-                                                            Some(balance.program_id.clone())
-                                                        },
-                                                    });
-                                                }
-                                            }
-                                        }
-
-                                        let grpc_recv_at = Instant::now();
-                                        let event = GeyserTransactionUpdate {
-                                            signature,
-                                            slot: tx_update.slot,
-                                            account_keys,
-                                            instruction_accounts,
-                                            instruction_data,
-                                            inner_instructions,
-                                            pre_token_balances,
-                                            post_token_balances,
-                                            pre_balances,
-                                            post_balances,
-                                            fee_lamports,
-                                            compute_units_consumed,
-                                            grpc_recv_at,
-                                        };
-
-                                        // Broadcast to subscribers
-                                        let _ = self.transaction_tx.send(event);
-                                        if !got_payload_since_subscribe {
-                                            got_payload_since_subscribe = true;
-                                            reconnect_backoff_ms =
-                                                rand::thread_rng().gen_range(100..=250);
-                                        }
-
-                                        if transaction_count % 100 == 0 {
-                                            info!(
-                                                total_transactions = transaction_count,
-                                                slot = tx_update.slot,
-                                                "geyser_listener: processing transactions"
-                                            );
-                                        }
-                                    }
-                                }
-                                UpdateOneof::BlockMeta(block_meta) => {
-                                    let event = GeyserBlockhashUpdate {
-                                        blockhash: block_meta.blockhash,
-                                        slot: block_meta.slot,
-                                        block_height: block_meta
-                                            .block_height
-                                            .map(|h| h.block_height)
-                                            .unwrap_or(0),
-                                    };
-                                    let _ = self.blockhash_tx.send(event);
-                                    if !got_payload_since_subscribe {
-                                        got_payload_since_subscribe = true;
-                                        reconnect_backoff_ms = rand::thread_rng().gen_range(100..=250);
-                                    }
-                                }
                                 UpdateOneof::Ping(_) => {
                                     // Keep-alive ping, ignore
                                 }
                                 _ => {
                                     // Slots, etc. - ignore
                                 }
-                            }
-                        }
-                    }
+                                        }
+                                    }
+                                }
                             }
                         },
-                        maybe_new = tracked_changed_fut => {
-                            if let Some(new_list) = maybe_new {
-                                if new_list != tracked_accounts_current {
+                        new_list = tracked_changed_fut => {
+                            if new_list != tracked_accounts_current {
                                     let _old_list =
                                         std::mem::replace(&mut tracked_accounts_current, new_list);
                                     if let Some(ref mut cf) = tracked_cuckoo_filter {
                                         if let Err(e) = Self::sync_tracked_cuckoo_filter(
                                             cf,
-                                            self.tracked_cuckoo_max_capacity.max(1),
+                                            tracked_cuckoo_max_capacity.max(1),
                                             &tracked_accounts_current,
                                         ) {
                                             error!(
@@ -900,8 +1024,7 @@ impl GeyserListener {
                                             return Err(e);
                                         }
                                     }
-                                    let threshold = self
-                                        .full_reconnect_tracked_threshold
+                                    let threshold = full_reconnect_tracked_threshold
                                         .load(Ordering::Relaxed);
                                     let now = Instant::now();
                                     let over_threshold =
@@ -922,22 +1045,22 @@ impl GeyserListener {
                                         );
                                         break 'read SessionExit::SubscriptionRebuild;
                                     }
-                                    let updated_request = Self::build_subscribe_request(
-                                        &self.program_ids,
+                                    let updated_request = build_account_subscribe_request(
+                                        &program_ids,
                                         tracked_cuckoo_filter.as_mut(),
                                     );
                                     if let Ok(mut g) = pending_subscription_request.lock() {
                                         *g = Some(updated_request);
                                     }
                                     subscription_notify.notify_one();
+                                    geyser_metrics_inc_account_listener_subscribe_updates_total();
                                     warn!(
                                         tracked_accounts = tracked_accounts_current.len(),
                                         "geyser_listener: subscription updated (NO reconnect; async sink)"
                                     );
                                 }
-                            }
                         }
-                    }
+                    };
                 };
 
                 subscription_updater_jh.abort();
@@ -947,8 +1070,8 @@ impl GeyserListener {
                         continue 'same_client;
                     }
                     SessionExit::HardReconnect => {
-                        geyser_metrics_set_connected(false);
-                        let sleep_ms = Self::geyser_reconnect_sleep_ms(reconnect_backoff_ms);
+                        geyser_metrics_set_account_session_connected(false);
+                        let sleep_ms = geyser_reconnect_sleep_ms(reconnect_backoff_ms);
                         sleep(Duration::from_millis(sleep_ms)).await;
                         reconnect_backoff_ms =
                             (reconnect_backoff_ms.saturating_mul(2)).min(RECONNECT_BACKOFF_CAP_MS);
@@ -956,7 +1079,7 @@ impl GeyserListener {
                     }
                     SessionExit::SubscriptionRebuild => {
                         geyser_metrics_inc_reconnect(GeyserReconnectReason::SubscriptionRebuild);
-                        geyser_metrics_set_connected(false);
+                        geyser_metrics_set_account_session_connected(false);
                         // Intentional full reconnect for large subscription churn — no error backoff sleep
                         // in this arm. Still reset reconnect jitter so a *prior* HardReconnect cannot leave a
                         // stale 60s-class backoff applied to the next outer connect attempt.
@@ -971,13 +1094,34 @@ impl GeyserListener {
 
 #[cfg(all(test, not(windows)))]
 mod geyser_resilience_tests {
-    use super::GeyserListener;
+    use super::{
+        build_account_subscribe_request, build_tx_subscribe_request, geyser_reconnect_sleep_ms,
+    };
     use yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet;
+
+    #[test]
+    fn build_tx_subscribe_has_dex_transactions_empty_accounts() {
+        let pk = solana_sdk::pubkey::Pubkey::new_from_array([7u8; 32]);
+        let req = build_tx_subscribe_request(std::slice::from_ref(&pk));
+        assert!(!req.transactions.is_empty());
+        assert!(req.accounts.is_empty());
+        assert!(!req
+            .accounts
+            .contains_key(super::TRACKED_CUCKOO_SUBSCRIBE_NAME));
+    }
+
+    #[test]
+    fn build_account_subscribe_has_accounts_empty_transactions() {
+        let pk = solana_sdk::pubkey::Pubkey::new_from_array([7u8; 32]);
+        let req = build_account_subscribe_request(std::slice::from_ref(&pk), None);
+        assert!(req.transactions.is_empty());
+        assert!(!req.accounts.is_empty());
+    }
 
     #[test]
     fn reconnect_sleep_ms_adds_bounded_jitter() {
         for _ in 0..20 {
-            let s = GeyserListener::geyser_reconnect_sleep_ms(500);
+            let s = geyser_reconnect_sleep_ms(500);
             assert!((500..=650).contains(&s), "s={s}");
         }
     }
@@ -987,7 +1131,7 @@ mod geyser_resilience_tests {
         let mut cuckoo = CompressedAccountFilterSet::with_capacity(16).unwrap();
         let pk = solana_pubkey::Pubkey::new_from_array([9u8; 32]);
         cuckoo.insert(pk).unwrap();
-        let req = GeyserListener::build_subscribe_request(&[], Some(&mut cuckoo));
+        let req = build_account_subscribe_request(&[], Some(&mut cuckoo));
         let f = req
             .accounts
             .get("tracked_accounts_cuckoo")

--- a/src/solana/geyser_pool_discovery.rs
+++ b/src/solana/geyser_pool_discovery.rs
@@ -1,8 +1,8 @@
 //! Professional Geyser-based Pool Discovery
 //! Simplified approach: TX-based for Pump.fun, Account-based for Raydium/Orca
 //!
-//! PR162: consumes the **unified** [`crate::solana::geyser_listener::GeyserListener`] broadcast feeds
-//! (no second Geyser gRPC connection).
+//! PR164: consumes **split** Geyser sessions — [`crate::solana::geyser_listener::GeyserTxListener`] (TX)
+//! and [`crate::solana::geyser_listener::GeyserAccountListener`] (accounts) — no second TX subscription.
 
 use crate::solana::geyser_listener::{GeyserAccountUpdate, GeyserTransactionUpdate};
 use crate::solana::rpc::SolanaRpc;
@@ -20,8 +20,8 @@ pub struct PoolDiscoveryIngest;
 impl PoolDiscoveryIngest {
     /// Spawn account + transaction processors that emit [`PoolDiscoveryEvent`] on `mpsc`.
     ///
-    /// Callers must pass [`GeyserListener::subscribe_account_updates`] /
-    /// [`GeyserListener::subscribe_transaction_updates`] **before** starting the listener so no
+    /// Callers must pass [`GeyserAccountListener::subscribe_account_updates`] /
+    /// [`GeyserTxListener::subscribe_transaction_updates`] **before** starting the listeners so no
     /// updates are missed.
     pub fn spawn_unified(
         mut account_rx: broadcast::Receiver<GeyserAccountUpdate>,


### PR DESCRIPTION
## Summary
- Split Geyser into **two gRPC sessions**: `GeyserTxListener` (DEX transactions + blocks_meta, subscribe once, never `subscribe_tx.send` after init) and `GeyserAccountListener` (owner accounts + Cuckoo pins, in-place updates via async sink #162).
- `market_data` spawns both listeners; `PoolDiscoveryIngest` uses TX broadcast from A and account broadcast from B.
- TX liveness gate: if no TX for 60s while `head_slot` advances, reconnect **TX session only**.
- New metrics: `geyser_tx_listener_transactions_total`, `geyser_account_listener_*`, `geyser_tx_session_connected` / `geyser_account_session_connected`; aggregate `geyser_connected` requires both.
- P1: dedupe repeated `PoolCreated` from account-path pool discovery per `pool_address`.

## Root cause
PR #162 unified ingest on one session; Cuckoo pin updates shared the subscribe sink with TX filters. After in-place full replace, Yellowstone kept delivering accounts but stopped transactions silently.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [ ] Eval Level 5 after merge (agent VM had no eval sibling)
- [ ] Prod smoke: sustained `Parsed DEX`, `geyser_tx_listener_subscribe_updates_total == 0`, trades flowing to momentum
