### PR TITLE
fix(confirm): remove duplicate slot in WalletTxConfirmed MarketEvent serde (PR3.2)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -89,10 +89,11 @@ use ironcrab::metrics::{
     PUMPSWAP_HOT_PATH_HEALING_SKIPPED_NO_NATS_TOTAL, PUMPSWAP_HOT_PATH_HEALING_TRIGGER_TOTAL,
     REJECT_CAPITAL_LOCK, REJECT_DUPLICATE, REJECT_RESOURCE_LOCK, REJECT_SEND_FAILED,
     REJECT_SIMULATION_FAIL, SIMULATION_FAILURES_TOTAL, TX_CONFIRMED_TOTAL,
-    TX_CONFIRM_JETSTREAM_ORPHAN_BUFFERED_TOTAL, TX_CONFIRM_JETSTREAM_ORPHAN_EVICTED_TOTAL,
-    TX_CONFIRM_JETSTREAM_ORPHAN_HIT_TOTAL, TX_CONFIRM_JETSTREAM_TOTAL, TX_CONFIRM_LATENCY_MS,
-    TX_CONFIRM_TIMEOUT_TOTAL, TX_SEND_ATTEMPTS_TOTAL, TX_SEND_JITO_TOTAL, TX_SEND_RPC_TOTAL,
-    TX_SEND_SUCCESS_TOTAL, TX_SEND_TPU_TOTAL, WALLET_TOTAL_SOL_LAMPORTS,
+    TX_CONFIRM_DESERIALIZE_ERRORS_TOTAL, TX_CONFIRM_JETSTREAM_ORPHAN_BUFFERED_TOTAL,
+    TX_CONFIRM_JETSTREAM_ORPHAN_EVICTED_TOTAL, TX_CONFIRM_JETSTREAM_ORPHAN_HIT_TOTAL,
+    TX_CONFIRM_JETSTREAM_TOTAL, TX_CONFIRM_LATENCY_MS, TX_CONFIRM_TIMEOUT_TOTAL,
+    TX_SEND_ATTEMPTS_TOTAL, TX_SEND_JITO_TOTAL, TX_SEND_RPC_TOTAL, TX_SEND_SUCCESS_TOTAL,
+    TX_SEND_TPU_TOTAL, WALLET_TOTAL_SOL_LAMPORTS,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
@@ -8403,22 +8404,30 @@ async fn main() -> Result<()> {
                                             Ok(event) => {
                                                 if let MarketEventKind::WalletTxConfirmed {
                                                     signature,
-                                                    slot,
                                                     err,
                                                     ..
                                                 } = event.kind
                                                 {
-                                                    dispatch_wallet_tx_confirmed(
-                                                        &ctx.pending_tx_confirms,
-                                                        &ctx.recent_orphan_tx_confirms,
-                                                        &signature,
-                                                        slot,
-                                                        err,
-                                                    );
+                                                    if let Some(slot) = event.slot {
+                                                        dispatch_wallet_tx_confirmed(
+                                                            &ctx.pending_tx_confirms,
+                                                            &ctx.recent_orphan_tx_confirms,
+                                                            &signature,
+                                                            slot,
+                                                            err,
+                                                        );
+                                                    } else {
+                                                        warn!(
+                                                            sig = %signature,
+                                                            "WalletTxConfirmed missing event.slot; skipping dispatch"
+                                                        );
+                                                    }
                                                 }
                                             }
                                             Err(e) => {
-                                                debug!(
+                                                TX_CONFIRM_DESERIALIZE_ERRORS_TOTAL
+                                                    .fetch_add(1, Ordering::Relaxed);
+                                                warn!(
                                                     error = %e,
                                                     "Failed to deserialize WalletTxConfirmed MarketEvent"
                                                 );

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -12262,7 +12262,6 @@ async fn run_geyser_loop(
                     MarketEventKind::WalletTxConfirmed {
                         wallet: wallet_str.clone(),
                         signature: update.signature.clone(),
-                        slot: update.slot,
                         err: update.err.clone(),
                     },
                 );

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -400,7 +400,6 @@ pub enum MarketEventKind {
         wallet: String,
         /// Transaction signature (base58)
         signature: String,
-        slot: u64,
         /// `None` = success; `Some` = on-chain error string
         err: Option<String>,
     },
@@ -2147,6 +2146,74 @@ mod tests {
 
         let parsed: MarketEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.event_id, "evt-001");
+    }
+
+    #[test]
+    fn wallet_tx_confirmed_market_event_serde_roundtrip_single_slot() {
+        let slot = 424_701_631_u64;
+        let wallet = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
+        let signature = "51aMkHyfExampleSignatureForRegressionTestOnly";
+        let event = MarketEvent::new(
+            "market-data",
+            "v0.1.0",
+            "run-wallet-tx",
+            format!("wallet_tx_confirm_{signature}_{slot}"),
+            "geyser_wallet_tx_confirm",
+            Some(slot),
+            MarketEventKind::WalletTxConfirmed {
+                wallet: wallet.to_string(),
+                signature: signature.to_string(),
+                err: None,
+            },
+        );
+
+        let json = serde_json::to_string(&event).expect("serialize WalletTxConfirmed");
+        assert_eq!(
+            json.matches("\"slot\":").count(),
+            1,
+            "WalletTxConfirmed JSON must contain exactly one slot field (got: {json})"
+        );
+
+        let parsed: MarketEvent =
+            serde_json::from_str(&json).expect("deserialize WalletTxConfirmed");
+        assert_eq!(parsed.slot, Some(slot));
+        if let MarketEventKind::WalletTxConfirmed {
+            wallet: parsed_wallet,
+            signature: parsed_sig,
+            err,
+        } = parsed.kind
+        {
+            assert_eq!(parsed_wallet, wallet);
+            assert_eq!(parsed_sig, signature);
+            assert!(err.is_none());
+        } else {
+            panic!("expected WalletTxConfirmed variant");
+        }
+    }
+
+    #[test]
+    fn wallet_tx_confirmed_duplicate_slot_json_fails_deserialize() {
+        // Regression: pre-PR3.2 prod payloads had slot in both MarketEvent and kind (flatten collision).
+        let legacy_json = r#"{
+            "schema_version":1,
+            "ts_unix_ms":1,
+            "component":"market-data",
+            "build":"v0.1.0",
+            "run_id":"run-wallet-tx",
+            "event_id":"wallet_tx_confirm_legacy",
+            "source":"geyser_wallet_tx_confirm",
+            "slot":424701631,
+            "kind":"WalletTxConfirmed",
+            "wallet":"7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "signature":"51aMkHyfExampleSignatureForRegressionTestOnly",
+            "slot":424701631,
+            "err":null
+        }"#;
+        let err = serde_json::from_str::<MarketEvent>(legacy_json).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate field"),
+            "expected duplicate field serde error, got: {err}"
+        );
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2031,6 +2031,8 @@ pub static TX_CONFIRMED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0))
 pub static TX_CONFIRM_TIMEOUT_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 // PR3: JetStream-based TX confirmation (market-data Geyser → JetStream → EE)
 pub static TX_CONFIRM_JETSTREAM_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+// PR3.2: JetStream WalletTxConfirmed deserialize failures (duplicate slot serde, etc.)
