### PR TITLE
fix(pump_amm): P184b — SELL #21/#22 immer für Intent-User ableiten

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2542,7 +2542,7 @@ fn raydium_cpmm_readiness_for_pool_cache_update(s: &RaydiumCpmmState) -> DexPool
 /// PumpSwap SELL-layout contract for JetStream / SLAVE SSOT.
 ///
 /// - Base-only SELL stays ready as long as the underlying refresh/observation says the base layout is usable.
-/// - Extended SELL is ready when the full observed tail (#21/#22/#23) is known and base layout is ready.
+/// - Extended SELL is ready when pool `third_meta` (+ fee tails when required) is known; #21/#22 are derived at build.
 #[allow(clippy::too_many_arguments)]
 fn pump_amm_sell_layout_publish_state(
     sell_requires_extended: bool,
@@ -2558,12 +2558,7 @@ fn pump_amm_sell_layout_publish_state(
         let third_ok = sell_cashback_third_meta
             .filter(|p| *p != Pubkey::default())
             .is_some();
-        let tail_ok = sell_extended_tail_0
-            .filter(|p| *p != Pubkey::default())
-            .is_some()
-            && sell_extended_tail_1
-                .filter(|p| *p != Pubkey::default())
-                .is_some();
+        let _ = (sell_extended_tail_0, sell_extended_tail_1);
         let needs_fee_tail = sell_requires_fee_tail
             || sell_extended_fee_tail_0.is_some()
             || sell_extended_fee_tail_1.is_some();
@@ -2577,7 +2572,7 @@ fn pump_amm_sell_layout_publish_state(
         } else {
             true
         };
-        third_ok && tail_ok && fee_ok && base_layout_ready
+        third_ok && fee_ok && base_layout_ready
     } else {
         base_layout_ready
     };
@@ -13396,7 +13391,7 @@ mod discovery_tests {
     }
 
     #[test]
-    fn test_pump_amm_trade_publish_extended_with_third_only_missing_tail_is_partial() {
+    fn test_pump_amm_trade_publish_extended_with_third_only_without_volume_tails_is_ready() {
         let (sell_layout_ready, dex_readiness) = pump_amm_sell_layout_publish_state(
             true,
             Some(Pubkey::new_unique()),
@@ -13408,10 +13403,10 @@ mod discovery_tests {
             true,
         );
         assert!(
-            !sell_layout_ready,
-            "extended SELL with third but missing tail0/tail1 must not be marked ready"
+            sell_layout_ready,
+            "extended SELL with third_meta only must be ready — volume tails #21/#22 are build-derived"
         );
-        assert_eq!(dex_readiness, DexPoolReadiness::Partial);
+        assert_eq!(dex_readiness, DexPoolReadiness::Ready);
     }
 
     #[test]

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -440,6 +440,7 @@ pub struct LivePoolCache {
     /// Third trailing meta for extended `sell` (ix account #23, writable in observed reference).
     pump_amm_sell_extended_third_meta_by_market: DashMap<Pubkey, Pubkey>,
     /// Observed extended SELL ix account #21 (readonly in reference); Scope 61.
+    /// Observed reference-trader volume meta #21 (diagnostics / JetStream; not used when building our SELL).
     pump_amm_sell_extended_tail_0_by_market: DashMap<Pubkey, Pubkey>,
     /// Observed extended SELL ix account #22 (readonly in reference); Scope 61.
     pump_amm_sell_extended_tail_1_by_market: DashMap<Pubkey, Pubkey>,
@@ -1205,13 +1206,12 @@ impl LivePoolCache {
         if !self.pump_amm_sell_layout_ready(pool_market) {
             return false;
         }
-        let (requires_extended, third, tail_0, tail_1) =
+        let (requires_extended, third, _volume_tail_0, _volume_tail_1) =
             self.pump_amm_sell_extended_layout(pool_market);
         let (fee_t0, fee_t1) = self.pump_amm_sell_fee_tail_layout(pool_market);
         if requires_extended {
             let third_ok = third.filter(|p| *p != Pubkey::default()).is_some();
-            let tail_ok = tail_0.filter(|p| *p != Pubkey::default()).is_some()
-                && tail_1.filter(|p| *p != Pubkey::default()).is_some();
+            // #21/#22 volume tails are intent-user derivable at build time — not required in cache.
             let needs_fee_tail = self.pump_amm_sell_requires_fee_tail(pool_market)
                 || fee_t0.is_some()
                 || fee_t1.is_some();
@@ -1221,7 +1221,7 @@ impl LivePoolCache {
             } else {
                 true
             };
-            third_ok && tail_ok && fee_ok
+            third_ok && fee_ok
         } else {
             true
         }
@@ -2838,7 +2838,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pump_amm_extended_flag_with_third_only_missing_tail_blocks_ready_gate() {
+    fn test_pump_amm_extended_flag_with_third_only_is_swap_ready_without_observed_volume_tails() {
         let cache = LivePoolCache::new();
         let pool_market = Pubkey::new_unique();
         let base_mint = Pubkey::new_unique();
@@ -2857,7 +2857,7 @@ mod tests {
             100,
         );
         cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Ready);
-        // Legacy partial: extended flag + third only (no observed #21/#22) — Scope 61 must not count ready.
+        // Extended flag + third only: volume tails #21/#22 are derived at build — swap-ready without cache tails.
         cache.merge_pump_amm_sell_extended_layout(
             &pool_market,
             true,
@@ -2871,8 +2871,8 @@ mod tests {
         cache.set_pump_amm_sell_layout_ready(&pool_market, true);
 
         assert!(
-            !cache.pump_amm_swap_accounts_ready_by_base_mint(&base_mint),
-            "extended SELL with third but missing tail0/tail1 must not count as swap-ready"
+            cache.pump_amm_swap_accounts_ready_by_base_mint(&base_mint),
+            "extended SELL with third_meta + layout_ready must be swap-ready without observed volume tails"
         );
     }
 

--- a/src/execution/tx_builder.rs
+++ b/src/execution/tx_builder.rs
@@ -922,16 +922,8 @@ pub async fn build_tx_plan(
             } else {
                 None
             },
-            if intent.side == TradeSide::Sell {
-                sell_extended_tail_0
-            } else {
-                None
-            },
-            if intent.side == TradeSide::Sell {
-                sell_extended_tail_1
-            } else {
-                None
-            },
+            None, // volume tails #21/#22: always derived for intent user in builder
+            None,
             if intent.side == TradeSide::Sell {
                 sell_extended_fee_tail_0
             } else {
@@ -979,11 +971,30 @@ pub async fn build_tx_plan(
                 .map(|m| m.pubkey.to_string())
                 .collect::<Vec<_>>()
                 .join(",");
+            let quote_tp = Pubkey::new_from_array(spl_token::id().to_bytes());
+            let quote_mint = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+            let (derived_tail_21, derived_tail_22) =
+                if sell_requires_cashback_remaining && intent.side == TradeSide::Sell {
+                    PumpFunAmmDex::pump_amm_sell_cashback_first_two_metas(
+                        wallet_pubkey,
+                        quote_mint,
+                        quote_tp,
+                    )
+                } else {
+                    (Pubkey::default(), Pubkey::default())
+                };
+            let cached_tail_mismatch =
+                sell_extended_tail_0
+                    .zip(sell_extended_tail_1)
+                    .is_some_and(|(c0, c1)| {
+                        c0 != Pubkey::default()
+                            && c1 != Pubkey::default()
+                            && (Some(c0) != Some(derived_tail_21)
+                                || Some(c1) != Some(derived_tail_22))
+                    });
             let sell_ext_tail_src =
-                if sell_extended_tail_0.is_some() && sell_extended_tail_1.is_some() {
-                    "livepoolcache_observed_tail"
-                } else if sell_requires_cashback_remaining && intent.side == TradeSide::Sell {
-                    "derived_first_two_metas"
+                if sell_requires_cashback_remaining && intent.side == TradeSide::Sell {
+                    "derived_for_intent_user"
                 } else {
                     "n/a"
                 };
@@ -991,12 +1002,16 @@ pub async fn build_tx_plan(
                 intent_id = %intent.intent_id,
                 scope = "44",
                 dex = "pump_amm",
+                intent_user = %wallet_pubkey,
                 pool_accounts_source = pool_accounts_build_source,
                 sell_extended = sell_requires_cashback_remaining && intent.side == TradeSide::Sell,
                 sell_cashback_third_meta = ?sell_cashback_third_meta,
                 sell_extended_tail_source = sell_ext_tail_src,
-                sell_extended_tail_0 = ?sell_extended_tail_0,
-                sell_extended_tail_1 = ?sell_extended_tail_1,
+                derived_tail_21 = %derived_tail_21,
+                derived_tail_22 = %derived_tail_22,
+                cached_tail_21 = ?sell_extended_tail_0,
+                cached_tail_22 = ?sell_extended_tail_1,
+                cached_tail_mismatch,
                 sell_extended_tail_2 = ?sell_cashback_third_meta,
                 sell_ix_meta_21 = %ixs[0].accounts.get(21).map(|m| m.pubkey.to_string()).unwrap_or_default(),
                 sell_ix_meta_22 = %ixs[0].accounts.get(22).map(|m| m.pubkey.to_string()).unwrap_or_default(),
@@ -1669,7 +1684,7 @@ async fn build_hop_pump_amm(
     cache: Option<&SharedLivePoolCache>,
 ) -> Result<Vec<Instruction>, UnsupportedTxPlan> {
     // PumpSwap AMM (graduated tokens) - get pool_accounts from cache
-    let (pool_accounts, sell_requires, sell_third, sell_t0, sell_t1, sell_fee_t0, sell_fee_t1) =
+    let (pool_accounts, sell_requires, sell_third, _sell_t0, _sell_t1, sell_fee_t0, sell_fee_t1) =
         if let Some(cache) = cache {
             match cache.get(pool_address) {
                 Some(CachedPoolState::PumpAmm(amm_state)) => {
@@ -1739,8 +1754,8 @@ async fn build_hop_pump_amm(
         None, // Token-2022 not yet supported in multi-hop arb
         sell_requires && is_sell_hop,
         if is_sell_hop { sell_third } else { None },
-        if is_sell_hop { sell_t0 } else { None },
-        if is_sell_hop { sell_t1 } else { None },
+        None, // volume tails: derived for wallet in builder
+        None,
         if is_sell_hop { sell_fee_t0 } else { None },
         if is_sell_hop { sell_fee_t1 } else { None },
     )
@@ -2234,10 +2249,15 @@ mod tests {
             sell_ix.accounts.len()
         );
         assert_eq!(sell_ix.accounts.last().unwrap().pubkey, third_meta);
-        assert_eq!(sell_ix.accounts[21].pubkey, tail0);
-        assert_eq!(sell_ix.accounts[22].pubkey, tail1);
-        assert!(!sell_ix.accounts[21].is_writable);
-        assert!(!sell_ix.accounts[22].is_writable);
+        let quote_tp = Pubkey::new_from_array(spl_token::id().to_bytes());
+        let (derived_21, derived_22) =
+            PumpFunAmmDex::pump_amm_sell_cashback_first_two_metas(wallet, quote_mint, quote_tp);
+        assert_eq!(sell_ix.accounts[21].pubkey, derived_21);
+        assert_eq!(sell_ix.accounts[22].pubkey, derived_22);
+        assert_ne!(derived_21, tail0);
+        assert_ne!(derived_22, tail1);
+        assert!(sell_ix.accounts[21].is_writable);
+        assert!(sell_ix.accounts[22].is_writable);
         assert!(sell_ix.accounts[23].is_writable);
     }
 

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -2101,9 +2101,9 @@ impl PumpFunAmmDex {
         Pubkey::find_program_address(&[b"user_volume_accumulator", user.as_ref()], &program_id).0
     }
 
-    /// First two trailing `sell` metas when cashback/extended path is active (mainnet order).
-    /// The **third** meta is pool/context-specific and must be supplied from authoritative observation
-    /// (Geyser / TX-history); it is not user-derivable.
+    /// First two trailing `sell` metas (#21 user volume WSOL ATA, #22 user volume accumulator) when
+    /// cashback/extended path is active — **always** derived from `(user, quote_mint, quote_tp)`.
+    /// The **third** meta (#23 pool-v2 / context) is pool-specific and must come from Geyser / TX-history.
     pub fn pump_amm_sell_cashback_first_two_metas(
         user: Pubkey,
         quote_mint: Pubkey,
@@ -2116,6 +2116,51 @@ impl PumpFunAmmDex {
         let user_vol_wsol_ata =
             Self::derive_ata_with_program(user_vol, quote_mint, quote_token_program);
         (user_vol_wsol_ata, user_vol)
+    }
+
+    /// Append extended/cashback SELL trailing metas: #21/#22 always from [`Self::pump_amm_sell_cashback_first_two_metas`],
+    /// #23 `third`, optional #24/#25 fee pair from observation. Cached reference-trader volume tails are ignored.
+    #[allow(clippy::too_many_arguments)]
+    fn push_pump_amm_sell_extended_trailing_metas(
+        metas: &mut Vec<AccountMeta>,
+        user: Pubkey,
+        quote_mint: Pubkey,
+        quote_token_program: Pubkey,
+        third: Pubkey,
+        sell_extended_fee_tail_0: Option<Pubkey>,
+        sell_extended_fee_tail_1: Option<Pubkey>,
+        cached_observed_volume_tail_0: Option<Pubkey>,
+        cached_observed_volume_tail_1: Option<Pubkey>,
+    ) {
+        let (user_vol_wsol_ata, user_vol) =
+            Self::pump_amm_sell_cashback_first_two_metas(user, quote_mint, quote_token_program);
+        if let (Some(c0), Some(c1)) = (
+            cached_observed_volume_tail_0.filter(|p| *p != Pubkey::default()),
+            cached_observed_volume_tail_1.filter(|p| *p != Pubkey::default()),
+        ) {
+            if c0 != user_vol_wsol_ata || c1 != user_vol {
+                warn!(
+                    intent_user = %user,
+                    cached_tail_21 = %c0,
+                    cached_tail_22 = %c1,
+                    derived_tail_21 = %user_vol_wsol_ata,
+                    derived_tail_22 = %user_vol,
+                    sell_extended_tail_source = "derived_for_intent_user",
+                    cached_tail_mismatch = true,
+                    "pump_amm SELL: ignoring cached volume tail #21/#22 from reference trader; using intent-user derivation"
+                );
+            }
+        }
+        metas.push(AccountMeta::new(user_vol_wsol_ata, false));
+        metas.push(AccountMeta::new(user_vol, false));
+        metas.push(AccountMeta::new(third, false));
+        if let (Some(f0), Some(f1)) = (
+            sell_extended_fee_tail_0.filter(|p| *p != Pubkey::default()),
+            sell_extended_fee_tail_1.filter(|p| *p != Pubkey::default()),
+        ) {
+            metas.push(AccountMeta::new_readonly(f0, false));
+            metas.push(AccountMeta::new_readonly(f1, false));
+        }
     }
 
     async fn rpc_get_account_owner_and_executable(
@@ -5473,8 +5518,8 @@ impl Dex for PumpFunAmmDex {
                                                                             // `pools_by_base` can be stale vs monotonic LivePoolCache (Geyser); prefer DashMap for extended SELL.
             let mut sell_requires_cashback_remaining = pool.sell_requires_cashback_remaining;
             let mut sell_cashback_third_meta = pool.sell_cashback_third_meta;
-            let mut sell_extended_tail_0 = pool.sell_extended_tail_0;
-            let mut sell_extended_tail_1 = pool.sell_extended_tail_1;
+            let mut cached_observed_volume_tail_0 = pool.sell_extended_tail_0;
+            let mut cached_observed_volume_tail_1 = pool.sell_extended_tail_1;
             let mut sell_extended_fee_tail_0 = pool.sell_extended_fee_tail_0;
             let mut sell_extended_fee_tail_1 = pool.sell_extended_fee_tail_1;
             if let Some(ref cache) = self.live_pool_cache {
@@ -5485,8 +5530,8 @@ impl Dex for PumpFunAmmDex {
                 if dash_flag {
                     sell_requires_cashback_remaining = true;
                     sell_cashback_third_meta = dash_third.or(sell_cashback_third_meta);
-                    sell_extended_tail_0 = dash_t0.or(sell_extended_tail_0);
-                    sell_extended_tail_1 = dash_t1.or(sell_extended_tail_1);
+                    cached_observed_volume_tail_0 = dash_t0.or(cached_observed_volume_tail_0);
+                    cached_observed_volume_tail_1 = dash_t1.or(cached_observed_volume_tail_1);
                     sell_extended_fee_tail_0 = dash_fee_t0.or(sell_extended_fee_tail_0);
                     sell_extended_fee_tail_1 = dash_fee_t1.or(sell_extended_fee_tail_1);
                 }
@@ -5498,31 +5543,17 @@ impl Dex for PumpFunAmmDex {
                         "pump_amm SELL: extended layout required but sell_cashback_third_meta missing (authoritative observation required)"
                     ));
                 };
-                let use_observed_tail = sell_extended_tail_0
-                    .filter(|p| *p != Pubkey::default())
-                    .zip(sell_extended_tail_1.filter(|p| *p != Pubkey::default()));
-                if let Some((t0, t1)) = use_observed_tail {
-                    metas.push(AccountMeta::new_readonly(t0, false));
-                    metas.push(AccountMeta::new_readonly(t1, false));
-                    metas.push(AccountMeta::new(third, false));
-                } else {
-                    let (user_vol_wsol_ata, user_vol) =
-                        Self::pump_amm_sell_cashback_first_two_metas(
-                            user,
-                            pool.quote_mint,
-                            quote_token_program,
-                        );
-                    metas.push(AccountMeta::new(user_vol_wsol_ata, false));
-                    metas.push(AccountMeta::new(user_vol, false));
-                    metas.push(AccountMeta::new_readonly(third, false));
-                }
-                if let (Some(f0), Some(f1)) = (
-                    sell_extended_fee_tail_0.filter(|p| *p != Pubkey::default()),
-                    sell_extended_fee_tail_1.filter(|p| *p != Pubkey::default()),
-                ) {
-                    metas.push(AccountMeta::new_readonly(f0, false));
-                    metas.push(AccountMeta::new_readonly(f1, false));
-                }
+                Self::push_pump_amm_sell_extended_trailing_metas(
+                    &mut metas,
+                    user,
+                    pool.quote_mint,
+                    quote_token_program,
+                    third,
+                    sell_extended_fee_tail_0,
+                    sell_extended_fee_tail_1,
+                    cached_observed_volume_tail_0,
+                    cached_observed_volume_tail_1,
+                );
             }
         }
 
@@ -5602,8 +5633,8 @@ impl PumpFunAmmDex {
     }
 
     /// Same as [`Self::build_swap_ix_from_pool_accounts`] plus optional observed extended SELL
-    /// ix accounts #21/#22 (Scope 61). Cold-path / tx_builder only — not part of the stable
-    /// 9-arg public contract.
+    /// fee tail (#24/#25). `sell_extended_tail_0/1` are ignored for build (user volume metas
+    /// #21/#22 are always derived for `user`). Cold-path / tx_builder only.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn build_swap_ix_from_pool_accounts_with_extended_tail(
         input_mint: &str,
@@ -5807,27 +5838,17 @@ impl PumpFunAmmDex {
                         "pump_amm SELL: extended layout required but sell_cashback_third_meta missing (MASTER/Geyser observation required)"
                     ));
                 };
-                let use_observed_tail = sell_extended_tail_0
-                    .filter(|p| *p != Pubkey::default())
-                    .zip(sell_extended_tail_1.filter(|p| *p != Pubkey::default()));
-                if let Some((t0, t1)) = use_observed_tail {
-                    metas.push(AccountMeta::new_readonly(t0, false)); // 21
-                    metas.push(AccountMeta::new_readonly(t1, false)); // 22
-                    metas.push(AccountMeta::new(third, false)); // 23
-                } else {
-                    let (user_vol_wsol_ata, user_vol) =
-                        Self::pump_amm_sell_cashback_first_two_metas(user, quote_mint, quote_tp);
-                    metas.push(AccountMeta::new(user_vol_wsol_ata, false)); // 21
-                    metas.push(AccountMeta::new(user_vol, false)); // 22
-                    metas.push(AccountMeta::new_readonly(third, false)); // 23
-                }
-                if let (Some(f0), Some(f1)) = (
-                    sell_extended_fee_tail_0.filter(|p| *p != Pubkey::default()),
-                    sell_extended_fee_tail_1.filter(|p| *p != Pubkey::default()),
-                ) {
-                    metas.push(AccountMeta::new_readonly(f0, false)); // 24
-                    metas.push(AccountMeta::new_readonly(f1, false)); // 25
-                }
+                Self::push_pump_amm_sell_extended_trailing_metas(
+                    &mut metas,
+                    user,
+                    quote_mint,
+                    quote_tp,
+                    third,
+                    sell_extended_fee_tail_0,
+                    sell_extended_fee_tail_1,
+                    sell_extended_tail_0,
+                    sell_extended_tail_1,
+                );
             }
             metas
         };
@@ -6867,11 +6888,16 @@ mod tests {
             Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG).unwrap()
         );
         assert_eq!(ixs[0].accounts[20].pubkey, fee_program);
-        assert_eq!(ixs[0].accounts[21].pubkey, ref_tail_0);
-        assert_eq!(ixs[0].accounts[22].pubkey, ref_tail_1);
+        let quote_tp = Pubkey::new_from_array(spl_token::id().to_bytes());
+        let (derived_21, derived_22) =
+            PumpFunAmmDex::pump_amm_sell_cashback_first_two_metas(user, wsol, quote_tp);
+        assert_eq!(ixs[0].accounts[21].pubkey, derived_21);
+        assert_eq!(ixs[0].accounts[22].pubkey, derived_22);
+        assert_ne!(derived_21, ref_tail_0);
+        assert_ne!(derived_22, ref_tail_1);
         assert_eq!(ixs[0].accounts[23].pubkey, third_meta);
-        assert!(!ixs[0].accounts[21].is_writable);
-        assert!(!ixs[0].accounts[22].is_writable);
+        assert!(ixs[0].accounts[21].is_writable);
+        assert!(ixs[0].accounts[22].is_writable);
         assert!(ixs[0].accounts[23].is_writable);
     }
 
@@ -7086,6 +7112,56 @@ mod tests {
     #[test]
     fn pumpswap_sell_fee_config_scope58_custom3002_regression_guard() {
         pumpswap_extended_sell_uses_global_fee_config();
+    }
+
+    /// P184b: foreign reference volume tails in cache must not override intent-user #21/#22.
+    #[test]
+    fn pumpswap_extended_sell_ignores_foreign_cached_volume_tails_at_build() {
+        let wsol = Pubkey::from_str(WSOL_MINT).unwrap();
+        let our_user = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let third_meta = Pubkey::new_unique();
+        let foreign_tail_0 = Pubkey::new_unique();
+        let foreign_tail_1 = Pubkey::new_unique();
+        let quote_tp = Pubkey::new_from_array(spl_token::id().to_bytes());
+        let pool_accounts: Vec<Pubkey> = vec![
+            Pubkey::new_unique(),
+            Pubkey::from_str(PUMPFUN_AMM_GLOBAL_CONFIG).unwrap(),
+            base_mint,
+            wsol,
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).unwrap(),
+        ];
+        let ixs = PumpFunAmmDex::build_swap_ix_from_pool_accounts_with_extended_tail(
+            &base_mint.to_string(),
+            WSOL_MINT,
+            1,
+            1,
+            our_user,
+            &pool_accounts,
+            None,
+            true,
+            Some(third_meta),
+            Some(foreign_tail_0),
+            Some(foreign_tail_1),
+            None,
+            None,
+        )
+        .expect("extended SELL");
+        let (expected_21, expected_22) =
+            PumpFunAmmDex::pump_amm_sell_cashback_first_two_metas(our_user, wsol, quote_tp);
+        assert_eq!(ixs[0].accounts[21].pubkey, expected_21);
+        assert_eq!(ixs[0].accounts[22].pubkey, expected_22);
+        assert_ne!(expected_21, foreign_tail_0);
+        assert_ne!(expected_22, foreign_tail_1);
     }
 
     /// SELL path: Token-2022 base mint — ix[11] must be Token-2022 program; user base ATA (ix[5]) must match derivation.

--- a/src/solana/dex_parser.rs
+++ b/src/solana/dex_parser.rs
@@ -101,9 +101,9 @@ pub enum ParsedDexEvent {
         pump_amm_sell_requires_cashback_remaining: bool,
         /// PumpSwap only: third trailing meta from the observed ix (ix #23; not user-derivable alone).
         pump_amm_sell_cashback_third_meta: Option<Pubkey>,
-        /// PumpSwap only: observed extended SELL ix account #21 (Scope 61).
+        /// PumpSwap only: observed reference-trader volume meta #21 (forensics only — not used at build).
         pump_amm_sell_extended_tail_0: Option<Pubkey>,
-        /// PumpSwap only: observed extended SELL ix account #22 (Scope 61).
+        /// PumpSwap only: observed reference-trader volume meta #22 (forensics only — not used at build).
         pump_amm_sell_extended_tail_1: Option<Pubkey>,
         /// PumpSwap only: observed cashback `sell` fee-recipient ix #24.
         pump_amm_sell_extended_fee_tail_0: Option<Pubkey>,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (Prod)

Nach P184 (#185) parsen 26-Account-SELLs korrekt, aber gebaute SELL-IX kopierten `#21/#22` (user volume WSOL ATA + user volume accumulator) aus Referenz-Trades fremder Wallets → Simulation/on-chain **Custom(6023)**.

## Fix

- **Builder** (`pumpfun_amm.rs`): `push_pump_amm_sell_extended_trailing_metas` — `#21/#22` immer via `pump_amm_sell_cashback_first_two_metas(intent_user, …)`; `#23` third_meta + `#24/#25` fee tails weiter aus Observation; WARN bei Cache-Mismatch (Forensik).
- **tx_builder**: übergibt keine cached volume tails mehr an den Builder; Scope44-Log mit `intent_user`, `derived_tail_21/22`, `cached_tail_*`, `cached_tail_mismatch`.
- **sell_layout_ready / swap-ready**: `live_pool_cache` + `market_data` — Readiness hängt nicht mehr von beobachteten `#21/#22` ab (nur third + fee tails wenn nötig).
- **dex_parser**: Kommentar — `pump_amm_sell_extended_tail_0/1` nur Forensik.

## STOP-CHECK

- I-7: Kein neuer RPC im Hot Path.
- I-4: Poolweite Felder weiter Geyser/Referenz; User-Metas deterministisch abgeleitet.
- I-9/I-12: unverändert.

## Tests

- `pumpswap_extended_sell_ignores_foreign_cached_volume_tails_at_build`
- Angepasste Readiness-/tx_builder-Tests
- P185 26-account parse tests unverändert grün

## Verifikation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe227ae4-0058-4beb-ae6f-87e3517882c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe227ae4-0058-4beb-ae6f-87e3517882c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

