### PR TITLE
fix(arb-strategy): JetStream SLAVE pool cache sync — known_pools BalanceUpdated + FIX-12

### DIFF
--- a/docs/RUNBOOK_PROD.md
+++ b/docs/RUNBOOK_PROD.md
@@ -419,6 +419,15 @@ Für lokale UI-Entwicklung mit SSH-Tunnel zum Server:
 
 Siehe `.github/copilot-instructions.md` für Details.
 
+## arb-strategy JetStream SLAVE-Sync (`known_pools`)
+
+arb-strategy synchronisiert den JetStream-`POOL_CACHE` **gleichwertig** zu execution-engine (`pool_cache_sync`):
+
+- Nach erfolgreichem Bootstrap: Heartbeat-Feld `known_pools` in der Größenordnung **>50_000** (nicht ~400), nahe der JetStream-Subject-Anzahl.
+- `pools_tracked` zählt Pools aus **MarketEvents** (Trade/PoolCreated); `known_pools` zählt den **MASTER/JetStream-SSOT** — beide Werte sind bewusst unterschiedlich.
+- Bei Concurrent-Deploy (`ironcrab.target`): `IRONCRAB_NATS_REQUEST_TIMEOUT_SECS=180` setzen (Default für arb-strategy und execution-engine), damit `create_consumer` auf großen Streams nicht nach 5s abbricht.
+- Log nach Restart: `SLAVE CACHE BOOTSTRAP: Complete pools_recovered=...` mit **>100_000** erwartet; kein zweites `LastPerSubject`-Consumer-Subscribe nach Bootstrap.
+
 ## 2-Hop Cross-DEX (arb-strategy)
 
 Nach `two_hop_enabled=true` (Control Plane / UI) liefert **arb-strategy** (Port 9803) Prometheus-Metriken für Debug und Prod-Gate:

--- a/src/arbitrage/arb_slave_sync.rs
+++ b/src/arbitrage/arb_slave_sync.rs
@@ -1,0 +1,129 @@
+//! Arb-strategy SLAVE sync: `known_pools` + multi-hop graph from JetStream `PoolCacheUpdate`.
+//!
+//! Mirrors execution-engine `pool_cache_sync` apply path; arb keeps a `HashSet` gate for 2-hop
+//! (`check_arbitrage`) without Pubkey parsing on every comparison.
+
+use parking_lot::RwLock;
+use solana_sdk::pubkey::Pubkey;
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::arbitrage::MultiHopArbitrage;
+use crate::execution::live_pool_cache::{CachedPoolState, LivePoolCache};
+use crate::execution::pool_cache_sync::apply_pool_cache_update;
+use crate::ipc::{PoolCacheUpdate, PoolCacheUpdateType};
+
+static ARB_KNOWN_POOLS_SYNCED_BOOTSTRAP: AtomicU64 = AtomicU64::new(0);
+static ARB_KNOWN_POOLS_SYNCED_INCREMENTAL: AtomicU64 = AtomicU64::new(0);
+
+/// Prometheus-visible totals (optional heartbeat/debug).
+pub fn arb_known_pools_synced_bootstrap_total() -> u64 {
+    ARB_KNOWN_POOLS_SYNCED_BOOTSTRAP.load(Ordering::Relaxed)
+}
+
+pub fn arb_known_pools_synced_incremental_total() -> u64 {
+    ARB_KNOWN_POOLS_SYNCED_INCREMENTAL.load(Ordering::Relaxed)
+}
+
+fn liquidity_usd_from_update(update: &PoolCacheUpdate) -> f64 {
+    update
+        .liquidity_lamports
+        .map(|l| l as f64 / 1e9 * 150.0)
+        .unwrap_or(10_000.0)
+}
+
+fn liquidity_usd_from_state(state: &CachedPoolState) -> f64 {
+    let (base, quote) = match state {
+        CachedPoolState::Orca(s) => (
+            s.vault_a_balance.unwrap_or(0),
+            s.vault_b_balance.unwrap_or(0),
+        ),
+        CachedPoolState::RaydiumAmm(s) => (s.coin_reserve.unwrap_or(0), s.pc_reserve.unwrap_or(0)),
+        CachedPoolState::RaydiumCpmm(s) => (s.reserve_0.unwrap_or(0), s.reserve_1.unwrap_or(0)),
+        CachedPoolState::Meteora(s) => (
+            s.reserve_x_balance.unwrap_or(0),
+            s.reserve_y_balance.unwrap_or(0),
+        ),
+        CachedPoolState::PumpAmm(s) => (s.base_reserve.unwrap_or(0), s.quote_reserve.unwrap_or(0)),
+        CachedPoolState::PumpFun(s) => (s.virtual_token_reserves, s.virtual_sol_reserves),
+        CachedPoolState::MeteoraCpmm(s) => (s.reserve_0, s.reserve_1),
+    };
+    let sol_side = base.max(quote) as f64 / 1e9 * 150.0;
+    sol_side.max(10_000.0)
+}
+
+fn mints_from_state(state: &CachedPoolState) -> (Pubkey, Pubkey) {
+    match state {
+        CachedPoolState::Orca(s) => (s.token_mint_a, s.token_mint_b),
+        CachedPoolState::RaydiumAmm(s) => (s.base_mint, s.quote_mint),
+        CachedPoolState::RaydiumCpmm(s) => (s.token_0_mint, s.token_1_mint),
+        CachedPoolState::Meteora(s) => (s.token_x_mint, s.token_y_mint),
+        CachedPoolState::MeteoraCpmm(s) => (s.token_0_mint, s.token_1_mint),
+        CachedPoolState::PumpFun(s) => (s.token_mint, Pubkey::default()),
+        CachedPoolState::PumpAmm(s) => (s.base_mint, s.quote_mint),
+    }
+}
+
+fn upsert_multi_hop_from_update(multi_hop: &MultiHopArbitrage, update: &PoolCacheUpdate) {
+    multi_hop.upsert_pool(
+        &update.pool_address,
+        &update.dex,
+        &update.base_mint,
+        &update.quote_mint,
+        liquidity_usd_from_update(update),
+        30,
+    );
+}
+
+/// Apply JetStream update to SLAVE `LivePoolCache` and sync arb indexes (`known_pools`, multi-hop).
+///
+/// Returns `true` when `apply_pool_cache_update` modified the cache (PoolDiscovered / BalanceUpdated).
+pub fn sync_arb_slave_from_pool_cache_update(
+    live_pool_cache: &LivePoolCache,
+    known_pools: &RwLock<HashSet<String>>,
+    multi_hop: &MultiHopArbitrage,
+    update: &PoolCacheUpdate,
+) -> bool {
+    match update.update_type {
+        PoolCacheUpdateType::PoolRemoved => {
+            known_pools.write().remove(&update.pool_address);
+            multi_hop.remove_pool(&update.pool_address);
+            false
+        }
+        PoolCacheUpdateType::PoolDiscovered | PoolCacheUpdateType::BalanceUpdated => {
+            let applied = apply_pool_cache_update(live_pool_cache, update);
+            if applied {
+                known_pools.write().insert(update.pool_address.clone());
+                upsert_multi_hop_from_update(multi_hop, update);
+                ARB_KNOWN_POOLS_SYNCED_INCREMENTAL.fetch_add(1, Ordering::Relaxed);
+            }
+            applied
+        }
+    }
+}
+
+/// Rebuild `known_pools` and multi-hop graph from SLAVE `LivePoolCache` after JetStream bootstrap.
+pub fn populate_arb_slave_from_live_pool_cache(
+    live_pool_cache: &LivePoolCache,
+    known_pools: &RwLock<HashSet<String>>,
+    multi_hop: &MultiHopArbitrage,
+) -> usize {
+    let mut pools = known_pools.write();
+    pools.clear();
+    let mut count = 0usize;
+    for (pool_pk, state) in live_pool_cache.iter() {
+        pools.insert(pool_pk.to_string());
+        let (mint_a, mint_b) = mints_from_state(&state);
+        multi_hop.upsert_pool(
+            &pool_pk.to_string(),
+            state.dex_name(),
+            &mint_a.to_string(),
+            &mint_b.to_string(),
+            liquidity_usd_from_state(&state),
+            30,
+        );
+        count += 1;
+    }
+    ARB_KNOWN_POOLS_SYNCED_BOOTSTRAP.store(count as u64, Ordering::Relaxed);
+    count
+}