+pub static TX_CONFIRM_DESERIALIZE_ERRORS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 // PR3.1: Orphan WalletTxConfirmed buffer (confirm arrived before waiter registration)
 pub static TX_CONFIRM_JETSTREAM_ORPHAN_BUFFERED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -3735,6 +3737,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "tx_confirm_jetstream_total",
         TX_CONFIRM_JETSTREAM_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "tx_confirm_deserialize_errors_total",
+        TX_CONFIRM_DESERIALIZE_ERRORS_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "tx_confirm_jetstream_orphan_buffered_total",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (Prod nach PR3 / PR3.1)

TX landet on-chain, market-data publiziert `WalletTxConfirmed` zu JetStream, EE-Consumer **delivered & acked** alle Messages — aber:

- `tx_confirm_jetstream_total = 0`
- `tx_confirm_jetstream_orphan_* = 0`
- Alle Intents enden `outcome=Sent` (Confirm-Timeout)
- Momentum: `entry_confirmed_slot=0`

**Root Cause:** `MarketEvent` nutzt `#[serde(flatten)]` auf `kind: MarketEventKind`. Beim Publish von `WalletTxConfirmed` wurden **zwei** JSON-Felder `"slot"` serialisiert:

1. `MarketEvent.slot: Option<u64>` (äußeres Feld)
2. `MarketEventKind::WalletTxConfirmed { slot: ... }` (flatten-kollidierend)

Serde-Fehler: `duplicate field slot` → EE dispatch nie aufgerufen → Waiter timeout.

## Fix

1. **`src/ipc/schema.rs`**: `slot` aus `WalletTxConfirmed`-Variante entfernt; Slot lebt nur in `MarketEvent.slot`
2. **`src/bin/market_data.rs`**: Publish ohne `slot` in Variante (behält `Some(update.slot)` in `MarketEvent::new`)
3. **`src/bin/execution_engine.rs`**: Slot aus `event.slot` lesen; bei fehlendem Slot `warn!` + ack (kein Poison-Redelivery)
4. **`src/metrics.rs`**: `tx_confirm_deserialize_errors_total` Counter; Deserialize-Fehler von `debug!` → `warn!`
5. **Unit-Tests**: Serde-Roundtrip mit genau einem `"slot"`; Regression-Test für Legacy-Duplicate-JSON

## Invarianten-Check

| Prüfung | Ergebnis |
|---------|----------|
| I-4 Geyser-First | ✓ Kein EE-Geyser-Reintroduce |
| I-7 Kein RPC-Fallback | ✓ Kein RPC bei Deserialize-Fail/Timeout |
| I-9 Simulation-Gate | ✓ Unverändert |
| I-12 Decision Record | ✓ Confirms können wieder `Confirmed` Outcome erzeugen |
| A.7 IPC Schema | ✓ Eindeutiges JSON-Schema, Roundtrip-Test |

## Prod-Verifikation nach Merge + Deploy

1. EE Metriken: `tx_confirm_jetstream_total > 0`, `tx_confirmed_total > 0`
2. EE Logs: `outcome=Confirmed` statt nur `Sent`
3. Momentum: neue Entries mit `entry_confirmed_slot > 0`
4. JetStream: neue Messages haben **genau ein** `"slot"`-Feld im JSON

## Tests

```
cargo fmt --all
cargo clippy -- -D warnings
cargo test
```

Alle 420+ Unit-Tests grün.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a832ada9-17d6-4b15-97a2-37774d86e53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a832ada9-17d6-4b15-97a2-37774d86e53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

