### PR TITLE
fix(market-data): PR166 — TX ingest stall, payload liveness metrics, NATS noise policy

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,12 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### PR166-MARKET-DATA-TX-INGEST-STALL: TX-Handler-Blockade, Payload-Liveness-Metriken, NATS-Noise-Policy
+**Datum**: 2026-05-28  
+**Problem** (Prod `0c04bac` nach PR165): `market_data_tx_channel_lag_ms_count` friert (~1128); `handle_geyser_transaction` verarbeitet keine weiteren TXs (`futex_wait_queue`); `geyser_tx_listener_transactions_total` steigt weiter (Zähler vor Payload-Check) → TX-Liveness-Reconnect greift nicht; `Parsed DEX transaction` / NATS `Trade` stoppen; Pool-Discovery/Account-Pfad lebt.  
+**Fix**: (1) **TX-Hot-Path**: neuer Mint → `schedule_geyser_sync_batch_debounced` statt sofortigem `sync_geyser_tracked_accounts()` (kein Sync-Lock-Sturm mit Account-Workern). (2) **Metriken**: `market_data_tx_handler_processed_total` + `market_data_tx_handler_last_progress_unix_ms` am Handler-Start; `geyser_tx_listener_transactions_total` / `geyser_tx_listener_payload_broadcast_total` nur bei erfolgreichem Payload-Broadcast; TX-Liveness in `geyser_tx_listener` nutzt Handler-Counter. (3) **TX-Stall-Watchdog** (10 s, 120 s Grace, 60 s Fenster): `market_data_tx_handler_stalls_total`, Reconnect-Request an TX-Session, danach `exit(1)` wie PR165. (4) **NATS**: `market_event_should_nats_core` filtert `AccountUpdate` / `TransactionDetected`; unparsed Geyser-Fallbacks early-return + Drop-Metriken. **Invarianten**: kein RPC im Geyser-Ingest (I-7), PR165/164/160 unangetastet.  
+**Dateien**: `src/bin/market_data.rs`, `src/solana/geyser_listener.rs`, `src/metrics.rs`, `docs/BUGS_FIXES.md`
+
 ### PR165-MARKET-DATA-RUNTIME-LIVENESS: Tokio-Liveness, JSONL off Hot-Path, PumpAmm-RPC aus Geyser-Handler entfernt
 **Datum**: 2026-05-27  
 **Problem** (Prod `bdfbcda`): `market-data` friert ~14 s nach Restart ein — Prozess lebt, JSONL `market_events` wächst auf Multi-GB (sync Flush + Mutex), `/metrics` und `/live` timeouten (selbe Tokio-Runtime), systemd restartet nicht (PR163 OS-Watchdog pingt weiter), hunderte `pump_amm: pre-loaded vault balances via RPC (Cold Start Bootstrap)` aus `handle_geyser_account` (nicht Wallet-Bootstrap).  

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -14216,10 +14216,12 @@ mod pr_b_geyser_tracking_tests {
     fn pr166_geyser_tx_payload_broadcast_increments_listener_counters() {
         use ironcrab::metrics::{
             geyser_metrics_inc_tx_listener_payload_broadcast_total,
+            geyser_metrics_inc_tx_listener_transactions_total,
             GEYSER_TX_LISTENER_PAYLOAD_BROADCAST_TOTAL, GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL,
         };
         let tx0 = GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL.load(Ordering::Relaxed);
         let payload0 = GEYSER_TX_LISTENER_PAYLOAD_BROADCAST_TOTAL.load(Ordering::Relaxed);
+        geyser_metrics_inc_tx_listener_transactions_total();
         geyser_metrics_inc_tx_listener_payload_broadcast_total();
         assert_eq!(
             GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL.load(Ordering::Relaxed),

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -10006,7 +10006,6 @@ async fn handle_geyser_transaction(
     let tx_geyser_recv_at = recv_at;
     market_data_bump_geyser_head_slot(tx_update.slot);
     tx_count.fetch_add(1, Ordering::Relaxed);
-    record_market_data_tokio_progress();
     ironcrab::metrics::record_activity();
 
     // Phase 2 (Roadmap, Option C):

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -56,9 +56,12 @@ use ironcrab::metrics::{
     inc_market_data_account_low_priority_queue_depth,
     inc_market_data_account_publish_enqueue_dropped_total,
     inc_market_data_account_publish_queue_depth, inc_market_data_account_worker_queue_depth,
-    inc_market_data_jsonl_enqueue_dropped_total, market_data_bump_geyser_head_slot,
-    record_market_data_account_broadcast_lagged, record_market_data_account_channel_lag_ms,
-    record_market_data_account_early_drop_total, record_market_data_account_handler_duration_us,
+    inc_market_data_jsonl_enqueue_dropped_total, inc_market_data_unparsed_account_dropped_total,
+    inc_market_data_unparsed_tx_dropped_total, market_data_bump_geyser_head_slot,
+    market_data_geyser_head_slot_value, market_data_request_tx_session_reconnect,
+    market_data_tx_handler_processed_value, record_market_data_account_broadcast_lagged,
+    record_market_data_account_channel_lag_ms, record_market_data_account_early_drop_total,
+    record_market_data_account_handler_duration_us,
     record_market_data_account_publish_worker_job_duration_us,
     record_market_data_account_publish_worker_reconnect,
     record_market_data_account_publish_worker_stall,
@@ -70,7 +73,8 @@ use ironcrab::metrics::{
     record_market_data_momentum_active_pool_messages_total,
     record_market_data_pool_mint_map_to_devwallet_ms, record_market_data_tokio_liveness_stall,
     record_market_data_tokio_progress, record_market_data_trade_after_bonding_publish_ms,
-    record_market_data_tx_broadcast_lagged, record_market_data_tx_channel_lag_ms, serve_metrics,
+    record_market_data_tx_broadcast_lagged, record_market_data_tx_channel_lag_ms,
+    record_market_data_tx_handler_processed, record_market_data_tx_handler_stall, serve_metrics,
     set_market_data_account_broadcast_queue_depth,
     set_market_data_account_publish_worker_last_success_unix_ms,
     set_market_data_geyser_merge_pending, set_market_data_geyser_sync_pending,
@@ -244,6 +248,24 @@ fn market_event_should_jsonl(kind: &MarketEventKind) -> bool {
     )
 }
 
+/// PR166: raw Geyser fallback kinds excluded from core NATS (strategies use derived events only).
+fn market_event_should_nats_core(kind: &MarketEventKind) -> bool {
+    !matches!(
+        kind,
+        MarketEventKind::AccountUpdate { .. } | MarketEventKind::TransactionDetected { .. }
+    )
+}
+
+/// PR166: TX-handler liveness — chain head advanced but handler counter flat.
+fn market_data_tx_handler_liveness_stalled(
+    head_now: u64,
+    head_prev: u64,
+    handler_now: u64,
+    handler_prev: u64,
+) -> bool {
+    head_now > head_prev && handler_now == handler_prev
+}
+
 /// Optional Geyser→core-publish latency trace (same `recv_at` for all publishes from one Geyser message).
 #[derive(Clone, Copy)]
 pub(crate) struct MarketEventCorePublishTrace {
@@ -273,6 +295,9 @@ pub(crate) async fn publish_market_event_core_and_momentum_ex(
     trace: Option<MarketEventCorePublishTrace>,
     ctx: Option<&MarketDataContext>,
 ) -> bool {
+    if !market_event_should_nats_core(&event.kind) {
+        return false;
+    }
     match nats.publish(TOPIC_MARKET_EVENTS, event).await {
         Ok(true) => {
             NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
@@ -6528,6 +6553,7 @@ async fn main() -> Result<()> {
     record_market_data_tokio_progress();
     let process_started = Instant::now();
     spawn_market_data_tokio_liveness_task(process_started);
+    spawn_market_data_tx_handler_liveness_task(process_started);
 
     // Setup NATS (optional in dry-run mode)
     let nats = if args.dry_run {
@@ -7858,6 +7884,64 @@ fn spawn_market_data_tokio_liveness_task(process_started: Instant) {
     });
 }
 
+/// PR166: detect TX ingest stall (head slot advances, `handle_geyser_transaction` counter frozen).
+fn spawn_market_data_tx_handler_liveness_task(process_started: Instant) {
+    tokio::spawn(async move {
+        const CHECK_INTERVAL: Duration = Duration::from_secs(10);
+        const STALL_WINDOW: Duration = Duration::from_secs(60);
+        const STARTUP_GRACE: Duration = Duration::from_secs(120);
+        let mut last_head = market_data_geyser_head_slot_value();
+        let mut last_handler = market_data_tx_handler_processed_value();
+        let mut stalled_since: Option<Instant> = None;
+        let mut reconnect_requested_at: Option<Instant> = None;
+        let mut interval = tokio::time::interval(CHECK_INTERVAL);
+        loop {
+            interval.tick().await;
+            if process_started.elapsed() < STARTUP_GRACE {
+                last_head = market_data_geyser_head_slot_value();
+                last_handler = market_data_tx_handler_processed_value();
+                stalled_since = None;
+                reconnect_requested_at = None;
+                continue;
+            }
+            let head = market_data_geyser_head_slot_value();
+            let handler = market_data_tx_handler_processed_value();
+            let stalled =
+                market_data_tx_handler_liveness_stalled(head, last_head, handler, last_handler);
+            last_head = head;
+            last_handler = handler;
+            if stalled {
+                let since = *stalled_since.get_or_insert_with(Instant::now);
+                if since.elapsed() >= STALL_WINDOW {
+                    record_market_data_tx_handler_stall();
+                    if reconnect_requested_at.is_none() {
+                        error!(
+                            stall_secs = STALL_WINDOW.as_secs(),
+                            head_slot = head,
+                            tx_handler_processed = handler,
+                            "PR166: TX handler stalled — requesting Geyser TX session reconnect"
+                        );
+                        market_data_request_tx_session_reconnect();
+                        reconnect_requested_at = Some(Instant::now());
+                        stalled_since = None;
+                    } else if reconnect_requested_at.is_some_and(|t| t.elapsed() >= STALL_WINDOW) {
+                        error!(
+                            stall_secs = STALL_WINDOW.as_secs(),
+                            "PR166: TX handler still stalled after reconnect request — exiting for systemd restart"
+                        );
+                        #[cfg(unix)]
+                        MD_SYSTEMD_WATCHDOG_NOTIFY.store(false, Ordering::Relaxed);
+                        std::process::exit(1);
+                    }
+                }
+            } else {
+                stalled_since = None;
+                reconnect_requested_at = None;
+            }
+        }
+    });
+}
+
 /// PR160: isolated publish thread + multi-worker Tokio (no NATS await on main Geyser runtime).
 fn spawn_market_data_account_publish_runtime(
     ctx: Arc<MarketDataContext>,
@@ -8189,6 +8273,9 @@ async fn account_path_enqueue_core_market_event(
     event: MarketEvent,
     trace: Option<MarketEventCorePublishTrace>,
 ) -> bool {
+    if !market_event_should_nats_core(&event.kind) {
+        return false;
+    }
     if let Some(tx) = publish_tx {
         let event_id = event.event_id.clone();
         let job = AccountPathNatsJob::CoreMarketEvent {
@@ -9866,17 +9953,13 @@ async fn handle_geyser_account(
         return;
     }
 
-    let event_kind = if let Some(parsed) = parsed {
-        debug!(slot = account_update.slot, "Parsed DEX account update");
-        parsed.to_market_event_kind()
-    } else {
-        // Fallback to raw event for unknown accounts
-        MarketEventKind::AccountUpdate {
-            pubkey: account_update.pubkey.to_string(),
-            owner: account_update.owner.to_string(),
-            data_len: account_update.data.len(),
-        }
+    let Some(parsed) = parsed else {
+        inc_market_data_unparsed_account_dropped_total();
+        return;
     };
+
+    debug!(slot = account_update.slot, "Parsed DEX account update");
+    let event_kind = parsed.to_market_event_kind();
 
     let event = MarketEvent::new(
         "market-data",
@@ -9917,6 +10000,7 @@ async fn handle_geyser_transaction(
     tx_count: &AtomicU64,
     account_publish_tx: Option<&mpsc::Sender<AccountPathNatsJob>>,
 ) {
+    record_market_data_tx_handler_processed();
     let recv_at = Instant::now();
     record_market_data_tx_channel_lag_ms(tx_update.grpc_recv_at, recv_at);
     let tx_geyser_recv_at = recv_at;
@@ -10008,11 +10092,11 @@ async fn handle_geyser_transaction(
         if let Some((mint, dex_opt)) = mint_and_dex {
             let is_new = ctx.track_mint_for_geyser_metadata(mint, None);
             if is_new {
-                ctx.sync_geyser_tracked_accounts();
+                ctx.schedule_geyser_sync_batch_debounced();
                 debug!(
                     mint = %mint,
                     dex = ?dex_opt,
-                    "New mint tracked for Geyser metadata, waiting for mint account delivery"
+                    "New mint tracked for Geyser metadata (batched sync), waiting for mint account delivery"
                 );
             }
         }
@@ -10515,76 +10599,52 @@ async fn handle_geyser_transaction(
         }
     }
 
-    let event_kind = if let Some(parsed) = parsed_event {
-        info!(
-            slot = tx_update.slot,
-            sig = %tx_update.signature,
-            "Parsed DEX transaction"
-        );
-        let mut kind = parsed.to_market_event_kind();
+    let Some(parsed) = parsed_event else {
+        inc_market_data_unparsed_tx_dropped_total();
+        return;
+    };
 
-        // Enrich Trade events with creator from cache (P0: PumpFun intent building)
-        if let MarketEventKind::Trade {
-            ref pool_address,
-            ref mint,
-            ref dex,
-            ref mut creator,
-            ..
-        } = kind
-        {
-            if dex == "pumpfun" || dex == "pump_amm" {
-                // Try creator_cache first (mint -> creator)
-                let mut found_creator = None;
-                {
-                    let cache = ctx.creator_cache.read();
-                    if let Some(cached_creator) = cache.get(mint) {
-                        found_creator = Some(cached_creator.clone());
-                    }
-                }
+    info!(
+        slot = tx_update.slot,
+        sig = %tx_update.signature,
+        "Parsed DEX transaction"
+    );
+    let mut kind = parsed.to_market_event_kind();
 
-                // Fallback to pool_creator_cache (pool -> creator) from BondingCurveUpdate
-                if found_creator.is_none() {
-                    let pool_cache = ctx.pool_creator_cache.read();
-                    if let Some(pool_creator) = pool_cache.get(pool_address) {
-                        found_creator = Some(pool_creator.clone());
-
-                        // Also populate creator_cache for future lookups
-                        drop(pool_cache);
-                        ctx.creator_cache
-                            .write()
-                            .insert(mint.clone(), found_creator.clone().unwrap());
-                        debug!(
-                            mint = %mint,
-                            pool = %pool_address,
-                            creator = %found_creator.as_ref().unwrap(),
-                            "Populated creator_cache from pool_creator_cache"
-                        );
-                    }
-                }
-
-                if let Some(cached_creator) = found_creator {
-                    *creator = Some(cached_creator.clone());
-                    debug!(
-                        mint = %mint,
-                        dex = %dex,
-                        creator = %cached_creator,
-                        "Enriched Trade event with cached creator"
-                    );
+    // Enrich Trade events with creator from cache (P0: PumpFun intent building)
+    if let MarketEventKind::Trade {
+        ref pool_address,
+        ref mint,
+        ref dex,
+        ref mut creator,
+        ..
+    } = kind
+    {
+        if dex == "pumpfun" || dex == "pump_amm" {
+            let mut found_creator = None;
+            {
+                let cache = ctx.creator_cache.read();
+                if let Some(cached_creator) = cache.get(mint) {
+                    found_creator = Some(cached_creator.clone());
                 }
             }
+            if found_creator.is_none() {
+                let pool_cache = ctx.pool_creator_cache.read();
+                if let Some(pool_creator) = pool_cache.get(pool_address) {
+                    found_creator = Some(pool_creator.clone());
+                    drop(pool_cache);
+                    ctx.creator_cache
+                        .write()
+                        .insert(mint.clone(), found_creator.clone().unwrap());
+                }
+            }
+            if let Some(cached_creator) = found_creator {
+                *creator = Some(cached_creator.clone());
+            }
         }
-        kind
-    } else {
-        // Fallback to raw event for unknown transactions
-        MarketEventKind::TransactionDetected {
-            signature: tx_update.signature.clone(),
-            program: tx_update
-                .account_keys
-                .first()
-                .map(|k| k.to_string())
-                .unwrap_or_default(),
-        }
-    };
+    }
+
+    let event_kind = kind;
 
     let event = MarketEvent::new(
         "market-data",
@@ -14102,6 +14162,112 @@ mod pr_b_geyser_tracking_tests {
             MARKET_DATA_GEYSER_SYNC_BATCH_TOTAL.load(Ordering::Relaxed),
             batch0
         );
+    }
+
+    #[test]
+    fn pr166_nats_core_skips_high_volume_noise_kinds() {
+        assert!(!market_event_should_nats_core(
+            &MarketEventKind::AccountUpdate {
+                pubkey: "x".into(),
+                owner: "y".into(),
+                data_len: 0,
+            }
+        ));
+        assert!(!market_event_should_nats_core(
+            &MarketEventKind::TransactionDetected {
+                signature: "sig".into(),
+                program: "prog".into(),
+            }
+        ));
+        assert!(market_event_should_nats_core(&MarketEventKind::Trade {
+            pool_address: "p".into(),
+            mint: "m".into(),
+            quote_mint: NATIVE_SOL_MINT.to_string(),
+            trader: "t".into(),
+            is_buy: true,
+            sol_amount: 1,
+            token_amount: 1,
+            token_decimals: 6,
+            signature: None,
+            dex: "pumpfun".into(),
+            creator: None,
+            token_program: None,
+        }));
+    }
+
+    #[test]
+    fn pr166_tx_handler_liveness_stall_detection() {
+        assert!(market_data_tx_handler_liveness_stalled(100, 90, 5, 5));
+        assert!(!market_data_tx_handler_liveness_stalled(100, 100, 5, 5));
+        assert!(!market_data_tx_handler_liveness_stalled(100, 90, 5, 6));
+    }
+
+    #[test]
+    fn pr166_tx_handler_processed_metric_advances() {
+        use ironcrab::metrics::{
+            record_market_data_tx_handler_processed, MARKET_DATA_TX_HANDLER_PROCESSED_TOTAL,
+        };
+        let before = MARKET_DATA_TX_HANDLER_PROCESSED_TOTAL.load(Ordering::Relaxed);
+        record_market_data_tx_handler_processed();
+        assert!(MARKET_DATA_TX_HANDLER_PROCESSED_TOTAL.load(Ordering::Relaxed) > before);
+    }
+
+    #[test]
+    fn pr166_geyser_tx_payload_broadcast_increments_listener_counters() {
+        use ironcrab::metrics::{
+            geyser_metrics_inc_tx_listener_payload_broadcast_total,
+            GEYSER_TX_LISTENER_PAYLOAD_BROADCAST_TOTAL, GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL,
+        };
+        let tx0 = GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL.load(Ordering::Relaxed);
+        let payload0 = GEYSER_TX_LISTENER_PAYLOAD_BROADCAST_TOTAL.load(Ordering::Relaxed);
+        geyser_metrics_inc_tx_listener_payload_broadcast_total();
+        assert_eq!(
+            GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL.load(Ordering::Relaxed),
+            tx0 + 1
+        );
+        assert_eq!(
+            GEYSER_TX_LISTENER_PAYLOAD_BROADCAST_TOTAL.load(Ordering::Relaxed),
+            payload0 + 1
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pr166_tx_handler_not_blocked_by_pool_mint_map_write_lock() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let lock_ctx = Arc::clone(&ctx);
+        let hold = tokio::task::spawn_blocking(move || {
+            let _guard = lock_ctx.pool_mint_map.write();
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        });
+        let tx_count = AtomicU64::new(0);
+        let tx_update = GeyserTransactionUpdate {
+            signature: "sig".into(),
+            slot: 1,
+            account_keys: vec![],
+            instruction_accounts: vec![],
+            instruction_data: vec![],
+            inner_instructions: vec![],
+            pre_token_balances: vec![],
+            post_token_balances: vec![],
+            pre_balances: vec![],
+            post_balances: vec![],
+            fee_lamports: 0,
+            compute_units_consumed: None,
+            grpc_recv_at: Instant::now(),
+        };
+        let done = tokio::time::timeout(
+            std::time::Duration::from_millis(150),
+            handle_geyser_transaction(ctx, "run-pr166", tx_update, &tx_count, None),
+        )
+        .await;
+        assert!(
+            done.is_ok(),
+            "TX handler must not block on pool_mint_map write lock"
+        );
+        let _ = hold.await;
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -242,6 +242,8 @@ pub static GEYSER_ACCOUNT_SESSION_CONNECTED: Lazy<AtomicU64> = Lazy::new(|| Atom
 
 /// PR164: `UpdateOneof::Transaction` received on the TX-only session.
 pub static GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static GEYSER_TX_LISTENER_PAYLOAD_BROADCAST_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// PR164: Account updates received on the account-only session.
 pub static GEYSER_ACCOUNT_LISTENER_ACCOUNT_UPDATES_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -433,8 +435,60 @@ pub fn geyser_metrics_set_account_session_connected(connected: bool) {
 }
 
 #[inline]
-pub fn geyser_metrics_inc_tx_listener_transactions_total() {
+pub fn geyser_metrics_inc_tx_listener_payload_broadcast_total() {
     GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL.fetch_add(1, Ordering::Relaxed);
+    GEYSER_TX_LISTENER_PAYLOAD_BROADCAST_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// PR166: `handle_geyser_transaction` entered (TX ingest progress; liveness / stall detection).
+pub static MARKET_DATA_TX_HANDLER_PROCESSED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_TX_HANDLER_LAST_PROGRESS_UNIX_MS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_TX_HANDLER_STALLS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_UNPARSED_TX_DROPPED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_UNPARSED_ACCOUNT_DROPPED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_TX_HANDLER_RECONNECT_REQUESTED: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn record_market_data_tx_handler_processed() {
+    MARKET_DATA_TX_HANDLER_PROCESSED_TOTAL.fetch_add(1, Ordering::Relaxed);
+    MARKET_DATA_TX_HANDLER_LAST_PROGRESS_UNIX_MS.store(wall_clock_unix_ms_now(), Ordering::Relaxed);
+    record_market_data_tokio_progress();
+}
+
+#[inline]
+pub fn market_data_tx_handler_processed_value() -> u64 {
+    MARKET_DATA_TX_HANDLER_PROCESSED_TOTAL.load(Ordering::Relaxed)
+}
+
+#[inline]
+pub fn record_market_data_tx_handler_stall() {
+    MARKET_DATA_TX_HANDLER_STALLS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_unparsed_tx_dropped_total() {
+    MARKET_DATA_UNPARSED_TX_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_unparsed_account_dropped_total() {
+    MARKET_DATA_UNPARSED_ACCOUNT_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn market_data_request_tx_session_reconnect() {
+    MARKET_DATA_TX_HANDLER_RECONNECT_REQUESTED.store(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn market_data_take_tx_session_reconnect_request() -> bool {
+    MARKET_DATA_TX_HANDLER_RECONNECT_REQUESTED
+        .compare_exchange(1, 0, Ordering::Relaxed, Ordering::Relaxed)
+        .is_ok()
 }
 
 #[inline]
@@ -2565,6 +2619,30 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "geyser_tx_listener_transactions_total",
         GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "geyser_tx_listener_payload_broadcast_total",
+        GEYSER_TX_LISTENER_PAYLOAD_BROADCAST_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_tx_handler_processed_total",
+        MARKET_DATA_TX_HANDLER_PROCESSED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_tx_handler_last_progress_unix_ms",
+        MARKET_DATA_TX_HANDLER_LAST_PROGRESS_UNIX_MS.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_tx_handler_stalls_total",
+        MARKET_DATA_TX_HANDLER_STALLS_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_unparsed_tx_dropped_total",
+        MARKET_DATA_UNPARSED_TX_DROPPED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_unparsed_account_dropped_total",
+        MARKET_DATA_UNPARSED_ACCOUNT_DROPPED_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "geyser_account_listener_account_updates_total",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -435,8 +435,12 @@ pub fn geyser_metrics_set_account_session_connected(connected: bool) {
 }
 
 #[inline]
-pub fn geyser_metrics_inc_tx_listener_payload_broadcast_total() {
+pub fn geyser_metrics_inc_tx_listener_transactions_total() {
     GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn geyser_metrics_inc_tx_listener_payload_broadcast_total() {
     GEYSER_TX_LISTENER_PAYLOAD_BROADCAST_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -40,6 +40,7 @@ use crate::metrics::{
     geyser_metrics_inc_stream_error, geyser_metrics_inc_tracked_cuckoo_table_full,
     geyser_metrics_inc_tx_listener_liveness_reconnect_total,
     geyser_metrics_inc_tx_listener_payload_broadcast_total,
+    geyser_metrics_inc_tx_listener_transactions_total,
     geyser_metrics_set_account_session_connected, geyser_metrics_set_tx_session_connected,
     market_data_geyser_head_slot_value, market_data_take_tx_session_reconnect_request,
     market_data_tx_handler_processed_value, GeyserReconnectReason,
@@ -440,6 +441,7 @@ impl GeyserTxListener {
                                     if let Some(update) = msg.update_oneof {
                                         match update {
                                             UpdateOneof::Transaction(tx_update) => {
+                                                geyser_metrics_inc_tx_listener_transactions_total();
                                                 transaction_count = transaction_count.saturating_add(1);
                                                 if let Some(tx) = tx_update.transaction {
                                                     seen_tx_since_connect = true;

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -39,9 +39,10 @@ use crate::metrics::{
     geyser_metrics_inc_listener_stream_payload, geyser_metrics_inc_reconnect,
     geyser_metrics_inc_stream_error, geyser_metrics_inc_tracked_cuckoo_table_full,
     geyser_metrics_inc_tx_listener_liveness_reconnect_total,
-    geyser_metrics_inc_tx_listener_transactions_total,
+    geyser_metrics_inc_tx_listener_payload_broadcast_total,
     geyser_metrics_set_account_session_connected, geyser_metrics_set_tx_session_connected,
-    market_data_geyser_head_slot_value, GeyserReconnectReason,
+    market_data_geyser_head_slot_value, market_data_take_tx_session_reconnect_request,
+    market_data_tx_handler_processed_value, GeyserReconnectReason,
 };
 #[cfg(not(windows))]
 use rand::Rng;
@@ -286,9 +287,6 @@ impl GeyserTxListener {
 
     #[cfg(not(windows))]
     async fn start_tx_impl(self) -> Result<()> {
-        use crate::metrics::GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL;
-        use std::sync::atomic::Ordering as AtomicOrdering;
-
         enum SessionExit {
             StreamEnded,
             HardReconnect,
@@ -315,7 +313,7 @@ impl GeyserTxListener {
         let mut last_log = std::time::Instant::now();
         let mut transaction_count: u64 = 0;
         let mut seen_tx_since_connect = false;
-        let mut last_liveness_tx_total: u64 = 0;
+        let mut last_liveness_tx_handler_total: u64 = 0;
         let mut last_liveness_head_slot: u64 = 0;
         let mut first_liveness_window = true;
 
@@ -383,29 +381,36 @@ impl GeyserTxListener {
                     tokio::select! {
                         biased;
                         _ = liveness.tick() => {
+                            if market_data_take_tx_session_reconnect_request() {
+                                warn!(
+                                    "geyser_tx_listener: TX handler stall watchdog requested reconnect"
+                                );
+                                geyser_metrics_inc_tx_listener_liveness_reconnect_total();
+                                break 'read SessionExit::TxLivenessStale;
+                            }
                             let head = market_data_geyser_head_slot_value();
-                            let tx_total = GEYSER_TX_LISTENER_TRANSACTIONS_TOTAL.load(AtomicOrdering::Relaxed);
+                            let tx_handler_total = market_data_tx_handler_processed_value();
                             if first_liveness_window {
                                 last_liveness_head_slot = head;
-                                last_liveness_tx_total = tx_total;
+                                last_liveness_tx_handler_total = tx_handler_total;
                                 first_liveness_window = false;
                                 continue;
                             }
                             if seen_tx_since_connect
-                                && tx_total == last_liveness_tx_total
+                                && tx_handler_total == last_liveness_tx_handler_total
                                 && head > last_liveness_head_slot
                             {
                                 warn!(
-                                    tx_total,
+                                    tx_handler_total,
                                     head_slot = head,
                                     prev_head_slot = last_liveness_head_slot,
-                                    "geyser_tx_listener: TX stream stale — forcing reconnect"
+                                    "geyser_tx_listener: TX handler stale while chain advanced — forcing reconnect"
                                 );
                                 geyser_metrics_inc_tx_listener_liveness_reconnect_total();
                                 break 'read SessionExit::TxLivenessStale;
                             }
                             last_liveness_head_slot = head;
-                            last_liveness_tx_total = tx_total;
+                            last_liveness_tx_handler_total = tx_handler_total;
                         }
                         maybe_message = stream.next() => {
                             match maybe_message {
@@ -435,7 +440,6 @@ impl GeyserTxListener {
                                     if let Some(update) = msg.update_oneof {
                                         match update {
                                             UpdateOneof::Transaction(tx_update) => {
-                                                geyser_metrics_inc_tx_listener_transactions_total();
                                                 transaction_count = transaction_count.saturating_add(1);
                                                 if let Some(tx) = tx_update.transaction {
                                                     seen_tx_since_connect = true;
@@ -614,7 +618,9 @@ impl GeyserTxListener {
                                                         compute_units_consumed,
                                                         grpc_recv_at,
                                                     };
-                                                    let _ = transaction_tx.send(event);
+                                                    if transaction_tx.send(event).is_ok() {
+                                                        geyser_metrics_inc_tx_listener_payload_broadcast_total();
+                                                    }
                                                     if !got_payload_since_subscribe {
                                                         got_payload_since_subscribe = true;
                                                         reconnect_backoff_ms =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses production TX ingest stall after PR165: `handle_geyser_transaction` stopped processing while Geyser frames still arrived, so misleading `geyser_tx_listener_transactions_total` prevented TX liveness reconnect and Trade NATS dried up.

## Changes

### P0 — TX handler stall
- New mint on TX path uses `schedule_geyser_sync_batch_debounced()` instead of immediate `sync_geyser_tracked_accounts()` to avoid lock contention with account workers.
- `record_market_data_tx_handler_processed()` at start of `handle_geyser_transaction`.
- TX stall watchdog (10s check, 120s grace, 60s window): `market_data_tx_handler_stalls_total`, reconnect request to Geyser TX session, then `exit(1)` if still stalled.

### P0 — Metrics & liveness
- `geyser_tx_listener_transactions_total` / `geyser_tx_listener_payload_broadcast_total` increment only on successful payload broadcast.
- TX liveness reconnect in `geyser_tx_listener` compares `market_data_tx_handler_processed_total` vs rising `market_data_geyser_head_slot`.
- New gauges: `market_data_tx_handler_last_progress_unix_ms`, drop counters for unparsed account/tx.

### P1 — NATS noise
- `market_event_should_nats_core` excludes `AccountUpdate` and `TransactionDetected` from core NATS (aligned with JSONL policy).
- Unparsed Geyser fallbacks return early without JSONL/NATS.

## Invariants

- No new RPC in Geyser handlers (I-7).
- PR165/164/160 behavior preserved.

## Verification

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`

## Prod smoke (post-deploy)

- `market_data_tx_handler_processed_total` rises continuously
- `market_data_last_trade_publish_ts_unix_ms` fresh (<30s)
- `market_data_tx_handler_stalls_total` == 0
- NATS `Trade` events on `ironcrab.v1.market_events`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbb14a60-213a-4ab9-9e79-38e6917c32d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbb14a60-213a-4ab9-9e79-38e6917c32d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

