### PR TITLE
fix(obs): P172 trades_server tail-read + execution_results segment rotation

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,13 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### P172-TRADES-SERVER-TAIL-JSONL-SEGMENTS: Grafana Timeout on Large execution_results JSONL
+**Datum**: 2026-06-04  
+**Problem** (Prod `ironcrab-prod`): `trades-server` active but `:9899` timed out — single-threaded HTTP blocked on `/pnl_24h` full-file scan. `execution_results-20260604.jsonl` ~103k lines / 109 MB; `load_all_trades([0,1,2])` read every line of three days (~540k lines). Dashboard empty while WORLDCUP-Sell was in logs.  
+**Root Cause**: Daily UTC filename rotation only; no size cap on active segment. `trades_server.py` used `for line in f` (O(n) per file). `metrics.rs` `read_trades_from_jsonl` loaded all lines into `Vec` before tail (unchanged in P172; Python path fixed).  
+**Fix**: (1) `trades_server`: `_iter_jsonl_tail` (reverse chunk read), `IRONCRAB_TRADES_JSONL_TAIL_LINES` default 15000; lookback `[0]` limit / `[0,1]` run+pnl. (2) `JsonlWriter` optional same-day segments for `execution_results` only (default 32 MiB / 50k records → `.2.jsonl`, …). (3) trades_server reads all segments per day with tail per segment.  
+**Dateien**: `scripts/trades_server.py`, `src/storage/jsonl_writer.rs`, `src/bin/execution_engine.rs`, `docs/BUGS_FIXES.md`, `docs/RUNBOOK_PROD.md`
+
 ### P171-TRADES-SERVER-DUPES-UTC-BLOCKTIME: Grafana Duplicate Recent Trades + UTC Date Split
 **Datum**: 2026-05-31  
 **Problem** (Prod `142be782`, Grafana „Recent Trades (Current Run)“): doppelte Zeilen pro `tx_hash` — eine mit leerem `run_id`/null `reason`, eine vollständig; `:9899/trades?mode=run` zeigte 19 Dupes bei ~26 Trades.  

--- a/docs/RUNBOOK_PROD.md
+++ b/docs/RUNBOOK_PROD.md
@@ -145,6 +145,20 @@ journalctl -u execution-engine -n 100 --no-pager
 | execution-engine Metrics | `http://localhost:9804/metrics` | Prometheus |
 | Control Plane API | `http://localhost:8080` | REST API |
 | Trades API | `http://localhost:9899/trades` | Grafana Infinity |
+| Trades health | `http://localhost:9899/health` | Liveness (should stay fast under load; P172 tail-read) |
+
+### trades-server / execution_results JSONL (P172)
+
+`trades-server` tail-reads JSONL (default last **15000** non-empty lines per file). Env on the service unit:
+
+| Variable | Default | Zweck |
+|----------|---------|--------|
+| `IRONCRAB_TRADES_JSONL_TAIL_LINES` | `15000` | Max lines scanned per JSONL file |
+| `IRONCRAB_TRADES_DAYS_LOOKBACK` | (unset) | Override `0` / `0,1` — else limit=`[0]`, run+pnl=`[0,1]` |
+
+`execution-engine` segments same-day `execution_results` when a segment exceeds **32 MiB** or **50_000** records (env `IRONCRAB_EXEC_JSONL_SEGMENT_MAX_MB`, `IRONCRAB_EXEC_JSONL_SEGMENT_MAX_RECORDS`). Files: `execution_results-YYYYMMDD.jsonl`, `.2.jsonl`, … Forensic archives under `trade_logs/executions/` are not trimmed by rotation.
+
+Smoke after deploy: `time curl -s http://127.0.0.1:9899/trades?mode=run | jq length` and `curl -s http://127.0.0.1:9899/health`.
 
 ### Geyser / market-data Metriken (PR #143)
 

--- a/scripts/trades_server.py
+++ b/scripts/trades_server.py
@@ -4,7 +4,13 @@ Simple HTTP server that serves trade data from JSONL execution_results files.
 Run this separately from the bot to keep trade history available even when bot is stopped.
 
 Reads from: trade_logs/executions/execution_results-YYYYMMDD.jsonl
+(and optional same-day segments execution_results-YYYYMMDD.2.jsonl, .3.jsonl, …)
 Grafana Infinity data source connects to this for "Recent Trades" table panel.
