### PR TITLE
P184h: PumpSwap Extended-v2 SELL layout SSOT authority (validation, merge, recovery)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -1970,7 +1970,7 @@ async fn wait_for_usable_pump_amm_cache_state(
     false
 }
 
-/// Evidence tuple for PumpSwap cold-path force-refresh wait (Bug #34 / #36).
+/// Evidence tuple for PumpSwap cold-path force-refresh wait (Bug #34 / #36, P184h).
 type PumpAmmSlaveRecoveryEvidence = (
     u64,            // cache entry slot
     Option<u64>,    // base_reserve
@@ -1983,6 +1983,8 @@ type PumpAmmSlaveRecoveryEvidence = (
     bool,           // sell_layout_ready
     bool,           // sell_requires_pre_fee_metas (27-account SSOT)
     u8,             // inferred sell_ix_account_count
+    Option<Pubkey>, // sell_pre_fee_meta_1 (ix #20 on 27-account layout)
+    u64,            // layout_generation (monotonic per pool)
 );
 
 /// Snapshot of the PumpSwap SLAVE row for the specific `pool`.
@@ -2018,7 +2020,28 @@ fn pump_amm_slave_recovery_snapshot(
         sell_layout_ready,
         sell_requires_pre_fee_metas,
         sell_ix_account_count,
+        cache.pump_amm_sell_pre_fee_meta_1(pool),
+        cache.pump_amm_layout_generation(pool),
     ))
+}
+
+fn pump_amm_slave_recovery_evidence_changed(
+    before: &PumpAmmSlaveRecoveryEvidence,
+    after: &PumpAmmSlaveRecoveryEvidence,
+) -> bool {
+    before.0 != after.0
+        || before.1 != after.1
+        || before.2 != after.2
+        || before.3 != after.3
+        || before.4 != after.4
+        || before.5 != after.5
+        || before.6 != after.6
+        || before.7 != after.7
+        || before.8 != after.8
+        || before.9 != after.9
+        || before.10 != after.10
+        || before.11 != after.11
+        || before.12 != after.12
 }
 
 /// After `EnsurePumpAmmPoolAccounts(force_refresh=true)` + JetStream merge: bounded wait until
