### PR TITLE
fix(dashboard): trades_server run-mode perf — no yesterday exec scan + ThreadingHTTPServer (P174)

### DIFF
--- a/docs/SCRIPTS_README.md
+++ b/docs/SCRIPTS_README.md
@@ -130,6 +130,21 @@ Plus Python-Services:
 - `control_plane/main.py` — REST API, Config, Kill-Switch
 - `scripts/trades_server.py` — Grafana Infinity Datasource
 
+### trades_server Run-Mode Performance (P174)
+
+`GET /trades?mode=run` loads **today** from `recent_trades` + `execution_results*` (rotated segments).
+**Yesterday** is tail-only (~500 recent lines) for prev-run context — no full execution scan.
+
+After deploying P174, remove any prod hotfix override:
+
+```bash
+# /etc/systemd/system/trades-server.service.d/override.conf
+# Delete IRONCRAB_TRADES_DAYS_LOOKBACK=0 (and reload/restart trades-server)
+sudo systemctl daemon-reload && sudo systemctl restart trades-server
+```
+
+Env vars: `IRONCRAB_TRADES_CACHE_TTL_SEC` (default 15), `IRONCRAB_TRADES_RUN_PREV_RECENT_TAIL`, `IRONCRAB_TRADES_RUN_PREV_EXEC_TAIL`.
+
 ## Prerequisites
 
 1. **Rust 1.89+**: Install from https://rustup.rs/

--- a/docs/systemd/trades-server.service
+++ b/docs/systemd/trades-server.service
@@ -14,6 +14,7 @@ Restart=on-failure
 RestartSec=5
 StandardOutput=journal
 StandardError=journal
+Environment="IRONCRAB_TRADES_CACHE_TTL_SEC=15"
 
 # Resource limits
 MemoryLimit=256M

--- a/scripts/test_trades_server.py
+++ b/scripts/test_trades_server.py
@@ -221,3 +221,138 @@ class TestCache:
         third = handler.load_all_trades([0])
         assert third is not first
         assert third[0]["tx_hash"] == "cached-new"