+
+Tail-read (P172): only the last N lines per file are scanned (not full-file O(n) loads).
+Env:
+  IRONCRAB_TRADES_JSONL_TAIL_LINES — max non-empty lines per file (default 15000)
+  IRONCRAB_TRADES_DAYS_LOOKBACK — optional override; endpoints use [0], [0,1], or [0,1] for pnl
 
 `timestamp_ms` on each trade is the on-chain block time (UTC) when `block_time_unix_ms`
 is present on the JSONL record; otherwise confirm wall-clock (`ts_unix_ms` / legacy).
@@ -20,9 +26,12 @@ Query params (GET /trades):
 import http.server
 import json
 import os
+import re
+import tempfile
+from collections import deque
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import List, Optional
+from typing import Iterator, List, Optional
 from urllib.parse import urlparse, parse_qs
 import argparse
 
@@ -33,6 +42,33 @@ DECISIONS_DIR = Path(EXEC_LOG_DIR) / "decisions"
 RECENT_TRADES_DIR = Path(
     os.environ.get("IRONCRAB_TRADE_LOG_DIR", "trade_logs")
 )
+
+_SEGMENT_SUFFIX_RE = re.compile(r"\.(\d+)\.jsonl$")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return int(raw)
+
+
+# P172: cap lines read per JSONL file (execution_results can exceed 100k lines/day).
+JSONL_TAIL_LINES = max(1, _env_int("IRONCRAB_TRADES_JSONL_TAIL_LINES", 15000))
+# Optional global override; per-endpoint defaults apply when unset.
+DAYS_LOOKBACK_OVERRIDE: Optional[List[int]] = None
+_raw_lookback = os.environ.get("IRONCRAB_TRADES_DAYS_LOOKBACK", "").strip()
+if _raw_lookback:
+    DAYS_LOOKBACK_OVERRIDE = [int(x.strip()) for x in _raw_lookback.split(",") if x.strip() != ""]
+
+
+def _days_for_endpoint(endpoint: str) -> List[int]:
+    """Lookback UTC days: limit=[0], run/pnl=[0,1] unless env override."""
+    if DAYS_LOOKBACK_OVERRIDE is not None:
+        return DAYS_LOOKBACK_OVERRIDE
+    if endpoint == "limit":
+        return [0]
+    return [0, 1]
 
 
 def _utc_date_str(days_ago: int) -> str:
@@ -50,6 +86,66 @@ def _trade_record_score(trade: dict) -> int:
     if trade.get("wallet_sol_delta") is not None:
         score += 1
     return score
+
+
+def _iter_jsonl_tail(path: Path, max_lines: int) -> Iterator[str]:
+    """Yield up to max_lines non-empty lines from the end of path (oldest-first within tail).
+
+    Does not load the full file into RAM. Reads backwards in fixed-size chunks from EOF.
+    """
+    if max_lines <= 0 or not path.is_file():
+        return iter(())
+
+    chunk_size = 64 * 1024
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return iter(())
+    if size == 0:
+        return iter(())
+
+    collected: deque[bytes] = deque(maxlen=max_lines)
+    with open(path, "rb") as f:
+        pos = size
+        carry = b""
+        while pos > 0 and len(collected) < max_lines:
+            read_len = min(chunk_size, pos)
+            pos -= read_len
+            f.seek(pos)
+            chunk = f.read(read_len) + carry
+            parts = chunk.split(b"\n")
+            carry = parts[0]
+            for part in reversed(parts[1:]):
+                if not part.strip():
+                    continue
+                collected.appendleft(part)
+                if len(collected) >= max_lines:
+                    break
+        if len(collected) < max_lines and carry.strip():
+            collected.appendleft(carry)
+
+    def _decode_line(raw: bytes) -> str:
+        return raw.decode("utf-8", errors="replace")
+
+    return (_decode_line(b) for b in collected)
+
+
+def _jsonl_segment_paths(directory: Path, prefix: str, date: str) -> List[Path]:
+    """All JSONL segments for one UTC day, chronological (base, .2, .3, …)."""
+    base = directory / f"{prefix}-{date}.jsonl"
+    numbered: List[tuple[int, Path]] = []
+    for path in directory.glob(f"{prefix}-{date}.*.jsonl"):
+        if path == base:
+            continue
+        m = _SEGMENT_SUFFIX_RE.search(path.name)
+        if m:
+            numbered.append((int(m.group(1)), path))
+    numbered.sort(key=lambda item: item[0])
+    segments: List[Path] = []
+    if base.is_file():
+        segments.append(base)
+    segments.extend(p for _, p in numbered)
+    return segments
 
 
 def _effective_timestamp_ms_from_record(record: dict) -> int:
