### PR TITLE
feat(execution-engine): TX confirm slot-delta metrics, fee observability, TPU rebroadcast

### DIFF
--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -57,7 +57,19 @@ Component name: `execution-engine`
 | `confirmation_timeout_ms` | u64 | 30000 | 500-300000 | Confirmation timeout after send (ms) |
 | `confirm_commitment` | string | "confirmed" | finalized, confirmed | Commitment level for TX confirmation. Default `"confirmed"`: lower confirmation latency with **reorg risk** (slot can still reorganize). `"finalized"`: typical ~12–15s extra latency, stronger fork resistance. **market-data** Geyser `transactions_status` subscription uses this value at market-data startup (restart market-data to apply consistently). execution-engine waits on JetStream `WalletTxConfirmed` only (no RPC fallback). |
 | `jetstream_tx_confirm_enabled` | bool | true | true/false | Wait for `WalletTxConfirmed` on JetStream after send (PR3). **Deprecated alias:** `geyser_confirm_enabled` (hot-reload still accepted). No RPC fallback on timeout (I-7). |
+| `rebroadcast_interval_ms` | u64 | 2000 | 500-30000 | Interval between rebroadcasts of the same signed TX during confirm wait (ms) |
+| `max_rebroadcasts` | u32 | 5 | 0-20 | Max rebroadcast attempts per TX during confirm wait |
+| `rebroadcast_use_tpu` | bool | true* | true/false | Rebroadcast via TxSender/TPU when available; RPC fallback on failure. *Default follows `[execution_engine.tx_submission].tpu_enabled` when unset. |
 | `send_enabled` | bool | false | true/false | If true, engine signs and submits transactions |