--- a/src/arbitrage/arb_slave_sync.rs
+++ b/src/arbitrage/arb_slave_sync.rs
@@ -5,6 +5,7 @@
 
 use parking_lot::RwLock;
 use solana_sdk::pubkey::Pubkey;
+use spl_token::native_mint;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -52,7 +53,10 @@ fn mints_from_state(state: &CachedPoolState) -> (Pubkey, Pubkey) {
         CachedPoolState::RaydiumCpmm(s) => (s.token_0_mint, s.token_1_mint),
         CachedPoolState::Meteora(s) => (s.token_x_mint, s.token_y_mint),
         CachedPoolState::MeteoraCpmm(s) => (s.token_0_mint, s.token_1_mint),
-        CachedPoolState::PumpFun(s) => (s.token_mint, Pubkey::default()),
+        CachedPoolState::PumpFun(s) => (
+            s.token_mint,
+            Pubkey::new_from_array(native_mint::id().to_bytes()),
+        ),
         CachedPoolState::PumpAmm(s) => (s.base_mint, s.quote_mint),
     }
 }

--- a/src/arbitrage/arb_slave_sync.rs
+++ b/src/arbitrage/arb_slave_sync.rs
@@ -25,13 +25,6 @@ pub fn arb_known_pools_synced_incremental_total() -> u64 {
     ARB_KNOWN_POOLS_SYNCED_INCREMENTAL.load(Ordering::Relaxed)
 }
 
