### PR TITLE
fix(momentum): PR170 — trade ingest gap forensics for active pool trackers

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,13 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### PR170-MOMENTUM-TRADE-INGEST-GAP: Active-Pool Tracker Forensics + False Bot-Concentration Reject
+**Datum**: 2026-05-30  
+**Problem** (Prod XHAT `Eyav991r…pump`, 2026-05-30 14:00–14:05 UTC): market-data JSONL zeigte 99+ Buys / 15+ distinct Buyers im Pump-Fenster; momentum blieb bei `buyers 2 < 3` ohne Logs während des Pumps. Tracker existierte (Dev-Sell/CTO sichtbar), Eval aber stumm.  
+**Root Cause**: `REJECT_BOT_CONCENTRATION` feuerte ohne `min_samples`-Guard (im Gegensatz zu `REJECT_MICRO_BUY_SPAM`) — bei 2–4 frühen Buys oft 100% top1 → terminal `Rejected` → `check_for_signals` skippt (`is_entry_complete`) → keine `WAIT_BUYER_WINDOW`-Logs trotz weiterer MD-Trades; nach 5-Min-Cleanup Re-Discovery mit leerem Tracker. Zusätzlich: `MomentumContext::record_trade` no-op ohne Tracker ohne Metrik/Log.  
+**Fix** (PR170): (1) Buyer-Quality-Reject nur wenn `unique_buyers >= min_unique_buyers.max(5)` (gleiches Pattern wie Micro-Buy-Spam). (2) Prometheus: `momentum_tracker_trades_recorded_total`, `momentum_trades_received_no_tracker_total`, `momentum_tracker_rejected_*_total`. (3) `warn!` bei jedem `TokenTracker::reject`, rate-limited warn bei Trade ohne Tracker, cleanup log mit `trade_count`/`state`, debug ingest sample alle 50 Trades. (4) Unit-Tests: 5-Buyer-Fenster, trade-discovery, CTO+10-Buyer-Regression. **Invarianten**: I-7 (kein RPC), I-12 (Reject/Removal sichtbar), keine Schwellen-Tuning-Änderung an `min_unique_buyers`/`buyer_window_secs`.  
+**Dateien**: `src/bin/momentum_bot.rs`, `src/metrics.rs`, `docs/BUGS_FIXES.md`
+
 ### PHASE-R-R4B-ACCOUNT-WORKERS-DISCOVERY-DEFER: Account Workers 2 + LivePoolCache off Ingest
 **Datum**: 2026-05-30  
 **Problem** (Prod post-R4 `1d963ae`, Soak FAIL): TX-Stopp ~20 s (besser als R3 ~3 s, reicht nicht); Teil-Freeze — Account + Head leben, aber `md-sidefx` jobs Δ0 bei Queue ~385 und `md-state` jobs Δ0 bei Queue ~703 (Lock-Deadlock/Convoy mit 8 Account-Workern + schwerem Account-Handler: `live_pool_cache` writes, Discovery-Publish, `.await` auf Publish-Pfad).  

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -25,6 +25,7 @@
 
 use anyhow::Result;
 use clap::Parser;
