### PR TITLE
fix(momentum): window-based buy_dominance/trades_per_min + dev-sell revalidation delay (remove CTO)

### DIFF
--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -130,16 +130,13 @@ Component name: `momentum-bot`
 | `dump_recovery_min_net_inflow_lamports` | u64 | 1_000_000_000 | >= 0 | Minimum net SOL inflow for recovery |
 | `dump_recovery_min_recovery_secs` | u64 | 10 | > 0 | Minimum time after dump before allowing entry |
 
-### CTO Candidate Mode
+### Dev-Sell Re-Validation (pre-entry)
 
 | Key | Type | Default | Range | Description |
 |-----|------|---------|-------|-------------|
-| `cto_enabled` | bool | false | true/false | If true, pre-entry dev sell transitions to CTO_Candidate instead of reject |
-| `cto_entry_delay_secs` | u64 | 30 | > 0 | Delay after dev sell before evaluating recovery |
-| `cto_confirm_window_secs` | u64 | 30 | > 0 | Confirmation window for CTO recovery |
-| `cto_min_unique_buyers` | u64 | 5 | > 0 | Minimum unique buyers for CTO recovery |
-| `cto_min_buy_dominance` | f64 | 0.55 | 0.0-1.0 | Minimum buy dominance for CTO recovery |
-| `cto_min_net_inflow_lamports` | u64 | 1_000_000_000 | >= 0 | Minimum net inflow for CTO recovery |
+| `dev_sell_revalidation_delay_secs` | u64 | 30 | > 0 | Pause after any pre-entry dev sell; standard soft gates must pass on fresh window data after delay |
+
+Deprecated (ignored with warn log): `cto_*`, `dev_early_sell_window_secs`, `dev_rebuy_positive`. Legacy `cto_entry_delay_secs` migrates to `dev_sell_revalidation_delay_secs` (max if both set).
 
 ### Mint Safety Gates
 
@@ -172,14 +169,8 @@ Component name: `momentum-bot`
 | `inflow_window_secs` | u64 | 60 | > 0 | Time window for SOL inflow tracking |
 | `max_single_dump_lamports` | u64 | 20_000_000_000 | > 0 | Max allowed single sell (20 SOL) |
 
-### Filter 4: Dev Behavior
 
-| Key | Type | Default | Range | Description |
-|-----|------|---------|-------|-------------|
-| `dev_early_sell_window_secs` | u64 | 90 | > 0 | Dev sells in first N secs = bad signal |
-| `dev_rebuy_positive` | bool | true | true/false | Dev rebuy is considered positive signal |
-
-### Exit Strategy
+### Mint Safety Gates
 
 | Key | Type | Default | Range | Description |
 |-----|------|---------|-------|-------------|

--- a/docs/MOMENTUM_V2_SPEC.md
+++ b/docs/MOMENTUM_V2_SPEC.md
@@ -8,14 +8,14 @@
 |---------|--------|-------|
 | Two-Phase Entry (Probe + Scale-In) | ✅ | `probe_buy_pct`, `scale_in_confirm_window_secs` |
 | Explicit State Machine | ✅ | `TrackerState` enum with 7 states |
-| Reason Codes | ✅ | `REJECT_*`, `WAIT_*`, `EXIT_*`, `CTO_*` |
+| Reason Codes | ✅ | `REJECT_*`, `WAIT_*`, `EXIT_*` |
 | fill_in/fill_out Position Accounting | ✅ | From `ExecutionResult` |
 | DexPoolAccounts (14 accounts) | ✅ | PumpSwap deterministic routing |
 | TokenMintInfo Gates | ✅ | `mint_authority`, `freeze_authority` |
-| CTO Mode | ✅ | `cto_enabled`, recovery confirmation |
+| Dev-Sell Re-Validation | ✅ | `dev_sell_revalidation_delay_secs`, `WAIT_DEV_SELL_REVALIDATION` |
 | Buyer Quality / Anti-Bot | ✅ | `top1_buyer_share_cap`, `small_buy_ratio_cap` |
 | Exit Policies | ✅ | `hard_stop`, `trailing_stop`, `take_profit`, `max_hold_time` |
-| Dev Sell Detection | ✅ | Pre-entry reject, post-entry exit |
+| Dev Sell Detection | ✅ | Pre-entry WAIT + revalidation, post-entry exit |
 | LP Removal Detection | ✅ | `REJECT_LP_REMOVED` |
 | PendingIntent Tracking | ✅ | Correlation via `intent_id` |
 
@@ -118,7 +118,7 @@ Discovery → Validation → ProbeBuyPending → PositionOpenProbe
 - ScaleInPending → PositionOpenFull (on buy success)
 - ScaleInPending → Rejected (on execution failure/timeout)
 
-**Note**: CTO mode and Dump-Recovery are handled as **sub-states within Validation** via additional fields (`cto_started_at`, `dump_observed_at`, `recovery_started_at`), not as separate `TrackerState` variants.
+**Note**: Dev-sell revalidation delay and Dump-Recovery are handled as **sub-states within Validation** via additional fields (`dev_sell_observed_at`, `dump_observed_at`, `recovery_started_slot`), not as separate `TrackerState` variants.
 
 ---
 
@@ -203,11 +203,11 @@ Reason codes are uppercase snake case. A decision must include exactly one **pri
 - `WAIT_MINT_INFO`
 - `WAIT_BUYER_WINDOW`
 - `WAIT_CONFIRMATION`
+- `WAIT_DEV_SELL_REVALIDATION`
 
 ### Reject (pre-entry)
 - `REJECT_LP_REMOVED`
 - `REJECT_DEV_SUPPLY_TOO_HIGH`
-- `REJECT_DEV_SELL_EARLY`
 - `REJECT_MINT_AUTHORITY_NOT_RENOUNCED`
 - `REJECT_FREEZE_AUTHORITY_SET`
 - `REJECT_INSUFFICIENT_BUYERS`
@@ -217,10 +217,6 @@ Reason codes are uppercase snake case. A decision must include exactly one **pri
 - `REJECT_BOT_CONCENTRATION` (top buyer share too high)
 - `REJECT_MICRO_BUY_SPAM` (small-buy ratio too high)
 - `REJECT_UNSUPPORTED_TOKEN_PROGRAM` (token program not supported by current execution path)
-
-### CTO Mode
-- `CTO_WAIT_RECOVERY`
-- `CTO_RECOVERY_CONFIRMED`
 
 ### Intents
 - `ENTER_PROBE_BUY`
@@ -466,13 +462,8 @@ Dump recovery:
 - `dump_recovery_min_net_inflow_lamports`
 - `dump_recovery_min_recovery_secs`
 
-CTO mode:
-- `cto_enabled`
-- `cto_entry_delay_secs`
-- `cto_confirm_window_secs`
-- `cto_min_unique_buyers`
-- `cto_min_buy_dominance`
-- `cto_min_net_inflow_lamports`
+Dev-sell revalidation (pre-entry):
+- `dev_sell_revalidation_delay_secs`
 
 Mint safety:
 - `require_mint_authority_renounced`

--- a/my_config.server.toml
+++ b/my_config.server.toml
@@ -324,9 +324,7 @@ min_sol_inflow_lamports = 500_000_000    # 0.5 SOL net inflow (WAS 20 SOL!!!)
 inflow_window_secs = 60              # 60 second window (was 30s)
 max_single_dump_lamports = 20_000_000_000 # 20 SOL max single sell (was 5 SOL)
 