-fn liquidity_usd_from_update(update: &PoolCacheUpdate) -> f64 {
-    update
-        .liquidity_lamports
-        .map(|l| l as f64 / 1e9 * 150.0)
-        .unwrap_or(10_000.0)
-}
-
 fn liquidity_usd_from_state(state: &CachedPoolState) -> f64 {
     let (base, quote) = match state {
         CachedPoolState::Orca(s) => (
@@ -64,13 +57,24 @@ fn mints_from_state(state: &CachedPoolState) -> (Pubkey, Pubkey) {
     }
 }
 
-fn upsert_multi_hop_from_update(multi_hop: &MultiHopArbitrage, update: &PoolCacheUpdate) {
+fn upsert_multi_hop_from_cache(
+    multi_hop: &MultiHopArbitrage,
+    live_pool_cache: &LivePoolCache,
+    pool_address: &str,
+) {
+    let Ok(pool_pk) = pool_address.parse::<Pubkey>() else {
+        return;
+    };
+    let Some(state) = live_pool_cache.get(&pool_pk) else {
+        return;
+    };
+    let (mint_a, mint_b) = mints_from_state(&state);
     multi_hop.upsert_pool(
-        &update.pool_address,
-        &update.dex,
-        &update.base_mint,
-        &update.quote_mint,
-        liquidity_usd_from_update(update),
+        pool_address,
+        state.dex_name(),
+        &mint_a.to_string(),
+        &mint_b.to_string(),
+        liquidity_usd_from_state(&state),
         30,
     );
 }
@@ -94,7 +98,7 @@ pub fn sync_arb_slave_from_pool_cache_update(
             let applied = apply_pool_cache_update(live_pool_cache, update);
             if applied {
                 known_pools.write().insert(update.pool_address.clone());
-                upsert_multi_hop_from_update(multi_hop, update);
+                upsert_multi_hop_from_cache(multi_hop, live_pool_cache, &update.pool_address);
                 ARB_KNOWN_POOLS_SYNCED_INCREMENTAL.fetch_add(1, Ordering::Relaxed);
             }
             applied

--- a/src/arbitrage/mod.rs
+++ b/src/arbitrage/mod.rs
@@ -27,6 +27,7 @@
 //!
 //! See `docs/MULTI_HOP_ARBITRAGE.md` for full algorithm design.
 
+pub mod arb_slave_sync;
 pub mod cycle_finder;
 pub mod multi_hop_integration;
 pub mod pool_graph;
@@ -34,6 +35,10 @@ pub mod pool_ranker;
 pub mod types;
 
 // Re-exports for convenient access
+pub use arb_slave_sync::{
+    arb_known_pools_synced_bootstrap_total, arb_known_pools_synced_incremental_total,
+    populate_arb_slave_from_live_pool_cache, sync_arb_slave_from_pool_cache_update,
+};
 pub use cycle_finder::{BeamCycleFinder, CycleFinderConfig};
 pub use multi_hop_integration::{
     CachedQuoteProvider, MultiHopArbitrage, MultiHopConfig, MultiHopStats, WSOL_MINT,

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -26,8 +26,13 @@ use std::time::{Duration, Instant};
 use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
-use ironcrab::arbitrage::{MultiHopArbitrage, MultiHopConfig};
+use ironcrab::arbitrage::{
+    populate_arb_slave_from_live_pool_cache, sync_arb_slave_from_pool_cache_update,
+    MultiHopArbitrage, MultiHopConfig,
+};
 use ironcrab::config::Config as AppConfig;
+use ironcrab::execution::live_pool_cache::{create_shared_cache, SharedLivePoolCache};
+use ironcrab::execution::pool_cache_sync::bootstrap_pool_cache_from_jetstream;
 use ironcrab::ipc::{
     BinData, ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, ExplicitAmount, IntentOrigin,
     IntentTier, MarketEvent, MarketEventKind, PoolCacheUpdate, TradeIntent, TradeResources,
@@ -41,7 +46,8 @@ use ironcrab::metrics::{
     POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
-    config_consumer_config, config_subject, slave_consumer_config, CONFIG_STREAM_NAME, STREAM_NAME,
+    config_consumer_config, config_subject, pool_cache_live_fallback_consumer_config,
+    CONFIG_STREAM_NAME, STREAM_NAME,
 };
 use ironcrab::nats::{NatsClient, NatsConfig};
 use ironcrab::nats::{TOPIC_MARKET_EVENTS, TOPIC_TRADE_INTENTS};
@@ -651,8 +657,11 @@ struct ArbContext {
     // =========================================================================
     // SLAVE Cache: Known Pools from market-data MASTER (Single Source of Truth)
     // =========================================================================
+    /// SLAVE LivePoolCache — same JetStream SSOT apply path as execution-engine.
+    live_pool_cache: SharedLivePoolCache,
+
     /// Set of pool addresses that exist in market-data MASTER LivePoolCache.
-    /// Updated from PoolCacheUpdate::PoolDiscovered/PoolRemoved events.
+    /// Updated from every parsable PoolCacheUpdate (PoolDiscovered, BalanceUpdated, PoolRemoved).
     /// ONLY generate intents for pools in this set - ensures execution-engine can execute them.
     known_pools: RwLock<HashSet<String>>,
 
@@ -1914,128 +1923,6 @@ fn create_arb_intent(ctx: &ArbContext, opp: &ArbOpportunity) -> Option<TradeInte
     Some(intent)
 }
 
-/// Bootstrap known_pools from JetStream (state recovery after restart)
-///
-/// This function pulls the last PoolCacheUpdate for each pool from JetStream,
-/// giving arb-strategy immediate awareness of all parseable pools. After bootstrap,
-/// the SLAVE subscribes to incremental updates via regular NATS subscription.
-///
-/// # Arguments
-///
-/// * `nats_client` - Connected NATS client
-/// * `known_pools` - HashSet to populate with pool addresses
-/// * `multi_hop` - Multi-hop arbitrage instance to populate with pools
-///
-/// # Returns
-///
-/// Number of pools recovered from JetStream
-async fn bootstrap_known_pools_from_jetstream(
-    nats_client: &NatsClient,
-    known_pools: &RwLock<HashSet<String>>,
-    multi_hop: &MultiHopArbitrage,
-) -> Result<usize> {
-    use async_nats::jetstream;
-    use futures::StreamExt;
-
-    info!("SLAVE CACHE BOOTSTRAP: Pulling known pools from JetStream...");
-
-    let jetstream = jetstream::new(nats_client.client().clone());
-
-    // Get or create stream (idempotent)
-    let stream = match jetstream.get_stream(STREAM_NAME).await {
-        Ok(s) => s,
-        Err(e) => {
-            warn!(error = %e, stream = STREAM_NAME, "JetStream stream not found (market-data may not be running)");
-            return Ok(0);
-        }
-    };
-
-    // Create ephemeral consumer with LastPerSubject deliver policy
-    let consumer_config = slave_consumer_config();
-    let consumer = stream.create_consumer(consumer_config).await?;
-
-    let mut pools_recovered = 0;
-    let batch_size = 1000; // Fetch up to 1000 messages per batch
-
-    // Fetch all available messages in batches until exhausted
-    loop {
-        let mut messages = consumer.fetch().max_messages(batch_size).messages().await?;
-        let mut batch_count = 0;
-
-        while let Some(msg) = messages.next().await {
-            let msg = match msg {
-                Ok(m) => m,
-                Err(e) => {
-                    warn!(error = %e, "Error fetching message from JetStream");
-                    continue;
-                }
-            };
-
-            batch_count += 1;
-
-            // Deserialize PoolCacheUpdate
-            let pool_update: PoolCacheUpdate = match serde_json::from_slice(&msg.payload) {
-                Ok(u) => u,
-                Err(e) => {
-                    warn!(error = %e, "Failed to deserialize PoolCacheUpdate from JetStream");
-                    if let Err(ack_err) = msg.ack().await {
-                        warn!(error = %ack_err, "Failed to ack message");
-                    }
-                    continue;
-                }
-            };
-
-            // Add pool to known_pools and multi-hop graph
-            match pool_update.update_type {
-                ironcrab::ipc::PoolCacheUpdateType::PoolDiscovered
-                | ironcrab::ipc::PoolCacheUpdateType::BalanceUpdated => {
-                    let mut pools = known_pools.write();
-                    pools.insert(pool_update.pool_address.clone());
-                    pools_recovered += 1;
-
-                    // Multi-hop: Add pool to graph for N-hop arbitrage detection
-                    let liquidity_usd = pool_update
-                        .liquidity_lamports
-                        .map(|l| l as f64 / 1e9 * 150.0)
-                        .unwrap_or(10_000.0);
-                    multi_hop.upsert_pool(
-                        &pool_update.pool_address,
-                        &pool_update.dex,
-                        &pool_update.base_mint,
-                        &pool_update.quote_mint,
-                        liquidity_usd,
-                        30, // Default 0.3% fee
-                    );
-
-                    debug!(
-                        pool = %pool_update.pool_address,
-                        dex = %pool_update.dex,
-                        "SLAVE CACHE BOOTSTRAP: Recovered pool from JetStream"
-                    );
-                }
-                ironcrab::ipc::PoolCacheUpdateType::PoolRemoved => {
-                    // Skip removed pools during bootstrap
-                }
-            }
-
-            if let Err(ack_err) = msg.ack().await {
-                warn!(error = %ack_err, "Failed to ack message");
-            }
-        }
-
-        // If we got fewer messages than batch_size, we've exhausted the stream
-        if batch_count < batch_size {
-            break;
-        }
-    }
-
-    info!(
-        pools_recovered,
-        "SLAVE CACHE BOOTSTRAP: Complete (known_pools populated)"
-    );
-    Ok(pools_recovered)
-}
-
 // ============================================================================
 // Main
 // ============================================================================
@@ -2099,7 +1986,8 @@ async fn main() -> Result<()> {
         info!("Dry-run mode: NATS publishing disabled");
         None
     } else {
-        let config = NatsConfig::new(&args.nats_url, "arb-strategy");
+        let mut config = NatsConfig::new(&args.nats_url, "arb-strategy");
+        config.request_timeout = NatsConfig::request_timeout_from_env(180);
         let mut client = NatsClient::new(config);
         if let Err(e) = client.connect().await {
             error!(error = %e, "Failed to connect to NATS");
@@ -2126,32 +2014,41 @@ async fn main() -> Result<()> {
         last_market_event: RwLock::new(Instant::now()),
         vault_balances: RwLock::new(HashMap::new()),
         bin_arrays: RwLock::new(HashMap::new()),
+        live_pool_cache: create_shared_cache(),
         known_pools: RwLock::new(HashSet::new()),
         // Multi-hop arbitrage: disabled and shadow mode by default for safe rollout
         multi_hop: MultiHopArbitrage::new(MultiHopConfig::default()),
     });
 
-    // Bootstrap known_pools from JetStream (state recovery after restart)
-    // Also populates multi-hop graph with recovered pools
-    if let Some(ref nats_client) = ctx.nats {
-        match bootstrap_known_pools_from_jetstream(nats_client, &ctx.known_pools, &ctx.multi_hop)
-            .await
-        {
-            Ok(pools_recovered) => {
+    // Bootstrap SLAVE LivePoolCache from JetStream (same path as execution-engine).
+    // Consumer is returned for reuse in the main loop (FIX-12 — no second LastPerSubject replay).
+    let bootstrap_consumer = if let Some(ref nats_client) = ctx.nats {
+        match bootstrap_pool_cache_from_jetstream(nats_client, &ctx.live_pool_cache).await {
+            Ok((pools_recovered, consumer)) => {
+                let known_count = populate_arb_slave_from_live_pool_cache(
+                    &ctx.live_pool_cache,
+                    &ctx.known_pools,
+                    &ctx.multi_hop,
+                );
                 let mh_stats = ctx.multi_hop.stats();
                 info!(
                     pools_recovered,
+                    known_pools = known_count,
                     multi_hop_pools = mh_stats.graph_pools,
                     multi_hop_vertices = mh_stats.graph_vertices,
                     "SLAVE CACHE: known_pools and multi-hop graph recovered from JetStream"
                 );
-                POOLS_TRACKED_GAUGE.store(pools_recovered as u64, Ordering::Relaxed);
+                POOLS_TRACKED_GAUGE.store(known_count as u64, Ordering::Relaxed);
+                consumer
             }
             Err(e) => {
                 warn!(error = %e, "SLAVE CACHE: JetStream bootstrap failed (will rely on incremental updates)");
+                None
             }
         }
-    }
+    } else {
+        None
+    };
 
     // Subscribe to MarketEvents
     let market_subscription = if let Some(ref nats) = ctx.nats {
@@ -2247,32 +2144,38 @@ async fn main() -> Result<()> {
         (None, None)
     };
 
-    // Subscribe to PoolCacheUpdates from JetStream (SLAVE sync from market-data MASTER)
-    // market-data publishes to JetStream, so we need JetStream consumer (not Core NATS)
-    let pool_cache_consumer = if let Some(ref nats) = ctx.nats {
+    // Subscribe to PoolCacheUpdates from JetStream (SLAVE sync from market-data MASTER).
+    // CRITICAL: Reuse bootstrap consumer when available (FIX-12). Fallback: DeliverPolicy::New only.
+    let pool_cache_consumer = if let Some(consumer) = bootstrap_consumer {
+        info!(
+            stream = STREAM_NAME,
+            "Reusing bootstrap consumer for live PoolCacheUpdate sync (no duplicate LastPerSubject replay)"
+        );
+        Some(consumer)
+    } else if let Some(ref nats) = ctx.nats {
         use async_nats::jetstream;
 
-        let js = jetstream::new(nats.client().clone());
+        let jetstream = jetstream::new(nats.client().clone());
 
-        match js.get_stream(STREAM_NAME).await {
+        match jetstream.get_stream(STREAM_NAME).await {
             Ok(stream) => {
-                // Create ephemeral consumer for live updates with LastPerSubject delivery
-                match stream.create_consumer(slave_consumer_config()).await {
+                let config = pool_cache_live_fallback_consumer_config();
+                match stream.create_consumer(config).await {
                     Ok(consumer) => {
                         info!(
                             stream = STREAM_NAME,
-                            "Subscribed to JetStream PoolCacheUpdates (SLAVE cache sync from market-data MASTER)"
+                            "Created NEW JetStream consumer (no bootstrap, DeliverPolicy::New)"
                         );
                         Some(consumer)
                     }
                     Err(e) => {
-                        warn!(error = %e, "Failed to create JetStream consumer for PoolCacheUpdates - multi-hop will not receive pool cache");
+                        warn!(error = %e, "Failed to create JetStream consumer for PoolCacheUpdates");
                         None
                     }
                 }
             }
             Err(e) => {
-                warn!(error = %e, stream = STREAM_NAME, "JetStream stream not found (market-data may not be running) - multi-hop will not receive pool cache");
+                warn!(error = %e, stream = STREAM_NAME, "JetStream stream not found (market-data may not be running)");
                 None
             }
         }
@@ -2415,8 +2318,13 @@ async fn main() -> Result<()> {
             _ = async {
                 use futures::StreamExt;
                 if let Some(ref consumer) = pool_cache_consumer_opt {
-                    // Try to pull up to 100 messages in batch (non-blocking)
-                    match consumer.fetch().max_messages(100).messages().await {
+                    match consumer
+                        .fetch()
+                        .max_messages(100)
+                        .expires(Duration::from_millis(100))
+                        .messages()
+                        .await
+                    {
                         Ok(mut messages) => {
                             while let Some(msg_result) = messages.next().await {
                                 match msg_result {
@@ -2424,40 +2332,24 @@ async fn main() -> Result<()> {
                                         NATS_MESSAGES_RECEIVED_TOTAL.fetch_add(1, Ordering::Relaxed);
                                         match serde_json::from_slice::<PoolCacheUpdate>(&msg.payload) {
                                             Ok(update) => {
-                                                use ironcrab::ipc::PoolCacheUpdateType;
-                                                match update.update_type {
-                                                    PoolCacheUpdateType::PoolDiscovered => {
-                                                        ctx.known_pools.write().insert(update.pool_address.clone());
-                                                        debug!(pool = %update.pool_address, dex = %update.dex, "SLAVE CACHE: Pool added to known_pools (JetStream)");
-
-                                                        // Multi-hop: Add pool to graph for N-hop arbitrage detection
-                                                        let liquidity_usd = update.liquidity_lamports
-                                                            .map(|l| l as f64 / 1e9 * 150.0)
-                                                            .unwrap_or(10_000.0);
-                                                        ctx.multi_hop.upsert_pool(
-                                                            &update.pool_address,
-                                                            &update.dex,
-                                                            &update.base_mint,
-                                                            &update.quote_mint,
-                                                            liquidity_usd,
-                                                            30,
-                                                        );
-                                                    }
-                                                    PoolCacheUpdateType::PoolRemoved => {
-                                                        ctx.known_pools.write().remove(&update.pool_address);
-                                                        debug!(pool = %update.pool_address, "SLAVE CACHE: Pool removed (JetStream)");
-                                                        ctx.multi_hop.remove_pool(&update.pool_address);
-                                                    }
-                                                    PoolCacheUpdateType::BalanceUpdated => {
-                                                        debug!(pool = %update.pool_address, "SLAVE CACHE: Balance update (JetStream)");
-                                                    }
+                                                if sync_arb_slave_from_pool_cache_update(
+                                                    &ctx.live_pool_cache,
+                                                    &ctx.known_pools,
+                                                    &ctx.multi_hop,
+                                                    &update,
+                                                ) {
+                                                    debug!(
+                                                        pool = %update.pool_address,
+                                                        dex = %update.dex,
+                                                        update_type = ?update.update_type,
+                                                        "SLAVE CACHE: Pool cache update applied (JetStream)"
+                                                    );
                                                 }
                                             }
                                             Err(e) => {
                                                 warn!(error = %e, "Failed to deserialize PoolCacheUpdate from JetStream");
                                             }
                                         }
-                                        // Acknowledge the message
                                         if let Err(e) = msg.ack().await {
                                             warn!(error = %e, "Failed to ack JetStream message");
                                         }
@@ -2469,13 +2361,12 @@ async fn main() -> Result<()> {
                             }
                         }
                         Err(e) => {
-                            // Fetch timeout or no messages is normal
                             trace!(error = %e, "JetStream fetch returned (timeout or no messages)");
                         }
                     }
+                } else {
+                    std::future::pending::<()>().await
                 }
-                // Small delay to prevent busy-loop
-                tokio::time::sleep(Duration::from_millis(100)).await;
             } => {}
 
             // Heartbeat

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -7072,7 +7072,8 @@ async fn main() -> Result<()> {
     // NOTE: `--dry-run` means "never send on-chain transactions".
     // It must NOT disable NATS consumption, otherwise we can't end-to-end test the pipeline.
     let nats = {
-        let config = NatsConfig::new(&args.nats_url, "execution-engine");
+        let mut config = NatsConfig::new(&args.nats_url, "execution-engine");
+        config.request_timeout = NatsConfig::request_timeout_from_env(180);
         let mut client = NatsClient::new(config);
         if let Err(e) = client.connect().await {
             warn!(error = %e, "Failed to connect to NATS (continuing without)");

--- a/src/nats/client.rs
+++ b/src/nats/client.rs
@@ -54,6 +54,19 @@ impl NatsConfig {
             ..Default::default()
         }
     }
+
+    /// Request timeout from `IRONCRAB_NATS_REQUEST_TIMEOUT_SECS` or `default_secs`.
+    ///
+    /// JetStream `create_consumer` on large `POOL_CACHE` streams can exceed the 5s client default
+    /// during concurrent restarts (`ironcrab.target`).
+    pub fn request_timeout_from_env(default_secs: u64) -> Duration {
+        std::env::var("IRONCRAB_NATS_REQUEST_TIMEOUT_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .filter(|&secs| secs > 0)
+            .map(Duration::from_secs)
+            .unwrap_or_else(|| Duration::from_secs(default_secs))
+    }
 }
 
 // ============================================================================

--- a/src/nats/jetstream.rs
+++ b/src/nats/jetstream.rs
@@ -400,12 +400,27 @@ pub fn slave_consumer_config() -> jetstream::consumer::pull::Config {
     }
 }
 
+/// Ephemeral fallback when JetStream bootstrap did not run (empty SLAVE cache).
+///
+/// `DeliverPolicy::New` — no replay of per-subject historical snapshots. Used by execution-engine
+/// and arb-strategy when bootstrap failed or was skipped (FIX-12).
+pub fn pool_cache_live_fallback_consumer_config() -> jetstream::consumer::pull::Config {
+    jetstream::consumer::pull::Config {
+        deliver_policy: jetstream::consumer::DeliverPolicy::New,
+        ack_policy: jetstream::consumer::AckPolicy::Explicit,
+        max_ack_pending: 1000,
+        filter_subject: "ironcrab.pool_cache.>".to_string(),
+        ..Default::default()
+    }
+}
+
 /// Consumer config for live `POOL_CACHE` updates only (`DeliverPolicy::New`).
 ///
 /// Used by **momentum-bot** so the runtime does not replay the per-subject last snapshot for every
-/// pool in the stream (hundreds of thousands of messages). Cold-path tools (execution-engine,
-/// `sell_all_keyless`, arb-strategy known-pools bootstrap) continue to use
-/// `slave_consumer_config` / `pool_cache_sync::bootstrap_pool_cache_from_jetstream`.
+/// pool in the stream (hundreds of thousands of messages). Cold-path bootstrap (execution-engine,
+/// arb-strategy, `sell_all_keyless`) uses `slave_consumer_config` via
+/// `pool_cache_sync::bootstrap_pool_cache_from_jetstream`; live fallback uses
+/// [`pool_cache_live_fallback_consumer_config`].
 pub fn pool_cache_live_consumer_config() -> jetstream::consumer::pull::Config {
     jetstream::consumer::pull::Config {
         deliver_policy: jetstream::consumer::DeliverPolicy::New,

--- a/tests/arb_known_pools_sync.rs
+++ b/tests/arb_known_pools_sync.rs
@@ -1,0 +1,193 @@
+//! Arb-strategy `known_pools` sync from JetStream PoolCacheUpdate (BalanceUpdated path).
+
+use ironcrab::arbitrage::{
+    populate_arb_slave_from_live_pool_cache, sync_arb_slave_from_pool_cache_update,
+    MultiHopArbitrage, MultiHopConfig,
+};
+use ironcrab::execution::live_pool_cache::create_shared_cache;
+use ironcrab::ipc::PoolCacheUpdate;
+use parking_lot::RwLock;
+use solana_sdk::pubkey::Pubkey;
+use std::collections::HashSet;
+
+const TEST_COMPONENT: &str = "test";
+const TEST_BUILD: &str = "0.0.0";
+const TEST_RUN: &str = "run-test";
+
+fn empty_known_pools() -> RwLock<HashSet<String>> {
+    RwLock::new(HashSet::new())
+}
+
+#[test]
+fn balance_updated_only_populates_known_pools() {
+    let cache = create_shared_cache();
+    let known_pools = empty_known_pools();
+    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default());
+
+    let pool = Pubkey::new_unique().to_string();
+    let base_mint = Pubkey::new_unique().to_string();
+    let quote_mint = "So11111111111111111111111111111111111111112";
+
+    let update = PoolCacheUpdate::new_balance_updated(
+        TEST_COMPONENT,
+        TEST_BUILD,
+        TEST_RUN,
+        pool.to_string(),
+        "raydium".to_string(),
+        base_mint.to_string(),
+        quote_mint.to_string(),
+        1_000_000,
+        2_000_000,
+        42,
+    );
+
+    assert!(sync_arb_slave_from_pool_cache_update(
+        &cache,
+        &known_pools,
+        &multi_hop,
+        &update,
+    ));
+    assert!(known_pools.read().contains(&pool));
+}
+
+#[test]
+fn pool_removed_evicts_known_pools_entry() {
+    let cache = create_shared_cache();
+    let known_pools = empty_known_pools();
+    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default());
+
+    let pool = Pubkey::new_unique().to_string();
+    let base_mint = Pubkey::new_unique().to_string();
+    let quote_mint = "So11111111111111111111111111111111111111112";
+
+    let discovered = PoolCacheUpdate::new_pool_discovered(
+        TEST_COMPONENT,
+        TEST_BUILD,
+        TEST_RUN,
+        pool.to_string(),
+        "orca".to_string(),
+        base_mint.to_string(),
+        quote_mint.to_string(),
+        1_000_000,
+        2_000_000,
+        None,
+        1,
+    );
+    sync_arb_slave_from_pool_cache_update(&cache, &known_pools, &multi_hop, &discovered);
+    assert!(known_pools.read().contains(&pool));
+
+    let removed = PoolCacheUpdate::new_pool_removed(
+        TEST_COMPONENT,
+        TEST_BUILD,
+        TEST_RUN,
+        pool.to_string(),
+        "orca".to_string(),
+        2,
+    );
+    sync_arb_slave_from_pool_cache_update(&cache, &known_pools, &multi_hop, &removed);
+    assert!(!known_pools.read().contains(&pool));
+}
+
+#[test]
+fn pool_discovered_then_balance_updated_keeps_single_known_pools_entry() {
+    let cache = create_shared_cache();
+    let known_pools = empty_known_pools();
+    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default());
+
+    let pool = Pubkey::new_unique().to_string();
+    let base_mint = Pubkey::new_unique().to_string();
+    let quote_mint = "So11111111111111111111111111111111111111112";
+
+    let discovered = PoolCacheUpdate::new_pool_discovered(
+        TEST_COMPONENT,
+        TEST_BUILD,
+        TEST_RUN,
+        pool.to_string(),
+        "meteora_dlmm".to_string(),
+        base_mint.to_string(),
+        quote_mint.to_string(),
+        500_000,
+        600_000,
+        None,
+        10,
+    );
+    sync_arb_slave_from_pool_cache_update(&cache, &known_pools, &multi_hop, &discovered);
+
+    let balance = PoolCacheUpdate::new_balance_updated(
+        TEST_COMPONENT,
+        TEST_BUILD,
+        TEST_RUN,
+        pool.to_string(),
+        "meteora_dlmm".to_string(),
+        base_mint.to_string(),
+        quote_mint.to_string(),
+        700_000,
+        800_000,
+        11,
+    );
+    sync_arb_slave_from_pool_cache_update(&cache, &known_pools, &multi_hop, &balance);
+
+    let pools: Vec<_> = known_pools.read().iter().cloned().collect();
+    assert_eq!(pools.len(), 1);
+    assert_eq!(pools[0], pool);
+}
+
+#[test]
+fn balance_updated_upserts_multi_hop_idempotently() {
+    let cache = create_shared_cache();
+    let known_pools = empty_known_pools();
+    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default());
+
+    let pool = Pubkey::new_unique().to_string();
+    let base_mint = Pubkey::new_unique().to_string();
+    let quote_mint = "So11111111111111111111111111111111111111112";
+
+    let balance = PoolCacheUpdate::new_balance_updated(
+        TEST_COMPONENT,
+        TEST_BUILD,
+        TEST_RUN,
+        pool.to_string(),
+        "raydium_cpmm".to_string(),
+        base_mint.to_string(),
+        quote_mint.to_string(),
+        1_000_000,
+        2_000_000,
+        5,
+    );
+    sync_arb_slave_from_pool_cache_update(&cache, &known_pools, &multi_hop, &balance);
+    let stats_after_first = multi_hop.stats();
+
+    sync_arb_slave_from_pool_cache_update(&cache, &known_pools, &multi_hop, &balance);
+    let stats_after_second = multi_hop.stats();
+
+    assert_eq!(stats_after_first.graph_pools, 1);
+    assert_eq!(stats_after_second.graph_pools, 1);
+    assert!(known_pools.read().contains(&pool));
+}
+
+#[test]
+fn populate_from_live_cache_matches_cache_len() {
+    let cache = create_shared_cache();
+    let known_pools = empty_known_pools();
+    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default());
+
+    let pool = Pubkey::new_unique().to_string();
+    let update = PoolCacheUpdate::new_balance_updated(
+        TEST_COMPONENT,
+        TEST_BUILD,
+        TEST_RUN,
+        pool.clone(),
+        "orca".to_string(),
+        Pubkey::new_unique().to_string(),
+        "So11111111111111111111111111111111111111112".to_string(),
+        1,
+        2,
+        1,
+    );
+    sync_arb_slave_from_pool_cache_update(&cache, &known_pools, &multi_hop, &update);
+
+    known_pools.write().clear();
+    let count = populate_arb_slave_from_live_pool_cache(&cache, &known_pools, &multi_hop);
+    assert_eq!(count, cache.len());
+    assert!(known_pools.read().contains(&pool));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (Prod 2026-06-07)

arb-strategy `known_pools` stuck at **~418** after 1.5h while JetStream `POOL_CACHE` had **~671k** subjects. Dominant reject: `arb_two_hop_rejected{reason="insufficient_pools"}`.

**Root causes:**
1. Duplicate bootstrap logic in `arb_strategy.rs` instead of shared `pool_cache_sync`
2. Incremental loop only inserted `known_pools` on `PoolDiscovered`; `BalanceUpdated` was debug-only (~99% of live updates)
3. Second ephemeral `LastPerSubject` consumer after bootstrap (FIX-12 / KNOWN_BUG_PATTERNS #8)
4. Bootstrap-fail fallback recreated `LastPerSubject` instead of `DeliverPolicy::New`
5. NATS `request_timeout` default 5s too short for `create_consumer` on large streams

## Fix

Mirrors **execution-engine** `pool_cache_sync` pattern:

- `bootstrap_pool_cache_from_jetstream` → SLAVE `LivePoolCache` + **reuse consumer** in main loop
- `sync_arb_slave_from_pool_cache_update`: `apply_pool_cache_update` + `known_pools` / multi-hop sync for **PoolDiscovered + BalanceUpdated**; remove on `PoolRemoved`
- Fallback consumer: `pool_cache_live_fallback_consumer_config()` (`DeliverPolicy::New`)
- Non-blocking fetch: `max_messages(100).expires(100ms)`
- `IRONCRAB_NATS_REQUEST_TIMEOUT_SECS` (default **180s** for arb-strategy and execution-engine)

## Tests

- `tests/arb_known_pools_sync.rs` — BalanceUpdated-only, PoolRemoved, idempotent multi-hop

## Prod gate (post-deploy)

- Bootstrap log: `pools_recovered` / `known_pools` >> 10k
- No second `LastPerSubject` subscribe after bootstrap
- `insufficient_pools` reject rate should drop

## STOP-CHECK

- No new RPC in hot path (JetStream/MarketEvent loop only)
- No new NATS topics (existing `POOL_CACHE`)
- Simulation gate unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f613b325-c56b-4022-9aac-2bff2da26eb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f613b325-c56b-4022-9aac-2bff2da26eb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

