### PR TITLE
feat(pumpswap): P184d 27-account SELL layout with pre-fee metas #19/#20

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -12903,6 +12903,8 @@ mod execution_engine_tests {
                 None,
                 None,
                 false,
+                false,
+                None,
             );
             cache_clone.set_pump_amm_sell_layout_ready(&pool, true);
         });

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -621,6 +621,8 @@ enum MdSidefxCommand {
         pump_amm_sell_extended_fee_tail_0: Option<Pubkey>,
         pump_amm_sell_extended_fee_tail_1: Option<Pubkey>,
         pump_amm_sell_requires_fee_tail: bool,
+        pump_amm_sell_requires_pre_fee_metas: bool,
+        pump_amm_sell_pre_fee_meta_1: Option<Pubkey>,
         tx_geyser_recv_at: Instant,
     },
     GenericDexFirstTradeAccounts {
@@ -980,6 +982,8 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
         pump_amm_sell_extended_fee_tail_0,
         pump_amm_sell_extended_fee_tail_1,
         pump_amm_sell_requires_fee_tail,
+        pump_amm_sell_requires_pre_fee_metas,
+        pump_amm_sell_pre_fee_meta_1,
         tx_geyser_recv_at,
     } = job
     else {
@@ -990,7 +994,8 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
         .or(filter_opt_pk(*pump_amm_sell_extended_tail_0))
         .or(filter_opt_pk(*pump_amm_sell_extended_tail_1))
         .or(filter_opt_pk(*pump_amm_sell_extended_fee_tail_0))
-        .or(filter_opt_pk(*pump_amm_sell_extended_fee_tail_1));
+        .or(filter_opt_pk(*pump_amm_sell_extended_fee_tail_1))
+        .or(filter_opt_pk(*pump_amm_sell_pre_fee_meta_1));
     let this_tx_defines_sell_layout =
         *pump_amm_sell_requires_cashback_remaining || this_tx_tail.is_some();
     let (ext_flag_prior, ext_third_prior, ext_t0_prior, ext_t1_prior) = w
@@ -1005,6 +1010,14 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
         .ctx
         .live_pool_cache
         .pump_amm_sell_requires_fee_tail(pool_address);
+    let ext_requires_pre_fee_prior = w
+        .ctx
+        .live_pool_cache
+        .pump_amm_sell_requires_pre_fee_metas(pool_address);
+    let ext_pre_fee_meta_1_prior = w
+        .ctx
+        .live_pool_cache
+        .pump_amm_sell_pre_fee_meta_1(pool_address);
     let merge_requires_fee_tail = if this_tx_defines_sell_layout {
         *pump_amm_sell_requires_fee_tail
     } else {
@@ -1040,12 +1053,24 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
     } else {
         filter_opt_pk(*pump_amm_sell_extended_fee_tail_1).or(ext_fee_t1_prior)
     };
+    let merge_requires_pre_fee_metas = if this_tx_defines_sell_layout {
+        *pump_amm_sell_requires_pre_fee_metas
+    } else {
+        ext_requires_pre_fee_prior || *pump_amm_sell_requires_pre_fee_metas
+    };
+    let merge_pre_fee_meta_1 = if this_tx_defines_sell_layout {
+        filter_opt_pk(*pump_amm_sell_pre_fee_meta_1)
+    } else {
+        filter_opt_pk(*pump_amm_sell_pre_fee_meta_1).or(ext_pre_fee_meta_1_prior)
+    };
     if merge_requires
         || merge_third.is_some()
         || merge_t0.is_some()
         || merge_t1.is_some()
         || merge_fee_t0.is_some()
         || merge_fee_t1.is_some()
+        || merge_requires_pre_fee_metas
+        || merge_pre_fee_meta_1.is_some()
     {
         w.ctx.live_pool_cache.merge_pump_amm_sell_extended_layout(
             pool_address,
@@ -1056,6 +1081,8 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
             merge_fee_t0,
             merge_fee_t1,
             merge_requires_fee_tail,
+            merge_requires_pre_fee_metas,
+            merge_pre_fee_meta_1,
         );
     }
     let base_mint = pool_accounts
@@ -1151,10 +1178,28 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
             .ctx
             .live_pool_cache
             .pump_amm_sell_requires_fee_tail(pool_address);
+        let ext_requires_pre_fee = w
+            .ctx
+            .live_pool_cache
+            .pump_amm_sell_requires_pre_fee_metas(pool_address);
         let merged_requires_fee_tail = if this_tx_defines_sell_layout {
             *pump_amm_sell_requires_fee_tail
         } else {
             ext_requires_fee_tail || *pump_amm_sell_requires_fee_tail
+        };
+        let merged_requires_pre_fee_metas = if this_tx_defines_sell_layout {
+            *pump_amm_sell_requires_pre_fee_metas
+        } else {
+            ext_requires_pre_fee || *pump_amm_sell_requires_pre_fee_metas
+        };
+        let merged_pre_fee_meta_1 = if this_tx_defines_sell_layout {
+            filter_opt_pk(*pump_amm_sell_pre_fee_meta_1)
+        } else {
+            w.ctx
+                .live_pool_cache
+                .pump_amm_sell_pre_fee_meta_1(pool_address)
+                .or(*pump_amm_sell_pre_fee_meta_1)
+                .and_then(|p| filter_opt_pk(Some(p)))
         };
         let merged_flag = if this_tx_defines_sell_layout {
             *pump_amm_sell_requires_cashback_remaining
@@ -1204,6 +1249,8 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
             merged_fee_t0,
             merged_fee_t1,
             merged_requires_fee_tail,
+            merged_requires_pre_fee_metas,
+            merged_pre_fee_meta_1,
             true,
         );
         w.ctx
@@ -1223,6 +1270,8 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
                         merged_fee_t0,
                         merged_fee_t1,
                         merged_requires_fee_tail,
+                        merged_requires_pre_fee_metas,
+                        merged_pre_fee_meta_1,
                     );
                 ironcrab::metrics::record_pump_amm_geyser_sell_layout_ready();
                 info!(
@@ -1273,6 +1322,15 @@ fn md_sidefx_process_pump_amm_trade(w: &MdSidefxWorkerCtx, job: &MdSidefxCommand
                     "pump_amm_sell_requires_fee_tail".to_string(),
                     "true".to_string(),
                 );
+            }
+            if merged_requires_pre_fee_metas {
+                meta.insert(
+                    "pump_amm_sell_requires_pre_fee_metas".to_string(),
+                    "true".to_string(),
+                );
+            }
+            if let Some(pk) = merged_pre_fee_meta_1 {
+                meta.insert("pump_amm_sell_pre_fee_meta_1".to_string(), pk.to_string());
             }
             if let Some(pk) = merged_third {
                 meta.insert(
@@ -2552,6 +2610,8 @@ fn pump_amm_sell_layout_publish_state(
     sell_extended_fee_tail_0: Option<Pubkey>,
     sell_extended_fee_tail_1: Option<Pubkey>,
     sell_requires_fee_tail: bool,
+    sell_requires_pre_fee_metas: bool,
+    sell_pre_fee_meta_1: Option<Pubkey>,
     base_layout_ready: bool,
 ) -> (bool, DexPoolReadiness) {
     let sell_layout_ready = if sell_requires_extended {
@@ -2559,10 +2619,21 @@ fn pump_amm_sell_layout_publish_state(
             .filter(|p| *p != Pubkey::default())
             .is_some();
         let _ = (sell_extended_tail_0, sell_extended_tail_1);
+        let pre_fee_ok = if sell_requires_pre_fee_metas {
+            sell_pre_fee_meta_1
+                .filter(|p| *p != Pubkey::default())
+                .is_some()
+        } else {
+            true
+        };
         let needs_fee_tail = sell_requires_fee_tail
             || sell_extended_fee_tail_0.is_some()
             || sell_extended_fee_tail_1.is_some();
-        let fee_ok = if needs_fee_tail {
+        let fee_ok = if sell_requires_pre_fee_metas {
+            sell_extended_fee_tail_0
+                .filter(|p| *p != Pubkey::default())
+                .is_some()
+        } else if needs_fee_tail {
             sell_extended_fee_tail_0
                 .filter(|p| *p != Pubkey::default())
                 .is_some()
@@ -2572,7 +2643,7 @@ fn pump_amm_sell_layout_publish_state(
         } else {
             true
         };
-        third_ok && fee_ok && base_layout_ready
+        third_ok && pre_fee_ok && fee_ok && base_layout_ready
     } else {
         base_layout_ready
     };
@@ -2597,6 +2668,8 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
     cached_fee_tail_0: Option<Pubkey>,
     cached_fee_tail_1: Option<Pubkey>,
     cached_requires_fee_tail: bool,
+    cached_requires_pre_fee_metas: bool,
+    cached_pre_fee_meta_1: Option<Pubkey>,
     refresh_requires_extended: bool,
     refresh_third_meta: Option<Pubkey>,
     refresh_tail_0: Option<Pubkey>,
@@ -2604,6 +2677,8 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
     refresh_fee_tail_0: Option<Pubkey>,
     refresh_fee_tail_1: Option<Pubkey>,
     refresh_requires_fee_tail: bool,
+    refresh_requires_pre_fee_metas: bool,
+    refresh_pre_fee_meta_1: Option<Pubkey>,
     refresh_layout_ready: bool,
 ) -> (
     bool,
@@ -2613,6 +2688,8 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
     Option<Pubkey>,
     Option<Pubkey>,
     bool,
+    bool,
+    Option<Pubkey>,
     bool,
     DexPoolReadiness,
 ) {
@@ -2624,6 +2701,8 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
         effective_fee_tail_0,
         effective_fee_tail_1,
         effective_requires_fee_tail,
+        effective_requires_pre_fee_metas,
+        effective_pre_fee_meta_1,
         base_layout_ready,
     ) = if force_refresh {
         (
@@ -2634,6 +2713,8 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
             refresh_fee_tail_0.filter(|p| *p != Pubkey::default()),
             refresh_fee_tail_1.filter(|p| *p != Pubkey::default()),
             refresh_requires_fee_tail,
+            refresh_requires_pre_fee_metas,
+            refresh_pre_fee_meta_1.filter(|p| *p != Pubkey::default()),
             refresh_layout_ready,
         )
     } else {
@@ -2655,6 +2736,10 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
                 .or(cached_fee_tail_1)
                 .filter(|p| *p != Pubkey::default()),
             cached_requires_fee_tail || refresh_requires_fee_tail,
+            cached_requires_pre_fee_metas || refresh_requires_pre_fee_metas,
+            refresh_pre_fee_meta_1
+                .or(cached_pre_fee_meta_1)
+                .filter(|p| *p != Pubkey::default()),
             refresh_layout_ready,
         )
     };
@@ -2666,6 +2751,8 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
         effective_fee_tail_0,
         effective_fee_tail_1,
         effective_requires_fee_tail,
+        effective_requires_pre_fee_metas,
+        effective_pre_fee_meta_1,
         base_layout_ready,
     );
     (
@@ -2676,6 +2763,8 @@ fn pump_amm_sell_layout_state_for_ensure_publish(
         effective_fee_tail_0,
         effective_fee_tail_1,
         effective_requires_fee_tail,
+        effective_requires_pre_fee_metas,
+        effective_pre_fee_meta_1,
         sell_layout_ready,
         dex_readiness,
     )
@@ -9122,6 +9211,8 @@ async fn handle_ensure_pump_amm_pool_accounts(
             let sell_tail_1 = wrapped.sell_extended_tail_1;
             let sell_fee_tail_0 = wrapped.sell_extended_fee_tail_0;
             let sell_fee_tail_1 = wrapped.sell_extended_fee_tail_1;
+            let sell_requires_pre_fee_metas = wrapped.sell_requires_pre_fee_metas;
+            let sell_pre_fee_meta_1 = wrapped.sell_pre_fee_meta_1;
             let sell_layout_ready_from_refresh = wrapped.sell_layout_ready;
             let pump_amm_force_refresh_sell_diag = wrapped.force_refresh_sell_layout_diag;
             let accounts = wrapped.accounts;
@@ -9160,6 +9251,12 @@ async fn handle_ensure_pump_amm_pool_accounts(
             let ext_requires_fee_cache = ctx
                 .live_pool_cache
                 .pump_amm_sell_requires_fee_tail(&pool_address);
+            let ext_requires_pre_fee_cache = ctx
+                .live_pool_cache
+                .pump_amm_sell_requires_pre_fee_metas(&pool_address);
+            let ext_pre_fee_meta_1_cache = ctx
+                .live_pool_cache
+                .pump_amm_sell_pre_fee_meta_1(&pool_address);
             let refresh_requires_fee_tail = sell_fee_tail_0.is_some() && sell_fee_tail_1.is_some();
             let (
                 sell_flag_merged,
@@ -9169,6 +9266,8 @@ async fn handle_ensure_pump_amm_pool_accounts(
                 fee_tail0_merged,
                 fee_tail1_merged,
                 requires_fee_tail_merged,
+                requires_pre_fee_metas_merged,
+                pre_fee_meta_1_merged,
                 sell_layout_ready,
                 dex_readiness,
             ) = pump_amm_sell_layout_state_for_ensure_publish(
@@ -9180,6 +9279,8 @@ async fn handle_ensure_pump_amm_pool_accounts(
                 ext_fee_t0_cache,
                 ext_fee_t1_cache,
                 ext_requires_fee_cache,
+                ext_requires_pre_fee_cache,
+                ext_pre_fee_meta_1_cache,
                 sell_cashback_remaining,
                 sell_cashback_third,
                 sell_tail_0,
@@ -9187,6 +9288,8 @@ async fn handle_ensure_pump_amm_pool_accounts(
                 sell_fee_tail_0,
                 sell_fee_tail_1,
                 refresh_requires_fee_tail,
+                sell_requires_pre_fee_metas,
+                sell_pre_fee_meta_1,
                 sell_layout_ready_from_refresh,
             );
 
@@ -9247,6 +9350,8 @@ async fn handle_ensure_pump_amm_pool_accounts(
                     fee_tail0_merged,
                     fee_tail1_merged,
                     requires_fee_tail_merged,
+                    requires_pre_fee_metas_merged,
+                    pre_fee_meta_1_merged,
                 );
             } else {
                 ctx.live_pool_cache.merge_pump_amm_sell_extended_layout(
@@ -9258,6 +9363,8 @@ async fn handle_ensure_pump_amm_pool_accounts(
                     fee_tail0_merged,
                     fee_tail1_merged,
                     requires_fee_tail_merged,
+                    requires_pre_fee_metas_merged,
+                    pre_fee_meta_1_merged,
                 );
             }
             ctx.live_pool_cache
@@ -9303,6 +9410,15 @@ async fn handle_ensure_pump_amm_pool_accounts(
                         "pump_amm_sell_requires_fee_tail".to_string(),
                         "true".to_string(),
                     );
+                }
+                if requires_pre_fee_metas_merged {
+                    meta.insert(
+                        "pump_amm_sell_requires_pre_fee_metas".to_string(),
+                        "true".to_string(),
+                    );
+                }
+                if let Some(pk) = pre_fee_meta_1_merged {
+                    meta.insert("pump_amm_sell_pre_fee_meta_1".to_string(), pk.to_string());
                 }
                 if let Some(pk) = third_merged {
                     meta.insert(
@@ -11387,6 +11503,8 @@ async fn handle_geyser_transaction(
         pump_amm_sell_extended_fee_tail_0,
         pump_amm_sell_extended_fee_tail_1,
         pump_amm_sell_requires_fee_tail,
+        pump_amm_sell_requires_pre_fee_metas,
+        pump_amm_sell_pre_fee_meta_1,
         ..
     }) = parsed_event.as_ref()
     {
@@ -11407,6 +11525,8 @@ async fn handle_geyser_transaction(
                 pump_amm_sell_extended_fee_tail_0: *pump_amm_sell_extended_fee_tail_0,
                 pump_amm_sell_extended_fee_tail_1: *pump_amm_sell_extended_fee_tail_1,
                 pump_amm_sell_requires_fee_tail: *pump_amm_sell_requires_fee_tail,
+                pump_amm_sell_requires_pre_fee_metas: *pump_amm_sell_requires_pre_fee_metas,
+                pump_amm_sell_pre_fee_meta_1: *pump_amm_sell_pre_fee_meta_1,
                 tx_geyser_recv_at,
             },
         );
@@ -13381,8 +13501,9 @@ mod discovery_tests {
 
     #[test]
     fn test_pump_amm_trade_publish_extended_without_third_meta_is_partial() {
-        let (sell_layout_ready, dex_readiness) =
-            pump_amm_sell_layout_publish_state(true, None, None, None, None, None, false, true);
+        let (sell_layout_ready, dex_readiness) = pump_amm_sell_layout_publish_state(
+            true, None, None, None, None, None, false, false, None, true,
+        );
         assert!(
             !sell_layout_ready,
             "extended SELL without authoritative third meta must not be marked ready"
@@ -13400,6 +13521,8 @@ mod discovery_tests {
             None,
             None,
             false,
+            false,
+            None,
             true,
         );
         assert!(
@@ -13420,6 +13543,8 @@ mod discovery_tests {
             None,
             None,
             false,
+            false,
+            None,
             true,
         );
         assert!(
@@ -13442,6 +13567,8 @@ mod discovery_tests {
             _effective_fee_tail_0,
             _effective_fee_tail_1,
             _effective_requires_fee_tail,
+            _effective_requires_pre_fee_metas,
+            _effective_pre_fee_meta_1,
             sell_layout_ready,
             dex_readiness,
         ) = pump_amm_sell_layout_state_for_ensure_publish(
@@ -13455,11 +13582,15 @@ mod discovery_tests {
             false,
             false,
             None,
+            false,
+            None,
             None,
             None,
             None,
             None,
             false,
+            false,
+            None,
             true,
         );
         assert!(

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -110,7 +110,10 @@ use ironcrab::solana::dex::meteora_bin_array_layout::BinArray;
 use ironcrab::solana::dex::meteora_dlmm::METEORA_DLMM_PROGRAM;
 use ironcrab::solana::dex::meteora_swap_builder::MeteoraDlmmSwapBuilder;
 use ironcrab::solana::dex::pumpfun::{BondingCurveState, PumpFunDex};
-use ironcrab::solana::dex::pumpfun_amm::{PumpAmmPoolAccountsDiagnostic, PumpFunAmmDex};
+use ironcrab::solana::dex::pumpfun_amm::{
+    pump_amm_sell_extended_layout_ready, PumpAmmPoolAccountsDiagnostic,
+    PumpAmmSellExtendedReadinessParams, PumpFunAmmDex,
+};
 use ironcrab::solana::dex::raydium::Raydium;
 use ironcrab::solana::dex_parser::{
     parse_account_update, parse_transaction_update_with_pool_lookup, DexType, OrcaPoolInfo,
@@ -2615,35 +2618,16 @@ fn pump_amm_sell_layout_publish_state(
     base_layout_ready: bool,
 ) -> (bool, DexPoolReadiness) {
     let sell_layout_ready = if sell_requires_extended {
-        let third_ok = sell_cashback_third_meta
-            .filter(|p| *p != Pubkey::default())
-            .is_some();
         let _ = (sell_extended_tail_0, sell_extended_tail_1);
-        let pre_fee_ok = if sell_requires_pre_fee_metas {
-            sell_pre_fee_meta_1
-                .filter(|p| *p != Pubkey::default())
-                .is_some()
-        } else {
-            true
-        };
-        let needs_fee_tail = sell_requires_fee_tail
-            || sell_extended_fee_tail_0.is_some()
-            || sell_extended_fee_tail_1.is_some();
-        let fee_ok = if sell_requires_pre_fee_metas {
-            sell_extended_fee_tail_0
-                .filter(|p| *p != Pubkey::default())
-                .is_some()
-        } else if needs_fee_tail {
-            sell_extended_fee_tail_0
-                .filter(|p| *p != Pubkey::default())
-                .is_some()
-                && sell_extended_fee_tail_1
-                    .filter(|p| *p != Pubkey::default())
-                    .is_some()
-        } else {
-            true
-        };
-        third_ok && pre_fee_ok && fee_ok && base_layout_ready
+        pump_amm_sell_extended_layout_ready(PumpAmmSellExtendedReadinessParams {
+            sell_requires_extended: true,
+            third_meta: sell_cashback_third_meta,
+            fee_tail_0: sell_extended_fee_tail_0,
+            fee_tail_1: sell_extended_fee_tail_1,
+            sell_requires_fee_tail,
+            sell_requires_pre_fee_metas,
+            sell_pre_fee_meta_1,
+        }) && base_layout_ready
     } else {
         base_layout_ready
     };

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -46,6 +46,9 @@ use crate::ipc::DexPoolReadiness;
 // Re-export parsers
 use crate::solana::dex::meteora_dlmm_layout::DlmmPool;
 use crate::solana::dex::orca_whirlpool_layout::{self, WhirlpoolParsed};
+use crate::solana::dex::pumpfun_amm::{
+    pump_amm_sell_extended_layout_ready, PumpAmmSellExtendedReadinessParams,
+};
 
 // ============================================================================
 // DEX-specific cached state structs
@@ -1277,32 +1280,15 @@ impl LivePoolCache {
         let (requires_extended, third, _volume_tail_0, _volume_tail_1) =
             self.pump_amm_sell_extended_layout(pool_market);
         let (fee_t0, fee_t1) = self.pump_amm_sell_fee_tail_layout(pool_market);
-        if requires_extended {
-            let third_ok = third.filter(|p| *p != Pubkey::default()).is_some();
-            // #21/#22 volume tails are intent-user derivable at build time — not required in cache.
-            let needs_pre_fee = self.pump_amm_sell_requires_pre_fee_metas(pool_market);
-            let pre_fee_ok = if needs_pre_fee {
-                self.pump_amm_sell_pre_fee_meta_1(pool_market)
-                    .filter(|p| *p != Pubkey::default())
-                    .is_some()
-            } else {
-                true
-            };
-            let needs_fee_tail = self.pump_amm_sell_requires_fee_tail(pool_market)
-                || fee_t0.is_some()
-                || fee_t1.is_some();
-            let fee_ok = if needs_pre_fee {
-                fee_t0.filter(|p| *p != Pubkey::default()).is_some()
-            } else if needs_fee_tail {
-                fee_t0.filter(|p| *p != Pubkey::default()).is_some()
-                    && fee_t1.filter(|p| *p != Pubkey::default()).is_some()
-            } else {
-                true
-            };
-            third_ok && pre_fee_ok && fee_ok
-        } else {
-            true
-        }
+        pump_amm_sell_extended_layout_ready(PumpAmmSellExtendedReadinessParams {
+            sell_requires_extended: requires_extended,
+            third_meta: third,
+            fee_tail_0: fee_t0,
+            fee_tail_1: fee_t1,
+            sell_requires_fee_tail: self.pump_amm_sell_requires_fee_tail(pool_market),
+            sell_requires_pre_fee_metas: self.pump_amm_sell_requires_pre_fee_metas(pool_market),
+            sell_pre_fee_meta_1: self.pump_amm_sell_pre_fee_meta_1(pool_market),
+        })
     }
 
     /// Set Raydium AMM Serum/OpenBook accounts (bids, asks, event_queue).

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -447,8 +447,12 @@ pub struct LivePoolCache {
     /// Observed cashback `sell` fee-recipient pair (ix #24/#25).
     pump_amm_sell_extended_fee_tail_0_by_market: DashMap<Pubkey, Pubkey>,
     pump_amm_sell_extended_fee_tail_1_by_market: DashMap<Pubkey, Pubkey>,
+    /// 27-account extended `sell`: second pre-fee meta at ix #20.
+    pump_amm_sell_pre_fee_meta_1_by_market: DashMap<Pubkey, Pubkey>,
     /// Monotonic: observed `sell` used 26 accounts (fee-recipient pair required).
     pump_amm_sell_requires_fee_tail_by_market: DashMap<Pubkey, bool>,
+    /// Monotonic: observed `sell` used 27 accounts (pre-fee metas at ix #19/#20).
+    pump_amm_sell_requires_pre_fee_metas_by_market: DashMap<Pubkey, bool>,
     /// PumpSwap pool-market -> whether the authoritative source has proven the current SELL layout
     /// is fully known. `false` means "do not treat this as sell-ready truth yet", even if
     /// pool_accounts/reserves are otherwise present.
@@ -495,7 +499,9 @@ impl LivePoolCache {
             pump_amm_sell_extended_tail_1_by_market: DashMap::new(),
             pump_amm_sell_extended_fee_tail_0_by_market: DashMap::new(),
             pump_amm_sell_extended_fee_tail_1_by_market: DashMap::new(),
+            pump_amm_sell_pre_fee_meta_1_by_market: DashMap::new(),
             pump_amm_sell_requires_fee_tail_by_market: DashMap::new(),
+            pump_amm_sell_requires_pre_fee_metas_by_market: DashMap::new(),
             pump_amm_sell_layout_ready_by_market: DashMap::new(),
         }
     }
@@ -962,6 +968,13 @@ impl LivePoolCache {
             let requires_fee_tail = m
                 .get("pump_amm_sell_requires_fee_tail")
                 .is_some_and(|v| v == "true");
+            let requires_pre_fee_metas = m
+                .get("pump_amm_sell_requires_pre_fee_metas")
+                .is_some_and(|v| v == "true");
+            let pre_fee_meta_1 = m
+                .get("pump_amm_sell_pre_fee_meta_1")
+                .and_then(|s| Pubkey::from_str(s).ok())
+                .filter(|pk| *pk != Pubkey::default());
             self.set_pump_amm_sell_layout_authoritative(
                 pool,
                 requires_extended,
@@ -971,6 +984,8 @@ impl LivePoolCache {
                 fee_tail_0,
                 fee_tail_1,
                 requires_fee_tail,
+                requires_pre_fee_metas,
+                pre_fee_meta_1,
             );
         } else {
             if m.get("pump_amm_sell_cashback_remaining")
@@ -1025,6 +1040,20 @@ impl LivePoolCache {
                 self.pump_amm_sell_requires_fee_tail_by_market
                     .insert(*pool, true);
             }
+            if m.get("pump_amm_sell_requires_pre_fee_metas")
+                .is_some_and(|v| v == "true")
+            {
+                self.pump_amm_sell_requires_pre_fee_metas_by_market
+                    .insert(*pool, true);
+            }
+            if let Some(s) = m.get("pump_amm_sell_pre_fee_meta_1") {
+                if let Ok(pk) = Pubkey::from_str(s) {
+                    if pk != Pubkey::default() {
+                        self.pump_amm_sell_pre_fee_meta_1_by_market
+                            .insert(*pool, pk);
+                    }
+                }
+            }
         }
     }
 
@@ -1040,12 +1069,22 @@ impl LivePoolCache {
         fee_tail_0: Option<Pubkey>,
         fee_tail_1: Option<Pubkey>,
         requires_fee_tail: bool,
+        requires_pre_fee_metas: bool,
+        pre_fee_meta_1: Option<Pubkey>,
     ) {
         self.pump_amm_sell_extended_flag_by_market
             .insert(*pool, requires_extended);
         if requires_fee_tail {
             self.pump_amm_sell_requires_fee_tail_by_market
                 .insert(*pool, true);
+        }
+        if requires_pre_fee_metas {
+            self.pump_amm_sell_requires_pre_fee_metas_by_market
+                .insert(*pool, true);
+        }
+        if let Some(pk) = pre_fee_meta_1.filter(|p| *p != Pubkey::default()) {
+            self.pump_amm_sell_pre_fee_meta_1_by_market
+                .insert(*pool, pk);
         }
         if let Some(pk) = third_meta.filter(|p| *p != Pubkey::default()) {
             self.pump_amm_sell_extended_third_meta_by_market
@@ -1087,11 +1126,24 @@ impl LivePoolCache {
         fee_tail_0: Option<Pubkey>,
         fee_tail_1: Option<Pubkey>,
         requires_fee_tail: bool,
+        requires_pre_fee_metas: bool,
+        pre_fee_meta_1: Option<Pubkey>,
     ) {
         self.pump_amm_sell_extended_flag_by_market
             .insert(*pool, requires_extended);
         self.pump_amm_sell_requires_fee_tail_by_market
             .insert(*pool, requires_fee_tail);
+        self.pump_amm_sell_requires_pre_fee_metas_by_market
+            .insert(*pool, requires_pre_fee_metas);
+        match pre_fee_meta_1.filter(|p| *p != Pubkey::default()) {
+            Some(pk) => {
+                self.pump_amm_sell_pre_fee_meta_1_by_market
+                    .insert(*pool, pk);
+            }
+            None => {
+                self.pump_amm_sell_pre_fee_meta_1_by_market.remove(pool);
+            }
+        }
         match third_meta.filter(|p| *p != Pubkey::default()) {
             Some(pk) => {
                 self.pump_amm_sell_extended_third_meta_by_market
@@ -1177,6 +1229,22 @@ impl LivePoolCache {
             .unwrap_or(false)
     }
 
+    /// 27-account extended `sell`: second pre-fee meta (ix #20).
+    #[must_use]
+    pub fn pump_amm_sell_pre_fee_meta_1(&self, pool_market: &Pubkey) -> Option<Pubkey> {
+        self.pump_amm_sell_pre_fee_meta_1_by_market
+            .get(pool_market)
+            .map(|e| *e.value())
+    }
+
+    #[must_use]
+    pub fn pump_amm_sell_requires_pre_fee_metas(&self, pool_market: &Pubkey) -> bool {
+        self.pump_amm_sell_requires_pre_fee_metas_by_market
+            .get(pool_market)
+            .map(|e| *e.value())
+            .unwrap_or(false)
+    }
+
     /// Observed cashback `sell` fee-recipient pair (ix #24/#25), when layout uses 26 accounts.
     #[must_use]
     pub fn pump_amm_sell_fee_tail_layout(
@@ -1212,16 +1280,26 @@ impl LivePoolCache {
         if requires_extended {
             let third_ok = third.filter(|p| *p != Pubkey::default()).is_some();
             // #21/#22 volume tails are intent-user derivable at build time — not required in cache.
+            let needs_pre_fee = self.pump_amm_sell_requires_pre_fee_metas(pool_market);
+            let pre_fee_ok = if needs_pre_fee {
+                self.pump_amm_sell_pre_fee_meta_1(pool_market)
+                    .filter(|p| *p != Pubkey::default())
+                    .is_some()
+            } else {
+                true
+            };
             let needs_fee_tail = self.pump_amm_sell_requires_fee_tail(pool_market)
                 || fee_t0.is_some()
                 || fee_t1.is_some();
-            let fee_ok = if needs_fee_tail {
+            let fee_ok = if needs_pre_fee {
+                fee_t0.filter(|p| *p != Pubkey::default()).is_some()
+            } else if needs_fee_tail {
                 fee_t0.filter(|p| *p != Pubkey::default()).is_some()
                     && fee_t1.filter(|p| *p != Pubkey::default()).is_some()
             } else {
                 true
             };
-            third_ok && fee_ok
+            third_ok && pre_fee_ok && fee_ok
         } else {
             true
         }
@@ -2781,6 +2859,8 @@ mod tests {
             None,
             None,
             false,
+            false,
+            None,
         );
         cache.set_pump_amm_sell_layout_ready(&pool_market, false);
 
@@ -2818,6 +2898,8 @@ mod tests {
             None,
             None,
             false,
+            false,
+            None,
         );
         cache.merge_pump_amm_pool_accounts_readiness(pool_market, DexPoolReadiness::Ready);
 
@@ -2867,6 +2949,8 @@ mod tests {
             None,
             None,
             false,
+            false,
+            None,
         );
         cache.set_pump_amm_sell_layout_ready(&pool_market, true);
 
@@ -2911,6 +2995,8 @@ mod tests {
             None,
             None,
             false,
+            false,
+            None,
         );
         cache.set_pump_amm_sell_layout_ready(&pool_market, true);
 
@@ -2981,6 +3067,8 @@ mod tests {
             None,
             None,
             false,
+            false,
+            None,
         );
         cache.set_pump_amm_sell_layout_ready(&pool_market, false);
         cache.merge_pump_amm_sell_layout_from_metadata(&pool_market, Some(&meta));

--- a/src/execution/tx_builder.rs
+++ b/src/execution/tx_builder.rs
@@ -967,47 +967,46 @@ pub async fn build_tx_plan(
             if let Some((fee_config_ix, fee_program_ix)) =
                 pump_amm_sell_ix_uses_global_fee_at(ixs[0].accounts.len())
             {
-            let sell_ix_accounts = &ixs[0].accounts;
-            let canonical_fee_cfg =
-                Pubkey::from_str(PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR).unwrap_or_default();
-            let canonical_fee_prog =
-                Pubkey::from_str(PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR).unwrap_or_default();
-            let v12_fc = pool_accounts[12];
-            let v12_fp = pool_accounts[13];
-            let ix_fc = sell_ix_accounts
-                .get(fee_config_ix)
-                .map(|m| m.pubkey)
-                .unwrap_or_default();
-            let ix_fp = sell_ix_accounts
-                .get(fee_program_ix)
-                .map(|m| m.pubkey)
-                .unwrap_or_default();
-            let fee_config_uses_global_constant = ix_fc == canonical_fee_cfg;
-            let fee_program_uses_expected = ix_fp == canonical_fee_prog;
-            let fee_config_differs_from_v14_row = v12_fc != ix_fc;
-            let fee_program_differs_from_v14_row = v12_fp != ix_fp;
-            let pfr_preserved = ixs[0].accounts[9].pubkey == pool_accounts[6];
-            let pfr_ta_preserved = ixs[0].accounts[10].pubkey == pool_accounts[7];
-            let sell_csv: String = ixs[0]
-                .accounts
-                .iter()
-                .map(|m| m.pubkey.to_string())
-                .collect::<Vec<_>>()
-                .join(",");
-            let quote_tp = Pubkey::new_from_array(spl_token::id().to_bytes());
-            let quote_mint = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
-            let (derived_tail_21, derived_tail_22) =
-                if sell_requires_cashback_remaining && intent.side == TradeSide::Sell {
-                    PumpFunAmmDex::pump_amm_sell_cashback_first_two_metas(
-                        wallet_pubkey,
-                        quote_mint,
-                        quote_tp,
-                    )
-                } else {
-                    (Pubkey::default(), Pubkey::default())
-                };
-            let cached_tail_mismatch =
-                sell_extended_tail_0
+                let sell_ix_accounts = &ixs[0].accounts;
+                let canonical_fee_cfg =
+                    Pubkey::from_str(PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR).unwrap_or_default();
+                let canonical_fee_prog =
+                    Pubkey::from_str(PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR).unwrap_or_default();
+                let v12_fc = pool_accounts[12];
+                let v12_fp = pool_accounts[13];
+                let ix_fc = sell_ix_accounts
+                    .get(fee_config_ix)
+                    .map(|m| m.pubkey)
+                    .unwrap_or_default();
+                let ix_fp = sell_ix_accounts
+                    .get(fee_program_ix)
+                    .map(|m| m.pubkey)
+                    .unwrap_or_default();
+                let fee_config_uses_global_constant = ix_fc == canonical_fee_cfg;
+                let fee_program_uses_expected = ix_fp == canonical_fee_prog;
+                let fee_config_differs_from_v14_row = v12_fc != ix_fc;
+                let fee_program_differs_from_v14_row = v12_fp != ix_fp;
+                let pfr_preserved = ixs[0].accounts[9].pubkey == pool_accounts[6];
+                let pfr_ta_preserved = ixs[0].accounts[10].pubkey == pool_accounts[7];
+                let sell_csv: String = ixs[0]
+                    .accounts
+                    .iter()
+                    .map(|m| m.pubkey.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let quote_tp = Pubkey::new_from_array(spl_token::id().to_bytes());
+                let quote_mint = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+                let (derived_tail_21, derived_tail_22) =
+                    if sell_requires_cashback_remaining && intent.side == TradeSide::Sell {
+                        PumpFunAmmDex::pump_amm_sell_cashback_first_two_metas(
+                            wallet_pubkey,
+                            quote_mint,
+                            quote_tp,
+                        )
+                    } else {
+                        (Pubkey::default(), Pubkey::default())
+                    };
+                let cached_tail_mismatch = sell_extended_tail_0
                     .zip(sell_extended_tail_1)
                     .is_some_and(|(c0, c1)| {
                         c0 != Pubkey::default()
@@ -1015,128 +1014,128 @@ pub async fn build_tx_plan(
                             && (Some(c0) != Some(derived_tail_21)
                                 || Some(c1) != Some(derived_tail_22))
                     });
-            let sell_ext_tail_src =
-                if sell_requires_cashback_remaining && intent.side == TradeSide::Sell {
-                    "derived_for_intent_user"
-                } else {
-                    "n/a"
-                };
-            let sell_ix_account_count = sell_ix_accounts.len();
-            let (tail0_ix, tail1_ix, tail2_ix) =
+                let sell_ext_tail_src =
+                    if sell_requires_cashback_remaining && intent.side == TradeSide::Sell {
+                        "derived_for_intent_user"
+                    } else {
+                        "n/a"
+                    };
+                let sell_ix_account_count = sell_ix_accounts.len();
+                let (tail0_ix, tail1_ix, tail2_ix) =
+                    if sell_ix_account_count == PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS {
+                        (
+                            PUMPFUN_AMM_SELL_EXT_TAIL_0_IX_V2,
+                            PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2,
+                            PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2,
+                        )
+                    } else {
+                        (
+                            PUMPFUN_AMM_SELL_EXT_TAIL_0_IX,
+                            PUMPFUN_AMM_SELL_EXT_TAIL_1_IX,
+                            PUMPFUN_AMM_SELL_EXT_THIRD_META_IX,
+                        )
+                    };
+                let sell_ix_tail0 = sell_ix_accounts
+                    .get(tail0_ix)
+                    .map(|m| m.pubkey.to_string())
+                    .unwrap_or_default();
+                let sell_ix_tail1 = sell_ix_accounts
+                    .get(tail1_ix)
+                    .map(|m| m.pubkey.to_string())
+                    .unwrap_or_default();
+                let sell_ix_tail2 = sell_ix_accounts
+                    .get(tail2_ix)
+                    .map(|m| m.pubkey.to_string())
+                    .unwrap_or_default();
+                let sell_ix_tail2_writable = sell_ix_accounts
+                    .get(tail2_ix)
+                    .map(|m| m.is_writable)
+                    .unwrap_or(false);
                 if sell_ix_account_count == PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS {
-                    (
-                        PUMPFUN_AMM_SELL_EXT_TAIL_0_IX_V2,
-                        PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2,
-                        PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2,
-                    )
+                    info!(
+                        intent_id = %intent.intent_id,
+                        scope = "44",
+                        dex = "pump_amm",
+                        intent_user = %wallet_pubkey,
+                        pool_accounts_source = pool_accounts_build_source,
+                        sell_extended = sell_requires_cashback_remaining && intent.side == TradeSide::Sell,
+                        sell_cashback_third_meta = ?sell_cashback_third_meta,
+                        sell_extended_tail_source = sell_ext_tail_src,
+                        derived_tail_21 = %derived_tail_21,
+                        derived_tail_22 = %derived_tail_22,
+                        cached_tail_21 = ?sell_extended_tail_0,
+                        cached_tail_22 = ?sell_extended_tail_1,
+                        cached_tail_mismatch,
+                        sell_extended_tail_2 = ?sell_cashback_third_meta,
+                        sell_ix_meta_23 = %sell_ix_tail0,
+                        sell_ix_meta_24 = %sell_ix_tail1,
+                        sell_ix_meta_25 = %sell_ix_tail2,
+                        sell_ix_meta_25_writable = sell_ix_tail2_writable,
+                        sell_ix_account_count,
+                        pool = %pool_id,
+                        input_mint = %intent.resources.input_mint,
+                        base_token_program_override = ?token_program_override,
+                        v14_csv = %PumpAmmPoolAccountsDiagnostic::format_v14_csv(&pool_accounts[..14]),
+                        sell_ix_accounts_csv = %sell_csv,
+                        v14_fee_config_row = %v12_fc,
+                        v14_fee_program_row = %v12_fp,
+                        sell_ix_fee_config_meta = %ix_fc,
+                        sell_ix_fee_program_meta = %ix_fp,
+                        fee_config_uses_global_constant = fee_config_uses_global_constant,
+                        fee_program_matches_expected_fee_program = fee_program_uses_expected,
+                        protocol_fee_recipient_preserved_from_v14 = pfr_preserved,
+                        protocol_fee_recipient_ta_preserved_from_v14 = pfr_ta_preserved,
+                        v14_fee_config_differs_from_global_constant = (v12_fc != canonical_fee_cfg),
+                        v14_fee_program_differs_from_expected = (v12_fp != canonical_fee_prog),
+                        fee_config_differs_from_v14_row = fee_config_differs_from_v14_row,
+                        fee_program_differs_from_v14_row = fee_program_differs_from_v14_row,
+                        sell_ix_fee_config_ix = fee_config_ix,
+                        sell_ix_fee_program_ix = fee_program_ix,
+                        "Scope44: pump_amm SELL plan (27-account) — meta #21/#22 must be global FeeConfig + fee_program (v14[12] is informational; wrong type → Custom 3002)"
+                    );
                 } else {
-                    (
-                        PUMPFUN_AMM_SELL_EXT_TAIL_0_IX,
-                        PUMPFUN_AMM_SELL_EXT_TAIL_1_IX,
-                        PUMPFUN_AMM_SELL_EXT_THIRD_META_IX,
-                    )
-                };
-            let sell_ix_tail0 = sell_ix_accounts
-                .get(tail0_ix)
-                .map(|m| m.pubkey.to_string())
-                .unwrap_or_default();
-            let sell_ix_tail1 = sell_ix_accounts
-                .get(tail1_ix)
-                .map(|m| m.pubkey.to_string())
-                .unwrap_or_default();
-            let sell_ix_tail2 = sell_ix_accounts
-                .get(tail2_ix)
-                .map(|m| m.pubkey.to_string())
-                .unwrap_or_default();
-            let sell_ix_tail2_writable = sell_ix_accounts
-                .get(tail2_ix)
-                .map(|m| m.is_writable)
-                .unwrap_or(false);
-            if sell_ix_account_count == PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS {
-                info!(
-                    intent_id = %intent.intent_id,
-                    scope = "44",
-                    dex = "pump_amm",
-                    intent_user = %wallet_pubkey,
-                    pool_accounts_source = pool_accounts_build_source,
-                    sell_extended = sell_requires_cashback_remaining && intent.side == TradeSide::Sell,
-                    sell_cashback_third_meta = ?sell_cashback_third_meta,
-                    sell_extended_tail_source = sell_ext_tail_src,
-                    derived_tail_21 = %derived_tail_21,
-                    derived_tail_22 = %derived_tail_22,
-                    cached_tail_21 = ?sell_extended_tail_0,
-                    cached_tail_22 = ?sell_extended_tail_1,
-                    cached_tail_mismatch,
-                    sell_extended_tail_2 = ?sell_cashback_third_meta,
-                    sell_ix_meta_23 = %sell_ix_tail0,
-                    sell_ix_meta_24 = %sell_ix_tail1,
-                    sell_ix_meta_25 = %sell_ix_tail2,
-                    sell_ix_meta_25_writable = sell_ix_tail2_writable,
-                    sell_ix_account_count,
-                    pool = %pool_id,
-                    input_mint = %intent.resources.input_mint,
-                    base_token_program_override = ?token_program_override,
-                    v14_csv = %PumpAmmPoolAccountsDiagnostic::format_v14_csv(&pool_accounts[..14]),
-                    sell_ix_accounts_csv = %sell_csv,
-                    v14_fee_config_row = %v12_fc,
-                    v14_fee_program_row = %v12_fp,
-                    sell_ix_fee_config_meta = %ix_fc,
-                    sell_ix_fee_program_meta = %ix_fp,
-                    fee_config_uses_global_constant = fee_config_uses_global_constant,
-                    fee_program_matches_expected_fee_program = fee_program_uses_expected,
-                    protocol_fee_recipient_preserved_from_v14 = pfr_preserved,
-                    protocol_fee_recipient_ta_preserved_from_v14 = pfr_ta_preserved,
-                    v14_fee_config_differs_from_global_constant = (v12_fc != canonical_fee_cfg),
-                    v14_fee_program_differs_from_expected = (v12_fp != canonical_fee_prog),
-                    fee_config_differs_from_v14_row = fee_config_differs_from_v14_row,
-                    fee_program_differs_from_v14_row = fee_program_differs_from_v14_row,
-                    sell_ix_fee_config_ix = fee_config_ix,
-                    sell_ix_fee_program_ix = fee_program_ix,
-                    "Scope44: pump_amm SELL plan (27-account) — meta #21/#22 must be global FeeConfig + fee_program (v14[12] is informational; wrong type → Custom 3002)"
-                );
-            } else {
-                info!(
-                    intent_id = %intent.intent_id,
-                    scope = "44",
-                    dex = "pump_amm",
-                    intent_user = %wallet_pubkey,
-                    pool_accounts_source = pool_accounts_build_source,
-                    sell_extended = sell_requires_cashback_remaining && intent.side == TradeSide::Sell,
-                    sell_cashback_third_meta = ?sell_cashback_third_meta,
-                    sell_extended_tail_source = sell_ext_tail_src,
-                    derived_tail_21 = %derived_tail_21,
-                    derived_tail_22 = %derived_tail_22,
-                    cached_tail_21 = ?sell_extended_tail_0,
-                    cached_tail_22 = ?sell_extended_tail_1,
-                    cached_tail_mismatch,
-                    sell_extended_tail_2 = ?sell_cashback_third_meta,
-                    sell_ix_meta_21 = %sell_ix_tail0,
-                    sell_ix_meta_22 = %sell_ix_tail1,
-                    sell_ix_meta_23 = %sell_ix_tail2,
-                    sell_ix_meta_23_writable = sell_ix_tail2_writable,
-                    sell_ix_account_count,
-                    pool = %pool_id,
-                    input_mint = %intent.resources.input_mint,
-                    base_token_program_override = ?token_program_override,
-                    v14_csv = %PumpAmmPoolAccountsDiagnostic::format_v14_csv(&pool_accounts[..14]),
-                    sell_ix_accounts_csv = %sell_csv,
-                    v14_fee_config_row = %v12_fc,
-                    v14_fee_program_row = %v12_fp,
-                    sell_ix_fee_config_meta = %ix_fc,
-                    sell_ix_fee_program_meta = %ix_fp,
-                    fee_config_uses_global_constant = fee_config_uses_global_constant,
-                    fee_program_matches_expected_fee_program = fee_program_uses_expected,
-                    protocol_fee_recipient_preserved_from_v14 = pfr_preserved,
-                    protocol_fee_recipient_ta_preserved_from_v14 = pfr_ta_preserved,
-                    v14_fee_config_differs_from_global_constant = (v12_fc != canonical_fee_cfg),
-                    v14_fee_program_differs_from_expected = (v12_fp != canonical_fee_prog),
-                    fee_config_differs_from_v14_row = fee_config_differs_from_v14_row,
-                    fee_program_differs_from_v14_row = fee_program_differs_from_v14_row,
-                    sell_ix_fee_config_ix = fee_config_ix,
-                    sell_ix_fee_program_ix = fee_program_ix,
-                    "Scope44: pump_amm SELL plan — meta #19/#20 must be global FeeConfig + fee_program (v14[12] is informational; wrong type → Custom 3002)"
-                );
-            }
+                    info!(
+                        intent_id = %intent.intent_id,
+                        scope = "44",
+                        dex = "pump_amm",
+                        intent_user = %wallet_pubkey,
+                        pool_accounts_source = pool_accounts_build_source,
+                        sell_extended = sell_requires_cashback_remaining && intent.side == TradeSide::Sell,
+                        sell_cashback_third_meta = ?sell_cashback_third_meta,
+                        sell_extended_tail_source = sell_ext_tail_src,
+                        derived_tail_21 = %derived_tail_21,
+                        derived_tail_22 = %derived_tail_22,
+                        cached_tail_21 = ?sell_extended_tail_0,
+                        cached_tail_22 = ?sell_extended_tail_1,
+                        cached_tail_mismatch,
+                        sell_extended_tail_2 = ?sell_cashback_third_meta,
+                        sell_ix_meta_21 = %sell_ix_tail0,
+                        sell_ix_meta_22 = %sell_ix_tail1,
+                        sell_ix_meta_23 = %sell_ix_tail2,
+                        sell_ix_meta_23_writable = sell_ix_tail2_writable,
+                        sell_ix_account_count,
+                        pool = %pool_id,
+                        input_mint = %intent.resources.input_mint,
+                        base_token_program_override = ?token_program_override,
+                        v14_csv = %PumpAmmPoolAccountsDiagnostic::format_v14_csv(&pool_accounts[..14]),
+                        sell_ix_accounts_csv = %sell_csv,
+                        v14_fee_config_row = %v12_fc,
+                        v14_fee_program_row = %v12_fp,
+                        sell_ix_fee_config_meta = %ix_fc,
+                        sell_ix_fee_program_meta = %ix_fp,
+                        fee_config_uses_global_constant = fee_config_uses_global_constant,
+                        fee_program_matches_expected_fee_program = fee_program_uses_expected,
+                        protocol_fee_recipient_preserved_from_v14 = pfr_preserved,
+                        protocol_fee_recipient_ta_preserved_from_v14 = pfr_ta_preserved,
+                        v14_fee_config_differs_from_global_constant = (v12_fc != canonical_fee_cfg),
+                        v14_fee_program_differs_from_expected = (v12_fp != canonical_fee_prog),
+                        fee_config_differs_from_v14_row = fee_config_differs_from_v14_row,
+                        fee_program_differs_from_v14_row = fee_program_differs_from_v14_row,
+                        sell_ix_fee_config_ix = fee_config_ix,
+                        sell_ix_fee_program_ix = fee_program_ix,
+                        "Scope44: pump_amm SELL plan — meta #19/#20 must be global FeeConfig + fee_program (v14[12] is informational; wrong type → Custom 3002)"
+                    );
+                }
             }
         }
 

--- a/src/execution/tx_builder.rs
+++ b/src/execution/tx_builder.rs
@@ -6,7 +6,10 @@ use crate::solana::dex::orca_whirlpool_layout;
 use crate::solana::dex::pumpfun::PumpFunDex;
 use crate::solana::dex::pumpfun_amm::{
     PumpAmmPoolAccountsDiagnostic, PumpFunAmmDex, PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR,
-    PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR,
+    PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR, PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS,
+    PUMPFUN_AMM_SELL_EXT_TAIL_0_IX, PUMPFUN_AMM_SELL_EXT_TAIL_0_IX_V2,
+    PUMPFUN_AMM_SELL_EXT_TAIL_1_IX, PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2,
+    PUMPFUN_AMM_SELL_EXT_THIRD_META_IX, PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2,
 };
 use crate::solana::dex::raydium::Raydium;
 use crate::solana::dex::Dex;
@@ -1008,45 +1011,119 @@ pub async fn build_tx_plan(
                 } else {
                     "n/a"
                 };
-            info!(
-                intent_id = %intent.intent_id,
-                scope = "44",
-                dex = "pump_amm",
-                intent_user = %wallet_pubkey,
-                pool_accounts_source = pool_accounts_build_source,
-                sell_extended = sell_requires_cashback_remaining && intent.side == TradeSide::Sell,
-                sell_cashback_third_meta = ?sell_cashback_third_meta,
-                sell_extended_tail_source = sell_ext_tail_src,
-                derived_tail_21 = %derived_tail_21,
-                derived_tail_22 = %derived_tail_22,
-                cached_tail_21 = ?sell_extended_tail_0,
-                cached_tail_22 = ?sell_extended_tail_1,
-                cached_tail_mismatch,
-                sell_extended_tail_2 = ?sell_cashback_third_meta,
-                sell_ix_meta_21 = %ixs[0].accounts.get(21).map(|m| m.pubkey.to_string()).unwrap_or_default(),
-                sell_ix_meta_22 = %ixs[0].accounts.get(22).map(|m| m.pubkey.to_string()).unwrap_or_default(),
-                sell_ix_meta_23 = %ixs[0].accounts.get(23).map(|m| m.pubkey.to_string()).unwrap_or_default(),
-                sell_ix_meta_23_writable = ixs[0].accounts.get(23).map(|m| m.is_writable).unwrap_or(false),
-                sell_ix_account_count = ixs[0].accounts.len(),
-                pool = %pool_id,
-                input_mint = %intent.resources.input_mint,
-                base_token_program_override = ?token_program_override,
-                v14_csv = %PumpAmmPoolAccountsDiagnostic::format_v14_csv(&pool_accounts[..14]),
-                sell_ix_accounts_csv = %sell_csv,
-                v14_fee_config_row = %v12_fc,
-                v14_fee_program_row = %v12_fp,
-                sell_ix_fee_config_meta = %ix_fc,
-                sell_ix_fee_program_meta = %ix_fp,
-                fee_config_uses_global_constant = fee_config_uses_global_constant,
-                fee_program_matches_expected_fee_program = fee_program_uses_expected,
-                protocol_fee_recipient_preserved_from_v14 = pfr_preserved,
-                protocol_fee_recipient_ta_preserved_from_v14 = pfr_ta_preserved,
-                v14_fee_config_differs_from_global_constant = (v12_fc != canonical_fee_cfg),
-                v14_fee_program_differs_from_expected = (v12_fp != canonical_fee_prog),
-                fee_config_differs_from_v14_row = fee_config_differs_from_v14_row,
-                fee_program_differs_from_v14_row = fee_program_differs_from_v14_row,
-                "Scope44: pump_amm SELL plan — meta #19/#20 must be global FeeConfig + fee_program (v14[12] is informational; wrong type → Custom 3002)"
-            );
+            let sell_ix_accounts = &ixs[0].accounts;
+            let sell_ix_account_count = sell_ix_accounts.len();
+            let (tail0_ix, tail1_ix, tail2_ix) =
+                if sell_ix_account_count == PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS {
+                    (
+                        PUMPFUN_AMM_SELL_EXT_TAIL_0_IX_V2,
+                        PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2,
+                        PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2,
+                    )
+                } else {
+                    (
+                        PUMPFUN_AMM_SELL_EXT_TAIL_0_IX,
+                        PUMPFUN_AMM_SELL_EXT_TAIL_1_IX,
+                        PUMPFUN_AMM_SELL_EXT_THIRD_META_IX,
+                    )
+                };
+            let sell_ix_tail0 = sell_ix_accounts
+                .get(tail0_ix)
+                .map(|m| m.pubkey.to_string())
+                .unwrap_or_default();
+            let sell_ix_tail1 = sell_ix_accounts
+                .get(tail1_ix)
+                .map(|m| m.pubkey.to_string())
+                .unwrap_or_default();
+            let sell_ix_tail2 = sell_ix_accounts
+                .get(tail2_ix)
+                .map(|m| m.pubkey.to_string())
+                .unwrap_or_default();
+            let sell_ix_tail2_writable = sell_ix_accounts
+                .get(tail2_ix)
+                .map(|m| m.is_writable)
+                .unwrap_or(false);
+            if sell_ix_account_count == PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS {
+                info!(
+                    intent_id = %intent.intent_id,
+                    scope = "44",
+                    dex = "pump_amm",
+                    intent_user = %wallet_pubkey,
+                    pool_accounts_source = pool_accounts_build_source,
+                    sell_extended = sell_requires_cashback_remaining && intent.side == TradeSide::Sell,
+                    sell_cashback_third_meta = ?sell_cashback_third_meta,
+                    sell_extended_tail_source = sell_ext_tail_src,
+                    derived_tail_21 = %derived_tail_21,
+                    derived_tail_22 = %derived_tail_22,
+                    cached_tail_21 = ?sell_extended_tail_0,
+                    cached_tail_22 = ?sell_extended_tail_1,
+                    cached_tail_mismatch,
+                    sell_extended_tail_2 = ?sell_cashback_third_meta,
+                    sell_ix_meta_23 = %sell_ix_tail0,
+                    sell_ix_meta_24 = %sell_ix_tail1,
+                    sell_ix_meta_25 = %sell_ix_tail2,
+                    sell_ix_meta_25_writable = sell_ix_tail2_writable,
+                    sell_ix_account_count,
+                    pool = %pool_id,
+                    input_mint = %intent.resources.input_mint,
+                    base_token_program_override = ?token_program_override,
+                    v14_csv = %PumpAmmPoolAccountsDiagnostic::format_v14_csv(&pool_accounts[..14]),
+                    sell_ix_accounts_csv = %sell_csv,
+                    v14_fee_config_row = %v12_fc,
+                    v14_fee_program_row = %v12_fp,
+                    sell_ix_fee_config_meta = %ix_fc,
+                    sell_ix_fee_program_meta = %ix_fp,
+                    fee_config_uses_global_constant = fee_config_uses_global_constant,
+                    fee_program_matches_expected_fee_program = fee_program_uses_expected,
+                    protocol_fee_recipient_preserved_from_v14 = pfr_preserved,
+                    protocol_fee_recipient_ta_preserved_from_v14 = pfr_ta_preserved,
+                    v14_fee_config_differs_from_global_constant = (v12_fc != canonical_fee_cfg),
+                    v14_fee_program_differs_from_expected = (v12_fp != canonical_fee_prog),
+                    fee_config_differs_from_v14_row = fee_config_differs_from_v14_row,
+                    fee_program_differs_from_v14_row = fee_program_differs_from_v14_row,
+                    "Scope44: pump_amm SELL plan — meta #19/#20 must be global FeeConfig + fee_program (v14[12] is informational; wrong type → Custom 3002)"
+                );
+            } else {
+                info!(
+                    intent_id = %intent.intent_id,
+                    scope = "44",
+                    dex = "pump_amm",
+                    intent_user = %wallet_pubkey,
+                    pool_accounts_source = pool_accounts_build_source,
+                    sell_extended = sell_requires_cashback_remaining && intent.side == TradeSide::Sell,
+                    sell_cashback_third_meta = ?sell_cashback_third_meta,
+                    sell_extended_tail_source = sell_ext_tail_src,
+                    derived_tail_21 = %derived_tail_21,
+                    derived_tail_22 = %derived_tail_22,
+                    cached_tail_21 = ?sell_extended_tail_0,
+                    cached_tail_22 = ?sell_extended_tail_1,
+                    cached_tail_mismatch,
+                    sell_extended_tail_2 = ?sell_cashback_third_meta,
+                    sell_ix_meta_21 = %sell_ix_tail0,
+                    sell_ix_meta_22 = %sell_ix_tail1,
+                    sell_ix_meta_23 = %sell_ix_tail2,
+                    sell_ix_meta_23_writable = sell_ix_tail2_writable,
+                    sell_ix_account_count,
+                    pool = %pool_id,
+                    input_mint = %intent.resources.input_mint,
+                    base_token_program_override = ?token_program_override,
+                    v14_csv = %PumpAmmPoolAccountsDiagnostic::format_v14_csv(&pool_accounts[..14]),
+                    sell_ix_accounts_csv = %sell_csv,
+                    v14_fee_config_row = %v12_fc,
+                    v14_fee_program_row = %v12_fp,
+                    sell_ix_fee_config_meta = %ix_fc,
+                    sell_ix_fee_program_meta = %ix_fp,
+                    fee_config_uses_global_constant = fee_config_uses_global_constant,
+                    fee_program_matches_expected_fee_program = fee_program_uses_expected,
+                    protocol_fee_recipient_preserved_from_v14 = pfr_preserved,
+                    protocol_fee_recipient_ta_preserved_from_v14 = pfr_ta_preserved,
+                    v14_fee_config_differs_from_global_constant = (v12_fc != canonical_fee_cfg),
+                    v14_fee_program_differs_from_expected = (v12_fp != canonical_fee_prog),
+                    fee_config_differs_from_v14_row = fee_config_differs_from_v14_row,
+                    fee_program_differs_from_v14_row = fee_program_differs_from_v14_row,
+                    "Scope44: pump_amm SELL plan — meta #19/#20 must be global FeeConfig + fee_program (v14[12] is informational; wrong type → Custom 3002)"
+                );
+            }
         }
 
         // NOTE: No in-TX wrap for BUYs!

--- a/src/execution/tx_builder.rs
+++ b/src/execution/tx_builder.rs
@@ -772,6 +772,10 @@ pub async fn build_tx_plan(
         let (sell_extended_fee_tail_0, sell_extended_fee_tail_1) = cache
             .map(|c| c.pump_amm_sell_fee_tail_layout(&pool_id))
             .unwrap_or((None, None));
+        let sell_requires_pre_fee_metas = cache
+            .map(|c| c.pump_amm_sell_requires_pre_fee_metas(&pool_id))
+            .unwrap_or(false);
+        let sell_pre_fee_meta_1 = cache.and_then(|c| c.pump_amm_sell_pre_fee_meta_1(&pool_id));
 
         let mut pool_accounts_build_source = if accounts_len == 0 {
             "slave_livepoolcache"
@@ -919,6 +923,12 @@ pub async fn build_tx_plan(
             sell_requires_cashback_remaining && intent.side == TradeSide::Sell,
             if intent.side == TradeSide::Sell {
                 sell_cashback_third_meta
+            } else {
+                None
+            },
+            sell_requires_pre_fee_metas && intent.side == TradeSide::Sell,
+            if intent.side == TradeSide::Sell {
+                sell_pre_fee_meta_1
             } else {
                 None
             },
@@ -1685,61 +1695,71 @@ async fn build_hop_pump_amm(
     cache: Option<&SharedLivePoolCache>,
 ) -> Result<Vec<Instruction>, UnsupportedTxPlan> {
     // PumpSwap AMM (graduated tokens) - get pool_accounts from cache
-    let (pool_accounts, sell_requires, sell_third, _sell_t0, _sell_t1, sell_fee_t0, sell_fee_t1) =
-        if let Some(cache) = cache {
-            match cache.get(pool_address) {
-                Some(CachedPoolState::PumpAmm(amm_state)) => {
-                    let (sell_requires, sell_third, sell_t0, sell_t1) =
-                        cache.pump_amm_sell_extended_layout(pool_address);
-                    let (sell_fee_t0, sell_fee_t1) =
-                        cache.pump_amm_sell_fee_tail_layout(pool_address);
-                    if amm_state.pool_accounts.len() >= 14 {
-                        tracing::debug!(
-                            pool = %pool_address,
-                            accounts_len = amm_state.pool_accounts.len(),
-                            "multi-hop pump_amm: using cached pool_accounts"
-                        );
-                        (
-                            amm_state.pool_accounts.clone(),
-                            sell_requires,
-                            sell_third,
-                            sell_t0,
-                            sell_t1,
-                            sell_fee_t0,
-                            sell_fee_t1,
-                        )
-                    } else {
-                        return Err(UnsupportedTxPlan {
-                            reason: RejectReason::UnsupportedIntent,
-                            details: format!(
-                                "pump_amm: cached pool_accounts too short (got {}, need 14)",
-                                amm_state.pool_accounts.len()
-                            ),
-                        });
-                    }
-                }
-                Some(_) => {
+    let (
+        pool_accounts,
+        sell_requires,
+        sell_third,
+        _sell_t0,
+        _sell_t1,
+        sell_fee_t0,
+        sell_fee_t1,
+        sell_requires_pre_fee,
+        sell_pre_fee_meta_1,
+    ) = if let Some(cache) = cache {
+        match cache.get(pool_address) {
+            Some(CachedPoolState::PumpAmm(amm_state)) => {
+                let (sell_requires, sell_third, sell_t0, sell_t1) =
+                    cache.pump_amm_sell_extended_layout(pool_address);
+                let (sell_fee_t0, sell_fee_t1) = cache.pump_amm_sell_fee_tail_layout(pool_address);
+                if amm_state.pool_accounts.len() >= 14 {
+                    tracing::debug!(
+                        pool = %pool_address,
+                        accounts_len = amm_state.pool_accounts.len(),
+                        "multi-hop pump_amm: using cached pool_accounts"
+                    );
+                    (
+                        amm_state.pool_accounts.clone(),
+                        sell_requires,
+                        sell_third,
+                        sell_t0,
+                        sell_t1,
+                        sell_fee_t0,
+                        sell_fee_t1,
+                        cache.pump_amm_sell_requires_pre_fee_metas(pool_address),
+                        cache.pump_amm_sell_pre_fee_meta_1(pool_address),
+                    )
+                } else {
                     return Err(UnsupportedTxPlan {
                         reason: RejectReason::UnsupportedIntent,
                         details: format!(
-                            "pump_amm: cache hit but wrong DEX type for {}",
-                            pool_address
+                            "pump_amm: cached pool_accounts too short (got {}, need 14)",
+                            amm_state.pool_accounts.len()
                         ),
                     });
                 }
-                None => {
-                    return Err(UnsupportedTxPlan {
-                        reason: RejectReason::UnsupportedIntent,
-                        details: format!("pump_amm: pool {} not in cache", pool_address),
-                    });
-                }
             }
-        } else {
-            return Err(UnsupportedTxPlan {
-                reason: RejectReason::UnsupportedIntent,
-                details: "pump_amm: no cache available for multi-hop".to_string(),
-            });
-        };
+            Some(_) => {
+                return Err(UnsupportedTxPlan {
+                    reason: RejectReason::UnsupportedIntent,
+                    details: format!(
+                        "pump_amm: cache hit but wrong DEX type for {}",
+                        pool_address
+                    ),
+                });
+            }
+            None => {
+                return Err(UnsupportedTxPlan {
+                    reason: RejectReason::UnsupportedIntent,
+                    details: format!("pump_amm: pool {} not in cache", pool_address),
+                });
+            }
+        }
+    } else {
+        return Err(UnsupportedTxPlan {
+            reason: RejectReason::UnsupportedIntent,
+            details: "pump_amm: no cache available for multi-hop".to_string(),
+        });
+    };
 
     // Use static method with pool_accounts from cache
     // Note: Multi-hop arb doesn't pass token_program yet; Token-2022 arb tokens are rare.
@@ -1755,6 +1775,12 @@ async fn build_hop_pump_amm(
         None, // Token-2022 not yet supported in multi-hop arb
         sell_requires && is_sell_hop,
         if is_sell_hop { sell_third } else { None },
+        sell_requires_pre_fee && is_sell_hop,
+        if is_sell_hop {
+            sell_pre_fee_meta_1
+        } else {
+            None
+        },
         None, // volume tails: derived for wallet in builder
         None,
         if is_sell_hop { sell_fee_t0 } else { None },
@@ -2218,6 +2244,8 @@ mod tests {
             None,
             None,
             false,
+            false,
+            None,
         );
 
         let mut intent = base_intent();
@@ -2319,6 +2347,8 @@ mod tests {
             None,
             None,
             false,
+            false,
+            None,
         );
 
         // Target pool: explicit JetStream Ready (force_refresh / PoolCacheUpdate path).
@@ -2346,6 +2376,8 @@ mod tests {
             None,
             None,
             false,
+            false,
+            None,
         );
 
         let mut intent = base_intent();

--- a/src/execution/tx_builder.rs
+++ b/src/execution/tx_builder.rs
@@ -5,11 +5,12 @@ use crate::solana::dex::orca::Orca;
 use crate::solana::dex::orca_whirlpool_layout;
 use crate::solana::dex::pumpfun::PumpFunDex;
 use crate::solana::dex::pumpfun_amm::{
-    PumpAmmPoolAccountsDiagnostic, PumpFunAmmDex, PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR,
-    PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR, PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS,
-    PUMPFUN_AMM_SELL_EXT_TAIL_0_IX, PUMPFUN_AMM_SELL_EXT_TAIL_0_IX_V2,
-    PUMPFUN_AMM_SELL_EXT_TAIL_1_IX, PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2,
-    PUMPFUN_AMM_SELL_EXT_THIRD_META_IX, PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2,
+    pump_amm_sell_ix_uses_global_fee_at, PumpAmmPoolAccountsDiagnostic, PumpFunAmmDex,
+    PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR, PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR,
+    PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS, PUMPFUN_AMM_SELL_EXT_TAIL_0_IX,
+    PUMPFUN_AMM_SELL_EXT_TAIL_0_IX_V2, PUMPFUN_AMM_SELL_EXT_TAIL_1_IX,
+    PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2, PUMPFUN_AMM_SELL_EXT_THIRD_META_IX,
+    PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2,
 };
 use crate::solana::dex::raydium::Raydium;
 use crate::solana::dex::Dex;
@@ -962,16 +963,25 @@ pub async fn build_tx_plan(
             && intent.side == TradeSide::Sell
             && pool_accounts.len() >= 14
             && !ixs.is_empty()
-            && ixs[0].accounts.len() >= 21
         {
+            if let Some((fee_config_ix, fee_program_ix)) =
+                pump_amm_sell_ix_uses_global_fee_at(ixs[0].accounts.len())
+            {
+            let sell_ix_accounts = &ixs[0].accounts;
             let canonical_fee_cfg =
                 Pubkey::from_str(PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR).unwrap_or_default();
             let canonical_fee_prog =
                 Pubkey::from_str(PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR).unwrap_or_default();
             let v12_fc = pool_accounts[12];
             let v12_fp = pool_accounts[13];
-            let ix_fc = ixs[0].accounts[19].pubkey;
-            let ix_fp = ixs[0].accounts[20].pubkey;
+            let ix_fc = sell_ix_accounts
+                .get(fee_config_ix)
+                .map(|m| m.pubkey)
+                .unwrap_or_default();
+            let ix_fp = sell_ix_accounts
+                .get(fee_program_ix)
+                .map(|m| m.pubkey)
+                .unwrap_or_default();
             let fee_config_uses_global_constant = ix_fc == canonical_fee_cfg;
             let fee_program_uses_expected = ix_fp == canonical_fee_prog;
             let fee_config_differs_from_v14_row = v12_fc != ix_fc;
@@ -1011,7 +1021,6 @@ pub async fn build_tx_plan(
                 } else {
                     "n/a"
                 };
-            let sell_ix_accounts = &ixs[0].accounts;
             let sell_ix_account_count = sell_ix_accounts.len();
             let (tail0_ix, tail1_ix, tail2_ix) =
                 if sell_ix_account_count == PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS {
@@ -1081,7 +1090,9 @@ pub async fn build_tx_plan(
                     v14_fee_program_differs_from_expected = (v12_fp != canonical_fee_prog),
                     fee_config_differs_from_v14_row = fee_config_differs_from_v14_row,
                     fee_program_differs_from_v14_row = fee_program_differs_from_v14_row,
-                    "Scope44: pump_amm SELL plan — meta #19/#20 must be global FeeConfig + fee_program (v14[12] is informational; wrong type → Custom 3002)"
+                    sell_ix_fee_config_ix = fee_config_ix,
+                    sell_ix_fee_program_ix = fee_program_ix,
+                    "Scope44: pump_amm SELL plan (27-account) — meta #21/#22 must be global FeeConfig + fee_program (v14[12] is informational; wrong type → Custom 3002)"
                 );
             } else {
                 info!(
@@ -1121,8 +1132,11 @@ pub async fn build_tx_plan(
                     v14_fee_program_differs_from_expected = (v12_fp != canonical_fee_prog),
                     fee_config_differs_from_v14_row = fee_config_differs_from_v14_row,
                     fee_program_differs_from_v14_row = fee_program_differs_from_v14_row,
+                    sell_ix_fee_config_ix = fee_config_ix,
+                    sell_ix_fee_program_ix = fee_program_ix,
                     "Scope44: pump_amm SELL plan — meta #19/#20 must be global FeeConfig + fee_program (v14[12] is informational; wrong type → Custom 3002)"
                 );
+            }
             }
         }
 

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -165,6 +165,60 @@ pub const PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2: usize = 24;
 pub const PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2: usize = 25;
 pub const PUMPFUN_AMM_SELL_FEE_TAIL_0_IX_V2: usize = 26;
 
+/// Inputs for extended PumpSwap SELL layout readiness (JetStream publish + SLAVE gate).
+#[derive(Debug, Clone, Copy)]
+pub struct PumpAmmSellExtendedReadinessParams {
+    pub sell_requires_extended: bool,
+    pub third_meta: Option<Pubkey>,
+    pub fee_tail_0: Option<Pubkey>,
+    pub fee_tail_1: Option<Pubkey>,
+    pub sell_requires_fee_tail: bool,
+    pub sell_requires_pre_fee_metas: bool,
+    pub sell_pre_fee_meta_1: Option<Pubkey>,
+}
+
+/// Whether an extended PumpSwap SELL layout has the pool-specific metas required before build.
+///
+/// Volume tails at ix #21/#22 are intent-user derivable at build time and are not part of this gate.
+#[must_use]
+pub fn pump_amm_sell_extended_layout_ready(params: PumpAmmSellExtendedReadinessParams) -> bool {
+    if !params.sell_requires_extended {
+        return true;
+    }
+    let third_ok = params
+        .third_meta
+        .filter(|p| *p != Pubkey::default())
+        .is_some();
+    let pre_fee_ok = if params.sell_requires_pre_fee_metas {
+        params
+            .sell_pre_fee_meta_1
+            .filter(|p| *p != Pubkey::default())
+            .is_some()
+    } else {
+        true
+    };
+    let needs_fee_tail =
+        params.sell_requires_fee_tail || params.fee_tail_0.is_some() || params.fee_tail_1.is_some();
+    let fee_ok = if params.sell_requires_pre_fee_metas {
+        params
+            .fee_tail_0
+            .filter(|p| *p != Pubkey::default())
+            .is_some()
+    } else if needs_fee_tail {
+        params
+            .fee_tail_0
+            .filter(|p| *p != Pubkey::default())
+            .is_some()
+            && params
+                .fee_tail_1
+                .filter(|p| *p != Pubkey::default())
+                .is_some()
+    } else {
+        true
+    };
+    third_ok && pre_fee_ok && fee_ok
+}
+
 /// `pool-v2` PDA appended on post-upgrade PumpSwap swaps (`["pool-v2", base_mint]`).
 #[must_use]
 pub fn pump_amm_pool_v2_pda(base_mint: &Pubkey, program_id: &Pubkey) -> Pubkey {
@@ -2048,6 +2102,21 @@ impl PumpFunAmmDex {
                             ),
                             _ => (None, None, None, None, None),
                         };
+                    let (tail0_ix, tail1_ix, tail2_ix) = if usize::from(sell_ix_account_count)
+                        == PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS
+                    {
+                        (
+                            PUMPFUN_AMM_SELL_EXT_TAIL_0_IX_V2,
+                            PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2,
+                            PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2,
+                        )
+                    } else {
+                        (
+                            PUMPFUN_AMM_SELL_EXT_TAIL_0_IX,
+                            PUMPFUN_AMM_SELL_EXT_TAIL_1_IX,
+                            PUMPFUN_AMM_SELL_EXT_THIRD_META_IX,
+                        )
+                    };
                     info!(
                         pool = %pool_market,
                         base_mint = %base_mint,
@@ -2069,9 +2138,12 @@ impl PumpFunAmmDex {
                         sell_extended_tail_2 = ?tail2_log,
                         sell_ix_meta_19 = ?pre0_log,
                         sell_ix_meta_20 = ?pre1_log,
-                        sell_ix_meta_21 = ?tail0_log,
-                        sell_ix_meta_22 = ?tail1_log,
-                        sell_ix_meta_23 = ?tail2_log,
+                        sell_ix_tail_0_ix = tail0_ix,
+                        sell_ix_meta_at_tail_0 = ?tail0_log,
+                        sell_ix_tail_1_ix = tail1_ix,
+                        sell_ix_meta_at_tail_1 = ?tail1_log,
+                        sell_ix_tail_2_ix = tail2_ix,
+                        sell_ix_meta_at_tail_2 = ?tail2_log,
                         transactions_fetched = summary.transactions_fetched,
                         pump_amm_instructions_seen = summary.pump_amm_instructions_seen,
                         sell_candidates_seen = summary.sell_candidates_seen,
@@ -2149,6 +2221,21 @@ impl PumpFunAmmDex {
                 PumpAmmAuthoritativeSellLayout::Base => 21,
                 PumpAmmAuthoritativeSellLayout::Unknown => 0,
             };
+            let (tail0_ix, tail1_ix, tail2_ix) = if usize::from(sell_ix_account_count)
+                == PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS
+            {
+                (
+                    PUMPFUN_AMM_SELL_EXT_TAIL_0_IX_V2,
+                    PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2,
+                    PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2,
+                )
+            } else {
+                (
+                    PUMPFUN_AMM_SELL_EXT_TAIL_0_IX,
+                    PUMPFUN_AMM_SELL_EXT_TAIL_1_IX,
+                    PUMPFUN_AMM_SELL_EXT_THIRD_META_IX,
+                )
+            };
             info!(
                 pool = %pool_market,
                 base_mint = %base_mint,
@@ -2169,9 +2256,12 @@ impl PumpFunAmmDex {
                 sell_extended_tail_2 = ?tail2_log,
                 sell_ix_meta_19 = ?pre0_log,
                 sell_ix_meta_20 = ?pre1_log,
-                sell_ix_meta_21 = ?tail0_log,
-                sell_ix_meta_22 = ?tail1_log,
-                sell_ix_meta_23 = ?tail2_log,
+                sell_ix_tail_0_ix = tail0_ix,
+                sell_ix_meta_at_tail_0 = ?tail0_log,
+                sell_ix_tail_1_ix = tail1_ix,
+                sell_ix_meta_at_tail_1 = ?tail1_log,
+                sell_ix_tail_2_ix = tail2_ix,
+                sell_ix_meta_at_tail_2 = ?tail2_log,
                 transactions_fetched = summary.transactions_fetched,
                 pump_amm_instructions_seen = summary.pump_amm_instructions_seen,
                 sell_candidates_seen = summary.sell_candidates_seen,
@@ -2300,7 +2390,7 @@ impl PumpFunAmmDex {
         sell_extended_fee_tail_1: Option<Pubkey>,
         cached_observed_volume_tail_0: Option<Pubkey>,
         cached_observed_volume_tail_1: Option<Pubkey>,
-    ) {
+    ) -> Result<()> {
         let (user_vol_wsol_ata, user_vol) =
             Self::pump_amm_sell_cashback_first_two_metas(user, quote_mint, quote_token_program);
         if let (Some(c0), Some(c1)) = (
@@ -2324,9 +2414,14 @@ impl PumpFunAmmDex {
         metas.push(AccountMeta::new(user_vol, false));
         metas.push(AccountMeta::new_readonly(third, false));
         if sell_requires_pre_fee_metas {
-            if let Some(f0) = sell_extended_fee_tail_0.filter(|p| *p != Pubkey::default()) {
-                metas.push(AccountMeta::new_readonly(f0, false));
-            }
+            let f0 = sell_extended_fee_tail_0
+                .filter(|p| *p != Pubkey::default())
+                .ok_or_else(|| {
+                    anyhow!(
+                        "pump_amm SELL: 27-account layout requires sell_extended_fee_tail_0 (authoritative observation required)"
+                    )
+                })?;
+            metas.push(AccountMeta::new_readonly(f0, false));
         } else if let (Some(f0), Some(f1)) = (
             sell_extended_fee_tail_0.filter(|p| *p != Pubkey::default()),
             sell_extended_fee_tail_1.filter(|p| *p != Pubkey::default()),
@@ -2334,6 +2429,7 @@ impl PumpFunAmmDex {
             metas.push(AccountMeta::new_readonly(f0, false));
             metas.push(AccountMeta::new_readonly(f1, false));
         }
+        Ok(())
     }
 
     async fn rpc_get_account_owner_and_executable(
@@ -5770,7 +5866,7 @@ impl Dex for PumpFunAmmDex {
                     sell_extended_fee_tail_1,
                     cached_observed_volume_tail_0,
                     cached_observed_volume_tail_1,
-                );
+                )?;
             }
         }
 
@@ -6076,7 +6172,7 @@ impl PumpFunAmmDex {
                     sell_extended_fee_tail_1,
                     sell_extended_tail_0,
                     sell_extended_tail_1,
-                );
+                )?;
             }
             metas
         };
@@ -7038,6 +7134,57 @@ mod tests {
                 fee_tail_0: None,
                 fee_tail_1: None,
             }
+        );
+    }
+
+    #[test]
+    fn test_pump_amm_sell_extended_layout_ready_v2_requires_fee_tail_0() {
+        let third = Pubkey::new_unique();
+        let pre1 = Pubkey::new_unique();
+        let fee0 = Pubkey::new_unique();
+        assert!(
+            !pump_amm_sell_extended_layout_ready(PumpAmmSellExtendedReadinessParams {
+                sell_requires_extended: true,
+                third_meta: Some(third),
+                fee_tail_0: None,
+                fee_tail_1: None,
+                sell_requires_fee_tail: false,
+                sell_requires_pre_fee_metas: true,
+                sell_pre_fee_meta_1: Some(pre1),
+            }),
+            "27-account layout must not be ready without fee_tail_0"
+        );
+        assert!(pump_amm_sell_extended_layout_ready(
+            PumpAmmSellExtendedReadinessParams {
+                sell_requires_extended: true,
+                third_meta: Some(third),
+                fee_tail_0: Some(fee0),
+                fee_tail_1: None,
+                sell_requires_fee_tail: false,
+                sell_requires_pre_fee_metas: true,
+                sell_pre_fee_meta_1: Some(pre1),
+            }
+        ));
+    }
+
+    #[test]
+    fn test_push_pump_amm_sell_extended_trailing_metas_v2_errors_without_fee_tail_0() {
+        let mut metas = Vec::new();
+        let err = PumpFunAmmDex::push_pump_amm_sell_extended_trailing_metas(
+            &mut metas,
+            Pubkey::new_unique(),
+            Pubkey::from_str(WSOL_MINT).unwrap(),
+            Pubkey::new_from_array(spl_token::id().to_bytes()),
+            Pubkey::new_unique(),
+            true,
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(
+            err.is_err(),
+            "V2 extended SELL must fail when fee_tail_0 is missing"
         );
     }
 

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -4718,10 +4718,16 @@ impl PumpFunAmmDex {
                     continue;
                 }
 
+                let program_id = Pubkey::from_str(PUMPFUN_AMM_PROGRAM_ID)?;
                 let ua = PumpAmmUserAccounts {
                     user_base_ta: Pubkey::from_str(acc_strings[5].as_str())?,
                     user_quote_ta: Pubkey::from_str(acc_strings[6].as_str())?,
-                    user_volume_accumulator: Pubkey::from_str(acc_strings[20].as_str())?,
+                    // SELL layouts place fee/pre-fee metas at #19/#20, not user_volume (BUY #19).
+                    user_volume_accumulator: Self::derive_user_volume_accumulator(
+                        program_id,
+                        pool_market,
+                        user,
+                    ),
                 };
                 self.user_accounts.insert((pool_market, user), ua.clone());
                 return Ok(Some(ua));

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -143,6 +143,10 @@ pub const PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS: usize = 24;
 /// See Pump `@pump_tech_updates` (2026): non-cashback `sell` = 24 accounts (`pool-v2` at #21); cashback `sell` = 26.
 pub const PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS: usize = 26;
 
+/// Extended cashback `sell` with two Pump-owned pre-fee metas before global FeeConfig/FeeProgram (mainnet ref
+/// `3XPKr7ynZzRSwvwiVvWpDr58pFCUVUqwySBiUwPMqwUTDGETFWaZXpYWm84DnAuSet4rQRmcwUwsfZ8Vg8gJqeae`, pool `GrgDaBg4…`).
+pub const PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS: usize = 27;
+
 /// Extended SELL tail indices (shared by legacy 24-account cashback and 26-account layouts).
 pub const PUMPFUN_AMM_SELL_EXT_TAIL_0_IX: usize = 21;
 pub const PUMPFUN_AMM_SELL_EXT_TAIL_1_IX: usize = 22;
@@ -150,6 +154,16 @@ pub const PUMPFUN_AMM_SELL_EXT_THIRD_META_IX: usize = 23;
 /// Cashback `sell` fee-recipient pair after post-upgrade `pool-v2` meta (#23).
 pub const PUMPFUN_AMM_SELL_FEE_TAIL_0_IX: usize = 24;
 pub const PUMPFUN_AMM_SELL_FEE_TAIL_1_IX: usize = 25;
+
+/// 27-account extended SELL: pre-fee metas before global fee pair; fee + trailing indices shifted by +2.
+pub const PUMPFUN_AMM_SELL_PRE_FEE_0_IX_V2: usize = 19;
+pub const PUMPFUN_AMM_SELL_PRE_FEE_1_IX_V2: usize = 20;
+pub const PUMPFUN_AMM_SELL_FEE_CONFIG_IX_V2: usize = 21;
+pub const PUMPFUN_AMM_SELL_FEE_PROGRAM_IX_V2: usize = 22;
+pub const PUMPFUN_AMM_SELL_EXT_TAIL_0_IX_V2: usize = 23;
+pub const PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2: usize = 24;
+pub const PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2: usize = 25;
+pub const PUMPFUN_AMM_SELL_FEE_TAIL_0_IX_V2: usize = 26;
 
 /// `pool-v2` PDA appended on post-upgrade PumpSwap swaps (`["pool-v2", base_mint]`).
 #[must_use]
@@ -160,8 +174,12 @@ pub fn pump_amm_pool_v2_pda(base_mint: &Pubkey, program_id: &Pubkey) -> Pubkey {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PumpAmmSellExtendedFields {
     pub requires_extended: bool,
+    /// 27-account extended `sell`: two readonly pre-fee metas at #19/#20 before global FeeConfig/FeeProgram.
+    pub requires_pre_fee_metas: bool,
     /// Cashback `sell` (26 accounts): fee-recipient pair at ix #24/#25.
     pub requires_fee_tail: bool,
+    pub pre_fee_meta_0: Option<Pubkey>,
+    pub pre_fee_meta_1: Option<Pubkey>,
     pub tail_0: Option<Pubkey>,
     pub tail_1: Option<Pubkey>,
     pub third_meta: Option<Pubkey>,
@@ -173,8 +191,24 @@ pub struct PumpAmmSellExtendedFields {
 pub fn pump_amm_sell_ix_account_len_supported(n: usize) -> bool {
     matches!(
         n,
-        21 | PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS | PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS
+        21 | PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS
+            | PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS
+            | PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS
     )
+}
+
+#[must_use]
+pub fn pump_amm_sell_ix_uses_global_fee_at(n: usize) -> Option<(usize, usize)> {
+    match n {
+        PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS => Some((
+            PUMPFUN_AMM_SELL_FEE_CONFIG_IX_V2,
+            PUMPFUN_AMM_SELL_FEE_PROGRAM_IX_V2,
+        )),
+        21
+        | PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS
+        | PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS => Some((19, 20)),
+        _ => None,
+    }
 }
 
 /// Map observed `sell` instruction accounts to extended-layout fields (Geyser + RPC history).
@@ -189,23 +223,63 @@ pub fn pump_amm_sell_extended_fields_from_ix_accounts(
     let program_id = Pubkey::from_str(PUMPFUN_AMM_PROGRAM_ID).ok()?;
     let pool_v2 = pump_amm_pool_v2_pda(&base_mint, &program_id);
 
+    let global_fee_config = Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG).ok()?;
+    let global_fee_program = Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).ok()?;
+
     match n {
         21 => Some(PumpAmmSellExtendedFields {
             requires_extended: false,
+            requires_pre_fee_metas: false,
             requires_fee_tail: false,
+            pre_fee_meta_0: None,
+            pre_fee_meta_1: None,
             tail_0: None,
             tail_1: None,
             third_meta: None,
             fee_tail_0: None,
             fee_tail_1: None,
         }),
+        PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS => {
+            let fee_at_21 = *instruction_accounts.get(PUMPFUN_AMM_SELL_FEE_CONFIG_IX_V2)?;
+            let fee_at_22 = *instruction_accounts.get(PUMPFUN_AMM_SELL_FEE_PROGRAM_IX_V2)?;
+            if fee_at_21 != global_fee_config || fee_at_22 != global_fee_program {
+                return None;
+            }
+            Some(PumpAmmSellExtendedFields {
+                requires_extended: true,
+                requires_pre_fee_metas: true,
+                requires_fee_tail: false,
+                pre_fee_meta_0: instruction_accounts
+                    .get(PUMPFUN_AMM_SELL_PRE_FEE_0_IX_V2)
+                    .copied(),
+                pre_fee_meta_1: instruction_accounts
+                    .get(PUMPFUN_AMM_SELL_PRE_FEE_1_IX_V2)
+                    .copied(),
+                tail_0: instruction_accounts
+                    .get(PUMPFUN_AMM_SELL_EXT_TAIL_0_IX_V2)
+                    .copied(),
+                tail_1: instruction_accounts
+                    .get(PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2)
+                    .copied(),
+                third_meta: instruction_accounts
+                    .get(PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2)
+                    .copied(),
+                fee_tail_0: instruction_accounts
+                    .get(PUMPFUN_AMM_SELL_FEE_TAIL_0_IX_V2)
+                    .copied(),
+                fee_tail_1: None,
+            })
+        }
         PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS => {
             let at_21 = *instruction_accounts.get(PUMPFUN_AMM_SELL_EXT_TAIL_0_IX)?;
             if at_21 == pool_v2 {
                 // Post-upgrade non-cashback: #21 pool-v2, #22/#23 protocol fee recipient pair.
                 Some(PumpAmmSellExtendedFields {
                     requires_extended: true,
+                    requires_pre_fee_metas: false,
                     requires_fee_tail: false,
+                    pre_fee_meta_0: None,
+                    pre_fee_meta_1: None,
                     tail_0: Some(at_21),
                     tail_1: instruction_accounts
                         .get(PUMPFUN_AMM_SELL_EXT_TAIL_1_IX)
@@ -220,7 +294,10 @@ pub fn pump_amm_sell_extended_fields_from_ix_accounts(
                 // Legacy extended cashback: #21/#22 volume metas, #23 third (often pool-v2).
                 Some(PumpAmmSellExtendedFields {
                     requires_extended: true,
+                    requires_pre_fee_metas: false,
                     requires_fee_tail: false,
+                    pre_fee_meta_0: None,
+                    pre_fee_meta_1: None,
                     tail_0: instruction_accounts
                         .get(PUMPFUN_AMM_SELL_EXT_TAIL_0_IX)
                         .copied(),
@@ -237,7 +314,10 @@ pub fn pump_amm_sell_extended_fields_from_ix_accounts(
         }
         PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS => Some(PumpAmmSellExtendedFields {
             requires_extended: true,
+            requires_pre_fee_metas: false,
             requires_fee_tail: true,
+            pre_fee_meta_0: None,
+            pre_fee_meta_1: None,
             tail_0: instruction_accounts
                 .get(PUMPFUN_AMM_SELL_EXT_TAIL_0_IX)
                 .copied(),
@@ -443,6 +523,10 @@ pub struct PumpAmmPoolStatic {
     /// Observed cashback `sell` fee-recipient pair (ix #24/#25) when layout has 26 accounts.
     pub sell_extended_fee_tail_0: Option<Pubkey>,
     pub sell_extended_fee_tail_1: Option<Pubkey>,
+    /// 27-account extended `sell`: readonly pre-fee metas at ix #19/#20 before global fee pair.
+    pub sell_requires_pre_fee_metas: bool,
+    /// Second pre-fee meta (ix #20 on 27-account layout); first is usually `global_volume_accumulator` / v14[11].
+    pub sell_pre_fee_meta_1: Option<Pubkey>,
     /// Set when this struct was built inside `pumpfun_amm` (parse / tx-history / cache reconstruct).
     pub last_parse_diagnostics: Option<PumpAmmPoolAccountsDiagnostic>,
 }
@@ -459,6 +543,8 @@ pub struct PoolAccountsV14WithDiagnostic {
     pub sell_extended_tail_1: Option<Pubkey>,
     pub sell_extended_fee_tail_0: Option<Pubkey>,
     pub sell_extended_fee_tail_1: Option<Pubkey>,
+    pub sell_requires_pre_fee_metas: bool,
+    pub sell_pre_fee_meta_1: Option<Pubkey>,
     /// `true` only when the cold-path result is authoritative enough for SELL planning.
     pub sell_layout_ready: bool,
     /// Scope 49: structured outcome when `force_refresh` could not resolve SELL layout (empty if ready).
@@ -646,11 +732,15 @@ struct SellLayoutObserveOutcome {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
 enum PumpAmmAuthoritativeSellLayout {
     Unknown,
     Base,
-    /// Extended `sell`: trailing metas #21/#22/#23; optional #24/#25 fee pair for 26-account cashback.
+    /// Extended `sell`: trailing metas #21/#22/#23 (26-account) or shifted #23–#26 (27-account);
+    /// optional pre-fee pair at #19/#20 for 27-account layouts.
     Extended {
+        pre_fee_0: Option<Pubkey>,
+        pre_fee_1: Option<Pubkey>,
         tail_0: Pubkey,
         tail_1: Pubkey,
         tail_2: Pubkey,
@@ -1201,6 +1291,9 @@ impl PumpFunAmmDex {
                             sell_extended_tail_1: sell_t1,
                             sell_extended_fee_tail_0: sell_fee_t0,
                             sell_extended_fee_tail_1: sell_fee_t1,
+                            sell_requires_pre_fee_metas: cache
+                                .pump_amm_sell_requires_pre_fee_metas(&pool_market),
+                            sell_pre_fee_meta_1: cache.pump_amm_sell_pre_fee_meta_1(&pool_market),
                             sell_layout_ready: true,
                             force_refresh_sell_layout_diag: None,
                         }));
@@ -1376,9 +1469,13 @@ impl PumpFunAmmDex {
                     pool.sell_extended_tail_1 = None;
                     pool.sell_extended_fee_tail_0 = None;
                     pool.sell_extended_fee_tail_1 = None;
+                    pool.sell_requires_pre_fee_metas = false;
+                    pool.sell_pre_fee_meta_1 = None;
                     (true, None)
                 }
                 PumpAmmAuthoritativeSellLayout::Extended {
+                    pre_fee_0,
+                    pre_fee_1,
                     tail_0,
                     tail_1,
                     tail_2,
@@ -1386,6 +1483,13 @@ impl PumpFunAmmDex {
                     fee_tail_1,
                 } => {
                     pool.sell_requires_cashback_remaining = true;
+                    pool.sell_requires_pre_fee_metas =
+                        pre_fee_0.filter(|p| *p != Pubkey::default()).is_some()
+                            && pre_fee_1.filter(|p| *p != Pubkey::default()).is_some();
+                    if let Some(p0) = pre_fee_0.filter(|p| *p != Pubkey::default()) {
+                        pool.global_volume_accumulator = p0;
+                    }
+                    pool.sell_pre_fee_meta_1 = pre_fee_1.filter(|p| *p != Pubkey::default());
                     pool.sell_extended_tail_0 = Some(tail_0);
                     pool.sell_extended_tail_1 = Some(tail_1);
                     pool.sell_cashback_third_meta = Some(tail_2);
@@ -1407,6 +1511,8 @@ impl PumpFunAmmDex {
             sell_extended_tail_1: pool.sell_extended_tail_1,
             sell_extended_fee_tail_0: pool.sell_extended_fee_tail_0,
             sell_extended_fee_tail_1: pool.sell_extended_fee_tail_1,
+            sell_requires_pre_fee_metas: pool.sell_requires_pre_fee_metas,
+            sell_pre_fee_meta_1: pool.sell_pre_fee_meta_1,
             sell_layout_ready,
             force_refresh_sell_layout_diag,
         })
@@ -1923,16 +2029,25 @@ impl PumpFunAmmDex {
                     summary.termination_reason = PumpAmmSellLayoutTerminationReason::LayoutFound;
                     summary.elapsed_total_ms = t0.elapsed().as_millis();
                     let sell_ix_account_count = acc_strings.len() as u8;
-                    let (tail0_log, tail1_log, tail2_log) = match best_obs.layout {
-                        PumpAmmAuthoritativeSellLayout::Extended {
-                            tail_0,
-                            tail_1,
-                            tail_2,
-                            fee_tail_0: _,
-                            fee_tail_1: _,
-                        } => (Some(tail_0), Some(tail_1), Some(tail_2)),
-                        _ => (None, None, None),
-                    };
+                    let (tail0_log, tail1_log, tail2_log, pre0_log, pre1_log) =
+                        match best_obs.layout {
+                            PumpAmmAuthoritativeSellLayout::Extended {
+                                pre_fee_0,
+                                pre_fee_1,
+                                tail_0,
+                                tail_1,
+                                tail_2,
+                                fee_tail_0: _,
+                                fee_tail_1: _,
+                            } => (
+                                Some(tail_0),
+                                Some(tail_1),
+                                Some(tail_2),
+                                pre_fee_0,
+                                pre_fee_1,
+                            ),
+                            _ => (None, None, None, None, None),
+                        };
                     info!(
                         pool = %pool_market,
                         base_mint = %base_mint,
@@ -1952,6 +2067,8 @@ impl PumpFunAmmDex {
                         sell_extended_tail_0 = ?tail0_log,
                         sell_extended_tail_1 = ?tail1_log,
                         sell_extended_tail_2 = ?tail2_log,
+                        sell_ix_meta_19 = ?pre0_log,
+                        sell_ix_meta_20 = ?pre1_log,
                         sell_ix_meta_21 = ?tail0_log,
                         sell_ix_meta_22 = ?tail1_log,
                         sell_ix_meta_23 = ?tail2_log,
@@ -1989,17 +2106,34 @@ impl PumpFunAmmDex {
         if best_obs.layout != PumpAmmAuthoritativeSellLayout::Unknown {
             summary.termination_reason = PumpAmmSellLayoutTerminationReason::LayoutFound;
             summary.elapsed_total_ms = t0.elapsed().as_millis();
-            let (tail0_log, tail1_log, tail2_log) = match best_obs.layout {
+            let (tail0_log, tail1_log, tail2_log, pre0_log, pre1_log) = match best_obs.layout {
                 PumpAmmAuthoritativeSellLayout::Extended {
+                    pre_fee_0,
+                    pre_fee_1,
                     tail_0,
                     tail_1,
                     tail_2,
                     fee_tail_0: _,
                     fee_tail_1: _,
-                } => (Some(tail_0), Some(tail_1), Some(tail_2)),
-                _ => (None, None, None),
+                } => (
+                    Some(tail_0),
+                    Some(tail_1),
+                    Some(tail_2),
+                    pre_fee_0,
+                    pre_fee_1,
+                ),
+                _ => (None, None, None, None, None),
             };
             let sell_ix_account_count = match best_obs.layout {
+                PumpAmmAuthoritativeSellLayout::Extended {
+                    pre_fee_0,
+                    pre_fee_1,
+                    ..
+                } if pre_fee_0.filter(|p| *p != Pubkey::default()).is_some()
+                    && pre_fee_1.filter(|p| *p != Pubkey::default()).is_some() =>
+                {
+                    PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS as u8
+                }
                 PumpAmmAuthoritativeSellLayout::Extended {
                     fee_tail_0,
                     fee_tail_1,
@@ -2033,6 +2167,8 @@ impl PumpFunAmmDex {
                 sell_extended_tail_0 = ?tail0_log,
                 sell_extended_tail_1 = ?tail1_log,
                 sell_extended_tail_2 = ?tail2_log,
+                sell_ix_meta_19 = ?pre0_log,
+                sell_ix_meta_20 = ?pre1_log,
                 sell_ix_meta_21 = ?tail0_log,
                 sell_ix_meta_22 = ?tail1_log,
                 sell_ix_meta_23 = ?tail2_log,
@@ -2116,6 +2252,27 @@ impl PumpFunAmmDex {
         let user_vol_wsol_ata =
             Self::derive_ata_with_program(user_vol, quote_mint, quote_token_program);
         (user_vol_wsol_ata, user_vol)
+    }
+
+    /// Insert global FeeConfig + FeeProgram after coin-creator vault authority; optional 27-account pre-fee pair first.
+    fn push_pump_amm_sell_global_fee_metas(
+        metas: &mut Vec<AccountMeta>,
+        sell_requires_pre_fee_metas: bool,
+        pre_fee_meta_0: Pubkey,
+        sell_pre_fee_meta_1: Option<Pubkey>,
+        sell_fee_config: Pubkey,
+        sell_fee_program: Pubkey,
+    ) {
+        if sell_requires_pre_fee_metas {
+            if pre_fee_meta_0 != Pubkey::default() {
+                metas.push(AccountMeta::new_readonly(pre_fee_meta_0, false));
+            }
+            if let Some(p1) = sell_pre_fee_meta_1.filter(|p| *p != Pubkey::default()) {
+                metas.push(AccountMeta::new_readonly(p1, false));
+            }
+        }
+        metas.push(AccountMeta::new_readonly(sell_fee_config, false));
+        metas.push(AccountMeta::new_readonly(sell_fee_program, false));
     }
 
     /// Append extended/cashback SELL trailing metas for the **derived intent-user path**:
@@ -3602,6 +3759,8 @@ impl PumpFunAmmDex {
             sell_extended_tail_1: None,
             sell_extended_fee_tail_0: None,
             sell_extended_fee_tail_1: None,
+            sell_requires_pre_fee_metas: false,
+            sell_pre_fee_meta_1: None,
             last_parse_diagnostics: Some(diag),
         }))
     }
@@ -4005,6 +4164,9 @@ impl PumpFunAmmDex {
                             sell_extended_fee_tail_1: cache
                                 .pump_amm_sell_fee_tail_layout(&accounts[0])
                                 .1,
+                            sell_requires_pre_fee_metas: cache
+                                .pump_amm_sell_requires_pre_fee_metas(&accounts[0]),
+                            sell_pre_fee_meta_1: cache.pump_amm_sell_pre_fee_meta_1(&accounts[0]),
                             last_parse_diagnostics: Some(Self::pump_amm_livepoolcache_diagnostic(
                                 "discover_pool_static_livepoolcache_reconstruct",
                                 force_refresh,
@@ -4529,8 +4691,7 @@ impl PumpFunAmmDex {
                 else {
                     continue;
                 };
-                // PumpSwap AMM `sell` uses 21 base metas or 24 extended; legacy scans used 21-only.
-                if acc_strings.len() != 21 && acc_strings.len() != 24 {
+                if !pump_amm_sell_ix_account_len_supported(acc_strings.len()) {
                     continue;
                 }
 
@@ -4747,6 +4908,8 @@ impl PumpFunAmmDex {
                 sell_extended_tail_1: None,
                 sell_extended_fee_tail_0: None,
                 sell_extended_fee_tail_1: None,
+                sell_requires_pre_fee_metas: false,
+                sell_pre_fee_meta_1: None,
                 last_parse_diagnostics: Some(diag_factory(None)),
             });
         }
@@ -4775,6 +4938,13 @@ impl PumpFunAmmDex {
             } else {
                 (None, None, None, None, None)
             };
+            let (fee_config_ix, fee_program_ix) =
+                pump_amm_sell_ix_uses_global_fee_at(acc_accounts.len())?;
+            let gva = if ext.requires_pre_fee_metas {
+                filter_pk(ext.pre_fee_meta_0).unwrap_or(singleton_gva)
+            } else {
+                singleton_gva
+            };
             return Some(PumpAmmPoolStatic {
                 pool_market,
                 global_config: parse_pk(2)?,
@@ -4787,15 +4957,17 @@ impl PumpFunAmmDex {
                 event_authority: parse_pk(15)?,
                 coin_creator_vault_ata: parse_pk(17)?,
                 coin_creator_vault_authority: parse_pk(18)?,
-                global_volume_accumulator: singleton_gva,
-                fee_config: parse_pk(19)?,
-                fee_program: parse_pk(20)?,
+                global_volume_accumulator: gva,
+                fee_config: parse_pk(fee_config_ix)?,
+                fee_program: parse_pk(fee_program_ix)?,
                 sell_requires_cashback_remaining: ext.requires_extended,
                 sell_cashback_third_meta: third,
                 sell_extended_tail_0: tail_0,
                 sell_extended_tail_1: tail_1,
                 sell_extended_fee_tail_0: fee_t0,
                 sell_extended_fee_tail_1: fee_t1,
+                sell_requires_pre_fee_metas: ext.requires_pre_fee_metas,
+                sell_pre_fee_meta_1: filter_pk(ext.pre_fee_meta_1),
                 last_parse_diagnostics: Some(diag_factory(None)),
             });
         }
@@ -4821,6 +4993,12 @@ impl PumpFunAmmDex {
             PumpAmmAuthoritativeSellLayout::Base
         } else {
             PumpAmmAuthoritativeSellLayout::Extended {
+                pre_fee_0: if pool.sell_requires_pre_fee_metas {
+                    Some(pool.global_volume_accumulator)
+                } else {
+                    None
+                },
+                pre_fee_1: pool.sell_pre_fee_meta_1,
                 tail_0: pool
                     .sell_extended_tail_0
                     .filter(|p| *p != Pubkey::default())?,
@@ -5236,6 +5414,8 @@ impl Dex for PumpFunAmmDex {
             sell_extended_tail_1: None,
             sell_extended_fee_tail_0: None,
             sell_extended_fee_tail_1: None,
+            sell_requires_pre_fee_metas: false,
+            sell_pre_fee_meta_1: None,
             last_parse_diagnostics: None,
         };
 
@@ -5515,15 +5695,15 @@ impl Dex for PumpFunAmmDex {
                 pool.coin_creator_vault_authority,
                 false,
             )); // 18
-            metas.push(AccountMeta::new_readonly(sell_fee_config, false)); // 19
-            metas.push(AccountMeta::new_readonly(sell_fee_program, false)); // 20
-                                                                            // `pools_by_base` can be stale vs monotonic LivePoolCache (Geyser); prefer DashMap for extended SELL.
+                // `pools_by_base` can be stale vs monotonic LivePoolCache (Geyser); prefer DashMap for extended SELL.
             let mut sell_requires_cashback_remaining = pool.sell_requires_cashback_remaining;
             let mut sell_cashback_third_meta = pool.sell_cashback_third_meta;
             let mut cached_observed_volume_tail_0 = pool.sell_extended_tail_0;
             let mut cached_observed_volume_tail_1 = pool.sell_extended_tail_1;
             let mut sell_extended_fee_tail_0 = pool.sell_extended_fee_tail_0;
             let mut sell_extended_fee_tail_1 = pool.sell_extended_fee_tail_1;
+            let mut sell_requires_pre_fee_metas = pool.sell_requires_pre_fee_metas;
+            let mut sell_pre_fee_meta_1 = pool.sell_pre_fee_meta_1;
             if let Some(ref cache) = self.live_pool_cache {
                 let (dash_flag, dash_third, dash_t0, dash_t1) =
                     cache.pump_amm_sell_extended_layout(&pool.pool_market);
@@ -5537,7 +5717,21 @@ impl Dex for PumpFunAmmDex {
                     sell_extended_fee_tail_0 = dash_fee_t0.or(sell_extended_fee_tail_0);
                     sell_extended_fee_tail_1 = dash_fee_t1.or(sell_extended_fee_tail_1);
                 }
+                if cache.pump_amm_sell_requires_pre_fee_metas(&pool.pool_market) {
+                    sell_requires_pre_fee_metas = true;
+                }
+                sell_pre_fee_meta_1 = cache
+                    .pump_amm_sell_pre_fee_meta_1(&pool.pool_market)
+                    .or(sell_pre_fee_meta_1);
             }
+            Self::push_pump_amm_sell_global_fee_metas(
+                &mut metas,
+                sell_requires_pre_fee_metas,
+                pool.global_volume_accumulator,
+                sell_pre_fee_meta_1,
+                sell_fee_config,
+                sell_fee_program,
+            );
             if sell_requires_cashback_remaining {
                 let Some(third) = sell_cashback_third_meta.filter(|p| *p != Pubkey::default())
                 else {
@@ -5627,6 +5821,8 @@ impl PumpFunAmmDex {
             base_token_program,
             sell_requires_cashback_remaining,
             sell_cashback_third_meta,
+            false,
+            None,
             None,
             None,
             None,
@@ -5648,6 +5844,8 @@ impl PumpFunAmmDex {
         base_token_program: Option<Pubkey>,
         sell_requires_cashback_remaining: bool,
         sell_cashback_third_meta: Option<Pubkey>,
+        sell_requires_pre_fee_metas: bool,
+        sell_pre_fee_meta_1: Option<Pubkey>,
         sell_extended_tail_0: Option<Pubkey>,
         sell_extended_tail_1: Option<Pubkey>,
         sell_extended_fee_tail_0: Option<Pubkey>,
@@ -5830,9 +6028,15 @@ impl PumpFunAmmDex {
                 AccountMeta::new_readonly(program_id, false), // 16
                 AccountMeta::new(coin_creator_vault_ata, false), // 17
                 AccountMeta::new_readonly(coin_creator_vault_authority, false), // 18
-                AccountMeta::new_readonly(sell_fee_config, false), // 19
-                AccountMeta::new_readonly(sell_fee_program, false), // 20
             ];
+            Self::push_pump_amm_sell_global_fee_metas(
+                &mut metas,
+                sell_requires_pre_fee_metas,
+                global_volume_accumulator,
+                sell_pre_fee_meta_1,
+                sell_fee_config,
+                sell_fee_program,
+            );
             if sell_requires_cashback_remaining {
                 let Some(third) = sell_cashback_third_meta.filter(|p| *p != Pubkey::default())
                 else {
@@ -6109,6 +6313,8 @@ mod tests {
         };
         let ext_obs = PumpAmmSellReferenceObservation {
             layout: PumpAmmAuthoritativeSellLayout::Extended {
+                pre_fee_0: None,
+                pre_fee_1: None,
                 tail_0: t0,
                 tail_1: t1,
                 tail_2: t2,
@@ -6126,6 +6332,8 @@ mod tests {
             )
             .layout,
             PumpAmmAuthoritativeSellLayout::Extended {
+                pre_fee_0: None,
+                pre_fee_1: None,
                 tail_0: t0,
                 tail_1: t1,
                 tail_2: t2,
@@ -6150,6 +6358,8 @@ mod tests {
         assert_eq!(
             merged2.layout,
             PumpAmmAuthoritativeSellLayout::Extended {
+                pre_fee_0: None,
+                pre_fee_1: None,
                 tail_0: t0,
                 tail_1: t1,
                 tail_2: t2,
@@ -6207,6 +6417,8 @@ mod tests {
             },
             PumpAmmSellReferenceObservation {
                 layout: PumpAmmAuthoritativeSellLayout::Extended {
+                    pre_fee_0: None,
+                    pre_fee_1: None,
                     tail_0: t0,
                     tail_1: t1,
                     tail_2: t2,
@@ -6225,6 +6437,8 @@ mod tests {
         assert_eq!(
             out.layout,
             PumpAmmAuthoritativeSellLayout::Extended {
+                pre_fee_0: None,
+                pre_fee_1: None,
                 tail_0: t0,
                 tail_1: t1,
                 tail_2: t2,
@@ -6698,6 +6912,8 @@ mod tests {
         assert_eq!(
             observed.2,
             PumpAmmAuthoritativeSellLayout::Extended {
+                pre_fee_0: None,
+                pre_fee_1: None,
                 tail_0: tail0,
                 tail_1: tail1,
                 tail_2: third_meta,
@@ -6705,6 +6921,61 @@ mod tests {
                 fee_tail_1: Some(fee_tail1),
             }
         );
+    }
+
+    /// P184d: 27-account extended `sell` — pre-fee readonly metas at #19/#20, global fee pair at #21/#22.
+    #[test]
+    fn p184d_sell_layout_observation_parses_27_account_pre_fee_extended_sell() {
+        let pool_market = Pubkey::from_str("GrgDaBg4TGBQCDZk9HHw8JT24RnoDHtQnvgguKxGKStb").unwrap();
+        let base_mint = Pubkey::new_unique();
+        let pre_fee_0 = Pubkey::new_unique();
+        let pre_fee_1 = Pubkey::new_unique();
+        let third_meta = Pubkey::new_unique();
+        let tail0 = Pubkey::new_unique();
+        let tail1 = Pubkey::new_unique();
+        let fee_tail0 = Pubkey::new_unique();
+        let fee_config = Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG).unwrap();
+        let fee_program = Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).unwrap();
+        let mut account_keys: Vec<Pubkey> = (0..27).map(|_| Pubkey::new_unique()).collect();
+        account_keys[0] = pool_market;
+        account_keys[2] = Pubkey::from_str(PUMPFUN_AMM_GLOBAL_CONFIG).unwrap();
+        account_keys[3] = base_mint;
+        account_keys[4] = Pubkey::from_str(WSOL_MINT).unwrap();
+        account_keys[PUMPFUN_AMM_SELL_PRE_FEE_0_IX_V2] = pre_fee_0;
+        account_keys[PUMPFUN_AMM_SELL_PRE_FEE_1_IX_V2] = pre_fee_1;
+        account_keys[PUMPFUN_AMM_SELL_FEE_CONFIG_IX_V2] = fee_config;
+        account_keys[PUMPFUN_AMM_SELL_FEE_PROGRAM_IX_V2] = fee_program;
+        account_keys[PUMPFUN_AMM_SELL_EXT_TAIL_0_IX_V2] = tail0;
+        account_keys[PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2] = tail1;
+        account_keys[PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2] = third_meta;
+        account_keys[PUMPFUN_AMM_SELL_FEE_TAIL_0_IX_V2] = fee_tail0;
+        let acc_strings: Vec<String> = account_keys.iter().map(ToString::to_string).collect();
+        let ix_data = pump_amm_sell_ix_discriminator().to_vec();
+
+        let observed = PumpFunAmmDex::pump_amm_sell_layout_observation_from_parsed_swap_ix(
+            &acc_strings,
+            &ix_data,
+        )
+        .expect("27-account sell observation");
+
+        assert_eq!(observed.0, pool_market);
+        assert_eq!(observed.1, base_mint);
+        assert_eq!(
+            observed.2,
+            PumpAmmAuthoritativeSellLayout::Extended {
+                pre_fee_0: Some(pre_fee_0),
+                pre_fee_1: Some(pre_fee_1),
+                tail_0: tail0,
+                tail_1: tail1,
+                tail_2: third_meta,
+                fee_tail_0: Some(fee_tail0),
+                fee_tail_1: None,
+            }
+        );
+        let ext = pump_amm_sell_extended_fields_from_ix_accounts(&account_keys).expect("fields");
+        assert!(ext.requires_pre_fee_metas);
+        assert_eq!(ext.pre_fee_meta_0, Some(pre_fee_0));
+        assert_eq!(ext.pre_fee_meta_1, Some(pre_fee_1));
     }
 
     #[test]
@@ -6737,6 +7008,8 @@ mod tests {
         assert_eq!(
             observed.2,
             PumpAmmAuthoritativeSellLayout::Extended {
+                pre_fee_0: None,
+                pre_fee_1: None,
                 tail_0: tail0,
                 tail_1: tail1,
                 tail_2: third_meta,
@@ -6780,6 +7053,8 @@ mod tests {
             sell_extended_tail_1: None,
             sell_extended_fee_tail_0: None,
             sell_extended_fee_tail_1: None,
+            sell_requires_pre_fee_metas: false,
+            sell_pre_fee_meta_1: None,
             last_parse_diagnostics: None,
         };
 
@@ -6814,6 +7089,8 @@ mod tests {
         assert_eq!(
             sell_obs.layout,
             PumpAmmAuthoritativeSellLayout::Extended {
+                pre_fee_0: None,
+                pre_fee_1: None,
                 tail_0: ref_t0,
                 tail_1: ref_t1,
                 tail_2: third_meta,
@@ -6875,6 +7152,8 @@ mod tests {
             None,
             true,
             Some(third_meta),
+            false,
+            None,
             Some(ref_tail_0),
             Some(ref_tail_1),
             None,
@@ -6932,6 +7211,8 @@ mod tests {
             sell_extended_tail_1: None,
             sell_extended_fee_tail_0: None,
             sell_extended_fee_tail_1: None,
+            sell_requires_pre_fee_metas: false,
+            sell_pre_fee_meta_1: None,
             last_parse_diagnostics: None,
         };
         PumpFunAmmDex::apply_sell_reference_protocol_fee_recipients_for_force_refresh(
@@ -7155,6 +7436,8 @@ mod tests {
             None,
             true,
             Some(third_meta),
+            false,
+            None,
             Some(foreign_tail_0),
             Some(foreign_tail_1),
             None,
@@ -7263,6 +7546,8 @@ mod tests {
             sell_extended_tail_1: None,
             sell_extended_fee_tail_0: None,
             sell_extended_fee_tail_1: None,
+            sell_requires_pre_fee_metas: false,
+            sell_pre_fee_meta_1: None,
             last_parse_diagnostics: None,
         };
         dex.pools_by_base.insert(base_mint, pool);

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -2313,11 +2313,10 @@ impl PumpFunAmmDex {
         metas.push(AccountMeta::new(user_vol_wsol_ata, false));
         metas.push(AccountMeta::new(user_vol, false));
         metas.push(AccountMeta::new_readonly(third, false));
-        if let (Some(f0), Some(f1)) = (
-            sell_extended_fee_tail_0.filter(|p| *p != Pubkey::default()),
-            sell_extended_fee_tail_1.filter(|p| *p != Pubkey::default()),
-        ) {
+        if let Some(f0) = sell_extended_fee_tail_0.filter(|p| *p != Pubkey::default()) {
             metas.push(AccountMeta::new_readonly(f0, false));
+        }
+        if let Some(f1) = sell_extended_fee_tail_1.filter(|p| *p != Pubkey::default()) {
             metas.push(AccountMeta::new_readonly(f1, false));
         }
     }

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -2262,17 +2262,26 @@ impl PumpFunAmmDex {
         sell_pre_fee_meta_1: Option<Pubkey>,
         sell_fee_config: Pubkey,
         sell_fee_program: Pubkey,
-    ) {
+    ) -> Result<()> {
         if sell_requires_pre_fee_metas {
-            if pre_fee_meta_0 != Pubkey::default() {
-                metas.push(AccountMeta::new_readonly(pre_fee_meta_0, false));
+            if pre_fee_meta_0 == Pubkey::default() {
+                return Err(anyhow!(
+                    "pump_amm SELL: 27-account layout requires global_volume_accumulator pre_fee_meta_0"
+                ));
             }
-            if let Some(p1) = sell_pre_fee_meta_1.filter(|p| *p != Pubkey::default()) {
-                metas.push(AccountMeta::new_readonly(p1, false));
-            }
+            let pre_fee_1 = sell_pre_fee_meta_1
+                .filter(|p| *p != Pubkey::default())
+                .ok_or_else(|| {
+                    anyhow!(
+                        "pump_amm SELL: 27-account layout requires sell_pre_fee_meta_1 (authoritative observation required)"
+                    )
+                })?;
+            metas.push(AccountMeta::new_readonly(pre_fee_meta_0, false));
+            metas.push(AccountMeta::new_readonly(pre_fee_1, false));
         }
         metas.push(AccountMeta::new_readonly(sell_fee_config, false));
         metas.push(AccountMeta::new_readonly(sell_fee_program, false));
+        Ok(())
     }
 
     /// Append extended/cashback SELL trailing metas for the **derived intent-user path**:
@@ -2286,6 +2295,7 @@ impl PumpFunAmmDex {
         quote_mint: Pubkey,
         quote_token_program: Pubkey,
         third: Pubkey,
+        sell_requires_pre_fee_metas: bool,
         sell_extended_fee_tail_0: Option<Pubkey>,
         sell_extended_fee_tail_1: Option<Pubkey>,
         cached_observed_volume_tail_0: Option<Pubkey>,
@@ -2313,10 +2323,15 @@ impl PumpFunAmmDex {
         metas.push(AccountMeta::new(user_vol_wsol_ata, false));
         metas.push(AccountMeta::new(user_vol, false));
         metas.push(AccountMeta::new_readonly(third, false));
-        if let Some(f0) = sell_extended_fee_tail_0.filter(|p| *p != Pubkey::default()) {
+        if sell_requires_pre_fee_metas {
+            if let Some(f0) = sell_extended_fee_tail_0.filter(|p| *p != Pubkey::default()) {
+                metas.push(AccountMeta::new_readonly(f0, false));
+            }
+        } else if let (Some(f0), Some(f1)) = (
+            sell_extended_fee_tail_0.filter(|p| *p != Pubkey::default()),
+            sell_extended_fee_tail_1.filter(|p| *p != Pubkey::default()),
+        ) {
             metas.push(AccountMeta::new_readonly(f0, false));
-        }
-        if let Some(f1) = sell_extended_fee_tail_1.filter(|p| *p != Pubkey::default()) {
             metas.push(AccountMeta::new_readonly(f1, false));
         }
     }
@@ -5730,7 +5745,7 @@ impl Dex for PumpFunAmmDex {
                 sell_pre_fee_meta_1,
                 sell_fee_config,
                 sell_fee_program,
-            );
+            )?;
             if sell_requires_cashback_remaining {
                 let Some(third) = sell_cashback_third_meta.filter(|p| *p != Pubkey::default())
                 else {
@@ -5744,6 +5759,7 @@ impl Dex for PumpFunAmmDex {
                     pool.quote_mint,
                     quote_token_program,
                     third,
+                    sell_requires_pre_fee_metas,
                     sell_extended_fee_tail_0,
                     sell_extended_fee_tail_1,
                     cached_observed_volume_tail_0,
@@ -6035,7 +6051,7 @@ impl PumpFunAmmDex {
                 sell_pre_fee_meta_1,
                 sell_fee_config,
                 sell_fee_program,
-            );
+            )?;
             if sell_requires_cashback_remaining {
                 let Some(third) = sell_cashback_third_meta.filter(|p| *p != Pubkey::default())
                 else {
@@ -6049,6 +6065,7 @@ impl PumpFunAmmDex {
                     quote_mint,
                     quote_tp,
                     third,
+                    sell_requires_pre_fee_metas,
                     sell_extended_fee_tail_0,
                     sell_extended_fee_tail_1,
                     sell_extended_tail_0,

--- a/src/solana/dex_parser.rs
+++ b/src/solana/dex_parser.rs
@@ -111,6 +111,10 @@ pub enum ParsedDexEvent {
         pump_amm_sell_extended_fee_tail_1: Option<Pubkey>,
         /// PumpSwap only: observed `sell` used 26 accounts (fee-recipient pair required).
         pump_amm_sell_requires_fee_tail: bool,
+        /// PumpSwap only: observed `sell` used 27 accounts (pre-fee metas at ix #19/#20).
+        pump_amm_sell_requires_pre_fee_metas: bool,
+        /// PumpSwap only: second pre-fee meta (ix #20); first is usually global_volume_accumulator.
+        pump_amm_sell_pre_fee_meta_1: Option<Pubkey>,
     },
     /// Liquidity removed (potential rug)
     LiquidityRemoved {
@@ -541,6 +545,8 @@ fn parse_raydium_swap(
         pump_amm_sell_extended_fee_tail_0: None,
         pump_amm_sell_extended_fee_tail_1: None,
         pump_amm_sell_requires_fee_tail: false,
+        pump_amm_sell_requires_pre_fee_metas: false,
+        pump_amm_sell_pre_fee_meta_1: None,
     })
 }
 
@@ -776,6 +782,8 @@ fn parse_orca_transaction(
         pump_amm_sell_extended_fee_tail_0: None,
         pump_amm_sell_extended_fee_tail_1: None,
         pump_amm_sell_requires_fee_tail: false,
+        pump_amm_sell_requires_pre_fee_metas: false,
+        pump_amm_sell_pre_fee_meta_1: None,
     })
 }
 
@@ -977,6 +985,8 @@ fn build_pumpfun_trade_event(
         pump_amm_sell_extended_fee_tail_0: None,
         pump_amm_sell_extended_fee_tail_1: None,
         pump_amm_sell_requires_fee_tail: false,
+        pump_amm_sell_requires_pre_fee_metas: false,
+        pump_amm_sell_pre_fee_meta_1: None,
     }
 }
 
@@ -1318,17 +1328,22 @@ fn parse_pumpfun_amm_transaction(update: &GeyserTransactionUpdate) -> Option<Par
     };
     let sell_requires_cashback_remaining = sell_ext.map(|e| e.requires_extended).unwrap_or(false);
     let sell_requires_fee_tail = sell_ext.map(|e| e.requires_fee_tail).unwrap_or(false);
+    let sell_requires_pre_fee_metas = sell_ext.map(|e| e.requires_pre_fee_metas).unwrap_or(false);
     let sell_cashback_third_meta = sell_ext.and_then(|e| e.third_meta);
     let sell_extended_tail_0 = sell_ext.and_then(|e| e.tail_0);
     let sell_extended_tail_1 = sell_ext.and_then(|e| e.tail_1);
     let sell_extended_fee_tail_0 = sell_ext.and_then(|e| e.fee_tail_0);
     let sell_extended_fee_tail_1 = sell_ext.and_then(|e| e.fee_tail_1);
+    let sell_pre_fee_meta_1 = sell_ext.and_then(|e| e.pre_fee_meta_1);
     if sell_requires_cashback_remaining && sell_cashback_third_meta.is_none() {
         return None;
     }
     if sell_ext.is_some_and(|e| e.requires_fee_tail)
         && (sell_extended_fee_tail_0.is_none() || sell_extended_fee_tail_1.is_none())
     {
+        return None;
+    }
+    if sell_ext.is_some_and(|e| e.requires_pre_fee_metas) && sell_pre_fee_meta_1.is_none() {
         return None;
     }
 
@@ -1501,6 +1516,8 @@ fn parse_pumpfun_amm_transaction(update: &GeyserTransactionUpdate) -> Option<Par
         pump_amm_sell_extended_fee_tail_0: sell_extended_fee_tail_0,
         pump_amm_sell_extended_fee_tail_1: sell_extended_fee_tail_1,
         pump_amm_sell_requires_fee_tail: sell_requires_fee_tail,
+        pump_amm_sell_requires_pre_fee_metas: sell_requires_pre_fee_metas,
+        pump_amm_sell_pre_fee_meta_1: sell_pre_fee_meta_1,
     })
 }
 
@@ -1838,6 +1855,8 @@ fn parse_meteora_transaction(update: &GeyserTransactionUpdate) -> Option<ParsedD
         pump_amm_sell_extended_fee_tail_0: None,
         pump_amm_sell_extended_fee_tail_1: None,
         pump_amm_sell_requires_fee_tail: false,
+        pump_amm_sell_requires_pre_fee_metas: false,
+        pump_amm_sell_pre_fee_meta_1: None,
     })
 }
 
@@ -1971,6 +1990,8 @@ fn parse_raydium_cpmm_transaction(update: &GeyserTransactionUpdate) -> Option<Pa
         pump_amm_sell_extended_fee_tail_0: None,
         pump_amm_sell_extended_fee_tail_1: None,
         pump_amm_sell_requires_fee_tail: false,
+        pump_amm_sell_requires_pre_fee_metas: false,
+        pump_amm_sell_pre_fee_meta_1: None,
     })
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **P184d**: PumpSwap extended `sell` for **27-account** instructions with two readonly **pre-fee metas at ix #19/#20** before the global `FeeConfig` / `FeeProgram` pair (indices shifted to #21/#22). Reference: mainnet sig `3XPKr7ynZzRSwvwiVvWpDr58pFCUVUqwySBiUwPMqwUTDGETFWaZXpYWm84DnAuSet4rQRmcwUwsfZ8Vg8gJqeae`, pool `GrgDaBg4TGBQCDZk9HHw8JT24RnoDHtQnvgguKxGKStb`.

## Changes

- `pumpfun_amm.rs`: constants, `pump_amm_sell_extended_fields_from_ix_accounts`, `push_pump_amm_sell_global_fee_metas`, builder + observation paths, unit test `p184d_sell_layout_observation_parses_27_account_pre_fee_extended_sell`
- `live_pool_cache.rs`: monotonic `pump_amm_sell_requires_pre_fee_metas` / `pump_amm_sell_pre_fee_meta_1`, readiness gate
- `dex_parser.rs` + `market_data.rs`: Geyser trade → cache/SSOT merge + JetStream metadata
- `tx_builder.rs`: cold-path builder passes pre-fee flags from cache

## Invariants

- **STOP-CHECK**: no new RPC on hot path; existing `allow_rpc_on_miss` patterns unchanged
- **I-9**: no change to simulation gate

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --quiet`
- [x] `p184d_sell_layout_observation_parses_27_account_pre_fee_extended_sell`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd39913b-02db-424e-a29b-b31c16af115f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd39913b-02db-424e-a29b-b31c16af115f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