@@ -158,7 +254,7 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
     
     def read_recent_trades(self, limit: int) -> list:
         """Read last N trades from execution_results JSONL (fallback: recent_trades JSONL)."""
-        trades = self.load_all_trades(days_ago_list=[0, 1, 2])
+        trades = self.load_all_trades(days_ago_list=_days_for_endpoint("limit"))
 
         # Compute running PnL.
         #
@@ -228,7 +324,7 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
         belonging to that run, plus up to 20 trades from the most recent
         previous run (for context). PnL calculation covers all returned trades.
         """
-        all_trades = self.load_all_trades(days_ago_list=[0, 1, 2])
+        all_trades = self.load_all_trades(days_ago_list=_days_for_endpoint("run"))
 
         if not all_trades:
             return []
@@ -351,7 +447,7 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
             (datetime.now(timezone.utc) - timedelta(hours=24)).timestamp() * 1000
         )
 
-        all_trades = self.load_all_trades(days_ago_list=[0, 1, 2])
+        all_trades = self.load_all_trades(days_ago_list=_days_for_endpoint("pnl"))
 
         if not all_trades:
             return {"realized_pnl_sol": 0.0, "trade_count": 0, "wins": 0, "losses": 0}
@@ -478,7 +574,7 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
     def load_all_trades(self, days_ago_list: Optional[List[int]] = None) -> list:
         """Load confirmed trades from execution_results; fallback to recent_trades JSONL (P166)."""
         if days_ago_list is None:
-            days_ago_list = [0, 1, 2]
+            days_ago_list = _days_for_endpoint("limit")
         trades = []
         used_fallback = False
         for days_ago in days_ago_list:
@@ -549,14 +645,9 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
         trades = []
         for days_ago in days_ago_list:
             date = _utc_date_str(days_ago)
-            jsonl_path = EXECUTIONS_DIR / f"execution_results-{date}.jsonl"
-            if not jsonl_path.exists():
-                continue
-            try:
-                with open(jsonl_path, "r") as f:
-                    for line in f:
-                        if not line.strip():
-                            continue
+            for jsonl_path in _jsonl_segment_paths(EXECUTIONS_DIR, "execution_results", date):
+                try:
+                    for line in _iter_jsonl_tail(jsonl_path, JSONL_TAIL_LINES):
                         try:
                             record = json.loads(line)
                             status = str(record.get("status") or "").lower()
@@ -566,8 +657,8 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
                                     trades.append(trade)
                         except json.JSONDecodeError:
                             continue
-            except Exception as e:
-                print(f"Error reading {jsonl_path}: {e}")
+                except Exception as e:
+                    print(f"Error reading {jsonl_path}: {e}")
         return trades
 
     def _load_trades_from_recent_jsonl(self, days_ago_list: list) -> list:
@@ -576,20 +667,17 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
         for days_ago in days_ago_list:
             date = _utc_date_str(days_ago)
             jsonl_path = RECENT_TRADES_DIR / f"recent_trades-{date}.jsonl"
-            if not jsonl_path.exists():
+            if not jsonl_path.is_file():
                 continue
             try:
-                with open(jsonl_path, "r") as f:
-                    for line in f:
-                        if not line.strip():
-                            continue
-                        try:
-                            record = json.loads(line)
-                            trade = self.parse_recent_trade(record)
-                            if trade:
-                                trades.append(trade)
-                        except json.JSONDecodeError:
-                            continue
+                for line in _iter_jsonl_tail(jsonl_path, JSONL_TAIL_LINES):
+                    try:
+                        record = json.loads(line)
+                        trade = self.parse_recent_trade(record)
+                        if trade:
+                            trades.append(trade)
+                    except json.JSONDecodeError:
+                        continue
             except Exception as e:
                 print(f"Error reading {jsonl_path}: {e}")
         return trades
@@ -992,6 +1080,34 @@ def _self_check():
         }
     )
     assert parsed and parsed["action"] == "BUY" and parsed["mint_full"]
+
+    # P172: tail-read returns the last line of a large synthetic file without full scan in RAM.
+    with tempfile.TemporaryDirectory() as tmp:
+        big = Path(tmp) / "execution_results-test.jsonl"
+        line_count = 100_000
+        with open(big, "w", encoding="utf-8") as f:
+            for i in range(line_count - 1):
+                f.write(json.dumps({"n": i}) + "\n")
+            f.write(json.dumps({"status": "confirmed", "marker": "tail"}) + "\n")
+        tail_lines = list(_iter_jsonl_tail(big, 5))
+        assert len(tail_lines) == 5
+        last = json.loads(tail_lines[-1])
+        assert last.get("marker") == "tail"
+
+        seg_dir = Path(tmp) / "executions"
+        seg_dir.mkdir()
+        base_seg = seg_dir / "execution_results-20990101.jsonl"
+        base_seg.write_text('{"status":"confirmed","intent_id":"old"}\n', encoding="utf-8")
+        seg2 = seg_dir / "execution_results-20990101.2.jsonl"
+        seg2.write_text(
+            '{"status":"confirmed","intent_id":"arb-3","signature":"s",'
+            '"fill_in":{"raw":0,"decimals":9},"fill_out":{"raw":0,"decimals":6},'
+            '"source":"arb-strategy"}\n',
+            encoding="utf-8",
+        )
+        paths = _jsonl_segment_paths(seg_dir, "execution_results", "20990101")
+        assert paths == [base_seg, seg2]
+
     print("trades_server: self-check OK")
 
 

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -117,7 +117,7 @@ use ironcrab::solana::token_utils::get_token_decimals_or_default;
 use ironcrab::solana::tx_sender::TxSender;
 use ironcrab::storage::{
     locks::{LockHolder, LockManager, LockResult, ResourceType},
-    JsonlWriter, JsonlWriterConfig,
+    JsonlWriter, JsonlWriterConfig, SegmentRotationLimits,
 };
 use ironcrab::wallet::Treasury;
 use parking_lot::Mutex as ParkingMutex;
@@ -6714,9 +6714,11 @@ async fn main() -> Result<()> {
         .with_flush_each_write(true);
     let decision_writer = JsonlWriter::new(decision_config)?;
 
+    // P172: same-day segment rotation so a single UTC file cannot grow unbounded (Grafana tail-read).
     let execution_config = JsonlWriterConfig::new("execution_results")
         .with_log_dir(log_base.join("executions"))
-        .with_flush_each_write(true);
+        .with_flush_each_write(true)
+        .with_segment_rotation(SegmentRotationLimits::execution_results_from_env());
     let execution_writer = JsonlWriter::new(execution_config)?;
 
     let burn_config = JsonlWriterConfig::new("burn_ops").with_log_dir(log_base.join("burns"));

--- a/src/storage/jsonl_writer.rs
+++ b/src/storage/jsonl_writer.rs
@@ -20,6 +20,42 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 use tracing::{debug, error, warn};
 
+/// Size/record caps for same-day JSONL segments (P172: execution_results only).
+#[derive(Debug, Clone, Copy)]
+pub struct SegmentRotationLimits {
+    /// Rotate when current segment file size reaches this (bytes). 0 = disabled.
+    pub max_bytes: u64,
+    /// Rotate when this many records were written to the current segment. 0 = disabled.
+    pub max_records: u64,
+}
+
+impl SegmentRotationLimits {
+    /// Defaults: 32 MiB and 50_000 records (`IRONCRAB_EXEC_JSONL_SEGMENT_MAX_*` env).
+    pub fn execution_results_from_env() -> Self {
+        let max_mb: u64 = std::env::var("IRONCRAB_EXEC_JSONL_SEGMENT_MAX_MB")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(32);
+        let max_records: u64 = std::env::var("IRONCRAB_EXEC_JSONL_SEGMENT_MAX_RECORDS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(50_000);
+        Self {
+            max_bytes: max_mb.saturating_mul(1024 * 1024),
+            max_records,
+        }
+    }
+
+    fn should_rotate(&self, segment_bytes: u64, segment_records: u64) -> bool {
+        (self.max_bytes > 0 && segment_bytes >= self.max_bytes)
+            || (self.max_records > 0 && segment_records >= self.max_records)
+    }
+
+    fn file_exceeds_cap(&self, file_len: u64) -> bool {
+        self.max_bytes > 0 && file_len >= self.max_bytes
+    }
+}
+
 /// Configuration for JSONL writer
 ///
 /// All defaults documented (DoD K) P0: No hidden defaults).
@@ -33,6 +69,8 @@ pub struct JsonlWriterConfig {
     pub buffer_size: usize,
     /// Flush after each write (safer but slower). Default: false
     pub flush_each_write: bool,
+    /// Same-day segment rotation when file grows too large (optional; P172 execution_results).
+    pub segment_rotation: Option<SegmentRotationLimits>,
 }
 
 impl Default for JsonlWriterConfig {
@@ -44,6 +82,7 @@ impl Default for JsonlWriterConfig {
             prefix: "records".to_string(),
             buffer_size: 8192,       // 8KB buffer
             flush_each_write: false, // batch writes for performance
+            segment_rotation: None,
         }
     }
 }
@@ -65,6 +104,41 @@ impl JsonlWriterConfig {
         self.flush_each_write = flush;
         self
     }
+
+    /// Enable same-day segment files `{prefix}-YYYYMMDD.jsonl`, `.2.jsonl`, … when caps are hit.
+    pub fn with_segment_rotation(mut self, limits: SegmentRotationLimits) -> Self {
+        self.segment_rotation = Some(limits);
+        self
+    }
+}
+
+fn segment_filename(prefix: &str, date: &str, segment_index: u32) -> String {
+    if segment_index <= 1 {
+        format!("{prefix}-{date}.jsonl")
+    } else {
+        format!("{prefix}-{date}.{segment_index}.jsonl")
+    }
+}
+
+fn resolve_append_segment(
+    log_dir: &Path,
+    prefix: &str,
+    date: &str,
+    limits: &SegmentRotationLimits,
+) -> u32 {
+    let mut idx = 1u32;
+    loop {
+        let path = log_dir.join(segment_filename(prefix, date, idx));
+        if !path.exists() {
+            return idx;
+        }
+        let len = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        if limits.file_exceeds_cap(len) {
+            idx += 1;
+            continue;
+        }
+        return idx;
+    }
 }
 
 /// Thread-safe append-only JSONL writer with daily rotation
@@ -77,6 +151,9 @@ struct WriterState {
     writer: Option<BufWriter<File>>,
     current_date: Option<String>,
     current_path: Option<PathBuf>,
+    segment_index: u32,
+    segment_records: u64,
+    segment_bytes: u64,
     records_written: u64,
     bytes_written: u64,
 }
@@ -93,6 +170,9 @@ impl JsonlWriter {
                 writer: None,
                 current_date: None,
                 current_path: None,
+                segment_index: 1,
+                segment_records: 0,
+                segment_bytes: 0,
                 records_written: 0,
                 bytes_written: 0,
             }),
@@ -117,7 +197,7 @@ impl JsonlWriter {
 
         let today = Utc::now().format("%Y%m%d").to_string();
         if state.current_date.as_ref() != Some(&today) {
-            self.rotate_locked(&mut state, &today)?;
+            self.open_day_locked(&mut state, &today)?;
         }
 
         if let Some(writer) = state.writer.as_mut() {
@@ -129,8 +209,17 @@ impl JsonlWriter {
                 writer.flush()?;
             }
         }
+        let line_len = json.len() as u64 + 1;
         state.records_written += 1;
-        state.bytes_written += json.len() as u64 + 1;
+        state.bytes_written += line_len;
+        state.segment_records += 1;
+        state.segment_bytes += line_len;
+
+        if let Some(limits) = self.config.segment_rotation {
+            if limits.should_rotate(state.segment_bytes, state.segment_records) {
+                self.rotate_segment_locked(&mut state, &today)?;
+            }
+        }
 
         Ok(())
     }
@@ -165,25 +254,56 @@ impl JsonlWriter {
         (state.records_written, state.bytes_written)
     }
 
-    fn rotate_locked(&self, state: &mut WriterState, date: &str) -> std::io::Result<()> {
+    fn open_day_locked(&self, state: &mut WriterState, date: &str) -> std::io::Result<()> {
         if let Some(mut writer) = state.writer.take() {
             writer.flush()?;
         }
 
-        let filename = format!("{}-{}.jsonl", self.config.prefix, date);
+        state.segment_index = if let Some(limits) = self.config.segment_rotation {
+            resolve_append_segment(&self.config.log_dir, &self.config.prefix, date, &limits)
+        } else {
+            1
+        };
+        state.segment_records = 0;
+        state.segment_bytes = 0;
+        self.open_segment_locked(state, date, state.segment_index)
+    }
+
+    fn rotate_segment_locked(&self, state: &mut WriterState, date: &str) -> std::io::Result<()> {
+        if let Some(mut writer) = state.writer.take() {
+            writer.flush()?;
+        }
+        state.segment_index = state.segment_index.saturating_add(1);
+        state.segment_records = 0;
+        state.segment_bytes = 0;
+        self.open_segment_locked(state, date, state.segment_index)
+    }
+
+    fn open_segment_locked(
+        &self,
+        state: &mut WriterState,
+        date: &str,
+        segment_index: u32,
+    ) -> std::io::Result<()> {
+        let filename = segment_filename(&self.config.prefix, date, segment_index);
         let path = self.config.log_dir.join(&filename);
 
         debug!(
             prefix = %self.config.prefix,
             path = %path.display(),
-            "Rotating JSONL writer to new file"
+            segment_index,
+            "Opening JSONL segment"
         );
 
+        let existing_len = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
         let file = OpenOptions::new().create(true).append(true).open(&path)?;
 
         state.writer = Some(BufWriter::with_capacity(self.config.buffer_size, file));
         state.current_date = Some(date.to_string());
         state.current_path = Some(path);
+        state.segment_index = segment_index;
+        state.segment_bytes = existing_len;
+        // segment_records stays 0 on reopen; byte cap still protects across restarts.
 
         Ok(())
     }
@@ -522,6 +642,44 @@ mod tests {
             size_after_write > 0,
             "dev/test build: write() must flush for test harness disk visibility"
         );
+    }
+
+    #[test]
+    fn test_execution_results_segment_rotation_by_record_cap() {
+        let dir = tempdir().unwrap();
+        let limits = SegmentRotationLimits {
+            max_bytes: 0,
+            max_records: 3,
+        };
+        let config = JsonlWriterConfig::new("execution_results")
+            .with_log_dir(dir.path())
+            .with_flush_each_write(true)
+            .with_segment_rotation(limits);
+
+        let writer = JsonlWriter::new(config).unwrap();
+        for i in 0..5 {
+            writer
+                .write(&TestRecord {
+                    id: format!("r{i}"),
+                    value: i,
+                })
+                .unwrap();
+        }
+        writer.flush().unwrap();
+
+        let today = Utc::now().format("%Y%m%d").to_string();
+        let seg1 = dir.path().join(format!("execution_results-{today}.jsonl"));
+        let seg2 = dir
+            .path()
+            .join(format!("execution_results-{today}.2.jsonl"));
+        assert!(seg1.exists());
+        assert!(seg2.exists());
+        let content1 = fs::read_to_string(&seg1).unwrap();
+        let content2 = fs::read_to_string(&seg2).unwrap();
+        let lines1: Vec<_> = content1.lines().collect();
+        let lines2: Vec<_> = content2.lines().collect();
+        assert_eq!(lines1.len(), 3);
+        assert_eq!(lines2.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **trades_server**: tail-read from EOF (chunked), env caps, lookback `[0]` / `[0,1]` per endpoint, multi-segment JSONL per day
- **JsonlWriter**: same-day segment rotation for `execution_results` only (32 MiB / 50k records)
- Docs: BUGS_FIXES P172, RUNBOOK env + smoke curl

## Prod context
Grafana Recent Trades timed out when `execution_results` grew to 100k+ lines/day; trades-server scanned full files for 3 UTC days.

## Test plan
- [x] `python3 scripts/trades_server.py --self-check`
- [x] `cargo fmt --check`, `cargo clippy`, `cargo test`
- [ ] After deploy: `curl :9899/health` and `curl :9899/trades?mode=run`