+use once_cell::sync::Lazy;
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -52,7 +53,9 @@ use ironcrab::metrics::{
     record_momentum_core_market_events_received_kind, record_momentum_ingest_to_process_us,
     record_momentum_market_events_last_applied_slot,
     record_momentum_market_events_subscription_max_dequeued_slot,
-    record_momentum_nats_batch_prepare_us, record_momentum_signal_eval_us, serve_metrics,
+    record_momentum_nats_batch_prepare_us, record_momentum_signal_eval_us,
+    record_momentum_tracker_rejected, record_momentum_tracker_trades_recorded,
+    record_momentum_trades_received_no_tracker, serve_metrics,
     set_momentum_bot_process_start_unix_sec,
     set_momentum_market_events_ingest_max_wall_lag_ms_last_batch, set_readiness_nats_connected,
     try_record_momentum_event_to_ingest_ms, try_record_momentum_event_to_intent_publish_ms,
@@ -114,6 +117,15 @@ const ORPHANED_RECOVERED_INTENT_IDS_CAP: usize = 50_000;
 const MOMENTUM_ACTIVE_POOLS_WIRE_VERSION: u32 = 1;
 /// Discovery/Validation trackers without a trade for this long are dropped (PR-D plan #4).
 const MOMENTUM_STALE_DISCOVERY_SECS: u64 = 30 * 60;
+
+/// Rate-limit `trade without tracker` warnings (per mint+pool).
+const MOMENTUM_NO_TRACKER_WARN_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// Emit `debug!` ingest forensics every N trades on an active (non-rejected) tracker row.
+const MOMENTUM_TRACKER_TRADE_INGEST_DEBUG_EVERY: usize = 50;
+
+static MOMENTUM_NO_TRACKER_WARN_LAST: Lazy<parking_lot::Mutex<HashMap<String, Instant>>> =
+    Lazy::new(|| parking_lot::Mutex::new(HashMap::new()));
 
 #[derive(Debug, Default)]
 struct MomentumActivePoolPublishQueue {
@@ -1820,9 +1832,19 @@ impl TokenTracker {
 
     /// Transition to Rejected state with reason
     fn reject(&mut self, reason: impl Into<String>) {
+        let reason = reason.into();
         self.last_wait_filter_obs_key = None;
         self.state = TrackerState::Rejected;
-        self.blacklist_reason = Some(reason.into());
+        self.blacklist_reason = Some(reason.clone());
+        record_momentum_tracker_rejected(reason.as_str());
+        warn!(
+            mint = %self.mint,
+            pool = %self.pool,
+            dex = %self.dex,
+            reason = %reason,
+            trade_count = self.trades.len(),
+            "Tracker rejected (terminal)"
+        );
     }
 
     /// Check if tracker was previously not rejected (for metrics)
@@ -2488,49 +2510,53 @@ impl TokenTracker {
             return (false, reason);
         }
 
-        // Filter 2b: Buyer Quality (anti-bot / concentration)
+        // Filter 2b: Buyer Quality (anti-bot / concentration) — same min_samples guard as micro-buy spam
+        // so early pumps with few buyers cannot false-reject and silence entry eval (PR170).
         let bq = self.buyer_quality_stats_at(config, chain_head_slot);
+        let buyer_quality_min_samples = config.min_unique_buyers.max(5);
 
-        if bq.top1_share > config.top1_buyer_share_cap {
-            FILTER_REJECTED_BUYER_QUALITY.fetch_add(1, Ordering::Relaxed);
-            FILTER_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
-            let reason = format!(
-                "REJECT_BOT_CONCENTRATION: top1 share {:.0}% > {:.0}% (buyers={}, buy_vol={:.2} SOL)",
-                bq.top1_share * 100.0,
-                config.top1_buyer_share_cap * 100.0,
-                bq.unique_buyers,
-                bq.total_buy_volume_lamports as f64 / 1_000_000_000.0
-            );
-            self.reject(reason.clone());
-            return (false, reason);
-        }
+        if bq.unique_buyers >= buyer_quality_min_samples {
+            if bq.top1_share > config.top1_buyer_share_cap {
+                FILTER_REJECTED_BUYER_QUALITY.fetch_add(1, Ordering::Relaxed);
+                FILTER_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                let reason = format!(
+                    "REJECT_BOT_CONCENTRATION: top1 share {:.0}% > {:.0}% (buyers={}, buy_vol={:.2} SOL)",
+                    bq.top1_share * 100.0,
+                    config.top1_buyer_share_cap * 100.0,
+                    bq.unique_buyers,
+                    bq.total_buy_volume_lamports as f64 / 1_000_000_000.0
+                );
+                self.reject(reason.clone());
+                return (false, reason);
+            }
 
-        if bq.top3_share > config.top3_buyer_share_cap {
-            FILTER_REJECTED_BUYER_QUALITY.fetch_add(1, Ordering::Relaxed);
-            FILTER_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
-            let reason = format!(
-                "REJECT_BOT_CONCENTRATION: top3 share {:.0}% > {:.0}% (buyers={}, buy_vol={:.2} SOL)",
-                bq.top3_share * 100.0,
-                config.top3_buyer_share_cap * 100.0,
-                bq.unique_buyers,
-                bq.total_buy_volume_lamports as f64 / 1_000_000_000.0
-            );
-            self.reject(reason.clone());
-            return (false, reason);
-        }
+            if bq.top3_share > config.top3_buyer_share_cap {
+                FILTER_REJECTED_BUYER_QUALITY.fetch_add(1, Ordering::Relaxed);
+                FILTER_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                let reason = format!(
+                    "REJECT_BOT_CONCENTRATION: top3 share {:.0}% > {:.0}% (buyers={}, buy_vol={:.2} SOL)",
+                    bq.top3_share * 100.0,
+                    config.top3_buyer_share_cap * 100.0,
+                    bq.unique_buyers,
+                    bq.total_buy_volume_lamports as f64 / 1_000_000_000.0
+                );
+                self.reject(reason.clone());
+                return (false, reason);
+            }
 
-        if bq.repeat_buyer_ratio < config.repeat_buyer_min_ratio {
-            FILTER_REJECTED_BUYER_QUALITY.fetch_add(1, Ordering::Relaxed);
-            FILTER_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
-            let reason = format!(
-                "REJECT_BOT_CONCENTRATION: repeat buyer ratio {:.0}% < {:.0}% (buyers={}, buy_vol={:.2} SOL)",
-                bq.repeat_buyer_ratio * 100.0,
-                config.repeat_buyer_min_ratio * 100.0,
-                bq.unique_buyers,
-                bq.total_buy_volume_lamports as f64 / 1_000_000_000.0
-            );
-            self.reject(reason.clone());
-            return (false, reason);
+            if bq.repeat_buyer_ratio < config.repeat_buyer_min_ratio {
+                FILTER_REJECTED_BUYER_QUALITY.fetch_add(1, Ordering::Relaxed);
+                FILTER_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                let reason = format!(
+                    "REJECT_BOT_CONCENTRATION: repeat buyer ratio {:.0}% < {:.0}% (buyers={}, buy_vol={:.2} SOL)",
+                    bq.repeat_buyer_ratio * 100.0,
+                    config.repeat_buyer_min_ratio * 100.0,
+                    bq.unique_buyers,
+                    bq.total_buy_volume_lamports as f64 / 1_000_000_000.0
+                );
+                self.reject(reason.clone());
+                return (false, reason);
+            }
         }
 
         // Filter 3: SOL Inflow
@@ -4569,6 +4595,25 @@ impl MomentumContext {
         }
     }
 
+    fn maybe_warn_trade_without_tracker(mint: &str, pool: &str, is_buy: bool) {
+        let dedupe_key = format!("{mint}\x1f{pool}");
+        let now = Instant::now();
+        let mut last = MOMENTUM_NO_TRACKER_WARN_LAST.lock();
+        let should_warn = last
+            .get(&dedupe_key)
+            .map(|t| now.duration_since(*t) >= MOMENTUM_NO_TRACKER_WARN_COOLDOWN)
+            .unwrap_or(true);
+        if should_warn {
+            last.insert(dedupe_key, now);
+            warn!(
+                mint = %mint,
+                pool = %pool,
+                is_buy,
+                "Trade received but no pool-scoped tracker row (discovery guard or pool key mismatch)"
+            );
+        }
+    }
+
     /// Record a trade for a token **on a specific pool** (pool-scoped tracker row).
     #[allow(clippy::too_many_arguments)] // MarketEvent trade fields — keep explicit for hot path clarity
     fn record_trade(
@@ -4581,13 +4626,14 @@ impl MomentumContext {
         token_amount: u64,
         signature: &str,
         trade_slot: u64,
-    ) {
+    ) -> bool {
         let _rt = MomentumRecordTradeTimer(Instant::now());
         let config = self.config.read().clone();
+        let head_slot = self.last_event_slot.load(Ordering::Relaxed);
         let mut trackers = self.token_trackers.write();
         let key = Self::tracker_storage_key(mint, pool);
         let mut sync_sibling_dev_sell_early = false;
-        if let Some(tracker) = trackers.get_mut(&key) {
+        let recorded = if let Some(tracker) = trackers.get_mut(&key) {
             let was_not_rejected = tracker.was_not_rejected();
             tracker.record_trade(
                 trader,
@@ -4598,6 +4644,7 @@ impl MomentumContext {
                 trade_slot,
                 &config,
             );
+            record_momentum_tracker_trades_recorded();
             if was_not_rejected && tracker.is_rejected() {
                 self.record_token_blacklisted_once(mint);
                 let reason = tracker.blacklist_reason.as_deref().unwrap_or("rejected");
@@ -4605,13 +4652,33 @@ impl MomentumContext {
             }
             sync_sibling_dev_sell_early =
                 tracker.blacklist_reason.as_deref() == Some("REJECT_DEV_SELL_EARLY");
-        }
+            if !tracker.is_rejected()
+                && tracker
+                    .trades
+                    .len()
+                    .is_multiple_of(MOMENTUM_TRACKER_TRADE_INGEST_DEBUG_EVERY)
+            {
+                let metrics = tracker.calculate_metrics(&config, head_slot);
+                debug!(
+                    mint = %mint,
+                    pool = %pool,
+                    trades_len = tracker.trades.len(),
+                    unique_buyers_in_window = metrics.unique_buyers_in_window,
+                    head_slot,
+                    "Tracker trade ingest sample"
+                );
+            }
+            true
+        } else {
+            record_momentum_trades_received_no_tracker();
+            false
+        };
         self.mark_entry_eval_dirty_key(&key);
         // Same-mint sibling pools: one pool's dev-sell-early reject must apply to all pool rows
         // (Trade event is per-pool; mint-wide creator was applied before `record_trade`).
         if sync_sibling_dev_sell_early {
             let Some(source_dev) = trackers.get(&key).and_then(|t| t.dev_wallet.clone()) else {
-                return;
+                return recorded;
             };
             let sibling_keys =
                 self.sibling_tracker_storage_keys_same_mint_excluding_pool(mint, pool, &trackers);
@@ -4639,6 +4706,7 @@ impl MomentumContext {
                 self.mark_entry_eval_dirty_key(&sk);
             }
         }
+        recorded
     }
 
     /// Record dev info for a token
@@ -5088,7 +5156,7 @@ impl MomentumContext {
         let open_mints: std::collections::HashSet<_> =
             self.positions.read().keys().cloned().collect();
         let cutoff = Duration::from_secs(300); // 5 minutes
-        let pruned: Vec<(String, String)> = {
+        let pruned: Vec<(String, String, usize, String)> = {
             let trackers = self.token_trackers.read();
             trackers
                 .values()
@@ -5097,10 +5165,25 @@ impl MomentumContext {
                         && tracker.first_seen.elapsed() >= cutoff
                         && tracker.state.is_terminal()
                 })
-                .map(|t| (t.mint.clone(), t.pool.clone()))
+                .map(|t| {
+                    (
+                        t.mint.clone(),
+                        t.pool.clone(),
+                        t.trades.len(),
+                        format!("{:?}", t.state),
+                    )
+                })
                 .collect()
         };
-        for (mint, pool) in &pruned {
+        for (mint, pool, trade_count, state) in &pruned {
+            warn!(
+                mint = %mint,
+                pool = %pool,
+                reason = "tracker_cleanup",
+                trade_count,
+                state = %state,
+                "Removing terminal pool-scoped tracker (5m TTL)"
+            );
             self.queue_momentum_active_pool_removed(mint, pool.as_str(), "tracker_cleanup");
         }
         let mut trackers = self.token_trackers.write();
@@ -12063,6 +12146,265 @@ mod tests {
     }
 
     #[test]
+    fn pr170_tracker_records_five_distinct_buyers_in_window() {
+        let mut cfg = MomentumConfig::default();
+        cfg.buyer_window_secs = 120;
+        cfg.early_min_liquidity_sol = 0.0;
+        cfg.min_unique_buyers = 0;
+        cfg.min_trades_per_min = 0.0;
+        cfg.min_buy_dominance = 0.0;
+        cfg.min_sol_inflow_lamports = 0;
+        cfg.require_mint_authority_renounced = false;
+        cfg.require_freeze_authority_none = false;
+        cfg.top1_buyer_share_cap = 1.0;
+        cfg.top3_buyer_share_cap = 1.0;
+        cfg.repeat_buyer_min_ratio = 0.0;
+        cfg.min_trade_size_lamports = 0;
+        cfg.small_buy_ratio_cap = 1.0;
+        cfg.dump_recovery_window_secs = 0;
+        cfg.cto_enabled = false;
+
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = empty_test_context(jsonl_writer);
+        *ctx.config.write() = cfg.clone();
+
+        let mint = "MintPr170Buyers111111111111111111111111111";
+        let pool = "poolPr170Buyers11111111111111111111111111";
+        assert!(ctx.get_or_create_tracker(mint, pool, "pumpfun", 100, 30_000_000_000));
+
+        let head = 200u64;
+        ctx.last_event_slot.store(head, Ordering::Relaxed);
+        for i in 0..5 {
+            assert!(ctx.record_trade(
+                mint,
+                pool,
+                &format!("buyer{i}"),
+                true,
+                50_000_000,
+                1_000_000,
+                &format!("sig{i}"),
+                head.saturating_sub(i as u64),
+            ));
+        }
+
+        let metrics = ctx
+            .token_trackers
+            .read()
+            .get(&MomentumContext::tracker_storage_key(mint, pool))
+            .expect("tracker")
+            .calculate_metrics(&cfg, head);
+        assert_eq!(metrics.unique_buyers_in_window, 5);
+    }
+
+    #[test]
+    fn pr170_trade_based_discovery_records_first_buy() {
+        let mut cfg = MomentumConfig::default();
+        cfg.cto_enabled = false;
+
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = Arc::new(empty_test_context(jsonl_writer));
+        *ctx.config.write() = cfg;
+
+        let mint = "MintPr170Disc1111111111111111111111111111";
+        let pool = "poolPr170Disc111111111111111111111111111";
+        let evt = MarketEvent {
+            header: RecordHeader::new("test", BUILD_VERSION, "run"),
+            event_id: "ev-pr170-disc".into(),
+            source: "geyser".into(),
+            slot: Some(50),
+            kind: MarketEventKind::Trade {
+                pool_address: pool.to_string(),
+                mint: mint.to_string(),
+                quote_mint: WSOL_MINT.to_string(),
+                trader: "buyer0".to_string(),
+                is_buy: true,
+                sol_amount: 10_000_000,
+                token_amount: 1,
+                token_decimals: 6,
+                signature: Some("sig0".into()),
+                dex: "pumpfun".into(),
+                creator: None,
+                token_program: None,
+            },
+        };
+
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            process_market_event(&ctx, &evt, true)
+                .await
+                .expect("trade discovery");
+        });
+
+        let tk = MomentumContext::tracker_storage_key(mint, pool);
+        let trackers = ctx.token_trackers.read();
+        let tr = trackers.get(&tk).expect("tracker row");
+        assert_eq!(tr.trades.len(), 1);
+    }
+
+    #[test]
+    fn pr170_reject_logs_terminal_state_and_reason() {
+        let mut cfg = MomentumConfig::default();
+        cfg.max_single_dump_lamports = 1;
+
+        let mut tracker = TokenTracker::new("m", "p", "pumpfun", 1, 30_000_000_000);
+        tracker.record_trade("dumper", false, 5_000_000_000, 1, "sig", 10, &cfg);
+        assert!(tracker.is_rejected());
+        assert!(tracker
+            .blacklist_reason
+            .as_deref()
+            .unwrap_or("")
+            .contains("Large dump"));
+    }
+
+    #[test]
+    fn pr170_bot_concentration_waits_with_few_buyers_not_terminal_reject() {
+        let mut cfg = MomentumConfig::default();
+        cfg.early_min_liquidity_sol = 0.0;
+        cfg.min_unique_buyers = 3;
+        cfg.min_trades_per_min = 0.0;
+        cfg.min_buy_dominance = 0.0;
+        cfg.min_sol_inflow_lamports = 0;
+        cfg.require_mint_authority_renounced = false;
+        cfg.require_freeze_authority_none = false;
+        cfg.top1_buyer_share_cap = 0.30;
+        cfg.top3_buyer_share_cap = 1.0;
+        cfg.repeat_buyer_min_ratio = 0.0;
+        cfg.min_trade_size_lamports = 0;
+        cfg.small_buy_ratio_cap = 1.0;
+        cfg.dump_recovery_window_secs = 0;
+        cfg.cto_enabled = false;
+
+        let mut tracker = TokenTracker::new("m", "p", "pumpfun", 100, 30_000_000_000);
+        tracker.record_trade("whale", true, 900_000_000, 1, "s0", 150, &cfg);
+        tracker.record_trade("retail", true, 50_000_000, 1, "s1", 151, &cfg);
+
+        let (ok, reason) = tracker.should_generate_intent(&cfg, None, 200, Instant::now());
+        assert!(!ok);
+        assert!(!tracker.is_rejected(), "must not false-reject: {reason}");
+        assert!(reason.contains("WAIT_BUYER_WINDOW"), "{reason}");
+    }
+
+    #[test]
+    fn pr170_xhat_style_cto_pump_accumulates_ten_buyers() {
+        let mut cfg = MomentumConfig::default();
+        cfg.early_min_liquidity_sol = 0.0;
+        cfg.min_unique_buyers = 3;
+        cfg.min_trades_per_min = 0.0;
+        cfg.min_buy_dominance = 0.0;
+        cfg.min_sol_inflow_lamports = 0;
+        cfg.require_mint_authority_renounced = false;
+        cfg.require_freeze_authority_none = false;
+        cfg.top1_buyer_share_cap = 0.95;
+        cfg.top3_buyer_share_cap = 1.0;
+        cfg.repeat_buyer_min_ratio = 0.0;
+        cfg.min_trade_size_lamports = 0;
+        cfg.small_buy_ratio_cap = 1.0;
+        cfg.dump_recovery_window_secs = 0;
+        cfg.cto_enabled = true;
+        cfg.cto_entry_delay_secs = 0;
+        cfg.cto_min_unique_buyers = 3;
+        cfg.dev_early_sell_window_secs = 3600;
+
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = Arc::new(empty_test_context(jsonl_writer));
+        *ctx.config.write() = cfg.clone();
+
+        let mint = "MintPr170Xhat1111111111111111111111111111";
+        let pool = "poolPr170Xhat111111111111111111111111111";
+        let dev = "DevWalletPr170Xhat1111111111111111111111";
+        let head = 140u64;
+        ctx.last_event_slot.store(head, Ordering::Relaxed);
+
+        assert!(ctx.get_or_create_tracker(mint, pool, "pumpfun", 100, 30_000_000_000));
+        {
+            let mut trackers = ctx.token_trackers.write();
+            let tr = trackers
+                .get_mut(&MomentumContext::tracker_storage_key(mint, pool))
+                .expect("tracker");
+            tr.set_dev_info(dev, 1.0, &cfg);
+        }
+
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            let dev_sell = MarketEvent {
+                header: RecordHeader::new("test", BUILD_VERSION, "run"),
+                event_id: "ev-dev-sell".into(),
+                source: "geyser".into(),
+                slot: Some(110),
+                kind: MarketEventKind::Trade {
+                    pool_address: pool.to_string(),
+                    mint: mint.to_string(),
+                    quote_mint: WSOL_MINT.to_string(),
+                    trader: dev.to_string(),
+                    is_buy: false,
+                    sol_amount: 100_000_000,
+                    token_amount: 1,
+                    token_decimals: 6,
+                    signature: Some("sig-dev".into()),
+                    dex: "pumpfun".into(),
+                    creator: Some(dev.to_string()),
+                    token_program: None,
+                },
+            };
+            process_market_event(&ctx, &dev_sell, true)
+                .await
+                .expect("dev sell");
+
+            for i in 0..10 {
+                let buy = MarketEvent {
+                    header: RecordHeader::new("test", BUILD_VERSION, "run"),
+                    event_id: format!("ev-buy-{i}"),
+                    source: "geyser".into(),
+                    slot: Some(120 + i),
+                    kind: MarketEventKind::Trade {
+                        pool_address: pool.to_string(),
+                        mint: mint.to_string(),
+                        quote_mint: WSOL_MINT.to_string(),
+                        trader: format!("pumpBuyer{i}"),
+                        is_buy: true,
+                        sol_amount: 20_000_000,
+                        token_amount: 1,
+                        token_decimals: 6,
+                        signature: Some(format!("sig-buy-{i}")),
+                        dex: "pumpfun".into(),
+                        creator: Some(dev.to_string()),
+                        token_program: None,
+                    },
+                };
+                process_market_event(&ctx, &buy, true)
+                    .await
+                    .expect("pump buy");
+            }
+        });
+
+        let trackers = ctx.token_trackers.read();
+        let tr = trackers
+            .get(&MomentumContext::tracker_storage_key(mint, pool))
+            .expect("tracker");
+        assert!(
+            !tr.is_rejected(),
+            "CTO pump must not false-reject on bot concentration: {:?}",
+            tr.blacklist_reason
+        );
+        let metrics = tr.calculate_metrics(&cfg, head);
+        let trades_len = tr.trades.len();
+        let buyers = metrics.unique_buyers_in_window;
+        drop(trackers);
+        assert!(
+            buyers >= 10,
+            "buyers in window {} trades_len {}",
+            buyers,
+            trades_len
+        );
+    }
+
+    #[test]
     fn micro_buy_spam_rejects_when_ratio_too_high() {
         let mut cfg = MomentumConfig::default();
         cfg.buyer_window_secs = 60;
@@ -16999,6 +17341,7 @@ async fn process_market_event(
                     })
                 };
 
+            let mut discovery_created = false;
             if !tracker_exists
                 && *sol_amount > 0
                 && (*is_buy || is_dev)
@@ -17032,10 +17375,10 @@ async fn process_market_event(
                     0
                 };
 
-                let created =
+                discovery_created =
                     ctx.get_or_create_tracker(mint, pool_address, &dex, slot, initial_liq_lamports);
 
-                if created {
+                if discovery_created {
                     // A.2 Phase 5: Explicitly register pool when discovered via trade
                     ctx.register_pool(mint, pool_address, &dex, slot);
                     let tk = MomentumContext::tracker_storage_key(mint, pool_address);
@@ -17108,7 +17451,7 @@ async fn process_market_event(
                 }
             }
 
-            ctx.record_trade(
+            let recorded = ctx.record_trade(
                 mint,
                 pool_address,
                 trader,
@@ -17118,6 +17461,9 @@ async fn process_market_event(
                 &sig,
                 event.slot.unwrap_or(0),
             );
+            if !recorded && !discovery_created {
+                MomentumContext::maybe_warn_trade_without_tracker(mint, pool_address, *is_buy);
+            }
 
             // P1: If Trade event carries token_program (from PumpFun Geyser parsing), cache it.
             // This enables deterministic ATA creation without waiting for TokenMintInfo event.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1610,7 +1610,7 @@ pub fn record_momentum_tracker_rejected(reason: &str) {
         MOMENTUM_TRACKER_REJECTED_MINT_AUTHORITY_TOTAL.fetch_add(1, Ordering::Relaxed);
     } else if reason.starts_with("REJECT_PUMPFUN_BONDING_COMPLETE") {
         MOMENTUM_TRACKER_REJECTED_PUMPFUN_BONDING_COMPLETE_TOTAL.fetch_add(1, Ordering::Relaxed);
-    } else if reason.starts_with("Dev holds too much") {
+    } else if reason.starts_with("REJECT_DEV_SUPPLY_TOO_HIGH") {
         MOMENTUM_TRACKER_REJECTED_DEV_SUPPLY_TOTAL.fetch_add(1, Ordering::Relaxed);
     } else if reason.starts_with("Large dump detected") {
         MOMENTUM_TRACKER_REJECTED_LARGE_DUMP_TOTAL.fetch_add(1, Ordering::Relaxed);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1560,6 +1560,65 @@ pub fn record_momentum_entry_buy_suppressed_missing_creator() {
     MOMENTUM_ENTRY_BUY_SUPPRESSED_MISSING_CREATOR_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+// PR170: tracker trade ingest forensics (static metric names — no dynamic labels).
+pub static MOMENTUM_TRACKER_TRADES_RECORDED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_TRADES_RECEIVED_NO_TRACKER_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_TRACKER_REJECTED_DEV_SELL_EARLY_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_TRACKER_REJECTED_MICRO_BUY_SPAM_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_TRACKER_REJECTED_BOT_CONCENTRATION_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_TRACKER_REJECTED_LP_REMOVED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_TRACKER_REJECTED_MINT_AUTHORITY_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_TRACKER_REJECTED_PUMPFUN_BONDING_COMPLETE_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_TRACKER_REJECTED_DEV_SUPPLY_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_TRACKER_REJECTED_LARGE_DUMP_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_TRACKER_REJECTED_OTHER_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn record_momentum_tracker_trades_recorded() {
+    MOMENTUM_TRACKER_TRADES_RECORDED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_momentum_trades_received_no_tracker() {
+    MOMENTUM_TRADES_RECEIVED_NO_TRACKER_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Maps `TokenTracker::reject` reason strings to low-cardinality Prometheus counters.
+#[inline]
+pub fn record_momentum_tracker_rejected(reason: &str) {
+    if reason.starts_with("REJECT_DEV_SELL_EARLY") {
+        MOMENTUM_TRACKER_REJECTED_DEV_SELL_EARLY_TOTAL.fetch_add(1, Ordering::Relaxed);
+    } else if reason.starts_with("REJECT_MICRO_BUY_SPAM") {
+        MOMENTUM_TRACKER_REJECTED_MICRO_BUY_SPAM_TOTAL.fetch_add(1, Ordering::Relaxed);
+    } else if reason.starts_with("REJECT_BOT_CONCENTRATION") {
+        MOMENTUM_TRACKER_REJECTED_BOT_CONCENTRATION_TOTAL.fetch_add(1, Ordering::Relaxed);
+    } else if reason.starts_with("REJECT_LP_REMOVED") {
+        MOMENTUM_TRACKER_REJECTED_LP_REMOVED_TOTAL.fetch_add(1, Ordering::Relaxed);
+    } else if reason.starts_with("REJECT_MINT_AUTHORITY")
+        || reason.starts_with("REJECT_FREEZE_AUTHORITY")
+    {
+        MOMENTUM_TRACKER_REJECTED_MINT_AUTHORITY_TOTAL.fetch_add(1, Ordering::Relaxed);
+    } else if reason.starts_with("REJECT_PUMPFUN_BONDING_COMPLETE") {
+        MOMENTUM_TRACKER_REJECTED_PUMPFUN_BONDING_COMPLETE_TOTAL.fetch_add(1, Ordering::Relaxed);
+    } else if reason.starts_with("Dev holds too much") {
+        MOMENTUM_TRACKER_REJECTED_DEV_SUPPLY_TOTAL.fetch_add(1, Ordering::Relaxed);
+    } else if reason.starts_with("Large dump detected") {
+        MOMENTUM_TRACKER_REJECTED_LARGE_DUMP_TOTAL.fetch_add(1, Ordering::Relaxed);
+    } else {
+        MOMENTUM_TRACKER_REJECTED_OTHER_TOTAL.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
 // Per-kind counters (static label keys via metric name — no dynamic labels).
 pub static MOMENTUM_CORE_MARKET_EVENTS_RECV_TRADE_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -3272,6 +3331,50 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "momentum_entry_buy_suppressed_missing_creator_total",
         MOMENTUM_ENTRY_BUY_SUPPRESSED_MISSING_CREATOR_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_tracker_trades_recorded_total",
+        MOMENTUM_TRACKER_TRADES_RECORDED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_trades_received_no_tracker_total",
+        MOMENTUM_TRADES_RECEIVED_NO_TRACKER_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_tracker_rejected_dev_sell_early_total",
+        MOMENTUM_TRACKER_REJECTED_DEV_SELL_EARLY_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_tracker_rejected_micro_buy_spam_total",
+        MOMENTUM_TRACKER_REJECTED_MICRO_BUY_SPAM_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_tracker_rejected_bot_concentration_total",
+        MOMENTUM_TRACKER_REJECTED_BOT_CONCENTRATION_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_tracker_rejected_lp_removed_total",
+        MOMENTUM_TRACKER_REJECTED_LP_REMOVED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_tracker_rejected_mint_authority_total",
+        MOMENTUM_TRACKER_REJECTED_MINT_AUTHORITY_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_tracker_rejected_pumpfun_bonding_complete_total",
+        MOMENTUM_TRACKER_REJECTED_PUMPFUN_BONDING_COMPLETE_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_tracker_rejected_dev_supply_total",
+        MOMENTUM_TRACKER_REJECTED_DEV_SUPPLY_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_tracker_rejected_large_dump_total",
+        MOMENTUM_TRACKER_REJECTED_LARGE_DUMP_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_tracker_rejected_other_total",
+        MOMENTUM_TRACKER_REJECTED_OTHER_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "momentum_core_market_events_ingest_consecutive_cap_hit_streak",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Prod incident (XHAT, 2026-05-30): market-data JSONL showed 99+ buys and 15+ distinct buyers during the pump window, while momentum logged `buyers 2 < 3` and went silent after dev-sell/CTO.

## Root cause

`REJECT_BOT_CONCENTRATION` applied without the `min_samples` guard already used by `REJECT_MICRO_BUY_SPAM`. With only 2–4 early buyers, top1 share is often 100% → terminal `Rejected` → `check_for_signals` skips (`is_entry_complete`) → no `WAIT_BUYER_WINDOW` logs while MD keeps publishing. After 5m terminal cleanup, trade-based re-discovery starts with an empty tracker (“buyers 2” artifact).

`MomentumContext::record_trade` was also a silent no-op when no pool-scoped row existed (no metric/log).

## Fix

- Gate buyer-quality rejects behind `unique_buyers >= min_unique_buyers.max(5)` (consistency pattern, not threshold tuning).
- Prometheus: `momentum_tracker_trades_recorded_total`, `momentum_trades_received_no_tracker_total`, `momentum_tracker_rejected_*_total`.
- I-12 forensics: `warn!` on every `TokenTracker::reject`, rate-limited warn on trade-without-tracker, cleanup log with `trade_count`/`state`, debug ingest sample every 50 trades on active rows.

## Tests

- 5 distinct buyers in slot window after `record_trade`
- Trade-based discovery + first buy recorded
- Reject reason persisted on large dump
- Bot concentration waits (no false reject) with 2 buyers
- XHAT-style regression: CTO dev-sell + 10 pump buys → `unique_buyers_in_window >= 10`

## STOP-CHECK

- I-7: no new RPC in hot path
- I-9: unchanged simulation gate
- I-12: reject/removal now mint-visible
- No changes to `min_unique_buyers`, `buyer_window_secs`, or CTO thresholds

## Verification

```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```

Eval (Level 5) to run post-merge on Impl CI or manual workflow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-863691d9-4bf5-4e71-841b-169e637b157a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-863691d9-4bf5-4e71-841b-169e637b157a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

