### PR TITLE
fix(arbitrage): multi-hop shadow profit sanity + return_bps overflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,3 +179,8 @@ path = "src/bin/burn_manual_keyless.rs"
 name = "manual-swap"
 path = "src/bin/manual_swap.rs"
 
+[[test]]
+name = "multi_hop_sanity"
+path = "tests/multi_hop_sanity.rs"
+required-features = ["test_helpers"]
+

--- a/docs/MULTI_HOP_ARBITRAGE.md
+++ b/docs/MULTI_HOP_ARBITRAGE.md
@@ -35,6 +35,19 @@ Das Design wurde von einem Senior-Reviewer analysiert. **Gesamturteil: Realistis
 - Early `best_profit` seeding aus 2-Hop Scan
 - `edge_count` Tracking korrigieren (Metrics)
 
+### Profit / `return_bps` Sanity (Shadow-Mode, 2026-06)
+
+Shadow-Mode loggt Zyklen zur Prod-Validierung. Ohne Caps explodieren kumulative `edge_ratio`-Produkte und `estimated_return_bps` kann `i32::MAX` werden (kein interpretierbares Signal).
+
+| Konstante | Wert | Semantik |
+|-----------|------|----------|
+| `MIN_EDGE_RATIO` / `MAX_EDGE_RATIO` | 0.01 / 1.05 | Per-Hop Clamp auf Probe-Quote |
+| `MAX_CYCLE_PROFIT_MULTIPLIER` | 10.0 | Cumulative profit cap während Beam-Search |
+| `MIN_RETURN_BPS` / `MAX_RETURN_BPS` | −10_000 / 50_000 | −100% .. +500% ROI-Schätzung |
+| `is_trustworthy_profit_estimate()` | — | `false` bei Cap/Saturierung → nicht „profitable“, kein Intent |
+
+Prometheus (arb-strategy :9803): `multi_hop_return_bps_saturated_total`, `multi_hop_cycle_rejected_sanity_total{reason=edge_ratio|profit_cap|return_bps_cap}`, `multi_hop_hop_missing_quote_total`, `multi_hop_shadow_logged_total`.
+
 ## Motivation
 
 Aktuell: 2-Hop Arbitrage (WSOL → Token → WSOL auf verschiedenen DEXes)

--- a/src/arbitrage/mod.rs
+++ b/src/arbitrage/mod.rs
@@ -40,7 +40,11 @@ pub use multi_hop_integration::{
 };
 pub use pool_graph::{GraphStats, PoolGraph};
 pub use pool_ranker::{PoolRanker, QuoteProvider, RankerConfig};
-pub use types::{ArbCycle, DexType, ParseDexTypeError, PoolEdge, RankedPool, SearchNode};
+pub use types::{
+    clamp_edge_ratio, profit_to_return_bps, ArbCycle, DexType, ParseDexTypeError, PoolEdge,
+    RankedPool, SearchNode, MAX_CYCLE_PROFIT_MULTIPLIER, MAX_EDGE_RATIO, MAX_RETURN_BPS,
+    MIN_EDGE_RATIO, MIN_RETURN_BPS,
+};
 
 #[cfg(any(test, feature = "test_helpers"))]
 pub use pool_ranker::MockQuoteProvider;

--- a/src/arbitrage/multi_hop_integration.rs
+++ b/src/arbitrage/multi_hop_integration.rs
@@ -188,6 +188,23 @@ impl QuoteProvider for CachedQuoteProvider {
             .get(&(*pool_address, *input_mint, *output_mint))
             .is_some_and(|(_, ts)| ts.elapsed() < self.cache_ttl)
     }
+
+    fn get_cached_probe_quote(
+        &self,
+        pool_address: &Pubkey,
+        _dex: DexType,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+        amount_in: u64,
+    ) -> Option<u64> {
+        let cache = self.cache.read();
+        let (cached_output, ts) = cache.get(&(*pool_address, *input_mint, *output_mint))?;
+        if ts.elapsed() >= self.cache_ttl {
+            return None;
+        }
+        let probe = 10_000_000u64;
+        Some((*cached_output as u128 * amount_in as u128 / probe as u128) as u64)
+    }
 }
 
 /// Token search state for cooldown tracking
