### PR TITLE
fix(P179): allow scale-in BUY when max_open_positions reached

### DIFF
--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -45,7 +45,7 @@ Component name: `execution-engine`
 | Key | Type | Default | Range | Description |
 |-----|------|---------|-------|-------------|
 | `max_position_size_lamports` | u64 | 500_000_000 | > 0 | Maximum SOL per single position (0.5 SOL) |
-| `max_open_positions` | u32 | 5 | > 0 | Maximum open positions at once |
+| `max_open_positions` | u32 | 5 | > 0 | Maximum open positions at once (new token mints). Momentum scale-in BUYs (`metadata.entry_kind=scale_in`) with an existing LockManager balance on `output_mint` do not count against this limit. |
 | `daily_loss_limit_lamports` | u64 | 5_000_000_000 | > 0 | Daily loss limit before auto-kill (5 SOL) |
 | `max_slippage_bps` | u32 | 500 | 1-10000 | Maximum slippage in basis points (5%) |
 

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -8634,6 +8634,28 @@ fn max_open_positions_buy_gate(
     (passed, details)
 }
 
+/// Scale-in BUY adds to an existing mint position; it must not consume a new `max_open_positions` slot.
+///
+/// Returns skip details when `entry_kind=scale_in` **and** LockManager already tracks a non-zero
+/// balance for `output_mint` (defense-in-depth vs metadata spoofing). Otherwise returns `None` and
+/// the normal [`max_open_positions_buy_gate`] applies.
+fn scale_in_max_open_positions_skip_details(
+    entry_kind: Option<&str>,
+    output_mint: &str,
+    lock_manager: &LockManager,
+) -> Option<String> {
+    if entry_kind != Some("scale_in") {
+        return None;
+    }
+    let existing_balance_raw = lock_manager.available_token_balance(output_mint);
+    if existing_balance_raw == 0 {
+        return None;
+    }
+    Some(format!(
+        "skipped_for_scale_in (does not open new position; existing_balance_raw={existing_balance_raw})"
+    ))
+}
+
 /// After a successful send: `cached_blockhash.slot` minus intent metadata `slot` (Geyser chain position).
 #[inline]
 fn record_execution_slot_lag_at_send_if_applicable(ctx: &ExecutionContext, intent: &TradeIntent) {
@@ -8848,35 +8870,55 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
     // Check 3c: Max open positions (applies to BUY only; SELL exits should remain possible)
     // Authoritative count: LockManager non-zero token balances (A.28). Strategy metadata is kept
     // for observability but must not be the sole enforcement source (Scope 49).
+    // Scale-in BUY (`entry_kind=scale_in`) skips this gate when LockManager already holds the mint
+    // (P179): adds to an existing probe position, does not open a new token mint slot.
     if intent.side == TradeSide::Buy {
-        let metadata_current = intent
-            .metadata
-            .get("current_open_positions")
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(0);
-        let authoritative_current = ctx.get_open_positions();
-        let (passed, details) = max_open_positions_buy_gate(
-            metadata_current,
-            authoritative_current,
-            config.max_open_positions,
-        );
-
-        if !passed {
-            let reason = RejectReason::RiskMaxOpenPositions;
+        let entry_kind = intent.metadata.get("entry_kind").map(|s| s.as_str());
+        if let Some(skip_details) = scale_in_max_open_positions_skip_details(
+            entry_kind,
+            &intent.resources.output_mint,
+            &ctx.lock_manager,
+        ) {
             checks.push(CheckResult {
                 check_name: "max_open_positions".to_string(),
-                passed: false,
-                reason_code: Some(reason.to_string()),
+                passed: true,
+                reason_code: None,
+                details: Some(skip_details),
+            });
+        } else {
+            let metadata_current = intent
+                .metadata
+                .get("current_open_positions")
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or(0);
+            let authoritative_current = ctx.get_open_positions();
+            let (passed, details) = max_open_positions_buy_gate(
+                metadata_current,
+                authoritative_current,
+                config.max_open_positions,
+            );
+
+            if !passed {
+                let reason = RejectReason::RiskMaxOpenPositions;
+                checks.push(CheckResult {
+                    check_name: "max_open_positions".to_string(),
+                    passed: false,
+                    reason_code: Some(reason.to_string()),
+                    details: Some(if entry_kind == Some("scale_in") {
+                        format!("{details}; scale_in_bypass_denied_no_existing_balance")
+                    } else {
+                        details
+                    }),
+                });
+                return emit_rejected_decision(ctx, decision_id, &intent, checks, reason).await;
+            }
+            checks.push(CheckResult {
+                check_name: "max_open_positions".to_string(),
+                passed: true,
+                reason_code: None,
                 details: Some(details),
             });
-            return emit_rejected_decision(ctx, decision_id, &intent, checks, reason).await;
         }
-        checks.push(CheckResult {
-            check_name: "max_open_positions".to_string(),
-            passed: true,
-            reason_code: None,
-            details: Some(details),
-        });
     } else {
         checks.push(CheckResult {
             check_name: "max_open_positions".to_string(),
@@ -11986,9 +12028,9 @@ mod execution_engine_tests {
         pump_amm_hint_pool_cache_usable_for_tx_plan_builder,
         pump_amm_liquidation_quote_timeout_str, pump_amm_pool_market_hint_merge,
         pump_amm_slave_recovery_snapshot, record_pump_amm_hot_path_refresh_after_success,
-        scope48_confirmed_sell_close_decision, sort_route_candidates_by_amount_out,
-        take_next_multi_pool_buildable_fallback_route, try_pump_amm_hot_path_refresh_publish,
-        wait_for_meteora_dlmm_slave_after_recovery,
+        scale_in_max_open_positions_skip_details, scope48_confirmed_sell_close_decision,
+        sort_route_candidates_by_amount_out, take_next_multi_pool_buildable_fallback_route,
+        try_pump_amm_hot_path_refresh_publish, wait_for_meteora_dlmm_slave_after_recovery,
         wait_for_pump_amm_pool_hint_ready_for_tx_plan_builder,
         wait_for_pump_amm_slave_after_recovery, wait_for_pumpfun_bonding_cache_refresh,
         DiscoveryRequestOutcome, PumpAmmHotPathRefreshDecision, RouteCandidate,
@@ -12040,6 +12082,45 @@ mod execution_engine_tests {
         assert!(details.contains("authoritative_current=3"));
         assert!(details.contains("effective_current=3"));
         assert!(details.contains("< max=5"));
+    }
+
+    #[test]
+    fn max_open_positions_gate_skipped_for_scale_in_metadata() {
+        const MINT: &str = "ScaleInMintP179";
+        let lm = LockManager::new(0);
+        lm.set_available_token_balance(MINT.to_string(), 1_000_000);
+        let skip = scale_in_max_open_positions_skip_details(Some("scale_in"), MINT, &lm);
+        assert!(skip.is_some());
+        let details = skip.unwrap();
+        assert!(details.contains("skipped_for_scale_in"));
+        assert!(details.contains("existing_balance_raw=1000000"));
+        let (passed, _) = max_open_positions_buy_gate(10, 10, 5);
+        assert!(
+            !passed,
+            "gate would reject at limit; skip must bypass in process_intent"
+        );
+    }
+
+    #[test]
+    fn max_open_positions_gate_still_rejects_probe_at_limit() {
+        let max_open = 5usize;
+        let (passed, details) = max_open_positions_buy_gate(10, 10, max_open);
+        assert!(!passed);
+        assert!(details.contains("effective_current=10"));
+        let lm = LockManager::new(0);
+        assert!(scale_in_max_open_positions_skip_details(Some("probe"), "AnyMint", &lm).is_none());
+    }
+
+    #[test]
+    fn max_open_positions_gate_scale_in_without_balance_applies_gate() {
+        let lm = LockManager::new(0);
+        assert!(
+            scale_in_max_open_positions_skip_details(Some("scale_in"), "NoBalanceMint", &lm)
+                .is_none()
+        );
+        let (passed, details) = max_open_positions_buy_gate(10, 10, 5);
+        assert!(!passed);
+        assert!(details.contains(">="));
     }
 
     /// Scope 51: timeout log text matches `PUMPSWAP_LIQUIDATION_QUOTE_TIMEOUT_SECS` (45s).


### PR DESCRIPTION
## Summary
- Scale-in BUYs (`metadata.entry_kind=scale_in`) skip the `max_open_positions` risk gate when LockManager already holds a non-zero balance for the target mint (adds to probe position, does not open a new slot).
- Probe and other BUY intents remain limited; scale-in without existing balance still runs the normal gate (spoofing defense).
- Decision records log `skipped_for_scale_in` with existing balance raw amount.

## Prod context
On ironcrab-prod, valid scale-in intents (e.g. `int-225d6bfb-000380`) were rejected with `RISK_MAX_OPEN_POSITIONS` while probe positions stayed probe-only.

## Test plan
- [x] `cargo test -p ironcrab --bin execution-engine` (agent: 43 passed)
- [ ] CI green on PR
- [ ] After deploy: scale-in at position limit no longer shows `RISK_MAX_OPEN_POSITIONS` in execution-engine logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows a risk limit for a specific entry_kind using LockManager balance, which is appropriate but increases exposure on existing positions when at the mint cap.
> 
> **Overview**
> **Momentum scale-in BUYs** no longer hit `RISK_MAX_OPEN_POSITIONS` when the wallet is already at the open-position cap on *other* mints. The execution engine treats `metadata.entry_kind=scale_in` as adding to an existing probe: it **bypasses** the BUY `max_open_positions` check only when **LockManager** reports a non-zero balance on `output_mint` (not strategy metadata alone). Probe and other BUYs still use the existing gate; scale-in without an on-engine balance is rejected as before, with `scale_in_bypass_denied_no_existing_balance` on the decision record. Successful bypasses log `skipped_for_scale_in` with `existing_balance_raw`.
> 
> `docs/CONFIG_SCHEMA.md` documents that scale-in on an existing mint does not consume a new slot. Unit tests cover skip, probe-at-limit, and scale-in-without-balance paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d8291580b73a405920133120400046f1adcd29a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->