### PR TITLE
P184c: PumpSwap extended SELL #23 third_meta readonly (PrivilegeEscalation fix)

### DIFF
--- a/src/execution/tx_builder.rs
+++ b/src/execution/tx_builder.rs
@@ -1016,6 +1016,7 @@ pub async fn build_tx_plan(
                 sell_ix_meta_21 = %ixs[0].accounts.get(21).map(|m| m.pubkey.to_string()).unwrap_or_default(),
                 sell_ix_meta_22 = %ixs[0].accounts.get(22).map(|m| m.pubkey.to_string()).unwrap_or_default(),
                 sell_ix_meta_23 = %ixs[0].accounts.get(23).map(|m| m.pubkey.to_string()).unwrap_or_default(),
+                sell_ix_meta_23_writable = ixs[0].accounts.get(23).map(|m| m.is_writable).unwrap_or(false),
                 sell_ix_account_count = ixs[0].accounts.len(),
                 pool = %pool_id,
                 input_mint = %intent.resources.input_mint,
@@ -2258,7 +2259,10 @@ mod tests {
         assert_ne!(derived_22, tail1);
         assert!(sell_ix.accounts[21].is_writable);
         assert!(sell_ix.accounts[22].is_writable);
-        assert!(sell_ix.accounts[23].is_writable);
+        assert!(
+            !sell_ix.accounts[23].is_writable,
+            "derived-user extended SELL: #23 third_meta must be readonly"
+        );
     }
 
     /// Two PumpSwap pools for the same base mint: only the intent’s `pools[0]` row (explicit Ready)

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -2118,8 +2118,10 @@ impl PumpFunAmmDex {
         (user_vol_wsol_ata, user_vol)
     }
 
-    /// Append extended/cashback SELL trailing metas: #21/#22 always from [`Self::pump_amm_sell_cashback_first_two_metas`],
-    /// #23 `third`, optional #24/#25 fee pair from observation. Cached reference-trader volume tails are ignored.
+    /// Append extended/cashback SELL trailing metas for the **derived intent-user path**:
+    /// #21/#22 always from [`Self::pump_amm_sell_cashback_first_two_metas`] (writable),
+    /// #23 pool `third_meta` readonly (derived-user layout; writable #23 → on-chain PrivilegeEscalation),
+    /// optional #24/#25 fee pair readonly from observation. Cached reference-trader volume tails are ignored.
     #[allow(clippy::too_many_arguments)]
     fn push_pump_amm_sell_extended_trailing_metas(
         metas: &mut Vec<AccountMeta>,
@@ -2153,7 +2155,7 @@ impl PumpFunAmmDex {
         }
         metas.push(AccountMeta::new(user_vol_wsol_ata, false));
         metas.push(AccountMeta::new(user_vol, false));
-        metas.push(AccountMeta::new(third, false));
+        metas.push(AccountMeta::new_readonly(third, false));
         if let (Some(f0), Some(f1)) = (
             sell_extended_fee_tail_0.filter(|p| *p != Pubkey::default()),
             sell_extended_fee_tail_1.filter(|p| *p != Pubkey::default()),
@@ -6898,7 +6900,10 @@ mod tests {
         assert_eq!(ixs[0].accounts[23].pubkey, third_meta);
         assert!(ixs[0].accounts[21].is_writable);
         assert!(ixs[0].accounts[22].is_writable);
-        assert!(ixs[0].accounts[23].is_writable);
+        assert!(
+            !ixs[0].accounts[23].is_writable,
+            "derived-user extended SELL: #23 third_meta must be readonly"
+        );
     }
 
     /// Scope 60: without a TX-backed observation, apply must not rewrite protocol fee recipients.
@@ -7162,6 +7167,10 @@ mod tests {
         assert_eq!(ixs[0].accounts[22].pubkey, expected_22);
         assert_ne!(expected_21, foreign_tail_0);
         assert_ne!(expected_22, foreign_tail_1);
+        assert!(
+            !ixs[0].accounts[23].is_writable,
+            "derived-user extended SELL: #23 third_meta must be readonly"
+        );
     }
 
     /// SELL path: Token-2022 base mint — ix[11] must be Token-2022 program; user base ATA (ix[5]) must match derivation.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes prod regression from P184b (#186): extended 26-account PumpSwap SELLs fail simulation with `PrivilegeEscalation` because `#23 third_meta` was marked writable while the derived intent-user path requires readonly.

## Root cause

`push_pump_amm_sell_extended_trailing_metas` correctly derives `#21/#22` from intent user (P184b) but inherited writable `#23` from the reference-trader observation branch. On-chain derived-user 26er SELLs expect `AccountMeta::new_readonly(third)`.

## Changes

- **`pumpfun_amm.rs`**: `#23 third_meta` → `AccountMeta::new_readonly(third, false)` in derived-user trailing metas; doc comment clarifies derived vs reference patterns
- **`tx_builder.rs`**: Scope44 log field `sell_ix_meta_23_writable` for prod diagnostics
- **Tests**: assert `accounts[23].is_writable == false` in `pumpswap_extended_sell_ignores_foreign_cached_volume_tails_at_build`, `scope60_extended_sell_preserves_reference_fee_metas_and_global_fee_slots`, and cold-path tx_builder test

## Unchanged (P184b preserved)

- `#21/#22` still derived via `pump_amm_sell_cashback_first_two_metas(intent_user, …)` — no revert to foreign cached volume tails
- `#24/#25` fee tails remain readonly from observation

## STOP-CHECK

- I-7: no new RPC in hot path
- I-4: Geyser-first unchanged
- I-9: fix enables successful simulation (no bypass)
- Level-5: no eval test reads

## Verification

```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```

All pass locally.

## Prod follow-up

After deploy, verify Stuck-Token pool `GrgDaBg4TGBQCDZk9HHw8JT24RnoDHtQnvgguKxGKStb` no longer hits `PrivilegeEscalation`; Scope44 should show `sell_ix_meta_23_writable=false`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd6c9b00-1061-43cb-8817-83f6289a835c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd6c9b00-1061-43cb-8817-83f6289a835c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