+
+### Fee policy (`[execution_engine.fee_policy]` TOML / hot-reload via nested updates)
+
+| Key | Type | Default | Range | Description |
+|-----|------|---------|-------|-------------|
+| `tier1_fee_percentile` | u8 | 50 | 25, 50, 75, 90 | Percentile base for Tier1 dynamic fee (execution-engine recomputes from NATS `PriorityFeePercentiles`; does not raise static floor) |
+| `tier1_fee_multiplier` | f64 | 1.2 | > 0 | Multiplier applied to Tier1 percentile base; effective fee remains `max(dynamic, static_floor)` |
+
+Prometheus (execution-engine `:9803/metrics`): `tx_send_to_confirm_ms`, `tx_confirmed_slot_delta_slots`, `tx_priority_fee_source_total{source}`, `tx_rebroadcast_total`, `tx_rebroadcast_method_total{method}`.
 
 ### Validation Rules
 - `max_slippage_bps` must be between 1 and 10000 (0.01% to 100%)

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -71,7 +71,9 @@ use ironcrab::ipc::{
 use ironcrab::ipc::{ControlRequest, ControlRequestKind, ControlResponse, ControlResponseStatus};
 use ironcrab::metrics::{
     record_execution_process_intent_us, record_execution_slot_lag_at_send_slots,
-    record_recent_trade, record_tx_slot_to_send_ms, serve_metrics,
+    record_recent_trade, record_tx_confirmed_slot_delta_slots, record_tx_priority_fee_source,
+    record_tx_rebroadcast, record_tx_rebroadcast_during_confirm_ms, record_tx_rebroadcast_method,
+    record_tx_send_to_confirm_ms, record_tx_slot_to_send_ms, serve_metrics,
     set_readiness_control_response_sub_active, set_readiness_control_sub_active,
     set_readiness_mode, set_readiness_nats_connected, set_readiness_state_paths_initialized,
     try_record_execution_intent_header_to_receive_ms, try_record_execution_intent_to_confirm_ms,
@@ -1509,6 +1511,8 @@ struct ExecutionConfig {
     rebroadcast_interval_ms: u64,
     /// Max rebroadcasts per TX during confirmation
     max_rebroadcasts: u32,
+    /// Rebroadcast via TPU (TxSender) when available; RPC fallback on failure.
+    rebroadcast_use_tpu: bool,
 
     // === Account Janitor Config (hot-reloadable) ===
     janitor_enabled: bool,
@@ -1567,6 +1571,7 @@ impl Default for ExecutionConfig {
             confirm_commitment: "confirmed".to_string(),
             rebroadcast_interval_ms: 2_000,
             max_rebroadcasts: 5,
+            rebroadcast_use_tpu: true,
             // Account Janitor defaults
             janitor_enabled: false,
             janitor_close_ata_interval_secs: 3600,
@@ -2546,49 +2551,13 @@ impl ExecutionContext {
         self.kill_switch_context.read().clone()
     }
 
-    /// Get priority fee for an intent using dynamic percentiles with static config as floor.
-    ///
-    /// P2: Dynamic Priority Fee Usage
-    /// - If market-data is publishing percentiles via NATS, use tier-specific recommended fee
-    /// - Always use static config (fee_policy) as minimum floor to ensure configured fees
-    ///   (especially liquidation_priority_fee) are respected even when network fees are low
-    /// - This prevents time-critical operations (liquidation, exits) from using fees that
-    ///   are too low to land on-chain during normal network conditions
-    fn get_priority_fee_for_intent(&self, intent: &TradeIntent, fee_policy: &FeePolicy) -> u64 {
-        // Static fee from config serves as the floor (minimum guaranteed fee)
-        let static_fee = fee_policy.priority_fee_for_intent(intent);
-
-        if let Some(ref percentiles) = *self.dynamic_fee_percentiles.read() {
-            let dynamic_fee = match intent.tier {
-                IntentTier::Tier0 => percentiles.tier0_recommended,
-                IntentTier::Tier1 => percentiles.tier1_recommended,
-                IntentTier::Arb => percentiles.arb_recommended,
-            };
-
-            // Use maximum of dynamic and static fee to ensure config is respected as floor
-            let effective_fee = dynamic_fee.max(static_fee);
-
-            tracing::debug!(
-                intent_id = %intent.intent_id,
-                tier = ?intent.tier,
-                dynamic_fee_micro_lamports = dynamic_fee,
-                static_fee_micro_lamports = static_fee,
-                effective_fee_micro_lamports = effective_fee,
-                p50 = percentiles.p50,
-                p90 = percentiles.p90,
-                sample_count = percentiles.sample_count,
-                "Priority fee: max(dynamic, static) - static config as floor"
-            );
-            effective_fee
-        } else {
-            tracing::debug!(
-                intent_id = %intent.intent_id,
-                tier = ?intent.tier,
-                static_fee_micro_lamports = static_fee,
-                "Using STATIC priority fee (no dynamic percentiles available)"
-            );
-            static_fee
-        }
+    fn get_priority_fee_for_intent(
+        &self,
+        intent: &TradeIntent,
+        fee_policy: &FeePolicy,
+    ) -> PriorityFeeSelection {
+        let percentiles = self.dynamic_fee_percentiles.read();
+        select_priority_fee_for_intent(intent, fee_policy, percentiles.as_ref())
     }
 
     #[inline]
@@ -5917,6 +5886,15 @@ impl ExecutionContext {
                         rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
                     }
                 }
+                "rebroadcast_use_tpu" => {
+                    if let Some(v) = value.as_bool() {
+                        config.rebroadcast_use_tpu = v;
+                        applied.push(key.clone());
+                        info!(key = %key, new_value = %v, "Config updated");
+                    } else {
+                        rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
+                    }
+                }
                 "skip_preflight" => {
                     if let Some(v) = value.as_bool() {
                         config.send_skip_preflight = v;
@@ -6825,6 +6803,8 @@ async fn main() -> Result<()> {
             urgency_multiplier_urgent: 5.0,
             max_tx_cost_lamports: fp.max_tx_cost_lamports,
             min_profit_after_fees_bps: fp.min_profit_after_fees_bps,
+            tier1_fee_percentile: fp.tier1_fee_percentile,
+            tier1_fee_multiplier: fp.tier1_fee_multiplier,
         }
     } else {
         FeePolicy::default()
@@ -6898,6 +6878,14 @@ async fn main() -> Result<()> {
         confirm_commitment: exec_eng_cfg
             .and_then(|e| e.confirm_commitment.clone())
             .unwrap_or_else(|| "confirmed".to_string()),
+        rebroadcast_use_tpu: exec_eng_cfg
+            .and_then(|e| e.rebroadcast_use_tpu)
+            .unwrap_or_else(|| {
+                exec_eng_cfg
+                    .and_then(|e| e.tx_submission.as_ref())
+                    .map(|t| t.tpu_enabled)
+                    .unwrap_or(true)
+            }),
         ..Default::default()
     };
 
@@ -9064,6 +9052,98 @@ fn scale_in_max_open_positions_skip_details(
     ))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PriorityFeeSelection {
+    fee_micro_lamports: u64,
+    source: &'static str,
+}
+
+fn tier1_dynamic_fee_from_percentiles(
+    percentiles: &PriorityFeePercentiles,
+    fee_policy: &FeePolicy,
+) -> u64 {
+    let base = match fee_policy.tier1_fee_percentile {
+        75 => percentiles.p75,
+        90 => percentiles.p90,
+        25 => percentiles.p25,
+        _ => percentiles.p50,
+    };
+    ((base as f64) * fee_policy.tier1_fee_multiplier) as u64
+}
+
+fn select_priority_fee_for_intent(
+    intent: &TradeIntent,
+    fee_policy: &FeePolicy,
+    dynamic_percentiles: Option<&PriorityFeePercentiles>,
+) -> PriorityFeeSelection {
+    let static_fee = fee_policy.priority_fee_for_intent(intent);
+
+    let Some(percentiles) = dynamic_percentiles else {
+        return PriorityFeeSelection {
+            fee_micro_lamports: static_fee,
+            source: "static_floor",
+        };
+    };
+
+    let dynamic_fee = match intent.tier {
+        IntentTier::Tier0 => percentiles.tier0_recommended,
+        IntentTier::Tier1 => tier1_dynamic_fee_from_percentiles(percentiles, fee_policy),
+        IntentTier::Arb => percentiles.arb_recommended,
+    };
+    let effective_fee = dynamic_fee.max(static_fee);
+    let source = if effective_fee > static_fee {
+        "dynamic"
+    } else {
+        "static_floor"
+    };
+
+    tracing::debug!(
+        intent_id = %intent.intent_id,
+        tier = ?intent.tier,
+        dynamic_fee_micro_lamports = dynamic_fee,
+        static_fee_micro_lamports = static_fee,
+        effective_fee_micro_lamports = effective_fee,
+        source = source,
+        p50 = percentiles.p50,
+        p90 = percentiles.p90,
+        sample_count = percentiles.sample_count,
+        "Priority fee: max(dynamic, static) - static config as floor"
+    );
+
+    PriorityFeeSelection {
+        fee_micro_lamports: effective_fee,
+        source,
+    }
+}
+
+#[inline]
+fn slot_at_send_from_context(ctx: &ExecutionContext) -> Option<u64> {
+    ctx.cached_blockhash.read().as_ref().map(|c| c.slot)
+}
+
+#[inline]
+fn confirmed_slot_delta_slots(slot_at_send: u64, confirmed_slot: u64) -> u64 {
+    if slot_at_send == 0 {
+        0
+    } else {
+        confirmed_slot.saturating_sub(slot_at_send)
+    }
+}
+
+#[inline]
+fn record_confirm_latency_metrics(
+    start: std::time::Instant,
+    slot_at_send: Option<u64>,
+    confirmed_slot: Option<u64>,
+) {
+    let elapsed_ms = start.elapsed().as_millis() as u64;
+    TX_CONFIRM_LATENCY_MS.store(elapsed_ms, Ordering::Relaxed);
+    record_tx_send_to_confirm_ms(elapsed_ms);
+    if let (Some(send_slot), Some(conf_slot)) = (slot_at_send, confirmed_slot) {
+        record_tx_confirmed_slot_delta_slots(confirmed_slot_delta_slots(send_slot, conf_slot));
+    }
+}
+
 /// After a successful send: `cached_blockhash.slot` minus intent metadata `slot` (Geyser chain position).
 #[inline]
 fn record_execution_slot_lag_at_send_if_applicable(ctx: &ExecutionContext, intent: &TradeIntent) {
@@ -9461,7 +9541,8 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
     });
 
     // Check: Priority fee within limit (P2: use dynamic fees if available)
-    let priority_fee = ctx.get_priority_fee_for_intent(&intent, &effective_fee_policy);
+    let priority_fee_selection = ctx.get_priority_fee_for_intent(&intent, &effective_fee_policy);
+    let priority_fee = priority_fee_selection.fee_micro_lamports;
     if priority_fee > effective_fee_policy.max_priority_fee_micro_lamports {
         let reason = RejectReason::FeePriorityExceedsLimit;
         checks.push(CheckResult {
@@ -9479,7 +9560,10 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
         check_name: "fee_priority_limit".to_string(),
         passed: true,
         reason_code: None,
-        details: Some(format!("priority_fee_micro_lamports={}", priority_fee)),
+        details: Some(format!(
+            "priority_fee_micro_lamports={} source={}",
+            priority_fee, priority_fee_selection.source
+        )),
     });
 
     // Check: Total transaction cost within limit
@@ -9939,8 +10023,9 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                 // Include compute budget ixs so simulation matches send (and CU limit is sufficient).
                 // P2: Use dynamic priority fees if available from Geyser
                 let compute_units = effective_fee_policy.compute_units_for_intent(&intent);
-                let micro_lamports_per_cu =
-                    ctx.get_priority_fee_for_intent(&intent, &effective_fee_policy);
+                let micro_lamports_per_cu = ctx
+                    .get_priority_fee_for_intent(&intent, &effective_fee_policy)
+                    .fee_micro_lamports;
 
                 let mut ixs = Vec::new();
                 ixs.push(
@@ -10688,6 +10773,8 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
     let mut sent_tx: Option<Transaction> = None;
     let mut sent_anything = false;
     let mut send_failed = false;
+    let mut slot_at_send: Option<u64> = None;
+    let mut rebroadcast_count: u32 = 0;
 
     // === Send (if enabled) ===
     if config.send_enabled {
@@ -10896,6 +10983,8 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                         record_tx_slot_to_send_ms(now_ms.saturating_sub(seen));
                     }
                     record_execution_slot_lag_at_send_if_applicable(ctx, &intent);
+                    slot_at_send = slot_at_send_from_context(ctx);
+                    record_tx_priority_fee_source(priority_fee_selection.source);
                     checks.push(CheckResult {
                         check_name: "send".to_string(),
                         passed: true,
@@ -10905,7 +10994,14 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                             bundle_tip_lamports.unwrap_or(config.jito_tip_lamports)
                         )),
                     });
-                    info!(intent_id = %intent.intent_id, bundle_id = %bid, "Bundle submitted via Jito");
+                    info!(
+                        intent_id = %intent.intent_id,
+                        bundle_id = %bid,
+                        priority_fee_micro_lamports = priority_fee_selection.fee_micro_lamports,
+                        source = priority_fee_selection.source,
+                        slot_at_send = ?slot_at_send,
+                        "Bundle submitted via Jito"
+                    );
                 }
                 Err(e) => {
                     send_failed = true;
@@ -10951,6 +11047,8 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                         record_tx_slot_to_send_ms(now_ms.saturating_sub(seen));
                     }
                     record_execution_slot_lag_at_send_if_applicable(ctx, &intent);
+                    slot_at_send = slot_at_send_from_context(ctx);
+                    record_tx_priority_fee_source(priority_fee_selection.source);
                     send_signature = Some(result.signature.clone());
                     send_method_used = Some(result.method.clone());
                     sent_tx = Some(result.tx);
@@ -10967,6 +11065,9 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                         intent_id = %intent.intent_id,
                         signature = %result.signature,
                         method = %result.method,
+                        priority_fee_micro_lamports = priority_fee_selection.fee_micro_lamports,
+                        source = priority_fee_selection.source,
+                        slot_at_send = ?slot_at_send,
                         "Transaction submitted via TxSender"
                     );
                 }
@@ -11126,36 +11227,64 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                     config.confirmation_timeout_ms,
                     sent_tx.as_ref(),
                     wallet_tx_confirm_rx.take(),
+                    slot_at_send,
                 )
                 .await
                 {
-                    Ok(ConfirmOutcome::Confirmed { details, slot }) => {
+                    Ok((ConfirmOutcome::Confirmed { details, slot }, rb_count)) => {
                         tx_landing_slot = slot;
+                        rebroadcast_count = rb_count;
                         checks.push(CheckResult {
                             check_name: "confirm".to_string(),
                             passed: true,
                             reason_code: None,
                             details: Some(details),
                         });
+                        if rb_count > 0 {
+                            checks.push(CheckResult {
+                                check_name: "rebroadcast".to_string(),
+                                passed: true,
+                                reason_code: None,
+                                details: Some(format!("count={rb_count}")),
+                            });
+                        }
                         final_outcome = DecisionOutcome::Confirmed;
                     }
-                    Ok(ConfirmOutcome::FailedConfirmed { details, slot }) => {
+                    Ok((ConfirmOutcome::FailedConfirmed { details, slot }, rb_count)) => {
                         tx_landing_slot = slot;
+                        rebroadcast_count = rb_count;
                         checks.push(CheckResult {
                             check_name: "confirm".to_string(),
                             passed: false,
                             reason_code: Some("confirmed_err".to_string()),
                             details: Some(details),
                         });
+                        if rb_count > 0 {
+                            checks.push(CheckResult {
+                                check_name: "rebroadcast".to_string(),
+                                passed: true,
+                                reason_code: None,
+                                details: Some(format!("count={rb_count}")),
+                            });
+                        }
                         final_outcome = DecisionOutcome::FailedConfirmed;
                     }
-                    Ok(ConfirmOutcome::TimeoutSent { details }) => {
+                    Ok((ConfirmOutcome::TimeoutSent { details }, rb_count)) => {
+                        rebroadcast_count = rb_count;
                         checks.push(CheckResult {
                             check_name: "confirm".to_string(),
                             passed: false,
                             reason_code: Some("confirm_timeout".to_string()),
                             details: Some(details),
                         });
+                        if rb_count > 0 {
+                            checks.push(CheckResult {
+                                check_name: "rebroadcast".to_string(),
+                                passed: true,
+                                reason_code: None,
+                                details: Some(format!("count={rb_count}")),
+                            });
+                        }
                         final_outcome = DecisionOutcome::Sent;
                     }
                     Err(e) => {
@@ -11175,6 +11304,19 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
 
     let mut input_snapshots = build_input_snapshots(&intent);
     input_snapshots.insert("fee_policy".to_string(), fee_policy_label.to_string());
+    if let Some(s) = slot_at_send {
+        input_snapshots.insert("slot_at_send".to_string(), s.to_string());
+    }
+    if let (Some(send_slot), Some(conf_slot)) = (slot_at_send, tx_landing_slot) {
+        let delta = confirmed_slot_delta_slots(send_slot, conf_slot);
+        input_snapshots.insert("confirmed_slot_delta".to_string(), delta.to_string());
+    }
+    if sent_anything {
+        input_snapshots.insert(
+            "priority_fee_source".to_string(),
+            priority_fee_selection.source.to_string(),
+        );
+    }
 
     // Emit decision record
     let decision = if config.send_enabled && sent_anything {
@@ -11414,6 +11556,26 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                     exec.confirmed_slot = Some(slot);
                     exec.metadata
                         .insert("confirmed_slot".to_string(), slot.to_string());
+                }
+                if let Some(s) = slot_at_send {
+                    exec.metadata
+                        .insert("slot_at_send".to_string(), s.to_string());
+                }
+                if let (Some(send_slot), Some(conf_slot)) = (slot_at_send, tx_landing_slot) {
+                    exec.metadata.insert(
+                        "confirmed_slot_delta".to_string(),
+                        confirmed_slot_delta_slots(send_slot, conf_slot).to_string(),
+                    );
+                }
+                exec.metadata.insert(
+                    "priority_fee_source".to_string(),
+                    priority_fee_selection.source.to_string(),
+                );
+                if rebroadcast_count > 0 {
+                    exec.metadata.insert(
+                        "rebroadcast_count".to_string(),
+                        rebroadcast_count.to_string(),
+                    );
                 }
             }
             // Scope 48: always classify confirmed SELL for market-data, even when fill RPC path
@@ -12475,26 +12637,35 @@ async fn confirm_signature_status(
     timeout_ms: u64,
     rebroadcast_tx: Option<&Transaction>,
     pre_registered_rx: Option<tokio::sync::oneshot::Receiver<WalletTxConfirmNotify>>,
-) -> std::result::Result<ConfirmOutcome, String> {
+    slot_at_send: Option<u64>,
+) -> std::result::Result<(ConfirmOutcome, u32), String> {
     let start = std::time::Instant::now();
     let deadline = Duration::from_millis(timeout_ms.max(1));
     let config = ctx.config.read().clone();
+    let rebroadcast_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
 
     // Spawn rebroadcast task (runs in parallel for both strategies)
     let rebroadcast_handle = if let Some(tx) = rebroadcast_tx {
         let rpc = Arc::clone(&ctx.rpc);
+        let tx_sender = ctx.tx_sender.clone();
         let sig_str = signature_base58.to_string();
         let tx_clone = tx.clone();
         let interval_ms = config.rebroadcast_interval_ms;
         let max_rebroadcasts = config.max_rebroadcasts;
+        let rebroadcast_use_tpu = config.rebroadcast_use_tpu;
+        let rb_count = Arc::clone(&rebroadcast_count);
         Some(tokio::spawn(async move {
             spawn_rebroadcast_loop(
                 rpc,
+                tx_sender,
+                rebroadcast_use_tpu,
                 &sig_str,
                 tx_clone,
                 deadline,
                 interval_ms,
                 max_rebroadcasts,
+                start,
+                rb_count,
             )
             .await;
         }))
@@ -12506,7 +12677,8 @@ async fn confirm_signature_status(
         #[cfg(windows)]
         {
             let _ = pre_registered_rx;
-            let outcome = confirm_via_rpc_polling(ctx, signature_base58, deadline, start).await;
+            let outcome =
+                confirm_via_rpc_polling(ctx, signature_base58, deadline, start, slot_at_send).await;
             ctx.pending_tx_confirms.write().remove(signature_base58);
             outcome
         }
@@ -12519,6 +12691,7 @@ async fn confirm_signature_status(
                 start,
                 &config,
                 pre_registered_rx,
+                slot_at_send,
             )
             .await
         }
@@ -12529,7 +12702,8 @@ async fn confirm_signature_status(
         handle.abort();
     }
 
-    outcome
+    let count = rebroadcast_count.load(Ordering::Relaxed);
+    outcome.map(|o| (o, count))
 }
 
 /// JetStream-based confirmation: register pending signature, wait for main-loop dispatch or timeout.
@@ -12540,6 +12714,7 @@ async fn confirm_via_jetstream(
     start: std::time::Instant,
     config: &ExecutionConfig,
     pre_registered_rx: Option<tokio::sync::oneshot::Receiver<WalletTxConfirmNotify>>,
+    slot_at_send: Option<u64>,
 ) -> std::result::Result<ConfirmOutcome, String> {
     if !config.jetstream_tx_confirm_enabled {
         ctx.pending_tx_confirms.write().remove(signature_base58);
@@ -12566,7 +12741,7 @@ async fn confirm_via_jetstream(
                     let elapsed_ms = start.elapsed().as_millis() as u64;
                     TX_CONFIRMED_TOTAL.fetch_add(1, Ordering::Relaxed);
                     TX_CONFIRM_JETSTREAM_TOTAL.fetch_add(1, Ordering::Relaxed);
-                    TX_CONFIRM_LATENCY_MS.store(elapsed_ms, Ordering::Relaxed);
+                    record_confirm_latency_metrics(start, slot_at_send, Some(confirm.slot));
                     Ok(ConfirmOutcome::Confirmed {
                         details: format!(
                             "method=jetstream slot={} elapsed_ms={elapsed_ms} signature={signature_base58}",
@@ -12577,7 +12752,7 @@ async fn confirm_via_jetstream(
                 }
                 Ok(confirm) => {
                     let elapsed_ms = start.elapsed().as_millis() as u64;
-                    TX_CONFIRM_LATENCY_MS.store(elapsed_ms, Ordering::Relaxed);
+                    record_confirm_latency_metrics(start, slot_at_send, Some(confirm.slot));
                     Ok(ConfirmOutcome::FailedConfirmed {
                         details: format!(
                             "method=jetstream err={} slot={} elapsed_ms={elapsed_ms} signature={signature_base58}",
@@ -12622,6 +12797,7 @@ async fn confirm_via_rpc_polling(
     signature_base58: &str,
     deadline: Duration,
     start: std::time::Instant,
+    slot_at_send: Option<u64>,
 ) -> std::result::Result<ConfirmOutcome, String> {
     let signature =
         Signature::from_str(signature_base58).map_err(|e| format!("invalid_signature:{e}"))?;
@@ -12679,7 +12855,7 @@ async fn confirm_via_rpc_polling(
                 let elapsed_ms = start.elapsed().as_millis() as u64;
                 TX_CONFIRMED_TOTAL.fetch_add(1, Ordering::Relaxed);
                 ironcrab::metrics::TX_CONFIRM_RPC_FALLBACK_TOTAL.fetch_add(1, Ordering::Relaxed);
-                TX_CONFIRM_LATENCY_MS.store(elapsed_ms, Ordering::Relaxed);
+                record_confirm_latency_metrics(start, slot_at_send, Some(st.slot));
                 return Ok(ConfirmOutcome::Confirmed {
                     details: format!(
                         "method=rpc_polling confirmations={:?} confirmation_status={:?} slot={} elapsed_ms={elapsed_ms}",
@@ -12700,49 +12876,105 @@ async fn confirm_via_rpc_polling(
 
 /// Periodic rebroadcast loop running in a parallel task.
 /// Aborted by the caller when confirmation arrives.
+#[allow(clippy::too_many_arguments)]
 async fn spawn_rebroadcast_loop(
     rpc: Arc<ironcrab::solana::rpc::SolanaRpc>,
+    tx_sender: Option<Arc<TxSender>>,
+    rebroadcast_use_tpu: bool,
     signature_base58: &str,
     tx: Transaction,
     deadline: Duration,
     interval_ms: u64,
     max_rebroadcasts: u32,
+    confirm_start: std::time::Instant,
+    rebroadcast_count: Arc<std::sync::atomic::AtomicU32>,
 ) {
-    let start = std::time::Instant::now();
+    let loop_start = std::time::Instant::now();
     let mut rebroadcasts: u32 = 0;
     let interval = Duration::from_millis(interval_ms);
 
     // Wait one interval before first rebroadcast
     tokio::time::sleep(interval).await;
 
-    while rebroadcasts < max_rebroadcasts && start.elapsed() < deadline {
-        let cfg = RpcSendTransactionConfig {
-            skip_preflight: true,
-            preflight_commitment: None,
-            encoding: Some(UiTransactionEncoding::Base64),
-            max_retries: Some(3),
-            min_context_slot: None,
-        };
+    while rebroadcasts < max_rebroadcasts && loop_start.elapsed() < deadline {
+        let mut sent = false;
 
-        let vtx = solana_sdk::transaction::VersionedTransaction::from(tx.clone());
-        match rpc.rpc.send_transaction_with_config(&vtx, cfg).await {
-            Ok(sig) => {
-                rebroadcasts += 1;
-                info!(
-                    signature = %sig,
-                    original_signature = %signature_base58,
-                    rebroadcasts = rebroadcasts,
-                    "Rebroadcasted TX during confirmation wait"
-                );
+        if rebroadcast_use_tpu {
+            if let Some(ref sender) = tx_sender {
+                match sender.send_with_fallback(&tx, false).await {
+                    Ok(result) => {
+                        rebroadcasts += 1;
+                        rebroadcast_count.store(rebroadcasts, Ordering::Relaxed);
+                        record_tx_rebroadcast();
+                        record_tx_rebroadcast_during_confirm_ms(
+                            confirm_start.elapsed().as_millis() as u64,
+                        );
+                        let method = result.method.to_string();
+                        record_tx_rebroadcast_method(&method);
+                        info!(
+                            signature = %result.signature,
+                            original_signature = %signature_base58,
+                            rebroadcasts = rebroadcasts,
+                            method = %method,
+                            "Rebroadcasted TX during confirmation wait"
+                        );
+                        sent = true;
+                    }
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            original_signature = %signature_base58,
+                            rebroadcasts = rebroadcasts + 1,
+                            "Rebroadcast TxSender failed, falling back to RPC"
+                        );
+                    }
+                }
             }
-            Err(e) => {
-                rebroadcasts += 1;
-                warn!(
-                    error = %e,
-                    original_signature = %signature_base58,
-                    rebroadcasts = rebroadcasts,
-                    "Rebroadcast attempt failed"
-                );
+        }
+
+        if !sent {
+            let cfg = RpcSendTransactionConfig {
+                skip_preflight: true,
+                preflight_commitment: None,
+                encoding: Some(UiTransactionEncoding::Base64),
+                max_retries: Some(3),
+                min_context_slot: None,
+            };
+
+            let vtx = solana_sdk::transaction::VersionedTransaction::from(tx.clone());
+            match rpc.rpc.send_transaction_with_config(&vtx, cfg).await {
+                Ok(sig) => {
+                    rebroadcasts += 1;
+                    rebroadcast_count.store(rebroadcasts, Ordering::Relaxed);
+                    record_tx_rebroadcast();
+                    record_tx_rebroadcast_during_confirm_ms(
+                        confirm_start.elapsed().as_millis() as u64
+                    );
+                    record_tx_rebroadcast_method("rpc");
+                    info!(
+                        signature = %sig,
+                        original_signature = %signature_base58,
+                        rebroadcasts = rebroadcasts,
+                        method = "rpc",
+                        "Rebroadcasted TX during confirmation wait"
+                    );
+                }
+                Err(e) => {
+                    rebroadcasts += 1;
+                    rebroadcast_count.store(rebroadcasts, Ordering::Relaxed);
+                    record_tx_rebroadcast();
+                    record_tx_rebroadcast_during_confirm_ms(
+                        confirm_start.elapsed().as_millis() as u64
+                    );
+                    record_tx_rebroadcast_method("rpc");
+                    warn!(
+                        error = %e,
+                        original_signature = %signature_base58,
+                        rebroadcasts = rebroadcasts,
+                        method = "rpc",
+                        "Rebroadcast attempt failed"
+                    );
+                }
             }
         }
 
@@ -14386,6 +14618,7 @@ mod execution_engine_tests {
             Instant::now(),
             &config,
             Some(pre_rx),
+            Some(40),
         )
         .await
         .expect("confirm_via_jetstream");
@@ -14394,6 +14627,65 @@ mod execution_engine_tests {
             ConfirmOutcome::Confirmed { slot, .. } => assert_eq!(slot, Some(42)),
             other => panic!("expected Confirmed, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn priority_fee_static_floor_when_dynamic_below_config() {
+        use super::{select_priority_fee_for_intent, PriorityFeeSelection};
+        use ironcrab::ipc::{
+            ExplicitAmount, FeePolicy, IntentOrigin, IntentTier, PriorityFeePercentiles,
+            TradeIntent, TradeResources, TradeSide, TradingRegime,
+        };
+
+        let intent = TradeIntent::new(
+            "test",
+            "v0.1.0",
+            "run",
+            "id-1".to_string(),
+            "momentum-bot",
+            IntentTier::Tier1,
+            IntentOrigin::StrategyA,
+            ExplicitAmount::new(1_000_000, 9),
+            TradeResources {
+                input_mint: ironcrab::ipc::NATIVE_SOL_MINT.to_string(),
+                output_mint: "Mint111111111111111111111111111111111111111".to_string(),
+                pools: vec!["Pool123".to_string()],
+                accounts: vec![],
+                token_program: None,
+            },
+            0,
+            200,
+            TradeSide::Buy,
+            TradingRegime::Early,
+        );
+        let mut fee_policy = FeePolicy::default();
+        fee_policy.default_priority_fee_micro_lamports = 100_000;
+
+        let percentiles = PriorityFeePercentiles::new(
+            "test", "test", "run", 50, 100, 10_000, 50_000, 90_000, 120_000, 120_000, 60_000, 70_000,
+        );
+        let sel = select_priority_fee_for_intent(&intent, &fee_policy, Some(&percentiles));
+        assert_eq!(
+            sel,
+            PriorityFeeSelection {
+                fee_micro_lamports: 100_000,
+                source: "static_floor",
+            }
+        );
+
+        fee_policy.tier1_fee_percentile = 75;
+        fee_policy.tier1_fee_multiplier = 1.2;
+        let sel_dynamic = select_priority_fee_for_intent(&intent, &fee_policy, Some(&percentiles));
+        assert_eq!(sel_dynamic.source, "dynamic");
+        assert!(sel_dynamic.fee_micro_lamports > 100_000);
+    }
+
+    #[test]
+    fn confirmed_slot_delta_saturating_sub_edge_cases() {
+        use super::confirmed_slot_delta_slots;
+        assert_eq!(confirmed_slot_delta_slots(0, 99), 0);
+        assert_eq!(confirmed_slot_delta_slots(100, 102), 2);
+        assert_eq!(confirmed_slot_delta_slots(200, 100), 0);
     }
 
     #[test]

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -14662,7 +14662,8 @@ mod execution_engine_tests {
         fee_policy.default_priority_fee_micro_lamports = 100_000;
 
         let percentiles = PriorityFeePercentiles::new(
-            "test", "test", "run", 50, 100, 10_000, 50_000, 90_000, 120_000, 120_000, 60_000, 70_000,
+            "test", "test", "run", 50, 100, 10_000, 50_000, 90_000, 120_000, 120_000, 60_000,
+            70_000,
         );
         let sel = select_priority_fee_for_intent(&intent, &fee_policy, Some(&percentiles));
         assert_eq!(

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -12946,7 +12946,7 @@ async fn spawn_rebroadcast_loop(
 
         if rebroadcast_use_tpu {
             if let Some(ref sender) = tx_sender {
-                match sender.send_with_fallback(&tx, false).await {
+                match sender.send_tpu_then_rpc(&tx).await {
                     Ok(result) => {
                         rebroadcasts += 1;
                         rebroadcast_count.store(rebroadcasts, Ordering::Relaxed);

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -2512,12 +2512,13 @@ struct BurnOpRecord {
 impl ExecutionContext {
     /// Get a recent blockhash, preferring the Geyser-cached version.
     /// Falls back to RPC if cache is empty or stale (> MAX_BLOCKHASH_AGE_SECS).
-    async fn get_latest_blockhash(&self) -> Result<solana_sdk::hash::Hash, String> {
+    /// Returns the slot that corresponds to the blockhash source (cache or RPC).
+    async fn get_latest_blockhash(&self) -> Result<(solana_sdk::hash::Hash, Option<u64>), String> {
         // Try cached blockhash first
         if let Some(ref cached) = *self.cached_blockhash.read() {
             let age_secs = cached.received_at.elapsed().as_secs();
             if age_secs <= MAX_BLOCKHASH_AGE_SECS {
-                return Ok(cached.hash);
+                return Ok((cached.hash, Some(cached.slot)));
             }
             warn!(
                 age_secs,
@@ -2528,10 +2529,13 @@ impl ExecutionContext {
 
         // RPC fallback
         warn!("BLOCKHASH_SOURCE_RPC_FALLBACK: no fresh Geyser blockhash, using RPC");
-        self.rpc
+        let hash = self
+            .rpc
             .get_latest_blockhash_retry()
             .await
-            .map_err(|e| format!("rpc_error:{e}"))
+            .map_err(|e| format!("rpc_error:{e}"))?;
+        let slot = self.rpc.rpc.get_slot().await.ok();
+        Ok((hash, slot))
     }
 
     /// Get current config (read lock)
@@ -9117,11 +9121,6 @@ fn select_priority_fee_for_intent(
 }
 
 #[inline]
-fn slot_at_send_from_context(ctx: &ExecutionContext) -> Option<u64> {
-    ctx.cached_blockhash.read().as_ref().map(|c| c.slot)
-}
-
-#[inline]
 fn confirmed_slot_delta_slots(slot_at_send: u64, confirmed_slot: u64) -> u64 {
     if slot_at_send == 0 {
         0
@@ -10804,8 +10803,8 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                 .expect("bundle_config gate ensures jito_client is present");
 
             let signer = treasury.signer_ref();
-            let blockhash = match ctx.get_latest_blockhash().await {
-                Ok(bh) => bh,
+            let (blockhash, blockhash_slot) = match ctx.get_latest_blockhash().await {
+                Ok(pair) => pair,
                 Err(e) => {
                     let reason = RejectReason::BundleFailed;
                     checks.push(CheckResult {
@@ -10983,7 +10982,7 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                         record_tx_slot_to_send_ms(now_ms.saturating_sub(seen));
                     }
                     record_execution_slot_lag_at_send_if_applicable(ctx, &intent);
-                    slot_at_send = slot_at_send_from_context(ctx);
+                    slot_at_send = blockhash_slot;
                     record_tx_priority_fee_source(priority_fee_selection.source);
                     checks.push(CheckResult {
                         check_name: "send".to_string(),
@@ -11047,7 +11046,7 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                         record_tx_slot_to_send_ms(now_ms.saturating_sub(seen));
                     }
                     record_execution_slot_lag_at_send_if_applicable(ctx, &intent);
-                    slot_at_send = slot_at_send_from_context(ctx);
+                    slot_at_send = result.slot_at_send;
                     record_tx_priority_fee_source(priority_fee_selection.source);
                     send_signature = Some(result.signature.clone());
                     send_method_used = Some(result.method.clone());
@@ -12045,8 +12044,8 @@ async fn simulate_transaction(
             };
 
             // Get a recent blockhash (Geyser cache → RPC fallback)
-            let blockhash = match ctx.get_latest_blockhash().await {
-                Ok(bh) => bh,
+            let (blockhash, _) = match ctx.get_latest_blockhash().await {
+                Ok(pair) => pair,
                 Err(e) => {
                     return SimulationResult {
                         success: false,
@@ -12075,8 +12074,8 @@ async fn simulate_transaction(
             }
         } else {
             // Fallback to legacy transaction (will fail if too large)
-            let blockhash = match ctx.get_latest_blockhash().await {
-                Ok(bh) => bh,
+            let (blockhash, _) = match ctx.get_latest_blockhash().await {
+                Ok(pair) => pair,
                 Err(e) => {
                     return SimulationResult {
                         success: false,
@@ -12177,7 +12176,7 @@ async fn send_transaction_rpc(
         .ok_or_else(|| "no_signer_configured".to_string())?;
 
     let signer = treasury.signer_ref();
-    let blockhash = ctx.get_latest_blockhash().await?;
+    let (blockhash, _) = ctx.get_latest_blockhash().await?;
 
     // Build Versioned Transaction with ALT if available
     let tx: VersionedTransaction = if let Some(ref alt) = ctx.address_lookup_table {
@@ -12230,6 +12229,7 @@ struct SendTxResult {
     signature: String,
     method: String,  // "tpu", "jito", "rpc"
     tx: Transaction, // signed legacy transaction (for rebroadcast during confirm)
+    slot_at_send: Option<u64>,
 }
 
 /// Send transaction with TxSender fallback chain (TPU → Jito → RPC).
@@ -12253,7 +12253,7 @@ async fn send_transaction_with_fallback(
         .ok_or_else(|| "no_signer_configured".to_string())?;
 
     let signer = treasury.signer_ref();
-    let blockhash = ctx.get_latest_blockhash().await?;
+    let (blockhash, blockhash_slot) = ctx.get_latest_blockhash().await?;
 
     // Build legacy Transaction for TxSender (TxSender handles signing internally for TPU)
     // Note: We sign here because TxSender.send_with_fallback() expects a signed Transaction
@@ -12279,6 +12279,7 @@ async fn send_transaction_with_fallback(
                     signature: result.signature.to_string(),
                     method: method_str,
                     tx,
+                    slot_at_send: blockhash_slot,
                 });
             }
             Err(e) => {
@@ -12313,6 +12314,7 @@ async fn send_transaction_with_fallback(
             signature: sig.to_string(),
             method: "rpc".into(),
             tx,
+            slot_at_send: blockhash_slot,
         }),
         Err(e) => Err(format!("rpc_error:{e}")),
     }

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -14658,8 +14658,10 @@ mod execution_engine_tests {
             TradeSide::Buy,
             TradingRegime::Early,
         );
-        let mut fee_policy = FeePolicy::default();
-        fee_policy.default_priority_fee_micro_lamports = 100_000;
+        let fee_policy = FeePolicy {
+            default_priority_fee_micro_lamports: 100_000,
+            ..Default::default()
+        };
 
         let percentiles = PriorityFeePercentiles::new(
             "test", "test", "run", 50, 100, 10_000, 50_000, 90_000, 120_000, 120_000, 60_000,
@@ -14674,9 +14676,14 @@ mod execution_engine_tests {
             }
         );
 
-        fee_policy.tier1_fee_percentile = 75;
-        fee_policy.tier1_fee_multiplier = 1.2;
-        let sel_dynamic = select_priority_fee_for_intent(&intent, &fee_policy, Some(&percentiles));
+        let fee_policy_dynamic = FeePolicy {
+            default_priority_fee_micro_lamports: 100_000,
+            tier1_fee_percentile: 75,
+            tier1_fee_multiplier: 1.2,
+            ..Default::default()
+        };
+        let sel_dynamic =
+            select_priority_fee_for_intent(&intent, &fee_policy_dynamic, Some(&percentiles));
         assert_eq!(sel_dynamic.source, "dynamic");
         assert!(sel_dynamic.fee_micro_lamports > 100_000);
     }

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -1978,6 +1978,28 @@ struct CachedBlockhash {
     received_at: std::time::Instant,
 }
 
+/// Blockhash + slot used to sign a TX (must stay paired for `slot_at_send` metrics).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BlockhashForSend {
+    hash: solana_sdk::hash::Hash,
+    slot: u64,
+}
+
+/// Persist RPC-fallback blockhash so later readers see the same slot as the signing hash.
+fn apply_rpc_blockhash_cache_fallback(
+    cache: &mut Option<CachedBlockhash>,
+    hash: solana_sdk::hash::Hash,
+    slot: u64,
+    received_at: std::time::Instant,
+) {
+    *cache = Some(CachedBlockhash {
+        hash,
+        slot,
+        block_height: 0,
+        received_at,
+    });
+}
+
 /// Maximum age (in seconds) before we fall back to RPC for blockhash.
 /// Solana blockhashes expire after ~150 slots (~60s). We use a conservative 30s.
 const MAX_BLOCKHASH_AGE_SECS: u64 = 30;
@@ -2510,15 +2532,16 @@ struct BurnOpRecord {
 }
 
 impl ExecutionContext {
-    /// Get a recent blockhash, preferring the Geyser-cached version.
-    /// Falls back to RPC if cache is empty or stale (> MAX_BLOCKHASH_AGE_SECS).
-    /// Returns the slot that corresponds to the blockhash source (cache or RPC).
-    async fn get_latest_blockhash(&self) -> Result<(solana_sdk::hash::Hash, Option<u64>), String> {
-        // Try cached blockhash first
+    /// Blockhash + slot for TX signing. Slot is always paired with the hash we sign with.
+    /// Falls back to RPC if Geyser cache is empty/stale and refreshes `cached_blockhash`.
+    async fn get_latest_blockhash_for_send(&self) -> Result<BlockhashForSend, String> {
         if let Some(ref cached) = *self.cached_blockhash.read() {
             let age_secs = cached.received_at.elapsed().as_secs();
             if age_secs <= MAX_BLOCKHASH_AGE_SECS {
-                return Ok((cached.hash, Some(cached.slot)));
+                return Ok(BlockhashForSend {
+                    hash: cached.hash,
+                    slot: cached.slot,
+                });
             }
             warn!(
                 age_secs,
@@ -2527,15 +2550,32 @@ impl ExecutionContext {
             );
         }
 
-        // RPC fallback
         warn!("BLOCKHASH_SOURCE_RPC_FALLBACK: no fresh Geyser blockhash, using RPC");
         let hash = self
             .rpc
             .get_latest_blockhash_retry()
             .await
             .map_err(|e| format!("rpc_error:{e}"))?;
-        let slot = self.rpc.rpc.get_slot().await.ok();
-        Ok((hash, slot))
+        let slot = self
+            .rpc
+            .rpc
+            .get_slot()
+            .await
+            .map_err(|e| format!("rpc_error:{e}"))?;
+        let received_at = std::time::Instant::now();
+        apply_rpc_blockhash_cache_fallback(
+            &mut self.cached_blockhash.write(),
+            hash,
+            slot,
+            received_at,
+        );
+        Ok(BlockhashForSend { hash, slot })
+    }
+
+    /// Get a recent blockhash, preferring the Geyser-cached version.
+    /// Falls back to RPC if cache is empty or stale (> MAX_BLOCKHASH_AGE_SECS).
+    async fn get_latest_blockhash(&self) -> Result<solana_sdk::hash::Hash, String> {
+        Ok(self.get_latest_blockhash_for_send().await?.hash)
     }
 
     /// Get current config (read lock)
@@ -10803,8 +10843,8 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                 .expect("bundle_config gate ensures jito_client is present");
 
             let signer = treasury.signer_ref();
-            let (blockhash, blockhash_slot) = match ctx.get_latest_blockhash().await {
-                Ok(pair) => pair,
+            let blockhash_for_send = match ctx.get_latest_blockhash_for_send().await {
+                Ok(bh) => bh,
                 Err(e) => {
                     let reason = RejectReason::BundleFailed;
                     checks.push(CheckResult {
@@ -10821,6 +10861,8 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                     return emit_rejected_decision(ctx, decision_id, &intent, checks, reason).await;
                 }
             };
+            let blockhash = blockhash_for_send.hash;
+            let bundle_send_slot = blockhash_for_send.slot;
 
             // CRITICAL: Jito bundles REQUIRE tip instruction
             // If no tip instruction present, reject intent immediately
@@ -10982,7 +11024,7 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                         record_tx_slot_to_send_ms(now_ms.saturating_sub(seen));
                     }
                     record_execution_slot_lag_at_send_if_applicable(ctx, &intent);
-                    slot_at_send = blockhash_slot;
+                    slot_at_send = Some(bundle_send_slot);
                     record_tx_priority_fee_source(priority_fee_selection.source);
                     checks.push(CheckResult {
                         check_name: "send".to_string(),
@@ -11046,7 +11088,7 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                         record_tx_slot_to_send_ms(now_ms.saturating_sub(seen));
                     }
                     record_execution_slot_lag_at_send_if_applicable(ctx, &intent);
-                    slot_at_send = result.slot_at_send;
+                    slot_at_send = Some(result.slot_at_send);
                     record_tx_priority_fee_source(priority_fee_selection.source);
                     send_signature = Some(result.signature.clone());
                     send_method_used = Some(result.method.clone());
@@ -12044,8 +12086,8 @@ async fn simulate_transaction(
             };
 
             // Get a recent blockhash (Geyser cache → RPC fallback)
-            let (blockhash, _) = match ctx.get_latest_blockhash().await {
-                Ok(pair) => pair,
+            let blockhash = match ctx.get_latest_blockhash().await {
+                Ok(hash) => hash,
                 Err(e) => {
                     return SimulationResult {
                         success: false,
@@ -12074,8 +12116,8 @@ async fn simulate_transaction(
             }
         } else {
             // Fallback to legacy transaction (will fail if too large)
-            let (blockhash, _) = match ctx.get_latest_blockhash().await {
-                Ok(pair) => pair,
+            let blockhash = match ctx.get_latest_blockhash().await {
+                Ok(hash) => hash,
                 Err(e) => {
                     return SimulationResult {
                         success: false,
@@ -12176,7 +12218,7 @@ async fn send_transaction_rpc(
         .ok_or_else(|| "no_signer_configured".to_string())?;
 
     let signer = treasury.signer_ref();
-    let (blockhash, _) = ctx.get_latest_blockhash().await?;
+    let blockhash = ctx.get_latest_blockhash().await?;
 
     // Build Versioned Transaction with ALT if available
     let tx: VersionedTransaction = if let Some(ref alt) = ctx.address_lookup_table {
@@ -12229,7 +12271,7 @@ struct SendTxResult {
     signature: String,
     method: String,  // "tpu", "jito", "rpc"
     tx: Transaction, // signed legacy transaction (for rebroadcast during confirm)
-    slot_at_send: Option<u64>,
+    slot_at_send: u64,
 }
 
 /// Send transaction with TxSender fallback chain (TPU → Jito → RPC).
@@ -12253,7 +12295,7 @@ async fn send_transaction_with_fallback(
         .ok_or_else(|| "no_signer_configured".to_string())?;
 
     let signer = treasury.signer_ref();
-    let (blockhash, blockhash_slot) = ctx.get_latest_blockhash().await?;
+    let blockhash_for_send = ctx.get_latest_blockhash_for_send().await?;
 
     // Build legacy Transaction for TxSender (TxSender handles signing internally for TPU)
     // Note: We sign here because TxSender.send_with_fallback() expects a signed Transaction
@@ -12261,7 +12303,7 @@ async fn send_transaction_with_fallback(
         &plan.instructions,
         Some(&wallet_pubkey),
         &[signer],
-        blockhash,
+        blockhash_for_send.hash,
     );
 
     // If TxSender is available, use it for the fallback chain
@@ -12273,13 +12315,14 @@ async fn send_transaction_with_fallback(
                     signature = %result.signature,
                     method = %method_str,
                     bundle_id = ?result.bundle_id,
+                    slot_at_send = blockhash_for_send.slot,
                     "TX sent via TxSender"
                 );
                 return Ok(SendTxResult {
                     signature: result.signature.to_string(),
                     method: method_str,
                     tx,
-                    slot_at_send: blockhash_slot,
+                    slot_at_send: blockhash_for_send.slot,
                 });
             }
             Err(e) => {
@@ -12314,7 +12357,7 @@ async fn send_transaction_with_fallback(
             signature: sig.to_string(),
             method: "rpc".into(),
             tx,
-            slot_at_send: blockhash_slot,
+            slot_at_send: blockhash_for_send.slot,
         }),
         Err(e) => Err(format!("rpc_error:{e}")),
     }
@@ -14696,6 +14739,28 @@ mod execution_engine_tests {
         assert_eq!(confirmed_slot_delta_slots(0, 99), 0);
         assert_eq!(confirmed_slot_delta_slots(100, 102), 2);
         assert_eq!(confirmed_slot_delta_slots(200, 100), 0);
+    }
+
+    #[test]
+    fn rpc_blockhash_cache_fallback_pairs_signing_slot_with_hash() {
+        use super::{apply_rpc_blockhash_cache_fallback, CachedBlockhash};
+        use solana_sdk::hash::Hash;
+        use std::time::Instant;
+
+        let signing_hash = Hash::new_from_array([7u8; 32]);
+        let stale_hash = Hash::new_from_array([1u8; 32]);
+        let mut cache = Some(CachedBlockhash {
+            hash: stale_hash,
+            slot: 10,
+            block_height: 0,
+            received_at: Instant::now(),
+        });
+        let now = Instant::now();
+        apply_rpc_blockhash_cache_fallback(&mut cache, signing_hash, 42, now);
+        let updated = cache.expect("cache updated");
+        assert_eq!(updated.hash, signing_hash);
+        assert_eq!(updated.slot, 42);
+        assert_ne!(updated.slot, 10);
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -11624,10 +11624,11 @@ async fn handle_geyser_transaction(
                     debug!(error = %e, "Failed to publish priority fee percentiles");
                 }
             }
-            debug!(
+            info!(
                 samples = sample_count,
                 p50 = percentiles.p50,
                 p90 = percentiles.p90,
+                tier1_recommended = ctx.priority_fee_tracker.get_fee_for_tier(IntentTier::Tier1),
                 last_fee = priority_fee,
                 "priority_fee: published percentiles"
             );

--- a/src/config.rs
+++ b/src/config.rs
@@ -303,6 +303,9 @@ pub struct ExecutionEngineCfg {
     /// When set to `"finalized"`, confirmation accepts only finalized on-chain status (stricter than `"confirmed"`).
     #[serde(default)]
     pub confirm_commitment: Option<String>,
+    /// Rebroadcast signed TX via TPU when TxSender is available (fallback RPC). Default: true when TPU enabled.
+    #[serde(default)]
+    pub rebroadcast_use_tpu: Option<bool>,
 }
 
 /// Fee Policy Configuration
@@ -343,6 +346,12 @@ pub struct FeePolicyCfg {
     /// Optional: override max total TX cost for liquidation sells (lamports)
     #[serde(default)]
     pub liquidation_max_tx_cost_lamports: Option<u64>,
+    /// Tier1 dynamic fee percentile (50 = P50, 75 = P75). Default: 50
+    #[serde(default = "default_tier1_fee_percentile")]
+    pub tier1_fee_percentile: u8,
+    /// Tier1 dynamic fee multiplier. Default: 1.2
+    #[serde(default = "default_tier1_fee_multiplier")]
+    pub tier1_fee_multiplier: f64,
 }
 
 fn default_compute_units() -> u32 {
@@ -369,6 +378,12 @@ fn default_max_tx_cost() -> u64 {
 fn default_min_profit_after_fees() -> i32 {
     10
 }
+fn default_tier1_fee_percentile() -> u8 {
+    50
+}
+fn default_tier1_fee_multiplier() -> f64 {
+    1.2
+}
 
 impl Default for FeePolicyCfg {
     fn default() -> Self {
@@ -384,6 +399,8 @@ impl Default for FeePolicyCfg {
             liquidation_priority_fee_micro_lamports: None,
             liquidation_max_priority_fee_micro_lamports: None,
             liquidation_max_tx_cost_lamports: None,
+            tier1_fee_percentile: default_tier1_fee_percentile(),
+            tier1_fee_multiplier: default_tier1_fee_multiplier(),
         }
     }
 }

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -654,6 +654,14 @@ pub struct FeePolicy {
     /// Priority fee for Tier0 urgent intents
     pub tier0_priority_fee_micro_lamports: u64,
 
+    /// Tier1 dynamic fee percentile base when recomputing from NATS samples (50 or 75)
+    #[serde(default = "default_tier1_fee_percentile")]
+    pub tier1_fee_percentile: u8,
+
+    /// Tier1 dynamic fee multiplier applied to [`Self::tier1_fee_percentile`] base
+    #[serde(default = "default_tier1_fee_multiplier")]
+    pub tier1_fee_multiplier: f64,
+
     /// Multiplier for elevated urgency (urgency=1)
     pub urgency_multiplier_elevated: f64,
 
@@ -668,6 +676,14 @@ pub struct FeePolicy {
     pub min_profit_after_fees_bps: i32,
 }
 
+fn default_tier1_fee_percentile() -> u8 {
+    50
+}
+
+fn default_tier1_fee_multiplier() -> f64 {
+    1.2
+}
+
 impl Default for FeePolicy {
     fn default() -> Self {
         Self {
@@ -680,6 +696,8 @@ impl Default for FeePolicy {
             default_priority_fee_micro_lamports: 1_000, // 0.001 lamports/CU
             max_priority_fee_micro_lamports: 100_000,   // 0.1 lamports/CU
             tier0_priority_fee_micro_lamports: 10_000,  // 0.01 lamports/CU
+            tier1_fee_percentile: default_tier1_fee_percentile(),
+            tier1_fee_multiplier: default_tier1_fee_multiplier(),
 
             // Urgency multipliers
             urgency_multiplier_elevated: 2.0,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2107,6 +2107,46 @@ pub static TX_SLOT_TO_SEND_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(||
 pub static TX_SLOT_TO_SEND_MS_SUM_MS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static TX_SLOT_TO_SEND_MS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
+// Send → Geyser/JetStream confirm (wall clock from confirm wait start to success).
+const TX_SEND_TO_CONFIRM_MS_BUCKETS: &[u64] = EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS;
+pub static TX_SEND_TO_CONFIRM_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    TX_SEND_TO_CONFIRM_MS_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static TX_SEND_TO_CONFIRM_MS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static TX_SEND_TO_CONFIRM_MS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+// Confirmed slot minus blockhash slot at send (slots until on-chain landing).
+const TX_CONFIRMED_SLOT_DELTA_SLOTS_BUCKETS: &[u64] = &[0, 1, 2, 3, 4, 5, 10, 20, 50];
+pub static TX_CONFIRMED_SLOT_DELTA_SLOTS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    TX_CONFIRMED_SLOT_DELTA_SLOTS_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static TX_CONFIRMED_SLOT_DELTA_SLOTS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static TX_CONFIRMED_SLOT_DELTA_SLOTS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+pub static TX_PRIORITY_FEE_SOURCE_STATIC_FLOOR_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static TX_PRIORITY_FEE_SOURCE_DYNAMIC_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+pub static TX_REBROADCAST_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static TX_REBROADCAST_METHOD_TPU_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static TX_REBROADCAST_METHOD_RPC_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+const TX_REBROADCAST_DURING_CONFIRM_MS_BUCKETS: &[u64] = TX_SEND_TO_CONFIRM_MS_BUCKETS;
+pub static TX_REBROADCAST_DURING_CONFIRM_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    TX_REBROADCAST_DURING_CONFIRM_MS_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static TX_REBROADCAST_DURING_CONFIRM_MS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static TX_REBROADCAST_DURING_CONFIRM_MS_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 // --- execution-engine pipeline latency (histograms; complements TX_CONFIRM_LATENCY_MS gauge) ---
 pub static EXECUTION_INTENT_HEADER_TO_RECEIVE_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
     Lazy::new(|| {
@@ -2836,6 +2876,77 @@ pub fn record_swap_latency(ns: u64) {
 /// Record swap latency from Duration
 pub fn record_swap_latency_duration(duration: std::time::Duration) {
     record_swap_latency(duration.as_nanos() as u64);
+}
+
+/// Wall-clock send→confirm latency (ms). Canonical histogram vs `TX_CONFIRM_LATENCY_MS` gauge.
+#[inline]
+pub fn record_tx_send_to_confirm_ms(ms: u64) {
+    record_histogram_u64_into(
+        TX_SEND_TO_CONFIRM_MS_BUCKETS,
+        TX_SEND_TO_CONFIRM_MS_BUCKET_COUNTS.as_slice(),
+        &TX_SEND_TO_CONFIRM_MS_SUM,
+        &TX_SEND_TO_CONFIRM_MS_COUNT,
+        ms,
+        MOMENTUM_LATENCY_MS_SUM_CAP,
+    );
+}
+
+/// On-chain slot delta: `confirmed_slot.saturating_sub(slot_at_send)` (0 when `slot_at_send==0`).
+#[inline]
+pub fn record_tx_confirmed_slot_delta_slots(delta_slots: u64) {
+    record_histogram_u64_into(
+        TX_CONFIRMED_SLOT_DELTA_SLOTS_BUCKETS,
+        TX_CONFIRMED_SLOT_DELTA_SLOTS_BUCKET_COUNTS.as_slice(),
+        &TX_CONFIRMED_SLOT_DELTA_SLOTS_SUM,
+        &TX_CONFIRMED_SLOT_DELTA_SLOTS_COUNT,
+        delta_slots,
+        u64::MAX,
+    );
+}
+
+/// `source` must be `"static_floor"` or `"dynamic"`.
+#[inline]
+pub fn record_tx_priority_fee_source(source: &str) {
+    match source {
+        "static_floor" => {
+            TX_PRIORITY_FEE_SOURCE_STATIC_FLOOR_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+        "dynamic" => {
+            TX_PRIORITY_FEE_SOURCE_DYNAMIC_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+        _ => {}
+    }
+}
+
+#[inline]
+pub fn record_tx_rebroadcast() {
+    TX_REBROADCAST_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// `method` must be `"tpu"` or `"rpc"`.
+#[inline]
+pub fn record_tx_rebroadcast_method(method: &str) {
+    match method {
+        "tpu" => {
+            TX_REBROADCAST_METHOD_TPU_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+        "rpc" => {
+            TX_REBROADCAST_METHOD_RPC_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+        _ => {}
+    }
+}
+
+#[inline]
+pub fn record_tx_rebroadcast_during_confirm_ms(ms: u64) {
+    record_histogram_u64_into(
+        TX_REBROADCAST_DURING_CONFIRM_MS_BUCKETS,
+        TX_REBROADCAST_DURING_CONFIRM_MS_BUCKET_COUNTS.as_slice(),
+        &TX_REBROADCAST_DURING_CONFIRM_MS_SUM,
+        &TX_REBROADCAST_DURING_CONFIRM_MS_COUNT,
+        ms,
+        MOMENTUM_LATENCY_MS_SUM_CAP,
+    );
 }
 
 /// Record slot-to-send latency (ms): time from Geyser event/slot observation to TX send.
@@ -3868,6 +3979,62 @@ async fn metrics_response() -> Response<Body> {
     ));
     out.push_str(&format!("tx_slot_to_send_ms_sum {}\n", sts_sum));
     out.push_str(&format!("tx_slot_to_send_ms_count {}\n", sts_count));
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "tx_send_to_confirm_ms",
+        TX_SEND_TO_CONFIRM_MS_BUCKETS,
+        &TX_SEND_TO_CONFIRM_MS_BUCKET_COUNTS,
+        &TX_SEND_TO_CONFIRM_MS_SUM,
+        &TX_SEND_TO_CONFIRM_MS_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "tx_confirmed_slot_delta_slots",
+        TX_CONFIRMED_SLOT_DELTA_SLOTS_BUCKETS,
+        &TX_CONFIRMED_SLOT_DELTA_SLOTS_BUCKET_COUNTS,
+        &TX_CONFIRMED_SLOT_DELTA_SLOTS_SUM,
+        &TX_CONFIRMED_SLOT_DELTA_SLOTS_COUNT,
+    );
+    out.push_str("tx_priority_fee_source_total{source=\"static_floor\"} ");
+    out.push_str(
+        &TX_PRIORITY_FEE_SOURCE_STATIC_FLOOR_TOTAL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("tx_priority_fee_source_total{source=\"dynamic\"} ");
+    out.push_str(
+        &TX_PRIORITY_FEE_SOURCE_DYNAMIC_TOTAL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    line!(
+        "tx_rebroadcast_total",
+        TX_REBROADCAST_TOTAL.load(Ordering::Relaxed)
+    );
+    out.push_str("tx_rebroadcast_method_total{method=\"tpu\"} ");
+    out.push_str(
+        &TX_REBROADCAST_METHOD_TPU_TOTAL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("tx_rebroadcast_method_total{method=\"rpc\"} ");
+    out.push_str(
+        &TX_REBROADCAST_METHOD_RPC_TOTAL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "tx_rebroadcast_during_confirm_ms",
+        TX_REBROADCAST_DURING_CONFIRM_MS_BUCKETS,
+        &TX_REBROADCAST_DURING_CONFIRM_MS_BUCKET_COUNTS,
+        &TX_REBROADCAST_DURING_CONFIRM_MS_SUM,
+        &TX_REBROADCAST_DURING_CONFIRM_MS_COUNT,
+    );
     append_momentum_latency_histogram_prometheus(
         &mut out,
         "execution_intent_header_to_receive_ms",

--- a/src/solana/priority_fee_tracker.rs
+++ b/src/solana/priority_fee_tracker.rs
@@ -55,7 +55,9 @@ pub struct PriorityFeeConfig {
     pub max_priority_fee_micro_lamports: u64,
     /// Tier0 multiplier (applied to P90)
     pub tier0_multiplier: f64,
-    /// Tier1 multiplier (applied to P50)
+    /// Tier1 percentile base (50 = P50, 75 = P75)
+    pub tier1_fee_percentile: u8,
+    /// Tier1 multiplier (applied to tier1 percentile)
     pub tier1_multiplier: f64,
     /// Arb multiplier (applied to P75)
     pub arb_multiplier: f64,
@@ -70,6 +72,7 @@ impl Default for PriorityFeeConfig {
             min_priority_fee_micro_lamports: 10_000, // 0.01 lamports/CU
             max_priority_fee_micro_lamports: 2_000_000, // 2 lamports/CU
             tier0_multiplier: 1.5,
+            tier1_fee_percentile: 50,
             tier1_multiplier: 1.2,
             arb_multiplier: 1.3,
             base_fee_lamports: 5_000,
@@ -229,7 +232,10 @@ impl PriorityFeeTracker {
 
         let (base_percentile, multiplier) = match tier {
             IntentTier::Tier0 => (percentiles.p90, self.config.tier0_multiplier),
-            IntentTier::Tier1 => (percentiles.p50, self.config.tier1_multiplier),
+            IntentTier::Tier1 => (
+                Self::percentile_for_tier1(self.config.tier1_fee_percentile, &percentiles),
+                self.config.tier1_multiplier,
+            ),
             IntentTier::Arb => (percentiles.p75, self.config.arb_multiplier),
         };
 
@@ -240,6 +246,16 @@ impl PriorityFeeTracker {
             self.config.min_priority_fee_micro_lamports,
             self.config.max_priority_fee_micro_lamports,
         )
+    }
+
+    /// Resolve configured Tier1 percentile (50 or 75) from cached percentiles.
+    fn percentile_for_tier1(percentile: u8, percentiles: &FeePercentiles) -> u64 {
+        match percentile {
+            75 => percentiles.p75,
+            90 => percentiles.p90,
+            25 => percentiles.p25,
+            _ => percentiles.p50,
+        }
     }
 
     /// Get sample count
@@ -325,6 +341,37 @@ mod tests {
         // Should be clamped to minimum
         let fee = tracker.get_fee_for_tier(IntentTier::Tier1);
         assert!(fee >= 50_000);
+    }
+
+    #[test]
+    fn test_tier1_p50_vs_p75_percentile_config() {
+        let tracker_p50 = PriorityFeeTracker::with_config(PriorityFeeConfig {
+            tier1_fee_percentile: 50,
+            tier1_multiplier: 1.2,
+            min_priority_fee_micro_lamports: 1_000,
+            max_priority_fee_micro_lamports: 10_000_000,
+            ..PriorityFeeConfig::default()
+        });
+        let tracker_p75 = PriorityFeeTracker::with_config(PriorityFeeConfig {
+            tier1_fee_percentile: 75,
+            tier1_multiplier: 1.2,
+            min_priority_fee_micro_lamports: 1_000,
+            max_priority_fee_micro_lamports: 10_000_000,
+            ..PriorityFeeConfig::default()
+        });
+
+        for i in 1..=20u64 {
+            let fee = 5_000 + i * 2_000;
+            tracker_p50.add_sample(i, fee, Some(100_000));
+            tracker_p75.add_sample(i, fee, Some(100_000));
+        }
+
+        let fee_p50 = tracker_p50.get_fee_for_tier(IntentTier::Tier1);
+        let fee_p75 = tracker_p75.get_fee_for_tier(IntentTier::Tier1);
+        assert!(
+            fee_p75 > fee_p50,
+            "P75×1.2 should exceed P50×1.2 on same samples"
+        );
     }
 
     #[test]

--- a/src/solana/tx_sender.rs
+++ b/src/solana/tx_sender.rs
@@ -209,6 +209,37 @@ impl TxSender {
         self.send_sequential(tx).await
     }
 
+    /// Rebroadcast-safe send: TPU and/or RPC only, never Jito.
+    ///
+    /// Used during confirmation wait where rebroadcast must mirror the
+    /// documented TPU-with-RPC-fallback semantics, not the full fallback chain.
+    pub async fn send_tpu_then_rpc(&self, tx: &Transaction) -> Result<SendResult, SendError> {
+        if self.config.parallel_send && self.tpu.is_some() {
+            return self.send_parallel(tx).await;
+        }
+
+        if self.tpu.is_some() {
+            match self.send_via_tpu(tx).await {
+                Ok(sig) => {
+                    return Ok(SendResult {
+                        signature: sig,
+                        method: SendMethod::TpuDirect,
+                        bundle_id: None,
+                    });
+                }
+                Err(e) => {
+                    warn!(error = %e, "Rebroadcast: TPU failed, falling back to RPC");
+                }
+            }
+        }
+
+        self.send_via_rpc(tx).await.map(|sig| SendResult {
+            signature: sig,
+            method: SendMethod::Rpc,
+            bundle_id: None,
+        })
+    }
+
     /// Send via TPU and RPC in parallel. First success wins.
     /// Both methods send the same signed TX, so Solana deduplicates by signature.
     /// This ensures maximum reliability without paying double fees.


### PR DESCRIPTION
## Summary
- Phase A: Histograms for send-to-confirm latency and confirmed slot delta; priority-fee source counters; rebroadcast metrics; DecisionRecord metadata (`slot_at_send`, `priority_fee_source`, `rebroadcast` count).
- Phase B: Configurable Tier1 dynamic fee percentile/multiplier without raising static floor.
- Phase C: Rebroadcast via TPU (TxSender) with RPC fallback; `rebroadcast_use_tpu` config.
- Phase D intentionally omitted (fee-bump resend / dual-watch race risk).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [ ] CI green on PR
- [ ] Supervisor invariant review
- [ ] Bugbot gate
- [ ] Post-deploy: EE metrics `tx_send_to_confirm_ms`, `tx_confirmed_slot_delta_slots` on prod

Handoff: `Iron_crab-eval/docs/supervisor/handoff_tx_confirm_latency_fee_slot_observability.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live TX send, confirm wait, rebroadcast, and fee selection paths; misconfiguration or TPU rebroadcast issues could affect landing behavior, though static fee floors and RPC fallback limit fee regressions.
> 
> **Overview**
> Adds **TX confirm observability** and **send-path correctness** for slot metrics: execution-engine pairs blockhash with slot via `get_latest_blockhash_for_send`, updates the cache on RPC fallback, tracks `slot_at_send` through Jito/TxSender/RPC sends, and records send→confirm latency plus `confirmed_slot` delta in Prometheus and DecisionRecord metadata (`priority_fee_source`, `rebroadcast_count`).
> 
> **Tier1 priority fees** are now configurable (`tier1_fee_percentile`, `tier1_fee_multiplier`) with explicit `static_floor` vs `dynamic` selection and counters; market-data’s fee tracker aligns on the same percentile knobs.
> 
> **Rebroadcast during confirm wait** can use TPU via new `TxSender::send_tpu_then_rpc` when `rebroadcast_use_tpu` is set (default follows `tpu_enabled`), with RPC fallback and rebroadcast method/latency metrics. Config schema and hot-reload document the new keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba407787ccd24e08328a9fe4a24de3b832743f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->