-# FILTER 4: Dev Behavior
-dev_early_sell_window_secs = 90     # Dev sells in first 90s = bad (was 60s)
-dev_rebuy_positive = true           # Dev rebuy = positive signal
+dev_sell_revalidation_delay_secs = 30   # Pause after pre-entry dev sell before re-checking soft gates
 
 # EXIT STRATEGY
 hard_stop_loss_pct = 15.0           # -15% hard stop

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -7193,6 +7193,10 @@ impl MomentumContext {
         let mut config = self.config.write();
         let mut applied = Vec::new();
         let mut rejected = Vec::new();
+        let dev_sell_delay_dual_key_update = update
+            .config
+            .contains_key("dev_sell_revalidation_delay_secs")
+            && update.config.contains_key("cto_entry_delay_secs");
 
         for (key, value) in &update.config {
             match key.as_str() {
@@ -7439,7 +7443,12 @@ impl MomentumContext {
                 "dev_sell_revalidation_delay_secs" => {
                     if let Some(v) = value.as_u64() {
                         if v > 0 {
-                            config.dev_sell_revalidation_delay_secs = v;
+                            config.dev_sell_revalidation_delay_secs =
+                                if dev_sell_delay_dual_key_update {
+                                    config.dev_sell_revalidation_delay_secs.max(v)
+                                } else {
+                                    v
+                                };
                             applied.push(key.clone());
                             info!(key = %key, new_value = %v, "Config updated");
                         } else {

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -446,11 +446,9 @@ struct MomentumConfig {
     /// Max single dump size (lamports). Default: 5 SOL
     max_single_dump_lamports: u64,
 
-    // === Filter 4: Dev Behavior ===
-    /// Dev early sell triggers exit (seconds after pool creation). Default: 60s
-    dev_early_sell_window_secs: u64,
-    /// Dev rebuy is positive signal. Default: true
-    dev_rebuy_positive: bool,
+    // === Dev-Sell Re-Validation (pre-entry) ===
+    /// Pause after pre-entry dev sell before re-evaluating standard soft gates (seconds). Default: 30
+    dev_sell_revalidation_delay_secs: u64,
 
     // === Token Safety: Mint/Freeze Authority ===
     /// Require mint authority to be renounced (mint_authority == None) before entering.
@@ -486,14 +484,6 @@ struct MomentumConfig {
     dump_recovery_min_buy_dominance: f64,
     dump_recovery_min_net_inflow_lamports: u64,
     dump_recovery_min_recovery_secs: u64,
-
-    // === CTO Mode (pre-entry dev sell handling) ===
-    cto_enabled: bool,
-    cto_entry_delay_secs: u64,
-    cto_confirm_window_secs: u64,
-    cto_min_unique_buyers: u32,
-    cto_min_buy_dominance: f64,
-    cto_min_net_inflow_lamports: u64,
 
     // === Exit Strategy ===
     /// Hard stop-loss percentage from entry (e.g., 15 = -15%). Default: 15%
@@ -553,9 +543,8 @@ impl Default for MomentumConfig {
             inflow_window_secs: 30,                  // in 30 seconds
             max_single_dump_lamports: 5_000_000_000, // Max 5 SOL single sell
 
-            // Filter 4: Dev Behavior
-            dev_early_sell_window_secs: 60, // Dev sells in first 60s = bad
-            dev_rebuy_positive: true,       // Dev rebuy = positive signal
+            // Dev-Sell Re-Validation
+            dev_sell_revalidation_delay_secs: 30,
 
             // Token Safety
             require_mint_authority_renounced: false,
@@ -580,14 +569,6 @@ impl Default for MomentumConfig {
             dump_recovery_min_buy_dominance: 0.55,
             dump_recovery_min_net_inflow_lamports: 1_000_000_000, // 1 SOL
             dump_recovery_min_recovery_secs: 10,
-
-            // CTO Mode
-            cto_enabled: false,
-            cto_entry_delay_secs: 30,
-            cto_confirm_window_secs: 30,
-            cto_min_unique_buyers: 5,
-            cto_min_buy_dominance: 0.55,
-            cto_min_net_inflow_lamports: 1_000_000_000, // 1 SOL
 
             // Exit Strategy
             hard_stop_loss_pct: 15.0,      // -15% hard stop
@@ -630,8 +611,7 @@ impl MomentumConfig {
             min_sol_inflow_lamports: cfg.min_sol_inflow_lamports,
             inflow_window_secs: cfg.inflow_window_secs,
             max_single_dump_lamports: cfg.max_single_dump_lamports,
-            dev_early_sell_window_secs: cfg.dev_early_sell_window_secs,
-            dev_rebuy_positive: cfg.dev_rebuy_positive,
+            dev_sell_revalidation_delay_secs: cfg.dev_sell_revalidation_delay_secs,
             require_mint_authority_renounced: cfg.require_mint_authority_renounced,
             require_freeze_authority_none: cfg.require_freeze_authority_none,
             top1_buyer_share_cap: cfg.top1_buyer_share_cap,
@@ -643,12 +623,6 @@ impl MomentumConfig {
             dump_recovery_min_buy_dominance: cfg.dump_recovery_min_buy_dominance,
             dump_recovery_min_net_inflow_lamports: cfg.dump_recovery_min_net_inflow_lamports,
             dump_recovery_min_recovery_secs: cfg.dump_recovery_min_recovery_secs,
-            cto_enabled: cfg.cto_enabled,
-            cto_entry_delay_secs: cfg.cto_entry_delay_secs,
-            cto_confirm_window_secs: cfg.cto_confirm_window_secs,
-            cto_min_unique_buyers: cfg.cto_min_unique_buyers,
-            cto_min_buy_dominance: cfg.cto_min_buy_dominance,
-            cto_min_net_inflow_lamports: cfg.cto_min_net_inflow_lamports,
             hard_stop_loss_pct: cfg.hard_stop_loss_pct,
             trailing_stop_pct: cfg.trailing_stop_pct,
             trailing_activation_pct: cfg.trailing_activation_pct,
@@ -1712,8 +1686,8 @@ struct TokenTracker {
 
     // Dev behavior
     dev_sold: bool,
-    dev_sold_early: bool, // Sold within dev_early_sell_window
-    dev_rebought: bool,
+    /// Wall-clock time of the most recent pre-entry dev sell (delay resets on each sell).
+    dev_sell_observed_at: Option<Instant>,
 
     // LP tracking
     lp_removed: bool,
@@ -1729,10 +1703,6 @@ struct TokenTracker {
     // Dump-recovery gating (pre-entry), chain-time aware (slot / head slot)
     dump_observed_slot: Option<u64>,
     recovery_started_slot: Option<u64>,
-
-    // CTO mode (pre-entry dev-sell handling)
-    cto_started_at: Option<Instant>,
-    cto_recovery_confirmed: bool,
 
     /// Explicit lifecycle state (replaces probe_sent_at, probe_filled_at, etc.)
     state: TrackerState,
@@ -1775,16 +1745,13 @@ impl TokenTracker {
             buy_count: 0,
             sell_count: 0,
             dev_sold: false,
-            dev_sold_early: false,
-            dev_rebought: false,
+            dev_sell_observed_at: None,
             lp_removed: false,
             lp_removal_slot: None,
             lp_removal_observed_at: None,
             max_trade_slot: 0,
             dump_observed_slot: None,
             recovery_started_slot: None,
-            cto_started_at: None,
-            cto_recovery_confirmed: false,
             state: TrackerState::Discovery,
             blacklist_reason: None,
             last_trade_at: None,
@@ -1975,114 +1942,24 @@ impl TokenTracker {
         None
     }
 
-    fn cto_confirm_stats_at(
+    fn dev_sell_revalidation_wait_reason(
         &self,
         config: &MomentumConfig,
-        head_slot: u64,
-    ) -> Option<(u32, f64, i128, u32)> {
-        if config.cto_confirm_window_secs == 0 {
-            return None;
-        }
-
-        let window_slots = momentum_secs_to_slot_span(config.cto_confirm_window_secs);
-        let hs = self.chain_head_for_filters(head_slot);
-        let mut unique_buyers: HashSet<&str> = HashSet::new();
-        let mut buy_count: u32 = 0;
-        let mut sell_count: u32 = 0;
-        let mut buy_vol: u64 = 0;
-        let mut sell_vol: u64 = 0;
-
-        for t in self
-            .trades
-            .iter()
-            .filter(|t| momentum_trade_in_chain_slot_window(t.slot, hs, window_slots))
-        {
-            if t.is_buy {
-                buy_count = buy_count.saturating_add(1);
-                buy_vol = buy_vol.saturating_add(t.sol_amount);
-                unique_buyers.insert(t.trader.as_str());
-            } else {
-                sell_count = sell_count.saturating_add(1);
-                sell_vol = sell_vol.saturating_add(t.sol_amount);
-            }
-        }
-
-        let total = buy_count.saturating_add(sell_count);
-        if total == 0 {
-            return None;
-        }
-
-        let buy_dominance = buy_count as f64 / total as f64;
-        let net_inflow = buy_vol as i128 - sell_vol as i128;
-        Some((unique_buyers.len() as u32, buy_dominance, net_inflow, total))
-    }
-
-    fn cto_wait_reason(
-        &mut self,
-        config: &MomentumConfig,
-        head_slot: u64,
         now: Instant,
     ) -> Option<String> {
-        if !config.cto_enabled {
+        if self.dev_sell_observed_at.is_none() || !self.dev_sold {
             return None;
         }
-        if self.cto_recovery_confirmed {
-            return None;
+        let observed = self.dev_sell_observed_at?;
+        let since = now.duration_since(observed).as_secs();
+        if since < config.dev_sell_revalidation_delay_secs {
+            Some(format!(
+                "WAIT_DEV_SELL_REVALIDATION: delay {}/{}s",
+                since, config.dev_sell_revalidation_delay_secs
+            ))
+        } else {
+            None
         }
-
-        let started = self.cto_started_at.get_or_insert(now);
-        let since = now.duration_since(*started).as_secs();
-        if since < config.cto_entry_delay_secs {
-            return Some(format!(
-                "CTO_WAIT_RECOVERY: entry delay {}/{}s",
-                since, config.cto_entry_delay_secs
-            ));
-        }
-
-        let Some((buyers, dom, net_inflow, samples)) = self.cto_confirm_stats_at(config, head_slot)
-        else {
-            return Some("CTO_WAIT_RECOVERY: awaiting confirmation window data".to_string());
-        };
-
-        // Use configured threshold (separate from early min_unique_buyers) and a small sample guard.
-        if samples < config.cto_min_unique_buyers.max(5) {
-            return Some(format!(
-                "CTO_WAIT_RECOVERY: not enough samples in confirm window ({} < {})",
-                samples,
-                config.cto_min_unique_buyers.max(5)
-            ));
-        }
-
-        if buyers < config.cto_min_unique_buyers {
-            return Some(format!(
-                "CTO_WAIT_RECOVERY: not enough buyers in confirm window ({} < {})",
-                buyers, config.cto_min_unique_buyers
-            ));
-        }
-
-        if dom < config.cto_min_buy_dominance {
-            return Some(format!(
-                "CTO_WAIT_RECOVERY: buy dominance {:.0}% < {:.0}%",
-                dom * 100.0,
-                config.cto_min_buy_dominance * 100.0
-            ));
-        }
-
-        if net_inflow < config.cto_min_net_inflow_lamports as i128 {
-            return Some(format!(
-                "CTO_WAIT_RECOVERY: net inflow {:.2} SOL < {:.2} SOL",
-                net_inflow as f64 / 1_000_000_000.0,
-                config.cto_min_net_inflow_lamports as f64 / 1_000_000_000.0
-            ));
-        }
-
-        // Optional positive signal (non-gating): read config so it isn't dead, and enrich reason in logs.
-        if config.dev_rebuy_positive && self.dev_rebought {
-            debug!(mint = %self.mint, "CTO recovery has dev rebuy positive signal");
-        }
-
-        self.cto_recovery_confirmed = true;
-        None
     }
 
     /// Record a trade event (`trade_slot`: Geyser tx slot from `MarketEvent.slot`, `0` if unknown).
@@ -2128,51 +2005,17 @@ impl TokenTracker {
             }
         }
 
-        // Dev behavior tracking
+        // Dev behavior tracking (pre-entry: wait + revalidation delay, never hard-reject)
         if let Some(ref dev) = self.dev_wallet {
-            if trader == dev {
-                if is_buy && self.dev_sold {
-                    self.dev_rebought = true;
-                    info!(mint = %self.mint, "Dev rebought - positive signal");
-                } else if !is_buy {
-                    self.dev_sold = true;
-                    let early_by_slot = self.first_slot > 0
-                        && trade_slot > 0
-                        && trade_slot.saturating_sub(self.first_slot)
-                            < momentum_secs_to_slot_span(config.dev_early_sell_window_secs);
-                    let early_fallback_wallclock = self.first_slot == 0 || trade_slot == 0;
-                    let early = if early_fallback_wallclock {
-                        self.first_seen.elapsed().as_secs() < config.dev_early_sell_window_secs
-                    } else {
-                        early_by_slot
-                    };
-                    if early {
-                        self.dev_sold_early = true;
-
-                        if config.cto_enabled {
-                            // CTO mode: do not hard-reject pre-entry dev sells.
-                            // Instead, mark CTO candidate and wait for recovery confirmation.
-                            self.cto_started_at.get_or_insert_with(Instant::now);
-                            warn!(
-                                mint = %self.mint,
-                                dev_sell_slot = trade_slot,
-                                first_slot = self.first_slot,
-                                "Dev sold early - CTO candidate (chain-slot timing; wall fallback={})",
-                                early_fallback_wallclock
-                            );
-                        } else {
-                            // No CTO mode: hard reject.
-                            self.reject("REJECT_DEV_SELL_EARLY");
-                            warn!(
-                                mint = %self.mint,
-                                dev_sell_slot = trade_slot,
-                                first_slot = self.first_slot,
-                                "Dev sold early - blacklisting (chain-slot timing; wall fallback={})",
-                                early_fallback_wallclock
-                            );
-                        }
-                    }
-                }
+            if trader == dev && !is_buy {
+                self.dev_sold = true;
+                self.dev_sell_observed_at = Some(Instant::now());
+                warn!(
+                    mint = %self.mint,
+                    dev_sell_slot = trade_slot,
+                    first_slot = self.first_slot,
+                    "Dev sold pre-entry — revalidation delay started"
+                );
             }
         }
 
@@ -2309,27 +2152,34 @@ impl TokenTracker {
                 }
             });
 
-        let total_trades = self.buy_count + self.sell_count;
-        let mut min_sl = u64::MAX;
-        let mut max_sl = 0u64;
-        let mut trades_with_chain_slot = 0u32;
-        for t in &self.trades {
+        let mut buy_count_in_window = 0u32;
+        let mut sell_count_in_window = 0u32;
+        let mut trades_with_slot_in_window = 0u32;
+        for t in self
+            .trades
+            .iter()
+            .filter(|t| momentum_trade_in_chain_slot_window(t.slot, hs, buyer_window_slots))
+        {
+            if t.is_buy {
+                buy_count_in_window = buy_count_in_window.saturating_add(1);
+            } else {
+                sell_count_in_window = sell_count_in_window.saturating_add(1);
+            }
             if t.slot > 0 {
-                trades_with_chain_slot = trades_with_chain_slot.saturating_add(1);
-                min_sl = min_sl.min(t.slot);
-                max_sl = max_sl.max(t.slot);
+                trades_with_slot_in_window = trades_with_slot_in_window.saturating_add(1);
             }
         }
-        let chain_span_slots = if min_sl != u64::MAX {
-            max_sl.saturating_sub(min_sl).max(1)
-        } else {
-            1u64
-        };
-        let chain_secs = (chain_span_slots as f64) * (MOMENTUM_APPROX_SLOT_MS as f64 / 1000.0);
-        let trades_per_min = (trades_with_chain_slot as f64) / (chain_secs / 60.0).max(1e-9);
 
-        let buy_dominance = if total_trades > 0 {
-            self.buy_count as f64 / total_trades as f64
+        let total_in_window = buy_count_in_window.saturating_add(sell_count_in_window);
+        let buy_dominance = if total_in_window > 0 {
+            buy_count_in_window as f64 / total_in_window as f64
+        } else {
+            0.0
+        };
+
+        let window_secs = config.buyer_window_secs as f64;
+        let trades_per_min = if window_secs > 0.0 {
+            trades_with_slot_in_window as f64 / (window_secs / 60.0)
         } else {
             0.0
         };
@@ -2339,7 +2189,6 @@ impl TokenTracker {
             trades_per_min,
             buy_dominance,
             net_sol_inflow: recent_buy_vol.saturating_sub(recent_sell_vol),
-            dev_sold_early: self.dev_sold_early,
             lp_removed: self.lp_removed,
             initial_liquidity_sol: self.initial_liquidity as f64 / 1_000_000_000.0,
         }
@@ -2451,6 +2300,15 @@ impl TokenTracker {
             self.reject("REJECT_LP_REMOVED");
             warn!(mint = %self.mint, pool = %self.pool, dex = %self.dex, "🚫 Filter rejected: LP_REMOVED (blacklisted)");
             return (false, "REJECT_LP_REMOVED".to_string());
+        }
+
+        // Dev-sell revalidation delay (pre-entry WAIT; after delay standard filters decide on fresh window data)
+        if let Some(wait) = self.dev_sell_revalidation_wait_reason(config, wall_now) {
+            return self.record_wait_filter_rejection_and_return(
+                &FILTER_REJECTED_DEV_BEHAVIOR,
+                wait,
+                "WAIT_DEV_SELL_REVALIDATION",
+            );
         }
 
         // Filter 2: Buyer Velocity
@@ -2578,20 +2436,6 @@ impl TokenTracker {
             return (false, wait_reason);
         }
 
-        // Filter 4: Dev Behavior (pre-entry)
-        if metrics.dev_sold_early {
-            if config.cto_enabled {
-                if let Some(wait) = self.cto_wait_reason(config, chain_head_slot, wall_now) {
-                    return (false, wait);
-                }
-            } else {
-                FILTER_REJECTED_DEV_BEHAVIOR.fetch_add(1, Ordering::Relaxed);
-                FILTER_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                self.reject("REJECT_DEV_SELL_EARLY");
-                return (false, "REJECT_DEV_SELL_EARLY".to_string());
-            }
-        }
-
         // All filters passed!
         self.last_wait_filter_obs_key = None;
         FILTER_PASSED_TOTAL.fetch_add(1, Ordering::Relaxed);
@@ -2620,7 +2464,6 @@ struct TokenMetrics {
     trades_per_min: f64,
     buy_dominance: f64,
     net_sol_inflow: u64,
-    dev_sold_early: bool,
     lp_removed: bool,
     initial_liquidity_sol: f64,
 }
@@ -4632,9 +4475,10 @@ impl MomentumContext {
         let head_slot = self.last_event_slot.load(Ordering::Relaxed);
         let mut trackers = self.token_trackers.write();
         let key = Self::tracker_storage_key(mint, pool);
-        let mut sync_sibling_dev_sell_early = false;
+        let mut sync_sibling_dev_sell = false;
         let recorded = if let Some(tracker) = trackers.get_mut(&key) {
             let was_not_rejected = tracker.was_not_rejected();
+            let dev_sell_obs_before = tracker.dev_sell_observed_at;
             tracker.record_trade(
                 trader,
                 is_buy,
@@ -4650,8 +4494,8 @@ impl MomentumContext {
                 let reason = tracker.blacklist_reason.as_deref().unwrap_or("rejected");
                 self.queue_momentum_active_pool_removed(mint, pool, reason);
             }
-            sync_sibling_dev_sell_early =
-                tracker.blacklist_reason.as_deref() == Some("REJECT_DEV_SELL_EARLY");
+            sync_sibling_dev_sell = tracker.dev_sell_observed_at.is_some()
+                && tracker.dev_sell_observed_at != dev_sell_obs_before;
             if !tracker.is_rejected()
                 && tracker
                     .trades
@@ -4674,10 +4518,13 @@ impl MomentumContext {
             false
         };
         self.mark_entry_eval_dirty_key(&key);
-        // Same-mint sibling pools: one pool's dev-sell-early reject must apply to all pool rows
-        // (Trade event is per-pool; mint-wide creator was applied before `record_trade`).
-        if sync_sibling_dev_sell_early {
-            let Some(source_dev) = trackers.get(&key).and_then(|t| t.dev_wallet.clone()) else {
+        // Same-mint sibling pools: propagate dev-sell revalidation state (WAIT, not reject).
+        if sync_sibling_dev_sell {
+            let Some((source_dev, dev_sell_at)) = trackers
+                .get(&key)
+                .map(|t| (t.dev_wallet.clone(), t.dev_sell_observed_at))
+                .and_then(|(dev, at)| dev.zip(at))
+            else {
                 return recorded;
             };
             let sibling_keys =
@@ -4696,13 +4543,7 @@ impl MomentumContext {
                     continue;
                 }
                 t.dev_sold = true;
-                t.dev_sold_early = true;
-                t.reject("REJECT_DEV_SELL_EARLY");
-                self.queue_momentum_active_pool_removed(
-                    t.mint.as_str(),
-                    t.pool.as_str(),
-                    "rejected",
-                );
+                t.dev_sell_observed_at = Some(dev_sell_at);
                 self.mark_entry_eval_dirty_key(&sk);
             }
         }
@@ -7594,22 +7435,32 @@ impl MomentumContext {
                     }
                 }
 
-                // === CTO Mode ===
-                "cto_enabled" => {
-                    if let Some(v) = value.as_bool() {
-                        config.cto_enabled = v;
-                        applied.push(key.clone());
-                        info!(key = %key, new_value = %v, "Config updated");
+                // === Dev-Sell Re-Validation ===
+                "dev_sell_revalidation_delay_secs" => {
+                    if let Some(v) = value.as_u64() {
+                        if v > 0 {
+                            config.dev_sell_revalidation_delay_secs = v;
+                            applied.push(key.clone());
+                            info!(key = %key, new_value = %v, "Config updated");
+                        } else {
+                            rejected.push((key.clone(), "Must be > 0".to_string()));
+                        }
                     } else {
-                        rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
+                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
                     }
                 }
                 "cto_entry_delay_secs" => {
                     if let Some(v) = value.as_u64() {
                         if v > 0 {
-                            config.cto_entry_delay_secs = v;
+                            warn!(
+                                legacy_key = %key,
+                                dev_sell_revalidation_delay_secs = v,
+                                "JetStream config: deprecated key `cto_entry_delay_secs`; applied as `dev_sell_revalidation_delay_secs`"
+                            );
+                            config.dev_sell_revalidation_delay_secs =
+                                config.dev_sell_revalidation_delay_secs.max(v);
                             applied.push(key.clone());
-                            info!(key = %key, new_value = %v, "Config updated");
+                            info!(key = %key, new_value = %v, "Config updated (deprecated alias)");
                         } else {
                             rejected.push((key.clone(), "Must be > 0".to_string()));
                         }
@@ -7617,53 +7468,18 @@ impl MomentumContext {
                         rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
                     }
                 }
-                "cto_confirm_window_secs" => {
-                    if let Some(v) = value.as_u64() {
-                        if v > 0 {
-                            config.cto_confirm_window_secs = v;
-                            applied.push(key.clone());
-                            info!(key = %key, new_value = %v, "Config updated");
-                        } else {
-                            rejected.push((key.clone(), "Must be > 0".to_string()));
-                        }
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
-                    }
-                }
-                "cto_min_unique_buyers" => {
-                    if let Some(v) = value.as_u64() {
-                        if v > 0 {
-                            config.cto_min_unique_buyers = v as u32;
-                            applied.push(key.clone());
-                            info!(key = %key, new_value = %v, "Config updated");
-                        } else {
-                            rejected.push((key.clone(), "Must be > 0".to_string()));
-                        }
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
-                    }
-                }
-                "cto_min_buy_dominance" => {
-                    if let Some(v) = value.as_f64() {
-                        if (0.0..=1.0).contains(&v) {
-                            config.cto_min_buy_dominance = v;
-                            applied.push(key.clone());
-                            info!(key = %key, new_value = %v, "Config updated");
-                        } else {
-                            rejected.push((key.clone(), "Must be in [0.0, 1.0]".to_string()));
-                        }
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected f64".to_string()));
-                    }
-                }
-                "cto_min_net_inflow_lamports" => {
-                    if let Some(v) = value.as_u64() {
-                        config.cto_min_net_inflow_lamports = v;
-                        applied.push(key.clone());
-                        info!(key = %key, new_value = %v, "Config updated");
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
-                    }
+                "cto_enabled"
+                | "cto_confirm_window_secs"
+                | "cto_min_unique_buyers"
+                | "cto_min_buy_dominance"
+                | "cto_min_net_inflow_lamports"
+                | "dev_early_sell_window_secs"
+                | "dev_rebuy_positive" => {
+                    warn!(
+                        key = %key,
+                        "JetStream config: deprecated momentum key ignored (dev-sell revalidation delay replaces CTO / early-window gates)"
+                    );
+                    applied.push(key.clone());
                 }
                 "require_mint_authority_renounced" => {
                     if let Some(v) = value.as_bool() {
@@ -7815,30 +7631,6 @@ impl MomentumContext {
                         info!(key = %key, new_value = %v, "Config updated");
                     } else {
                         rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
-                    }
-                }
-
-                // === Filter 4: Dev Behavior ===
-                "dev_early_sell_window_secs" => {
-                    if let Some(v) = value.as_u64() {
-                        if v > 0 {
-                            config.dev_early_sell_window_secs = v;
-                            applied.push(key.clone());
-                            info!(key = %key, new_value = %v, "Config updated");
-                        } else {
-                            rejected.push((key.clone(), "Must be > 0".to_string()));
-                        }
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
-                    }
-                }
-                "dev_rebuy_positive" => {
-                    if let Some(v) = value.as_bool() {
-                        config.dev_rebuy_positive = v;
-                        applied.push(key.clone());
-                        info!(key = %key, new_value = %v, "Config updated");
-                    } else {
-                        rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
                     }
                 }
 
@@ -11096,7 +10888,7 @@ mod tests {
         cfg.min_unique_buyers = 3;
         cfg.min_buy_dominance = 0.0;
         cfg.min_sol_inflow_lamports = 0;
-        cfg.min_trades_per_min = 30.0;
+        cfg.min_trades_per_min = 4.0;
         cfg.require_mint_authority_renounced = false;
         cfg.require_freeze_authority_none = false;
         cfg.buyer_window_secs = 120;
@@ -12118,7 +11910,6 @@ mod tests {
         cfg.min_trade_size_lamports = 0;
         cfg.small_buy_ratio_cap = 1.0;
         cfg.dump_recovery_window_secs = 0;
-        cfg.cto_enabled = false;
 
         let now = Instant::now();
         let mut tracker = TokenTracker::new("m", "p", "d", 1, 0);
@@ -12162,7 +11953,6 @@ mod tests {
         cfg.min_trade_size_lamports = 0;
         cfg.small_buy_ratio_cap = 1.0;
         cfg.dump_recovery_window_secs = 0;
-        cfg.cto_enabled = false;
 
         let tmp = TempDir::new().expect("tempdir");
         let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
@@ -12200,8 +11990,7 @@ mod tests {
 
     #[test]
     fn pr170_trade_based_discovery_records_first_buy() {
-        let mut cfg = MomentumConfig::default();
-        cfg.cto_enabled = false;
+        let cfg = MomentumConfig::default();
 
         let tmp = TempDir::new().expect("tempdir");
         let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
@@ -12276,7 +12065,6 @@ mod tests {
         cfg.min_trade_size_lamports = 0;
         cfg.small_buy_ratio_cap = 1.0;
         cfg.dump_recovery_window_secs = 0;
-        cfg.cto_enabled = false;
 
         let mut tracker = TokenTracker::new("m", "p", "pumpfun", 100, 30_000_000_000);
         tracker.record_trade("whale", true, 900_000_000, 1, "s0", 150, &cfg);
@@ -12289,7 +12077,7 @@ mod tests {
     }
 
     #[test]
-    fn pr170_xhat_style_cto_pump_accumulates_ten_buyers() {
+    fn pr170_xhat_style_dev_sell_pump_accumulates_ten_buyers() {
         let mut cfg = MomentumConfig::default();
         cfg.early_min_liquidity_sol = 0.0;
         cfg.min_unique_buyers = 3;
@@ -12304,10 +12092,7 @@ mod tests {
         cfg.min_trade_size_lamports = 0;
         cfg.small_buy_ratio_cap = 1.0;
         cfg.dump_recovery_window_secs = 0;
-        cfg.cto_enabled = true;
-        cfg.cto_entry_delay_secs = 0;
-        cfg.cto_min_unique_buyers = 3;
-        cfg.dev_early_sell_window_secs = 3600;
+        cfg.dev_sell_revalidation_delay_secs = 0;
 
         let tmp = TempDir::new().expect("tempdir");
         let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
@@ -12389,7 +12174,7 @@ mod tests {
             .expect("tracker");
         assert!(
             !tr.is_rejected(),
-            "CTO pump must not false-reject on bot concentration: {:?}",
+            "dev-sell pump must not false-reject on bot concentration: {:?}",
             tr.blacklist_reason
         );
         let metrics = tr.calculate_metrics(&cfg, head);
@@ -13792,12 +13577,10 @@ mod tests {
         );
     }
 
-    /// Trade `creator` applies mint-wide before `record_trade`: sibling pool dev sell early rejects.
+    /// Trade `creator` applies mint-wide before `record_trade`: sibling pool gets dev-sell WAIT state.
     #[test]
-    fn trade_creator_mint_wide_dev_sell_early_rejects_sibling_pool_tracker() {
-        let mut cfg = MomentumConfig::default();
-        cfg.cto_enabled = false;
-        cfg.dev_early_sell_window_secs = 300;
+    fn dev_sell_sibling_pools_sync_wait_not_reject() {
+        let cfg = MomentumConfig::default();
 
         let tmp = TempDir::new().expect("tempdir");
         let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
@@ -13850,17 +13633,23 @@ mod tests {
                 .expect("process trade");
         });
 
-        let sibling_rejected = {
+        let (sibling_rejected, sibling_dev_sold, sibling_has_obs) = {
             let trackers = ctx.token_trackers.read();
-            trackers
+            let t = trackers
                 .get(&MomentumContext::tracker_storage_key(mint, pool_a))
-                .expect("sibling pool_a tracker (did not receive Trade)")
-                .is_rejected()
+                .expect("sibling pool_a tracker (did not receive Trade)");
+            (
+                t.is_rejected(),
+                t.dev_sold,
+                t.dev_sell_observed_at.is_some(),
+            )
         };
         assert!(
-            sibling_rejected,
-            "pool_a sibling tracker should reject dev sell early after mint-wide creator from Trade on pool_b"
+            !sibling_rejected,
+            "pool_a sibling tracker must not reject on dev sell from pool_b"
         );
+        assert!(sibling_dev_sold);
+        assert!(sibling_has_obs);
     }
 
     /// Trade-driven reject: `tokens_blacklisted` bumps at most once per mint across pool rows.
@@ -14065,11 +13854,8 @@ mod tests {
         assert!(should_trade);
     }
 
-    #[test]
-    fn cto_disabled_rejects_dev_sell_early() {
+    fn relaxed_entry_gates_helper_cfg() -> MomentumConfig {
         let mut cfg = MomentumConfig::default();
-
-        // Disable other gates to isolate CTO behavior.
         cfg.early_min_liquidity_sol = 0.0;
         cfg.min_unique_buyers = 0;
         cfg.min_trades_per_min = 0.0;
@@ -14082,89 +13868,176 @@ mod tests {
         cfg.repeat_buyer_min_ratio = 0.0;
         cfg.min_trade_size_lamports = 0;
         cfg.small_buy_ratio_cap = 1.0;
-
-        cfg.cto_enabled = false;
-        cfg.dev_early_sell_window_secs = 999;
-
-        let mut tracker = TokenTracker::new("mint", "pool", "dex", 1, 0);
-        tracker.dev_wallet = Some("dev".to_string());
-
-        // Dev sells early.
-        tracker.record_trade("dev", false, 1_000, 1, "sig", 50, &cfg);
-        assert!(tracker.dev_sold_early);
-
-        let (should_trade, reason) =
-            tracker.should_generate_intent(&cfg, None, 50_000, Instant::now());
-        assert!(!should_trade);
-        assert_eq!(reason, "REJECT_DEV_SELL_EARLY");
-        assert!(tracker.is_rejected());
+        cfg.dump_recovery_window_secs = 0;
+        cfg
     }
 
     #[test]
-    fn cto_enabled_waits_then_allows_after_recovery_confirm() {
-        let mut cfg = MomentumConfig::default();
-
-        // Disable other gates to isolate CTO behavior.
-        cfg.early_min_liquidity_sol = 0.0;
-        cfg.min_unique_buyers = 0;
-        cfg.min_trades_per_min = 0.0;
+    fn buy_dominance_uses_buyer_window_not_lifetime() {
+        let mut cfg = relaxed_entry_gates_helper_cfg();
+        cfg.buyer_window_secs = 60;
         cfg.min_buy_dominance = 0.0;
-        cfg.min_sol_inflow_lamports = 0;
-        cfg.require_mint_authority_renounced = false;
-        cfg.require_freeze_authority_none = false;
-        cfg.top1_buyer_share_cap = 1.0;
-        cfg.top3_buyer_share_cap = 1.0;
-        cfg.repeat_buyer_min_ratio = 0.0;
-        cfg.min_trade_size_lamports = 0;
-        cfg.small_buy_ratio_cap = 1.0;
 
-        cfg.cto_enabled = true;
-        cfg.cto_entry_delay_secs = 10;
-        cfg.cto_confirm_window_secs = 120;
-        cfg.cto_min_unique_buyers = 2;
-        cfg.cto_min_buy_dominance = 0.60;
-        cfg.cto_min_net_inflow_lamports = 100;
-        cfg.dev_early_sell_window_secs = 999;
+        let mut tracker = TokenTracker::new("mint", "pool", "dex", 1, 10_000_000_000);
+        let head = 10_000u64;
+        let window_slots = momentum_secs_to_slot_span(cfg.buyer_window_secs);
 
-        // Disable dump-recovery gate to isolate CTO behavior.
-        cfg.dump_recovery_window_secs = 0;
+        // Lifetime-heavy buys outside the buyer window.
+        for i in 0..20 {
+            tracker.record_trade(
+                &format!("old_buy{i}"),
+                true,
+                100_000_000,
+                1,
+                &format!("ob{i}"),
+                head.saturating_sub(window_slots + 100 + i as u64),
+                &cfg,
+            );
+        }
+        // Recent sells dominate the buyer window.
+        for i in 0..8 {
+            tracker.record_trade(
+                &format!("recent_sell{i}"),
+                false,
+                50_000_000,
+                1,
+                &format!("rs{i}"),
+                head.saturating_sub(i as u64),
+                &cfg,
+            );
+        }
 
-        let now = Instant::now();
-        let mut tracker = TokenTracker::new("mint", "pool", "dex", 1, 0);
+        let metrics = tracker.calculate_metrics(&cfg, head);
+        assert!(
+            metrics.buy_dominance < 0.2,
+            "window dominance should be low (sells in window), got {}",
+            metrics.buy_dominance
+        );
+        let lifetime_dom =
+            tracker.buy_count as f64 / (tracker.buy_count + tracker.sell_count) as f64;
+        assert!(
+            lifetime_dom > 0.6,
+            "lifetime dominance should stay high for contrast, got {lifetime_dom}"
+        );
+    }
+
+    #[test]
+    fn trades_per_min_uses_buyer_window_not_lifetime() {
+        let mut cfg = relaxed_entry_gates_helper_cfg();
+        cfg.buyer_window_secs = 60;
+
+        let mut tracker = TokenTracker::new("mint", "pool", "dex", 1, 10_000_000_000);
+        let head = 20_000u64;
+        let window_slots = momentum_secs_to_slot_span(cfg.buyer_window_secs);
+
+        // Burst outside buyer window.
+        for i in 0..50 {
+            tracker.record_trade(
+                &format!("burst{i}"),
+                true,
+                10_000_000,
+                1,
+                &format!("b{i}"),
+                head.saturating_sub(window_slots + 200 + i as u64),
+                &cfg,
+            );
+        }
+        // Only two trades inside buyer window.
+        tracker.record_trade("in1", true, 10_000_000, 1, "in1", head - 1, &cfg);
+        tracker.record_trade("in2", true, 10_000_000, 1, "in2", head, &cfg);
+
+        let metrics = tracker.calculate_metrics(&cfg, head);
+        let expected = 2.0 / (cfg.buyer_window_secs as f64 / 60.0);
+        assert!(
+            (metrics.trades_per_min - expected).abs() < 0.01,
+            "expected ~{expected} trades/min, got {}",
+            metrics.trades_per_min
+        );
+    }
+
+    #[test]
+    fn dev_sell_pre_entry_waits_not_rejects() {
+        let mut cfg = relaxed_entry_gates_helper_cfg();
+        cfg.dev_sell_revalidation_delay_secs = 30;
+
+        let mut tracker = TokenTracker::new("mint", "pool", "dex", 1, 10_000_000_000);
+        tracker.dev_wallet = Some("dev".to_string());
+        tracker.record_trade("dev", false, 1_000, 1, "sig", 50, &cfg);
+        assert!(tracker.dev_sold);
+        assert!(tracker.dev_sell_observed_at.is_some());
+
+        let (should_trade, reason) =
+            tracker.should_generate_intent(&cfg, None, 50_000, Instant::now());
+        assert!(!should_trade);
+        assert!(reason.contains("WAIT_DEV_SELL_REVALIDATION"), "{reason}");
+        assert!(!tracker.is_rejected());
+    }
+
+    #[test]
+    fn dev_sell_after_delay_requires_fresh_filter_pass() {
+        let mut cfg = relaxed_entry_gates_helper_cfg();
+        cfg.dev_sell_revalidation_delay_secs = 1;
+        cfg.min_buy_dominance = 0.60;
+        cfg.buyer_window_secs = 120;
+
+        let mut tracker = TokenTracker::new("mint", "pool", "dex", 1, 10_000_000_000);
         tracker.dev_wallet = Some("dev".to_string());
 
-        // Dev sells early -> CTO candidate.
-        tracker.record_trade("dev", false, 200, 1, "sd", 120, &cfg);
-        assert!(tracker.dev_sold_early);
-
-        // Before delay: WAIT.
-        tracker.cto_started_at = Some(now);
-        let (should_trade, reason) =
-            tracker.should_generate_intent(&cfg, None, 50_000, Instant::now());
-        assert!(!should_trade);
-        assert!(reason.contains("CTO_WAIT_RECOVERY"));
-
-        // After delay, but without confirmation trades: still WAIT.
-        tracker.cto_started_at = Some(now - Duration::from_secs(11));
-        let (should_trade, reason) =
-            tracker.should_generate_intent(&cfg, None, 50_000, Instant::now());
-        assert!(!should_trade);
-        assert!(reason.contains("CTO_WAIT_RECOVERY"));
-
-        // Add recovery trades in confirm window: include the initial dev sell as well.
-        // With 6 sells total (dev + 5), we need >=9 buys to hit >=60% buy dominance.
+        // Green window before dev sell.
         for i in 0..5 {
-            tracker.record_trade("w", false, 50, 1, &format!("s{i}"), 130 + i, &cfg);
+            tracker.record_trade(
+                &format!("b{i}"),
+                true,
+                100_000_000,
+                1,
+                &format!("pb{i}"),
+                100 + i,
+                &cfg,
+            );
         }
-        for i in 0..9 {
-            let buyer = format!("b{i}");
-            tracker.record_trade(&buyer, true, 120, 1, &format!("bb{i}"), 140 + i, &cfg);
+        tracker.record_trade("dev", false, 1_000, 1, "ds", 110, &cfg);
+        tracker.dev_sell_observed_at = Some(Instant::now() - Duration::from_secs(2));
+
+        // After delay: only sells in buyer window → WAIT_BUYER_WINDOW, not entry.
+        for i in 0..6 {
+            tracker.record_trade(
+                &format!("s{i}"),
+                false,
+                50_000_000,
+                1,
+                &format!("ps{i}"),
+                200 + i,
+                &cfg,
+            );
         }
 
-        let (should_trade, _reason) =
-            tracker.should_generate_intent(&cfg, None, 400, Instant::now());
-        assert!(should_trade);
-        assert!(tracker.cto_recovery_confirmed);
+        let (should_trade, reason) =
+            tracker.should_generate_intent(&cfg, None, 300, Instant::now());
+        assert!(!should_trade);
+        assert!(reason.contains("WAIT_BUYER_WINDOW"), "{reason}");
+        assert!(!tracker.is_rejected());
+    }
+
+    #[test]
+    fn dev_sell_resets_delay_on_resell() {
+        let mut cfg = relaxed_entry_gates_helper_cfg();
+        cfg.dev_sell_revalidation_delay_secs = 30;
+
+        let mut tracker = TokenTracker::new("mint", "pool", "dex", 1, 10_000_000_000);
+        tracker.dev_wallet = Some("dev".to_string());
+
+        tracker.record_trade("dev", false, 1_000, 1, "ds1", 50, &cfg);
+        tracker.dev_sell_observed_at = Some(Instant::now() - Duration::from_secs(25));
+
+        // Second dev sell before delay ends → timer reset.
+        tracker.record_trade("dev", false, 1_000, 1, "ds2", 51, &cfg);
+
+        let (should_trade, reason) =
+            tracker.should_generate_intent(&cfg, None, 50_000, Instant::now());
+        assert!(!should_trade);
+        assert!(reason.contains("WAIT_DEV_SELL_REVALIDATION"), "{reason}");
+        let observed = tracker.dev_sell_observed_at.expect("observed");
+        assert!(observed.elapsed().as_secs() < 5);
     }
 
     #[test]
@@ -17420,7 +17293,7 @@ async fn process_market_event(
 
             // P1: Trade `creator` is mint-level PumpFun metadata (Geyser / market-data cache, no RPC).
             // Apply to every pool-scoped tracker for this mint **before** `record_trade` so sibling pools
-            // run the same `dev_wallet` / dev_sell_early / `REJECT_DEV_SELL_EARLY` logic as the pool that
+            // run the same `dev_wallet` / dev-sell revalidation WAIT logic as the pool that
             // received the Trade event.
             if let Some(ref creator) = trade_creator {
                 let config = ctx.config.read().clone();
@@ -17585,21 +17458,6 @@ async fn process_market_event(
                     Some(pool_address),
                     event.slot,
                 );
-            }
-
-            if is_dev {
-                // Record dev trade behavior in tracker
-                let mut trackers = ctx.token_trackers.write();
-                let tk = MomentumContext::tracker_storage_key(mint, pool_address);
-                if let Some(tracker) = trackers.get_mut(&tk) {
-                    if *is_buy {
-                        tracker.dev_rebought = true;
-                        info!(mint = %mint, trader = %trader, "📈 Dev rebuy detected - positive signal");
-                    } else {
-                        tracker.dev_sold = true;
-                        info!(mint = %mint, trader = %trader, sol = sol_lamports, "⚠️ Dev sell detected");
-                    }
-                }
             }
 
             debug!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,6 +101,77 @@ pub fn migrate_momentum_trade_velocity_keys_in_table(
     );
 }
 
+const DEPRECATED_MOMENTUM_DEV_SELL_KEYS: &[&str] = &[
+    "cto_enabled",
+    "cto_confirm_window_secs",
+    "cto_min_unique_buyers",
+    "cto_min_buy_dominance",
+    "cto_min_net_inflow_lamports",
+    "dev_early_sell_window_secs",
+    "dev_rebuy_positive",
+];
+
+fn momentum_toml_u64(v: &toml::Value) -> Option<u64> {
+    v.as_integer()
+        .map(|i| i.max(0) as u64)
+        .or_else(|| v.as_float().map(|f| f.max(0.0) as u64))
+}
+
+/// Migrates deprecated CTO / dev-behavior keys to `dev_sell_revalidation_delay_secs`.
+/// If both `cto_entry_delay_secs` and `dev_sell_revalidation_delay_secs` are set, uses the max.
+pub fn migrate_momentum_dev_sell_config_keys_in_table(
+    table: &mut toml::map::Map<String, toml::Value>,
+) {
+    use tracing::warn;
+
+    let cto_delay = table
+        .get("cto_entry_delay_secs")
+        .and_then(momentum_toml_u64);
+    let new_delay = table
+        .get("dev_sell_revalidation_delay_secs")
+        .and_then(momentum_toml_u64);
+
+    match (cto_delay, new_delay) {
+        (Some(c), None) => {
+            warn!(
+                cto_entry_delay_secs = c,
+                dev_sell_revalidation_delay_secs = c,
+                "`cto_entry_delay_secs` is deprecated; migrated to `dev_sell_revalidation_delay_secs`"
+            );
+            table.insert(
+                "dev_sell_revalidation_delay_secs".to_string(),
+                toml::Value::Integer(c as i64),
+            );
+        }
+        (Some(c), Some(n)) => {
+            let merged = c.max(n);
+            if c != n {
+                warn!(
+                    cto_entry_delay_secs = c,
+                    dev_sell_revalidation_delay_secs = n,
+                    merged,
+                    "Both `cto_entry_delay_secs` and `dev_sell_revalidation_delay_secs` set; using max"
+                );
+            }
+            table.insert(
+                "dev_sell_revalidation_delay_secs".to_string(),
+                toml::Value::Integer(merged as i64),
+            );
+        }
+        _ => {}
+    }
+    table.remove("cto_entry_delay_secs");
+
+    for key in DEPRECATED_MOMENTUM_DEV_SELL_KEYS {
+        if table.remove(*key).is_some() {
+            warn!(
+                key = *key,
+                "Deprecated `[momentum]` config key ignored (dev-sell revalidation delay replaces CTO / early-window gates)"
+            );
+        }
+    }
+}
+
 fn momentum_cfg_from_toml_value(val: toml::Value) -> Result<MomentumCfg, String> {
     toml::to_string(&val)
         .map_err(|e| e.to_string())
@@ -119,6 +190,7 @@ where
     };
     if let Some(t) = v.as_table_mut() {
         migrate_momentum_trade_velocity_keys_in_table(t);
+        migrate_momentum_dev_sell_config_keys_in_table(t);
     }
     momentum_cfg_from_toml_value(v)
         .map_err(serde::de::Error::custom)
@@ -716,13 +788,10 @@ pub struct MomentumCfg {
     #[serde(default = "default_max_single_dump")]
     pub max_single_dump_lamports: u64,
 
-    // === Filter 4: Dev Behavior ===
-    /// Dev early sell triggers exit (seconds after pool creation). Default: 60s
-    #[serde(default = "default_dev_early_sell_window")]
-    pub dev_early_sell_window_secs: u64,
-    /// Dev rebuy is positive signal. Default: true
-    #[serde(default = "default_dev_rebuy_positive")]
-    pub dev_rebuy_positive: bool,
+    // === Dev-Sell Re-Validation (pre-entry) ===
+    /// Pause after any pre-entry dev sell before re-evaluating standard soft gates. Default: 30s
+    #[serde(default = "default_dev_sell_revalidation_delay_secs")]
+    pub dev_sell_revalidation_delay_secs: u64,
 
     // === Token Safety: Mint/Freeze Authority (via TokenMintInfo MarketEvents) ===
     /// Require mint authority to be renounced (mint_authority == None) before entering.
@@ -818,33 +887,6 @@ pub struct MomentumCfg {
     /// Default: 10s.
     #[serde(default = "default_dump_recovery_min_recovery_secs")]
     pub dump_recovery_min_recovery_secs: u64,
-
-    // === CTO Mode (pre-entry dev sell handling) ===
-    /// If true, a pre-entry dev sell transitions into CTO candidate state (wait-for-recovery)
-    /// instead of hard reject.
-    /// Default: false.
-    #[serde(default = "default_cto_enabled")]
-    pub cto_enabled: bool,
-    /// Minimum delay (seconds) after pre-entry dev sell before CTO recovery evaluation.
-    /// Default: 30s.
-    #[serde(default = "default_cto_entry_delay_secs")]
-    pub cto_entry_delay_secs: u64,
-    /// Confirmation window (seconds) used to evaluate CTO recovery.
-    /// Default: 30s.
-    #[serde(default = "default_cto_confirm_window_secs")]
-    pub cto_confirm_window_secs: u64,
-    /// Minimum unique buyers required during CTO recovery.
-    /// Default: 5.
-    #[serde(default = "default_cto_min_unique_buyers")]
-    pub cto_min_unique_buyers: u32,
-    /// Minimum buy dominance required during CTO recovery.
-    /// Default: 0.55.
-    #[serde(default = "default_cto_min_buy_dominance")]
-    pub cto_min_buy_dominance: f64,
-    /// Minimum net SOL inflow (lamports) required during CTO recovery.
-    /// Default: 1 SOL.
-    #[serde(default = "default_cto_min_net_inflow_lamports")]
-    pub cto_min_net_inflow_lamports: u64,
 }
 
 // Momentum config defaults - tuned to be less strict than original hardcoded values
@@ -902,11 +944,8 @@ fn default_inflow_window() -> u64 {
 fn default_max_single_dump() -> u64 {
     10_000_000_000
 } // 10 SOL
-fn default_dev_early_sell_window() -> u64 {
-    60
-}
-fn default_dev_rebuy_positive() -> bool {
-    true
+fn default_dev_sell_revalidation_delay_secs() -> u64 {
+    30
 }
 fn default_require_mint_authority_renounced() -> bool {
     false
@@ -979,25 +1018,6 @@ fn default_dump_recovery_min_recovery_secs() -> u64 {
     10
 }
 
-fn default_cto_enabled() -> bool {
-    false
-}
-fn default_cto_entry_delay_secs() -> u64 {
-    30
-}
-fn default_cto_confirm_window_secs() -> u64 {
-    30
-}
-fn default_cto_min_unique_buyers() -> u32 {
-    5
-}
-fn default_cto_min_buy_dominance() -> f64 {
-    0.55
-}
-fn default_cto_min_net_inflow_lamports() -> u64 {
-    1_000_000_000
-} // 1 SOL
-
 impl Default for MomentumCfg {
     fn default() -> Self {
         Self {
@@ -1019,8 +1039,7 @@ impl Default for MomentumCfg {
             min_sol_inflow_lamports: default_min_sol_inflow(),
             inflow_window_secs: default_inflow_window(),
             max_single_dump_lamports: default_max_single_dump(),
-            dev_early_sell_window_secs: default_dev_early_sell_window(),
-            dev_rebuy_positive: default_dev_rebuy_positive(),
+            dev_sell_revalidation_delay_secs: default_dev_sell_revalidation_delay_secs(),
             require_mint_authority_renounced: default_require_mint_authority_renounced(),
             require_freeze_authority_none: default_require_freeze_authority_none(),
             hard_stop_loss_pct: default_hard_stop_loss(),
@@ -1045,12 +1064,6 @@ impl Default for MomentumCfg {
             dump_recovery_min_buy_dominance: default_dump_recovery_min_buy_dominance(),
             dump_recovery_min_net_inflow_lamports: default_dump_recovery_min_net_inflow_lamports(),
             dump_recovery_min_recovery_secs: default_dump_recovery_min_recovery_secs(),
-            cto_enabled: default_cto_enabled(),
-            cto_entry_delay_secs: default_cto_entry_delay_secs(),
-            cto_confirm_window_secs: default_cto_confirm_window_secs(),
-            cto_min_unique_buyers: default_cto_min_unique_buyers(),
-            cto_min_buy_dominance: default_cto_min_buy_dominance(),
-            cto_min_net_inflow_lamports: default_cto_min_net_inflow_lamports(),
         }
     }
 }

--- a/ui/src/pages/ComponentDetail.tsx
+++ b/ui/src/pages/ComponentDetail.tsx
@@ -171,9 +171,9 @@ const CONFIG_DESCRIPTIONS: Record<string, Record<string, string>> = {
     inflow_window_secs: 'FILTER 3: Time window for SOL inflow tracking (seconds)',
     max_single_dump_lamports: 'FILTER 3: Max allowed single sell (lamports)',
     
-    // Filter 4: Dev Behavior
-    dev_early_sell_window_secs: 'FILTER 4: Dev sells in first N secs = bad signal',
-    dev_rebuy_positive: 'FILTER 4: Dev rebuy is positive signal (true/false)',
+    // Dev-Sell Re-Validation (pre-entry)
+    dev_sell_revalidation_delay_secs:
+      'DEV SELL: Pause after pre-entry dev sell before re-checking soft gates (seconds)',
     
     // Buyer Quality (Anti-Bot)
     top1_buyer_share_cap: 'ANTI-BOT: Max share for top-1 buyer (0.35 = 35%)',
@@ -189,14 +189,6 @@ const CONFIG_DESCRIPTIONS: Record<string, Record<string, string>> = {
     dump_recovery_min_buy_dominance: 'DUMP: Min buy dominance for recovery (0.55 = 55%)',
     dump_recovery_min_net_inflow_lamports: 'DUMP: Min net inflow for recovery (lamports)',
     dump_recovery_min_recovery_secs: 'DUMP: Min seconds of recovery before entry',
-    
-    // CTO Mode (Community Takeover)
-    cto_enabled: 'CTO: Enable CTO mode (wait for recovery after dev sells)',
-    cto_entry_delay_secs: 'CTO: Delay before allowing entry after dev sell (seconds)',
-    cto_confirm_window_secs: 'CTO: Window to confirm recovery (seconds)',
-    cto_min_unique_buyers: 'CTO: Min unique buyers for recovery confirmation',
-    cto_min_buy_dominance: 'CTO: Min buy dominance for recovery (0.55 = 55%)',
-    cto_min_net_inflow_lamports: 'CTO: Min net inflow for recovery (lamports)',
     
     // Exit Strategy
     hard_stop_loss_pct: 'EXIT: Hard stop-loss from entry (%, 15=15%)',
@@ -316,9 +308,8 @@ const CONFIG_GROUPS: Record<string, Record<string, string[]>> = {
       'inflow_window_secs',
       'max_single_dump_lamports',
     ],
-    'Filter 4: Dev Behavior': [
-      'dev_early_sell_window_secs',
-      'dev_rebuy_positive',
+    'Dev-Sell Re-Validation': [
+      'dev_sell_revalidation_delay_secs',
     ],
     'Anti-Bot (Buyer Quality)': [
       'top1_buyer_share_cap',
@@ -334,14 +325,6 @@ const CONFIG_GROUPS: Record<string, Record<string, string[]>> = {
       'dump_recovery_min_buy_dominance',
       'dump_recovery_min_net_inflow_lamports',
       'dump_recovery_min_recovery_secs',
-    ],
-    'CTO Mode (Community Takeover)': [
-      'cto_enabled',
-      'cto_entry_delay_secs',
-      'cto_confirm_window_secs',
-      'cto_min_unique_buyers',
-      'cto_min_buy_dominance',
-      'cto_min_net_inflow_lamports',
     ],
     'Exit Strategy': [
       'hard_stop_loss_pct',
@@ -457,9 +440,8 @@ const DEFAULT_CONFIGS: Record<string, ComponentConfig> = {
     inflow_window_secs: 60,
     max_single_dump_lamports: 20000000000, // 20 SOL
     
-    // Filter 4: Dev Behavior
-    dev_early_sell_window_secs: 90,
-    dev_rebuy_positive: true,
+    // Dev-Sell Re-Validation
+    dev_sell_revalidation_delay_secs: 30,
     
     // Anti-Bot (Buyer Quality)
     top1_buyer_share_cap: 0.35,
@@ -475,14 +457,6 @@ const DEFAULT_CONFIGS: Record<string, ComponentConfig> = {
     dump_recovery_min_buy_dominance: 0.55,
     dump_recovery_min_net_inflow_lamports: 1000000000, // 1 SOL
     dump_recovery_min_recovery_secs: 10,
-    
-    // CTO Mode (Community Takeover)
-    cto_enabled: false,
-    cto_entry_delay_secs: 30,
-    cto_confirm_window_secs: 30,
-    cto_min_unique_buyers: 5,
-    cto_min_buy_dominance: 0.55,
-    cto_min_net_inflow_lamports: 1000000000, // 1 SOL
     
     // Exit Strategy
     hard_stop_loss_pct: 15.0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two related pre-entry momentum issues:

1. **Window metrics bug:** `buy_dominance` and `trades_per_min` in `calculate_metrics` now use the `buyer_window_secs` chain-slot window (same pattern as `unique_buyers_in_window`, dump-recovery, post-entry momentum exit) instead of lifetime aggregates.

2. **Dev-sell gating:** Any pre-entry dev sell triggers `WAIT_DEV_SELL_REVALIDATION` for `dev_sell_revalidation_delay_secs` (default 30s). After the delay, standard soft gates (Filter 2+3) must pass on **fresh** window data — no sticky bypass. CTO mode and `REJECT_DEV_SELL_EARLY` are removed.

## Changes

- `TokenTracker`: `dev_sell_observed_at` replaces `dev_sold_early`, CTO state, and hard-reject path
- Config: new `dev_sell_revalidation_delay_secs`; removed `cto_*`, `dev_early_sell_window_secs`, `dev_rebuy_positive`
- TOML migration: deprecated keys warn + ignore; `cto_entry_delay_secs` → `dev_sell_revalidation_delay_secs` (max if both)
- Sibling pool sync: propagates `dev_sell_observed_at` without blacklist
- Docs/UI/example config updated

## STOP-CHECK (performed)

- I-7: No new RPC in hot path (filter/trade ingest only)
- I-4/I-16: Chain-slot windows remain authoritative
- I-9: Simulation gate unchanged
- I-12: `WAIT_DEV_SELL_REVALIDATION` reason code emitted via existing WAIT path

## Tests

- `buy_dominance_uses_buyer_window_not_lifetime`
- `trades_per_min_uses_buyer_window_not_lifetime`
- `dev_sell_pre_entry_waits_not_rejects`
- `dev_sell_after_delay_requires_fresh_filter_pass`
- `dev_sell_resets_delay_on_resell`
- `dev_sell_sibling_pools_sync_wait_not_reject`
- Replaced legacy CTO tests

```
cargo fmt --check
cargo clippy -- -D warnings
cargo test --bin momentum-bot  # 129 passed
cargo test --quiet
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9afc87e1-cde0-4c5d-a231-4a5c16d625b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9afc87e1-cde0-4c5d-a231-4a5c16d625b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

