### PR TITLE
fix(dashboard): trades_server read rotated execution_results + recent_trades fast path

### DIFF
--- a/scripts/test_trades_server.py
+++ b/scripts/test_trades_server.py
@@ -1,0 +1,223 @@
+"""Tests for trades_server JSONL loading (rotation, run fast-path, pre_confirm skip)."""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+import trades_server as ts  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    ts.clear_trades_cache()
+    yield
+    ts.clear_trades_cache()
+
+
+@pytest.fixture
+def log_dirs(tmp_path, monkeypatch):
+    """Point EXECUTIONS_DIR and RECENT_TRADES_DIR at a temp tree."""
+    exec_dir = tmp_path / "executions"
+    recent_dir = tmp_path / "recent"
+    exec_dir.mkdir()
+    recent_dir.mkdir()
+    monkeypatch.setattr(ts, "EXECUTIONS_DIR", exec_dir)
+    monkeypatch.setattr(ts, "RECENT_TRADES_DIR", recent_dir)
+    fixed_date = "20990606"
+    monkeypatch.setattr(ts, "_utc_date_str", lambda days_ago: fixed_date)
+    return exec_dir, recent_dir, fixed_date
+
+
+def _minimal_buy_record(
+    signature: str,
+    *,
+    run_id: str = "run-current",
+    ts_ms: int = 1_800_000_000_000,
+    side: str = "BUY",
+    exit_type: str | None = None,
+    phase: str | None = None,
+    status: str = "confirmed",
+) -> dict:
+    metadata = {"side": side}
+    if exit_type:
+        metadata["exit_type"] = exit_type
+    if phase:
+        metadata["phase"] = phase
+    return {
+        "status": status,
+        "ts_unix_ms": ts_ms,
+        "run_id": run_id,
+        "signature": signature,
+        "token_mint": "Mint1111111111111111111111111111111111111",
+        "fill_in": {"raw": 10_000_000, "decimals": 9},
+        "fill_out": {"raw": 1_000_000, "decimals": 6},
+        "metadata": metadata,
+    }
+
+
+def _minimal_sell_record(
+    signature: str,
+    *,
+    run_id: str = "run-current",
+    ts_ms: int = 1_800_000_100_000,
+    exit_type: str = "TAKE_PROFIT",
+) -> dict:
+    return _minimal_buy_record(
+        signature,
+        run_id=run_id,
+        ts_ms=ts_ms,
+        side="SELL",
+        exit_type=exit_type,
+    )
+
+
+def _recent_trade_line(
+    signature: str,
+    action: str,
+    *,
+    ts_ms: int = 1_800_000_100_000,
+    run_id: str = "",
+) -> dict:
+    return {
+        "timestamp_ms": ts_ms,
+        "mint": "Mint1111111111111111111111111111111111111",
+        "action": action,
+        "tx_hash": signature,
+        "amount_tokens": 1.0,
+        "value_sol": 0.01,
+        "run_id": run_id,
+    }
+
+
+class TestRotatedExecutionResults:
+    def test_base_and_rotated_segment_both_loaded(self, log_dirs):
+        exec_dir, _, date = log_dirs
+        base = exec_dir / f"execution_results-{date}.jsonl"
+        rotated = exec_dir / f"execution_results-{date}.5.jsonl"
+        base.write_text(
+            json.dumps(_minimal_buy_record("sig-base")) + "\n", encoding="utf-8"
+        )
+        rotated.write_text(
+            json.dumps(_minimal_buy_record("sig-rotated", ts_ms=1_800_000_050_000))
+            + "\n",
+            encoding="utf-8",
+        )
+
+        handler = ts.TradesHandler.__new__(ts.TradesHandler)
+        trades = handler._load_trades_from_execution_jsonl([0])
+        hashes = {t["tx_hash"] for t in trades}
+
+        assert hashes == {"sig-base", "sig-rotated"}
+
+
+class TestPreConfirmSkip:
+    def test_pre_confirm_track_excluded(self, log_dirs):
+        exec_dir, _, date = log_dirs
+        path = exec_dir / f"execution_results-{date}.jsonl"
+        lines = [
+            _minimal_buy_record("good", phase=None),
+            _minimal_buy_record("noise", phase="pre_confirm_track"),
+            _minimal_buy_record("pending", status="sent"),
+        ]
+        path.write_text(
+            "\n".join(json.dumps(r) for r in lines) + "\n", encoding="utf-8"
+        )
+
+        handler = ts.TradesHandler.__new__(ts.TradesHandler)
+        trades = handler._load_trades_from_execution_jsonl([0])
+
+        assert len(trades) == 1
+        assert trades[0]["tx_hash"] == "good"
+
+
+class TestRunModeFastPath:
+    def test_recent_sell_enriched_with_execution_reason(self, log_dirs):
+        exec_dir, recent_dir, date = log_dirs
+        buy_sig = "buy-sig"
+        sell_sig = "sell-sig"
+
+        exec_path = exec_dir / f"execution_results-{date}.jsonl"
+        exec_path.write_text(
+            json.dumps(_minimal_buy_record(buy_sig, ts_ms=1_800_000_000_000))
+            + "\n"
+            + json.dumps(
+                _minimal_sell_record(
+                    sell_sig, ts_ms=1_800_000_100_000, exit_type="TAKE_PROFIT"
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        recent_path = recent_dir / f"recent_trades-{date}.jsonl"
+        recent_path.write_text(
+            json.dumps(_recent_trade_line(buy_sig, "BUY", ts_ms=1_800_000_000_000))
+            + "\n"
+            + json.dumps(
+                _recent_trade_line(sell_sig, "SELL", ts_ms=1_800_000_100_000)
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        handler = ts.TradesHandler.__new__(ts.TradesHandler)
+        trades = handler.read_trades_by_run()
+        actions = {t["action"]: t for t in trades}
+
+        assert "SELL" in actions
+        assert actions["SELL"]["reason"] == "TAKE_PROFIT"
+        assert actions["BUY"]["tx_hash"] == buy_sig
+
+    def test_run_id_less_recent_included_in_current_run_window(self, log_dirs):
+        exec_dir, recent_dir, date = log_dirs
+        exec_path = exec_dir / f"execution_results-{date}.jsonl"
+        exec_path.write_text(
+            json.dumps(_minimal_buy_record("exec-buy", run_id="run-A")) + "\n",
+            encoding="utf-8",
+        )
+
+        recent_path = recent_dir / f"recent_trades-{date}.jsonl"
+        recent_path.write_text(
+            json.dumps(
+                _recent_trade_line(
+                    "recent-sell",
+                    "SELL",
+                    ts_ms=1_800_000_000_000,
+                    run_id="",
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        handler = ts.TradesHandler.__new__(ts.TradesHandler)
+        trades = handler.read_trades_by_run()
+        hashes = {t["tx_hash"] for t in trades}
+
+        assert "recent-sell" in hashes
+        assert "exec-buy" in hashes
+
+
+class TestCache:
+    def test_cache_returns_same_object_within_ttl(self, log_dirs, monkeypatch):
+        exec_dir, _, date = log_dirs
+        path = exec_dir / f"execution_results-{date}.jsonl"
+        path.write_text(
+            json.dumps(_minimal_buy_record("cached")) + "\n", encoding="utf-8"
+        )
+
+        handler = ts.TradesHandler.__new__(ts.TradesHandler)
+        first = handler.load_all_trades([0])
+        second = handler.load_all_trades([0])
+        assert first is second
+
+        path.write_text(
+            json.dumps(_minimal_buy_record("cached-new")) + "\n", encoding="utf-8"
+        )
+        third = handler.load_all_trades([0])
+        assert third is not first
+        assert third[0]["tx_hash"] == "cached-new"

--- a/scripts/trades_server.py
+++ b/scripts/trades_server.py
@@ -70,6 +70,8 @@ _trades_cache: dict = {}
 
 # Fields copied from execution_results when enriching recent_trades rows.
 _EXEC_ENRICH_KEYS = (
+    "timestamp_ms",
+    "time",
     "reason",
     "reason_detail",
     "exit_type",

--- a/scripts/trades_server.py
+++ b/scripts/trades_server.py
@@ -8,8 +8,10 @@ Reads from: trade_logs/executions/execution_results-YYYYMMDD.jsonl
 Grafana Infinity data source connects to this for "Recent Trades" table panel.
 
 Tail-read (P172): only the last N lines per file are scanned (not full-file O(n) loads).
+Run mode (P173): recent_trades JSONL first, enrich from execution_results* (incl. rotated segments).
 Env:
   IRONCRAB_TRADES_JSONL_TAIL_LINES — max non-empty lines per file (default 15000)
+  IRONCRAB_TRADES_CACHE_TTL_SEC — in-memory cache TTL seconds (default 3)
   IRONCRAB_TRADES_DAYS_LOOKBACK — optional override; endpoints use [0], [0,1], or [0,1] for pnl
 
 `timestamp_ms` on each trade is the on-chain block time (UTC) when `block_time_unix_ms`
@@ -28,10 +30,11 @@ import json
 import os
 import re
 import tempfile
+import time
 from collections import deque
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Iterator, List, Optional
+from typing import Callable, Iterator, List, Optional, Tuple
 from urllib.parse import urlparse, parse_qs
 import argparse
 
@@ -60,6 +63,84 @@ DAYS_LOOKBACK_OVERRIDE: Optional[List[int]] = None
 _raw_lookback = os.environ.get("IRONCRAB_TRADES_DAYS_LOOKBACK", "").strip()
 if _raw_lookback:
     DAYS_LOOKBACK_OVERRIDE = [int(x.strip()) for x in _raw_lookback.split(",") if x.strip() != ""]
+
+# In-memory cache for JSONL loads (Grafana polls every 5s).
+TRADES_CACHE_TTL_SEC = max(2, _env_int("IRONCRAB_TRADES_CACHE_TTL_SEC", 3))
+_trades_cache: dict = {}
+
+# Fields copied from execution_results when enriching recent_trades rows.
+_EXEC_ENRICH_KEYS = (
+    "reason",
+    "reason_detail",
+    "exit_type",
+    "exit_reason",
+    "run_id",
+    "wallet_sol_delta",
+    "value_sol",
+    "amount_tokens",
+)
+
+
+def _should_skip_execution_record(record: dict) -> bool:
+    """Skip pre_confirm_track noise and non-terminal execution statuses."""
+    metadata = record.get("metadata") or {}
+    if isinstance(metadata, dict) and metadata.get("phase") == "pre_confirm_track":
+        return True
+    status = str(record.get("status") or "").lower()
+    return status not in ("confirmed", "failed_confirmed")
+
+
+def _enrich_trade_with_execution(recent: dict, execution: dict) -> dict:
+    """Overlay execution_results fields onto a recent_trades row (same tx_hash)."""
+    out = dict(recent)
+    for key in _EXEC_ENRICH_KEYS:
+        val = execution.get(key)
+        if val is not None and val != "":
+            out[key] = val
+    return out
+
+
+def _watch_paths_for_days(days_ago_list: List[int]) -> List[Path]:
+    """Paths whose mtime/size invalidate the trades cache."""
+    paths: List[Path] = []
+    for days_ago in days_ago_list:
+        date = _utc_date_str(days_ago)
+        paths.extend(_jsonl_segment_paths(EXECUTIONS_DIR, "execution_results", date))
+        recent_path = RECENT_TRADES_DIR / f"recent_trades-{date}.jsonl"
+        if recent_path.is_file():
+            paths.append(recent_path)
+    return paths
+
+
+def _paths_fingerprint(paths: List[Path]) -> Tuple[tuple, ...]:
+    fp: List[tuple] = []
+    for path in paths:
+        try:
+            if path.is_file():
+                st = path.stat()
+                fp.append((str(path), st.st_mtime_ns, st.st_size))
+            else:
+                fp.append((str(path), 0, 0))
+        except OSError:
+            fp.append((str(path), 0, 0))
+    return tuple(fp)
+
+
+def _cached_trades_load(cache_key: str, paths: List[Path], loader: Callable[[], list]) -> list:
+    """Return cached trade list when TTL + file fingerprints are unchanged."""
+    now = time.monotonic()
+    fp = _paths_fingerprint(paths)
+    entry = _trades_cache.get(cache_key)
+    if entry and now - entry["ts"] < TRADES_CACHE_TTL_SEC and entry["fp"] == fp:
+        return entry["data"]
+    data = loader()
+    _trades_cache[cache_key] = {"ts": now, "fp": fp, "data": data}
+    return data
+
+
+def clear_trades_cache() -> None:
+    """Test helper: drop in-memory trade cache."""
+    _trades_cache.clear()
 
 
 def _days_for_endpoint(endpoint: str) -> List[int]:
@@ -320,16 +401,57 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
     def read_trades_by_run(self) -> list:
         """Read all trades from the current run + last 20 from the previous run.
 
-        Identifies the latest run_id as the 'current run'. Returns all trades
-        belonging to that run, plus up to 20 trades from the most recent
-        previous run (for context). PnL calculation covers all returned trades.
+        Fast path (P173): load small recent_trades JSONL first, enrich from
+        execution_results* (rotated segments), then filter by run_id / time window.
         """
-        all_trades = self.load_all_trades(days_ago_list=_days_for_endpoint("run"))
+        days = _days_for_endpoint("run")
+        all_trades = self._load_run_mode_trades(days)
 
         if not all_trades:
             return []
 
-        # Step 2: Identify run_ids by most recent trade timestamp
+        trades = self._select_trades_for_current_and_prev_run(all_trades)
+        self._compute_running_pnl(trades)
+        trades.sort(key=lambda t: t.get('timestamp_ms', 0), reverse=True)
+        return trades
+
+    def _load_run_mode_trades(self, days_ago_list: List[int]) -> list:
+        """Recent-trades-first load with execution_results enrichment (mode=run)."""
+        paths = _watch_paths_for_days(days_ago_list)
+        cache_key = f"run_mode:{tuple(days_ago_list)}"
+
+        def loader() -> list:
+            recent_all: list = []
+            exec_all: list = []
+            for days_ago in days_ago_list:
+                recent_all.extend(self._load_trades_from_recent_jsonl([days_ago]))
+                exec_all.extend(self._load_trades_from_execution_jsonl([days_ago]))
+
+            exec_by_hash = {t["tx_hash"]: t for t in exec_all if t.get("tx_hash")}
+            merged: list = []
+            seen_hashes: set = set()
+
+            for trade in recent_all:
+                tx_hash = trade.get("tx_hash") or ""
+                if tx_hash and tx_hash in exec_by_hash:
+                    merged.append(_enrich_trade_with_execution(trade, exec_by_hash[tx_hash]))
+                else:
+                    merged.append(trade)
+                if tx_hash:
+                    seen_hashes.add(tx_hash)
+
+            for trade in exec_all:
+                tx_hash = trade.get("tx_hash") or ""
+                if tx_hash and tx_hash not in seen_hashes:
+                    merged.append(trade)
+                    seen_hashes.add(tx_hash)
+
+            return self._dedupe_trades_by_tx_hash(merged)
+
+        return _cached_trades_load(cache_key, paths, loader)
+
+    def _select_trades_for_current_and_prev_run(self, all_trades: list) -> list:
+        """Current run (+ run_id-less rows in its time window) + up to 20 prev-run rows."""
         run_last_ts = {}
         for t in all_trades:
             rid = t.get('run_id', '')
@@ -337,12 +459,9 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
             if rid and ts > run_last_ts.get(rid, 0):
                 run_last_ts[rid] = ts
 
-        # Sort runs by last trade timestamp descending
         sorted_runs = sorted(run_last_ts.keys(), key=lambda r: run_last_ts[r], reverse=True)
 
-        # Step 3: Collect trades for current run + last 20 from previous run
         if not sorted_runs:
-            # recent_trades JSONL has no run_id — scope by calendar day of newest trade
             all_trades.sort(key=lambda t: t.get('timestamp_ms', 0), reverse=True)
             newest_ts = all_trades[0].get('timestamp_ms', 0)
             newest_day = datetime.fromtimestamp(
@@ -365,20 +484,39 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
                 != newest_day
             ]
             prev_candidates.sort(key=lambda t: t.get('timestamp_ms', 0), reverse=True)
-            prev_trades = prev_candidates[:20]
-            trades = current_trades + prev_trades
-        else:
-            current_run = sorted_runs[0]
-            prev_run = sorted_runs[1] if len(sorted_runs) > 1 else None
-            current_trades = [t for t in all_trades if t.get('run_id') == current_run]
-            prev_trades = []
-            if prev_run:
-                prev_all = [t for t in all_trades if t.get('run_id') == prev_run]
-                prev_all.sort(key=lambda t: t.get('timestamp_ms', 0), reverse=True)
-                prev_trades = prev_all[:20]
-            trades = current_trades + prev_trades
+            return current_trades + prev_candidates[:20]
 
-        # Step 4: Running PnL calculation (same logic as read_recent_trades)
+        current_run = sorted_runs[0]
+        prev_run = sorted_runs[1] if len(sorted_runs) > 1 else None
+
+        current_run_rows = [t for t in all_trades if t.get('run_id') == current_run]
+        if current_run_rows:
+            ts_values = [t.get('timestamp_ms', 0) for t in current_run_rows]
+            run_min_ts = min(ts_values)
+            run_max_ts = max(ts_values)
+        else:
+            run_min_ts = run_max_ts = None
+
+        def in_current_run(trade: dict) -> bool:
+            if trade.get('run_id') == current_run:
+                return True
+            if trade.get('run_id'):
+                return False
+            if run_min_ts is None:
+                return False
+            ts = trade.get('timestamp_ms', 0)
+            return run_min_ts <= ts <= run_max_ts
+
+        current_trades = [t for t in all_trades if in_current_run(t)]
+        prev_trades: list = []
+        if prev_run:
+            prev_all = [t for t in all_trades if t.get('run_id') == prev_run]
+            prev_all.sort(key=lambda t: t.get('timestamp_ms', 0), reverse=True)
+            prev_trades = prev_all[:20]
+        return current_trades + prev_trades
+
+    def _compute_running_pnl(self, trades: list) -> None:
+        """Running PnL over trades sorted chronologically (mutates trade dicts)."""
         trades.sort(key=lambda t: t.get('timestamp_ms', 0))
         positions = {}
         for trade in trades:
@@ -392,7 +530,6 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
                 continue
 
             if action == "BUY":
-                # Cost: PREFER value_sol (fill_in) — actual swap amount
                 cost_sol = value_sol if (value_sol is not None and value_sol > 0) else None
                 if cost_sol is None and wallet_delta is not None:
                     cost_sol = abs(wallet_delta)
@@ -405,8 +542,6 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
                 trade["pnl_sol"] = 0.0
                 trade["pnl_pct"] = None
             elif action == "SELL":
-                # Proceeds: PREFER value_sol (fill_out) — wallet_delta doesn't include
-                # WSOL swap output for PumpSwap SELL.
                 proceeds_sol = value_sol if (value_sol is not None and value_sol > 0) else 0
                 if proceeds_sol == 0:
                     proceeds_sol = wallet_delta if (wallet_delta is not None and wallet_delta > 0) else 0
@@ -423,10 +558,6 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
                 else:
                     trade["pnl_sol"] = None
                     trade["pnl_pct"] = None
-
-        # Sort by timestamp descending for display
-        trades.sort(key=lambda t: t.get('timestamp_ms', 0), reverse=True)
-        return trades
 
     def serve_pnl_24h(self):
         """Serve 24h realized PnL summary as JSON."""
@@ -575,23 +706,29 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
         """Load confirmed trades from execution_results; fallback to recent_trades JSONL (P166)."""
         if days_ago_list is None:
             days_ago_list = _days_for_endpoint("limit")
-        trades = []
-        used_fallback = False
-        for days_ago in days_ago_list:
-            day_trades = self._load_trades_from_execution_jsonl([days_ago])
-            day_recent = self._load_trades_from_recent_jsonl([days_ago])
-            if day_trades and day_recent:
-                day_trades = self._merge_trades_by_tx_hash(day_trades, day_recent)
-            elif not day_trades and day_recent:
-                used_fallback = True
-                day_trades = day_recent
-            trades.extend(day_trades)
-        if used_fallback:
-            print(
-                "trades_server: using recent_trades JSONL fallback "
-                "(execution_results empty or unparseable for one or more days)"
-            )
-        return self._dedupe_trades_by_tx_hash(trades)
+        paths = _watch_paths_for_days(days_ago_list)
+        cache_key = f"load_all:{tuple(days_ago_list)}"
+
+        def loader() -> list:
+            trades = []
+            used_fallback = False
+            for days_ago in days_ago_list:
+                day_trades = self._load_trades_from_execution_jsonl([days_ago])
+                day_recent = self._load_trades_from_recent_jsonl([days_ago])
+                if day_trades and day_recent:
+                    day_trades = self._merge_trades_by_tx_hash(day_trades, day_recent)
+                elif not day_trades and day_recent:
+                    used_fallback = True
+                    day_trades = day_recent
+                trades.extend(day_trades)
+            if used_fallback:
+                print(
+                    "trades_server: using recent_trades JSONL fallback "
+                    "(execution_results empty or unparseable for one or more days)"
+                )
+            return self._dedupe_trades_by_tx_hash(trades)
+
+        return _cached_trades_load(cache_key, paths, loader)
 
     def _dedupe_trades_by_tx_hash(self, trades: list) -> list:
         """One row per tx_hash; keep the richer execution_results-style row."""
@@ -650,11 +787,11 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
                     for line in _iter_jsonl_tail(jsonl_path, JSONL_TAIL_LINES):
                         try:
                             record = json.loads(line)
-                            status = str(record.get("status") or "").lower()
-                            if status in ("confirmed", "failed_confirmed"):
-                                trade = self.parse_execution_result(record)
-                                if trade:
-                                    trades.append(trade)
+                            if _should_skip_execution_record(record):
+                                continue
+                            trade = self.parse_execution_result(record)
+                            if trade:
+                                trades.append(trade)
                         except json.JSONDecodeError:
                             continue
                 except Exception as e:


### PR DESCRIPTION
## Summary
- Fast-path mode=run via recent_trades JSONL with execution_results enrichment
- Skip pre_confirm_track noise when loading execution JSONL
- 3s in-memory cache with mtime invalidation
- Tests for rotation, run mode, pre_confirm skip, cache invalidation

## Test plan
- [x] python3 -m pytest scripts/test_trades_server.py -q
- [x] python3 scripts/trades_server.py --self-check
- [ ] Prod: time curl trades?mode=run under 1s with SELLs

Handoff: Iron_crab-eval/docs/supervisor/handoff_trades_server_dashboard_rotation_fastpath.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how dashboard trade/PnL rows are built (run scoping, dedupe, enrichment) and can briefly serve stale data within the cache TTL; logic is covered by new tests but affects operational visibility.
> 
> **Overview**
> **`mode=run`** no longer loads the full execution JSONL stack first. It reads **`recent_trades`** JSONL, merges **`execution_results`** rows (including rotated same-day segments like `.5.jsonl`) by `tx_hash`, and overlays fields such as **`reason`** / exit metadata. Current-run selection also keeps **`run_id`-less** recent rows whose timestamps fall inside the active run window.
> 
> Execution ingestion now drops **`pre_confirm_track`** lines and non-terminal statuses (`sent`, etc.) via **`_should_skip_execution_record`**. **`load_all_trades`** and run-mode loads share a **~3s in-memory cache** (`IRONCRAB_TRADES_CACHE_TTL_SEC`) invalidated by watched file **mtime/size** fingerprints.
> 
> Adds **`scripts/test_trades_server.py`** covering rotation, pre-confirm filtering, run enrichment, run-window inclusion, and cache refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca67e6fa073acd901f63737b0bc15de285242360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->