### PR TITLE
fix(execution-engine): wallet snapshot live consumer DeliverPolicy::New

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -6573,6 +6573,62 @@ async fn bootstrap_token_balances_from_wallet_snapshot(
     Ok(observed)
 }
 
+/// Create the durable live wallet snapshot consumer for the main loop.
+///
+/// When `bootstrap_observed == 0` (stream missing at bootstrap or no snapshots), uses
+/// `LastPerSubject` so the consumer backfills latest per-mint snapshots when the stream
+/// appears later. Otherwise uses `New` to avoid replaying history already seeded by bootstrap.
+async fn create_wallet_snapshot_live_consumer(
+    nats_client: &NatsClient,
+    wallet: &Pubkey,
+    bootstrap_observed: usize,
+) -> Option<async_nats::jetstream::consumer::Consumer<async_nats::jetstream::consumer::pull::Config>>
+{
+    use async_nats::jetstream;
+
+    let jetstream = jetstream::new(nats_client.client().clone());
+    let stream = match jetstream.get_stream(WALLET_SNAPSHOT_STREAM_NAME).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                error = %e,
+                stream = WALLET_SNAPSHOT_STREAM_NAME,
+                "JetStream wallet snapshot stream not found (market-data may not be running)"
+            );
+            return None;
+        }
+    };
+
+    let wallet_str = wallet.to_string();
+    let mut cfg = wallet_snapshot_live_consumer_config_execution_engine(&wallet_str);
+    if bootstrap_observed == 0 {
+        cfg.deliver_policy = jetstream::consumer::DeliverPolicy::LastPerSubject;
+    }
+
+    match stream.create_consumer(cfg).await {
+        Ok(consumer) => {
+            info!(
+                stream = WALLET_SNAPSHOT_STREAM_NAME,
+                wallet = %wallet_str,
+                deliver_policy = if bootstrap_observed == 0 {
+                    "LastPerSubject"
+                } else {
+                    "New"
+                },
+                "Subscribed to JetStream WalletBalanceSnapshot (live)"
+            );
+            Some(consumer)
+        }
+        Err(e) => {
+            warn!(
+                error = %e,
+                "Failed to create JetStream consumer for WalletBalanceSnapshot"
+            );
+            None
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize tracing
@@ -7011,12 +7067,25 @@ async fn main() -> Result<()> {
     // This also replaces the hardcoded 1 SOL default with the actual on-chain balance
     // from JetStream (persistent), avoiding the race condition with core NATS
     // WalletBalanceUpdate (fire-and-forget, can be missed if not yet subscribed).
-    if let (Some(ref nats_client), Some(wallet)) = (&nats, wallet_pubkey) {
-        if let Err(e) =
-            bootstrap_token_balances_from_wallet_snapshot(nats_client, &wallet, &lock_manager).await
+    // The live consumer is created immediately after bootstrap (reused in the main loop)
+    // so snapshots published during the long startup phase are not missed (DeliverPolicy::New).
+    let mut wallet_snapshot_bootstrap_observed = 0usize;
+    let wallet_snapshot_bootstrap_consumer = if let (Some(ref nats_client), Some(wallet)) =
+        (&nats, wallet_pubkey)
+    {
+        wallet_snapshot_bootstrap_observed = match bootstrap_token_balances_from_wallet_snapshot(
+            nats_client,
+            &wallet,
+            &lock_manager,
+        )
+        .await
         {
-            warn!(error = %e, "Wallet snapshot bootstrap: failed to seed token balances");
-        }
+            Ok(observed) => observed,
+            Err(e) => {
+                warn!(error = %e, "Wallet snapshot bootstrap: failed to seed token balances");
+                0
+            }
+        };
         // "Available WSOL" metric: always actual WSOL (0 when no ATA), never native SOL fallback.
         let wsol = lock_manager.available_wsol();
         AVAILABLE_SOL_LAMPORTS.store(wsol, Ordering::Relaxed);
@@ -7028,7 +7097,15 @@ async fn main() -> Result<()> {
             total_sol_wsol = (total_native_sol.saturating_add(wsol)) as f64 / 1e9,
             "Prometheus metrics refreshed after wallet snapshot bootstrap"
         );
-    }
+        create_wallet_snapshot_live_consumer(
+            nats_client,
+            &wallet,
+            wallet_snapshot_bootstrap_observed,
+        )
+        .await
+    } else {
+        None
+    };
 
     // Kill-switch persistence: survives restarts and is independent of day.
     let initial_kill_switch_active = snapshot
@@ -8080,44 +8157,17 @@ async fn main() -> Result<()> {
     // Subscribe to WalletBalanceSnapshot from JetStream (subject-per-wallet+mint).
     //
     // This keeps LockManager token balances synced WITHOUT any RPC calls.
-    let wallet_snapshot_consumer = if let (Some(ref nats), Some(wallet)) =
-        (&ctx.nats, ctx.wallet_pubkey)
-    {
-        use async_nats::jetstream;
-
-        let jetstream = jetstream::new(nats.client().clone());
-        match jetstream.get_stream(WALLET_SNAPSHOT_STREAM_NAME).await {
-            Ok(stream) => {
-                let wallet_str = wallet.to_string();
-                let mut cfg = wallet_snapshot_live_consumer_config_execution_engine();
-                cfg.filter_subject = format!("ironcrab.wallet_snapshot.{}.*", wallet_str);
-                match stream.create_consumer(cfg).await {
-                    Ok(consumer) => {
-                        info!(
-                            stream = WALLET_SNAPSHOT_STREAM_NAME,
-                            wallet = %wallet_str,
-                            "Subscribed to JetStream WalletBalanceSnapshot (live, DeliverPolicy::New)"
-                        );
-                        Some(consumer)
-                    }
-                    Err(e) => {
-                        warn!(
-                            error = %e,
-                            "Failed to create JetStream consumer for WalletBalanceSnapshot"
-                        );
-                        None
-                    }
-                }
-            }
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    stream = WALLET_SNAPSHOT_STREAM_NAME,
-                    "JetStream wallet snapshot stream not found (market-data may not be running)"
-                );
-                None
-            }
-        }
+    // Reuse the consumer created right after bootstrap when available; otherwise create
+    // now (e.g. stream appeared after bootstrap) with LastPerSubject if bootstrap missed.
+    let wallet_snapshot_consumer = if let Some(consumer) = wallet_snapshot_bootstrap_consumer {
+        info!(
+            stream = WALLET_SNAPSHOT_STREAM_NAME,
+            "Reusing early wallet snapshot consumer for live sync (no startup gap)"
+        );
+        Some(consumer)
+    } else if let (Some(ref nats), Some(wallet)) = (&ctx.nats, ctx.wallet_pubkey) {
+        create_wallet_snapshot_live_consumer(nats, &wallet, wallet_snapshot_bootstrap_observed)
+            .await
     } else {
         None
     };

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -95,7 +95,8 @@ use ironcrab::metrics::{
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
-    ensure_trade_intents_stream, wallet_snapshot_consumer_config, NatsClient, NatsConfig,
+    ensure_trade_intents_stream, wallet_snapshot_consumer_config,
+    wallet_snapshot_live_consumer_config_execution_engine, NatsClient, NatsConfig,
     CONFIG_STREAM_NAME, STREAM_NAME, TOPIC_CONTROL_REQUESTS, TOPIC_CONTROL_RESPONSES,
     TOPIC_DECISION_RECORDS, TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS,
     TOPIC_PRIORITY_FEE_SAMPLES, TOPIC_TRADE_INTENTS, TRADE_INTENTS_STREAM_NAME,
@@ -8088,14 +8089,14 @@ async fn main() -> Result<()> {
         match jetstream.get_stream(WALLET_SNAPSHOT_STREAM_NAME).await {
             Ok(stream) => {
                 let wallet_str = wallet.to_string();
-                let mut cfg = wallet_snapshot_consumer_config();
+                let mut cfg = wallet_snapshot_live_consumer_config_execution_engine();
                 cfg.filter_subject = format!("ironcrab.wallet_snapshot.{}.*", wallet_str);
                 match stream.create_consumer(cfg).await {
                     Ok(consumer) => {
                         info!(
                             stream = WALLET_SNAPSHOT_STREAM_NAME,
                             wallet = %wallet_str,
-                            "Subscribed to JetStream WalletBalanceSnapshot (token balance sync)"
+                            "Subscribed to JetStream WalletBalanceSnapshot (live, DeliverPolicy::New)"
                         );
                         Some(consumer)
                     }

--- a/src/nats/jetstream.rs
+++ b/src/nats/jetstream.rs
@@ -394,15 +394,16 @@ pub fn wallet_snapshot_live_consumer_config() -> jetstream::consumer::pull::Conf
 }
 
 /// Consumer config for live WalletBalanceSnapshot updates in execution-engine.
-/// Durable consumer with DeliverPolicy::New so reconnects receive fresh snapshots.
-pub fn wallet_snapshot_live_consumer_config_execution_engine() -> jetstream::consumer::pull::Config
-{
+/// Durable consumer scoped per wallet; DeliverPolicy may be overridden at create time.
+pub fn wallet_snapshot_live_consumer_config_execution_engine(
+    wallet: &str,
+) -> jetstream::consumer::pull::Config {
     jetstream::consumer::pull::Config {
         deliver_policy: jetstream::consumer::DeliverPolicy::New,
         ack_policy: jetstream::consumer::AckPolicy::Explicit,
-        durable_name: Some("execution-engine-wallet-snapshot".to_string()),
+        durable_name: Some(format!("execution-engine-wallet-snapshot-{}", wallet)),
         max_ack_pending: 1000,
-        filter_subject: "ironcrab.wallet_snapshot.>".to_string(),
+        filter_subject: format!("ironcrab.wallet_snapshot.{}.*", wallet),
         ..Default::default()
     }
 }
@@ -464,14 +465,16 @@ mod tests {
 
     #[test]
     fn wallet_snapshot_live_consumer_execution_engine_uses_new_deliver_policy() {
-        let live = wallet_snapshot_live_consumer_config_execution_engine();
+        let wallet = "WALLET123";
+        let live = wallet_snapshot_live_consumer_config_execution_engine(wallet);
         assert!(matches!(
             live.deliver_policy,
             jetstream::consumer::DeliverPolicy::New
         ));
         assert_eq!(
             live.durable_name.as_deref(),
-            Some("execution-engine-wallet-snapshot")
+            Some("execution-engine-wallet-snapshot-WALLET123")
         );
+        assert_eq!(live.filter_subject, "ironcrab.wallet_snapshot.WALLET123.*");
     }
 }

--- a/src/nats/jetstream.rs
+++ b/src/nats/jetstream.rs
@@ -393,6 +393,20 @@ pub fn wallet_snapshot_live_consumer_config() -> jetstream::consumer::pull::Conf
     }
 }
 
+/// Consumer config for live WalletBalanceSnapshot updates in execution-engine.
+/// Durable consumer with DeliverPolicy::New so reconnects receive fresh snapshots.
+pub fn wallet_snapshot_live_consumer_config_execution_engine() -> jetstream::consumer::pull::Config
+{
+    jetstream::consumer::pull::Config {
+        deliver_policy: jetstream::consumer::DeliverPolicy::New,
+        ack_policy: jetstream::consumer::AckPolicy::Explicit,
+        durable_name: Some("execution-engine-wallet-snapshot".to_string()),
+        max_ack_pending: 1000,
+        filter_subject: "ironcrab.wallet_snapshot.>".to_string(),
+        ..Default::default()
+    }
+}
+
 /// Consumer config for trade intents (All = includes intents published before we subscribed)
 pub fn trade_intents_consumer_config() -> jetstream::consumer::pull::Config {
     jetstream::consumer::pull::Config {
@@ -446,5 +460,18 @@ mod tests {
             slave.deliver_policy,
             jetstream::consumer::DeliverPolicy::LastPerSubject
         ));
+    }
+
+    #[test]
+    fn wallet_snapshot_live_consumer_execution_engine_uses_new_deliver_policy() {
+        let live = wallet_snapshot_live_consumer_config_execution_engine();
+        assert!(matches!(
+            live.deliver_policy,
+            jetstream::consumer::DeliverPolicy::New
+        ));
+        assert_eq!(
+            live.durable_name.as_deref(),
+            Some("execution-engine-wallet-snapshot")
+        );
     }
 }


### PR DESCRIPTION
## Summary

PR2: EE live WalletBalanceSnapshot consumer uses DeliverPolicy::New + durable execution-engine-wallet-snapshot (momentum-bot pattern). Bootstrap recovery stays LastPerSubject.

## Test plan

- [ ] CI green
- [ ] Unit test wallet_snapshot_live_consumer_execution_engine_uses_new_deliver_policy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how LockManager receives wallet balance updates during startup; incorrect policy could desync balances until recovery, but bootstrap plus LastPerSubject fallback limits exposure.
> 
> **Overview**
> Fixes a **startup gap** where wallet snapshots published during execution-engine’s long init could be missed before the main loop subscribed.
> 
> The live JetStream consumer is now created **immediately after** wallet snapshot bootstrap and **reused** in the main loop, using a new per-wallet durable config (`execution-engine-wallet-snapshot-{wallet}`) with **`DeliverPolicy::New`** so live sync does not replay history already applied by bootstrap. If bootstrap saw **no** snapshots (stream missing or empty), deliver policy is overridden to **`LastPerSubject`** for recovery when the stream appears later.
> 
> Bootstrap recovery continues to use the existing **`LastPerSubject`** path; only the live consumer wiring and policy selection changed (aligned with the momentum-bot wallet snapshot pattern).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f0b1f66c8657c560991279d21344756d8c88ac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->