@@ -681,6 +698,17 @@ impl QuoteProvider for Arc<CachedQuoteProvider> {
         output_mint: &Pubkey,
     ) -> bool {
         (**self).has_cached_quote(pool_address, input_mint, output_mint)
+    }
+
+    fn get_cached_probe_quote(
+        &self,
+        pool_address: &Pubkey,
+        dex: DexType,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+        amount_in: u64,
+    ) -> Option<u64> {
+        (**self).get_cached_probe_quote(pool_address, dex, input_mint, output_mint, amount_in)
     }
 }
 

--- a/src/arbitrage/multi_hop_integration.rs
+++ b/src/arbitrage/multi_hop_integration.rs
@@ -13,11 +13,15 @@
 
 use crate::arbitrage::{
     ArbCycle, BeamCycleFinder, CycleFinderConfig, DexType, PoolEdge, PoolGraph, PoolRanker,
-    QuoteProvider, RankerConfig,
+    QuoteProvider, RankerConfig, MAX_RETURN_BPS,
 };
 use crate::ipc::{
     ExplicitAmount, IntentOrigin, IntentTier, PoolAlternative, RecordHeader, SwapHop, TradeIntent,
     TradeResources, TradeSide, TradingRegime,
+};
+use crate::metrics::{
+    multi_hop_cycle_rejected_sanity_inc, multi_hop_return_bps_saturated_inc,
+    multi_hop_shadow_logged_inc, MultiHopSanityRejectReason,
 };
 use parking_lot::RwLock;
 use solana_sdk::pubkey::Pubkey;
@@ -169,8 +173,20 @@ impl QuoteProvider for CachedQuoteProvider {
             }
         }
 
-        // No cached quote - return conservative estimate
+        // No cached quote - return conservative estimate (ranker skips via has_cached_quote)
         Some((amount_in as f64 * self.default_edge_ratio) as u64)
+    }
+
+    fn has_cached_quote(
+        &self,
+        pool_address: &Pubkey,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+    ) -> bool {
+        let cache = self.cache.read();
+        cache
+            .get(&(*pool_address, *input_mint, *output_mint))
+            .is_some_and(|(_, ts)| ts.elapsed() < self.cache_ttl)
     }
 }
 
