### PR TITLE
feat(market-data): wallet balance from TX meta + pre-track ATA at send

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -10821,6 +10821,21 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
         None
     };
 
+    // PR1 Phase 2: pre-confirm ATA track — publish Sent ExecutionResult before confirm wait.
+    if config.send_enabled && sent_anything {
+        if let Some(ref sr) = send_result {
+            if let Err(e) =
+                publish_pre_confirm_execution_result(ctx, &intent, &decision_id, sr).await
+            {
+                warn!(
+                    intent_id = %intent.intent_id,
+                    error = %e,
+                    "Failed to publish pre-confirm ExecutionResult (ATA pre-track)"
+                );
+            }
+        }
+    }
+
     // === Confirm (RS-4.2 / RS-7.4) ===
     // - RPC path (non-bundle): confirm signature via getSignatureStatuses.
     // - Bundle path: wait for bundle landing via Jito block engine.
@@ -11132,108 +11147,14 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                 },
             );
 
-            // Ensure market-data can track the new ATA via Geyser after a BUY.
-            // The intent already carries token_program (from TradeResources) and the
-            // output_mint + wallet_pubkey are known — so we derive the ATA deterministically
-            // (PDA, no RPC call). Without these metadata fields market-data silently skips
-            // ExecutionResult processing and never subscribes the new ATA to Geyser.
-            if intent.side == TradeSide::Buy {
-                if let Some(wallet) = ctx.wallet_pubkey {
-                    let output_mint_str = &intent.resources.output_mint;
-                    if let Ok(output_mint_pk) = Pubkey::from_str(output_mint_str) {
-                        // token_program: use intent-provided value, fall back to SPL Token
-                        use spl_token::solana_program::pubkey::Pubkey as SplPubkey;
-
-                        let token_program_spl = intent
-                            .resources
-                            .token_program
-                            .as_ref()
-                            .and_then(|tp| Pubkey::from_str(tp).ok())
-                            .map(|pk| SplPubkey::new_from_array(pk.to_bytes()))
-                            .unwrap_or_else(spl_token::id);
-
-                        // Derive ATA deterministically (PDA — no RPC)
-                        let wallet_spl = SplPubkey::new_from_array(wallet.to_bytes());
-                        let mint_spl = SplPubkey::new_from_array(output_mint_pk.to_bytes());
-                        let ata_spl = spl_associated_token_account::get_associated_token_address_with_program_id(
-                            &wallet_spl, &mint_spl, &token_program_spl,
-                        );
-                        let ata_pk = Pubkey::new_from_array(ata_spl.to_bytes());
-                        let token_program_pk = Pubkey::new_from_array(token_program_spl.to_bytes());
-
-                        exec.metadata
-                            .entry("token_account".to_string())
-                            .or_insert_with(|| ata_pk.to_string());
-                        exec.metadata
-                            .entry("token_program".to_string())
-                            .or_insert_with(|| token_program_pk.to_string());
-
-                        // Also propagate mint_decimals if available in LivePoolCache
-                        if !exec.metadata.contains_key("mint_decimals") {
-                            if let Some(ref cache) = ctx.live_pool_cache {
-                                if let Some(d) = cache.get_mint_decimals(&output_mint_pk) {
-                                    exec.metadata
-                                        .insert("mint_decimals".to_string(), d.to_string());
-                                }
-                            }
-                        }
-
-                        info!(
-                            intent_id = %intent.intent_id,
-                            token_account = %ata_pk,
-                            token_program = %token_program_pk,
-                            "ExecutionResult: enriched metadata for market-data ATA tracking"
-                        );
-                    }
-                }
-            } else if intent.side == TradeSide::Sell {
-                // For SELL: derive ATA from wallet + input_mint + token_program (PDA, no RPC).
-                // market-data needs token_account/token_program to untrack the ATA after a sell.
-                if let Some(wallet) = ctx.wallet_pubkey {
-                    let input_mint_str = &intent.resources.input_mint;
-                    if let Ok(input_mint_pk) = Pubkey::from_str(input_mint_str) {
-                        use spl_token::solana_program::pubkey::Pubkey as SplPubkey;
-
-                        let token_program_spl = intent
-                            .resources
-                            .token_program
-                            .as_ref()
-                            .and_then(|tp| Pubkey::from_str(tp).ok())
-                            .map(|pk| SplPubkey::new_from_array(pk.to_bytes()))
-                            .unwrap_or_else(spl_token::id);
-
-                        let wallet_spl = SplPubkey::new_from_array(wallet.to_bytes());
-                        let mint_spl = SplPubkey::new_from_array(input_mint_pk.to_bytes());
-                        let ata_spl = spl_associated_token_account::get_associated_token_address_with_program_id(
-                            &wallet_spl, &mint_spl, &token_program_spl,
-                        );
-                        let ata_pk = Pubkey::new_from_array(ata_spl.to_bytes());
-                        let token_program_pk = Pubkey::new_from_array(token_program_spl.to_bytes());
-
-                        exec.metadata
-                            .entry("token_account".to_string())
-                            .or_insert_with(|| ata_pk.to_string());
-                        exec.metadata
-                            .entry("token_program".to_string())
-                            .or_insert_with(|| token_program_pk.to_string());
-
-                        if !exec.metadata.contains_key("mint_decimals") {
-                            if let Some(ref cache) = ctx.live_pool_cache {
-                                if let Some(d) = cache.get_mint_decimals(&input_mint_pk) {
-                                    exec.metadata
-                                        .insert("mint_decimals".to_string(), d.to_string());
-                                }
-                            }
-                        }
-
-                        info!(
-                            intent_id = %intent.intent_id,
-                            token_account = %ata_pk,
-                            token_program = %token_program_pk,
-                            "ExecutionResult: enriched metadata for market-data ATA untracking (SELL)"
-                        );
-                    }
-                }
+            enrich_execution_result_ata_metadata(&mut exec, ctx, &intent);
+            if let Some(token_account) = exec.metadata.get("token_account") {
+                info!(
+                    intent_id = %intent.intent_id,
+                    token_account = %token_account,
+                    side = ?exec.metadata.get("side"),
+                    "ExecutionResult: enriched metadata for market-data ATA tracking"
+                );
             }
 
             // Best-effort fill accounting: attach fills only when we have a signature and wallet.
@@ -12070,6 +11991,155 @@ enum ConfirmOutcome {
     TimeoutSent {
         details: String,
     },
+}
+
+/// Derive ATA metadata (PDA, no RPC) so market-data can pre-track wallet token accounts.
+fn enrich_execution_result_ata_metadata(
+    exec: &mut ExecutionResult,
+    ctx: &ExecutionContext,
+    intent: &TradeIntent,
+) {
+    if intent.side == TradeSide::Buy {
+        if let Some(wallet) = ctx.wallet_pubkey {
+            let output_mint_str = &intent.resources.output_mint;
+            if let Ok(output_mint_pk) = Pubkey::from_str(output_mint_str) {
+                use spl_token::solana_program::pubkey::Pubkey as SplPubkey;
+
+                let token_program_spl = intent
+                    .resources
+                    .token_program
+                    .as_ref()
+                    .and_then(|tp| Pubkey::from_str(tp).ok())
+                    .map(|pk| SplPubkey::new_from_array(pk.to_bytes()))
+                    .unwrap_or_else(spl_token::id);
+
+                let wallet_spl = SplPubkey::new_from_array(wallet.to_bytes());
+                let mint_spl = SplPubkey::new_from_array(output_mint_pk.to_bytes());
+                let ata_spl =
+                    spl_associated_token_account::get_associated_token_address_with_program_id(
+                        &wallet_spl,
+                        &mint_spl,
+                        &token_program_spl,
+                    );
+                let ata_pk = Pubkey::new_from_array(ata_spl.to_bytes());
+                let token_program_pk = Pubkey::new_from_array(token_program_spl.to_bytes());
+
+                exec.metadata
+                    .entry("token_account".to_string())
+                    .or_insert_with(|| ata_pk.to_string());
+                exec.metadata
+                    .entry("token_program".to_string())
+                    .or_insert_with(|| token_program_pk.to_string());
+
+                if !exec.metadata.contains_key("mint_decimals") {
+                    if let Some(ref cache) = ctx.live_pool_cache {
+                        if let Some(d) = cache.get_mint_decimals(&output_mint_pk) {
+                            exec.metadata
+                                .insert("mint_decimals".to_string(), d.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    } else if intent.side == TradeSide::Sell {
+        if let Some(wallet) = ctx.wallet_pubkey {
+            let input_mint_str = &intent.resources.input_mint;
+            if let Ok(input_mint_pk) = Pubkey::from_str(input_mint_str) {
+                use spl_token::solana_program::pubkey::Pubkey as SplPubkey;
+
+                let token_program_spl = intent
+                    .resources
+                    .token_program
+                    .as_ref()
+                    .and_then(|tp| Pubkey::from_str(tp).ok())
+                    .map(|pk| SplPubkey::new_from_array(pk.to_bytes()))
+                    .unwrap_or_else(spl_token::id);
+
+                let wallet_spl = SplPubkey::new_from_array(wallet.to_bytes());
+                let mint_spl = SplPubkey::new_from_array(input_mint_pk.to_bytes());
+                let ata_spl =
+                    spl_associated_token_account::get_associated_token_address_with_program_id(
+                        &wallet_spl,
+                        &mint_spl,
+                        &token_program_spl,
+                    );
+                let ata_pk = Pubkey::new_from_array(ata_spl.to_bytes());
+                let token_program_pk = Pubkey::new_from_array(token_program_spl.to_bytes());
+
+                exec.metadata
+                    .entry("token_account".to_string())
+                    .or_insert_with(|| ata_pk.to_string());
+                exec.metadata
+                    .entry("token_program".to_string())
+                    .or_insert_with(|| token_program_pk.to_string());
+
+                if !exec.metadata.contains_key("mint_decimals") {
+                    if let Some(ref cache) = ctx.live_pool_cache {
+                        if let Some(d) = cache.get_mint_decimals(&input_mint_pk) {
+                            exec.metadata
+                                .insert("mint_decimals".to_string(), d.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// PR1 Phase 2: publish `ExecutionStatus::Sent` immediately after send so market-data can
+/// pin the ATA before confirm (~30s). Uses a **distinct** `execution_id` from the post-confirm
+/// result so `execution_results_deduper` in market-data processes both events (ATA track is idempotent).
+async fn publish_pre_confirm_execution_result(
+    ctx: &ExecutionContext,
+    intent: &TradeIntent,
+    decision_id: &str,
+    send_result: &ironcrab::ipc::SendResult,
+) -> Result<()> {
+    let token_mint = match intent.side {
+        TradeSide::Buy => Some(intent.resources.output_mint.clone()),
+        TradeSide::Sell => Some(intent.resources.input_mint.clone()),
+    };
+
+    let mut exec = ExecutionResult::new_sent(
+        "execution-engine",
+        BUILD_VERSION,
+        &ctx.run_id,
+        ctx.next_execution_id(),
+        decision_id.to_string(),
+        intent.intent_id.clone(),
+        intent.source.clone(),
+        token_mint,
+        send_result.signature.clone(),
+        send_result.bundle_id.clone(),
+    )
+    .with_metadata(intent.metadata.clone());
+
+    exec.metadata.insert(
+        "side".to_string(),
+        match intent.side {
+            TradeSide::Buy => "BUY".to_string(),
+            TradeSide::Sell => "SELL".to_string(),
+        },
+    );
+    exec.metadata
+        .insert("phase".to_string(), "pre_confirm_track".to_string());
+
+    enrich_execution_result_ata_metadata(&mut exec, ctx, intent);
+
+    let token_account = exec.metadata.get("token_account").cloned();
+    info!(
+        intent_id = %intent.intent_id,
+        token_account = ?token_account,
+        phase = "pre_confirm_track",
+        "Early ExecutionResult published for market-data ATA pre-track"
+    );
+
+    ctx.execution_writer.write(&exec)?;
+    if let Some(ref nats) = ctx.nats {
+        nats.jetstream_publish(TOPIC_EXECUTION_RESULTS, &exec)
+            .await?;
+    }
+    Ok(())
 }
 
 /// FIX-32: Geyser-first TX confirmation with RPC-polling fallback.

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4649,6 +4649,202 @@ fn wallet_geyser_snapshots_to_publish(
     }
 }
 
+/// Wallet-owned WSOL `post_token_balances` row present — skip paired NATIVE_SOL publish (PR #201).
+fn wallet_tx_meta_has_wsol_post_balance(wallet: &Pubkey, tx: &GeyserTransactionUpdate) -> bool {
+    let wallet_str = wallet.to_string();
+    tx.post_token_balances
+        .iter()
+        .any(|b| b.mint == WSOL_MINT && b.owner.as_deref() == Some(wallet_str.as_str()))
+}
+
+fn wallet_tx_meta_native_sol_post_lamports(
+    wallet: &Pubkey,
+    tx: &GeyserTransactionUpdate,
+) -> Option<u64> {
+    let idx = tx.account_keys.iter().position(|k| k == wallet)?;
+    tx.post_balances.get(idx).copied()
+}
+
+/// Idempotent ATA pin + Geyser subscribe list refresh after a wallet TX meta balance row.
+fn wallet_tx_meta_pin_ata_from_balance(
+    ctx: &MarketDataContext,
+    tracked_wallet: &TrackedWallet,
+    tx: &GeyserTransactionUpdate,
+    balance: &ironcrab::solana::geyser_listener::TokenBalance,
+    md_state: &MdStateSender,
+) -> bool {
+    use ironcrab::solana::geyser_listener::geyser_token_balance_account_pubkey;
+
+    let Some(ata) = geyser_token_balance_account_pubkey(tx, balance) else {
+        return false;
+    };
+    let mut added_ata = false;
+    {
+        let mut set = ctx.tracked_wallet_token_accounts.write();
+        if set.insert(ata) {
+            added_ata = true;
+        }
+    }
+    if let Ok(mint) = Pubkey::from_str(&balance.mint) {
+        let needs_mint_track = ctx
+            .tracked_mints
+            .read()
+            .get(&mint)
+            .is_none_or(|info| !info.pinned || info.pin != Some(GeyserPinReason::Wallet));
+        if needs_mint_track {
+            md_state_try_enqueue(md_state, MdStateCommand::TrackWalletMint { mint });
+        }
+        ctx.tracked_wallet_mint_decimals
+            .write()
+            .insert(mint, balance.ui_token_amount.decimals);
+    }
+    if added_ata {
+        let mut accounts: Vec<Pubkey> = Vec::new();
+        accounts.push(tracked_wallet.wallet);
+        accounts.push(tracked_wallet.wsol_ata);
+        accounts.extend(ctx.tracked_wallet_token_accounts.read().iter().copied());
+        accounts.sort();
+        accounts.dedup();
+        let _ = ctx.tracked_wallet_tx.send(accounts);
+    }
+    added_ata
+}
+
+/// Phase 1 (PR1): publish `WalletBalanceSnapshot` from Geyser TX `post_token_balances` / native SOL meta.
+async fn process_wallet_balance_snapshots_from_tx_meta(
+    ctx: &Arc<MarketDataContext>,
+    run_id: &str,
+    tx: &GeyserTransactionUpdate,
+    account_publish_tx: Option<&mpsc::Sender<AccountPathNatsJob>>,
+    md_state: &MdStateSender,
+) {
+    use ironcrab::solana::geyser_listener::{
+        geyser_tx_involves_wallet, geyser_wallet_post_token_balances,
+    };
+
+    let Some(tracked_wallet) = ctx.tracked_wallet.as_ref() else {
+        return;
+    };
+    let wallet = tracked_wallet.wallet;
+    if !geyser_tx_involves_wallet(&wallet, tx) {
+        return;
+    }
+
+    let wallet_str = wallet.to_string();
+    let has_wsol_post = wallet_tx_meta_has_wsol_post_balance(&wallet, tx);
+    let can_publish = ctx.nats.is_some() || account_publish_tx.is_some();
+
+    if !has_wsol_post {
+        if let Some(lamports) = wallet_tx_meta_native_sol_post_lamports(&wallet, tx) {
+            let prev = tracked_wallet
+                .last_sol_balance
+                .swap(lamports, Ordering::Relaxed);
+            if lamports != prev && can_publish {
+                let sol_snapshot = MarketEvent::new(
+                    "market-data",
+                    BUILD_VERSION,
+                    run_id,
+                    format!("geyser_wallet_tx_sol_{}", tx.signature),
+                    "geyser_wallet_tx_meta",
+                    Some(tx.slot),
+                    MarketEventKind::WalletBalanceSnapshot {
+                        mint: "NATIVE_SOL".to_string(),
+                        balance_raw: lamports,
+                        decimals: 9,
+                        token_program: "system".to_string(),
+                    },
+                );
+                let sol_subject = wallet_snapshot_subject(&wallet_str, "NATIVE_SOL");
+                account_path_enqueue_jetstream(
+                    account_publish_tx,
+                    ctx.nats.as_ref(),
+                    sol_subject,
+                    &sol_snapshot,
+                    "native SOL WalletBalanceSnapshot (TX meta)",
+                    false,
+                )
+                .await;
+                info!(
+                    wallet = %wallet_str,
+                    sol_lamports = lamports,
+                    slot = tx.slot,
+                    sig = %tx.signature,
+                    "WalletBalanceSnapshot (NATIVE_SOL) enqueued from TX meta"
+                );
+            }
+        }
+    }
+
+    for balance in geyser_wallet_post_token_balances(&wallet, tx) {
+        let balance_raw = match balance.ui_token_amount.amount.parse::<u64>() {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    wallet = %wallet_str,
+                    mint = %balance.mint,
+                    amount = %balance.ui_token_amount.amount,
+                    error = %e,
+                    sig = %tx.signature,
+                    "Skipping wallet TX meta balance: invalid raw amount"
+                );
+                continue;
+            }
+        };
+        let decimals = balance.ui_token_amount.decimals;
+        let token_program = balance
+            .program_id
+            .clone()
+            .unwrap_or_else(|| spl_token::ID.to_string());
+
+        let snapshot_mint = if balance.mint == WSOL_MINT {
+            tracked_wallet
+                .last_wsol_balance
+                .store(balance_raw, Ordering::Relaxed);
+            tracked_wallet.wsol_seen.store(true, Ordering::Relaxed);
+            WSOL_MINT.to_string()
+        } else {
+            balance.mint.clone()
+        };
+
+        if can_publish {
+            let event = MarketEvent::new(
+                "market-data",
+                BUILD_VERSION,
+                run_id,
+                format!("geyser_wallet_tx_{}_{}", tx.signature, snapshot_mint),
+                "geyser_wallet_tx_meta",
+                Some(tx.slot),
+                MarketEventKind::WalletBalanceSnapshot {
+                    mint: snapshot_mint.clone(),
+                    balance_raw,
+                    decimals,
+                    token_program: token_program.clone(),
+                },
+            );
+            let subject = wallet_snapshot_subject(&wallet_str, &snapshot_mint);
+            account_path_enqueue_jetstream(
+                account_publish_tx,
+                ctx.nats.as_ref(),
+                subject,
+                &event,
+                "WalletBalanceSnapshot JetStream (TX meta)",
+                true,
+            )
+            .await;
+            info!(
+                wallet = %wallet_str,
+                mint = %snapshot_mint,
+                balance_raw,
+                slot = tx.slot,
+                sig = %tx.signature,
+                "WalletBalanceSnapshot enqueued from TX meta"
+            );
+        }
+
+        wallet_tx_meta_pin_ata_from_balance(ctx, tracked_wallet, tx, balance, md_state);
+    }
+}
+
 /// Wallet `mints_in_wallet` are non-zero balances from bootstrap RPC; pick at most `max_mints`
 /// unique pubkeys that still lack explicit Ready for any modeled slice per
 /// [`LivePoolCache::base_mint_has_any_ready_pool`] (PumpSwap, PumpFun, Raydium CPMM, Meteora CPMM, Meteora DLMM,
@@ -11311,6 +11507,16 @@ async fn handle_geyser_transaction(
     // This is needed to catch manual wallet actions (Phantom/Jupiter) that do not
     // produce ExecutionResults.
 
+    // PR1 Phase 1: wallet balance snapshots from TX meta (post_token_balances + native SOL).
+    process_wallet_balance_snapshots_from_tx_meta(
+        &ctx,
+        run_id,
+        &tx_update,
+        account_publish_tx,
+        md_state,
+    )
+    .await;
+
     // P2: Track priority fees from Geyser transactions (NO RPC calls!)
     if let Some(priority_fee) = ctx.priority_fee_tracker.add_sample(
         tx_update.slot,
@@ -14199,6 +14405,221 @@ mod wallet_geyser_snapshot_decouple_tests {
             })
             .is_none()
         );
+    }
+}
+
+/// PR1: wallet balance snapshots from Geyser TX meta (`post_token_balances`).
+#[cfg(test)]
+mod wallet_tx_meta_balance_tests {
+    use super::*;
+    use ironcrab::solana::geyser_listener::{
+        geyser_tx_involves_wallet, GeyserTransactionUpdate, TokenAmount, TokenBalance,
+    };
+    use std::sync::atomic::AtomicUsize;
+    use tokio::sync::mpsc;
+
+    fn spawn_test_md_state(ctx: &Arc<MarketDataContext>) -> MdStateSender {
+        spawn_md_state_worker(Arc::clone(ctx), tokio::runtime::Handle::current())
+    }
+
+    fn market_data_context_with_tracked_wallet(wallet: Pubkey) -> Arc<MarketDataContext> {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let (tracked_wallet_tx, _) = watch::channel(Vec::<Pubkey>::new());
+        let tracked = TrackedWallet::new(wallet);
+        let (tracked_mints_tx, _tracked_mints_rx) = watch::channel(Vec::<Pubkey>::new());
+        let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
+        let (tracked_bin_arrays_tx, _tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
+        Arc::new(MarketDataContext {
+            run_id: "run-wallet-tx-meta".to_string(),
+            config: parking_lot::RwLock::new(MarketDataConfig::default()),
+            geyser_full_reconnect_threshold_live: Arc::new(AtomicUsize::new(0)),
+            nats: None,
+            jsonl_writer: jsonl,
+            started_at: Instant::now(),
+            event_counter: std::sync::atomic::AtomicU64::new(0),
+            wallet_tracker: WalletTracker::new(WalletTrackerCfg::default()),
+            priority_fee_tracker: Arc::new(PriorityFeeTracker::new()),
+            tracked_mints: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            tracked_mints_tx,
+            active_pool_set: Arc::new(ActivePoolSet::new()),
+            known_pump_amm_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
+            known_trade_dex_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
+            pumpfun_pool_discovery_mint_info_emitted: parking_lot::RwLock::new(
+                std::collections::HashSet::new(),
+            ),
+            tracked_vaults: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            tracked_vaults_tx,
+            tracked_bin_arrays: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            tracked_bin_arrays_tx,
+            live_pool_cache: Arc::new(LivePoolCache::new()),
+            creator_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            pool_mint_map: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            pool_creator_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            high_priority_bonding_curves: parking_lot::RwLock::new(HashSet::new()),
+            raydium_serum_fetched: parking_lot::RwLock::new(std::collections::HashSet::new()),
+            tracked_wallet: Some(tracked),
+            tracked_wallet_tx,
+            tracked_wallet_token_accounts: parking_lot::RwLock::new(
+                std::collections::HashSet::new(),
+            ),
+            tracked_wallet_mint_decimals: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            execution_results_deduper: parking_lot::Mutex::new(ExecutionResultDeduper::default()),
+            last_emitted_curve_progress: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            bonding_curve_publish_times: parking_lot::Mutex::new(BondingCurvePublishTimes::new()),
+            pump_amm_dex: parking_lot::RwLock::new(None),
+            helius_rpc: None,
+            geyser_sync_batch_timer: parking_lot::Mutex::new(None),
+            ingest_tokio_handle: parking_lot::RwLock::new(None),
+            pool_discovery_poolcreated_emitted: parking_lot::RwLock::new(
+                std::collections::HashSet::new(),
+            ),
+        })
+    }
+
+    fn sample_wallet_tx_update(
+        wallet: Pubkey,
+        token_ata: Pubkey,
+        mint: &str,
+    ) -> GeyserTransactionUpdate {
+        let balance_raw = 1_500_000u64;
+        GeyserTransactionUpdate {
+            signature: "wallet_tx_meta_sig".into(),
+            slot: 99,
+            account_keys: vec![wallet, token_ata],
+            instruction_accounts: vec![],
+            instruction_data: vec![],
+            inner_instructions: vec![],
+            pre_token_balances: vec![],
+            post_token_balances: vec![TokenBalance {
+                account_index: 1,
+                mint: mint.to_string(),
+                ui_token_amount: TokenAmount {
+                    ui_amount: None,
+                    decimals: 6,
+                    amount: balance_raw.to_string(),
+                },
+                program_id: Some(spl_token::ID.to_string()),
+                owner: Some(wallet.to_string()),
+            }],
+            pre_balances: vec![5_000_000_000, 2_039_280],
+            post_balances: vec![4_900_000_000, 2_039_280],
+            fee_lamports: 5_000,
+            compute_units_consumed: Some(42_000),
+            grpc_recv_at: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn geyser_tx_involves_wallet_signer_or_token_owner() {
+        let wallet = Pubkey::new_unique();
+        let foreign = Pubkey::new_unique();
+        let ata = Pubkey::new_unique();
+        let signer_tx = GeyserTransactionUpdate {
+            signature: "s".into(),
+            slot: 1,
+            account_keys: vec![wallet],
+            instruction_accounts: vec![],
+            instruction_data: vec![],
+            inner_instructions: vec![],
+            pre_token_balances: vec![],
+            post_token_balances: vec![],
+            pre_balances: vec![1],
+            post_balances: vec![1],
+            fee_lamports: 0,
+            compute_units_consumed: None,
+            grpc_recv_at: Instant::now(),
+        };
+        assert!(geyser_tx_involves_wallet(&wallet, &signer_tx));
+        assert!(!geyser_tx_involves_wallet(&foreign, &signer_tx));
+
+        let owner_tx = sample_wallet_tx_update(wallet, ata, &Pubkey::new_unique().to_string());
+        assert!(geyser_tx_involves_wallet(&wallet, &owner_tx));
+        assert!(!geyser_tx_involves_wallet(&foreign, &owner_tx));
+    }
+
+    #[test]
+    fn wallet_tx_meta_skips_native_sol_when_wsol_post_balance_present() {
+        let wallet = Pubkey::new_unique();
+        let wsol_ata = Pubkey::new_unique();
+        let mut tx = sample_wallet_tx_update(wallet, wsol_ata, WSOL_MINT);
+        tx.post_token_balances[0].mint = WSOL_MINT.to_string();
+        assert!(wallet_tx_meta_has_wsol_post_balance(&wallet, &tx));
+        assert!(wallet_tx_meta_native_sol_post_lamports(&wallet, &tx).is_some());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn wallet_tx_meta_publishes_token_snapshot_and_pins_ata() {
+        let wallet = Pubkey::new_unique();
+        let token_ata = Pubkey::new_unique();
+        let mint = Pubkey::new_unique().to_string();
+        let ctx = market_data_context_with_tracked_wallet(wallet);
+        let md_state = spawn_test_md_state(&ctx);
+        let (publish_tx, mut publish_rx) = mpsc::channel(8);
+        let tx = sample_wallet_tx_update(wallet, token_ata, &mint);
+
+        process_wallet_balance_snapshots_from_tx_meta(
+            &ctx,
+            "run-wallet-tx-meta",
+            &tx,
+            Some(&publish_tx),
+            &md_state,
+        )
+        .await;
+
+        let mut snapshots: Vec<(String, u64)> = Vec::new();
+        while let Ok(job) = publish_rx.try_recv() {
+            if let AccountPathNatsJob::JetStream { payload, .. } = job {
+                if payload.get("kind").and_then(|v| v.as_str()) == Some("WalletBalanceSnapshot") {
+                    snapshots.push((
+                        payload
+                            .get("mint")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string(),
+                        payload
+                            .get("balance_raw")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0),
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            snapshots.iter().any(|(m, b)| m == &mint && *b == 1_500_000),
+            "expected token WalletBalanceSnapshot, got {snapshots:?}"
+        );
+        assert!(
+            ctx.tracked_wallet_token_accounts
+                .read()
+                .contains(&token_ata),
+            "ATA should be pinned from TX meta"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn foreign_wallet_tx_meta_publishes_nothing() {
+        let wallet = Pubkey::new_unique();
+        let foreign = Pubkey::new_unique();
+        let token_ata = Pubkey::new_unique();
+        let ctx = market_data_context_with_tracked_wallet(wallet);
+        let md_state = spawn_test_md_state(&ctx);
+        let (publish_tx, mut publish_rx) = mpsc::channel(8);
+        let tx = sample_wallet_tx_update(foreign, token_ata, &Pubkey::new_unique().to_string());
+
+        process_wallet_balance_snapshots_from_tx_meta(
+            &ctx,
+            "run-wallet-tx-meta",
+            &tx,
+            Some(&publish_tx),
+            &md_state,
+        )
+        .await;
+
+        assert!(publish_rx.try_recv().is_err());
+        assert!(ctx.tracked_wallet_token_accounts.read().is_empty());
     }
 }
 

--- a/src/solana/dex_parser.rs
+++ b/src/solana/dex_parser.rs
@@ -2139,6 +2139,7 @@ mod tests {
                 amount: "2000000".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
         let post_token = vec![TokenBalance {
             account_index: 5,
@@ -2149,6 +2150,7 @@ mod tests {
                 amount: "1000000".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
 
         let pre_balances = vec![1_000_000_000u64; account_keys.len()];
@@ -2265,6 +2267,7 @@ mod tests {
                 amount: "2000000".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
         let post_token = vec![TokenBalance {
             account_index: 5,
@@ -2275,6 +2278,7 @@ mod tests {
                 amount: "1000000".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
 
         let pre_balances = vec![1_000_000_000u64; account_keys.len()];
@@ -2391,6 +2395,7 @@ mod tests {
                 amount: "2000000".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
         let post_token = vec![TokenBalance {
             account_index: 5,
@@ -2401,6 +2406,7 @@ mod tests {
                 amount: "1000000".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
 
         let pre_balances = vec![1_000_000_000u64; account_keys.len()];
@@ -2518,6 +2524,7 @@ mod tests {
                 amount: "2000000".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
         let post_token = vec![TokenBalance {
             account_index: sell_account_indices[5],
@@ -2528,6 +2535,7 @@ mod tests {
                 amount: "1000000".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
 
         let update = GeyserTransactionUpdate {
@@ -2602,6 +2610,7 @@ mod tests {
                 amount: "0".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
         let post_token = vec![TokenBalance {
             account_index: user_ata_idx,
@@ -2612,6 +2621,7 @@ mod tests {
                 amount: TOKEN_RAW.to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
 
         let pre_balances = vec![2_005_000u64; account_keys.len()];
@@ -2699,6 +2709,7 @@ mod tests {
                 amount: "0".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
         let post_token = vec![TokenBalance {
             account_index: user_ata_idx,
@@ -2709,6 +2720,7 @@ mod tests {
                 amount: "1000000".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
 
         let update = GeyserTransactionUpdate {
@@ -2782,6 +2794,7 @@ mod tests {
                 amount: "0".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
         let post_token = vec![TokenBalance {
             account_index: user_ata_idx,
@@ -2792,6 +2805,7 @@ mod tests {
                 amount: "1000000".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
 
         let update = GeyserTransactionUpdate {
@@ -2854,6 +2868,7 @@ mod tests {
                 amount: "0".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
         let post_token = vec![TokenBalance {
             account_index: 15,
@@ -2864,6 +2879,7 @@ mod tests {
                 amount: "999000".to_string(),
             },
             program_id: Some(spl_token.to_string()),
+            owner: None,
         }];
 
         let update = GeyserTransactionUpdate {

--- a/src/solana/geyser_listener.rs
+++ b/src/solana/geyser_listener.rs
@@ -87,6 +87,38 @@ pub struct TokenBalance {
     pub ui_token_amount: TokenAmount,
     /// Token program ID (SPL Token or Token-2022) - authoritative source for token type
     pub program_id: Option<String>,
+    /// Wallet owner of the token account (from TX meta `post_token_balances.owner`).
+    pub owner: Option<String>,
+}
+
+/// True when `wallet` is a signer/fee-payer in `account_keys` or owns a `post_token_balances` row.
+pub fn geyser_tx_involves_wallet(wallet: &Pubkey, tx: &GeyserTransactionUpdate) -> bool {
+    if tx.account_keys.iter().any(|k| k == wallet) {
+        return true;
+    }
+    let wallet_str = wallet.to_string();
+    tx.post_token_balances
+        .iter()
+        .any(|b| b.owner.as_deref() == Some(wallet_str.as_str()))
+}
+
+/// Token account pubkey for a TX meta balance row (`account_keys[account_index]`).
+pub fn geyser_token_balance_account_pubkey(
+    tx: &GeyserTransactionUpdate,
+    balance: &TokenBalance,
+) -> Option<Pubkey> {
+    tx.account_keys.get(balance.account_index as usize).copied()
+}
+
+/// `post_token_balances` rows owned by `wallet`.
+pub fn geyser_wallet_post_token_balances<'a>(
+    wallet: &Pubkey,
+    tx: &'a GeyserTransactionUpdate,
+) -> impl Iterator<Item = &'a TokenBalance> {
+    let wallet_str = wallet.to_string();
+    tx.post_token_balances
+        .iter()
+        .filter(move |b| b.owner.as_deref() == Some(wallet_str.as_str()))
 }
 
 #[derive(Debug, Clone)]
@@ -601,6 +633,11 @@ impl GeyserTxListener {
                                                                     } else {
                                                                         Some(balance.program_id.clone())
                                                                     },
+                                                                    owner: if balance.owner.is_empty() {
+                                                                        None
+                                                                    } else {
+                                                                        Some(balance.owner.clone())
+                                                                    },
                                                                 });
                                                             }
                                                         }
@@ -618,6 +655,11 @@ impl GeyserTxListener {
                                                                         None
                                                                     } else {
                                                                         Some(balance.program_id.clone())
+                                                                    },
+                                                                    owner: if balance.owner.is_empty() {
+                                                                        None
+                                                                    } else {
+                                                                        Some(balance.owner.clone())
                                                                     },
                                                                 });
                                                             }

--- a/tests/dex_parser_orca.rs
+++ b/tests/dex_parser_orca.rs
@@ -30,6 +30,7 @@ fn token_balance(account_index: u8, mint: &Pubkey, amount: u64, decimals: u8) ->
             amount: amount.to_string(),
         },
         program_id: None,
+        owner: None,
     }
 }
 


### PR DESCRIPTION
## Summary

PR1 (Wallet SSOT): Behebt fehlende/verzögerte Token-`WalletBalanceSnapshot`-Events durch zwei strukturelle Fixes:

- **Phase 1 (market-data):** Publiziert `WalletBalanceSnapshot` aus Geyser-TX-`post_token_balances` und Native-SOL aus TX-Meta wenn die getrackte Wallet beteiligt ist — kein Account-Subscribe-Race mehr für eigene Trades.
- **Phase 2 (execution-engine):** Publiziert frühes `ExecutionStatus::Sent` ExecutionResult **vor** Confirm-Wartezeit mit PDA-derived ATA-Metadata, damit market-data ATAs sofort pinned.

Kein FIX-32 removal, kein RPC-Fallback. Handoff: `Iron_crab-eval/docs/supervisor/handoff_pr1_wallet_tx_meta_pretack_ata.md`.

## Test plan

- [ ] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (CI)
- [ ] Unit tests: `wallet_tx_meta_balance_tests`
- [ ] Prod nach Deploy: market-data log `WalletBalanceSnapshot` innerhalb 1-2 Slots nach BUY; EE `Token balance sync` ohne Minuten-Delay

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live wallet balance publishing, Geyser subscription churn from ATA pins, and an extra ExecutionResult per send; behavior is mostly additive with idempotent ATA tracking but affects timing-sensitive downstream consumers.
> 
> **Overview**
> **PR1 wallet SSOT:** Cuts the lag between send/confirm and wallet balance + ATA tracking by adding two parallel paths.
> 
> **market-data (Phase 1):** On each Geyser TX, when the tracked wallet is involved, it now emits `WalletBalanceSnapshot` from TX meta (`post_token_balances` + native SOL), skips duplicate native SOL when WSOL appears in post balances (PR #201), and idempotently pins ATAs / refreshes Geyser subscribe lists from those balance rows. Geyser `TokenBalance` gains an `owner` field and small helpers (`geyser_tx_involves_wallet`, etc.).
> 
> **execution-engine (Phase 2):** Right after a successful send (before confirm wait), it publishes an extra `ExecutionStatus::Sent` result with phase `pre_confirm_track`, a **new** `execution_id`, and PDA-derived ATA metadata via shared `enrich_execution_result_ata_metadata` (refactored out of the post-confirm path).
> 
> Tests cover TX-meta wallet snapshots and pinning; dex_parser/Orca fixtures updated for `owner: None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca3819c4608fae08fd99e64f8b83420b294d4856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->