@@ -2041,7 +2064,16 @@ async fn wait_for_pump_amm_slave_after_recovery(
             .is_some();
         if explicit_ready {
             let after = pump_amm_slave_recovery_snapshot(cache, pool);
-            if after.is_some() && (before.is_none() || after != before) {
+            let layout_gen_fresh = before
+                .as_ref()
+                .zip(after.as_ref())
+                .is_some_and(|(b, a)| a.12 > b.12);
+            let evidence_changed = match (&before, &after) {
+                (None, Some(_)) => true,
+                (Some(b), Some(a)) => pump_amm_slave_recovery_evidence_changed(b, a),
+                _ => false,
+            };
+            if after.is_some() && (before.is_none() || evidence_changed || layout_gen_fresh) {
                 return true;
             }
         }
@@ -13039,6 +13071,65 @@ mod execution_engine_tests {
         assert_eq!(
             snap.10,
             ironcrab::solana::dex::pumpfun_amm::PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS as u8
+        );
+        assert_eq!(snap.11, Some(pre1));
+    }
+
+    #[test]
+    fn pump_amm_force_refresh_wait_succeeds_on_layout_generation_bump_same_reserves() {
+        let cache = std::sync::Arc::new(LivePoolCache::new());
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let wsol = Pubkey::from_str(ironcrab::ipc::NATIVE_SOL_MINT).unwrap();
+        let accounts: Vec<Pubkey> = (0..14).map(|_| Pubkey::new_unique()).collect();
+        cache.upsert(
+            pool,
+            CachedPoolState::PumpAmm(PumpAmmState {
+                base_mint: base,
+                quote_mint: wsol,
+                pool_base_token_account: Pubkey::new_unique(),
+                pool_quote_token_account: Pubkey::new_unique(),
+                base_reserve: Some(1_000),
+                quote_reserve: Some(2_000),
+                pool_accounts: accounts,
+                creator: None,
+            }),
+            1,
+        );
+        cache.set_pump_amm_pool_accounts_readiness_authoritative(pool, DexPoolReadiness::Ready);
+        cache.set_pump_amm_sell_layout_ready(&pool, true);
+
+        let before = pump_amm_slave_recovery_snapshot(cache.as_ref(), &pool);
+        let cache_clone = std::sync::Arc::clone(&cache);
+        let new_pre1 = Pubkey::new_unique();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(30));
+            cache_clone.bump_pump_amm_layout_generation(&pool);
+            cache_clone.merge_pump_amm_sell_extended_layout(
+                &pool,
+                true,
+                Some(Pubkey::new_unique()),
+                Some(Pubkey::new_unique()),
+                Some(Pubkey::new_unique()),
+                Some(Pubkey::new_unique()),
+                None,
+                false,
+                true,
+                Some(new_pre1),
+            );
+        });
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let ok = rt.block_on(wait_for_pump_amm_slave_after_recovery(
+            cache.as_ref(),
+            &pool,
+            before,
+            500,
+            10,
+        ));
+        assert!(
+            ok,
+            "layout_generation bump with changed pre_fee must satisfy force-refresh wait even if reserves unchanged"
         );
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -9362,6 +9362,14 @@ async fn handle_ensure_pump_amm_pool_accounts(
             ctx.live_pool_cache
                 .set_pump_amm_pool_accounts_readiness_authoritative(pool_address, dex_readiness);
 
+            let layout_generation = if force_refresh {
+                ctx.live_pool_cache
+                    .bump_pump_amm_layout_generation(&pool_address)
+            } else {
+                ctx.live_pool_cache
+                    .pump_amm_layout_generation(&pool_address)
+            };
+
             // Publish JetStream PoolCacheUpdate (authoritative SSOT).
             // Reply Ok ONLY when JetStream write succeeds (I-24a).
             let jetstream_ok = if let Some(ref nats) = ctx.nats {
@@ -9395,6 +9403,10 @@ async fn handle_ensure_pump_amm_pool_accounts(
                         "true".to_string(),
                     );
                 }
+                meta.insert(
+                    "pump_amm_layout_generation".to_string(),
+                    layout_generation.to_string(),
+                );
                 if requires_fee_tail_merged {
                     meta.insert(
                         "pump_amm_sell_requires_fee_tail".to_string(),

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -460,6 +460,8 @@ pub struct LivePoolCache {
     /// is fully known. `false` means "do not treat this as sell-ready truth yet", even if
     /// pool_accounts/reserves are otherwise present.
     pump_amm_sell_layout_ready_by_market: DashMap<Pubkey, bool>,
+    /// Monotonic layout generation per pool-market (P184h). Incremented on authoritative JetStream merge.
+    pump_amm_layout_generation_by_market: DashMap<Pubkey, u64>,
 }
 
 /// Which vault position (A/B or X/Y or 0/1) this vault represents
@@ -506,6 +508,7 @@ impl LivePoolCache {
             pump_amm_sell_requires_fee_tail_by_market: DashMap::new(),
             pump_amm_sell_requires_pre_fee_metas_by_market: DashMap::new(),
             pump_amm_sell_layout_ready_by_market: DashMap::new(),
+            pump_amm_layout_generation_by_market: DashMap::new(),
         }
     }
 
@@ -934,6 +937,7 @@ impl LivePoolCache {
         pool: &Pubkey,
         meta: Option<&std::collections::HashMap<String, String>>,
     ) {
+        self.merge_pump_amm_layout_generation_from_metadata(pool, meta);
         let Some(m) = meta else {
             return;
         };
@@ -1238,6 +1242,49 @@ impl LivePoolCache {
         self.pump_amm_sell_pre_fee_meta_1_by_market
             .get(pool_market)
             .map(|e| *e.value())
+    }
+
+    /// Monotonic layout generation for PumpSwap pool-market (P184h recovery freshness).
+    #[must_use]
+    pub fn pump_amm_layout_generation(&self, pool_market: &Pubkey) -> u64 {
+        self.pump_amm_layout_generation_by_market
+            .get(pool_market)
+            .map(|e| *e.value())
+            .unwrap_or(0)
+    }
+
+    /// Increment layout generation (authoritative force-refresh publish or JetStream merge).
+    pub fn bump_pump_amm_layout_generation(&self, pool: &Pubkey) -> u64 {
+        let mut entry = self
+            .pump_amm_layout_generation_by_market
+            .entry(*pool)
+            .or_insert(0);
+        *entry += 1;
+        *entry
+    }
+
+    /// Set layout generation from JetStream metadata (monotonic max).
+    pub fn merge_pump_amm_layout_generation_from_metadata(
+        &self,
+        pool: &Pubkey,
+        meta: Option<&std::collections::HashMap<String, String>>,
+    ) {
+        let Some(m) = meta else {
+            return;
+        };
+        let Some(v) = m.get("pump_amm_layout_generation") else {
+            return;
+        };
+        let Ok(parsed) = v.parse::<u64>() else {
+            return;
+        };
+        let mut entry = self
+            .pump_amm_layout_generation_by_market
+            .entry(*pool)
+            .or_insert(0);
+        if parsed > *entry {
+            *entry = parsed;
+        }
     }
 
     #[must_use]

--- a/src/execution/tx_builder.rs
+++ b/src/execution/tx_builder.rs
@@ -5,12 +5,12 @@ use crate::solana::dex::orca::Orca;
 use crate::solana::dex::orca_whirlpool_layout;
 use crate::solana::dex::pumpfun::PumpFunDex;
 use crate::solana::dex::pumpfun_amm::{
-    pump_amm_sell_ix_uses_global_fee_at, PumpAmmPoolAccountsDiagnostic, PumpFunAmmDex,
-    PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR, PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR,
-    PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS, PUMPFUN_AMM_SELL_EXT_TAIL_0_IX,
-    PUMPFUN_AMM_SELL_EXT_TAIL_0_IX_V2, PUMPFUN_AMM_SELL_EXT_TAIL_1_IX,
-    PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2, PUMPFUN_AMM_SELL_EXT_THIRD_META_IX,
-    PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2,
+    pump_amm_resolve_sell_pre_fee_meta_1_for_build, pump_amm_sell_ix_uses_global_fee_at,
+    PumpAmmPoolAccountsDiagnostic, PumpFunAmmDex, PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR,
+    PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR, PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS,
+    PUMPFUN_AMM_SELL_EXT_TAIL_0_IX, PUMPFUN_AMM_SELL_EXT_TAIL_0_IX_V2,
+    PUMPFUN_AMM_SELL_EXT_TAIL_1_IX, PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2,
+    PUMPFUN_AMM_SELL_EXT_THIRD_META_IX, PUMPFUN_AMM_SELL_EXT_THIRD_META_IX_V2,
 };
 use crate::solana::dex::raydium::Raydium;
 use crate::solana::dex::Dex;
@@ -779,7 +779,8 @@ pub async fn build_tx_plan(
         let sell_requires_pre_fee_metas = cache
             .map(|c| c.pump_amm_sell_requires_pre_fee_metas(&pool_id))
             .unwrap_or(false);
-        let sell_pre_fee_meta_1 = cache.and_then(|c| c.pump_amm_sell_pre_fee_meta_1(&pool_id));
+        let cached_sell_pre_fee_meta_1 =
+            cache.and_then(|c| c.pump_amm_sell_pre_fee_meta_1(&pool_id));
 
         let mut pool_accounts_build_source = if accounts_len == 0 {
             "slave_livepoolcache"
@@ -891,6 +892,27 @@ pub async fn build_tx_plan(
             });
         }
 
+        let global_volume_accumulator = pool_accounts
+            .get(11)
+            .copied()
+            .filter(|p| *p != Pubkey::default());
+        let (sell_pre_fee_meta_1, pre_fee_source) = if allow_rpc_fallback
+            && intent.side == TradeSide::Sell
+            && sell_requires_pre_fee_metas
+        {
+            if let Some(gva) = global_volume_accumulator {
+                pump_amm_resolve_sell_pre_fee_meta_1_for_build(
+                    &pool_id,
+                    gva,
+                    cached_sell_pre_fee_meta_1,
+                )
+            } else {
+                (cached_sell_pre_fee_meta_1, "cache_unvalidated")
+            }
+        } else {
+            (cached_sell_pre_fee_meta_1, "cache")
+        };
+
         // Parse token_program from intent for Token-2022 support (same as pumpfun path).
         // TradeResources documents token_program as "output_mint" — on SELL, output is WSOL (SPL Token).
         // Producers may therefore set SPL Token program here even when the *input* (base) mint uses
@@ -956,6 +978,7 @@ pub async fn build_tx_plan(
             } else {
                 None
             },
+            allow_rpc_fallback,
         ) {
             Ok(ixs) => ixs,
             Err(e) => {
@@ -1045,13 +1068,22 @@ pub async fn build_tx_plan(
                             sell_extended_tail_0.filter(|p| *p != Pubkey::default()),
                             sell_extended_tail_1.filter(|p| *p != Pubkey::default()),
                         ) {
-                            (Some(_), Some(_)) if cached_tail_mismatch => "observed_cache_mismatch",
-                            (Some(_), Some(_)) => "observed_cache",
+                            (Some(_), Some(_)) if cached_tail_mismatch => {
+                                if allow_rpc_fallback {
+                                    "derived_wallet_pool"
+                                } else {
+                                    "observed_cache_mismatch"
+                                }
+                            }
+                            (Some(_), Some(_)) => "validated_cache",
                             _ => "derived_or_curated",
                         }
                     } else {
                         "derived_for_intent_user"
                     };
+                let layout_authoritative = sell_requires_pre_fee_metas
+                    && sell_pre_fee_meta_1.is_some()
+                    && sell_extended_fee_tail_0.is_some();
                 let sell_ix_account_count = sell_ix_accounts.len();
                 let (tail0_ix, tail1_ix, tail2_ix) =
                     if sell_ix_account_count == PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS {
@@ -1094,6 +1126,9 @@ pub async fn build_tx_plan(
                         sell_extended = sell_requires_cashback_remaining && intent.side == TradeSide::Sell,
                         sell_cashback_third_meta = ?sell_cashback_third_meta,
                         sell_extended_tail_source = sell_ext_tail_src,
+                        pre_fee_source,
+                        tail_source = sell_ext_tail_src,
+                        layout_authoritative,
                         cached_tail_mismatch,
                         derived_tail_21 = %derived_tail_21,
                         derived_tail_22 = %derived_tail_22,
@@ -1138,6 +1173,9 @@ pub async fn build_tx_plan(
                         sell_extended = sell_requires_cashback_remaining && intent.side == TradeSide::Sell,
                         sell_cashback_third_meta = ?sell_cashback_third_meta,
                         sell_extended_tail_source = sell_ext_tail_src,
+                        pre_fee_source,
+                        tail_source = sell_ext_tail_src,
+                        layout_authoritative,
                         cached_tail_mismatch,
                         derived_tail_21 = %derived_tail_21,
                         derived_tail_22 = %derived_tail_22,
@@ -1911,6 +1949,7 @@ async fn build_hop_pump_amm(
         None,
         if is_sell_hop { sell_fee_t0 } else { None },
         if is_sell_hop { sell_fee_t1 } else { None },
+        false,
     )
     .map_err(|e| UnsupportedTxPlan {
         reason: RejectReason::UnsupportedIntent,

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -911,16 +911,149 @@ fn authoritative_sell_layout_strength(layout: &PumpAmmAuthoritativeSellLayout) -
     }
 }
 
-/// True when the scan can stop early — 27-account extended `sell` with both pre-fee metas.
+/// True when the scan can stop early — strength ≥ 4 **and** layout passes structural validation.
 #[must_use]
 fn authoritative_sell_layout_is_terminal_for_scan(layout: &PumpAmmAuthoritativeSellLayout) -> bool {
     authoritative_sell_layout_strength(layout) >= 4
+        && pump_amm_extended_layout_is_authoritative(layout)
+}
+
+/// Structural validation for extended v2 (27-account) SELL SSOT — Cold Path / force_refresh only.
+///
+/// Does not RPC; checks pre-fee/fee/tail completeness and that pre-fee #0 is the singleton global
+/// volume accumulator. Newest-first scan alone is insufficient for v2 layout (P184h).
+#[must_use]
+fn pump_amm_extended_layout_is_authoritative(layout: &PumpAmmAuthoritativeSellLayout) -> bool {
+    let PumpAmmAuthoritativeSellLayout::Extended {
+        pre_fee_0,
+        pre_fee_1,
+        tail_0,
+        tail_1,
+        tail_2,
+        fee_tail_0,
+        fee_tail_1,
+    } = layout
+    else {
+        return false;
+    };
+    let pre0 = pre_fee_0.filter(|p| *p != Pubkey::default());
+    let pre1 = pre_fee_1.filter(|p| *p != Pubkey::default());
+    let has_pre_fee = pre0.is_some() && pre1.is_some();
+    if !has_pre_fee {
+        return false;
+    }
+    let program_id = match Pubkey::from_str(PUMPFUN_AMM_PROGRAM_ID) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    let global_vol = pump_amm_singleton_global_volume_accumulator(&program_id);
+    let fee_config = Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG).unwrap_or_default();
+    let fee_program = Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).unwrap_or_default();
+    if pre0 != Some(global_vol) {
+        return false;
+    }
+    if pre1 == Some(fee_config) || pre1 == Some(fee_program) {
+        return false;
+    }
+    if *tail_0 == Pubkey::default() || *tail_1 == Pubkey::default() || *tail_2 == Pubkey::default()
+    {
+        return false;
+    }
+    // 27-account v2: single fee tail at ix #26; 26-account uses pair at #24/#25.
+    if fee_tail_0.filter(|p| *p != Pubkey::default()).is_none() {
+        return false;
+    }
+    if fee_tail_1.filter(|p| *p != Pubkey::default()).is_some() {
+        return fee_tail_0.is_some();
+    }
+    true
+}
+
+/// Merge tie-break quality (higher = prefer). Authoritative v2 layouts beat incomplete strength-4 scans.
+#[must_use]
+fn pump_amm_extended_layout_merge_quality(layout: &PumpAmmAuthoritativeSellLayout) -> u8 {
+    if !pump_amm_extended_layout_is_authoritative(layout) {
+        return 0;
+    }
+    let PumpAmmAuthoritativeSellLayout::Extended {
+        fee_tail_0,
+        fee_tail_1,
+        ..
+    } = layout
+    else {
+        return 0;
+    };
+    let mut q = 10u8;
+    if fee_tail_0.filter(|p| *p != Pubkey::default()).is_some() {
+        q += 1;
+    }
+    if fee_tail_1.filter(|p| *p != Pubkey::default()).is_some() {
+        q += 1;
+    }
+    q
+}
+
+/// Whether a cached `sell_pre_fee_meta_1` is structurally consistent with validated v2 layout rules.
+#[must_use]
+pub fn pump_amm_sell_pre_fee_meta_1_is_valid(
+    pre_fee_meta_1: Pubkey,
+    pre_fee_meta_0: Pubkey,
+) -> bool {
+    if pre_fee_meta_1 == Pubkey::default() {
+        return false;
+    }
+    let program_id = match Pubkey::from_str(PUMPFUN_AMM_PROGRAM_ID) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    let global_vol = pump_amm_singleton_global_volume_accumulator(&program_id);
+    let fee_config = Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG).unwrap_or_default();
+    let fee_program = Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).unwrap_or_default();
+    if pre_fee_meta_0 != global_vol {
+        return false;
+    }
+    pre_fee_meta_1 != fee_config && pre_fee_meta_1 != fee_program
+}
+
+/// Pool-scoped volume accumulator for 27-account SELL pre-fee meta #20 (ix index).
+#[must_use]
+pub fn derive_pump_amm_pool_volume_accumulator(
+    program_id: &Pubkey,
+    pool_market: &Pubkey,
+) -> Pubkey {
+    Pubkey::find_program_address(
+        &[b"pool_volume_accumulator", pool_market.as_ref()],
+        program_id,
+    )
+    .0
+}
+
+/// Resolve `sell_pre_fee_meta_1` for cold-path build: validated cache value or pool PDA derivation.
+#[must_use]
+pub fn pump_amm_resolve_sell_pre_fee_meta_1_for_build(
+    pool_market: &Pubkey,
+    global_volume_accumulator: Pubkey,
+    cached_pre_fee_meta_1: Option<Pubkey>,
+) -> (Option<Pubkey>, &'static str) {
+    if let Some(pk) = cached_pre_fee_meta_1.filter(|p| *p != Pubkey::default()) {
+        if pump_amm_sell_pre_fee_meta_1_is_valid(pk, global_volume_accumulator) {
+            return (Some(pk), "validated_cache");
+        }
+    }
+    let program_id = Pubkey::from_str(PUMPFUN_AMM_PROGRAM_ID).expect("PUMPFUN_AMM_PROGRAM_ID");
+    let derived = derive_pump_amm_pool_volume_accumulator(&program_id, pool_market);
+    if pump_amm_sell_pre_fee_meta_1_is_valid(derived, global_volume_accumulator) {
+        (Some(derived), "derived_wallet_pool")
+    } else {
+        (None, "unresolved")
+    }
 }
 
 /// Merge SELL-layout observations while scanning **reverse-chronological** signatures (newest first).
 ///
-/// Prefer the **strongest** layout (27 > 26 > 24 > Base). On equal strength, keep `best` (newer
-/// evidence in newest-first scan). Fee recipient fields follow the winning layout (Scope 60).
+/// Prefer the **strongest** layout (27 > 26 > 24 > Base). On equal strength: **authoritative** v2
+/// layout beats incomplete scans; complete fee tails beat partial; then keep `best` (newer in
+/// newest-first scan). Newest-first alone is not enough for v2 layout (P184h).
 fn merge_pump_amm_authoritative_sell_reference_observation(
     best: PumpAmmSellReferenceObservation,
     candidate: PumpAmmSellReferenceObservation,
@@ -934,6 +1067,22 @@ fn merge_pump_amm_authoritative_sell_reference_observation(
     let best_strength = authoritative_sell_layout_strength(&best.layout);
     let cand_strength = authoritative_sell_layout_strength(&candidate.layout);
     if cand_strength > best_strength {
+        return candidate;
+    }
+    if cand_strength < best_strength {
+        return best;
+    }
+    let best_auth = pump_amm_extended_layout_is_authoritative(&best.layout);
+    let cand_auth = pump_amm_extended_layout_is_authoritative(&candidate.layout);
+    if cand_auth && !best_auth {
+        return candidate;
+    }
+    if best_auth && !cand_auth {
+        return best;
+    }
+    let best_q = pump_amm_extended_layout_merge_quality(&best.layout);
+    let cand_q = pump_amm_extended_layout_merge_quality(&candidate.layout);
+    if cand_q > best_q {
         candidate
     } else {
         best
@@ -990,8 +1139,8 @@ fn pump_amm_stuck_pool_curated_third_meta() -> Option<Pubkey> {
         .filter(|p| *p != Pubkey::default())
 }
 
-/// Cold-path reference `sell` txs known to use the 27-account extended layout (P184e/P184f).
-fn pump_amm_known_v2_sell_reference_signatures(pool_market: &Pubkey) -> &'static [&'static str] {
+/// Cold-path reference txs known to use the 27-account extended layout (P184e/P184f/P184h).
+fn pump_amm_known_v2_reference_signatures(pool_market: &Pubkey) -> &'static [&'static str] {
     if pump_amm_is_stuck_pool_market(pool_market) {
         &[PUMP_AMM_STUCK_POOL_V2_REF_SIG]
     } else {
@@ -1054,7 +1203,9 @@ fn pump_amm_stuck_pool_v2_seed_observation(
     if !pump_amm_is_stuck_pool_market(&pool.pool_market) {
         return None;
     }
-    if authoritative_sell_layout_strength(&obs.layout) >= 4 {
+    if authoritative_sell_layout_strength(&obs.layout) >= 4
+        && pump_amm_extended_layout_is_authoritative(&obs.layout)
+    {
         return None;
     }
     let PumpAmmAuthoritativeSellLayout::Extended {
@@ -1776,7 +1927,7 @@ impl PumpFunAmmDex {
         pool.protocol_fee_recipient_ta = obs.protocol_fee_recipient_ta;
     }
 
-    /// Cold-path only: when TX-history scan found a weaker extended layout, try curated 27-account refs.
+    /// Cold-path only: when TX-history scan found a weaker or invalid extended layout, try curated 27-account refs.
     async fn upgrade_sell_layout_observation_with_known_v2_reference(
         &self,
         pool: &PumpAmmPoolStatic,
@@ -1784,17 +1935,18 @@ impl PumpFunAmmDex {
         mut obs: PumpAmmSellReferenceObservation,
     ) -> PumpAmmSellReferenceObservation {
         let pool_market = pool.pool_market;
-        if authoritative_sell_layout_is_terminal_for_scan(&obs.layout) {
-            return obs;
-        }
+        let scan_authoritative = pump_amm_extended_layout_is_authoritative(&obs.layout);
         let baseline_strength = authoritative_sell_layout_strength(&obs.layout);
-        let curated_sigs = pump_amm_known_v2_sell_reference_signatures(&pool_market);
-        if !curated_sigs.is_empty() {
+        let baseline_quality = pump_amm_extended_layout_merge_quality(&obs.layout);
+        let curated_sigs = pump_amm_known_v2_reference_signatures(&pool_market);
+        if !curated_sigs.is_empty() && (!scan_authoritative || baseline_strength < 4) {
             info!(
                 pool = %pool_market,
                 base_mint = %base_mint,
                 baseline_strength,
+                scan_authoritative,
                 reference_count = curated_sigs.len(),
+                layout_authority_source = "reference",
                 "pump_amm: attempting force_refresh SELL layout upgrade from curated 27-account reference"
             );
         }
@@ -1820,32 +1972,53 @@ impl PumpFunAmmDex {
                 }
             };
             if let Some(ref_obs) = ref_obs {
-                obs = merge_pump_amm_authoritative_sell_reference_observation(obs, ref_obs);
-                if authoritative_sell_layout_strength(&obs.layout) > baseline_strength {
-                    let sell_ix_account_count =
-                        pump_amm_sell_ix_account_count_from_observation(&obs);
-                    info!(
+                let ref_auth = pump_amm_extended_layout_is_authoritative(&ref_obs.layout);
+                let ref_quality = pump_amm_extended_layout_merge_quality(&ref_obs.layout);
+                let ref_strength = authoritative_sell_layout_strength(&ref_obs.layout);
+                let should_apply = ref_auth
+                    && (!scan_authoritative
+                        || ref_quality > baseline_quality
+                        || ref_strength > baseline_strength);
+                if should_apply {
+                    obs = merge_pump_amm_authoritative_sell_reference_observation(obs, ref_obs);
+                    if pump_amm_extended_layout_is_authoritative(&obs.layout) {
+                        let sell_ix_account_count =
+                            pump_amm_sell_ix_account_count_from_observation(&obs);
+                        info!(
+                            pool = %pool_market,
+                            base_mint = %base_mint,
+                            reference_swap_signature = %obs.reference_swap_signature.as_deref().unwrap_or(""),
+                            sell_ix_account_count,
+                            layout = ?obs.layout,
+                            layout_authority_source = "reference",
+                            layout_authoritative = true,
+                            "pump_amm: upgraded force_refresh SELL layout from known 27-account reference tx"
+                        );
+                        return obs;
+                    }
+                } else {
+                    debug!(
                         pool = %pool_market,
-                        base_mint = %base_mint,
-                        reference_swap_signature = %obs.reference_swap_signature.as_deref().unwrap_or(""),
-                        sell_ix_account_count,
-                        layout = ?obs.layout,
-                        "pump_amm: upgraded force_refresh SELL layout from known 27-account reference tx"
+                        reference_swap_signature = %sig,
+                        ref_authoritative = ref_auth,
+                        scan_authoritative,
+                        "pump_amm: curated v2 reference did not beat scan observation quality"
                     );
-                    return obs;
                 }
             }
         }
-        if authoritative_sell_layout_strength(&obs.layout) < 4 {
+        if !pump_amm_extended_layout_is_authoritative(&obs.layout) {
             if let Some(seeded) = pump_amm_stuck_pool_v2_seed_observation(pool, &obs) {
                 obs = merge_pump_amm_authoritative_sell_reference_observation(obs, seeded);
-                if authoritative_sell_layout_strength(&obs.layout) >= 4 {
+                if pump_amm_extended_layout_is_authoritative(&obs.layout) {
                     info!(
                         pool = %pool_market,
                         base_mint = %base_mint,
                         sell_ix_account_count = PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS,
                         sell_pre_fee_meta_1 = %PUMP_AMM_STUCK_POOL_CURATED_PRE_FEE_1,
                         reference_swap_signature = %obs.reference_swap_signature.as_deref().unwrap_or(""),
+                        layout_authority_source = "seed",
+                        layout_authoritative = true,
                         "pump_amm: upgraded force_refresh SELL layout via stuck-pool v2 seed (scan had weaker layout)"
                     );
                     return obs;
@@ -1856,8 +2029,18 @@ impl PumpFunAmmDex {
                     pool = %pool_market,
                     base_mint = %base_mint,
                     baseline_strength,
+                    scan_authoritative,
                     final_strength = authoritative_sell_layout_strength(&obs.layout),
-                    "pump_amm: stuck-pool force_refresh still missing 27-account SELL layout after curated reference and seed"
+                    layout_authoritative = pump_amm_extended_layout_is_authoritative(&obs.layout),
+                    "pump_amm: stuck-pool force_refresh still missing authoritative 27-account SELL layout after curated reference and seed"
+                );
+            } else if !scan_authoritative && authoritative_sell_layout_strength(&obs.layout) >= 4 {
+                warn!(
+                    pool = %pool_market,
+                    base_mint = %base_mint,
+                    layout = ?obs.layout,
+                    layout_authoritative = false,
+                    "pump_amm: force_refresh scan has strength-4 extended layout but failed v2 authority validation"
                 );
             }
         }
@@ -2844,6 +3027,7 @@ impl PumpFunAmmDex {
         sell_extended_fee_tail_1: Option<Pubkey>,
         cached_observed_volume_tail_0: Option<Pubkey>,
         cached_observed_volume_tail_1: Option<Pubkey>,
+        cold_path_prefer_derived_on_mismatch: bool,
     ) -> Result<()> {
         let (derived_vol_wsol_ata, derived_vol) =
             Self::pump_amm_sell_cashback_first_two_metas(user, quote_mint, quote_token_program);
@@ -2859,7 +3043,31 @@ impl PumpFunAmmDex {
             if c0 != derived_vol_wsol_ata || c1 != derived_vol);
         let (user_vol_wsol_ata, user_vol, sell_extended_tail_source) =
             if sell_requires_pre_fee_metas {
-                if let (Some(c0), Some(c1)) = (observed_t0, observed_t1) {
+                if cold_path_prefer_derived_on_mismatch && cached_tail_mismatch {
+                    if let Some((c0, c1)) = curated_tails {
+                        warn!(
+                            intent_user = %user,
+                            sell_extended_tail_source = "reference",
+                            cached_tail_mismatch = true,
+                            sell_requires_pre_fee_metas = true,
+                            "pump_amm SELL: 27-account cold path — cached volume tails mismatch; using curated reference tails"
+                        );
+                        (c0, c1, "reference")
+                    } else {
+                        warn!(
+                            intent_user = %user,
+                            cached_tail_21 = ?observed_t0,
+                            cached_tail_22 = ?observed_t1,
+                            derived_tail_21 = %derived_vol_wsol_ata,
+                            derived_tail_22 = %derived_vol,
+                            sell_extended_tail_source = "derived_wallet_pool",
+                            cached_tail_mismatch = true,
+                            sell_requires_pre_fee_metas = true,
+                            "pump_amm SELL: 27-account cold path — ignoring mismatched cached volume tails; using intent-user derivation"
+                        );
+                        (derived_vol_wsol_ata, derived_vol, "derived_wallet_pool")
+                    }
+                } else if let (Some(c0), Some(c1)) = (observed_t0, observed_t1) {
                     let source = if cached_tail_mismatch {
                         "observed_cache_mismatch"
                     } else {
@@ -6365,6 +6573,7 @@ impl Dex for PumpFunAmmDex {
                     sell_extended_fee_tail_1,
                     cached_observed_volume_tail_0,
                     cached_observed_volume_tail_1,
+                    false,
                 )?;
             }
         }
@@ -6443,6 +6652,7 @@ impl PumpFunAmmDex {
             None,
             None,
             None,
+            false,
         )
     }
 
@@ -6466,6 +6676,7 @@ impl PumpFunAmmDex {
         sell_extended_tail_1: Option<Pubkey>,
         sell_extended_fee_tail_0: Option<Pubkey>,
         sell_extended_fee_tail_1: Option<Pubkey>,
+        cold_path_prefer_derived_on_mismatch: bool,
     ) -> Result<Vec<Instruction>> {
         // Require 14 accounts (v1 format with global_volume_accumulator)
         if pool_accounts.len() < 14 {
@@ -6672,6 +6883,7 @@ impl PumpFunAmmDex {
                     sell_extended_fee_tail_1,
                     sell_extended_tail_0,
                     sell_extended_tail_1,
+                    cold_path_prefer_derived_on_mismatch,
                 )?;
             }
             metas
@@ -7682,6 +7894,7 @@ mod tests {
             None,
             None,
             None,
+            false,
         );
         assert!(
             err.is_err(),
@@ -7828,6 +8041,7 @@ mod tests {
             Some(ref_tail_1),
             None,
             None,
+            false,
         )
         .expect("extended SELL");
 
@@ -8112,6 +8326,7 @@ mod tests {
             Some(foreign_tail_1),
             None,
             None,
+            false,
         )
         .expect("extended SELL");
         let (expected_21, expected_22) =
@@ -8434,6 +8649,7 @@ mod tests {
             Some(tail1),
             Some(fee0),
             Some(fee1),
+            false,
         )
         .expect("27-account SELL");
         assert_eq!(
@@ -8510,6 +8726,7 @@ mod tests {
             None,
             Some(observed0),
             Some(observed1),
+            false,
         )
         .expect("trailing metas");
         assert_eq!(metas.len(), 4);
@@ -8640,6 +8857,7 @@ mod tests {
             Some(tail1),
             Some(fee0),
             None,
+            false,
         )
         .expect("build");
         assert_eq!(
@@ -8654,5 +8872,180 @@ mod tests {
             ixs[0].accounts[PUMPFUN_AMM_SELL_EXT_TAIL_1_IX_V2].pubkey,
             tail1
         );
+    }
+
+    fn p184h_valid_v2_reference_observation() -> PumpAmmSellReferenceObservation {
+        let pre0 = Pubkey::from_str(PUMP_AMM_STUCK_POOL_CURATED_PRE_FEE_0).unwrap();
+        let pre1 = Pubkey::from_str(PUMP_AMM_STUCK_POOL_CURATED_PRE_FEE_1).unwrap();
+        let tail0 = Pubkey::from_str(PUMP_AMM_STUCK_POOL_CURATED_TAIL_0).unwrap();
+        let tail1 = Pubkey::from_str(PUMP_AMM_STUCK_POOL_CURATED_TAIL_1).unwrap();
+        let tail2 = Pubkey::from_str(PUMP_AMM_STUCK_POOL_CURATED_THIRD_META).unwrap();
+        let fee0 = Pubkey::new_unique();
+        PumpAmmSellReferenceObservation {
+            layout: PumpAmmAuthoritativeSellLayout::Extended {
+                pre_fee_0: Some(pre0),
+                pre_fee_1: Some(pre1),
+                tail_0: tail0,
+                tail_1: tail1,
+                tail_2: tail2,
+                fee_tail_0: Some(fee0),
+                fee_tail_1: None,
+            },
+            protocol_fee_recipient: Pubkey::new_unique(),
+            protocol_fee_recipient_ta: Pubkey::new_unique(),
+            reference_swap_signature: Some("sig_ref_valid".to_string()),
+        }
+    }
+
+    /// P184h: invalid strength-4 scan (missing fee tail) loses to valid reference at equal strength.
+    #[test]
+    fn p184h_merge_invalid_scan_loses_to_valid_reference_at_strength_4() {
+        let pre0 = Pubkey::from_str(PUMP_AMM_STUCK_POOL_CURATED_PRE_FEE_0).unwrap();
+        let bad_pre1 = Pubkey::new_unique();
+        let scan_obs = PumpAmmSellReferenceObservation {
+            layout: PumpAmmAuthoritativeSellLayout::Extended {
+                pre_fee_0: Some(pre0),
+                pre_fee_1: Some(bad_pre1),
+                tail_0: Pubkey::new_unique(),
+                tail_1: Pubkey::new_unique(),
+                tail_2: Pubkey::new_unique(),
+                fee_tail_0: None,
+                fee_tail_1: None,
+            },
+            protocol_fee_recipient: Pubkey::new_unique(),
+            protocol_fee_recipient_ta: Pubkey::new_unique(),
+            reference_swap_signature: Some("sig_scan_invalid".to_string()),
+        };
+        let ref_obs = p184h_valid_v2_reference_observation();
+        assert_eq!(authoritative_sell_layout_strength(&scan_obs.layout), 4);
+        assert!(!pump_amm_extended_layout_is_authoritative(&scan_obs.layout));
+        assert!(pump_amm_extended_layout_is_authoritative(&ref_obs.layout));
+        let merged =
+            merge_pump_amm_authoritative_sell_reference_observation(scan_obs, ref_obs.clone());
+        assert!(pump_amm_extended_layout_is_authoritative(&merged.layout));
+        assert_eq!(
+            merged.reference_swap_signature.as_deref(),
+            Some("sig_ref_valid")
+        );
+    }
+
+    /// P184h: strength-4 without fee_tail_0 is not terminal for scan.
+    #[test]
+    fn p184h_strength_4_without_fee_tail_not_terminal_for_scan() {
+        let pre0 = Pubkey::from_str(PUMP_AMM_STUCK_POOL_CURATED_PRE_FEE_0).unwrap();
+        let layout = PumpAmmAuthoritativeSellLayout::Extended {
+            pre_fee_0: Some(pre0),
+            pre_fee_1: Some(Pubkey::new_unique()),
+            tail_0: Pubkey::new_unique(),
+            tail_1: Pubkey::new_unique(),
+            tail_2: Pubkey::new_unique(),
+            fee_tail_0: None,
+            fee_tail_1: None,
+        };
+        assert_eq!(authoritative_sell_layout_strength(&layout), 4);
+        assert!(!authoritative_sell_layout_is_terminal_for_scan(&layout));
+    }
+
+    /// P184h: newest-first fold prefers valid older over invalid newer at strength 4.
+    #[test]
+    fn p184h_fold_newest_invalid_scan_valid_older_reference_wins() {
+        let pre0 = Pubkey::from_str(PUMP_AMM_STUCK_POOL_CURATED_PRE_FEE_0).unwrap();
+        let newer_invalid = PumpAmmSellReferenceObservation {
+            layout: PumpAmmAuthoritativeSellLayout::Extended {
+                pre_fee_0: Some(pre0),
+                pre_fee_1: Some(Pubkey::new_unique()),
+                tail_0: Pubkey::new_unique(),
+                tail_1: Pubkey::new_unique(),
+                tail_2: Pubkey::new_unique(),
+                fee_tail_0: None,
+                fee_tail_1: None,
+            },
+            protocol_fee_recipient: Pubkey::new_unique(),
+            protocol_fee_recipient_ta: Pubkey::new_unique(),
+            reference_swap_signature: Some("sig_newer_invalid".to_string()),
+        };
+        let older_valid = p184h_valid_v2_reference_observation();
+        let folded = fold_force_refresh_sell_reference_observations_newest_first(
+            newer_invalid,
+            [older_valid],
+        );
+        assert!(pump_amm_extended_layout_is_authoritative(&folded.layout));
+        assert_eq!(
+            folded.reference_swap_signature.as_deref(),
+            Some("sig_ref_valid")
+        );
+    }
+
+    /// P184h: cold path must not write mismatched observed tails into 27-account SELL ix.
+    #[test]
+    fn p184h_cold_path_trailing_metas_derived_on_cache_mismatch() {
+        let user = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(WSOL_MINT).unwrap();
+        let quote_tp = Pubkey::new_from_array(spl_token::id().to_bytes());
+        let third = Pubkey::new_unique();
+        let observed0 = Pubkey::from_str(PUMP_AMM_STUCK_POOL_CURATED_TAIL_0).unwrap();
+        let observed1 = Pubkey::from_str(PUMP_AMM_STUCK_POOL_CURATED_TAIL_1).unwrap();
+        let fee_tail0 = Pubkey::new_unique();
+        let (derived0, derived1) =
+            PumpFunAmmDex::pump_amm_sell_cashback_first_two_metas(user, quote_mint, quote_tp);
+        assert_ne!(observed0, derived0);
+        let mut metas = Vec::new();
+        PumpFunAmmDex::push_pump_amm_sell_extended_trailing_metas(
+            &mut metas,
+            *PUMP_AMM_STUCK_POOL_MARKET,
+            user,
+            quote_mint,
+            quote_tp,
+            third,
+            true,
+            Some(fee_tail0),
+            None,
+            Some(observed0),
+            Some(observed1),
+            true,
+        )
+        .expect("trailing metas");
+        assert_eq!(metas[0].pubkey, observed0);
+        assert_eq!(metas[1].pubkey, observed1);
+        let mut metas_cold = Vec::new();
+        PumpFunAmmDex::push_pump_amm_sell_extended_trailing_metas(
+            &mut metas_cold,
+            *PUMP_AMM_STUCK_POOL_MARKET,
+            user,
+            quote_mint,
+            quote_tp,
+            third,
+            true,
+            Some(fee_tail0),
+            None,
+            Some(observed0),
+            Some(observed1),
+            true,
+        )
+        .expect("cold trailing metas");
+        // Stuck pool has curated reference tails matching observed — cold path uses reference.
+        assert_eq!(metas_cold[0].pubkey, observed0);
+        assert_eq!(metas_cold[1].pubkey, observed1);
+
+        let foreign0 = Pubkey::new_unique();
+        let foreign1 = Pubkey::new_unique();
+        let mut metas_foreign = Vec::new();
+        PumpFunAmmDex::push_pump_amm_sell_extended_trailing_metas(
+            &mut metas_foreign,
+            Pubkey::new_unique(),
+            user,
+            quote_mint,
+            quote_tp,
+            third,
+            true,
+            Some(fee_tail0),
+            None,
+            Some(foreign0),
+            Some(foreign1),
+            true,
+        )
+        .expect("foreign cold trailing");
+        assert_eq!(metas_foreign[0].pubkey, derived0);
+        assert_eq!(metas_foreign[1].pubkey, derived1);
     }
 }

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -998,6 +998,7 @@ fn pump_amm_extended_layout_merge_quality(layout: &PumpAmmAuthoritativeSellLayou
 pub fn pump_amm_sell_pre_fee_meta_1_is_valid(
     pre_fee_meta_1: Pubkey,
     pre_fee_meta_0: Pubkey,
+    pool_market: &Pubkey,
 ) -> bool {
     if pre_fee_meta_1 == Pubkey::default() {
         return false;
@@ -1007,12 +1008,10 @@ pub fn pump_amm_sell_pre_fee_meta_1_is_valid(
         Err(_) => return false,
     };
     let global_vol = pump_amm_singleton_global_volume_accumulator(&program_id);
-    let fee_config = Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG).unwrap_or_default();
-    let fee_program = Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).unwrap_or_default();
     if pre_fee_meta_0 != global_vol {
         return false;
     }
-    pre_fee_meta_1 != fee_config && pre_fee_meta_1 != fee_program
+    pre_fee_meta_1 == derive_pump_amm_pool_volume_accumulator(&program_id, pool_market)
 }
 
 /// Pool-scoped volume accumulator for 27-account SELL pre-fee meta #20 (ix index).
@@ -1035,14 +1034,14 @@ pub fn pump_amm_resolve_sell_pre_fee_meta_1_for_build(
     global_volume_accumulator: Pubkey,
     cached_pre_fee_meta_1: Option<Pubkey>,
 ) -> (Option<Pubkey>, &'static str) {
+    let program_id = Pubkey::from_str(PUMPFUN_AMM_PROGRAM_ID).expect("PUMPFUN_AMM_PROGRAM_ID");
+    let derived = derive_pump_amm_pool_volume_accumulator(&program_id, pool_market);
     if let Some(pk) = cached_pre_fee_meta_1.filter(|p| *p != Pubkey::default()) {
-        if pump_amm_sell_pre_fee_meta_1_is_valid(pk, global_volume_accumulator) {
+        if pump_amm_sell_pre_fee_meta_1_is_valid(pk, global_volume_accumulator, pool_market) {
             return (Some(pk), "validated_cache");
         }
     }
-    let program_id = Pubkey::from_str(PUMPFUN_AMM_PROGRAM_ID).expect("PUMPFUN_AMM_PROGRAM_ID");
-    let derived = derive_pump_amm_pool_volume_accumulator(&program_id, pool_market);
-    if pump_amm_sell_pre_fee_meta_1_is_valid(derived, global_volume_accumulator) {
+    if pump_amm_sell_pre_fee_meta_1_is_valid(derived, global_volume_accumulator, pool_market) {
         (Some(derived), "derived_wallet_pool")
     } else {
         (None, "unresolved")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

Prod liquidation on pool `GrgDaBg4…` built a 27-account SELL with wrong `sell_pre_fee_meta_1` from a newest-first TX scan that was treated as **terminal** at strength 4 without structural validation. Curated reference `3XPKr7…` was not applied; cold-path builder wrote mismatched observed volume tails; recovery wait timed out because evidence tuple ignored `pre_fee_meta_1` / `layout_generation`.

## Changes

### `pumpfun_amm.rs`
- `pump_amm_extended_layout_is_authoritative`: validates pre-fee #0 = global volume accumulator, non-default tails, fee_tail_0 present
- `authoritative_sell_layout_is_terminal_for_scan`: requires authoritative layout (not just strength ≥ 4)
- Merge at equal strength: authoritative > incomplete; complete fee tails > partial; then newer-first
- `upgrade_sell_layout_observation_with_known_v2_reference`: no early return on invalid terminal scan; reference wins on higher quality
- Cold-path trailing meta builder flag: on cache mismatch, use derived/reference tails (never `observed_cache_mismatch` in IX)

### `tx_builder.rs` (cold path only, `allow_rpc_fallback=true`)
- Validate / derive `sell_pre_fee_meta_1` via `pump_amm_resolve_sell_pre_fee_meta_1_for_build`
- Pass `cold_path_prefer_derived_on_mismatch` into builder
- Scope44 logs: `pre_fee_source`, `tail_source`, `layout_authoritative`

### `live_pool_cache.rs` + `market_data.rs`
- Monotonic `pump_amm_layout_generation` per pool; bumped on `EnsurePumpAmmPoolAccounts` force_refresh publish
- Published in JetStream metadata; merged monotonically in SLAVE

### `execution_engine.rs`
- Recovery evidence extended with `sell_pre_fee_meta_1` + `layout_generation`
- Fresh wait: explicit-ready AND (evidence changed OR layout_generation increased)

## STOP-CHECK

- I-7: No new RPC in hot path; validation is structural; RPC unchanged in force_refresh cold path only
- I-9: No change to simulation gate
- Level-5: No eval test reads

## Tests

- Merge invalid scan vs valid reference at strength 4
- Terminal gate without fee_tail
- Newest-first fold: valid older beats invalid newer
- Cold-path trailing metas on mismatch
- Recovery wait on layout_generation bump + pre_fee change
- All existing P184b–g tests green

## CI

- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test` ✓
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94be1b7a-cc7c-4a49-952f-5820d50a6e3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94be1b7a-cc7c-4a49-952f-5820d50a6e3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

