### PR TITLE
feat(pump_amm): P184 Geyser 26-account SELL parse → LivePoolCache

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -12902,6 +12902,7 @@ mod execution_engine_tests {
                 Some(t1),
                 None,
                 None,
+                false,
             );
             cache_clone.set_pump_amm_sell_layout_ready(&pool, true);
         });

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -12900,6 +12900,8 @@ mod execution_engine_tests {
                 Some(third),
                 Some(t0),
                 Some(t1),
+                None,
+                None,
             );
             cache_clone.set_pump_amm_sell_layout_ready(&pool, true);
         });

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -612,6 +612,7 @@ enum MdSidefxCommand {
         pool_address: Pubkey,
         base_mint_pk: Pubkey,
         slot: u64,
+        is_buy: bool,
         pool_accounts: Vec<Pubkey>,
         pump_amm_sell_requires_cashback_remaining: bool,
         pump_amm_sell_cashback_third_meta: Option<Pubkey>,
@@ -966,6 +967,7 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
         pool_address,
         base_mint_pk,
         slot,
+        is_buy,
         pool_accounts,
         pump_amm_sell_requires_cashback_remaining,
         pump_amm_sell_cashback_third_meta,
@@ -1104,6 +1106,27 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
         w.ctx
             .live_pool_cache
             .set_pump_amm_sell_layout_ready(pool_address, sell_layout_ready);
+        if !*is_buy {
+            ironcrab::metrics::record_pump_amm_geyser_sell_parsed();
+            if sell_layout_ready {
+                w.ctx
+                    .live_pool_cache
+                    .set_pump_amm_sell_layout_authoritative(
+                        pool_address,
+                        merged_flag,
+                        merged_third,
+                        merged_t0,
+                        merged_t1,
+                    );
+                ironcrab::metrics::record_pump_amm_geyser_sell_layout_ready();
+                info!(
+                    pool = %pool_address,
+                    base_mint = %base_mint_pk,
+                    slot = *slot,
+                    "pump_amm: Geyser SELL set sell_layout_ready (authoritative extended layout)"
+                );
+            }
+        }
         w.ctx
             .live_pool_cache
             .set_pump_amm_pool_accounts_readiness_authoritative(*pool_address, dex_readiness);
@@ -11141,6 +11164,7 @@ async fn handle_geyser_transaction(
         pool_address,
         mint: base_mint_pk,
         dex: DexType::PumpFunAmm,
+        is_buy,
         pool_accounts: Some(pool_accounts),
         pump_amm_sell_requires_cashback_remaining,
         pump_amm_sell_cashback_third_meta,
@@ -11156,6 +11180,7 @@ async fn handle_geyser_transaction(
                 pool_address: *pool_address,
                 base_mint_pk: *base_mint_pk,
                 slot: tx_update.slot,
+                is_buy: *is_buy,
                 pool_accounts: pool_accounts.clone(),
                 pump_amm_sell_requires_cashback_remaining:
                     *pump_amm_sell_requires_cashback_remaining,

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -618,6 +618,8 @@ enum MdSidefxCommand {
         pump_amm_sell_cashback_third_meta: Option<Pubkey>,
         pump_amm_sell_extended_tail_0: Option<Pubkey>,
         pump_amm_sell_extended_tail_1: Option<Pubkey>,
+        pump_amm_sell_extended_fee_tail_0: Option<Pubkey>,
+        pump_amm_sell_extended_fee_tail_1: Option<Pubkey>,
         tx_geyser_recv_at: Instant,
     },
     GenericDexFirstTradeAccounts {
@@ -961,6 +963,7 @@ fn md_sidefx_process_pump_amm_create_pool(w: &MdSidefxWorkerCtx, job: &MdSidefxC
         .insert(pool_address.to_string(), base_mint.clone());
 }
 
+#[allow(clippy::type_complexity)]
 fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand) {
     let MdSidefxCommand::PumpAmmTradeWithAccounts {
         run_id,
@@ -973,32 +976,74 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
         pump_amm_sell_cashback_third_meta,
         pump_amm_sell_extended_tail_0,
         pump_amm_sell_extended_tail_1,
+        pump_amm_sell_extended_fee_tail_0,
+        pump_amm_sell_extended_fee_tail_1,
         tx_geyser_recv_at,
     } = job
     else {
         return;
     };
+    let filter_opt_pk = |p: Option<Pubkey>| p.filter(|pk| *pk != Pubkey::default());
+    let this_tx_tail = filter_opt_pk(*pump_amm_sell_cashback_third_meta)
+        .or(filter_opt_pk(*pump_amm_sell_extended_tail_0))
+        .or(filter_opt_pk(*pump_amm_sell_extended_tail_1))
+        .or(filter_opt_pk(*pump_amm_sell_extended_fee_tail_0))
+        .or(filter_opt_pk(*pump_amm_sell_extended_fee_tail_1));
+    let this_tx_defines_sell_layout =
+        *pump_amm_sell_requires_cashback_remaining || this_tx_tail.is_some();
     let (ext_flag_prior, ext_third_prior, ext_t0_prior, ext_t1_prior) = w
         .ctx
         .live_pool_cache
         .pump_amm_sell_extended_layout(pool_address);
-    let merge_requires = *pump_amm_sell_requires_cashback_remaining || ext_flag_prior;
-    let merge_third = (*pump_amm_sell_cashback_third_meta)
-        .filter(|p| *p != Pubkey::default())
-        .or(ext_third_prior);
-    let merge_t0 = (*pump_amm_sell_extended_tail_0)
-        .filter(|p| *p != Pubkey::default())
-        .or(ext_t0_prior);
-    let merge_t1 = (*pump_amm_sell_extended_tail_1)
-        .filter(|p| *p != Pubkey::default())
-        .or(ext_t1_prior);
-    if merge_requires || merge_third.is_some() || merge_t0.is_some() || merge_t1.is_some() {
+    let (ext_fee_t0_prior, ext_fee_t1_prior) = w
+        .ctx
+        .live_pool_cache
+        .pump_amm_sell_fee_tail_layout(pool_address);
+    let merge_requires = if this_tx_defines_sell_layout {
+        *pump_amm_sell_requires_cashback_remaining
+    } else {
+        *pump_amm_sell_requires_cashback_remaining || ext_flag_prior
+    };
+    let merge_third = if this_tx_defines_sell_layout {
+        filter_opt_pk(*pump_amm_sell_cashback_third_meta)
+    } else {
+        filter_opt_pk(*pump_amm_sell_cashback_third_meta).or(ext_third_prior)
+    };
+    let merge_t0 = if this_tx_defines_sell_layout {
+        filter_opt_pk(*pump_amm_sell_extended_tail_0)
+    } else {
+        filter_opt_pk(*pump_amm_sell_extended_tail_0).or(ext_t0_prior)
+    };
+    let merge_t1 = if this_tx_defines_sell_layout {
+        filter_opt_pk(*pump_amm_sell_extended_tail_1)
+    } else {
+        filter_opt_pk(*pump_amm_sell_extended_tail_1).or(ext_t1_prior)
+    };
+    let merge_fee_t0 = if this_tx_defines_sell_layout {
+        filter_opt_pk(*pump_amm_sell_extended_fee_tail_0)
+    } else {
+        filter_opt_pk(*pump_amm_sell_extended_fee_tail_0).or(ext_fee_t0_prior)
+    };
+    let merge_fee_t1 = if this_tx_defines_sell_layout {
+        filter_opt_pk(*pump_amm_sell_extended_fee_tail_1)
+    } else {
+        filter_opt_pk(*pump_amm_sell_extended_fee_tail_1).or(ext_fee_t1_prior)
+    };
+    if merge_requires
+        || merge_third.is_some()
+        || merge_t0.is_some()
+        || merge_t1.is_some()
+        || merge_fee_t0.is_some()
+        || merge_fee_t1.is_some()
+    {
         w.ctx.live_pool_cache.merge_pump_amm_sell_extended_layout(
             pool_address,
             merge_requires,
             merge_third,
             merge_t0,
             merge_t1,
+            merge_fee_t0,
+            merge_fee_t1,
         );
     }
     let base_mint = pool_accounts
@@ -1086,21 +1131,57 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
             .ctx
             .live_pool_cache
             .pump_amm_sell_extended_layout(pool_address);
-        let merged_flag = ext_flag || *pump_amm_sell_requires_cashback_remaining;
-        let merged_third = ext_third
-            .or(*pump_amm_sell_cashback_third_meta)
-            .filter(|p| *p != Pubkey::default());
-        let merged_t0 = ext_t0
-            .or(*pump_amm_sell_extended_tail_0)
-            .filter(|p| *p != Pubkey::default());
-        let merged_t1 = ext_t1
-            .or(*pump_amm_sell_extended_tail_1)
-            .filter(|p| *p != Pubkey::default());
+        let (ext_fee_t0, ext_fee_t1) = w
+            .ctx
+            .live_pool_cache
+            .pump_amm_sell_fee_tail_layout(pool_address);
+        let merged_flag = if this_tx_defines_sell_layout {
+            *pump_amm_sell_requires_cashback_remaining
+        } else {
+            ext_flag || *pump_amm_sell_requires_cashback_remaining
+        };
+        let merged_third = if this_tx_defines_sell_layout {
+            filter_opt_pk(*pump_amm_sell_cashback_third_meta)
+        } else {
+            ext_third
+                .or(*pump_amm_sell_cashback_third_meta)
+                .and_then(|p| filter_opt_pk(Some(p)))
+        };
+        let merged_t0 = if this_tx_defines_sell_layout {
+            filter_opt_pk(*pump_amm_sell_extended_tail_0)
+        } else {
+            ext_t0
+                .or(*pump_amm_sell_extended_tail_0)
+                .and_then(|p| filter_opt_pk(Some(p)))
+        };
+        let merged_t1 = if this_tx_defines_sell_layout {
+            filter_opt_pk(*pump_amm_sell_extended_tail_1)
+        } else {
+            ext_t1
+                .or(*pump_amm_sell_extended_tail_1)
+                .and_then(|p| filter_opt_pk(Some(p)))
+        };
+        let merged_fee_t0 = if this_tx_defines_sell_layout {
+            filter_opt_pk(*pump_amm_sell_extended_fee_tail_0)
+        } else {
+            ext_fee_t0
+                .or(*pump_amm_sell_extended_fee_tail_0)
+                .and_then(|p| filter_opt_pk(Some(p)))
+        };
+        let merged_fee_t1 = if this_tx_defines_sell_layout {
+            filter_opt_pk(*pump_amm_sell_extended_fee_tail_1)
+        } else {
+            ext_fee_t1
+                .or(*pump_amm_sell_extended_fee_tail_1)
+                .and_then(|p| filter_opt_pk(Some(p)))
+        };
         let (sell_layout_ready, dex_readiness) = pump_amm_sell_layout_publish_state(
             merged_flag,
             merged_third,
             merged_t0,
             merged_t1,
+            merged_fee_t0,
+            merged_fee_t1,
             true,
         );
         w.ctx
@@ -1117,6 +1198,8 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
                         merged_third,
                         merged_t0,
                         merged_t1,
+                        merged_fee_t0,
+                        merged_fee_t1,
                     );
                 ironcrab::metrics::record_pump_amm_geyser_sell_layout_ready();
                 info!(
@@ -2416,6 +2499,8 @@ fn pump_amm_sell_layout_publish_state(
     sell_cashback_third_meta: Option<Pubkey>,
     sell_extended_tail_0: Option<Pubkey>,
     sell_extended_tail_1: Option<Pubkey>,
+    sell_extended_fee_tail_0: Option<Pubkey>,
+    sell_extended_fee_tail_1: Option<Pubkey>,
     base_layout_ready: bool,
 ) -> (bool, DexPoolReadiness) {
     let sell_layout_ready = if sell_requires_extended {
@@ -2428,7 +2513,19 @@ fn pump_amm_sell_layout_publish_state(
             && sell_extended_tail_1
                 .filter(|p| *p != Pubkey::default())
                 .is_some();
-        third_ok && tail_ok && base_layout_ready
+        let needs_fee_tail =
+            sell_extended_fee_tail_0.is_some() || sell_extended_fee_tail_1.is_some();
+        let fee_ok = if needs_fee_tail {
+            sell_extended_fee_tail_0
+                .filter(|p| *p != Pubkey::default())
+                .is_some()
+                && sell_extended_fee_tail_1
+                    .filter(|p| *p != Pubkey::default())
+                    .is_some()
+        } else {
+            true
+        };
+        third_ok && tail_ok && fee_ok && base_layout_ready
     } else {
         base_layout_ready
     };
@@ -2443,20 +2540,26 @@ fn pump_amm_sell_layout_publish_state(
 /// Resolve PumpSwap SELL-layout state for the EnsurePumpAmmPoolAccounts publish path.
 ///
 /// `force_refresh=true` is authoritative and must be able to override stale monotonic cache hints.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
 fn pump_amm_sell_layout_state_for_ensure_publish(
     force_refresh: bool,
     cached_requires_extended: bool,
     cached_third_meta: Option<Pubkey>,
     cached_tail_0: Option<Pubkey>,
     cached_tail_1: Option<Pubkey>,
+    cached_fee_tail_0: Option<Pubkey>,
+    cached_fee_tail_1: Option<Pubkey>,
     refresh_requires_extended: bool,
     refresh_third_meta: Option<Pubkey>,
     refresh_tail_0: Option<Pubkey>,
     refresh_tail_1: Option<Pubkey>,
+    refresh_fee_tail_0: Option<Pubkey>,
+    refresh_fee_tail_1: Option<Pubkey>,
     refresh_layout_ready: bool,
 ) -> (
     bool,
+    Option<Pubkey>,
+    Option<Pubkey>,
     Option<Pubkey>,
     Option<Pubkey>,
     Option<Pubkey>,
@@ -2468,6 +2571,8 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
         effective_third_meta,
         effective_tail_0,
         effective_tail_1,
+        effective_fee_tail_0,
+        effective_fee_tail_1,
         base_layout_ready,
     ) = if force_refresh {
         (
@@ -2475,6 +2580,8 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
             refresh_third_meta.filter(|p| *p != Pubkey::default()),
             refresh_tail_0.filter(|p| *p != Pubkey::default()),
             refresh_tail_1.filter(|p| *p != Pubkey::default()),
+            refresh_fee_tail_0.filter(|p| *p != Pubkey::default()),
+            refresh_fee_tail_1.filter(|p| *p != Pubkey::default()),
             refresh_layout_ready,
         )
     } else {
@@ -2489,6 +2596,12 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
             refresh_tail_1
                 .or(cached_tail_1)
                 .filter(|p| *p != Pubkey::default()),
+            refresh_fee_tail_0
+                .or(cached_fee_tail_0)
+                .filter(|p| *p != Pubkey::default()),
+            refresh_fee_tail_1
+                .or(cached_fee_tail_1)
+                .filter(|p| *p != Pubkey::default()),
             refresh_layout_ready,
         )
     };
@@ -2497,6 +2610,8 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
         effective_third_meta,
         effective_tail_0,
         effective_tail_1,
+        effective_fee_tail_0,
+        effective_fee_tail_1,
         base_layout_ready,
     );
     (
@@ -2504,6 +2619,8 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
         effective_third_meta,
         effective_tail_0,
         effective_tail_1,
+        effective_fee_tail_0,
+        effective_fee_tail_1,
         sell_layout_ready,
         dex_readiness,
     )
@@ -8948,6 +9065,8 @@ async fn handle_ensure_pump_amm_pool_accounts(
             let sell_cashback_third = wrapped.sell_cashback_third_meta;
             let sell_tail_0 = wrapped.sell_extended_tail_0;
             let sell_tail_1 = wrapped.sell_extended_tail_1;
+            let sell_fee_tail_0 = wrapped.sell_extended_fee_tail_0;
+            let sell_fee_tail_1 = wrapped.sell_extended_fee_tail_1;
             let sell_layout_ready_from_refresh = wrapped.sell_layout_ready;
             let pump_amm_force_refresh_sell_diag = wrapped.force_refresh_sell_layout_diag;
             let accounts = wrapped.accounts;
@@ -8980,11 +9099,16 @@ async fn handle_ensure_pump_amm_pool_accounts(
             let (ext_flag_cache, ext_third_cache, ext_t0_cache, ext_t1_cache) = ctx
                 .live_pool_cache
                 .pump_amm_sell_extended_layout(&pool_address);
+            let (ext_fee_t0_cache, ext_fee_t1_cache) = ctx
+                .live_pool_cache
+                .pump_amm_sell_fee_tail_layout(&pool_address);
             let (
                 sell_flag_merged,
                 third_merged,
                 tail0_merged,
                 tail1_merged,
+                fee_tail0_merged,
+                fee_tail1_merged,
                 sell_layout_ready,
                 dex_readiness,
             ) = pump_amm_sell_layout_state_for_ensure_publish(
@@ -8993,10 +9117,14 @@ async fn handle_ensure_pump_amm_pool_accounts(
                 ext_third_cache,
                 ext_t0_cache,
                 ext_t1_cache,
+                ext_fee_t0_cache,
+                ext_fee_t1_cache,
                 sell_cashback_remaining,
                 sell_cashback_third,
                 sell_tail_0,
                 sell_tail_1,
+                sell_fee_tail_0,
+                sell_fee_tail_1,
                 sell_layout_ready_from_refresh,
             );
 
@@ -9054,6 +9182,8 @@ async fn handle_ensure_pump_amm_pool_accounts(
                     third_merged,
                     tail0_merged,
                     tail1_merged,
+                    fee_tail0_merged,
+                    fee_tail1_merged,
                 );
             } else {
                 ctx.live_pool_cache.merge_pump_amm_sell_extended_layout(
@@ -9062,6 +9192,8 @@ async fn handle_ensure_pump_amm_pool_accounts(
                     third_merged,
                     tail0_merged,
                     tail1_merged,
+                    fee_tail0_merged,
+                    fee_tail1_merged,
                 );
             }
             ctx.live_pool_cache
@@ -11170,6 +11302,8 @@ async fn handle_geyser_transaction(
         pump_amm_sell_cashback_third_meta,
         pump_amm_sell_extended_tail_0,
         pump_amm_sell_extended_tail_1,
+        pump_amm_sell_extended_fee_tail_0,
+        pump_amm_sell_extended_fee_tail_1,
         ..
     }) = parsed_event.as_ref()
     {
@@ -11187,6 +11321,8 @@ async fn handle_geyser_transaction(
                 pump_amm_sell_cashback_third_meta: *pump_amm_sell_cashback_third_meta,
                 pump_amm_sell_extended_tail_0: *pump_amm_sell_extended_tail_0,
                 pump_amm_sell_extended_tail_1: *pump_amm_sell_extended_tail_1,
+                pump_amm_sell_extended_fee_tail_0: *pump_amm_sell_extended_fee_tail_0,
+                pump_amm_sell_extended_fee_tail_1: *pump_amm_sell_extended_fee_tail_1,
                 tx_geyser_recv_at,
             },
         );
@@ -13162,7 +13298,7 @@ mod discovery_tests {
     #[test]
     fn test_pump_amm_trade_publish_extended_without_third_meta_is_partial() {
         let (sell_layout_ready, dex_readiness) =
-            pump_amm_sell_layout_publish_state(true, None, None, None, true);
+            pump_amm_sell_layout_publish_state(true, None, None, None, None, None, true);
         assert!(
             !sell_layout_ready,
             "extended SELL without authoritative third meta must not be marked ready"
@@ -13172,8 +13308,15 @@ mod discovery_tests {
 
     #[test]
     fn test_pump_amm_trade_publish_extended_with_third_only_missing_tail_is_partial() {
-        let (sell_layout_ready, dex_readiness) =
-            pump_amm_sell_layout_publish_state(true, Some(Pubkey::new_unique()), None, None, true);
+        let (sell_layout_ready, dex_readiness) = pump_amm_sell_layout_publish_state(
+            true,
+            Some(Pubkey::new_unique()),
+            None,
+            None,
+            None,
+            None,
+            true,
+        );
         assert!(
             !sell_layout_ready,
             "extended SELL with third but missing tail0/tail1 must not be marked ready"
@@ -13189,6 +13332,8 @@ mod discovery_tests {
             Some(Pubkey::new_unique()),
             Some(Pubkey::new_unique()),
             Some(Pubkey::new_unique()),
+            None,
+            None,
             true,
         );
         assert!(
@@ -13208,6 +13353,8 @@ mod discovery_tests {
             effective_third_meta,
             effective_tail_0,
             effective_tail_1,
+            _effective_fee_tail_0,
+            _effective_fee_tail_1,
             sell_layout_ready,
             dex_readiness,
         ) = pump_amm_sell_layout_state_for_ensure_publish(
@@ -13216,7 +13363,11 @@ mod discovery_tests {
             Some(stale_third),
             Some(stale_t0),
             Some(stale_t1),
+            None,
+            None,
             false,
+            None,
+            None,
             None,
             None,
             None,

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1251,6 +1251,18 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
             if let Some(pk) = merged_t1 {
                 meta.insert("pump_amm_sell_extended_tail_1".to_string(), pk.to_string());
             }
+            if let Some(pk) = merged_fee_t0 {
+                meta.insert(
+                    "pump_amm_sell_extended_fee_tail_0".to_string(),
+                    pk.to_string(),
+                );
+            }
+            if let Some(pk) = merged_fee_t1 {
+                meta.insert(
+                    "pump_amm_sell_extended_fee_tail_1".to_string(),
+                    pk.to_string(),
+                );
+            }
             pool_update.metadata = Some(meta);
             pool_update.set_dex_readiness_in_metadata(dex_readiness);
             let subject = pool_subject(&pool_address.to_string());
@@ -9245,6 +9257,18 @@ async fn handle_ensure_pump_amm_pool_accounts(
                 }
                 if let Some(pk) = tail1_merged {
                     meta.insert("pump_amm_sell_extended_tail_1".to_string(), pk.to_string());
+                }
+                if let Some(pk) = fee_tail0_merged {
+                    meta.insert(
+                        "pump_amm_sell_extended_fee_tail_0".to_string(),
+                        pk.to_string(),
+                    );
+                }
+                if let Some(pk) = fee_tail1_merged {
+                    meta.insert(
+                        "pump_amm_sell_extended_fee_tail_1".to_string(),
+                        pk.to_string(),
+                    );
                 }
                 if let Some(creator) = creator_opt {
                     meta.insert("creator".to_string(), creator.to_string());

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -620,6 +620,7 @@ enum MdSidefxCommand {
         pump_amm_sell_extended_tail_1: Option<Pubkey>,
         pump_amm_sell_extended_fee_tail_0: Option<Pubkey>,
         pump_amm_sell_extended_fee_tail_1: Option<Pubkey>,
+        pump_amm_sell_requires_fee_tail: bool,
         tx_geyser_recv_at: Instant,
     },
     GenericDexFirstTradeAccounts {
@@ -978,6 +979,7 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
         pump_amm_sell_extended_tail_1,
         pump_amm_sell_extended_fee_tail_0,
         pump_amm_sell_extended_fee_tail_1,
+        pump_amm_sell_requires_fee_tail,
         tx_geyser_recv_at,
     } = job
     else {
@@ -999,6 +1001,15 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
         .ctx
         .live_pool_cache
         .pump_amm_sell_fee_tail_layout(pool_address);
+    let ext_requires_fee_tail_prior = w
+        .ctx
+        .live_pool_cache
+        .pump_amm_sell_requires_fee_tail(pool_address);
+    let merge_requires_fee_tail = if this_tx_defines_sell_layout {
+        *pump_amm_sell_requires_fee_tail
+    } else {
+        ext_requires_fee_tail_prior || *pump_amm_sell_requires_fee_tail
+    };
     let merge_requires = if this_tx_defines_sell_layout {
         *pump_amm_sell_requires_cashback_remaining
     } else {
@@ -1044,6 +1055,7 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
             merge_t1,
             merge_fee_t0,
             merge_fee_t1,
+            merge_requires_fee_tail,
         );
     }
     let base_mint = pool_accounts
@@ -1135,6 +1147,15 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
             .ctx
             .live_pool_cache
             .pump_amm_sell_fee_tail_layout(pool_address);
+        let ext_requires_fee_tail = w
+            .ctx
+            .live_pool_cache
+            .pump_amm_sell_requires_fee_tail(pool_address);
+        let merged_requires_fee_tail = if this_tx_defines_sell_layout {
+            *pump_amm_sell_requires_fee_tail
+        } else {
+            ext_requires_fee_tail || *pump_amm_sell_requires_fee_tail
+        };
         let merged_flag = if this_tx_defines_sell_layout {
             *pump_amm_sell_requires_cashback_remaining
         } else {
@@ -1182,6 +1203,7 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
             merged_t1,
             merged_fee_t0,
             merged_fee_t1,
+            merged_requires_fee_tail,
             true,
         );
         w.ctx
@@ -1200,6 +1222,7 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
                         merged_t1,
                         merged_fee_t0,
                         merged_fee_t1,
+                        merged_requires_fee_tail,
                     );
                 ironcrab::metrics::record_pump_amm_geyser_sell_layout_ready();
                 info!(
@@ -1239,6 +1262,18 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
                 "pump_amm_sell_layout_ready".to_string(),
                 sell_layout_ready.to_string(),
             );
+            if !*is_buy && sell_layout_ready && this_tx_defines_sell_layout {
+                meta.insert(
+                    "pump_amm_sell_layout_authoritative".to_string(),
+                    "true".to_string(),
+                );
+            }
+            if merged_requires_fee_tail {
+                meta.insert(
+                    "pump_amm_sell_requires_fee_tail".to_string(),
+                    "true".to_string(),
+                );
+            }
             if let Some(pk) = merged_third {
                 meta.insert(
                     "pump_amm_sell_cashback_third_meta".to_string(),
@@ -1251,17 +1286,19 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
             if let Some(pk) = merged_t1 {
                 meta.insert("pump_amm_sell_extended_tail_1".to_string(), pk.to_string());
             }
-            if let Some(pk) = merged_fee_t0 {
-                meta.insert(
-                    "pump_amm_sell_extended_fee_tail_0".to_string(),
-                    pk.to_string(),
-                );
-            }
-            if let Some(pk) = merged_fee_t1 {
-                meta.insert(
-                    "pump_amm_sell_extended_fee_tail_1".to_string(),
-                    pk.to_string(),
-                );
+            if !*is_buy {
+                if let Some(pk) = merged_fee_t0 {
+                    meta.insert(
+                        "pump_amm_sell_extended_fee_tail_0".to_string(),
+                        pk.to_string(),
+                    );
+                }
+                if let Some(pk) = merged_fee_t1 {
+                    meta.insert(
+                        "pump_amm_sell_extended_fee_tail_1".to_string(),
+                        pk.to_string(),
+                    );
+                }
             }
             pool_update.metadata = Some(meta);
             pool_update.set_dex_readiness_in_metadata(dex_readiness);
@@ -2506,6 +2543,7 @@ fn raydium_cpmm_readiness_for_pool_cache_update(s: &RaydiumCpmmState) -> DexPool
 ///
 /// - Base-only SELL stays ready as long as the underlying refresh/observation says the base layout is usable.
 /// - Extended SELL is ready when the full observed tail (#21/#22/#23) is known and base layout is ready.
+#[allow(clippy::too_many_arguments)]
 fn pump_amm_sell_layout_publish_state(
     sell_requires_extended: bool,
     sell_cashback_third_meta: Option<Pubkey>,
@@ -2513,6 +2551,7 @@ fn pump_amm_sell_layout_publish_state(
     sell_extended_tail_1: Option<Pubkey>,
     sell_extended_fee_tail_0: Option<Pubkey>,
     sell_extended_fee_tail_1: Option<Pubkey>,
+    sell_requires_fee_tail: bool,
     base_layout_ready: bool,
 ) -> (bool, DexPoolReadiness) {
     let sell_layout_ready = if sell_requires_extended {
@@ -2525,8 +2564,9 @@ fn pump_amm_sell_layout_publish_state(
             && sell_extended_tail_1
                 .filter(|p| *p != Pubkey::default())
                 .is_some();
-        let needs_fee_tail =
-            sell_extended_fee_tail_0.is_some() || sell_extended_fee_tail_1.is_some();
+        let needs_fee_tail = sell_requires_fee_tail
+            || sell_extended_fee_tail_0.is_some()
+            || sell_extended_fee_tail_1.is_some();
         let fee_ok = if needs_fee_tail {
             sell_extended_fee_tail_0
                 .filter(|p| *p != Pubkey::default())
@@ -2561,12 +2601,14 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
     cached_tail_1: Option<Pubkey>,
     cached_fee_tail_0: Option<Pubkey>,
     cached_fee_tail_1: Option<Pubkey>,
+    cached_requires_fee_tail: bool,
     refresh_requires_extended: bool,
     refresh_third_meta: Option<Pubkey>,
     refresh_tail_0: Option<Pubkey>,
     refresh_tail_1: Option<Pubkey>,
     refresh_fee_tail_0: Option<Pubkey>,
     refresh_fee_tail_1: Option<Pubkey>,
+    refresh_requires_fee_tail: bool,
     refresh_layout_ready: bool,
 ) -> (
     bool,
@@ -2575,6 +2617,7 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
     Option<Pubkey>,
     Option<Pubkey>,
     Option<Pubkey>,
+    bool,
     bool,
     DexPoolReadiness,
 ) {
@@ -2585,6 +2628,7 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
         effective_tail_1,
         effective_fee_tail_0,
         effective_fee_tail_1,
+        effective_requires_fee_tail,
         base_layout_ready,
     ) = if force_refresh {
         (
@@ -2594,6 +2638,7 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
             refresh_tail_1.filter(|p| *p != Pubkey::default()),
             refresh_fee_tail_0.filter(|p| *p != Pubkey::default()),
             refresh_fee_tail_1.filter(|p| *p != Pubkey::default()),
+            refresh_requires_fee_tail,
             refresh_layout_ready,
         )
     } else {
@@ -2614,6 +2659,7 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
             refresh_fee_tail_1
                 .or(cached_fee_tail_1)
                 .filter(|p| *p != Pubkey::default()),
+            cached_requires_fee_tail || refresh_requires_fee_tail,
             refresh_layout_ready,
         )
     };
@@ -2624,6 +2670,7 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
         effective_tail_1,
         effective_fee_tail_0,
         effective_fee_tail_1,
+        effective_requires_fee_tail,
         base_layout_ready,
     );
     (
@@ -2633,6 +2680,7 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
         effective_tail_1,
         effective_fee_tail_0,
         effective_fee_tail_1,
+        effective_requires_fee_tail,
         sell_layout_ready,
         dex_readiness,
     )
@@ -9114,6 +9162,10 @@ async fn handle_ensure_pump_amm_pool_accounts(
             let (ext_fee_t0_cache, ext_fee_t1_cache) = ctx
                 .live_pool_cache
                 .pump_amm_sell_fee_tail_layout(&pool_address);
+            let ext_requires_fee_cache = ctx
+                .live_pool_cache
+                .pump_amm_sell_requires_fee_tail(&pool_address);
+            let refresh_requires_fee_tail = sell_fee_tail_0.is_some() && sell_fee_tail_1.is_some();
             let (
                 sell_flag_merged,
                 third_merged,
@@ -9121,6 +9173,7 @@ async fn handle_ensure_pump_amm_pool_accounts(
                 tail1_merged,
                 fee_tail0_merged,
                 fee_tail1_merged,
+                requires_fee_tail_merged,
                 sell_layout_ready,
                 dex_readiness,
             ) = pump_amm_sell_layout_state_for_ensure_publish(
@@ -9131,12 +9184,14 @@ async fn handle_ensure_pump_amm_pool_accounts(
                 ext_t1_cache,
                 ext_fee_t0_cache,
                 ext_fee_t1_cache,
+                ext_requires_fee_cache,
                 sell_cashback_remaining,
                 sell_cashback_third,
                 sell_tail_0,
                 sell_tail_1,
                 sell_fee_tail_0,
                 sell_fee_tail_1,
+                refresh_requires_fee_tail,
                 sell_layout_ready_from_refresh,
             );
 
@@ -9196,6 +9251,7 @@ async fn handle_ensure_pump_amm_pool_accounts(
                     tail1_merged,
                     fee_tail0_merged,
                     fee_tail1_merged,
+                    requires_fee_tail_merged,
                 );
             } else {
                 ctx.live_pool_cache.merge_pump_amm_sell_extended_layout(
@@ -9206,6 +9262,7 @@ async fn handle_ensure_pump_amm_pool_accounts(
                     tail1_merged,
                     fee_tail0_merged,
                     fee_tail1_merged,
+                    requires_fee_tail_merged,
                 );
             }
             ctx.live_pool_cache
@@ -9243,6 +9300,12 @@ async fn handle_ensure_pump_amm_pool_accounts(
                 if force_refresh {
                     meta.insert(
                         "pump_amm_sell_layout_authoritative".to_string(),
+                        "true".to_string(),
+                    );
+                }
+                if requires_fee_tail_merged {
+                    meta.insert(
+                        "pump_amm_sell_requires_fee_tail".to_string(),
                         "true".to_string(),
                     );
                 }
@@ -11328,6 +11391,7 @@ async fn handle_geyser_transaction(
         pump_amm_sell_extended_tail_1,
         pump_amm_sell_extended_fee_tail_0,
         pump_amm_sell_extended_fee_tail_1,
+        pump_amm_sell_requires_fee_tail,
         ..
     }) = parsed_event.as_ref()
     {
@@ -11347,6 +11411,7 @@ async fn handle_geyser_transaction(
                 pump_amm_sell_extended_tail_1: *pump_amm_sell_extended_tail_1,
                 pump_amm_sell_extended_fee_tail_0: *pump_amm_sell_extended_fee_tail_0,
                 pump_amm_sell_extended_fee_tail_1: *pump_amm_sell_extended_fee_tail_1,
+                pump_amm_sell_requires_fee_tail: *pump_amm_sell_requires_fee_tail,
                 tx_geyser_recv_at,
             },
         );
@@ -13322,7 +13387,7 @@ mod discovery_tests {
     #[test]
     fn test_pump_amm_trade_publish_extended_without_third_meta_is_partial() {
         let (sell_layout_ready, dex_readiness) =
-            pump_amm_sell_layout_publish_state(true, None, None, None, None, None, true);
+            pump_amm_sell_layout_publish_state(true, None, None, None, None, None, false, true);
         assert!(
             !sell_layout_ready,
             "extended SELL without authoritative third meta must not be marked ready"
@@ -13339,6 +13404,7 @@ mod discovery_tests {
             None,
             None,
             None,
+            false,
             true,
         );
         assert!(
@@ -13358,6 +13424,7 @@ mod discovery_tests {
             Some(Pubkey::new_unique()),
             None,
             None,
+            false,
             true,
         );
         assert!(
@@ -13379,6 +13446,7 @@ mod discovery_tests {
             effective_tail_1,
             _effective_fee_tail_0,
             _effective_fee_tail_1,
+            _effective_requires_fee_tail,
             sell_layout_ready,
             dex_readiness,
         ) = pump_amm_sell_layout_state_for_ensure_publish(
@@ -13390,11 +13458,13 @@ mod discovery_tests {
             None,
             None,
             false,
+            false,
             None,
             None,
             None,
             None,
             None,
+            false,
             true,
         );
         assert!(

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -947,14 +947,22 @@ impl LivePoolCache {
                 .get("pump_amm_sell_extended_tail_1")
                 .and_then(|s| Pubkey::from_str(s).ok())
                 .filter(|pk| *pk != Pubkey::default());
+            let fee_tail_0 = m
+                .get("pump_amm_sell_extended_fee_tail_0")
+                .and_then(|s| Pubkey::from_str(s).ok())
+                .filter(|pk| *pk != Pubkey::default());
+            let fee_tail_1 = m
+                .get("pump_amm_sell_extended_fee_tail_1")
+                .and_then(|s| Pubkey::from_str(s).ok())
+                .filter(|pk| *pk != Pubkey::default());
             self.set_pump_amm_sell_layout_authoritative(
                 pool,
                 requires_extended,
                 third_meta,
                 tail_0,
                 tail_1,
-                None,
-                None,
+                fee_tail_0,
+                fee_tail_1,
             );
         } else {
             if m.get("pump_amm_sell_cashback_remaining")
@@ -983,6 +991,22 @@ impl LivePoolCache {
                 if let Ok(pk) = Pubkey::from_str(s) {
                     if pk != Pubkey::default() {
                         self.pump_amm_sell_extended_tail_1_by_market
+                            .insert(*pool, pk);
+                    }
+                }
+            }
+            if let Some(s) = m.get("pump_amm_sell_extended_fee_tail_0") {
+                if let Ok(pk) = Pubkey::from_str(s) {
+                    if pk != Pubkey::default() {
+                        self.pump_amm_sell_extended_fee_tail_0_by_market
+                            .insert(*pool, pk);
+                    }
+                }
+            }
+            if let Some(s) = m.get("pump_amm_sell_extended_fee_tail_1") {
+                if let Ok(pk) = Pubkey::from_str(s) {
+                    if pk != Pubkey::default() {
+                        self.pump_amm_sell_extended_fee_tail_1_by_market
                             .insert(*pool, pk);
                     }
                 }

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -443,6 +443,9 @@ pub struct LivePoolCache {
     pump_amm_sell_extended_tail_0_by_market: DashMap<Pubkey, Pubkey>,
     /// Observed extended SELL ix account #22 (readonly in reference); Scope 61.
     pump_amm_sell_extended_tail_1_by_market: DashMap<Pubkey, Pubkey>,
+    /// Observed cashback `sell` fee-recipient pair (ix #24/#25).
+    pump_amm_sell_extended_fee_tail_0_by_market: DashMap<Pubkey, Pubkey>,
+    pump_amm_sell_extended_fee_tail_1_by_market: DashMap<Pubkey, Pubkey>,
     /// PumpSwap pool-market -> whether the authoritative source has proven the current SELL layout
     /// is fully known. `false` means "do not treat this as sell-ready truth yet", even if
     /// pool_accounts/reserves are otherwise present.
@@ -487,6 +490,8 @@ impl LivePoolCache {
             pump_amm_sell_extended_third_meta_by_market: DashMap::new(),
             pump_amm_sell_extended_tail_0_by_market: DashMap::new(),
             pump_amm_sell_extended_tail_1_by_market: DashMap::new(),
+            pump_amm_sell_extended_fee_tail_0_by_market: DashMap::new(),
+            pump_amm_sell_extended_fee_tail_1_by_market: DashMap::new(),
             pump_amm_sell_layout_ready_by_market: DashMap::new(),
         }
     }
@@ -948,6 +953,8 @@ impl LivePoolCache {
                 third_meta,
                 tail_0,
                 tail_1,
+                None,
+                None,
             );
         } else {
             if m.get("pump_amm_sell_cashback_remaining")
@@ -984,6 +991,7 @@ impl LivePoolCache {
     }
 
     /// Geyser trade path: mark pool-market as needing extended `sell` (monotonic flag + optional third meta).
+    #[allow(clippy::too_many_arguments)]
     pub fn merge_pump_amm_sell_extended_layout(
         &self,
         pool: &Pubkey,
@@ -991,11 +999,11 @@ impl LivePoolCache {
         third_meta: Option<Pubkey>,
         tail_0: Option<Pubkey>,
         tail_1: Option<Pubkey>,
+        fee_tail_0: Option<Pubkey>,
+        fee_tail_1: Option<Pubkey>,
     ) {
-        if requires_extended {
-            self.pump_amm_sell_extended_flag_by_market
-                .insert(*pool, true);
-        }
+        self.pump_amm_sell_extended_flag_by_market
+            .insert(*pool, requires_extended);
         if let Some(pk) = third_meta.filter(|p| *p != Pubkey::default()) {
             self.pump_amm_sell_extended_third_meta_by_market
                 .insert(*pool, pk);
@@ -1008,6 +1016,14 @@ impl LivePoolCache {
             self.pump_amm_sell_extended_tail_1_by_market
                 .insert(*pool, pk);
         }
+        if let Some(pk) = fee_tail_0.filter(|p| *p != Pubkey::default()) {
+            self.pump_amm_sell_extended_fee_tail_0_by_market
+                .insert(*pool, pk);
+        }
+        if let Some(pk) = fee_tail_1.filter(|p| *p != Pubkey::default()) {
+            self.pump_amm_sell_extended_fee_tail_1_by_market
+                .insert(*pool, pk);
+        }
     }
 
     /// Authoritative SELL-layout completeness for PumpSwap.
@@ -1017,6 +1033,7 @@ impl LivePoolCache {
     }
 
     /// Overwrite PumpSwap SELL-layout shape from an authoritative source (e.g. force-refresh SSOT).
+    #[allow(clippy::too_many_arguments)]
     pub fn set_pump_amm_sell_layout_authoritative(
         &self,
         pool: &Pubkey,
@@ -1024,6 +1041,8 @@ impl LivePoolCache {
         third_meta: Option<Pubkey>,
         tail_0: Option<Pubkey>,
         tail_1: Option<Pubkey>,
+        fee_tail_0: Option<Pubkey>,
+        fee_tail_1: Option<Pubkey>,
     ) {
         self.pump_amm_sell_extended_flag_by_market
             .insert(*pool, requires_extended);
@@ -1055,6 +1074,26 @@ impl LivePoolCache {
                 self.pump_amm_sell_extended_tail_1_by_market.remove(pool);
             }
         }
+        match fee_tail_0.filter(|p| *p != Pubkey::default()) {
+            Some(pk) => {
+                self.pump_amm_sell_extended_fee_tail_0_by_market
+                    .insert(*pool, pk);
+            }
+            None => {
+                self.pump_amm_sell_extended_fee_tail_0_by_market
+                    .remove(pool);
+            }
+        }
+        match fee_tail_1.filter(|p| *p != Pubkey::default()) {
+            Some(pk) => {
+                self.pump_amm_sell_extended_fee_tail_1_by_market
+                    .insert(*pool, pk);
+            }
+            None => {
+                self.pump_amm_sell_extended_fee_tail_1_by_market
+                    .remove(pool);
+            }
+        }
     }
 
     /// Extended PumpSwap `sell` layout: flag + observed tail pubkeys (if known).
@@ -1083,6 +1122,23 @@ impl LivePoolCache {
         (flag, third, t0, t1)
     }
 
+    /// Observed cashback `sell` fee-recipient pair (ix #24/#25), when layout uses 26 accounts.
+    #[must_use]
+    pub fn pump_amm_sell_fee_tail_layout(
+        &self,
+        pool_market: &Pubkey,
+    ) -> (Option<Pubkey>, Option<Pubkey>) {
+        let f0 = self
+            .pump_amm_sell_extended_fee_tail_0_by_market
+            .get(pool_market)
+            .map(|e| *e.value());
+        let f1 = self
+            .pump_amm_sell_extended_fee_tail_1_by_market
+            .get(pool_market)
+            .map(|e| *e.value());
+        (f0, f1)
+    }
+
     #[must_use]
     pub fn pump_amm_sell_layout_ready(&self, pool_market: &Pubkey) -> bool {
         self.pump_amm_sell_layout_ready_by_market
@@ -1097,11 +1153,19 @@ impl LivePoolCache {
         }
         let (requires_extended, third, tail_0, tail_1) =
             self.pump_amm_sell_extended_layout(pool_market);
+        let (fee_t0, fee_t1) = self.pump_amm_sell_fee_tail_layout(pool_market);
         if requires_extended {
             let third_ok = third.filter(|p| *p != Pubkey::default()).is_some();
             let tail_ok = tail_0.filter(|p| *p != Pubkey::default()).is_some()
                 && tail_1.filter(|p| *p != Pubkey::default()).is_some();
-            third_ok && tail_ok
+            let needs_fee_tail = fee_t0.is_some() || fee_t1.is_some();
+            let fee_ok = if needs_fee_tail {
+                fee_t0.filter(|p| *p != Pubkey::default()).is_some()
+                    && fee_t1.filter(|p| *p != Pubkey::default()).is_some()
+            } else {
+                true
+            };
+            third_ok && tail_ok && fee_ok
         } else {
             true
         }
@@ -2652,7 +2716,7 @@ mod tests {
             100,
         );
         cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Ready);
-        cache.merge_pump_amm_sell_extended_layout(&pool_market, true, None, None, None);
+        cache.merge_pump_amm_sell_extended_layout(&pool_market, true, None, None, None, None, None);
         cache.set_pump_amm_sell_layout_ready(&pool_market, false);
 
         assert!(
@@ -2680,7 +2744,7 @@ mod tests {
             ),
             100,
         );
-        cache.merge_pump_amm_sell_extended_layout(&pool_market, true, None, None, None);
+        cache.merge_pump_amm_sell_extended_layout(&pool_market, true, None, None, None, None, None);
         cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Ready);
 
         assert!(
@@ -2726,6 +2790,8 @@ mod tests {
             Some(Pubkey::new_unique()),
             None,
             None,
+            None,
+            None,
         );
         cache.set_pump_amm_sell_layout_ready(&pool_market, true);
 
@@ -2761,7 +2827,15 @@ mod tests {
         let t0 = Pubkey::new_unique();
         let t1 = Pubkey::new_unique();
         let t2 = Pubkey::new_unique();
-        cache.merge_pump_amm_sell_extended_layout(&pool_market, true, Some(t2), Some(t0), Some(t1));
+        cache.merge_pump_amm_sell_extended_layout(
+            &pool_market,
+            true,
+            Some(t2),
+            Some(t0),
+            Some(t1),
+            None,
+            None,
+        );
         cache.set_pump_amm_sell_layout_ready(&pool_market, true);
 
         assert!(
@@ -2828,6 +2902,8 @@ mod tests {
             Some(stale_third),
             Some(stale_t0),
             Some(stale_t1),
+            None,
+            None,
         );
         cache.set_pump_amm_sell_layout_ready(&pool_market, false);
         cache.merge_pump_amm_sell_layout_from_metadata(&pool_market, Some(&meta));

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -446,6 +446,8 @@ pub struct LivePoolCache {
     /// Observed cashback `sell` fee-recipient pair (ix #24/#25).
     pump_amm_sell_extended_fee_tail_0_by_market: DashMap<Pubkey, Pubkey>,
     pump_amm_sell_extended_fee_tail_1_by_market: DashMap<Pubkey, Pubkey>,
+    /// Monotonic: observed `sell` used 26 accounts (fee-recipient pair required).
+    pump_amm_sell_requires_fee_tail_by_market: DashMap<Pubkey, bool>,
     /// PumpSwap pool-market -> whether the authoritative source has proven the current SELL layout
     /// is fully known. `false` means "do not treat this as sell-ready truth yet", even if
     /// pool_accounts/reserves are otherwise present.
@@ -492,6 +494,7 @@ impl LivePoolCache {
             pump_amm_sell_extended_tail_1_by_market: DashMap::new(),
             pump_amm_sell_extended_fee_tail_0_by_market: DashMap::new(),
             pump_amm_sell_extended_fee_tail_1_by_market: DashMap::new(),
+            pump_amm_sell_requires_fee_tail_by_market: DashMap::new(),
             pump_amm_sell_layout_ready_by_market: DashMap::new(),
         }
     }
@@ -955,6 +958,9 @@ impl LivePoolCache {
                 .get("pump_amm_sell_extended_fee_tail_1")
                 .and_then(|s| Pubkey::from_str(s).ok())
                 .filter(|pk| *pk != Pubkey::default());
+            let requires_fee_tail = m
+                .get("pump_amm_sell_requires_fee_tail")
+                .is_some_and(|v| v == "true");
             self.set_pump_amm_sell_layout_authoritative(
                 pool,
                 requires_extended,
@@ -963,6 +969,7 @@ impl LivePoolCache {
                 tail_1,
                 fee_tail_0,
                 fee_tail_1,
+                requires_fee_tail,
             );
         } else {
             if m.get("pump_amm_sell_cashback_remaining")
@@ -1011,6 +1018,12 @@ impl LivePoolCache {
                     }
                 }
             }
+            if m.get("pump_amm_sell_requires_fee_tail")
+                .is_some_and(|v| v == "true")
+            {
+                self.pump_amm_sell_requires_fee_tail_by_market
+                    .insert(*pool, true);
+            }
         }
     }
 
@@ -1025,9 +1038,14 @@ impl LivePoolCache {
         tail_1: Option<Pubkey>,
         fee_tail_0: Option<Pubkey>,
         fee_tail_1: Option<Pubkey>,
+        requires_fee_tail: bool,
     ) {
         self.pump_amm_sell_extended_flag_by_market
             .insert(*pool, requires_extended);
+        if requires_fee_tail {
+            self.pump_amm_sell_requires_fee_tail_by_market
+                .insert(*pool, true);
+        }
         if let Some(pk) = third_meta.filter(|p| *p != Pubkey::default()) {
             self.pump_amm_sell_extended_third_meta_by_market
                 .insert(*pool, pk);
@@ -1067,9 +1085,12 @@ impl LivePoolCache {
         tail_1: Option<Pubkey>,
         fee_tail_0: Option<Pubkey>,
         fee_tail_1: Option<Pubkey>,
+        requires_fee_tail: bool,
     ) {
         self.pump_amm_sell_extended_flag_by_market
             .insert(*pool, requires_extended);
+        self.pump_amm_sell_requires_fee_tail_by_market
+            .insert(*pool, requires_fee_tail);
         match third_meta.filter(|p| *p != Pubkey::default()) {
             Some(pk) => {
                 self.pump_amm_sell_extended_third_meta_by_market
@@ -1146,6 +1167,15 @@ impl LivePoolCache {
         (flag, third, t0, t1)
     }
 
+    /// Whether an observed `sell` used 26 accounts (fee-recipient pair required).
+    #[must_use]
+    pub fn pump_amm_sell_requires_fee_tail(&self, pool_market: &Pubkey) -> bool {
+        self.pump_amm_sell_requires_fee_tail_by_market
+            .get(pool_market)
+            .map(|e| *e.value())
+            .unwrap_or(false)
+    }
+
     /// Observed cashback `sell` fee-recipient pair (ix #24/#25), when layout uses 26 accounts.
     #[must_use]
     pub fn pump_amm_sell_fee_tail_layout(
@@ -1182,7 +1212,9 @@ impl LivePoolCache {
             let third_ok = third.filter(|p| *p != Pubkey::default()).is_some();
             let tail_ok = tail_0.filter(|p| *p != Pubkey::default()).is_some()
                 && tail_1.filter(|p| *p != Pubkey::default()).is_some();
-            let needs_fee_tail = fee_t0.is_some() || fee_t1.is_some();
+            let needs_fee_tail = self.pump_amm_sell_requires_fee_tail(pool_market)
+                || fee_t0.is_some()
+                || fee_t1.is_some();
             let fee_ok = if needs_fee_tail {
                 fee_t0.filter(|p| *p != Pubkey::default()).is_some()
                     && fee_t1.filter(|p| *p != Pubkey::default()).is_some()
@@ -2740,7 +2772,16 @@ mod tests {
             100,
         );
         cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Ready);
-        cache.merge_pump_amm_sell_extended_layout(&pool_market, true, None, None, None, None, None);
+        cache.merge_pump_amm_sell_extended_layout(
+            &pool_market,
+            true,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+        );
         cache.set_pump_amm_sell_layout_ready(&pool_market, false);
 
         assert!(
@@ -2768,7 +2809,16 @@ mod tests {
             ),
             100,
         );
-        cache.merge_pump_amm_sell_extended_layout(&pool_market, true, None, None, None, None, None);
+        cache.merge_pump_amm_sell_extended_layout(
+            &pool_market,
+            true,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+        );
         cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Ready);
 
         assert!(
@@ -2816,6 +2866,7 @@ mod tests {
             None,
             None,
             None,
+            false,
         );
         cache.set_pump_amm_sell_layout_ready(&pool_market, true);
 
@@ -2859,6 +2910,7 @@ mod tests {
             Some(t1),
             None,
             None,
+            false,
         );
         cache.set_pump_amm_sell_layout_ready(&pool_market, true);
 
@@ -2928,6 +2980,7 @@ mod tests {
             Some(stale_t1),
             None,
             None,
+            false,
         );
         cache.set_pump_amm_sell_layout_ready(&pool_market, false);
         cache.merge_pump_amm_sell_layout_from_metadata(&pool_market, Some(&meta));

--- a/src/execution/tx_builder.rs
+++ b/src/execution/tx_builder.rs
@@ -769,6 +769,9 @@ pub async fn build_tx_plan(
         ) = cache
             .map(|c| c.pump_amm_sell_extended_layout(&pool_id))
             .unwrap_or((false, None, None, None));
+        let (sell_extended_fee_tail_0, sell_extended_fee_tail_1) = cache
+            .map(|c| c.pump_amm_sell_fee_tail_layout(&pool_id))
+            .unwrap_or((None, None));
 
         let mut pool_accounts_build_source = if accounts_len == 0 {
             "slave_livepoolcache"
@@ -926,6 +929,16 @@ pub async fn build_tx_plan(
             },
             if intent.side == TradeSide::Sell {
                 sell_extended_tail_1
+            } else {
+                None
+            },
+            if intent.side == TradeSide::Sell {
+                sell_extended_fee_tail_0
+            } else {
+                None
+            },
+            if intent.side == TradeSide::Sell {
+                sell_extended_fee_tail_1
             } else {
                 None
             },
@@ -1656,56 +1669,61 @@ async fn build_hop_pump_amm(
     cache: Option<&SharedLivePoolCache>,
 ) -> Result<Vec<Instruction>, UnsupportedTxPlan> {
     // PumpSwap AMM (graduated tokens) - get pool_accounts from cache
-    let (pool_accounts, sell_requires, sell_third, sell_t0, sell_t1) = if let Some(cache) = cache {
-        match cache.get(pool_address) {
-            Some(CachedPoolState::PumpAmm(amm_state)) => {
-                let (sell_requires, sell_third, sell_t0, sell_t1) =
-                    cache.pump_amm_sell_extended_layout(pool_address);
-                if amm_state.pool_accounts.len() >= 14 {
-                    tracing::debug!(
-                        pool = %pool_address,
-                        accounts_len = amm_state.pool_accounts.len(),
-                        "multi-hop pump_amm: using cached pool_accounts"
-                    );
-                    (
-                        amm_state.pool_accounts.clone(),
-                        sell_requires,
-                        sell_third,
-                        sell_t0,
-                        sell_t1,
-                    )
-                } else {
+    let (pool_accounts, sell_requires, sell_third, sell_t0, sell_t1, sell_fee_t0, sell_fee_t1) =
+        if let Some(cache) = cache {
+            match cache.get(pool_address) {
+                Some(CachedPoolState::PumpAmm(amm_state)) => {
+                    let (sell_requires, sell_third, sell_t0, sell_t1) =
+                        cache.pump_amm_sell_extended_layout(pool_address);
+                    let (sell_fee_t0, sell_fee_t1) =
+                        cache.pump_amm_sell_fee_tail_layout(pool_address);
+                    if amm_state.pool_accounts.len() >= 14 {
+                        tracing::debug!(
+                            pool = %pool_address,
+                            accounts_len = amm_state.pool_accounts.len(),
+                            "multi-hop pump_amm: using cached pool_accounts"
+                        );
+                        (
+                            amm_state.pool_accounts.clone(),
+                            sell_requires,
+                            sell_third,
+                            sell_t0,
+                            sell_t1,
+                            sell_fee_t0,
+                            sell_fee_t1,
+                        )
+                    } else {
+                        return Err(UnsupportedTxPlan {
+                            reason: RejectReason::UnsupportedIntent,
+                            details: format!(
+                                "pump_amm: cached pool_accounts too short (got {}, need 14)",
+                                amm_state.pool_accounts.len()
+                            ),
+                        });
+                    }
+                }
+                Some(_) => {
                     return Err(UnsupportedTxPlan {
                         reason: RejectReason::UnsupportedIntent,
                         details: format!(
-                            "pump_amm: cached pool_accounts too short (got {}, need 14)",
-                            amm_state.pool_accounts.len()
+                            "pump_amm: cache hit but wrong DEX type for {}",
+                            pool_address
                         ),
                     });
                 }
+                None => {
+                    return Err(UnsupportedTxPlan {
+                        reason: RejectReason::UnsupportedIntent,
+                        details: format!("pump_amm: pool {} not in cache", pool_address),
+                    });
+                }
             }
-            Some(_) => {
-                return Err(UnsupportedTxPlan {
-                    reason: RejectReason::UnsupportedIntent,
-                    details: format!(
-                        "pump_amm: cache hit but wrong DEX type for {}",
-                        pool_address
-                    ),
-                });
-            }
-            None => {
-                return Err(UnsupportedTxPlan {
-                    reason: RejectReason::UnsupportedIntent,
-                    details: format!("pump_amm: pool {} not in cache", pool_address),
-                });
-            }
-        }
-    } else {
-        return Err(UnsupportedTxPlan {
-            reason: RejectReason::UnsupportedIntent,
-            details: "pump_amm: no cache available for multi-hop".to_string(),
-        });
-    };
+        } else {
+            return Err(UnsupportedTxPlan {
+                reason: RejectReason::UnsupportedIntent,
+                details: "pump_amm: no cache available for multi-hop".to_string(),
+            });
+        };
 
     // Use static method with pool_accounts from cache
     // Note: Multi-hop arb doesn't pass token_program yet; Token-2022 arb tokens are rare.
@@ -1723,6 +1741,8 @@ async fn build_hop_pump_amm(
         if is_sell_hop { sell_third } else { None },
         if is_sell_hop { sell_t0 } else { None },
         if is_sell_hop { sell_t1 } else { None },
+        if is_sell_hop { sell_fee_t0 } else { None },
+        if is_sell_hop { sell_fee_t1 } else { None },
     )
     .map_err(|e| UnsupportedTxPlan {
         reason: RejectReason::UnsupportedIntent,
@@ -2179,6 +2199,8 @@ mod tests {
             Some(third_meta),
             Some(tail0),
             Some(tail1),
+            None,
+            None,
         );
 
         let mut intent = base_intent();
@@ -2269,6 +2291,8 @@ mod tests {
             Some(third_other),
             Some(t0_other),
             Some(t1_other),
+            None,
+            None,
         );
 
         // Target pool: explicit JetStream Ready (force_refresh / PoolCacheUpdate path).
@@ -2293,6 +2317,8 @@ mod tests {
             Some(third_target),
             Some(t0_target),
             Some(t1_target),
+            None,
+            None,
         );
 
         let mut intent = base_intent();

--- a/src/execution/tx_builder.rs
+++ b/src/execution/tx_builder.rs
@@ -2201,6 +2201,7 @@ mod tests {
             Some(tail1),
             None,
             None,
+            false,
         );
 
         let mut intent = base_intent();
@@ -2293,6 +2294,7 @@ mod tests {
             Some(t1_other),
             None,
             None,
+            false,
         );
 
         // Target pool: explicit JetStream Ready (force_refresh / PoolCacheUpdate path).
@@ -2319,6 +2321,7 @@ mod tests {
             Some(t1_target),
             None,
             None,
+            false,
         );
 
         let mut intent = base_intent();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -304,6 +304,20 @@ pub static MARKET_DATA_GEYSER_MERGE_IMMEDIATE_TOTAL: Lazy<AtomicU64> =
 /// PR161: 1 while a debounced merge flush is scheduled; 0 otherwise.
 pub static MARKET_DATA_GEYSER_MERGE_PENDING: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
+/// PumpSwap `sell` successfully parsed from Geyser (dex_parser → market-data sidefx).
+pub static PUMP_AMM_GEYSER_SELL_PARSED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// PumpSwap Geyser-observed SELL that set `sell_layout_ready=true` in LivePoolCache.
+pub static PUMP_AMM_GEYSER_SELL_LAYOUT_READY_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+pub fn record_pump_amm_geyser_sell_parsed() {
+    PUMP_AMM_GEYSER_SELL_PARSED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn record_pump_amm_geyser_sell_layout_ready() {
+    PUMP_AMM_GEYSER_SELL_LAYOUT_READY_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
 /// Reconnect after large explicit subscription set (PR-B: full client reconnect vs in-place churn).
 pub static GEYSER_RECONNECT_TOTAL_SUBSCRIPTION_REBUILD: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -147,6 +147,9 @@ pub const PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS: usize = 26;
 pub const PUMPFUN_AMM_SELL_EXT_TAIL_0_IX: usize = 21;
 pub const PUMPFUN_AMM_SELL_EXT_TAIL_1_IX: usize = 22;
 pub const PUMPFUN_AMM_SELL_EXT_THIRD_META_IX: usize = 23;
+/// Cashback `sell` fee-recipient pair after post-upgrade `pool-v2` meta (#23).
+pub const PUMPFUN_AMM_SELL_FEE_TAIL_0_IX: usize = 24;
+pub const PUMPFUN_AMM_SELL_FEE_TAIL_1_IX: usize = 25;
 
 /// `pool-v2` PDA appended on post-upgrade PumpSwap swaps (`["pool-v2", base_mint]`).
 #[must_use]
@@ -157,9 +160,13 @@ pub fn pump_amm_pool_v2_pda(base_mint: &Pubkey, program_id: &Pubkey) -> Pubkey {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PumpAmmSellExtendedFields {
     pub requires_extended: bool,
+    /// Cashback `sell` (26 accounts): fee-recipient pair at ix #24/#25.
+    pub requires_fee_tail: bool,
     pub tail_0: Option<Pubkey>,
     pub tail_1: Option<Pubkey>,
     pub third_meta: Option<Pubkey>,
+    pub fee_tail_0: Option<Pubkey>,
+    pub fee_tail_1: Option<Pubkey>,
 }
 
 #[must_use]
@@ -185,24 +192,35 @@ pub fn pump_amm_sell_extended_fields_from_ix_accounts(
     match n {
         21 => Some(PumpAmmSellExtendedFields {
             requires_extended: false,
+            requires_fee_tail: false,
             tail_0: None,
             tail_1: None,
             third_meta: None,
+            fee_tail_0: None,
+            fee_tail_1: None,
         }),
         PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS => {
             let at_21 = *instruction_accounts.get(PUMPFUN_AMM_SELL_EXT_TAIL_0_IX)?;
             if at_21 == pool_v2 {
                 // Post-upgrade non-cashback: #21 pool-v2, #22/#23 protocol fee recipient pair.
                 Some(PumpAmmSellExtendedFields {
-                    requires_extended: false,
-                    tail_0: None,
-                    tail_1: None,
-                    third_meta: None,
+                    requires_extended: true,
+                    requires_fee_tail: false,
+                    tail_0: Some(at_21),
+                    tail_1: instruction_accounts
+                        .get(PUMPFUN_AMM_SELL_EXT_TAIL_1_IX)
+                        .copied(),
+                    third_meta: instruction_accounts
+                        .get(PUMPFUN_AMM_SELL_EXT_THIRD_META_IX)
+                        .copied(),
+                    fee_tail_0: None,
+                    fee_tail_1: None,
                 })
             } else {
                 // Legacy extended cashback: #21/#22 volume metas, #23 third (often pool-v2).
                 Some(PumpAmmSellExtendedFields {
                     requires_extended: true,
+                    requires_fee_tail: false,
                     tail_0: instruction_accounts
                         .get(PUMPFUN_AMM_SELL_EXT_TAIL_0_IX)
                         .copied(),
@@ -212,11 +230,14 @@ pub fn pump_amm_sell_extended_fields_from_ix_accounts(
                     third_meta: instruction_accounts
                         .get(PUMPFUN_AMM_SELL_EXT_THIRD_META_IX)
                         .copied(),
+                    fee_tail_0: None,
+                    fee_tail_1: None,
                 })
             }
         }
         PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS => Some(PumpAmmSellExtendedFields {
             requires_extended: true,
+            requires_fee_tail: true,
             tail_0: instruction_accounts
                 .get(PUMPFUN_AMM_SELL_EXT_TAIL_0_IX)
                 .copied(),
@@ -225,6 +246,12 @@ pub fn pump_amm_sell_extended_fields_from_ix_accounts(
                 .copied(),
             third_meta: instruction_accounts
                 .get(PUMPFUN_AMM_SELL_EXT_THIRD_META_IX)
+                .copied(),
+            fee_tail_0: instruction_accounts
+                .get(PUMPFUN_AMM_SELL_FEE_TAIL_0_IX)
+                .copied(),
+            fee_tail_1: instruction_accounts
+                .get(PUMPFUN_AMM_SELL_FEE_TAIL_1_IX)
                 .copied(),
         }),
         _ => None,
@@ -413,6 +440,9 @@ pub struct PumpAmmPoolStatic {
     pub sell_extended_tail_0: Option<Pubkey>,
     /// Observed extended SELL ix account #22 (readonly); Scope 61.
     pub sell_extended_tail_1: Option<Pubkey>,
+    /// Observed cashback `sell` fee-recipient pair (ix #24/#25) when layout has 26 accounts.
+    pub sell_extended_fee_tail_0: Option<Pubkey>,
+    pub sell_extended_fee_tail_1: Option<Pubkey>,
     /// Set when this struct was built inside `pumpfun_amm` (parse / tx-history / cache reconstruct).
     pub last_parse_diagnostics: Option<PumpAmmPoolAccountsDiagnostic>,
 }
@@ -427,6 +457,8 @@ pub struct PoolAccountsV14WithDiagnostic {
     pub sell_cashback_third_meta: Option<Pubkey>,
     pub sell_extended_tail_0: Option<Pubkey>,
     pub sell_extended_tail_1: Option<Pubkey>,
+    pub sell_extended_fee_tail_0: Option<Pubkey>,
+    pub sell_extended_fee_tail_1: Option<Pubkey>,
     /// `true` only when the cold-path result is authoritative enough for SELL planning.
     pub sell_layout_ready: bool,
     /// Scope 49: structured outcome when `force_refresh` could not resolve SELL layout (empty if ready).
@@ -617,11 +649,13 @@ struct SellLayoutObserveOutcome {
 enum PumpAmmAuthoritativeSellLayout {
     Unknown,
     Base,
-    /// Extended 24-account `sell`: last three ix metas (#21/#22/#23) from observation (Scope 61).
+    /// Extended `sell`: trailing metas #21/#22/#23; optional #24/#25 fee pair for 26-account cashback.
     Extended {
         tail_0: Pubkey,
         tail_1: Pubkey,
         tail_2: Pubkey,
+        fee_tail_0: Option<Pubkey>,
+        fee_tail_1: Option<Pubkey>,
     },
 }
 
@@ -702,20 +736,22 @@ fn sell_layout_scan_termination_after_successful_tx_fetch(
 
 /// Merge SELL-layout observations while scanning **reverse-chronological** signatures (newest first).
 ///
-/// A newer **21-account** `sell` must not hide an older **24-account** extended `sell` for the same
-/// pool: `Extended` wins; `Base` is kept only until an `Extended` match appears.
-/// Fee recipient fields always follow the winning layout’s reference row (Scope 60).
+/// The **newest** matching `sell` wins. A newer **21-account** `sell` must not hide an older
+/// **24-account** extended `sell`, but a newer post-upgrade extended `sell` must not be replaced
+/// by an older legacy extended row. Fee recipient fields follow the winning layout (Scope 60).
 fn merge_pump_amm_authoritative_sell_reference_observation(
     best: PumpAmmSellReferenceObservation,
     candidate: PumpAmmSellReferenceObservation,
 ) -> PumpAmmSellReferenceObservation {
+    if matches!(best.layout, PumpAmmAuthoritativeSellLayout::Unknown) {
+        return candidate;
+    }
     match candidate.layout {
-        PumpAmmAuthoritativeSellLayout::Extended { .. } => candidate,
-        PumpAmmAuthoritativeSellLayout::Base => match best.layout {
-            PumpAmmAuthoritativeSellLayout::Unknown => candidate,
+        PumpAmmAuthoritativeSellLayout::Extended { .. } => match best.layout {
+            PumpAmmAuthoritativeSellLayout::Base => candidate,
             _ => best,
         },
-        PumpAmmAuthoritativeSellLayout::Unknown => best,
+        PumpAmmAuthoritativeSellLayout::Base | PumpAmmAuthoritativeSellLayout::Unknown => best,
     }
 }
 
@@ -1149,6 +1185,8 @@ impl PumpFunAmmDex {
                         let pool_market = accounts[0];
                         let (sell_requires, sell_third, sell_t0, sell_t1) =
                             cache.pump_amm_sell_extended_layout(&pool_market);
+                        let (sell_fee_t0, sell_fee_t1) =
+                            cache.pump_amm_sell_fee_tail_layout(&pool_market);
                         return Ok(Some(PoolAccountsV14WithDiagnostic {
                             accounts,
                             diagnostic: Self::pump_amm_livepoolcache_diagnostic(
@@ -1161,6 +1199,8 @@ impl PumpFunAmmDex {
                             sell_cashback_third_meta: sell_third,
                             sell_extended_tail_0: sell_t0,
                             sell_extended_tail_1: sell_t1,
+                            sell_extended_fee_tail_0: sell_fee_t0,
+                            sell_extended_fee_tail_1: sell_fee_t1,
                             sell_layout_ready: true,
                             force_refresh_sell_layout_diag: None,
                         }));
@@ -1334,17 +1374,23 @@ impl PumpFunAmmDex {
                     pool.sell_cashback_third_meta = None;
                     pool.sell_extended_tail_0 = None;
                     pool.sell_extended_tail_1 = None;
+                    pool.sell_extended_fee_tail_0 = None;
+                    pool.sell_extended_fee_tail_1 = None;
                     (true, None)
                 }
                 PumpAmmAuthoritativeSellLayout::Extended {
                     tail_0,
                     tail_1,
                     tail_2,
+                    fee_tail_0,
+                    fee_tail_1,
                 } => {
                     pool.sell_requires_cashback_remaining = true;
                     pool.sell_extended_tail_0 = Some(tail_0);
                     pool.sell_extended_tail_1 = Some(tail_1);
                     pool.sell_cashback_third_meta = Some(tail_2);
+                    pool.sell_extended_fee_tail_0 = fee_tail_0.filter(|p| *p != Pubkey::default());
+                    pool.sell_extended_fee_tail_1 = fee_tail_1.filter(|p| *p != Pubkey::default());
                     (true, None)
                 }
             }
@@ -1359,6 +1405,8 @@ impl PumpFunAmmDex {
             sell_cashback_third_meta: pool.sell_cashback_third_meta,
             sell_extended_tail_0: pool.sell_extended_tail_0,
             sell_extended_tail_1: pool.sell_extended_tail_1,
+            sell_extended_fee_tail_0: pool.sell_extended_fee_tail_0,
+            sell_extended_fee_tail_1: pool.sell_extended_fee_tail_1,
             sell_layout_ready,
             force_refresh_sell_layout_diag,
         })
@@ -1880,6 +1928,8 @@ impl PumpFunAmmDex {
                             tail_0,
                             tail_1,
                             tail_2,
+                            fee_tail_0: _,
+                            fee_tail_1: _,
                         } => (Some(tail_0), Some(tail_1), Some(tail_2)),
                         _ => (None, None, None),
                     };
@@ -1944,12 +1994,23 @@ impl PumpFunAmmDex {
                     tail_0,
                     tail_1,
                     tail_2,
+                    fee_tail_0: _,
+                    fee_tail_1: _,
                 } => (Some(tail_0), Some(tail_1), Some(tail_2)),
                 _ => (None, None, None),
             };
             let sell_ix_account_count = match best_obs.layout {
-                PumpAmmAuthoritativeSellLayout::Extended { .. } => {
+                PumpAmmAuthoritativeSellLayout::Extended {
+                    fee_tail_0,
+                    fee_tail_1,
+                    ..
+                } if fee_tail_0.filter(|p| *p != Pubkey::default()).is_some()
+                    && fee_tail_1.filter(|p| *p != Pubkey::default()).is_some() =>
+                {
                     PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS as u8
+                }
+                PumpAmmAuthoritativeSellLayout::Extended { .. } => {
+                    PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS as u8
                 }
                 PumpAmmAuthoritativeSellLayout::Base => 21,
                 PumpAmmAuthoritativeSellLayout::Unknown => 0,
@@ -3492,6 +3553,8 @@ impl PumpFunAmmDex {
             sell_cashback_third_meta: None,
             sell_extended_tail_0: None,
             sell_extended_tail_1: None,
+            sell_extended_fee_tail_0: None,
+            sell_extended_fee_tail_1: None,
             last_parse_diagnostics: Some(diag),
         }))
     }
@@ -3889,6 +3952,12 @@ impl PumpFunAmmDex {
                             sell_cashback_third_meta: sell_third,
                             sell_extended_tail_0: sell_t0,
                             sell_extended_tail_1: sell_t1,
+                            sell_extended_fee_tail_0: cache
+                                .pump_amm_sell_fee_tail_layout(&accounts[0])
+                                .0,
+                            sell_extended_fee_tail_1: cache
+                                .pump_amm_sell_fee_tail_layout(&accounts[0])
+                                .1,
                             last_parse_diagnostics: Some(Self::pump_amm_livepoolcache_diagnostic(
                                 "discover_pool_static_livepoolcache_reconstruct",
                                 force_refresh,
@@ -4629,6 +4698,8 @@ impl PumpFunAmmDex {
                 sell_cashback_third_meta: None,
                 sell_extended_tail_0: None,
                 sell_extended_tail_1: None,
+                sell_extended_fee_tail_0: None,
+                sell_extended_fee_tail_1: None,
                 last_parse_diagnostics: Some(diag_factory(None)),
             });
         }
@@ -4645,14 +4716,17 @@ impl PumpFunAmmDex {
                     .filter_map(|s| Pubkey::from_str(s).ok())
                     .collect::<Vec<_>>(),
             )?;
-            let (third, tail_0, tail_1) = if ext.requires_extended {
+            let filter_pk = |p: Option<Pubkey>| p.filter(|pk| *pk != Pubkey::default());
+            let (third, tail_0, tail_1, fee_t0, fee_t1) = if ext.requires_extended {
                 (
-                    ext.third_meta.filter(|p| *p != Pubkey::default()),
-                    ext.tail_0.filter(|p| *p != Pubkey::default()),
-                    ext.tail_1.filter(|p| *p != Pubkey::default()),
+                    filter_pk(ext.third_meta),
+                    filter_pk(ext.tail_0),
+                    filter_pk(ext.tail_1),
+                    filter_pk(ext.fee_tail_0),
+                    filter_pk(ext.fee_tail_1),
                 )
             } else {
-                (None, None, None)
+                (None, None, None, None, None)
             };
             return Some(PumpAmmPoolStatic {
                 pool_market,
@@ -4673,6 +4747,8 @@ impl PumpFunAmmDex {
                 sell_cashback_third_meta: third,
                 sell_extended_tail_0: tail_0,
                 sell_extended_tail_1: tail_1,
+                sell_extended_fee_tail_0: fee_t0,
+                sell_extended_fee_tail_1: fee_t1,
                 last_parse_diagnostics: Some(diag_factory(None)),
             });
         }
@@ -4707,6 +4783,8 @@ impl PumpFunAmmDex {
                 tail_2: pool
                     .sell_cashback_third_meta
                     .filter(|p| *p != Pubkey::default())?,
+                fee_tail_0: pool.sell_extended_fee_tail_0,
+                fee_tail_1: pool.sell_extended_fee_tail_1,
             }
         };
         let obs = PumpAmmSellReferenceObservation {
@@ -5109,6 +5187,8 @@ impl Dex for PumpFunAmmDex {
             sell_cashback_third_meta: None,
             sell_extended_tail_0: None,
             sell_extended_tail_1: None,
+            sell_extended_fee_tail_0: None,
+            sell_extended_fee_tail_1: None,
             last_parse_diagnostics: None,
         };
 
@@ -5395,14 +5475,20 @@ impl Dex for PumpFunAmmDex {
             let mut sell_cashback_third_meta = pool.sell_cashback_third_meta;
             let mut sell_extended_tail_0 = pool.sell_extended_tail_0;
             let mut sell_extended_tail_1 = pool.sell_extended_tail_1;
+            let mut sell_extended_fee_tail_0 = pool.sell_extended_fee_tail_0;
+            let mut sell_extended_fee_tail_1 = pool.sell_extended_fee_tail_1;
             if let Some(ref cache) = self.live_pool_cache {
                 let (dash_flag, dash_third, dash_t0, dash_t1) =
                     cache.pump_amm_sell_extended_layout(&pool.pool_market);
+                let (dash_fee_t0, dash_fee_t1) =
+                    cache.pump_amm_sell_fee_tail_layout(&pool.pool_market);
                 if dash_flag {
                     sell_requires_cashback_remaining = true;
                     sell_cashback_third_meta = dash_third.or(sell_cashback_third_meta);
                     sell_extended_tail_0 = dash_t0.or(sell_extended_tail_0);
                     sell_extended_tail_1 = dash_t1.or(sell_extended_tail_1);
+                    sell_extended_fee_tail_0 = dash_fee_t0.or(sell_extended_fee_tail_0);
+                    sell_extended_fee_tail_1 = dash_fee_t1.or(sell_extended_fee_tail_1);
                 }
             }
             if sell_requires_cashback_remaining {
@@ -5429,6 +5515,13 @@ impl Dex for PumpFunAmmDex {
                     metas.push(AccountMeta::new(user_vol_wsol_ata, false));
                     metas.push(AccountMeta::new(user_vol, false));
                     metas.push(AccountMeta::new_readonly(third, false));
+                }
+                if let (Some(f0), Some(f1)) = (
+                    sell_extended_fee_tail_0.filter(|p| *p != Pubkey::default()),
+                    sell_extended_fee_tail_1.filter(|p| *p != Pubkey::default()),
+                ) {
+                    metas.push(AccountMeta::new_readonly(f0, false));
+                    metas.push(AccountMeta::new_readonly(f1, false));
                 }
             }
         }
@@ -5503,6 +5596,8 @@ impl PumpFunAmmDex {
             sell_cashback_third_meta,
             None,
             None,
+            None,
+            None,
         )
     }
 
@@ -5522,6 +5617,8 @@ impl PumpFunAmmDex {
         sell_cashback_third_meta: Option<Pubkey>,
         sell_extended_tail_0: Option<Pubkey>,
         sell_extended_tail_1: Option<Pubkey>,
+        sell_extended_fee_tail_0: Option<Pubkey>,
+        sell_extended_fee_tail_1: Option<Pubkey>,
     ) -> Result<Vec<Instruction>> {
         // Require 14 accounts (v1 format with global_volume_accumulator)
         if pool_accounts.len() < 14 {
@@ -5723,6 +5820,13 @@ impl PumpFunAmmDex {
                     metas.push(AccountMeta::new(user_vol_wsol_ata, false)); // 21
                     metas.push(AccountMeta::new(user_vol, false)); // 22
                     metas.push(AccountMeta::new_readonly(third, false)); // 23
+                }
+                if let (Some(f0), Some(f1)) = (
+                    sell_extended_fee_tail_0.filter(|p| *p != Pubkey::default()),
+                    sell_extended_fee_tail_1.filter(|p| *p != Pubkey::default()),
+                ) {
+                    metas.push(AccountMeta::new_readonly(f0, false)); // 24
+                    metas.push(AccountMeta::new_readonly(f1, false)); // 25
                 }
             }
             metas
@@ -5985,6 +6089,8 @@ mod tests {
                 tail_0: t0,
                 tail_1: t1,
                 tail_2: t2,
+                fee_tail_0: None,
+                fee_tail_1: None,
             },
             protocol_fee_recipient: pfr_ext,
             protocol_fee_recipient_ta: pfr_ta_ext,
@@ -6000,6 +6106,8 @@ mod tests {
                 tail_0: t0,
                 tail_1: t1,
                 tail_2: t2,
+                fee_tail_0: None,
+                fee_tail_1: None,
             }
         );
         let merged =
@@ -6022,6 +6130,8 @@ mod tests {
                 tail_0: t0,
                 tail_1: t1,
                 tail_2: t2,
+                fee_tail_0: None,
+                fee_tail_1: None,
             }
         );
         assert_eq!(merged2.protocol_fee_recipient, pfr_ext);
@@ -6077,6 +6187,8 @@ mod tests {
                     tail_0: t0,
                     tail_1: t1,
                     tail_2: t2,
+                    fee_tail_0: None,
+                    fee_tail_1: None,
                 },
                 protocol_fee_recipient: pfr_ext,
                 protocol_fee_recipient_ta: pfr_ta_ext,
@@ -6093,6 +6205,8 @@ mod tests {
                 tail_0: t0,
                 tail_1: t1,
                 tail_2: t2,
+                fee_tail_0: None,
+                fee_tail_1: None,
             }
         );
         assert_eq!(out.protocol_fee_recipient, pfr_ext);
@@ -6536,6 +6650,8 @@ mod tests {
         let third_meta = Pubkey::new_unique();
         let tail0 = Pubkey::new_unique();
         let tail1 = Pubkey::new_unique();
+        let fee_tail0 = Pubkey::new_unique();
+        let fee_tail1 = Pubkey::new_unique();
         let mut account_keys: Vec<Pubkey> = (0..26).map(|_| Pubkey::new_unique()).collect();
         account_keys[0] = pool_market;
         account_keys[2] = Pubkey::from_str(PUMPFUN_AMM_GLOBAL_CONFIG).unwrap();
@@ -6545,6 +6661,8 @@ mod tests {
         account_keys[21] = tail0;
         account_keys[22] = tail1;
         account_keys[23] = third_meta;
+        account_keys[24] = fee_tail0;
+        account_keys[25] = fee_tail1;
         let acc_strings: Vec<String> = account_keys.iter().map(ToString::to_string).collect();
         let ix_data = pump_amm_sell_ix_discriminator().to_vec();
 
@@ -6560,6 +6678,8 @@ mod tests {
                 tail_0: tail0,
                 tail_1: tail1,
                 tail_2: third_meta,
+                fee_tail_0: Some(fee_tail0),
+                fee_tail_1: Some(fee_tail1),
             }
         );
     }
@@ -6597,6 +6717,8 @@ mod tests {
                 tail_0: tail0,
                 tail_1: tail1,
                 tail_2: third_meta,
+                fee_tail_0: None,
+                fee_tail_1: None,
             }
         );
     }
@@ -6633,6 +6755,8 @@ mod tests {
             sell_cashback_third_meta: None,
             sell_extended_tail_0: None,
             sell_extended_tail_1: None,
+            sell_extended_fee_tail_0: None,
+            sell_extended_fee_tail_1: None,
             last_parse_diagnostics: None,
         };
 
@@ -6670,6 +6794,8 @@ mod tests {
                 tail_0: ref_t0,
                 tail_1: ref_t1,
                 tail_2: third_meta,
+                fee_tail_0: None,
+                fee_tail_1: None,
             }
         );
 
@@ -6728,6 +6854,8 @@ mod tests {
             Some(third_meta),
             Some(ref_tail_0),
             Some(ref_tail_1),
+            None,
+            None,
         )
         .expect("extended SELL");
 
@@ -6771,6 +6899,8 @@ mod tests {
             sell_cashback_third_meta: None,
             sell_extended_tail_0: None,
             sell_extended_tail_1: None,
+            sell_extended_fee_tail_0: None,
+            sell_extended_fee_tail_1: None,
             last_parse_diagnostics: None,
         };
         PumpFunAmmDex::apply_sell_reference_protocol_fee_recipients_for_force_refresh(
@@ -7046,6 +7176,8 @@ mod tests {
             sell_cashback_third_meta: None,
             sell_extended_tail_0: None,
             sell_extended_tail_1: None,
+            sell_extended_fee_tail_0: None,
+            sell_extended_fee_tail_1: None,
             last_parse_diagnostics: None,
         };
         dex.pools_by_base.insert(base_mint, pool);

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -139,6 +139,98 @@ pub fn pump_amm_sell_ix_discriminator() -> [u8; 8] {
 /// Verified on mainnet (e.g. sig `2CCmRDScAErjuBLnVJbGEyV3jsWbuNZpniZ5iTLSwZoE84nmyf285hqJXjRStMHJUaJ9Ex7EvL9fgwAVM83qGd3o`).
 pub const PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS: usize = 24;
 
+/// Cashback-enabled `sell` after Pump fee-recipient upgrade: 21 base + volume metas #21/#22 + `pool-v2` #23 + fee pair #24/#25.
+/// See Pump `@pump_tech_updates` (2026): non-cashback `sell` = 24 accounts (`pool-v2` at #21); cashback `sell` = 26.
+pub const PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS: usize = 26;
+
+/// Extended SELL tail indices (shared by legacy 24-account cashback and 26-account layouts).
+pub const PUMPFUN_AMM_SELL_EXT_TAIL_0_IX: usize = 21;
+pub const PUMPFUN_AMM_SELL_EXT_TAIL_1_IX: usize = 22;
+pub const PUMPFUN_AMM_SELL_EXT_THIRD_META_IX: usize = 23;
+
+/// `pool-v2` PDA appended on post-upgrade PumpSwap swaps (`["pool-v2", base_mint]`).
+#[must_use]
+pub fn pump_amm_pool_v2_pda(base_mint: &Pubkey, program_id: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"pool-v2", base_mint.as_ref()], program_id).0
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PumpAmmSellExtendedFields {
+    pub requires_extended: bool,
+    pub tail_0: Option<Pubkey>,
+    pub tail_1: Option<Pubkey>,
+    pub third_meta: Option<Pubkey>,
+}
+
+#[must_use]
+pub fn pump_amm_sell_ix_account_len_supported(n: usize) -> bool {
+    matches!(
+        n,
+        21 | PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS | PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS
+    )
+}
+
+/// Map observed `sell` instruction accounts to extended-layout fields (Geyser + RPC history).
+pub fn pump_amm_sell_extended_fields_from_ix_accounts(
+    instruction_accounts: &[Pubkey],
+) -> Option<PumpAmmSellExtendedFields> {
+    let n = instruction_accounts.len();
+    if !pump_amm_sell_ix_account_len_supported(n) {
+        return None;
+    }
+    let base_mint = *instruction_accounts.get(3)?;
+    let program_id = Pubkey::from_str(PUMPFUN_AMM_PROGRAM_ID).ok()?;
+    let pool_v2 = pump_amm_pool_v2_pda(&base_mint, &program_id);
+
+    match n {
+        21 => Some(PumpAmmSellExtendedFields {
+            requires_extended: false,
+            tail_0: None,
+            tail_1: None,
+            third_meta: None,
+        }),
+        PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS => {
+            let at_21 = *instruction_accounts.get(PUMPFUN_AMM_SELL_EXT_TAIL_0_IX)?;
+            if at_21 == pool_v2 {
+                // Post-upgrade non-cashback: #21 pool-v2, #22/#23 protocol fee recipient pair.
+                Some(PumpAmmSellExtendedFields {
+                    requires_extended: false,
+                    tail_0: None,
+                    tail_1: None,
+                    third_meta: None,
+                })
+            } else {
+                // Legacy extended cashback: #21/#22 volume metas, #23 third (often pool-v2).
+                Some(PumpAmmSellExtendedFields {
+                    requires_extended: true,
+                    tail_0: instruction_accounts
+                        .get(PUMPFUN_AMM_SELL_EXT_TAIL_0_IX)
+                        .copied(),
+                    tail_1: instruction_accounts
+                        .get(PUMPFUN_AMM_SELL_EXT_TAIL_1_IX)
+                        .copied(),
+                    third_meta: instruction_accounts
+                        .get(PUMPFUN_AMM_SELL_EXT_THIRD_META_IX)
+                        .copied(),
+                })
+            }
+        }
+        PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS => Some(PumpAmmSellExtendedFields {
+            requires_extended: true,
+            tail_0: instruction_accounts
+                .get(PUMPFUN_AMM_SELL_EXT_TAIL_0_IX)
+                .copied(),
+            tail_1: instruction_accounts
+                .get(PUMPFUN_AMM_SELL_EXT_TAIL_1_IX)
+                .copied(),
+            third_meta: instruction_accounts
+                .get(PUMPFUN_AMM_SELL_EXT_THIRD_META_IX)
+                .copied(),
+        }),
+        _ => None,
+    }
+}
+
 /// Stable, structured reason when local (validator) market-account parsing cannot build `PumpAmmPoolStatic`.
 /// Used by `market-data` cold-path logging (Scope 42); not a global canonicalization of fee recipients.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1733,8 +1825,7 @@ impl PumpFunAmmDex {
                     continue;
                 };
                 if disc8 == sell_layout_sell_disc
-                    && acc_strings.len() != 21
-                    && acc_strings.len() != 24
+                    && !pump_amm_sell_ix_account_len_supported(acc_strings.len())
                 {
                     summary.termination_reason =
                         PumpAmmSellLayoutTerminationReason::LocalHistoryEmptyExternalPumpAmmSellAccountShapeUnsupported;
@@ -1783,11 +1874,7 @@ impl PumpFunAmmDex {
                 ) {
                     summary.termination_reason = PumpAmmSellLayoutTerminationReason::LayoutFound;
                     summary.elapsed_total_ms = t0.elapsed().as_millis();
-                    let sell_ix_account_count = match best_obs.layout {
-                        PumpAmmAuthoritativeSellLayout::Extended { .. } => 24u8,
-                        PumpAmmAuthoritativeSellLayout::Base => 21,
-                        PumpAmmAuthoritativeSellLayout::Unknown => 0,
-                    };
+                    let sell_ix_account_count = acc_strings.len() as u8;
                     let (tail0_log, tail1_log, tail2_log) = match best_obs.layout {
                         PumpAmmAuthoritativeSellLayout::Extended {
                             tail_0,
@@ -1861,7 +1948,9 @@ impl PumpFunAmmDex {
                 _ => (None, None, None),
             };
             let sell_ix_account_count = match best_obs.layout {
-                PumpAmmAuthoritativeSellLayout::Extended { .. } => 24u8,
+                PumpAmmAuthoritativeSellLayout::Extended { .. } => {
+                    PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS as u8
+                }
                 PumpAmmAuthoritativeSellLayout::Base => 21,
                 PumpAmmAuthoritativeSellLayout::Unknown => 0,
             };
@@ -4429,21 +4518,27 @@ impl PumpFunAmmDex {
         ix: &'a Value,
         message_account_keys: &'a [String],
     ) -> Option<&'a str> {
+        let ix = Self::pump_amm_instruction_json_body(ix);
         if let Some(s) = ix.get("programId").and_then(|v| v.as_str()) {
             return Some(s);
-        }
-        if let Some(w) = ix
-            .get("Parsed")
-            .and_then(|p| p.get("programId"))
-            .and_then(|v| v.as_str())
-        {
-            return Some(w);
         }
         let idx = ix.get("programIdIndex").and_then(|v| v.as_u64())? as usize;
         message_account_keys.get(idx).map(|s| s.as_str())
     }
 
+    /// Unwrap validator `jsonParsed` instruction envelopes (`Compiled` / `Parsed`).
+    fn pump_amm_instruction_json_body(ix: &Value) -> &Value {
+        if let Some(inner) = ix.get("Compiled") {
+            return inner;
+        }
+        if let Some(inner) = ix.get("Parsed") {
+            return inner;
+        }
+        ix
+    }
+
     fn pump_amm_ix_data_from_json(ix: &Value) -> Option<Vec<u8>> {
+        let ix = Self::pump_amm_instruction_json_body(ix);
         let d = ix.get("data")?;
         if let Some(s) = d.as_str() {
             return bs58::decode(s).into_vec().ok();
@@ -4468,6 +4563,7 @@ impl PumpFunAmmDex {
         ix: &Value,
         message_account_keys: &[String],
     ) -> Option<Vec<String>> {
+        let ix = Self::pump_amm_instruction_json_body(ix);
         let arr = ix.get("accounts")?.as_array()?;
         if arr.is_empty() {
             return None;
@@ -4538,18 +4634,22 @@ impl PumpFunAmmDex {
         }
 
         if disc == sell_disc {
-            let extended = match acc_accounts.len() {
-                21 => false,
-                24 => true,
-                _ => return None,
-            };
+            if !pump_amm_sell_ix_account_len_supported(acc_accounts.len()) {
+                return None;
+            }
             let pool_market = parse_pk(0)?;
             let base_mint = parse_pk(3)?;
-            let (third, tail_0, tail_1) = if extended {
+            let ext = pump_amm_sell_extended_fields_from_ix_accounts(
+                &acc_accounts
+                    .iter()
+                    .filter_map(|s| Pubkey::from_str(s).ok())
+                    .collect::<Vec<_>>(),
+            )?;
+            let (third, tail_0, tail_1) = if ext.requires_extended {
                 (
-                    Some(parse_pk(23)?),
-                    Some(parse_pk(21)?),
-                    Some(parse_pk(22)?),
+                    ext.third_meta.filter(|p| *p != Pubkey::default()),
+                    ext.tail_0.filter(|p| *p != Pubkey::default()),
+                    ext.tail_1.filter(|p| *p != Pubkey::default()),
                 )
             } else {
                 (None, None, None)
@@ -4569,7 +4669,7 @@ impl PumpFunAmmDex {
                 global_volume_accumulator: singleton_gva,
                 fee_config: parse_pk(19)?,
                 fee_program: parse_pk(20)?,
-                sell_requires_cashback_remaining: extended,
+                sell_requires_cashback_remaining: ext.requires_extended,
                 sell_cashback_third_meta: third,
                 sell_extended_tail_0: tail_0,
                 sell_extended_tail_1: tail_1,
@@ -4594,9 +4694,10 @@ impl PumpFunAmmDex {
                 Pubkey::default(),
             )
         })?;
-        let layout = match acc_accounts.len() {
-            21 => PumpAmmAuthoritativeSellLayout::Base,
-            24 => PumpAmmAuthoritativeSellLayout::Extended {
+        let layout = if !pool.sell_requires_cashback_remaining {
+            PumpAmmAuthoritativeSellLayout::Base
+        } else {
+            PumpAmmAuthoritativeSellLayout::Extended {
                 tail_0: pool
                     .sell_extended_tail_0
                     .filter(|p| *p != Pubkey::default())?,
@@ -4606,8 +4707,7 @@ impl PumpFunAmmDex {
                 tail_2: pool
                     .sell_cashback_third_meta
                     .filter(|p| *p != Pubkey::default())?,
-            },
-            _ => return None,
+            }
         };
         let obs = PumpAmmSellReferenceObservation {
             layout,
@@ -5823,6 +5923,19 @@ mod tests {
             Some(PUMPFUN_AMM_PROGRAM_ID)
         );
 
+        let ix_compiled: Value = json!({
+            "Compiled": {
+                "programId": PUMPFUN_AMM_PROGRAM_ID,
+                "accounts": ["11111111111111111111111111111111"],
+                "data": "33e685a4017f83ad00000000000000000000000000000000000000000000000000"
+            }
+        });
+        assert_eq!(
+            PumpFunAmmDex::pump_amm_ix_account_strings_from_json(&ix_compiled, &keys)
+                .map(|v| v.len()),
+            Some(1)
+        );
+
         let ix_idx: Value = json!({
             "programIdIndex": 0u64,
             "accounts": [],
@@ -6414,6 +6527,41 @@ mod tests {
         assert_eq!(observed.0, pool_market);
         assert_eq!(observed.1, base_mint);
         assert_eq!(observed.2, PumpAmmAuthoritativeSellLayout::Base);
+    }
+
+    #[test]
+    fn test_pump_amm_sell_layout_observation_parses_26_account_cashback_sell() {
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let third_meta = Pubkey::new_unique();
+        let tail0 = Pubkey::new_unique();
+        let tail1 = Pubkey::new_unique();
+        let mut account_keys: Vec<Pubkey> = (0..26).map(|_| Pubkey::new_unique()).collect();
+        account_keys[0] = pool_market;
+        account_keys[2] = Pubkey::from_str(PUMPFUN_AMM_GLOBAL_CONFIG).unwrap();
+        account_keys[3] = base_mint;
+        account_keys[4] = Pubkey::from_str(WSOL_MINT).unwrap();
+        account_keys[20] = Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).unwrap();
+        account_keys[21] = tail0;
+        account_keys[22] = tail1;
+        account_keys[23] = third_meta;
+        let acc_strings: Vec<String> = account_keys.iter().map(ToString::to_string).collect();
+        let ix_data = pump_amm_sell_ix_discriminator().to_vec();
+
+        let observed = PumpFunAmmDex::pump_amm_sell_layout_observation_from_parsed_swap_ix(
+            &acc_strings,
+            &ix_data,
+        )
+        .expect("26-account sell observation");
+
+        assert_eq!(
+            observed.2,
+            PumpAmmAuthoritativeSellLayout::Extended {
+                tail_0: tail0,
+                tail_1: tail1,
+                tail_2: third_meta,
+            }
+        );
     }
 
     #[test]

--- a/src/solana/dex_parser.rs
+++ b/src/solana/dex_parser.rs
@@ -8,7 +8,8 @@
 
 use crate::solana::dex::pumpfun::{BondingCurveState, PUMPFUN_BUY_EXACT_SOL_IN_DISCRIMINATOR};
 use crate::solana::dex::pumpfun_amm::{
-    pump_amm_sell_ix_discriminator, PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS,
+    pump_amm_sell_extended_fields_from_ix_accounts, pump_amm_sell_ix_account_len_supported,
+    pump_amm_sell_ix_discriminator,
 };
 use crate::solana::geyser_listener::{GeyserAccountUpdate, GeyserTransactionUpdate};
 use rust_decimal::Decimal;
@@ -273,6 +274,9 @@ fn try_parse_inner_instructions(
     let meteora = Pubkey::from_str(METEORA_DLMM).ok()?;
     let pumpfun = Pubkey::from_str(PUMPFUN_PROGRAM).ok()?;
     let pumpfun_amm = Pubkey::from_str(PUMPFUN_AMM_PROGRAM).ok()?;
+    let pump_amm_sell_disc = pump_amm_sell_ix_discriminator();
+
+    let mut pump_amm_fallback: Option<ParsedDexEvent> = None;
 
     for inner in &update.inner_instructions {
         if inner.data.len() < 8 {
@@ -308,12 +312,25 @@ fn try_parse_inner_instructions(
             _ => continue,
         };
 
-        if result.is_some() {
-            return result;
+        let Some(event) = result else {
+            continue;
+        };
+
+        if program_id == pumpfun_amm {
+            let is_pump_amm_sell = synth.instruction_data.get(..8) == Some(&pump_amm_sell_disc);
+            if is_pump_amm_sell {
+                return Some(event);
+            }
+            if pump_amm_fallback.is_none() {
+                pump_amm_fallback = Some(event);
+            }
+            continue;
         }
+
+        return Some(event);
     }
 
-    None
+    pump_amm_fallback
 }
 
 // ============================================================================
@@ -1270,8 +1287,7 @@ fn parse_pumpfun_amm_transaction(update: &GeyserTransactionUpdate) -> Option<Par
         }
         true
     } else if disc == sell_disc {
-        let n = update.instruction_accounts.len();
-        if n != 21 && n != PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS {
+        if !pump_amm_sell_ix_account_len_supported(update.instruction_accounts.len()) {
             return None;
         }
         false
@@ -1279,29 +1295,24 @@ fn parse_pumpfun_amm_transaction(update: &GeyserTransactionUpdate) -> Option<Par
         return None;
     };
 
-    let sell_requires_cashback_remaining =
-        !is_buy && update.instruction_accounts.len() == PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS;
-    let sell_cashback_third_meta = if sell_requires_cashback_remaining {
-        update.instruction_accounts.get(23).copied()
-    } else {
+    let sell_ext = if is_buy {
         None
-    };
-    let (sell_extended_tail_0, sell_extended_tail_1) = if sell_requires_cashback_remaining {
-        (
-            update.instruction_accounts.get(21).copied(),
-            update.instruction_accounts.get(22).copied(),
-        )
     } else {
-        (None, None)
+        pump_amm_sell_extended_fields_from_ix_accounts(&update.instruction_accounts)
     };
+    let sell_requires_cashback_remaining = sell_ext.map(|e| e.requires_extended).unwrap_or(false);
+    let sell_cashback_third_meta = sell_ext.and_then(|e| e.third_meta);
+    let sell_extended_tail_0 = sell_ext.and_then(|e| e.tail_0);
+    let sell_extended_tail_1 = sell_ext.and_then(|e| e.tail_1);
     if sell_requires_cashback_remaining && sell_cashback_third_meta.is_none() {
         return None;
     }
 
     // Observed account order from on-chain PumpFun AMM swap TX:
     // BUY: 23 accounts (includes global_volume_accumulator + user_volume)
-    // SELL: 21 base metas, or 24 with three trailing cashback/volume accounts (Pump docs / mainnet).
-    // See src/solana/dex/pumpfun_amm.rs build_swap_ix_from_pool_accounts for reference.
+    // SELL: 21 base; 24 = legacy extended (#21/#22 volume, #23 pool-v2) OR post-upgrade non-cashback (#21 pool-v2);
+    //       26 = cashback extended (#21/#22 volume, #23 pool-v2, #24/#25 fee recipient pair).
+    // See pumpfun_amm.rs `pump_amm_sell_extended_fields_from_ix_accounts` and build_swap_ix_from_pool_accounts.
     let pool_market = update.instruction_accounts[0];
     let trader = update
         .account_keys
@@ -1328,7 +1339,8 @@ fn parse_pumpfun_amm_transaction(update: &GeyserTransactionUpdate) -> Option<Par
     // BUY: [16]=global_volume_accumulator, [17]=coin_creator_vault_ata, [18]=coin_creator_vault_authority,
     //      [19]=user_volume, [20]=fee_config (pool-specific PDA), [21]=fee_program, [22]=program_id
     // SELL: [16]=program_id, [17]=coin_creator_vault_ata, [18]=coin_creator_vault_authority,
-    //       [19]=fee_config global, [20]=fee_program, [21..24]=optional cashback remaining metas
+    //       [19]=fee_config global, [20]=fee_program;
+    //       extended: #21/#22 volume metas, #23 pool-v2 (26-account also has #24/#25 fee pair).
     //
     // CRITICAL: BUY uses pool-specific fee_config in the ix; we still publish global constants in v14 cache.
     //   - PUMPFUN_AMM_FEE_CONFIG = 5PHirr8joyTMp9JMm6nW7hNDVyEYdkzDqazxPD7RaTjx
@@ -2244,6 +2256,255 @@ mod tests {
                 assert_eq!(pump_amm_sell_cashback_third_meta, Some(third_trailing));
                 assert_eq!(pump_amm_sell_extended_tail_0, Some(tail0));
                 assert_eq!(pump_amm_sell_extended_tail_1, Some(tail1));
+            }
+            _ => panic!("expected Trade"),
+        }
+    }
+
+    #[test]
+    fn test_pumpfun_amm_sell_26_accounts_sets_cashback_remaining_flag() {
+        let pool_market = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let global_config = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(SOL_MINT).unwrap();
+        let user_base = Pubkey::new_unique();
+        let user_quote = Pubkey::new_unique();
+        let pool_base_vault = Pubkey::new_unique();
+        let pool_quote_vault = Pubkey::new_unique();
+        let protocol_fee_recipient = Pubkey::new_unique();
+        let protocol_fee_recipient_ta = Pubkey::new_unique();
+        let spl_token = Pubkey::from_str("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA").unwrap();
+        let system = Pubkey::from_str("11111111111111111111111111111111").unwrap();
+        let ata_program = Pubkey::from_str("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL").unwrap();
+        let event_authority = Pubkey::new_unique();
+        let pumpfun_amm_program = Pubkey::from_str(PUMPFUN_AMM_PROGRAM).unwrap();
+        let coin_creator_vault_ata = Pubkey::new_unique();
+        let coin_creator_vault_authority = Pubkey::new_unique();
+        let fee_config = Pubkey::from_str("5PHirr8joyTMp9JMm6nW7hNDVyEYdkzDqazxPD7RaTjx").unwrap();
+        let fee_program = Pubkey::from_str("pfeeUxB6jkeY1Hxd7CsFCAjcbHA9rWtchMGdZ6VojVZ").unwrap();
+
+        let tail0 = Pubkey::new_unique();
+        let tail1 = Pubkey::new_unique();
+        let third_trailing = Pubkey::new_unique();
+        let trailing_fee_recipient = Pubkey::new_unique();
+        let trailing_fee_recipient_ta = Pubkey::new_unique();
+        let instruction_accounts = vec![
+            pool_market,
+            user,
+            global_config,
+            base_mint,
+            quote_mint,
+            user_base,
+            user_quote,
+            pool_base_vault,
+            pool_quote_vault,
+            protocol_fee_recipient,
+            protocol_fee_recipient_ta,
+            spl_token,
+            spl_token,
+            system,
+            ata_program,
+            event_authority,
+            pumpfun_amm_program,
+            coin_creator_vault_ata,
+            coin_creator_vault_authority,
+            fee_config,
+            fee_program,
+            tail0,
+            tail1,
+            third_trailing,
+            trailing_fee_recipient,
+            trailing_fee_recipient_ta,
+        ];
+        assert_eq!(instruction_accounts.len(), 26);
+
+        let sell_disc = anchor_disc("sell");
+        let mut instruction_data = sell_disc.to_vec();
+        instruction_data.extend_from_slice(&1_000_000u64.to_le_bytes());
+        instruction_data.extend_from_slice(&0u64.to_le_bytes());
+
+        let mut account_keys = instruction_accounts.clone();
+        account_keys.insert(0, user);
+
+        let base_mint_str = base_mint.to_string();
+        let pre_token = vec![TokenBalance {
+            account_index: 5,
+            mint: base_mint_str.clone(),
+            ui_token_amount: TokenAmount {
+                ui_amount: None,
+                decimals: 6,
+                amount: "2000000".to_string(),
+            },
+            program_id: Some(spl_token.to_string()),
+        }];
+        let post_token = vec![TokenBalance {
+            account_index: 5,
+            mint: base_mint_str,
+            ui_token_amount: TokenAmount {
+                ui_amount: None,
+                decimals: 6,
+                amount: "1000000".to_string(),
+            },
+            program_id: Some(spl_token.to_string()),
+        }];
+
+        let pre_balances = vec![1_000_000_000u64; account_keys.len()];
+        let mut post_balances = pre_balances.clone();
+        post_balances[0] = 1_000_050_000_000;
+
+        let update = GeyserTransactionUpdate {
+            signature: "sell_26_synth_sig".to_string(),
+            slot: 202,
+            account_keys,
+            instruction_accounts,
+            instruction_data,
+            inner_instructions: vec![],
+            pre_token_balances: pre_token,
+            post_token_balances: post_token,
+            pre_balances,
+            post_balances,
+            fee_lamports: 5000,
+            compute_units_consumed: None,
+            grpc_recv_at: Instant::now(),
+        };
+
+        let event = parse_transaction_update(&update).expect("26-account sell parse");
+        match event {
+            ParsedDexEvent::Trade {
+                pump_amm_sell_requires_cashback_remaining,
+                pump_amm_sell_cashback_third_meta,
+                pump_amm_sell_extended_tail_0,
+                pump_amm_sell_extended_tail_1,
+                pool_accounts,
+                ..
+            } => {
+                assert!(pump_amm_sell_requires_cashback_remaining);
+                assert_eq!(pump_amm_sell_cashback_third_meta, Some(third_trailing));
+                assert_eq!(pump_amm_sell_extended_tail_0, Some(tail0));
+                assert_eq!(pump_amm_sell_extended_tail_1, Some(tail1));
+                let accts = pool_accounts.expect("pool_accounts");
+                assert_eq!(accts[6], protocol_fee_recipient);
+            }
+            _ => panic!("expected Trade"),
+        }
+    }
+
+    #[test]
+    fn test_pumpfun_amm_inner_cpi_sell_26_accounts() {
+        use crate::solana::geyser_listener::InnerInstruction;
+
+        let pool_market = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let global_config = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(SOL_MINT).unwrap();
+        let spl_token = Pubkey::from_str("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA").unwrap();
+        let system = Pubkey::from_str("11111111111111111111111111111111").unwrap();
+        let ata_program = Pubkey::from_str("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL").unwrap();
+        let pumpfun_amm_program = Pubkey::from_str(PUMPFUN_AMM_PROGRAM).unwrap();
+        let fee_config = Pubkey::from_str("5PHirr8joyTMp9JMm6nW7hNDVyEYdkzDqazxPD7RaTjx").unwrap();
+        let fee_program = Pubkey::from_str("pfeeUxB6jkeY1Hxd7CsFCAjcbHA9rWtchMGdZ6VojVZ").unwrap();
+
+        let sell_accounts = vec![
+            pool_market,
+            user,
+            global_config,
+            base_mint,
+            quote_mint,
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            spl_token,
+            spl_token,
+            system,
+            ata_program,
+            Pubkey::new_unique(),
+            pumpfun_amm_program,
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            fee_config,
+            fee_program,
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+        ];
+        assert_eq!(sell_accounts.len(), 26);
+
+        let jupiter = Pubkey::new_unique();
+        let mut account_keys = vec![user, jupiter];
+        account_keys.extend(sell_accounts.iter().copied());
+
+        let pump_amm_idx = account_keys
+            .iter()
+            .position(|k| *k == pumpfun_amm_program)
+            .unwrap();
+        let sell_account_indices: Vec<u8> = sell_accounts
+            .iter()
+            .map(|pk| account_keys.iter().position(|k| k == pk).unwrap() as u8)
+            .collect();
+
+        let sell_disc = anchor_disc("sell");
+        let mut sell_data = sell_disc.to_vec();
+        sell_data.extend_from_slice(&500_000u64.to_le_bytes());
+        sell_data.extend_from_slice(&0u64.to_le_bytes());
+
+        let base_mint_str = base_mint.to_string();
+        let pre_token = vec![TokenBalance {
+            account_index: sell_account_indices[5],
+            mint: base_mint_str.clone(),
+            ui_token_amount: TokenAmount {
+                ui_amount: None,
+                decimals: 6,
+                amount: "2000000".to_string(),
+            },
+            program_id: Some(spl_token.to_string()),
+        }];
+        let post_token = vec![TokenBalance {
+            account_index: sell_account_indices[5],
+            mint: base_mint_str,
+            ui_token_amount: TokenAmount {
+                ui_amount: None,
+                decimals: 6,
+                amount: "1000000".to_string(),
+            },
+            program_id: Some(spl_token.to_string()),
+        }];
+
+        let update = GeyserTransactionUpdate {
+            signature: "inner_cpi_sell_sig".to_string(),
+            slot: 203,
+            account_keys: account_keys.clone(),
+            instruction_accounts: vec![user],
+            instruction_data: vec![0u8; 8],
+            inner_instructions: vec![InnerInstruction {
+                program_id_index: pump_amm_idx as u8,
+                accounts: sell_account_indices,
+                data: sell_data,
+            }],
+            pre_token_balances: pre_token,
+            post_token_balances: post_token,
+            pre_balances: vec![1_000_000_000u64; account_keys.len()],
+            post_balances: vec![1_000_050_000_000u64; account_keys.len()],
+            fee_lamports: 5000,
+            compute_units_consumed: None,
+            grpc_recv_at: Instant::now(),
+        };
+
+        let event = parse_transaction_update(&update).expect("inner CPI sell");
+        match event {
+            ParsedDexEvent::Trade {
+                is_buy,
+                pump_amm_sell_requires_cashback_remaining,
+                ..
+            } => {
+                assert!(!is_buy);
+                assert!(pump_amm_sell_requires_cashback_remaining);
             }
             _ => panic!("expected Trade"),
         }

--- a/src/solana/dex_parser.rs
+++ b/src/solana/dex_parser.rs
@@ -57,6 +57,7 @@ pub struct OrcaPoolInfo {
 // ============================================================================
 
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum ParsedDexEvent {
     /// New pool created
     PoolCreated {
@@ -104,6 +105,10 @@ pub enum ParsedDexEvent {
         pump_amm_sell_extended_tail_0: Option<Pubkey>,
         /// PumpSwap only: observed extended SELL ix account #22 (Scope 61).
         pump_amm_sell_extended_tail_1: Option<Pubkey>,
+        /// PumpSwap only: observed cashback `sell` fee-recipient ix #24.
+        pump_amm_sell_extended_fee_tail_0: Option<Pubkey>,
+        /// PumpSwap only: observed cashback `sell` fee-recipient ix #25.
+        pump_amm_sell_extended_fee_tail_1: Option<Pubkey>,
     },
     /// Liquidity removed (potential rug)
     LiquidityRemoved {
@@ -531,6 +536,8 @@ fn parse_raydium_swap(
         pump_amm_sell_cashback_third_meta: None,
         pump_amm_sell_extended_tail_0: None,
         pump_amm_sell_extended_tail_1: None,
+        pump_amm_sell_extended_fee_tail_0: None,
+        pump_amm_sell_extended_fee_tail_1: None,
     })
 }
 
@@ -763,6 +770,8 @@ fn parse_orca_transaction(
         pump_amm_sell_cashback_third_meta: None,
         pump_amm_sell_extended_tail_0: None,
         pump_amm_sell_extended_tail_1: None,
+        pump_amm_sell_extended_fee_tail_0: None,
+        pump_amm_sell_extended_fee_tail_1: None,
     })
 }
 
@@ -961,6 +970,8 @@ fn build_pumpfun_trade_event(
         pump_amm_sell_cashback_third_meta: None,
         pump_amm_sell_extended_tail_0: None,
         pump_amm_sell_extended_tail_1: None,
+        pump_amm_sell_extended_fee_tail_0: None,
+        pump_amm_sell_extended_fee_tail_1: None,
     }
 }
 
@@ -1304,7 +1315,14 @@ fn parse_pumpfun_amm_transaction(update: &GeyserTransactionUpdate) -> Option<Par
     let sell_cashback_third_meta = sell_ext.and_then(|e| e.third_meta);
     let sell_extended_tail_0 = sell_ext.and_then(|e| e.tail_0);
     let sell_extended_tail_1 = sell_ext.and_then(|e| e.tail_1);
+    let sell_extended_fee_tail_0 = sell_ext.and_then(|e| e.fee_tail_0);
+    let sell_extended_fee_tail_1 = sell_ext.and_then(|e| e.fee_tail_1);
     if sell_requires_cashback_remaining && sell_cashback_third_meta.is_none() {
+        return None;
+    }
+    if sell_ext.is_some_and(|e| e.requires_fee_tail)
+        && (sell_extended_fee_tail_0.is_none() || sell_extended_fee_tail_1.is_none())
+    {
         return None;
     }
 
@@ -1474,6 +1492,8 @@ fn parse_pumpfun_amm_transaction(update: &GeyserTransactionUpdate) -> Option<Par
         pump_amm_sell_cashback_third_meta: sell_cashback_third_meta,
         pump_amm_sell_extended_tail_0: sell_extended_tail_0,
         pump_amm_sell_extended_tail_1: sell_extended_tail_1,
+        pump_amm_sell_extended_fee_tail_0: sell_extended_fee_tail_0,
+        pump_amm_sell_extended_fee_tail_1: sell_extended_fee_tail_1,
     })
 }
 
@@ -1808,6 +1828,8 @@ fn parse_meteora_transaction(update: &GeyserTransactionUpdate) -> Option<ParsedD
         pump_amm_sell_cashback_third_meta: None,
         pump_amm_sell_extended_tail_0: None,
         pump_amm_sell_extended_tail_1: None,
+        pump_amm_sell_extended_fee_tail_0: None,
+        pump_amm_sell_extended_fee_tail_1: None,
     })
 }
 
@@ -1938,6 +1960,8 @@ fn parse_raydium_cpmm_transaction(update: &GeyserTransactionUpdate) -> Option<Pa
         pump_amm_sell_cashback_third_meta: None,
         pump_amm_sell_extended_tail_0: None,
         pump_amm_sell_extended_tail_1: None,
+        pump_amm_sell_extended_fee_tail_0: None,
+        pump_amm_sell_extended_fee_tail_1: None,
     })
 }
 

--- a/src/solana/dex_parser.rs
+++ b/src/solana/dex_parser.rs
@@ -109,6 +109,8 @@ pub enum ParsedDexEvent {
         pump_amm_sell_extended_fee_tail_0: Option<Pubkey>,
         /// PumpSwap only: observed cashback `sell` fee-recipient ix #25.
         pump_amm_sell_extended_fee_tail_1: Option<Pubkey>,
+        /// PumpSwap only: observed `sell` used 26 accounts (fee-recipient pair required).
+        pump_amm_sell_requires_fee_tail: bool,
     },
     /// Liquidity removed (potential rug)
     LiquidityRemoved {
@@ -538,6 +540,7 @@ fn parse_raydium_swap(
         pump_amm_sell_extended_tail_1: None,
         pump_amm_sell_extended_fee_tail_0: None,
         pump_amm_sell_extended_fee_tail_1: None,
+        pump_amm_sell_requires_fee_tail: false,
     })
 }
 
@@ -772,6 +775,7 @@ fn parse_orca_transaction(
         pump_amm_sell_extended_tail_1: None,
         pump_amm_sell_extended_fee_tail_0: None,
         pump_amm_sell_extended_fee_tail_1: None,
+        pump_amm_sell_requires_fee_tail: false,
     })
 }
 
@@ -972,6 +976,7 @@ fn build_pumpfun_trade_event(
         pump_amm_sell_extended_tail_1: None,
         pump_amm_sell_extended_fee_tail_0: None,
         pump_amm_sell_extended_fee_tail_1: None,
+        pump_amm_sell_requires_fee_tail: false,
     }
 }
 
@@ -1312,6 +1317,7 @@ fn parse_pumpfun_amm_transaction(update: &GeyserTransactionUpdate) -> Option<Par
         pump_amm_sell_extended_fields_from_ix_accounts(&update.instruction_accounts)
     };
     let sell_requires_cashback_remaining = sell_ext.map(|e| e.requires_extended).unwrap_or(false);
+    let sell_requires_fee_tail = sell_ext.map(|e| e.requires_fee_tail).unwrap_or(false);
     let sell_cashback_third_meta = sell_ext.and_then(|e| e.third_meta);
     let sell_extended_tail_0 = sell_ext.and_then(|e| e.tail_0);
     let sell_extended_tail_1 = sell_ext.and_then(|e| e.tail_1);
@@ -1494,6 +1500,7 @@ fn parse_pumpfun_amm_transaction(update: &GeyserTransactionUpdate) -> Option<Par
         pump_amm_sell_extended_tail_1: sell_extended_tail_1,
         pump_amm_sell_extended_fee_tail_0: sell_extended_fee_tail_0,
         pump_amm_sell_extended_fee_tail_1: sell_extended_fee_tail_1,
+        pump_amm_sell_requires_fee_tail: sell_requires_fee_tail,
     })
 }
 
@@ -1830,6 +1837,7 @@ fn parse_meteora_transaction(update: &GeyserTransactionUpdate) -> Option<ParsedD
         pump_amm_sell_extended_tail_1: None,
         pump_amm_sell_extended_fee_tail_0: None,
         pump_amm_sell_extended_fee_tail_1: None,
+        pump_amm_sell_requires_fee_tail: false,
     })
 }
 
@@ -1962,6 +1970,7 @@ fn parse_raydium_cpmm_transaction(update: &GeyserTransactionUpdate) -> Option<Pa
         pump_amm_sell_extended_tail_1: None,
         pump_amm_sell_extended_fee_tail_0: None,
         pump_amm_sell_extended_fee_tail_1: None,
+        pump_amm_sell_requires_fee_tail: false,
     })
 }
 


### PR DESCRIPTION
## Summary

- Parse PumpSwap `sell` with **21 / 24 / 26** accounts (post-upgrade cashback layout) in `dex_parser`; prefer **SELL over BUY** in inner/CPI path.
- On Geyser SELL: `set_pump_amm_sell_layout_authoritative` + metrics when `sell_layout_ready=true`.
- P2 parity: `force_refresh` unwraps Serde `Compiled`/`Parsed` JSON and accepts 26-account sells in history scan.

## Context

Prod incident: high-volume PumpSwap pool had GMGN activity but IronCrab saw `pump_amm_sell_discriminator_seen=0` and Sim **6023** because 26-account sells were dropped. Helius fallback not needed (local validator OK).

## Parallel PRs

- Does **not** touch `momentum_bot.rs` (open PR #184 P182b).
- P1 bonding-curve routing deferred.

## Test plan

- [ ] CI: fmt, clippy, unit tests
- [ ] Impl Eval (Level 5) after merge coordination
- [ ] Prod: `pump_amm_geyser_sell_parsed_total` / `sell_layout_ready` on active PumpSwap pools

Cloud Agent: `bc-be632587-945d-431f-90f1-828c710ae9bf` (commit `eee62c2`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes swap instruction account layout and SSOT readiness for live SELL execution; incorrect tail/fee metas would cause on-chain failures (e.g. prior sim 6023).
> 
> **Overview**
> Adds end-to-end support for PumpSwap **`sell` with 21, 24, or 26 accounts**, including the post-upgrade **26-account cashback layout** with fee-recipient metas at **#24/#25**, which were previously dropped and blocked `sell_layout_ready`.
> 
> **Parsing & discovery:** `pump_amm_sell_extended_fields_from_ix_accounts` classifies layouts (base, legacy extended, post-upgrade `pool-v2` at #21, 26-account cashback). `dex_parser` emits the new trade fields, validates fee tails when required, and **prefers an inner CPI `sell` over a `buy`** when both appear. `force_refresh` TX-history accepts 26-account sells and unwraps **`Compiled`/`Parsed`** JSON instruction envelopes.
> 
> **SSOT & execution:** `LivePoolCache` stores fee-tail pubkeys and `requires_fee_tail`; readiness/publish paths require the fee pair when needed. **Geyser SELL** paths call **`set_pump_amm_sell_layout_authoritative`** when layout is complete (plus new metrics). **`tx_builder`** appends observed fee-tail accounts on SELL builds. JetStream metadata and Ensure-publish merge logic are extended accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1fe3dfc8e4f475892c916f8738f4bd0e56e54c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->