@@ -433,10 +449,27 @@ impl MultiHopArbitrage {
         self.cycles_found
             .fetch_add(cycles.len() as u64, Ordering::Relaxed);
 
-        // Filter profitable
+        // Filter: trustworthy profit estimate + min threshold
         let profitable: Vec<_> = cycles
             .into_iter()
-            .filter(|c| c.estimated_return_bps >= config.min_profit_bps)
+            .filter(|c| {
+                if !c.is_trustworthy_profit_estimate() {
+                    if c.return_bps_saturated {
+                        multi_hop_return_bps_saturated_inc();
+                        multi_hop_cycle_rejected_sanity_inc(
+                            MultiHopSanityRejectReason::ReturnBpsCap,
+                        );
+                    }
+                    if c.profit_multiplier_capped {
+                        multi_hop_cycle_rejected_sanity_inc(MultiHopSanityRejectReason::ProfitCap);
+                    }
+                    if c.edge_ratio_clamped {
+                        multi_hop_cycle_rejected_sanity_inc(MultiHopSanityRejectReason::EdgeRatio);
+                    }
+                    return false;
+                }
+                c.estimated_return_bps >= config.min_profit_bps
+            })
             .collect();
 
         self.cycles_profitable
@@ -459,9 +492,13 @@ impl MultiHopArbitrage {
         // Shadow mode: log but don't generate intents
         if config.shadow_mode {
             for (i, cycle) in profitable.iter().enumerate() {
+                multi_hop_shadow_logged_inc();
+                let near_cap = cycle.estimated_return_bps > MAX_RETURN_BPS.saturating_sub(500);
                 info!(
                     rank = i + 1,
                     return_bps = cycle.estimated_return_bps,
+                    return_bps_capped = false,
+                    sanity_flags = if near_cap { "near_return_cap" } else { "" },
                     hops = cycle.hop_count(),
                     min_liquidity = cycle.min_liquidity_usd,
                     path = ?cycle.path.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
@@ -635,6 +672,15 @@ impl QuoteProvider for Arc<CachedQuoteProvider> {
         amount_in: u64,
     ) -> Option<u64> {
         (**self).get_quote(pool_address, dex, input_mint, output_mint, amount_in)
+    }
+
+    fn has_cached_quote(
+        &self,
+        pool_address: &Pubkey,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+    ) -> bool {
+        (**self).has_cached_quote(pool_address, input_mint, output_mint)
     }
 }
 

--- a/src/arbitrage/pool_ranker.rs
+++ b/src/arbitrage/pool_ranker.rs
@@ -76,6 +76,22 @@ pub trait QuoteProvider: Send + Sync {
     ) -> bool {
         true
     }
+
+    /// Fresh cached probe quote, or `None` if missing/stale.
+    /// Default uses separate cache checks (fine for mocks); TTL caches should override.
+    fn get_cached_probe_quote(
+        &self,
+        pool_address: &Pubkey,
+        dex: DexType,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+        amount_in: u64,
+    ) -> Option<u64> {
+        if !self.has_cached_quote(pool_address, input_mint, output_mint) {
+            return None;
+        }
+        self.get_quote(pool_address, dex, input_mint, output_mint, amount_in)
+    }
 }
 
 /// Pool ranker that pre-computes edge ratios using probe quotes
@@ -121,7 +137,7 @@ impl<Q: QuoteProvider> PoolRanker<Q> {
             for edge in pools {
                 if let Some(ranked) = self.rank_single_pool(&edge, input_mint, &output_mint) {
                     // Track max edge ratio for upper bound pruning
-                    max_edge_updates.push((*input_mint, ranked.edge_ratio));
+                    max_edge_updates.push((*input_mint, clamp_edge_ratio(ranked.edge_ratio)));
                     ranked_pools.push(ranked);
                 }
             }
@@ -160,26 +176,19 @@ impl<Q: QuoteProvider> PoolRanker<Q> {
         input_mint: &Pubkey,
         output_mint: &Pubkey,
     ) -> Option<RankedPool> {
-        if !self
-            .quote_provider
-            .has_cached_quote(&edge.pool_address, input_mint, output_mint)
-        {
-            crate::metrics::multi_hop_hop_missing_quote_inc();
-            return None;
-        }
-
-        // Get probe quote
-        let quote_out = self.quote_provider.get_quote(
+        let Some(quote_out) = self.quote_provider.get_cached_probe_quote(
             &edge.pool_address,
             edge.dex,
             input_mint,
             output_mint,
             self.config.probe_amount,
-        )?;
+        ) else {
+            crate::metrics::multi_hop_hop_missing_quote_inc();
+            return None;
+        };
 
-        // Edge ratio = output / input (accounts for fees & curve), then sanity clamp
-        let raw_ratio = quote_out as f64 / self.config.probe_amount as f64;
-        let edge_ratio = clamp_edge_ratio(raw_ratio);
+        // Edge ratio = output / input (accounts for fees & curve); clamp in beam expand
+        let edge_ratio = quote_out as f64 / self.config.probe_amount as f64;
 
         // Dampened liquidity score (clamped, NOT sqrt!)
         // From external review: clamp(liquidity/baseline, 0.3, 1.5)

--- a/src/arbitrage/pool_ranker.rs
+++ b/src/arbitrage/pool_ranker.rs
@@ -11,7 +11,7 @@
 //! > This is MORE ACCURATE than spot price because it includes fees & curve effects.
 
 use super::pool_graph::PoolGraph;
-use super::types::{DexType, PoolEdge, RankedPool};
+use super::types::{clamp_edge_ratio, DexType, PoolEdge, RankedPool};
 use solana_sdk::pubkey::Pubkey;
 use std::collections::HashMap;
 
@@ -65,6 +65,17 @@ pub trait QuoteProvider: Send + Sync {
         output_mint: &Pubkey,
         amount_in: u64,
     ) -> Option<u64>;
+
+    /// Whether a fresh cached probe quote exists for this pool direction.
+    /// Default `true` (mocks / providers without cache distinction).
+    fn has_cached_quote(
+        &self,
+        _pool_address: &Pubkey,
+        _input_mint: &Pubkey,
+        _output_mint: &Pubkey,
+    ) -> bool {
+        true
+    }
 }
 
 /// Pool ranker that pre-computes edge ratios using probe quotes
@@ -149,6 +160,14 @@ impl<Q: QuoteProvider> PoolRanker<Q> {
         input_mint: &Pubkey,
         output_mint: &Pubkey,
     ) -> Option<RankedPool> {
+        if !self
+            .quote_provider
+            .has_cached_quote(&edge.pool_address, input_mint, output_mint)
+        {
+            crate::metrics::multi_hop_hop_missing_quote_inc();
+            return None;
+        }
+
         // Get probe quote
         let quote_out = self.quote_provider.get_quote(
             &edge.pool_address,
@@ -158,8 +177,9 @@ impl<Q: QuoteProvider> PoolRanker<Q> {
             self.config.probe_amount,
         )?;
 
-        // Edge ratio = output / input (accounts for fees & curve)
-        let edge_ratio = quote_out as f64 / self.config.probe_amount as f64;
+        // Edge ratio = output / input (accounts for fees & curve), then sanity clamp
+        let raw_ratio = quote_out as f64 / self.config.probe_amount as f64;
+        let edge_ratio = clamp_edge_ratio(raw_ratio);
 
         // Dampened liquidity score (clamped, NOT sqrt!)
         // From external review: clamp(liquidity/baseline, 0.3, 1.5)

--- a/src/arbitrage/types.rs
+++ b/src/arbitrage/types.rs
@@ -143,7 +143,7 @@ pub struct RankedPool {
 impl RankedPool {
     /// Combined score for ranking (profit × liquidity_factor)
     pub fn combined_score(&self) -> f64 {
-        self.edge_ratio * self.liquidity_score
+        clamp_edge_ratio(self.edge_ratio) * self.liquidity_score
     }
 }
 

--- a/src/arbitrage/types.rs
+++ b/src/arbitrage/types.rs
@@ -202,7 +202,7 @@ pub struct ArbCycle {
 impl ArbCycle {
     /// Profit estimate is safe to compare against `min_profit_bps` / shadow logging.
     pub fn is_trustworthy_profit_estimate(&self) -> bool {
-        !self.return_bps_saturated && !self.profit_multiplier_capped
+        !self.return_bps_saturated && !self.profit_multiplier_capped && !self.edge_ratio_clamped
     }
 
     /// Number of hops in the cycle

--- a/src/arbitrage/types.rs
+++ b/src/arbitrage/types.rs
@@ -147,6 +147,38 @@ impl RankedPool {
     }
 }
 
+/// Maximum profit multiplier during beam search (10× = +900% raw product).
+pub const MAX_CYCLE_PROFIT_MULTIPLIER: f64 = 10.0;
+
+/// Per-hop edge ratio bounds (probe quote output/input). Rejects pathological quotes.
+pub const MIN_EDGE_RATIO: f64 = 0.01;
+pub const MAX_EDGE_RATIO: f64 = 1.05;
+
+/// `estimated_return_bps` clamp: −100% .. +500% (interpretable shadow/live signal).
+pub const MIN_RETURN_BPS: i32 = -10_000;
+pub const MAX_RETURN_BPS: i32 = 50_000;
+
+/// Clamp per-hop edge ratio before multiplying into cumulative profit.
+#[inline]
+pub fn clamp_edge_ratio(edge_ratio: f64) -> f64 {
+    edge_ratio.clamp(MIN_EDGE_RATIO, MAX_EDGE_RATIO)
+}
+
+/// Convert profit multiplier to basis points with saturating clamp.
+/// Returns `(bps, saturated)` where `saturated` means the raw value was outside bounds.
+#[inline]
+pub fn profit_to_return_bps(profit: f64) -> (i32, bool) {
+    let raw = (profit - 1.0) * 10_000.0;
+    if !raw.is_finite() {
+        return (MAX_RETURN_BPS, true);
+    }
+    let saturated = raw < f64::from(MIN_RETURN_BPS) || raw > f64::from(MAX_RETURN_BPS);
+    let bps = raw
+        .round()
+        .clamp(f64::from(MIN_RETURN_BPS), f64::from(MAX_RETURN_BPS)) as i32;
+    (bps, saturated)
+}
+
 /// A found arbitrage cycle with pool alternatives for fallback routing
 #[derive(Debug, Clone)]
 pub struct ArbCycle {
@@ -155,13 +187,24 @@ pub struct ArbCycle {
     /// Pools for each hop - WITH ALTERNATIVES for execution fallbacks!
     /// pools[hop_idx][0] = Best Pool, pools[hop_idx][1..] = Fallbacks
     pub pools: Vec<Vec<PoolEdge>>,
-    /// Estimated return in basis points (before slippage)
+    /// Estimated return in basis points (before slippage), clamped to [`MIN_RETURN_BPS`, `MAX_RETURN_BPS`]
     pub estimated_return_bps: i32,
     /// Minimum liquidity in the path (USD)
     pub min_liquidity_usd: f64,
+    /// True when cumulative profit hit [`MAX_CYCLE_PROFIT_MULTIPLIER`] during search.
+    pub profit_multiplier_capped: bool,
+    /// True when `estimated_return_bps` required clamping (or profit cap implies untrustworthy ROI).
+    pub return_bps_saturated: bool,
+    /// True when any hop used an edge ratio outside [`MIN_EDGE_RATIO`, `MAX_EDGE_RATIO`].
+    pub edge_ratio_clamped: bool,
 }
 
 impl ArbCycle {
+    /// Profit estimate is safe to compare against `min_profit_bps` / shadow logging.
+    pub fn is_trustworthy_profit_estimate(&self) -> bool {
+        !self.return_bps_saturated && !self.profit_multiplier_capped
+    }
+
     /// Number of hops in the cycle
     pub fn hop_count(&self) -> usize {
         self.pools.len()
@@ -199,6 +242,10 @@ pub struct SearchNode {
     pub min_liquidity: f64,
     /// Visited tokens for O(1) lookup (instead of O(n) path.contains)
     pub visited: HashSet<Pubkey>,
+    /// Cumulative profit hit [`MAX_CYCLE_PROFIT_MULTIPLIER`] on at least one expand step.
+    pub profit_multiplier_capped: bool,
+    /// At least one hop used an edge ratio outside sane bounds (after clamp).
+    pub edge_ratio_clamped: bool,
 }
 
 impl SearchNode {
@@ -216,6 +263,8 @@ impl SearchNode {
             depth: 0,
             min_liquidity: f64::MAX,
             visited,
+            profit_multiplier_capped: false,
+            edge_ratio_clamped: false,
         }
     }
 
@@ -234,7 +283,11 @@ impl SearchNode {
         let mut new_pools = self.pools.clone();
         new_pools.push(pool_alternatives);
 
-        let new_profit = self.profit * edge_ratio;
+        let clamped_ratio = clamp_edge_ratio(edge_ratio);
+        let edge_clamped = (clamped_ratio - edge_ratio).abs() > f64::EPSILON;
+        let uncapped_profit = self.profit * clamped_ratio;
+        let profit_hit_cap = uncapped_profit > MAX_CYCLE_PROFIT_MULTIPLIER;
+        let new_profit = uncapped_profit.min(MAX_CYCLE_PROFIT_MULTIPLIER);
         let new_liquidity = self.min_liquidity.min(liquidity_usd);
         let new_score = new_profit * liquidity_score;
 
@@ -250,6 +303,8 @@ impl SearchNode {
             depth: self.depth + 1,
             min_liquidity: new_liquidity,
             visited: new_visited,
+            profit_multiplier_capped: self.profit_multiplier_capped || profit_hit_cap,
+            edge_ratio_clamped: self.edge_ratio_clamped || edge_clamped,
         }
     }
 
@@ -264,13 +319,17 @@ impl SearchNode {
             return None;
         }
 
-        let return_bps = ((self.profit - 1.0) * 10000.0) as i32;
+        let (return_bps, return_saturated) = profit_to_return_bps(self.profit);
+        let return_bps_saturated = return_saturated || self.profit_multiplier_capped;
 
         Some(ArbCycle {
             path: self.path.clone(),
             pools: self.pools.clone(),
             estimated_return_bps: return_bps,
             min_liquidity_usd: self.min_liquidity,
+            profit_multiplier_capped: self.profit_multiplier_capped,
+            return_bps_saturated,
+            edge_ratio_clamped: self.edge_ratio_clamped,
         })
     }
 }
@@ -372,6 +431,60 @@ mod tests {
 
         // Higher score should be "greater" for max-heap
         assert!(node2 > node1);
+    }
+
+    #[test]
+    fn test_profit_overflow_never_returns_i32_max() {
+        let wsol = test_pubkey(0x01);
+        let mut node = SearchNode::start(wsol);
+        // Simulate pathological cumulative profit (would overflow naive cast)
+        node.profit = 1e12;
+        node.path = vec![wsol, test_pubkey(0x02), wsol];
+        node.pools = vec![vec![], vec![]];
+
+        let cycle = node.to_arb_cycle().expect("valid closed path");
+        assert_ne!(cycle.estimated_return_bps, i32::MAX);
+        assert_eq!(cycle.estimated_return_bps, MAX_RETURN_BPS);
+        assert!(cycle.return_bps_saturated);
+        assert!(!cycle.is_trustworthy_profit_estimate());
+    }
+
+    #[test]
+    fn test_extreme_edge_ratio_clamped() {
+        let wsol = test_pubkey(0x01);
+        let token_a = test_pubkey(0x0A);
+        let start = SearchNode::start(wsol);
+        let edge = PoolEdge::new(
+            test_pubkey(0x42),
+            DexType::RaydiumAmmV4,
+            wsol,
+            token_a,
+            5000.0,
+            30,
+        );
+        let expanded = start.expand(token_a, vec![edge], 999.0, 1.0, 5000.0);
+        assert!(expanded.edge_ratio_clamped);
+        assert!((expanded.profit - 1.05).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_profit_multiplier_cap_after_many_hops() {
+        let wsol = test_pubkey(0x01);
+        let token = test_pubkey(0x0A);
+        let edge = PoolEdge::new(
+            test_pubkey(0x42),
+            DexType::RaydiumAmmV4,
+            wsol,
+            token,
+            5000.0,
+            30,
+        );
+        let mut node = SearchNode::start(wsol);
+        for _ in 0..80 {
+            node = node.expand(token, vec![edge.clone()], 1.05, 1.0, 5000.0);
+        }
+        assert!(node.profit_multiplier_capped);
+        assert!((node.profit - MAX_CYCLE_PROFIT_MULTIPLIER).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2313,6 +2313,48 @@ pub fn arb_two_hop_rejected_inc(reason: ArbTwoHopRejectReason) {
 pub fn arb_two_hop_opportunity_inc() {
     ARB_TWO_HOP_OPPORTUNITIES.fetch_add(1, Ordering::Relaxed);
 }
+
+// --- Multi-hop shadow / cycle sanity (arb-strategy) ---
+pub static MULTI_HOP_RETURN_BPS_SATURATED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MULTI_HOP_SHADOW_LOGGED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MULTI_HOP_HOP_MISSING_QUOTE_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MULTI_HOP_CYCLE_REJECTED_SANITY_EDGE_RATIO: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MULTI_HOP_CYCLE_REJECTED_SANITY_PROFIT_CAP: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MULTI_HOP_CYCLE_REJECTED_SANITY_RETURN_BPS_CAP: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Sanity rejection reason for multi-hop cycles (Prometheus label `reason`).
+#[derive(Debug, Clone, Copy)]
+pub enum MultiHopSanityRejectReason {
+    EdgeRatio,
+    ProfitCap,
+    ReturnBpsCap,
+}
+
+pub fn multi_hop_return_bps_saturated_inc() {
+    MULTI_HOP_RETURN_BPS_SATURATED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn multi_hop_shadow_logged_inc() {
+    MULTI_HOP_SHADOW_LOGGED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn multi_hop_hop_missing_quote_inc() {
+    MULTI_HOP_HOP_MISSING_QUOTE_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn multi_hop_cycle_rejected_sanity_inc(reason: MultiHopSanityRejectReason) {
+    let counter = match reason {
+        MultiHopSanityRejectReason::EdgeRatio => &*MULTI_HOP_CYCLE_REJECTED_SANITY_EDGE_RATIO,
+        MultiHopSanityRejectReason::ProfitCap => &*MULTI_HOP_CYCLE_REJECTED_SANITY_PROFIT_CAP,
+        MultiHopSanityRejectReason::ReturnBpsCap => {
+            &*MULTI_HOP_CYCLE_REJECTED_SANITY_RETURN_BPS_CAP
+        }
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
 pub static QUOTE_LATENCY_TOTAL_NS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 // Generic cycle search metrics
 pub static CYCLE_PARTIAL_EXAMINED: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -3988,6 +4030,39 @@ async fn metrics_response() -> Response<Body> {
     out.push_str("arb_two_hop_rejected_total{reason=\"native_sol\"} ");
     out.push_str(
         &ARB_TWO_HOP_REJECTED_NATIVE_SOL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    line!(
+        "multi_hop_return_bps_saturated_total",
+        MULTI_HOP_RETURN_BPS_SATURATED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "multi_hop_shadow_logged_total",
+        MULTI_HOP_SHADOW_LOGGED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "multi_hop_hop_missing_quote_total",
+        MULTI_HOP_HOP_MISSING_QUOTE_TOTAL.load(Ordering::Relaxed)
+    );
+    out.push_str("multi_hop_cycle_rejected_sanity_total{reason=\"edge_ratio\"} ");
+    out.push_str(
+        &MULTI_HOP_CYCLE_REJECTED_SANITY_EDGE_RATIO
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("multi_hop_cycle_rejected_sanity_total{reason=\"profit_cap\"} ");
+    out.push_str(
+        &MULTI_HOP_CYCLE_REJECTED_SANITY_PROFIT_CAP
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("multi_hop_cycle_rejected_sanity_total{reason=\"return_bps_cap\"} ");
+    out.push_str(
+        &MULTI_HOP_CYCLE_REJECTED_SANITY_RETURN_BPS_CAP
             .load(Ordering::Relaxed)
             .to_string(),
     );

--- a/tests/multi_hop_sanity.rs
+++ b/tests/multi_hop_sanity.rs
@@ -1,0 +1,117 @@
+//! Multi-hop profit / return_bps sanity (shadow-mode signal quality).
+
+use ironcrab::arbitrage::{
+    clamp_edge_ratio, profit_to_return_bps, BeamCycleFinder, CycleFinderConfig, DexType,
+    MockQuoteProvider, PoolEdge, PoolGraph, PoolRanker, SearchNode, MAX_CYCLE_PROFIT_MULTIPLIER,
+    MAX_RETURN_BPS,
+};
+use solana_sdk::pubkey::Pubkey;
+
+fn test_pubkey(byte: u8) -> Pubkey {
+    Pubkey::new_from_array([byte; 32])
+}
+
+#[test]
+fn return_bps_never_i32_max_on_extreme_profit() {
+    let wsol = test_pubkey(0x01);
+    let mut node = SearchNode::start(wsol);
+    node.profit = 1e15;
+    node.path = vec![wsol, test_pubkey(0x02), wsol];
+    node.pools = vec![vec![], vec![]];
+
+    let cycle = node.to_arb_cycle().expect("closed cycle");
+    assert_ne!(cycle.estimated_return_bps, i32::MAX);
+    assert_eq!(cycle.estimated_return_bps, MAX_RETURN_BPS);
+    assert!(!cycle.is_trustworthy_profit_estimate());
+}
+
+#[test]
+fn extreme_edge_ratio_hop_rejected_by_clamp() {
+    let ratio = clamp_edge_ratio(500.0);
+    assert!((ratio - 1.05).abs() < f64::EPSILON);
+
+    let wsol = test_pubkey(0x01);
+    let token = test_pubkey(0x02);
+    let start = SearchNode::start(wsol);
+    let edge = PoolEdge::new(
+        test_pubkey(0x10),
+        DexType::RaydiumAmmV4,
+        wsol,
+        token,
+        10_000.0,
+        30,
+    );
+    let expanded = start.expand(token, vec![edge], 500.0, 1.0, 10_000.0);
+    assert!(expanded.profit <= MAX_CYCLE_PROFIT_MULTIPLIER);
+    assert!(expanded.edge_ratio_clamped || expanded.profit_multiplier_capped);
+}
+
+#[test]
+fn find_cycles_never_emits_i32_max_return_bps() {
+    let graph = PoolGraph::new();
+    let mut mock = MockQuoteProvider::new();
+    let wsol = test_pubkey(0x01);
+    let usdc = test_pubkey(0x02);
+    let token_a = test_pubkey(0x03);
+    let probe = 10_000_000u64;
+
+    let p1 = test_pubkey(0x10);
+    let p2 = test_pubkey(0x11);
+    let p3 = test_pubkey(0x12);
+
+    graph.upsert_pool(PoolEdge::new(
+        p1,
+        DexType::RaydiumAmmV4,
+        wsol,
+        usdc,
+        1_000_000.0,
+        30,
+    ));
+    graph.upsert_pool(PoolEdge::new(
+        p2,
+        DexType::RaydiumAmmV4,
+        usdc,
+        token_a,
+        500_000.0,
+        30,
+    ));
+    graph.upsert_pool(PoolEdge::new(
+        p3,
+        DexType::RaydiumAmmV4,
+        token_a,
+        wsol,
+        300_000.0,
+        30,
+    ));
+
+    mock.add_quote(p1, wsol, usdc, probe, probe * 200);
+    mock.add_quote(p2, usdc, token_a, probe, probe * 200);
+    mock.add_quote(p3, token_a, wsol, probe, probe * 200);
+
+    let config = CycleFinderConfig {
+        min_profit_bps: -1000,
+        base_mint: wsol,
+        ..Default::default()
+    };
+    let finder = BeamCycleFinder::new(config, PoolRanker::new(mock));
+    let cycles = finder.find_cycles(&graph);
+
+    for cycle in &cycles {
+        assert_ne!(
+            cycle.estimated_return_bps,
+            i32::MAX,
+            "return_bps must be clamped, not overflow cast"
+        );
+        assert!(cycle.estimated_return_bps <= MAX_RETURN_BPS);
+    }
+}
+
+#[test]
+fn profit_to_return_bps_clamp_semantics() {
+    let (bps, sat) = profit_to_return_bps(100.0);
+    assert!(sat);
+    assert_eq!(bps, MAX_RETURN_BPS);
+    let (bps2, sat2) = profit_to_return_bps(1.005);
+    assert!(!sat2);
+    assert_eq!(bps2, 50);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Multi-hop shadow mode was logging `return_bps=2147483647` (~41% of `[SHADOW]` lines on prod) because cumulative probe `edge_ratio` products were unbounded and `estimated_return_bps` used an unchecked `f64 → i32` cast.

This PR makes shadow profit numbers **interpretable** before any `multi_hop_shadow_mode=false` decision.

## Changes

### Profit / `return_bps` caps (`types.rs`)
- Per-hop `edge_ratio` clamp: **0.01 .. 1.05**
- Cumulative `profit` cap: **10×** (`MAX_CYCLE_PROFIT_MULTIPLIER`)
- `estimated_return_bps` clamp: **−10_000 .. +50_000** (−100% .. +500%)
- `ArbCycle::is_trustworthy_profit_estimate()` — `false` when cap/saturierung → **not** counted as `multi_hop_profitable`

### Quote sanity (`pool_ranker.rs`, `CachedQuoteProvider`)
- Hops ohne frischen Cache-Quote werden verworfen (kein stilles `default_edge_ratio=0.99` im Ranker)
- Counter: `multi_hop_hop_missing_quote_total`

### Prometheus (`metrics.rs`, port 9803)
- `multi_hop_return_bps_saturated_total`
- `multi_hop_cycle_rejected_sanity_total{reason="edge_ratio|profit_cap|return_bps_cap"}`
- `multi_hop_shadow_logged_total`
- `multi_hop_hop_missing_quote_total`

### Shadow log
- `[SHADOW]` erhält `return_bps_capped=false` (nur trustworthy cycles werden geloggt) und optional `sanity_flags=near_return_cap` nahe +500%-Cap

### Tests
- Unit + `tests/multi_hop_sanity.rs` (`test_helpers`): kein `i32::MAX`, extreme ratios gekappt

## STOP-CHECK (durchgeführt)
- **I-7 / I-4**: Keine neuen RPC-Calls im `on_pool_price_update` / Cycle-Finder-Pfad
- **I-9**: `shadow_mode` unverändert; keine Intent-Emission ohne Simulation-Gate
- **Scope**: Nur erlaubte Dateien; kein 2-Hop / momentum-bot / execution-engine Hot Path

## Prod-Gate (nach Deploy, Supervisor/User)
1. Anteil `return_bps=2147483647` in `[SHADOW]` **< 1%**
2. `multi_hop_cycles_found` ≠ `multi_hop_profitable` (Sanity filtert)
3. `multi_hop_cycle_rejected_sanity_total` / `multi_hop_return_bps_saturated_total` steigen sinnvoll
4. `intents_generated` bleibt **0** solange Shadow an

## CI
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --features test_helpers`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-605bd836-2cbe-451b-bb0f-a8eb11e1bd1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-605bd836-2cbe-451b-bb0f-a8eb11e1bd1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

