### PR TITLE
fix(market-data): PR167 — global ingest freeze, subscription backpressure, lock scope

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,12 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### PR167-MARKET-DATA-GLOBAL-INGEST-FREEZE: Global Ingest Stall, Subscription Backpressure, Lock Scope
+**Datum**: 2026-05-28  
+**Problem** (Prod `fa27eea` nach PR165/166): ~3 s nach Restart **kompletter** Ingest-Tod — `tx_handler_processed`, `geyser_account_listener_account_updates`, `market_data_geyser_head_slot` alle still 15+ s; NATS-Trades 0; Kernel Geyser Recv-Q ~1,76 MB (Daten kommen, `stream.next()` pollt nicht), Send-Q ~2,10 MB (Subscription-Sink staut); 14× `subscription updated` in 3 s; `geyser_sync_pending=1`; PR166 TX-Watchdog blind (Head auch still). Ursache: Tokio-Runtime-Kollaps unter Startup-Burst — Lock-Convoy auf `MarketDataContext` + blockierendes `subscribe_tx.send().await` im Subscription-Updater.  
+**Fix**: (1) **Global Ingest Stall Detector** (10 s Sample, 120 s Grace, 50 s Stall): alle drei Counter flat → `market_data_global_ingest_stalls_total`, Reconnect **TX + Account** Session, danach `exit(1)`; ersetzt PR165 Tokio- + PR166 TX-only-Watchdogs. (2) **Subscription Sink**: coalesce (latest wins), Rate-Limit 400 ms, 2 s send-timeout → `HardReconnect` statt ewig await; Startup tracked-set jump >50 in 1 s → `SubscriptionRebuild`. (3) **Pin/Sync**: Startup-Debounce min 250 ms (120 s); deferred TX worker (reserve register + geyser sync schedule); Lock-Scope in TX-Handler (pool_mint_map write → drop → await). **Invarianten**: kein RPC (I-7), PR165/166/164 unangetastet (Watchdogs konsolidiert, nicht revertiert). **Bricht PR141–166 Symptom-Kreis** — strukturell, nicht weiterer partieller Watchdog.  
+**Dateien**: `src/bin/market_data.rs`, `src/solana/geyser_listener.rs`, `src/metrics.rs`, `docs/BUGS_FIXES.md`
+
 ### PR166-MARKET-DATA-TX-INGEST-STALL: TX-Handler-Blockade, Payload-Liveness-Metriken, NATS-Noise-Policy
 **Datum**: 2026-05-28  
 **Problem** (Prod `0c04bac` nach PR165): `market_data_tx_channel_lag_ms_count` friert (~1128); `handle_geyser_transaction` verarbeitet keine weiteren TXs (`futex_wait_queue`); `geyser_tx_listener_transactions_total` steigt weiter (Zähler vor Payload-Check) → TX-Liveness-Reconnect greift nicht; `Parsed DEX transaction` / NATS `Trade` stoppen; Pool-Discovery/Account-Pfad lebt.  

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -50,15 +50,16 @@ use ironcrab::ipc::{
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
     dec_market_data_account_low_priority_queue_depth, dec_market_data_account_publish_queue_depth,
-    dec_market_data_account_worker_queue_depth, geyser_metrics_inc_tracked_evicted,
-    geyser_metrics_set_subscription_accounts, geyser_metrics_set_tracked_pinned_accounts,
-    inc_market_data_account_high_priority_queue_depth,
+    dec_market_data_account_worker_queue_depth, geyser_account_listener_account_updates_value,
+    geyser_metrics_inc_tracked_evicted, geyser_metrics_set_subscription_accounts,
+    geyser_metrics_set_tracked_pinned_accounts, inc_market_data_account_high_priority_queue_depth,
     inc_market_data_account_low_priority_queue_depth,
     inc_market_data_account_publish_enqueue_dropped_total,
     inc_market_data_account_publish_queue_depth, inc_market_data_account_worker_queue_depth,
-    inc_market_data_jsonl_enqueue_dropped_total, inc_market_data_unparsed_account_dropped_total,
-    inc_market_data_unparsed_tx_dropped_total, market_data_bump_geyser_head_slot,
-    market_data_geyser_head_slot_value, market_data_request_tx_session_reconnect,
+    inc_market_data_jsonl_enqueue_dropped_total, inc_market_data_tx_deferred_dropped_total,
+    inc_market_data_unparsed_account_dropped_total, inc_market_data_unparsed_tx_dropped_total,
+    market_data_bump_geyser_head_slot, market_data_geyser_head_slot_value,
+    market_data_request_account_session_reconnect, market_data_request_tx_session_reconnect,
     market_data_tx_handler_processed_value, record_market_data_account_broadcast_lagged,
     record_market_data_account_channel_lag_ms, record_market_data_account_early_drop_total,
     record_market_data_account_handler_duration_us,
@@ -69,22 +70,22 @@ use ironcrab::metrics::{
     record_market_data_bonding_to_trade_slot_delta_slots,
     record_market_data_geyser_merge_coalesced_total, record_market_data_geyser_sync_batch_total,
     record_market_data_geyser_sync_immediate_total,
-    record_market_data_geyser_to_publish_on_success,
+    record_market_data_geyser_to_publish_on_success, record_market_data_global_ingest_stall,
     record_market_data_momentum_active_pool_messages_total,
-    record_market_data_pool_mint_map_to_devwallet_ms, record_market_data_tokio_liveness_stall,
-    record_market_data_tokio_progress, record_market_data_trade_after_bonding_publish_ms,
-    record_market_data_tx_broadcast_lagged, record_market_data_tx_channel_lag_ms,
-    record_market_data_tx_handler_processed, record_market_data_tx_handler_stall, serve_metrics,
+    record_market_data_pool_mint_map_to_devwallet_ms, record_market_data_tokio_progress,
+    record_market_data_trade_after_bonding_publish_ms, record_market_data_tx_broadcast_lagged,
+    record_market_data_tx_channel_lag_ms, record_market_data_tx_handler_processed, serve_metrics,
     set_market_data_account_broadcast_queue_depth,
     set_market_data_account_publish_worker_last_success_unix_ms,
     set_market_data_geyser_merge_pending, set_market_data_geyser_sync_pending,
     set_market_data_momentum_active_pool_pins_gauge, set_market_data_tx_broadcast_queue_depth,
     set_readiness_control_sub_active, set_readiness_mode, set_readiness_nats_connected,
-    update_readiness_market_data_current, wall_clock_unix_ms_now, GeyserTrackedEvictKind,
-    MarketDataLatencySegment, MetricsComponent, MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS,
-    MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS, MARKET_EVENTS_MOMENTUM_FANOUT_PUBLISHED_TOTAL,
-    MARKET_EVENTS_PUBLISHED_TOTAL, MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL,
-    NATS_MESSAGES_PUBLISHED_TOTAL, POOLS_TRACKED_GAUGE,
+    touch_market_data_global_ingest_progress, update_readiness_market_data_current,
+    wall_clock_unix_ms_now, GeyserTrackedEvictKind, MarketDataLatencySegment, MetricsComponent,
+    MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS, MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS,
+    MARKET_EVENTS_MOMENTUM_FANOUT_PUBLISHED_TOTAL, MARKET_EVENTS_PUBLISHED_TOTAL,
+    MARKET_EVENTS_RECEIVED_TOTAL, NATS_ERRORS_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
+    POOLS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
@@ -128,6 +129,11 @@ static MD_SYSTEMD_WATCHDOG_NOTIFY: AtomicBool = AtomicBool::new(true);
 
 /// Default capacity for off-hot-path market-events JSONL queue.
 const MARKET_DATA_JSONL_QUEUE_CAP: usize = 16_384;
+/// PR167: bounded queue for deferred TX side-effects (reserve register, geyser sync schedule).
+const MARKET_DATA_TX_DEFERRED_QUEUE_CAP: usize = 4096;
+/// PR167: minimum debounce for explicit pin updates during startup burst (seconds).
+const MARKET_DATA_GEYSER_SYNC_STARTUP_WINDOW: Duration = Duration::from_secs(120);
+const MARKET_DATA_GEYSER_SYNC_STARTUP_MIN_MS: u64 = 250;
 
 /// ExecutionResult dedup: prevents replay storms from re-tracking the same ATA/mint over and over.
 ///
@@ -256,14 +262,47 @@ fn market_event_should_nats_core(kind: &MarketEventKind) -> bool {
     )
 }
 
-/// PR166: TX-handler liveness — chain head advanced but handler counter flat.
-fn market_data_tx_handler_liveness_stalled(
+/// PR167: global ingest stall — TX handler, account listener, and head slot all flat.
+fn market_data_global_ingest_stalled(
+    tx_now: u64,
+    tx_prev: u64,
+    account_now: u64,
+    account_prev: u64,
     head_now: u64,
     head_prev: u64,
-    handler_now: u64,
-    handler_prev: u64,
 ) -> bool {
-    head_now > head_prev && handler_now == handler_prev
+    tx_now == tx_prev && account_now == account_prev && head_now == head_prev
+}
+
+/// PR167: deferred TX side-effects (single FIFO worker — avoids lock convoy with account workers).
+enum TxDeferredSideEffect {
+    ScheduleGeyserSyncBatch,
+    RegisterReservesAfterTrade(Pubkey),
+}
+
+fn tx_deferred_try_enqueue(tx: &mpsc::Sender<TxDeferredSideEffect>, job: TxDeferredSideEffect) {
+    if tx.try_send(job).is_err() {
+        inc_market_data_tx_deferred_dropped_total();
+    }
+}
+
+fn spawn_market_data_tx_deferred_worker(
+    ctx: Arc<MarketDataContext>,
+) -> mpsc::Sender<TxDeferredSideEffect> {
+    let (tx, mut rx) = mpsc::channel(MARKET_DATA_TX_DEFERRED_QUEUE_CAP);
+    tokio::spawn(async move {
+        while let Some(job) = rx.recv().await {
+            match job {
+                TxDeferredSideEffect::ScheduleGeyserSyncBatch => {
+                    ctx.schedule_geyser_sync_batch_debounced();
+                }
+                TxDeferredSideEffect::RegisterReservesAfterTrade(pool) => {
+                    ctx.register_geyser_reserves_after_trade(pool);
+                }
+            }
+        }
+    });
+    tx
 }
 
 /// Optional Geyser→core-publish latency trace (same `recv_at` for all publishes from one Geyser message).
@@ -1435,8 +1474,18 @@ impl MarketDataContext {
         self.sync_geyser_tracked_accounts_core();
     }
 
+    /// PR167: longer debounce during startup pin burst (min 250 ms for first 120 s).
+    fn geyser_sync_batch_debounce_ms(&self) -> u64 {
+        let base = self.config.read().geyser_sync_batch_ms.clamp(10, 100);
+        if self.started_at.elapsed() < MARKET_DATA_GEYSER_SYNC_STARTUP_WINDOW {
+            base.max(MARKET_DATA_GEYSER_SYNC_STARTUP_MIN_MS)
+        } else {
+            base
+        }
+    }
+
     fn schedule_geyser_sync_batch_debounced(self: &Arc<Self>) {
-        let ms = self.config.read().geyser_sync_batch_ms.clamp(10, 100);
+        let ms = self.geyser_sync_batch_debounce_ms();
         set_market_data_geyser_sync_pending(1);
         let mut guard = self.geyser_sync_batch_timer.lock();
         if let Some(h) = guard.take() {
@@ -1463,7 +1512,7 @@ impl MarketDataContext {
         bin_arrays_rx: &watch::Receiver<Vec<Pubkey>>,
         wallet_rx: &watch::Receiver<Vec<Pubkey>>,
     ) {
-        let ms = ctx_merge.config.read().geyser_sync_batch_ms.clamp(10, 100);
+        let ms = ctx_merge.geyser_sync_batch_debounce_ms();
         set_market_data_geyser_merge_pending(1);
         let mut guard = debounce_timer.lock();
         if let Some(h) = guard.take() {
@@ -6552,8 +6601,7 @@ async fn main() -> Result<()> {
 
     record_market_data_tokio_progress();
     let process_started = Instant::now();
-    spawn_market_data_tokio_liveness_task(process_started);
-    spawn_market_data_tx_handler_liveness_task(process_started);
+    spawn_market_data_global_ingest_liveness_task(process_started);
 
     // Setup NATS (optional in dry-run mode)
     let nats = if args.dry_run {
@@ -7848,86 +7896,59 @@ fn spawn_market_data_metrics_runtime(addr: std::net::SocketAddr) {
         .expect("spawn md-metrics thread");
 }
 
-/// PR165: detect Tokio scheduler stall (OS-thread watchdog alone is insufficient).
-fn spawn_market_data_tokio_liveness_task(process_started: Instant) {
+/// PR167: detect global ingest stall (TX + account + head slot all frozen).
+fn spawn_market_data_global_ingest_liveness_task(process_started: Instant) {
     tokio::spawn(async move {
         const CHECK_INTERVAL: Duration = Duration::from_secs(10);
-        const STALL_THRESHOLD: Duration = Duration::from_secs(45);
+        const STALL_WINDOW: Duration = Duration::from_secs(50);
+        const RECOVERY_WAIT: Duration = Duration::from_secs(60);
         const STARTUP_GRACE: Duration = Duration::from_secs(120);
-        let mut last_tick =
-            ironcrab::metrics::MARKET_DATA_INGEST_PROGRESS_TICK.load(Ordering::Relaxed);
-        let mut last_ms =
-            ironcrab::metrics::MARKET_DATA_TOKIO_LAST_PROGRESS_UNIX_MS.load(Ordering::Relaxed);
-        let mut interval = tokio::time::interval(CHECK_INTERVAL);
-        loop {
-            interval.tick().await;
-            let tick = ironcrab::metrics::MARKET_DATA_INGEST_PROGRESS_TICK.load(Ordering::Relaxed);
-            let ms =
-                ironcrab::metrics::MARKET_DATA_TOKIO_LAST_PROGRESS_UNIX_MS.load(Ordering::Relaxed);
-            if tick != last_tick || ms != last_ms {
-                last_tick = tick;
-                last_ms = ms;
-                continue;
-            }
-            if process_started.elapsed() < STARTUP_GRACE {
-                continue;
-            }
-            record_market_data_tokio_liveness_stall();
-            error!(
-                stall_secs = STALL_THRESHOLD.as_secs(),
-                "PR165: Tokio ingest stalled — disabling systemd watchdog pings and exiting for Restart=always"
-            );
-            #[cfg(unix)]
-            MD_SYSTEMD_WATCHDOG_NOTIFY.store(false, Ordering::Relaxed);
-            std::process::exit(1);
-        }
-    });
-}
-
-/// PR166: detect TX ingest stall (head slot advances, `handle_geyser_transaction` counter frozen).
-fn spawn_market_data_tx_handler_liveness_task(process_started: Instant) {
-    tokio::spawn(async move {
-        const CHECK_INTERVAL: Duration = Duration::from_secs(10);
-        const STALL_WINDOW: Duration = Duration::from_secs(60);
-        const STARTUP_GRACE: Duration = Duration::from_secs(120);
+        let mut last_tx = market_data_tx_handler_processed_value();
+        let mut last_account = geyser_account_listener_account_updates_value();
         let mut last_head = market_data_geyser_head_slot_value();
-        let mut last_handler = market_data_tx_handler_processed_value();
         let mut stalled_since: Option<Instant> = None;
-        let mut reconnect_requested_at: Option<Instant> = None;
+        let mut recovery_requested_at: Option<Instant> = None;
         let mut interval = tokio::time::interval(CHECK_INTERVAL);
         loop {
             interval.tick().await;
             if process_started.elapsed() < STARTUP_GRACE {
+                last_tx = market_data_tx_handler_processed_value();
+                last_account = geyser_account_listener_account_updates_value();
                 last_head = market_data_geyser_head_slot_value();
-                last_handler = market_data_tx_handler_processed_value();
                 stalled_since = None;
-                reconnect_requested_at = None;
+                recovery_requested_at = None;
                 continue;
             }
+            let tx = market_data_tx_handler_processed_value();
+            let account = geyser_account_listener_account_updates_value();
             let head = market_data_geyser_head_slot_value();
-            let handler = market_data_tx_handler_processed_value();
-            let stalled =
-                market_data_tx_handler_liveness_stalled(head, last_head, handler, last_handler);
-            last_head = head;
-            last_handler = handler;
-            if stalled {
+            if market_data_global_ingest_stalled(
+                tx,
+                last_tx,
+                account,
+                last_account,
+                head,
+                last_head,
+            ) {
                 let since = *stalled_since.get_or_insert_with(Instant::now);
                 if since.elapsed() >= STALL_WINDOW {
-                    record_market_data_tx_handler_stall();
-                    if reconnect_requested_at.is_none() {
+                    record_market_data_global_ingest_stall();
+                    if recovery_requested_at.is_none() {
                         error!(
                             stall_secs = STALL_WINDOW.as_secs(),
+                            tx_handler_processed = tx,
+                            account_updates = account,
                             head_slot = head,
-                            tx_handler_processed = handler,
-                            "PR166: TX handler stalled — requesting Geyser TX session reconnect"
+                            "PR167: global ingest stalled — requesting Geyser TX + account session reconnect"
                         );
                         market_data_request_tx_session_reconnect();
-                        reconnect_requested_at = Some(Instant::now());
+                        market_data_request_account_session_reconnect();
+                        recovery_requested_at = Some(Instant::now());
                         stalled_since = None;
-                    } else if reconnect_requested_at.is_some_and(|t| t.elapsed() >= STALL_WINDOW) {
+                    } else if recovery_requested_at.is_some_and(|t| t.elapsed() >= RECOVERY_WAIT) {
                         error!(
-                            stall_secs = STALL_WINDOW.as_secs(),
-                            "PR166: TX handler still stalled after reconnect request — exiting for systemd restart"
+                            stall_secs = RECOVERY_WAIT.as_secs(),
+                            "PR167: global ingest still stalled after reconnect — exiting for systemd restart"
                         );
                         #[cfg(unix)]
                         MD_SYSTEMD_WATCHDOG_NOTIFY.store(false, Ordering::Relaxed);
@@ -7935,8 +7956,12 @@ fn spawn_market_data_tx_handler_liveness_task(process_started: Instant) {
                     }
                 }
             } else {
+                touch_market_data_global_ingest_progress();
                 stalled_since = None;
-                reconnect_requested_at = None;
+                recovery_requested_at = None;
+                last_tx = tx;
+                last_account = account;
+                last_head = head;
             }
         }
     });
@@ -9999,6 +10024,7 @@ async fn handle_geyser_transaction(
     tx_update: GeyserTransactionUpdate,
     tx_count: &AtomicU64,
     account_publish_tx: Option<&mpsc::Sender<AccountPathNatsJob>>,
+    tx_deferred_tx: &mpsc::Sender<TxDeferredSideEffect>,
 ) {
     record_market_data_tx_handler_processed();
     let recv_at = Instant::now();
@@ -10091,11 +10117,14 @@ async fn handle_geyser_transaction(
         if let Some((mint, dex_opt)) = mint_and_dex {
             let is_new = ctx.track_mint_for_geyser_metadata(mint, None);
             if is_new {
-                ctx.schedule_geyser_sync_batch_debounced();
+                tx_deferred_try_enqueue(
+                    tx_deferred_tx,
+                    TxDeferredSideEffect::ScheduleGeyserSyncBatch,
+                );
                 debug!(
                     mint = %mint,
                     dex = ?dex_opt,
-                    "New mint tracked for Geyser metadata (batched sync), waiting for mint account delivery"
+                    "New mint tracked for Geyser metadata (batched sync deferred), waiting for mint account delivery"
                 );
             }
         }
@@ -10108,17 +10137,21 @@ async fn handle_geyser_transaction(
                 dex: DexType::PumpFun,
                 ..
             } => {
-                ctx.pool_mint_map
-                    .write()
-                    .insert(pool_address.to_string(), base_mint.to_string());
-                ctx.high_priority_bonding_curves
-                    .write()
-                    .insert(*pool_address);
+                let pool_str = pool_address.to_string();
+                let mint_str = base_mint.to_string();
+                {
+                    ctx.pool_mint_map
+                        .write()
+                        .insert(pool_str.clone(), mint_str.clone());
+                    ctx.high_priority_bonding_curves
+                        .write()
+                        .insert(*pool_address);
+                }
                 maybe_emit_dev_wallet_after_pool_mint_map(
                     &ctx,
                     run_id,
                     pool_address,
-                    &base_mint.to_string(),
+                    &mint_str,
                     Some(tx_update.slot),
                     tx_update.grpc_recv_at,
                     account_publish_tx,
@@ -10132,17 +10165,21 @@ async fn handle_geyser_transaction(
                 dex: DexType::PumpFun,
                 ..
             } => {
-                ctx.pool_mint_map
-                    .write()
-                    .insert(pool_address.to_string(), mint.to_string());
-                ctx.high_priority_bonding_curves
-                    .write()
-                    .insert(*pool_address);
+                let pool_str = pool_address.to_string();
+                let mint_str = mint.to_string();
+                {
+                    ctx.pool_mint_map
+                        .write()
+                        .insert(pool_str.clone(), mint_str.clone());
+                    ctx.high_priority_bonding_curves
+                        .write()
+                        .insert(*pool_address);
+                }
                 maybe_emit_dev_wallet_after_pool_mint_map(
                     &ctx,
                     run_id,
                     pool_address,
-                    &mint.to_string(),
+                    &mint_str,
                     Some(tx_update.slot),
                     tx_update.grpc_recv_at,
                     account_publish_tx,
@@ -10157,7 +10194,10 @@ async fn handle_geyser_transaction(
     // PR-B: qualifying swap trade — refresh LRU timestamps and register reserve vaults / DLMM bins.
     if let Some(ParsedDexEvent::Trade { pool_address, .. }) = parsed_event.as_ref() {
         ctx.touch_tracked_pool_vaults_and_bins_if_tracked(*pool_address);
-        ctx.register_geyser_reserves_after_trade(*pool_address);
+        tx_deferred_try_enqueue(
+            tx_deferred_tx,
+            TxDeferredSideEffect::RegisterReservesAfterTrade(*pool_address),
+        );
     }
 
     // Pump.fun: propagate creator/dev wallet so strategy can build deterministic intents.
@@ -10916,6 +10956,9 @@ async fn run_geyser_loop(
             spawn_market_data_account_publish_runtime(Arc::clone(&ctx), template, n_workers)
         });
 
+    // PR167: single-worker deferred side-effects (reserve register, geyser sync schedule).
+    let tx_deferred_tx = spawn_market_data_tx_deferred_worker(Arc::clone(&ctx));
+
     // Option A (MARKET-DATA-TX-INGEST-FAIRNESS): dedizierter Tokio-Task für Geyser-Txs.
     // Verhindert, dass `transaction_rx.recv()` hinter langen Account-`select!`-Armen verhungert
     // (p50 `market_data_tx_channel_lag_ms` war ~1s+ bei gleichzeitig niedrigem Publish-Tail).
@@ -10924,6 +10967,7 @@ async fn run_geyser_loop(
     let run_id_geyser_tx = run_id.to_string();
     let tx_count_geyser_tx = Arc::clone(&tx_count);
     let account_publish_tx_geyser_tx = account_publish_tx.clone();
+    let tx_deferred_tx_geyser = tx_deferred_tx.clone();
     let mut transaction_rx_geyser = transaction_rx;
     tokio::spawn(async move {
         loop {
@@ -10936,6 +10980,7 @@ async fn run_geyser_loop(
                         tx_update,
                         tx_count_geyser_tx.as_ref(),
                         account_publish_tx_geyser_tx.as_ref(),
+                        &tx_deferred_tx_geyser,
                     )
                     .await;
                 }
@@ -14061,8 +14106,8 @@ mod pr_b_geyser_tracking_tests {
             "trade-path reserve registration must not immediate-sync before debounce flush"
         );
 
-        // Debounce window default 35 ms; wall-clock sleep so the spawned flush reliably runs.
-        tokio::time::sleep(Duration::from_millis(60)).await;
+        // PR167: startup debounce min 250 ms; wall-clock sleep so the spawned flush reliably runs.
+        tokio::time::sleep(Duration::from_millis(350)).await;
 
         assert_eq!(
             MARKET_DATA_GEYSER_SYNC_BATCH_TOTAL.load(Ordering::Relaxed),
@@ -14120,7 +14165,7 @@ mod pr_b_geyser_tracking_tests {
             let _ = ctx.tracked_mints_tx.send(vec![pk]);
         }
 
-        tokio::time::sleep(Duration::from_millis(120)).await;
+        tokio::time::sleep(Duration::from_millis(350)).await;
 
         let n = combined_change_count.load(Ordering::Relaxed);
         assert!(
@@ -14195,10 +14240,20 @@ mod pr_b_geyser_tracking_tests {
     }
 
     #[test]
-    fn pr166_tx_handler_liveness_stall_detection() {
-        assert!(market_data_tx_handler_liveness_stalled(100, 90, 5, 5));
-        assert!(!market_data_tx_handler_liveness_stalled(100, 100, 5, 5));
-        assert!(!market_data_tx_handler_liveness_stalled(100, 90, 5, 6));
+    fn pr167_global_ingest_stall_detection() {
+        assert!(market_data_global_ingest_stalled(5, 5, 10, 10, 100, 100));
+        assert!(!market_data_global_ingest_stalled(5, 5, 10, 11, 100, 100));
+        assert!(!market_data_global_ingest_stalled(5, 6, 10, 10, 100, 100));
+        assert!(!market_data_global_ingest_stalled(5, 5, 10, 10, 100, 101));
+    }
+
+    #[test]
+    fn pr167_geyser_sync_startup_debounce_ms() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        assert!(ctx.geyser_sync_batch_debounce_ms() >= MARKET_DATA_GEYSER_SYNC_STARTUP_MIN_MS);
     }
 
     #[test]
@@ -14259,9 +14314,17 @@ mod pr_b_geyser_tracking_tests {
             compute_units_consumed: None,
             grpc_recv_at: Instant::now(),
         };
+        let (tx_deferred_tx, _) = mpsc::channel(16);
         let done = tokio::time::timeout(
             std::time::Duration::from_millis(150),
-            handle_geyser_transaction(ctx, "run-pr166", tx_update, &tx_count, None),
+            handle_geyser_transaction(
+                ctx,
+                "run-pr166",
+                tx_update,
+                &tx_count,
+                None,
+                &tx_deferred_tx,
+            ),
         )
         .await;
         assert!(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -455,6 +455,27 @@ pub static MARKET_DATA_UNPARSED_ACCOUNT_DROPPED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 static MARKET_DATA_TX_HANDLER_RECONNECT_REQUESTED: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_ACCOUNT_SESSION_RECONNECT_REQUESTED: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// PR167: all three ingest progress signals flat (TX handler, account listener, head slot).
+pub static MARKET_DATA_GLOBAL_INGEST_STALLS_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GLOBAL_INGEST_LAST_PROGRESS_UNIX_MS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// PR167: subscription sink rate-limit skips (coalesced bursts during startup).
+pub static GEYSER_ACCOUNT_LISTENER_SUBSCRIBE_SINK_THROTTLED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// PR167: subscription sink send timeout / backpressure → full reconnect.
+pub static GEYSER_ACCOUNT_LISTENER_SUBSCRIBE_SINK_BACKPRESSURE_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// PR167: account session reconnect requested by global ingest stall recovery.
+pub static GEYSER_ACCOUNT_LISTENER_LIVENESS_RECONNECTS_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// PR167: deferred TX side-effect queue full (`try_send` drop).
+pub static MARKET_DATA_TX_DEFERRED_DROPPED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
 #[inline]
 pub fn record_market_data_tx_handler_processed() {
@@ -493,6 +514,54 @@ pub fn market_data_take_tx_session_reconnect_request() -> bool {
     MARKET_DATA_TX_HANDLER_RECONNECT_REQUESTED
         .compare_exchange(1, 0, Ordering::Relaxed, Ordering::Relaxed)
         .is_ok()
+}
+
+#[inline]
+pub fn market_data_request_account_session_reconnect() {
+    MARKET_DATA_ACCOUNT_SESSION_RECONNECT_REQUESTED.store(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn market_data_take_account_session_reconnect_request() -> bool {
+    MARKET_DATA_ACCOUNT_SESSION_RECONNECT_REQUESTED
+        .compare_exchange(1, 0, Ordering::Relaxed, Ordering::Relaxed)
+        .is_ok()
+}
+
+#[inline]
+pub fn geyser_account_listener_account_updates_value() -> u64 {
+    GEYSER_ACCOUNT_LISTENER_ACCOUNT_UPDATES_TOTAL.load(Ordering::Relaxed)
+}
+
+#[inline]
+pub fn record_market_data_global_ingest_stall() {
+    MARKET_DATA_GLOBAL_INGEST_STALLS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn touch_market_data_global_ingest_progress() {
+    MARKET_DATA_GLOBAL_INGEST_LAST_PROGRESS_UNIX_MS
+        .store(wall_clock_unix_ms_now(), Ordering::Relaxed);
+}
+
+#[inline]
+pub fn geyser_metrics_inc_account_listener_subscribe_sink_throttled() {
+    GEYSER_ACCOUNT_LISTENER_SUBSCRIBE_SINK_THROTTLED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn geyser_metrics_inc_account_listener_subscribe_sink_backpressure() {
+    GEYSER_ACCOUNT_LISTENER_SUBSCRIBE_SINK_BACKPRESSURE_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn geyser_metrics_inc_account_listener_liveness_reconnect_total() {
+    GEYSER_ACCOUNT_LISTENER_LIVENESS_RECONNECTS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_tx_deferred_dropped_total() {
+    MARKET_DATA_TX_DEFERRED_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -2641,6 +2710,18 @@ async fn metrics_response() -> Response<Body> {
         MARKET_DATA_TX_HANDLER_STALLS_TOTAL.load(Ordering::Relaxed)
     );
     line!(
+        "market_data_global_ingest_stalls_total",
+        MARKET_DATA_GLOBAL_INGEST_STALLS_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_global_ingest_last_progress_unix_ms",
+        MARKET_DATA_GLOBAL_INGEST_LAST_PROGRESS_UNIX_MS.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_tx_deferred_dropped_total",
+        MARKET_DATA_TX_DEFERRED_DROPPED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
         "market_data_unparsed_tx_dropped_total",
         MARKET_DATA_UNPARSED_TX_DROPPED_TOTAL.load(Ordering::Relaxed)
     );
@@ -2659,6 +2740,18 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "geyser_account_listener_subscribe_updates_total",
         GEYSER_ACCOUNT_LISTENER_SUBSCRIBE_UPDATES_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "geyser_account_listener_subscribe_sink_throttled_total",
+        GEYSER_ACCOUNT_LISTENER_SUBSCRIBE_SINK_THROTTLED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "geyser_account_listener_subscribe_sink_backpressure_total",
+        GEYSER_ACCOUNT_LISTENER_SUBSCRIBE_SINK_BACKPRESSURE_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "geyser_account_listener_liveness_reconnects_total",
+        GEYSER_ACCOUNT_LISTENER_LIVENESS_RECONNECTS_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "geyser_tx_listener_liveness_reconnects_total",

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::broadcast;
-use tokio::sync::watch;
+use tokio::sync::{watch, Notify};
 
 #[cfg(not(windows))]
 use futures::{SinkExt, StreamExt};
@@ -17,6 +17,10 @@ use solana_pubkey::Pubkey as CuckooPubkey;
 use solana_sdk::bs58;
 #[cfg(not(windows))]
 use std::collections::HashMap;
+#[cfg(not(windows))]
+use std::sync::Mutex;
+#[cfg(not(windows))]
+use std::time::Duration;
 #[cfg(not(windows))]
 use tracing::debug;
 #[cfg(not(windows))]
@@ -35,6 +39,9 @@ use yellowstone_grpc_proto::prelude::{
 #[cfg(not(windows))]
 use crate::metrics::{
     geyser_metrics_inc_account_listener_account_updates_total,
+    geyser_metrics_inc_account_listener_liveness_reconnect_total,
+    geyser_metrics_inc_account_listener_subscribe_sink_backpressure,
+    geyser_metrics_inc_account_listener_subscribe_sink_throttled,
     geyser_metrics_inc_account_listener_subscribe_updates_total,
     geyser_metrics_inc_listener_stream_payload, geyser_metrics_inc_reconnect,
     geyser_metrics_inc_stream_error, geyser_metrics_inc_tracked_cuckoo_table_full,
@@ -42,17 +49,12 @@ use crate::metrics::{
     geyser_metrics_inc_tx_listener_payload_broadcast_total,
     geyser_metrics_inc_tx_listener_transactions_total,
     geyser_metrics_set_account_session_connected, geyser_metrics_set_tx_session_connected,
-    market_data_geyser_head_slot_value, market_data_take_tx_session_reconnect_request,
-    market_data_tx_handler_processed_value, GeyserReconnectReason,
+    market_data_geyser_head_slot_value, market_data_take_account_session_reconnect_request,
+    market_data_take_tx_session_reconnect_request, market_data_tx_handler_processed_value,
+    GeyserReconnectReason,
 };
 #[cfg(not(windows))]
 use rand::Rng;
-#[cfg(not(windows))]
-use std::sync::Mutex;
-#[cfg(not(windows))]
-use std::time::Duration;
-#[cfg(not(windows))]
-use tokio::sync::Notify;
 #[cfg(not(windows))]
 use tokio::time::sleep;
 
@@ -763,6 +765,24 @@ impl GeyserAccountListener {
         Ok(f)
     }
 
+    /// PR167: latest subscribe request wins — coalesce startup bursts into one sink send.
+    #[cfg(not(windows))]
+    fn coalesce_pending_subscription(
+        pending: &Mutex<Option<SubscribeRequest>>,
+        req: SubscribeRequest,
+    ) {
+        if let Ok(mut g) = pending.lock() {
+            *g = Some(req);
+        }
+    }
+
+    #[cfg(not(windows))]
+    const SUBSCRIBE_SINK_MIN_INTERVAL: Duration = Duration::from_millis(400);
+    #[cfg(not(windows))]
+    const SUBSCRIBE_SINK_SEND_TIMEOUT: Duration = Duration::from_secs(2);
+    #[cfg(not(windows))]
+    const TRACKED_SET_JUMP_REBUILD_THRESHOLD: usize = 50;
+
     #[cfg(not(windows))]
     async fn start_account_impl(self) -> Result<()> {
         enum SessionExit {
@@ -819,6 +839,7 @@ impl GeyserAccountListener {
         // rebuild per interval; other updates use in-place subscribe (same as small sets).
         const LARGE_TRACKED_SUBSCRIBE_REBUILD_MIN_INTERVAL: Duration = Duration::from_secs(5);
         let mut last_large_set_subscription_rebuild: Option<Instant> = None;
+        let mut last_tracked_subscription_change: Option<Instant> = None;
 
         geyser_metrics_set_account_session_connected(false);
 
@@ -875,21 +896,60 @@ impl GeyserAccountListener {
                 let subscription_notify = Arc::new(Notify::new());
                 let pending_for_updater = Arc::clone(&pending_subscription_request);
                 let notify_for_updater = Arc::clone(&subscription_notify);
+                let sink_fail_notify = Arc::new(Notify::new());
+                let sink_fail_reader = Arc::clone(&sink_fail_notify);
+                let sink_fail_updater = Arc::clone(&sink_fail_notify);
                 let subscription_updater_jh = tokio::spawn(async move {
+                    let mut last_send = Instant::now() - Self::SUBSCRIBE_SINK_MIN_INTERVAL;
                     loop {
                         notify_for_updater.notified().await;
-                        let req = match pending_for_updater.lock() {
-                            Ok(mut g) => g.take(),
-                            Err(_) => continue,
-                        };
-                        let Some(req) = req else { continue };
-                        if let Err(e) = subscribe_tx.send(req).await {
-                            warn!(
-                                error = %e,
-                                "geyser_listener: subscription updater failed to push subscribe request (sink gone)"
-                            );
-                            geyser_metrics_inc_reconnect(GeyserReconnectReason::SinkGone);
-                            break;
+                        loop {
+                            let elapsed = last_send.elapsed();
+                            if elapsed < Self::SUBSCRIBE_SINK_MIN_INTERVAL {
+                                geyser_metrics_inc_account_listener_subscribe_sink_throttled();
+                                sleep(Self::SUBSCRIBE_SINK_MIN_INTERVAL - elapsed).await;
+                            }
+                            let req = match pending_for_updater.lock() {
+                                Ok(mut g) => g.take(),
+                                Err(_) => continue,
+                            };
+                            let Some(req) = req else {
+                                break;
+                            };
+                            match tokio::time::timeout(
+                                Self::SUBSCRIBE_SINK_SEND_TIMEOUT,
+                                subscribe_tx.send(req),
+                            )
+                            .await
+                            {
+                                Ok(Ok(())) => {
+                                    last_send = Instant::now();
+                                }
+                                Ok(Err(e)) => {
+                                    warn!(
+                                        error = %e,
+                                        "geyser_listener: subscription updater failed to push subscribe request (sink gone)"
+                                    );
+                                    geyser_metrics_inc_reconnect(GeyserReconnectReason::SinkGone);
+                                    return;
+                                }
+                                Err(_) => {
+                                    geyser_metrics_inc_account_listener_subscribe_sink_backpressure(
+                                    );
+                                    warn!(
+                                        "geyser_listener: subscription sink backpressure (send timeout) — requesting full reconnect"
+                                    );
+                                    sink_fail_updater.notify_one();
+                                    return;
+                                }
+                            }
+                            let has_more = pending_for_updater
+                                .lock()
+                                .map(|g| g.is_some())
+                                .unwrap_or(false);
+                            if !has_more {
+                                break;
+                            }
                         }
                     }
                 });
@@ -901,6 +961,8 @@ impl GeyserAccountListener {
                 );
 
                 let mut got_payload_since_subscribe = false;
+                let mut account_liveness = tokio::time::interval(Duration::from_secs(5));
+                account_liveness.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
                 let session_exit = 'read: loop {
                     if last_log.elapsed().as_secs() >= 60 {
@@ -918,6 +980,23 @@ impl GeyserAccountListener {
                     };
 
                     tokio::select! {
+                        biased;
+                        _ = sink_fail_reader.notified() => {
+                            warn!(
+                                tracked_accounts = tracked_accounts_current.len(),
+                                "geyser_listener: subscription sink backpressure — forcing full reconnect"
+                            );
+                            break 'read SessionExit::HardReconnect;
+                        }
+                        _ = account_liveness.tick() => {
+                            if market_data_take_account_session_reconnect_request() {
+                                warn!(
+                                    "geyser_account_listener: global ingest stall watchdog requested reconnect"
+                                );
+                                geyser_metrics_inc_account_listener_liveness_reconnect_total();
+                                break 'read SessionExit::HardReconnect;
+                            }
+                        }
                         maybe_message = stream.next() => {
                             match maybe_message {
                                 None => {
@@ -1017,6 +1096,7 @@ impl GeyserAccountListener {
                         },
                         new_list = tracked_changed_fut => {
                             if new_list != tracked_accounts_current {
+                                    let prev_len = tracked_accounts_current.len();
                                     let _old_list =
                                         std::mem::replace(&mut tracked_accounts_current, new_list);
                                     if let Some(ref mut cf) = tracked_cuckoo_filter {
@@ -1035,6 +1115,25 @@ impl GeyserAccountListener {
                                     let threshold = full_reconnect_tracked_threshold
                                         .load(Ordering::Relaxed);
                                     let now = Instant::now();
+                                    let new_len = tracked_accounts_current.len();
+                                    let jump = new_len.saturating_sub(prev_len);
+                                    if jump > Self::TRACKED_SET_JUMP_REBUILD_THRESHOLD
+                                        && last_tracked_subscription_change
+                                            .map(|t| {
+                                                now.saturating_duration_since(t)
+                                                    < Duration::from_secs(1)
+                                            })
+                                            .unwrap_or(true)
+                                    {
+                                        last_tracked_subscription_change = Some(now);
+                                        info!(
+                                            tracked_accounts = new_len,
+                                            jump,
+                                            "geyser_listener: tracked set jump — forcing full reconnect (skip in-place subscribe)"
+                                        );
+                                        break 'read SessionExit::SubscriptionRebuild;
+                                    }
+                                    last_tracked_subscription_change = Some(now);
                                     let over_threshold =
                                         tracked_accounts_current.len() > threshold;
                                     let allow_full_rebuild = over_threshold
@@ -1057,9 +1156,10 @@ impl GeyserAccountListener {
                                         &program_ids,
                                         tracked_cuckoo_filter.as_mut(),
                                     );
-                                    if let Ok(mut g) = pending_subscription_request.lock() {
-                                        *g = Some(updated_request);
-                                    }
+                                    Self::coalesce_pending_subscription(
+                                        &pending_subscription_request,
+                                        updated_request,
+                                    );
                                     subscription_notify.notify_one();
                                     geyser_metrics_inc_account_listener_subscribe_updates_total();
                                     warn!(
@@ -1104,7 +1204,9 @@ impl GeyserAccountListener {
 mod geyser_resilience_tests {
     use super::{
         build_account_subscribe_request, build_tx_subscribe_request, geyser_reconnect_sleep_ms,
+        GeyserAccountListener,
     };
+    use std::sync::Mutex;
     use yellowstone_grpc_proto::cuckoo::CompressedAccountFilterSet;
 
     #[test]
@@ -1124,6 +1226,19 @@ mod geyser_resilience_tests {
         let req = build_account_subscribe_request(std::slice::from_ref(&pk), None);
         assert!(req.transactions.is_empty());
         assert!(!req.accounts.is_empty());
+    }
+
+    #[test]
+    fn subscribe_request_coalesce_latest_wins() {
+        use yellowstone_grpc_proto::prelude::SubscribeRequest;
+        let pending = Mutex::new(None::<SubscribeRequest>);
+        let pk = solana_sdk::pubkey::Pubkey::new_from_array([1u8; 32]);
+        let req_a = build_account_subscribe_request(std::slice::from_ref(&pk), None);
+        let req_b = build_account_subscribe_request(&[], None);
+        GeyserAccountListener::coalesce_pending_subscription(&pending, req_a);
+        GeyserAccountListener::coalesce_pending_subscription(&pending, req_b);
+        let taken = pending.lock().unwrap().take().expect("pending req");
+        assert!(taken.accounts.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Global ingest stall detector (TX + account + head slot) with TX/account session reconnect and exit(1) recovery; consolidates PR165/166 watchdogs
- Harden account subscription updater: coalesce, 400ms rate limit, 2s send timeout → HardReconnect on backpressure; startup tracked-set jump rebuild
- Startup geyser sync debounce min 250ms; deferred TX worker for reserve register and geyser sync schedule; reduced lock scope in TX handler

## Prod context
After PR166 deploy, entire ingest freezes ~3s after restart (all counters + head slot flat, geyser recv/send backpressure). PR167 targets root cause, not another partial watchdog.

## Test plan
- [ ] CI green including Eval (Level 5)
- [ ] Bugbot review
- [ ] Prod smoke >5 min: tx_handler, account_listener, head_slot rising; NATS Trade > 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core Geyser ingest liveness, subscription updates, and TX-handler scheduling for market-data; mis-tuned thresholds could cause false reconnects or restarts in production.
> 
> **Overview**
> Addresses **total market-data ingest freeze** shortly after restart (TX handler, account updates, and head slot all flat) by treating it as a **runtime/scheduling collapse** under startup subscription bursts—not only a partial TX stall.
> 
> **Global ingest recovery** replaces the separate PR165 Tokio- and PR166 TX-only watchdogs with one detector: if TX processed count, account listener updates, and Geyser head slot are all unchanged for ~50s (after startup grace), it increments `market_data_global_ingest_stalls_total`, requests **reconnect on both TX and account** Geyser sessions, then **`exit(1)`** if still stalled so systemd can restart.
> 
> **Geyser account subscription path** is hardened: pending subscribe requests **coalesce** (latest wins), sends are **rate-limited** (~400ms) with a **2s timeout** that triggers **hard reconnect** instead of blocking the updater on `subscribe_tx.send().await`; large tracked-set jumps (>50 in 1s) force a **subscription rebuild**.
> 
> **TX hot path** defers heavy side effects to a **bounded FIFO worker** (Geyser sync schedule, reserve registration after trades), uses **tighter lock scope** around `pool_mint_map` writes before awaits, and applies a **longer Geyser sync debounce** during the first 120s of startup (min 250ms). New metrics cover global stalls, deferred-queue drops, and subscription sink throttle/backpressure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 027e740126a74b0ea28451f763f73dd67ce3122a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->