### PR TITLE
fix(momentum): orphan recovery sets PositionOpenProbe + exit amount authority hint (Scope 57)

### DIFF
--- a/docs/supervisor/handoff_scope57_orphan_scale_in_exit_authority.md
+++ b/docs/supervisor/handoff_scope57_orphan_scale_in_exit_authority.md
@@ -1,0 +1,108 @@
+# Handoff: Scope 57 — Orphan Recovery State-Machine + Exit Authority Hint
+
+WICHTIG: Lies und befolge die STOP-CHECK Regeln in `AGENTS.md` und `.cursor/rules/ironcrab-core.mdc` BEVOR du eine Datei aenderst. Wenn eine geplante Aenderung gegen eine Regel verstoesst, STOPPE sofort und melde den Verstoss statt die Aenderung durchzufuehren.
+
+## Task-Beschreibung
+
+**Prod-Symptome (2026-06-06, nach PR3.2 Confirm-Fix):**
+
+1. **Keine Scale-in-Intents:** `ENTER_SCALE_IN` / `ENTER_SCALE_IN_BUY` = 0 in ~2h; dagegen 42× `ENTER_PROBE`, 11× `ORPHANED BUY RECOVERED`, 8× `Position opened`.
+2. **Offene Positionen werden nicht vollstaendig verkauft:** PumpFun SELL-Fails (`6024`/`6023`), EE-Reject `SIM_INSUFFICIENT_BALANCE`, `RISK_MAX_OPEN_POSITIONS`.
+3. **Drift:** EE `open_positions=5`, Momentum-Gauge oft `0`; `exits_generated_total` hoch, aber Restpositionen bleiben on-chain / in LockManager.
+
+**Root Cause (validiert):**
+
+- Orphan-Pfad ruft `open_position()` ohne Tracker-State-Update → Scale-in-Gate (`PositionOpenProbe`) wird nie erreicht.
+- Exit-Sizing nutzt Momentum-Overlay; JetStream `WalletBalanceSnapshot` war nicht als Authority-Hint angebunden (PA-5 offen).
+
+**Phase-1-Fix (dieser Scope):** Orphan-Pfad an normale State-Machine; Exit-Amount aus Wallet-Snapshot wenn verfuegbar; Metriken.
+
+**Phase-2-Follow-up (separates Epic):** PA-4/PA-5/PA-6 laut `Iron_crab-eval/docs/plans/plan_position_authority_sot_migration.md` — dediziertes `position-manager`-Binary optional ab PA-6.
+
+## Relevante Invarianten (Volltext)
+
+### I-7 Hot Path RPC-Freiheit
+
+Keine blockierenden RPC-Calls in `process_intent`, `check_for_signals`, `process_exit_signals`, `generate_and_publish_exit_intent`. Authority-Snapshot nur aus Geyser/JetStream/KV/in-process Cache.
+
+### I-9 Simulation-Gate
+
+Keine TX ohne erfolgreiche Simulation. Exit-Amount-Aenderung darf Sim nicht umgehen.
+
+### I-12 Decision Record
+
+Orphan-Recovery und Exit-Suppression muessen geloggt/metriciert werden, nicht still.
+
+### I-13 Position-Pool-Matching
+
+Exit-Quotes und Scale-in-Gate nur aus `position.pool` / matching TokenTracker.
+
+### I-14 tokens_per_sol
+
+Scale-in-Gate und Exit-PnL weiter in einheitlicher `tokens_per_sol`-Konvention (Scope 56 Fix beibehalten).
+
+## Bestehendes Pattern
+
+Normaler BUY-Confirm setzt Tracker-State (`momentum_bot.rs` ~7318–7328):
+
+```rust
+match pending.entry_kind {
+    Some(EntryKind::Probe) => {
+        tr.state = TrackerState::PositionOpenProbe { filled_at: Instant::now() };
+    }
+    Some(EntryKind::ScaleIn) => {
+        tr.state = TrackerState::PositionOpenFull { filled_at: Instant::now() };
+    }
+    None => {}
+}
+```
+
+Orphan-Pfad muss dasselbe Pattern nach `open_position()` anwenden.
+
+Scope 50 `exit_generated`-Reset in `open_position` bei scale-in add beibehalten.
+
+## Implementierung (Scope 57)
+
+1. **Orphan Probe:** `PositionOpenProbe { filled_at }` nach neuer Position.
+2. **Orphan Scale-in (existing position):** `PositionOpenFull { filled_at }`.
+3. **Exit sizing:** `resolve_exit_token_amount_raw` — bevorzugt gecachtes `WalletBalanceSnapshot` (JetStream, kein RPC).
+4. **Metriken:** `momentum_orphan_probe_recovery_total`, `momentum_orphan_scale_in_recovery_total`, `momentum_exit_amount_overlay_only_total`, `momentum_scale_in_gate_blocked_total{reason=...}`.
+
+## Erlaubte Dateien
+
+- `src/bin/momentum_bot.rs`
+- `src/metrics.rs`
+- Unit-Tests in `momentum_bot.rs` test module
+
+## Verboten
+
+- Neues position-manager-Binary
+- RPC im Hot Path
+- Simulation-Gate oder I-12 Verwerfen ohne Record
+- Big-Bang Entfernung von `momentum.positions`
+
+## Pruef-Befehle
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test --bin momentum-bot
+```
+
+## PR-Titel
+
+`fix(momentum): orphan recovery sets PositionOpenProbe + exit amount authority hint (Scope 57)`
+
+Branch: `architecture-rebuild`
+
+## Prod-Verifikation nach Deploy
+
+```bash
+grep -c ENTER_SCALE_IN /path/to/momentum.log
+grep ORPHANED BUY RECOVERED momentum.log | tail -5
+grep "partial confirmed SELL" execution-engine.log
+curl -s localhost:9898/metrics | egrep 'open_positions|position_authority'
+curl -s localhost:9897/metrics | egrep 'open_positions|momentum_orphan|momentum_scale_in_gate'
+```
+
+Erwartung: `ENTER_SCALE_IN > 0` bei guten Probes; Momentum/EE `open_positions` naeher; keine Partial-SELL mit `sold_raw << total_pos` ohne Follow-up-Exit.

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -3233,6 +3233,8 @@ struct MomentumContext {
     /// Scope 56: in-memory idempotency for duplicate JetStream / replayed ExecutionResults
     /// on the orphaned-BUY path (no durable store in this scope).
     orphaned_recovered_intent_ids: parking_lot::RwLock<BoundedIntentIdCache>,
+    /// Scope 57: latest JetStream `WalletBalanceSnapshot` per mint (authority hint for exit sizing; I-7 no RPC).
+    latest_wallet_balance_raw_by_mint: parking_lot::RwLock<HashMap<String, u64>>,
     /// Stats — **unique mints** with at least one pool-scoped tracker row (not one increment per pool row).
     tokens_tracked: std::sync::atomic::AtomicU64,
     /// Prometheus / heartbeat: **unique tokens (mints)** that crossed into a rejected/blacklisted
@@ -5417,6 +5419,9 @@ impl MomentumContext {
                 let now = Instant::now();
                 if now.duration_since(filled_at).as_secs() > config.scale_in_confirm_window_secs {
                     // Confirmation window expired: keep probe position only.
+                    ironcrab::metrics::record_momentum_scale_in_gate_blocked_total(
+                        ironcrab::metrics::MomentumScaleInGateBlockedReason::WindowExpired,
+                    );
                     let tracker = trackers.get_mut(key).expect("tracker key from iteration");
                     tracker.state = TrackerState::PositionOpenFull { filled_at };
                     continue;
@@ -5425,6 +5430,9 @@ impl MomentumContext {
                 // Scale-in gate (I-14, I-7): same `executable_exit_quote` quality as exits — no RPC.
                 // Require strictly `exec_pnl > scale_in_min_probe_executable_pnl_pct` (default 0 ⇒ underwater probe never scales in).
                 let Some(pos) = positions.get(&mint) else {
+                    ironcrab::metrics::record_momentum_scale_in_gate_blocked_total(
+                        ironcrab::metrics::MomentumScaleInGateBlockedReason::MissingProbeState,
+                    );
                     trace!(
                         mint = %mint,
                         pool = %this_pool,
@@ -5434,6 +5442,9 @@ impl MomentumContext {
                     continue;
                 };
                 let Some(ex_q) = self.executable_exit_quote(pos, Some(trackers)) else {
+                    ironcrab::metrics::record_momentum_scale_in_gate_blocked_total(
+                        ironcrab::metrics::MomentumScaleInGateBlockedReason::NoQuote,
+                    );
                     trace!(
                         mint = %mint,
                         pool = %this_pool,
@@ -5446,6 +5457,9 @@ impl MomentumContext {
                 let gate_ok = exec_pnl.partial_cmp(&config.scale_in_min_probe_executable_pnl_pct)
                     == Some(std::cmp::Ordering::Greater);
                 if !gate_ok {
+                    ironcrab::metrics::record_momentum_scale_in_gate_blocked_total(
+                        ironcrab::metrics::MomentumScaleInGateBlockedReason::Pnl,
+                    );
                     trace!(
                         mint = %mint,
                         pool = %this_pool,
@@ -6816,6 +6830,80 @@ impl MomentumContext {
         exit_maybe
     }
 
+    /// Resolve `entry_kind` for orphaned BUY recovery (pending lifecycle or intent metadata).
+    fn resolve_orphan_entry_kind(
+        intent_id: &str,
+        metadata: &HashMap<String, String>,
+        pending_entries: &HashMap<String, PendingBuyEntry>,
+    ) -> EntryKind {
+        if let Some(entry) = pending_entries.get(intent_id) {
+            if let Some(kind) = entry.entry_kind {
+                return kind;
+            }
+        }
+        match metadata.get("entry_kind").map(|s| s.as_str()) {
+            Some("scale_in") => EntryKind::ScaleIn,
+            Some("probe") => EntryKind::Probe,
+            _ => EntryKind::Probe,
+        }
+    }
+
+    /// After orphan `open_position`, align `TokenTracker` with the normal BUY-confirm state machine.
+    fn apply_orphan_buy_tracker_state_after_recovery(
+        &self,
+        mint: &str,
+        pool: &str,
+        entry_kind: EntryKind,
+        applied_to_existing_position: bool,
+    ) {
+        let tk = Self::tracker_storage_key(mint, pool);
+        let mut trackers = self.token_trackers.write();
+        let Some(tr) = trackers.get_mut(&tk) else {
+            return;
+        };
+        let filled_at = Instant::now();
+        if applied_to_existing_position || entry_kind == EntryKind::ScaleIn {
+            tr.state = TrackerState::PositionOpenFull { filled_at };
+            ironcrab::metrics::record_momentum_orphan_scale_in_recovery_total();
+        } else {
+            tr.state = TrackerState::PositionOpenProbe { filled_at };
+            ironcrab::metrics::record_momentum_orphan_probe_recovery_total();
+        }
+        drop(trackers);
+        self.mark_entry_eval_dirty_key(&tk);
+    }
+
+    fn cache_wallet_balance_snapshot_raw(&self, mint: &str, balance_raw: u64) {
+        self.latest_wallet_balance_raw_by_mint
+            .write()
+            .insert(mint.to_string(), balance_raw);
+    }
+
+    /// Scope 57 interim exit sizing (PA-5 follow-up): prefer JetStream wallet snapshot when overlay drifts.
+    fn resolve_exit_token_amount_raw(&self, mint: &str, hint_amount: u64) -> u64 {
+        let overlay = self
+            .positions
+            .read()
+            .get(mint)
+            .map(|p| p.token_amount)
+            .filter(|t| *t > 0)
+            .unwrap_or(hint_amount);
+
+        match self
+            .latest_wallet_balance_raw_by_mint
+            .read()
+            .get(mint)
+            .copied()
+            .filter(|a| *a > 0)
+        {
+            Some(auth) => auth,
+            None => {
+                ironcrab::metrics::record_momentum_exit_amount_overlay_only_total();
+                overlay
+            }
+        }
+    }
+
     fn try_apply_reserve_hint_as_position_price(
         pos: &mut PositionTracker,
         hint: &CachedPoolReservePriceHint,
@@ -7022,6 +7110,14 @@ impl MomentumContext {
                                     });
                                 let used_position_routing = from_pos.is_some();
                                 if let Some((pool, dex, creator)) = from_pos.or(tracker_info) {
+                                    let entry_kind = {
+                                        let entries = self.pending_buy_entries.read();
+                                        Self::resolve_orphan_entry_kind(
+                                            &result.intent_id,
+                                            &result.metadata,
+                                            &entries,
+                                        )
+                                    };
                                     info!(
                                         intent_id = %result.intent_id,
                                         mint = %mint,
@@ -7030,6 +7126,7 @@ impl MomentumContext {
                                         sol_invested,
                                         token_amount_raw = fill_out.raw,
                                         used_position_routing = used_position_routing,
+                                        entry_kind = ?entry_kind,
                                         "⚠️ ORPHANED BUY APPLIED TO EXISTING POSITION — scale-in fill \
                                          recovered after pending intent was dropped"
                                     );
@@ -7050,6 +7147,9 @@ impl MomentumContext {
                                         ),
                                         initial_bonding,
                                     });
+                                    self.apply_orphan_buy_tracker_state_after_recovery(
+                                        mint, &pool, entry_kind, true,
+                                    );
                                     let ctx_exit = Arc::clone(self);
                                     tokio::spawn(async move {
                                         ctx_exit.process_exit_signals(None).await;
@@ -7067,6 +7167,14 @@ impl MomentumContext {
                                     );
                                 }
                             } else if let Some((pool, dex, creator)) = tracker_info {
+                                let entry_kind = {
+                                    let entries = self.pending_buy_entries.read();
+                                    Self::resolve_orphan_entry_kind(
+                                        &result.intent_id,
+                                        &result.metadata,
+                                        &entries,
+                                    )
+                                };
                                 warn!(
                                     intent_id = %result.intent_id,
                                     mint = %mint,
@@ -7074,6 +7182,7 @@ impl MomentumContext {
                                     dex = %dex,
                                     sol_invested,
                                     token_amount = fill_out.raw,
+                                    entry_kind = ?entry_kind,
                                     "⚠️ ORPHANED BUY RECOVERED — pending intent expired, \
                                      creating position from ExecutionResult"
                                 );
@@ -7095,6 +7204,9 @@ impl MomentumContext {
                                     ),
                                     initial_bonding,
                                 });
+                                self.apply_orphan_buy_tracker_state_after_recovery(
+                                    mint, &pool, entry_kind, false,
+                                );
                                 let ctx_exit = Arc::clone(self);
                                 tokio::spawn(async move {
                                     ctx_exit.process_exit_signals(None).await;
@@ -9293,6 +9405,7 @@ async fn main() -> Result<()> {
         orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
             ORPHANED_RECOVERED_INTENT_IDS_CAP,
         )),
+        latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
         tokens_tracked: std::sync::atomic::AtomicU64::new(0),
         tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
         blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -11333,6 +11446,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -13043,6 +13157,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -13111,6 +13226,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -15415,6 +15531,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -15536,6 +15653,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -15626,6 +15744,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -15710,6 +15829,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -15799,6 +15919,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -15919,6 +16040,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -16033,6 +16155,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -16132,6 +16255,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -16208,6 +16332,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -16276,6 +16401,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -17286,6 +17412,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -17352,6 +17479,15 @@ mod tests {
         Arc::clone(&ctx).handle_execution_result(&orphan);
 
         let expected = 12_345_672_542u64.saturating_add(scale_fill);
+        {
+            let sk = MomentumContext::tracker_storage_key(mint, pool);
+            let trackers = ctx.token_trackers.read();
+            let tr = trackers.get(&sk).expect("tracker after orphan scale-in");
+            assert!(
+                matches!(tr.state, TrackerState::PositionOpenFull { .. }),
+                "orphan scale-in on existing position must set PositionOpenFull"
+            );
+        }
         {
             let positions = ctx.positions.read();
             let pos = positions.get(mint).expect("position after orphan scale");
@@ -17425,6 +17561,7 @@ mod tests {
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
             )),
+            latest_wallet_balance_raw_by_mint: parking_lot::RwLock::new(HashMap::new()),
             tokens_tracked: std::sync::atomic::AtomicU64::new(0),
             tokens_blacklisted: std::sync::atomic::AtomicU64::new(0),
             blacklisted_mints_for_metric: parking_lot::RwLock::new(HashSet::new()),
@@ -17507,6 +17644,218 @@ mod tests {
         let exits = ctx.check_for_exits();
         assert_eq!(exits.len(), 1);
         assert_eq!(exits[0].5, expected);
+    }
+
+    /// Scope 57: orphan probe BUY must set `PositionOpenProbe` so scale-in gate can run.
+    #[tokio::test]
+    async fn scope57_orphan_probe_recovery_sets_position_open_probe() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = Arc::new(empty_test_context(jsonl_writer));
+
+        let mint = "OrphProbeMintttttttttttttttttttttttttttttttt";
+        let pool = "OrphProbePoolttttttttttttttttttttttttttttttt";
+        ctx.register_pool(mint, pool, "raydium", 1);
+        let sk = MomentumContext::tracker_storage_key(mint, pool);
+        {
+            let mut trackers = ctx.token_trackers.write();
+            let mut tr = TokenTracker::new(mint, pool, "raydium", 1, 0);
+            tr.state = TrackerState::ProbeBuyPending {
+                sent_at: Instant::now(),
+            };
+            trackers.insert(sk.clone(), tr);
+        }
+
+        let probe_fill = 7_159_492_133u64;
+        let sol_spent = 250_000_000u64;
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("side".to_string(), "BUY".to_string());
+        meta.insert("entry_kind".to_string(), "probe".to_string());
+        let orphan = ExecutionResult {
+            header: RecordHeader::new("test", BUILD_VERSION, "run-test"),
+            execution_id: "ex-orphan-probe".to_string(),
+            decision_id: "dec-orphan-probe".to_string(),
+            intent_id: "int-orphan-probe-001".to_string(),
+            source: "momentum-bot".to_string(),
+            token_mint: Some(mint.to_string()),
+            signature: Some("sig-orphan-probe".to_string()),
+            bundle_id: None,
+            status: ExecutionStatus::Confirmed,
+            fill_in: Some(ExplicitAmount::new(sol_spent, 9)),
+            fill_out: Some(ExplicitAmount::new(probe_fill, 6)),
+            fill_status: Some(FillStatus::Complete),
+            fill_unavailable_reason: None,
+            confirmed_slot: Some(100),
+            block_time_unix_ms: None,
+            fees: None,
+            pnl: None,
+            wallet_sol_delta_lamports: Some(-(sol_spent as i128)),
+            error_message: None,
+            error_code: None,
+            latency_ms: Some(1),
+            metadata: meta,
+        };
+
+        Arc::clone(&ctx).handle_execution_result(&orphan);
+
+        assert!(ctx.positions.read().contains_key(mint));
+        let trackers = ctx.token_trackers.read();
+        let tr = trackers.get(&sk).unwrap();
+        assert!(
+            matches!(tr.state, TrackerState::PositionOpenProbe { .. }),
+            "orphan probe recovery must advance tracker to PositionOpenProbe"
+        );
+    }
+
+    /// Scope 57: after orphan probe recovery, scale-in gate can emit ENTER_SCALE_IN within window.
+    #[tokio::test]
+    async fn scope57_scale_in_fires_after_orphan_probe_recovery() {
+        use solana_sdk::pubkey::Pubkey;
+
+        let mut cfg = MomentumConfig::default();
+        cfg.default_position_lamports = 1_000;
+        cfg.probe_buy_pct = 0.25;
+        cfg.early_min_liquidity_sol = 0.0;
+        cfg.min_unique_buyers = 0;
+        cfg.min_trades_per_min = 0.0;
+        cfg.min_buy_dominance = 0.0;
+        cfg.min_sol_inflow_lamports = 0;
+        cfg.require_mint_authority_renounced = false;
+        cfg.require_freeze_authority_none = false;
+        cfg.top1_buyer_share_cap = 1.0;
+        cfg.top3_buyer_share_cap = 1.0;
+        cfg.repeat_buyer_min_ratio = 0.0;
+        cfg.min_trade_size_lamports = 0;
+        cfg.small_buy_ratio_cap = 1.0;
+        cfg.min_token_age_secs = 0;
+        cfg.scale_in_confirm_window_secs = 120;
+        cfg.scale_in_min_probe_executable_pnl_pct = 0.0;
+
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = Arc::new(empty_test_context(jsonl_writer));
+        *ctx.config.write() = cfg;
+
+        let mint = Pubkey::new_from_array([0xC3u8; 32]).to_string();
+        let pool = Pubkey::new_from_array([0xD4u8; 32]).to_string();
+        ctx.register_pool(&mint, &pool, "raydium", 1);
+        let sk = MomentumContext::tracker_storage_key(&mint, &pool);
+        {
+            let mut trackers = ctx.token_trackers.write();
+            trackers.insert(sk.clone(), TokenTracker::new(&mint, &pool, "raydium", 1, 0));
+        }
+        {
+            let mut pi = PoolInfo::new(pool.clone(), "raydium".to_string(), 100);
+            pi.dex_pool_accounts = Some(vec![]);
+            ctx.mint_pools.write().insert(mint.clone(), vec![pi]);
+        }
+
+        let probe_fill = 7_159_492_133u64;
+        let sol_spent = 250_000_000u64;
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("side".to_string(), "BUY".to_string());
+        meta.insert("entry_kind".to_string(), "probe".to_string());
+        let orphan = ExecutionResult {
+            header: RecordHeader::new("test", BUILD_VERSION, "run-test"),
+            execution_id: "ex-orphan-probe-scale".to_string(),
+            decision_id: "dec-orphan-probe-scale".to_string(),
+            intent_id: "int-orphan-probe-scale-001".to_string(),
+            source: "momentum-bot".to_string(),
+            token_mint: Some(mint.clone()),
+            signature: Some("sig-orphan-probe-scale".to_string()),
+            bundle_id: None,
+            status: ExecutionStatus::Confirmed,
+            fill_in: Some(ExplicitAmount::new(sol_spent, 9)),
+            fill_out: Some(ExplicitAmount::new(probe_fill, 6)),
+            fill_status: Some(FillStatus::Complete),
+            fill_unavailable_reason: None,
+            confirmed_slot: Some(100),
+            block_time_unix_ms: None,
+            fees: None,
+            pnl: None,
+            wallet_sol_delta_lamports: Some(-(sol_spent as i128)),
+            error_message: None,
+            error_code: None,
+            latency_ms: Some(1),
+            metadata: meta,
+        };
+        Arc::clone(&ctx).handle_execution_result(&orphan);
+
+        let upd = pool_cache_update_stub(
+            &mint,
+            &pool,
+            10_000_000_000_000u64,
+            1_000_000_000_000u64,
+            900_000_000u64,
+            1,
+        );
+        assert!(
+            pool_cache_sync::apply_pool_cache_update(&ctx.live_pool_cache, &upd),
+            "pool cache apply failed"
+        );
+
+        let signals = ctx.check_for_signals();
+        assert_eq!(
+            signals.len(),
+            1,
+            "scale-in expected after orphan probe state"
+        );
+        assert_eq!(signals[0].kind, EntryKind::ScaleIn);
+    }
+
+    /// Scope 57: exit sizing prefers JetStream wallet snapshot when overlay understates holdings.
+    #[tokio::test]
+    async fn scope57_exit_amount_uses_wallet_authority_when_overlay_smaller() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_config = JsonlWriterConfig::new("trade_intents").with_log_dir(tmp.path());
+        let jsonl_writer = JsonlWriter::new(jsonl_config).expect("jsonl writer");
+        let ctx = Arc::new(empty_test_context(jsonl_writer));
+
+        let mint = "WalletAuthMintttttttttttttttttttttttttttttt";
+        let pool = "WalletAuthPoolttttttttttttttttttttttttttttt";
+        ctx.register_pool(mint, pool, "raydium", 1);
+        ctx.update_pool_accounts(mint, pool, vec!["a0".to_string(), "a1".to_string()]);
+
+        let probe_only = 14_099_749_285u64;
+        let wallet_total = probe_only.saturating_add(38_711_432_312);
+        ctx.open_position(OpenPositionParams {
+            mint,
+            pool,
+            dex: "raydium",
+            entry_price: 1.0,
+            token_decimals: 6,
+            token_amount: probe_only,
+            sol_invested: 1_000_000,
+            token_program: None,
+            creator: None,
+            entry_confirmed_slot: 100,
+            initial_bonding: None,
+        });
+        ctx.cache_wallet_balance_snapshot_raw(mint, wallet_total);
+
+        generate_and_publish_exit_intent(
+            ctx.as_ref(),
+            mint,
+            pool,
+            "raydium",
+            "TIME_EXIT",
+            "test",
+            probe_only,
+            None,
+        )
+        .await
+        .expect("exit intent");
+
+        let path = ctx.jsonl_writer.current_path().expect("jsonl path");
+        let content = std::fs::read_to_string(path).expect("read jsonl");
+        let line = content.lines().last().expect("intent line");
+        let intent: TradeIntent = serde_json::from_str(line).expect("parse TradeIntent");
+        assert_eq!(
+            intent.required_capital.raw, wallet_total,
+            "exit must use wallet authority when overlay is probe-only"
+        );
     }
 
     /// Scope A: BondingCurveProgress at 100% before `open_position` is merged via `initial_bonding`.
@@ -18272,15 +18621,8 @@ async fn generate_and_publish_exit_intent(
     // bootstrap, and any `check_for_exits()`-driven scan where one event is not tied to each exit.
     source_event_ts_unix_ms: Option<u64>,
 ) -> Result<()> {
-    // Authoritative sell size: open position total at publish time (handles probe+scale-in
-    // and races where the caller still had a stale hint amount).
-    let token_amount = ctx
-        .positions
-        .read()
-        .get(mint)
-        .map(|p| p.token_amount)
-        .filter(|t| *t > 0)
-        .unwrap_or(token_amount);
+    // Authoritative sell size: overlay + optional JetStream wallet snapshot (Scope 57 / PA-5 interim).
+    let token_amount = ctx.resolve_exit_token_amount_raw(mint, token_amount);
 
     // Phase 3: Slippage escalation — when prior sells failed with 6002, increase tolerance
     let max_slippage = {
@@ -19182,7 +19524,10 @@ async fn process_market_event(
                 return Ok(false);
             }
 
+            ctx.cache_wallet_balance_snapshot_raw(mint, *balance_raw);
+
             if *balance_raw == 0 {
+                ctx.latest_wallet_balance_raw_by_mint.write().remove(mint);
                 // Remove ghost position if wallet balance is zero
                 let was_tracked = {
                     let mut positions = ctx.positions.write();

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -6854,7 +6854,6 @@ impl MomentumContext {
         mint: &str,
         pool: &str,
         entry_kind: EntryKind,
-        applied_to_existing_position: bool,
     ) {
         let tk = Self::tracker_storage_key(mint, pool);
         let mut trackers = self.token_trackers.write();
@@ -6862,12 +6861,15 @@ impl MomentumContext {
             return;
         };
         let filled_at = Instant::now();
-        if applied_to_existing_position || entry_kind == EntryKind::ScaleIn {
-            tr.state = TrackerState::PositionOpenFull { filled_at };
-            ironcrab::metrics::record_momentum_orphan_scale_in_recovery_total();
-        } else {
-            tr.state = TrackerState::PositionOpenProbe { filled_at };
-            ironcrab::metrics::record_momentum_orphan_probe_recovery_total();
+        match entry_kind {
+            EntryKind::ScaleIn => {
+                tr.state = TrackerState::PositionOpenFull { filled_at };
+                ironcrab::metrics::record_momentum_orphan_scale_in_recovery_total();
+            }
+            EntryKind::Probe => {
+                tr.state = TrackerState::PositionOpenProbe { filled_at };
+                ironcrab::metrics::record_momentum_orphan_probe_recovery_total();
+            }
         }
         drop(trackers);
         self.mark_entry_eval_dirty_key(&tk);
@@ -7148,7 +7150,7 @@ impl MomentumContext {
                                         initial_bonding,
                                     });
                                     self.apply_orphan_buy_tracker_state_after_recovery(
-                                        mint, &pool, entry_kind, true,
+                                        mint, &pool, entry_kind,
                                     );
                                     let ctx_exit = Arc::clone(self);
                                     tokio::spawn(async move {
@@ -7205,7 +7207,7 @@ impl MomentumContext {
                                     initial_bonding,
                                 });
                                 self.apply_orphan_buy_tracker_state_after_recovery(
-                                    mint, &pool, entry_kind, false,
+                                    mint, &pool, entry_kind,
                                 );
                                 let ctx_exit = Arc::clone(self);
                                 tokio::spawn(async move {
@@ -7572,6 +7574,7 @@ impl MomentumContext {
                                     pos.exit_generated_at = None;
                                 }
                             }
+                            self.cache_wallet_balance_snapshot_raw(&pending.mint, remaining);
                             // Persist reduced position to KV
                             if let Some(pos) = self.positions.read().get(&pending.mint) {
                                 let tracker = pos.clone();
@@ -17451,6 +17454,7 @@ mod tests {
         let sol_spent = 3_750_000u64;
         let mut meta = std::collections::HashMap::new();
         meta.insert("side".to_string(), "BUY".to_string());
+        meta.insert("entry_kind".to_string(), "scale_in".to_string());
         let orphan = ExecutionResult {
             header: RecordHeader::new("test", BUILD_VERSION, "run-test"),
             execution_id: "ex-orphan".to_string(),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1580,6 +1580,60 @@ pub fn record_momentum_entry_buy_suppressed_missing_creator() {
     MOMENTUM_ENTRY_BUY_SUPPRESSED_MISSING_CREATOR_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+// Scope 57: orphan BUY recovery tracker-state alignment + exit amount authority hint.
+pub static MOMENTUM_ORPHAN_PROBE_RECOVERY_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_ORPHAN_SCALE_IN_RECOVERY_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_EXIT_AMOUNT_OVERLAY_ONLY_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+pub static MOMENTUM_SCALE_IN_GATE_BLOCKED_MISSING_PROBE_STATE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_SCALE_IN_GATE_BLOCKED_PNL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_SCALE_IN_GATE_BLOCKED_WINDOW_EXPIRED: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MOMENTUM_SCALE_IN_GATE_BLOCKED_NO_QUOTE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn record_momentum_orphan_probe_recovery_total() {
+    MOMENTUM_ORPHAN_PROBE_RECOVERY_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_momentum_orphan_scale_in_recovery_total() {
+    MOMENTUM_ORPHAN_SCALE_IN_RECOVERY_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_momentum_exit_amount_overlay_only_total() {
+    MOMENTUM_EXIT_AMOUNT_OVERLAY_ONLY_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Scale-in gate blocked reason (Prometheus label `reason`).
+#[derive(Debug, Clone, Copy)]
+pub enum MomentumScaleInGateBlockedReason {
+    MissingProbeState,
+    Pnl,
+    WindowExpired,
+    NoQuote,
+}
+
+#[inline]
+pub fn record_momentum_scale_in_gate_blocked_total(reason: MomentumScaleInGateBlockedReason) {
+    let counter = match reason {
+        MomentumScaleInGateBlockedReason::MissingProbeState => {
+            &*MOMENTUM_SCALE_IN_GATE_BLOCKED_MISSING_PROBE_STATE
+        }
+        MomentumScaleInGateBlockedReason::Pnl => &*MOMENTUM_SCALE_IN_GATE_BLOCKED_PNL,
+        MomentumScaleInGateBlockedReason::WindowExpired => {
+            &*MOMENTUM_SCALE_IN_GATE_BLOCKED_WINDOW_EXPIRED
+        }
+        MomentumScaleInGateBlockedReason::NoQuote => &*MOMENTUM_SCALE_IN_GATE_BLOCKED_NO_QUOTE,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
 // PR170: tracker trade ingest forensics (static metric names — no dynamic labels).
 pub static MOMENTUM_TRACKER_TRADES_RECORDED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -3470,6 +3524,46 @@ async fn metrics_response() -> Response<Body> {
         "momentum_entry_buy_suppressed_missing_creator_total",
         MOMENTUM_ENTRY_BUY_SUPPRESSED_MISSING_CREATOR_TOTAL.load(Ordering::Relaxed)
     );
+    line!(
+        "momentum_orphan_probe_recovery_total",
+        MOMENTUM_ORPHAN_PROBE_RECOVERY_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_orphan_scale_in_recovery_total",
+        MOMENTUM_ORPHAN_SCALE_IN_RECOVERY_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_exit_amount_overlay_only_total",
+        MOMENTUM_EXIT_AMOUNT_OVERLAY_ONLY_TOTAL.load(Ordering::Relaxed)
+    );
+    out.push_str("momentum_scale_in_gate_blocked_total{reason=\"missing_probe_state\"} ");
+    out.push_str(
+        &MOMENTUM_SCALE_IN_GATE_BLOCKED_MISSING_PROBE_STATE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("momentum_scale_in_gate_blocked_total{reason=\"pnl\"} ");
+    out.push_str(
+        &MOMENTUM_SCALE_IN_GATE_BLOCKED_PNL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("momentum_scale_in_gate_blocked_total{reason=\"window_expired\"} ");
+    out.push_str(
+        &MOMENTUM_SCALE_IN_GATE_BLOCKED_WINDOW_EXPIRED
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("momentum_scale_in_gate_blocked_total{reason=\"no_quote\"} ");
+    out.push_str(
+        &MOMENTUM_SCALE_IN_GATE_BLOCKED_NO_QUOTE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
     line!(
         "momentum_tracker_trades_recorded_total",
         MOMENTUM_TRACKER_TRADES_RECORDED_TOTAL.load(Ordering::Relaxed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes production symptoms where scale-in never fired after orphan BUY recovery and exits could undersell relative to wallet holdings.

### Root cause (validated)

- **Scale-in = 0:** Orphan path called `open_position()` but never set `TokenTracker` to `PositionOpenProbe`, so the scale-in gate was never reached.
- **Partial exits / drift:** Momentum overlay could understate holdings vs. JetStream wallet snapshots; exit intents used overlay-only sizing.

### Changes (Phase 1 / Scope 57)

1. **Orphan probe recovery** → sets `PositionOpenProbe { filled_at }` (mirrors normal BUY confirm path).
2. **Orphan scale-in on existing position** → sets `PositionOpenFull { filled_at }`; `entry_kind` from `pending_buy_entries` or intent metadata.
3. **Exit sizing interim (until PA-5):** cache `WalletBalanceSnapshot` per mint; `generate_and_publish_exit_intent` prefers wallet balance when available (JetStream only, no RPC).
4. **Metrics:** `momentum_orphan_probe_recovery_total`, `momentum_orphan_scale_in_recovery_total`, `momentum_exit_amount_overlay_only_total`, `momentum_scale_in_gate_blocked_total{reason=...}`.

### STOP-CHECK

- I-7: No new RPC; wallet hint from existing JetStream consumer only.
- I-9: Simulation gate unchanged.
- I-12: Orphan paths remain logged + metricated.

### Tests

- `scope57_orphan_probe_recovery_sets_position_open_probe`
- `scope57_scale_in_fires_after_orphan_probe_recovery`
- `scope57_exit_amount_uses_wallet_authority_when_overlay_smaller`
- Extended scope56 orphan scale-in test for `PositionOpenFull` tracker state

### Follow-up (Phase 2)

PA-4/PA-5/PA-6 position-authority SOT migration — see `docs/supervisor/handoff_scope57_orphan_scale_in_exit_authority.md`.

## Verification

```
cargo fmt --check
cargo clippy --bin momentum-bot -- -D warnings
cargo test --bin momentum-bot  # 158 passed
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8878ee46-dcdf-41ac-83f7-01606522cc64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8878ee46-dcdf-41ac-83f7-01606522cc64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