+
+
+class TestRunModePerformanceP174:
+    def test_run_mode_does_not_load_yesterday_execution_full_scan(
+        self, log_dirs, monkeypatch
+    ):
+        exec_dir, recent_dir, today = log_dirs
+        yesterday = "20990605"
+        calls: list = []
+
+        def track_exec_load(self, days_ago_list, *args, **kwargs):
+            calls.append(list(days_ago_list))
+            return []
+
+        monkeypatch.setattr(
+            ts.TradesHandler,
+            "_load_trades_from_execution_jsonl",
+            track_exec_load,
+        )
+        monkeypatch.setattr(
+            ts,
+            "_utc_date_str",
+            lambda days_ago: today if days_ago == 0 else yesterday,
+        )
+
+        # Huge yesterday execution file — must not trigger full-day loader for [1].
+        huge_yesterday = exec_dir / f"execution_results-{yesterday}.jsonl"
+        huge_yesterday.write_text(
+            "\n".join(
+                json.dumps(_minimal_buy_record(f"y-{i}", run_id="run-old"))
+                for i in range(5000)
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (exec_dir / f"execution_results-{today}.jsonl").write_text(
+            json.dumps(_minimal_buy_record("today-buy", run_id="run-current"))
+            + "\n",
+            encoding="utf-8",
+        )
+        (recent_dir / f"recent_trades-{today}.jsonl").write_text(
+            json.dumps(
+                _recent_trade_line("today-buy", "BUY", run_id="run-current")
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        handler = ts.TradesHandler.__new__(ts.TradesHandler)
+        handler._load_run_mode_trades()
+
+        assert calls == [[0]]
+        assert all(1 not in c for c in calls)
+
+    def test_run_mode_prev_run_from_recent_tail(self, log_dirs, monkeypatch):
+        exec_dir, recent_dir, today = log_dirs
+        yesterday = "20990605"
+
+        monkeypatch.setattr(
+            ts,
+            "_utc_date_str",
+            lambda days_ago: today if days_ago == 0 else yesterday,
+        )
+
+        prev_lines = []
+        for i in range(25):
+            prev_lines.append(
+                json.dumps(
+                    _recent_trade_line(
+                        f"prev-{i}",
+                        "SELL" if i % 2 else "BUY",
+                        ts_ms=1_800_000_000_000 + i * 1000,
+                        run_id="run-prev",
+                    )
+                )
+            )
+        (recent_dir / f"recent_trades-{yesterday}.jsonl").write_text(
+            "\n".join(prev_lines) + "\n", encoding="utf-8"
+        )
+
+        (exec_dir / f"execution_results-{today}.jsonl").write_text(
+            json.dumps(_minimal_buy_record("cur-buy", run_id="run-current"))
+            + "\n"
+            + json.dumps(_minimal_sell_record("cur-sell", run_id="run-current"))
+            + "\n",
+            encoding="utf-8",
+        )
+        (recent_dir / f"recent_trades-{today}.jsonl").write_text(
+            json.dumps(
+                _recent_trade_line("cur-buy", "BUY", run_id="run-current")
+            )
+            + "\n"
+            + json.dumps(
+                _recent_trade_line(
+                    "cur-sell", "SELL", ts_ms=1_800_000_200_000, run_id="run-current"
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        handler = ts.TradesHandler.__new__(ts.TradesHandler)
+        trades = handler.read_trades_by_run()
+        prev_rows = [t for t in trades if t.get("run_id") == "run-prev"]
+        current_rows = [t for t in trades if t.get("run_id") == "run-current"]
+
+        assert len(prev_rows) == 20
+        assert len(current_rows) == 2
+
+    def test_run_mode_cold_under_budget(self, log_dirs, monkeypatch):
+        exec_dir, recent_dir, today = log_dirs
+        (exec_dir / f"execution_results-{today}.jsonl").write_text(
+            json.dumps(_minimal_buy_record("fast")) + "\n", encoding="utf-8"
+        )
+        (recent_dir / f"recent_trades-{today}.jsonl").write_text(
+            json.dumps(_recent_trade_line("fast", "BUY")) + "\n", encoding="utf-8"
+        )
+
+        handler = ts.TradesHandler.__new__(ts.TradesHandler)
+        start = datetime.now(timezone.utc)
+        trades = handler._load_run_mode_trades()
+        elapsed_ms = (
+            datetime.now(timezone.utc) - start
+        ).total_seconds() * 1000
+
+        assert trades
+        assert elapsed_ms < 100
+
+
+class TestThreadingHTTPServer:
+    def test_threading_server_class_exists(self):
+        import http.server
+
+        assert issubclass(ts.ThreadingHTTPServer, http.server.HTTPServer)
+        assert ts.ThreadingHTTPServer.daemon_threads is True

--- a/scripts/test_trades_server.py
+++ b/scripts/test_trades_server.py
@@ -203,7 +203,7 @@ class TestRunModeFastPath:
 
 
 class TestCache:
-    def test_cache_returns_same_object_within_ttl(self, log_dirs, monkeypatch):
+    def test_cache_returns_copy_within_ttl(self, log_dirs, monkeypatch):
         exec_dir, _, date = log_dirs
         path = exec_dir / f"execution_results-{date}.jsonl"
         path.write_text(
@@ -213,14 +213,18 @@ class TestCache:
         handler = ts.TradesHandler.__new__(ts.TradesHandler)
         first = handler.load_all_trades([0])
         second = handler.load_all_trades([0])
-        assert first is second
+        assert first == second
+        assert first is not second
+        first[0]["tx_hash"] = "mutated"
+        third = handler.load_all_trades([0])
+        assert third[0]["tx_hash"] == "cached"
 
         path.write_text(
             json.dumps(_minimal_buy_record("cached-new")) + "\n", encoding="utf-8"
         )
-        third = handler.load_all_trades([0])
-        assert third is not first
-        assert third[0]["tx_hash"] == "cached-new"
+        fourth = handler.load_all_trades([0])
+        assert fourth is not first
+        assert fourth[0]["tx_hash"] == "cached-new"
 
 
 class TestRunModePerformanceP174:

--- a/scripts/trades_server.py
+++ b/scripts/trades_server.py
@@ -11,8 +11,13 @@ Tail-read (P172): only the last N lines per file are scanned (not full-file O(n)
 Run mode (P173): recent_trades JSONL first, enrich from execution_results* (incl. rotated segments).
 Env:
   IRONCRAB_TRADES_JSONL_TAIL_LINES — max non-empty lines per file (default 15000)
-  IRONCRAB_TRADES_CACHE_TTL_SEC — in-memory cache TTL seconds (default 3)
-  IRONCRAB_TRADES_DAYS_LOOKBACK — optional override; endpoints use [0], [0,1], or [0,1] for pnl
+  IRONCRAB_TRADES_CACHE_TTL_SEC — in-memory cache TTL seconds (default 15)
+  IRONCRAB_TRADES_DAYS_LOOKBACK — optional override; limit=[0], pnl=[0,1]; run mode uses decoupled loader
+  IRONCRAB_TRADES_RUN_PREV_RECENT_TAIL — max lines from yesterday recent_trades for prev-run (default 500)
+  IRONCRAB_TRADES_RUN_PREV_EXEC_TAIL — max lines from yesterday execution tail for enrich (default 2000)
+
+Prod override cleanup (P174): remove /etc/systemd/system/trades-server.service.d/override.conf
+  entries IRONCRAB_TRADES_DAYS_LOOKBACK=0 once this fix is deployed.
 
 `timestamp_ms` on each trade is the on-chain block time (UTC) when `block_time_unix_ms`
 is present on the JSONL record; otherwise confirm wall-clock (`ts_unix_ms` / legacy).
@@ -25,6 +30,7 @@ Query params (GET /trades):
   Response adds: time_utc, time_age, time_display
 """
 
+import argparse
 import http.server
 import json
 import os
@@ -34,9 +40,9 @@ import time
 from collections import deque
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from socketserver import ThreadingMixIn
 from typing import Callable, Iterator, List, Optional, Tuple
-from urllib.parse import urlparse, parse_qs
-import argparse
+from urllib.parse import parse_qs, urlparse
 
 EXEC_LOG_DIR = os.environ.get("IRONCRAB_LOG_DIR", "trade_logs")
 EXECUTIONS_DIR = Path(EXEC_LOG_DIR) / "executions"
@@ -65,7 +71,14 @@ if _raw_lookback:
     DAYS_LOOKBACK_OVERRIDE = [int(x.strip()) for x in _raw_lookback.split(",") if x.strip() != ""]
 
 # In-memory cache for JSONL loads (Grafana polls every 5s).
-TRADES_CACHE_TTL_SEC = max(2, _env_int("IRONCRAB_TRADES_CACHE_TTL_SEC", 3))
+TRADES_CACHE_TTL_SEC = max(2, _env_int("IRONCRAB_TRADES_CACHE_TTL_SEC", 15))
+# Run mode: small tail reads for prev-run context (avoid yesterday full execution scan).
+RUN_MODE_PREV_RECENT_TAIL_LINES = max(
+    1, _env_int("IRONCRAB_TRADES_RUN_PREV_RECENT_TAIL", 500)
+)
+RUN_MODE_PREV_EXEC_TAIL_LINES = max(
+    1, _env_int("IRONCRAB_TRADES_RUN_PREV_EXEC_TAIL", 2000)
+)
 _trades_cache: dict = {}
 
 # Fields copied from execution_results when enriching recent_trades rows.
@@ -114,6 +127,16 @@ def _watch_paths_for_days(days_ago_list: List[int]) -> List[Path]:
     return paths
 
 
+def _watch_paths_for_run_mode() -> List[Path]:
+    """Run-mode cache invalidation: today recent_trades + today execution segments only."""
+    date = _utc_date_str(0)
+    paths = list(_jsonl_segment_paths(EXECUTIONS_DIR, "execution_results", date))
+    recent_path = RECENT_TRADES_DIR / f"recent_trades-{date}.jsonl"
+    if recent_path.is_file():
+        paths.append(recent_path)
+    return paths
+
+
 def _paths_fingerprint(paths: List[Path]) -> Tuple[tuple, ...]:
     fp: List[tuple] = []
     for path in paths:
@@ -146,12 +169,26 @@ def clear_trades_cache() -> None:
 
 
 def _days_for_endpoint(endpoint: str) -> List[int]:
-    """Lookback UTC days: limit=[0], run/pnl=[0,1] unless env override."""
+    """Lookback UTC days: limit=[0], pnl=[0,1] unless env override.
+
+    Run mode (`mode=run`) uses `_days_for_run_mode()` / `_load_run_mode_trades()` instead.
+    """
     if DAYS_LOOKBACK_OVERRIDE is not None:
         return DAYS_LOOKBACK_OVERRIDE
     if endpoint == "limit":
         return [0]
+    if endpoint == "pnl":
+        return [0, 1]
     return [0, 1]
+
+
+def _days_for_run_mode() -> Tuple[List[int], List[int]]:
+    """Decoupled run-mode lookback: recent [0]+tail[1], execution today [0] only."""
+    if DAYS_LOOKBACK_OVERRIDE is not None:
+        override = DAYS_LOOKBACK_OVERRIDE
+        exec_days = [d for d in override if d == 0]
+        return override, exec_days if exec_days else [0]
+    return [0, 1], [0]
 
 
 def _utc_date_str(days_ago: int) -> str:
@@ -403,11 +440,11 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
     def read_trades_by_run(self) -> list:
         """Read all trades from the current run + last 20 from the previous run.
 
-        Fast path (P173): load small recent_trades JSONL first, enrich from
-        execution_results* (rotated segments), then filter by run_id / time window.
+        Fast path (P173/P174): today recent_trades + today execution_results*;
+        yesterday recent_trades tail only (prev-run); optional yesterday execution
+        tail for tx_hash enrichment — no full yesterday execution scan.
         """
-        days = _days_for_endpoint("run")
-        all_trades = self._load_run_mode_trades(days)
+        all_trades = self._load_run_mode_trades()
 
         if not all_trades:
             return []
@@ -417,17 +454,24 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
         trades.sort(key=lambda t: t.get('timestamp_ms', 0), reverse=True)
         return trades
 
-    def _load_run_mode_trades(self, days_ago_list: List[int]) -> list:
+    def _load_run_mode_trades(self) -> list:
         """Recent-trades-first load with execution_results enrichment (mode=run)."""
-        paths = _watch_paths_for_days(days_ago_list)
-        cache_key = f"run_mode:{tuple(days_ago_list)}"
+        days_recent, days_exec = _days_for_run_mode()
+        paths = _watch_paths_for_run_mode()
+        cache_key = f"run_mode:{tuple(days_recent)}:{tuple(days_exec)}"
 
         def loader() -> list:
             recent_all: list = []
+            if 0 in days_recent:
+                recent_all.extend(self._load_trades_from_recent_jsonl([0]))
+            if 1 in days_recent:
+                recent_all.extend(self._load_prev_day_recent_tail())
+
             exec_all: list = []
-            for days_ago in days_ago_list:
-                recent_all.extend(self._load_trades_from_recent_jsonl([days_ago]))
-                exec_all.extend(self._load_trades_from_execution_jsonl([days_ago]))
+            if days_exec:
+                exec_all.extend(self._load_trades_from_execution_jsonl(days_exec))
+            if 1 in days_recent:
+                exec_all.extend(self._load_prev_day_execution_enrichment())
 
             exec_by_hash = {t["tx_hash"]: t for t in exec_all if t.get("tx_hash")}
             merged: list = []
@@ -451,6 +495,49 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
             return self._dedupe_trades_by_tx_hash(merged)
 
         return _cached_trades_load(cache_key, paths, loader)
+
+    def _load_prev_day_recent_tail(self) -> list:
+        """Tail-only read from yesterday recent_trades (prev-run context, max ~500 lines)."""
+        date = _utc_date_str(1)
+        jsonl_path = RECENT_TRADES_DIR / f"recent_trades-{date}.jsonl"
+        if not jsonl_path.is_file():
+            return []
+        trades: list = []
+        try:
+            for line in _iter_jsonl_tail(jsonl_path, RUN_MODE_PREV_RECENT_TAIL_LINES):
+                try:
+                    record = json.loads(line)
+                    trade = self.parse_recent_trade(record)
+                    if trade:
+                        trades.append(trade)
+                except json.JSONDecodeError:
+                    continue
+        except Exception as e:
+            print(f"Error reading {jsonl_path}: {e}")
+        return trades
+
+    def _load_prev_day_execution_enrichment(self) -> list:
+        """Tail-only read from yesterday's last execution segment (enrichment, not full scan)."""
+        date = _utc_date_str(1)
+        segments = _jsonl_segment_paths(EXECUTIONS_DIR, "execution_results", date)
+        if not segments:
+            return []
+        last_path = segments[-1]
+        trades: list = []
+        try:
+            for line in _iter_jsonl_tail(last_path, RUN_MODE_PREV_EXEC_TAIL_LINES):
+                try:
+                    record = json.loads(line)
+                    if _should_skip_execution_record(record):
+                        continue
+                    trade = self.parse_execution_result(record)
+                    if trade:
+                        trades.append(trade)
+                except json.JSONDecodeError:
+                    continue
+        except Exception as e:
+            print(f"Error reading {last_path}: {e}")
+        return trades
 
     def _select_trades_for_current_and_prev_run(self, all_trades: list) -> list:
         """Current run (+ run_id-less rows in its time window) + up to 20 prev-run rows."""
@@ -1250,6 +1337,12 @@ def _self_check():
     print("trades_server: self-check OK")
 
 
+class ThreadingHTTPServer(ThreadingMixIn, http.server.HTTPServer):
+    """Handle concurrent Grafana polls without blocking on slow run-mode loads."""
+
+    daemon_threads = True
+
+
 def main():
     parser = argparse.ArgumentParser(description='Trades history server')
     parser.add_argument('--port', type=int, default=9899, help='Port to listen on (default: 9899)')
@@ -1264,7 +1357,7 @@ def main():
         _self_check()
         return
 
-    server = http.server.HTTPServer(('0.0.0.0', args.port), TradesHandler)
+    server = ThreadingHTTPServer(('0.0.0.0', args.port), TradesHandler)
     print(f"Trades server running on http://0.0.0.0:{args.port}/trades")
     print(f"Reading from: {EXECUTIONS_DIR}")
     server.serve_forever()

--- a/scripts/trades_server.py
+++ b/scripts/trades_server.py
@@ -31,6 +31,7 @@ Query params (GET /trades):
 """
 
 import argparse
+import copy
 import http.server
 import json
 import os
@@ -157,10 +158,10 @@ def _cached_trades_load(cache_key: str, paths: List[Path], loader: Callable[[], 
     fp = _paths_fingerprint(paths)
     entry = _trades_cache.get(cache_key)
     if entry and now - entry["ts"] < TRADES_CACHE_TTL_SEC and entry["fp"] == fp:
-        return entry["data"]
+        return copy.deepcopy(entry["data"])
     data = loader()
     _trades_cache[cache_key] = {"ts": now, "fp": fp, "data": data}
-    return data
+    return copy.deepcopy(data)
 
 
 def clear_trades_cache() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After PR #207, Grafana "Recent Trades" showed **No data** in production even though `recent_trades-*.jsonl` was correctly populated.

**Root cause:**
1. `mode=run` loaded execution JSONL for `[0, 1]` — yesterday's ~160 MB / ~145k lines across 5 rotated segments on every cache miss
2. Single-threaded `HTTPServer` blocked all requests during slow `/trades?mode=run` (~70–90 s)
3. 3 s cache TTL + mtime invalidation on growing files → constant cache misses during active trading

**Prod hotfix (temporary):** `IRONCRAB_TRADES_DAYS_LOOKBACK=0` + `CACHE_TTL_SEC=15` — fixed latency but broke prev-run context and pnl/limit lookback globally.

## Solution (P174)

### 1. Run-mode lookback decoupled
| Source | Today (current run) | Prev-run (max 20) |
|--------|---------------------|-------------------|
| `recent_trades` | `[0]` full tail | `[1]` tail-only (500 lines) |
| `execution_results*` | `[0]` only (all segments) | Last segment tail only (2000 lines, enrichment) |

- `_days_for_run_mode()` returns `([0,1], [0])` — execution loader never scans yesterday full-day
- `limit` and `pnl` endpoints unchanged (`[0]` / `[0,1]`)

### 2. ThreadingHTTPServer
Concurrent Grafana polls no longer block on slow run-mode loads.

### 3. Run-mode cache
- Watch paths: today `recent_trades` + today `execution_results*` only
- Default `IRONCRAB_TRADES_CACHE_TTL_SEC=15` (env override remains)

### 4. systemd + docs
- `docs/systemd/trades-server.service`: `IRONCRAB_TRADES_CACHE_TTL_SEC=15`
- `docs/SCRIPTS_README.md`: note to remove prod override `IRONCRAB_TRADES_DAYS_LOOKBACK=0` after deploy

## Tests

```
python3 -m pytest scripts/test_trades_server.py -q   # 9 passed
python3 scripts/trades_server.py --self-check        # OK
```

New tests:
- `test_run_mode_does_not_load_yesterday_execution_full_scan`
- `test_run_mode_prev_run_from_recent_tail`
- `test_run_mode_cold_under_budget`
- `test_threading_server_class_exists`

## Prod verification (after deploy, without LOOKBACK=0)

```bash
time curl -s -o /dev/null -w 'cold:%{time_total}s\n' 'http://127.0.0.1:9899/trades?mode=run'
time curl -s -o /dev/null -w 'warm:%{time_total}s\n' 'http://127.0.0.1:9899/trades?mode=run'
curl -s 'http://127.0.0.1:9899/trades?mode=run' | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d), any(t.get('action')=='SELL' for t in d))"
for i in 1 2 3 4 5; do curl -s -o /dev/null -w "$i:%{time_total}s " 'http://127.0.0.1:9899/trades?mode=run' & done; wait; echo
```

Expected: cold <1 s, warm <100 ms, SELLs present, 5 parallel requests non-blocking.

## STOP-CHECK (performed)

1. **I-7 Hot Path RPC:** N/A — Python dashboard server only, no Rust hot path changes
2. **Existing pattern:** N/A
3. **Architecture boundaries:** Scope limited to `trades_server.py` + tests + systemd docs
4. **I-9 Simulation gate:** N/A
5. **Level-5 separation:** No eval test reads
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d837f685-17fb-4c9e-b60d-7050d36df529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d837f685-17fb-4c9e-b60d-7050d36df529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

