### PR TITLE
feat(arb): multi-hop Phase 2 — LivePoolCache quotes via quote_calculator

### DIFF
--- a/docs/MULTI_HOP_ARBITRAGE.md
+++ b/docs/MULTI_HOP_ARBITRAGE.md
@@ -46,7 +46,15 @@ Shadow-Mode loggt Zyklen zur Prod-Validierung. Ohne Caps explodieren kumulative 
 | `MIN_RETURN_BPS` / `MAX_RETURN_BPS` | −10_000 / 50_000 | −100% .. +500% ROI-Schätzung |
 | `is_trustworthy_profit_estimate()` | — | `false` bei Cap/Saturierung → nicht „profitable“, kein Intent |
 
-Prometheus (arb-strategy :9803): `multi_hop_return_bps_saturated_total`, `multi_hop_cycle_rejected_sanity_total{reason=edge_ratio|profit_cap|return_bps_cap}`, `multi_hop_hop_missing_quote_total`, `multi_hop_shadow_logged_total`.
+Prometheus (arb-strategy :9803): `multi_hop_return_bps_saturated_total`, `multi_hop_cycle_rejected_sanity_total{reason=edge_ratio|profit_cap|return_bps_cap}`, `multi_hop_hop_missing_quote_total`, `multi_hop_shadow_logged_total`, `multi_hop_quote_from_cache_total`, `multi_hop_quote_from_trade_cache_total`.
+
+### Quote-Priorität (PoolRanker / `CachedQuoteProvider`)
+
+1. **Trade-Cache** — normalisierte Probe-Quotes aus beobachteten Trades (`update_quote` bei `on_pool_price_update`)
+2. **LivePoolCache** — `quote_calculator::quote_output_amount` aus Geyser-gespeister `CachedPoolState` (kein RPC)
+3. **Conservative default** — `edge_ratio = 0.99` nur wenn (1) und (2) fehlen; `multi_hop_hop_missing_quote_total`++
+
+Nach JetStream-Bootstrap: `warmup_quotes_from_live_pool_cache` seedet Top-N WSOL-Pools in den Trade-Cache.
 
 ## Motivation
 

--- a/src/arbitrage/multi_hop_integration.rs
+++ b/src/arbitrage/multi_hop_integration.rs
@@ -15,13 +15,16 @@ use crate::arbitrage::{
     ArbCycle, BeamCycleFinder, CycleFinderConfig, DexType, PoolEdge, PoolGraph, PoolRanker,
     QuoteProvider, RankerConfig, MAX_RETURN_BPS,
 };
+use crate::execution::live_pool_cache::{CachedPoolState, SharedLivePoolCache};
+use crate::execution::quote_calculator;
 use crate::ipc::{
     ExplicitAmount, IntentOrigin, IntentTier, PoolAlternative, RecordHeader, SwapHop, TradeIntent,
     TradeResources, TradeSide, TradingRegime,
 };
 use crate::metrics::{
-    multi_hop_cycle_rejected_sanity_inc, multi_hop_return_bps_saturated_inc,
-    multi_hop_shadow_logged_inc, MultiHopSanityRejectReason,
+    multi_hop_cycle_rejected_sanity_inc, multi_hop_hop_missing_quote_inc,
+    multi_hop_quote_from_cache_inc, multi_hop_quote_from_trade_cache_inc,
+    multi_hop_return_bps_saturated_inc, multi_hop_shadow_logged_inc, MultiHopSanityRejectReason,
 };
 use parking_lot::RwLock;
 use solana_sdk::pubkey::Pubkey;
@@ -34,6 +37,12 @@ use tracing::{debug, info, trace, warn};
 
 /// WSOL mint (native SOL wrapped)
 pub const WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
+
+/// Probe amount for trade-cache normalization (0.01 SOL).
+const PROBE_LAMPORTS: u64 = 10_000_000;
+
+/// Top-N WSOL pools to seed trade-cache quotes after JetStream bootstrap.
+const QUOTE_WARMUP_TOP_N: usize = 1000;
 
 /// Multi-hop arbitrage configuration
 #[derive(Debug, Clone)]
@@ -88,7 +97,7 @@ type QuoteCacheKey = (Pubkey, Pubkey, Pubkey);
 /// Cache value: (output_amount, timestamp)
 type QuoteCacheValue = (u64, Instant);
 
-/// Quote provider that uses cached pool data
+/// Quote provider: trade-normalized cache, then LivePoolCache (Geyser), then conservative default.
 pub struct CachedQuoteProvider {
     /// Cache: (pool, input_mint, output_mint) -> (output_amount, timestamp)
     cache: RwLock<HashMap<QuoteCacheKey, QuoteCacheValue>>,
@@ -96,14 +105,143 @@ pub struct CachedQuoteProvider {
     cache_ttl: Duration,
     /// Default edge ratio when no quote available (conservative)
     default_edge_ratio: f64,
+    /// SLAVE LivePoolCache (same SSOT as execution-engine) — no RPC on miss.
+    live_pool_cache: SharedLivePoolCache,
 }
 
 impl CachedQuoteProvider {
-    pub fn new(cache_ttl: Duration) -> Self {
+    pub fn new(cache_ttl: Duration, live_pool_cache: SharedLivePoolCache) -> Self {
         Self {
             cache: RwLock::new(HashMap::new()),
             cache_ttl,
             default_edge_ratio: 0.99, // Assume 1% loss when no data
+            live_pool_cache,
+        }
+    }
+
+    fn mints_from_state(state: &CachedPoolState) -> (Pubkey, Pubkey) {
+        match state {
+            CachedPoolState::Orca(s) => (s.token_mint_a, s.token_mint_b),
+            CachedPoolState::RaydiumAmm(s) => (s.base_mint, s.quote_mint),
+            CachedPoolState::RaydiumCpmm(s) => (s.token_0_mint, s.token_1_mint),
+            CachedPoolState::Meteora(s) => (s.token_x_mint, s.token_y_mint),
+            CachedPoolState::MeteoraCpmm(s) => (s.token_0_mint, s.token_1_mint),
+            CachedPoolState::PumpFun(s) => (
+                s.token_mint,
+                Pubkey::from_str(WSOL_MINT).unwrap_or_default(),
+            ),
+            CachedPoolState::PumpAmm(s) => (s.base_mint, s.quote_mint),
+        }
+    }
+
+    fn liquidity_usd_estimate(state: &CachedPoolState) -> f64 {
+        let (base, quote) = match state {
+            CachedPoolState::Orca(s) => (
+                s.vault_a_balance.unwrap_or(0),
+                s.vault_b_balance.unwrap_or(0),
+            ),
+            CachedPoolState::RaydiumAmm(s) => {
+                (s.coin_reserve.unwrap_or(0), s.pc_reserve.unwrap_or(0))
+            }
+            CachedPoolState::RaydiumCpmm(s) => (s.reserve_0.unwrap_or(0), s.reserve_1.unwrap_or(0)),
+            CachedPoolState::Meteora(s) => (
+                s.reserve_x_balance.unwrap_or(0),
+                s.reserve_y_balance.unwrap_or(0),
+            ),
+            CachedPoolState::PumpAmm(s) => {
+                (s.base_reserve.unwrap_or(0), s.quote_reserve.unwrap_or(0))
+            }
+            CachedPoolState::PumpFun(s) => (s.virtual_token_reserves, s.virtual_sol_reserves),
+            CachedPoolState::MeteoraCpmm(s) => (s.reserve_0, s.reserve_1),
+        };
+        let sol_side = base.max(quote) as f64 / 1e9 * 150.0;
+        sol_side.max(10_000.0)
+    }
+
+    fn try_quote_from_live_pool_cache(
+        &self,
+        pool_address: &Pubkey,
+        input_mint: &Pubkey,
+        amount_in: u64,
+    ) -> Option<u64> {
+        let state = self.live_pool_cache.get(pool_address)?;
+        let out = quote_calculator::quote_output_amount(&state, amount_in, input_mint).ok()?;
+        (out > 0).then_some(out)
+    }
+
+    fn quote_from_live_pool_cache(
+        &self,
+        pool_address: &Pubkey,
+        input_mint: &Pubkey,
+        amount_in: u64,
+    ) -> Option<u64> {
+        let out = self.try_quote_from_live_pool_cache(pool_address, input_mint, amount_in)?;
+        multi_hop_quote_from_cache_inc();
+        Some(out)
+    }
+
+    fn trade_cache_quote(
+        &self,
+        pool_address: &Pubkey,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+        amount_in: u64,
+    ) -> Option<u64> {
+        let cache = self.cache.read();
+        let (cached_output, ts) = cache.get(&(*pool_address, *input_mint, *output_mint))?;
+        if ts.elapsed() >= self.cache_ttl {
+            return None;
+        }
+        multi_hop_quote_from_trade_cache_inc();
+        Some((*cached_output as u128 * amount_in as u128 / PROBE_LAMPORTS as u128) as u64)
+    }
+
+    /// Seed trade-cache probe quotes from LivePoolCache for top WSOL pools (cold-start).
+    pub fn warmup_from_live_pool_cache(&self, top_n: usize) {
+        let Ok(wsol) = Pubkey::from_str(WSOL_MINT) else {
+            return;
+        };
+
+        let mut candidates: Vec<(Pubkey, CachedPoolState, f64)> = self
+            .live_pool_cache
+            .iter()
+            .filter_map(|(pool_pk, state)| {
+                let (mint_a, mint_b) = Self::mints_from_state(&state);
+                if mint_a != wsol && mint_b != wsol {
+                    return None;
+                }
+                let liq = Self::liquidity_usd_estimate(&state);
+                Some((pool_pk, state, liq))
+            })
+            .collect();
+
+        candidates.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
+        candidates.truncate(top_n);
+        let pool_count = candidates.len();
+
+        let mut seeded = 0usize;
+        for (pool_pk, state, _) in candidates {
+            let (mint_a, mint_b) = Self::mints_from_state(&state);
+            let other = if mint_a == wsol { mint_b } else { mint_a };
+
+            if let Some(out) = self.try_quote_from_live_pool_cache(&pool_pk, &wsol, PROBE_LAMPORTS)
+            {
+                self.update_quote(pool_pk, wsol, other, PROBE_LAMPORTS, out);
+                seeded += 1;
+            }
+            if let Some(out) = self.try_quote_from_live_pool_cache(&pool_pk, &other, PROBE_LAMPORTS)
+            {
+                self.update_quote(pool_pk, other, wsol, PROBE_LAMPORTS, out);
+                seeded += 1;
+            }
+        }
+
+        if seeded > 0 {
+            info!(
+                pools = pool_count,
+                quotes_seeded = seeded,
+                "Multi-hop quote warmup from LivePoolCache"
+            );
         }
     }
 
@@ -117,9 +255,8 @@ impl CachedQuoteProvider {
         output_amount: u64,
     ) {
         // Normalize to probe amount for consistent edge ratio
-        let probe = 10_000_000u64; // 0.01 SOL
         let normalized_output = if input_amount > 0 {
-            (output_amount as u128 * probe as u128 / input_amount as u128) as u64
+            (output_amount as u128 * PROBE_LAMPORTS as u128 / input_amount as u128) as u64
         } else {
             0
         };
@@ -164,16 +301,16 @@ impl QuoteProvider for CachedQuoteProvider {
         output_mint: &Pubkey,
         amount_in: u64,
     ) -> Option<u64> {
-        let cache = self.cache.read();
-
-        if let Some((cached_output, ts)) = cache.get(&(*pool_address, *input_mint, *output_mint)) {
-            if ts.elapsed() < self.cache_ttl {
-                let probe = 10_000_000u64;
-                return Some((*cached_output as u128 * amount_in as u128 / probe as u128) as u64);
-            }
+        if let Some(out) = self.trade_cache_quote(pool_address, input_mint, output_mint, amount_in)
+        {
+            return Some(out);
         }
 
-        // No cached quote - return conservative estimate (ranker skips via has_cached_quote)
+        if let Some(out) = self.quote_from_live_pool_cache(pool_address, input_mint, amount_in) {
+            return Some(out);
+        }
+
+        multi_hop_hop_missing_quote_inc();
         Some((amount_in as f64 * self.default_edge_ratio) as u64)
     }
 
@@ -184,9 +321,14 @@ impl QuoteProvider for CachedQuoteProvider {
         output_mint: &Pubkey,
     ) -> bool {
         let cache = self.cache.read();
-        cache
+        if cache
             .get(&(*pool_address, *input_mint, *output_mint))
             .is_some_and(|(_, ts)| ts.elapsed() < self.cache_ttl)
+        {
+            return true;
+        }
+        self.try_quote_from_live_pool_cache(pool_address, input_mint, PROBE_LAMPORTS)
+            .is_some()
     }
 
     fn get_cached_probe_quote(
@@ -197,13 +339,12 @@ impl QuoteProvider for CachedQuoteProvider {
         output_mint: &Pubkey,
         amount_in: u64,
     ) -> Option<u64> {
-        let cache = self.cache.read();
-        let (cached_output, ts) = cache.get(&(*pool_address, *input_mint, *output_mint))?;
-        if ts.elapsed() >= self.cache_ttl {
-            return None;
+        if let Some(out) = self.trade_cache_quote(pool_address, input_mint, output_mint, amount_in)
+        {
+            return Some(out);
         }
-        let probe = 10_000_000u64;
-        Some((*cached_output as u128 * amount_in as u128 / probe as u128) as u64)
+
+        self.quote_from_live_pool_cache(pool_address, input_mint, amount_in)
     }
 }
 
@@ -232,11 +373,14 @@ pub struct MultiHopArbitrage {
 }
 
 impl MultiHopArbitrage {
-    pub fn new(config: MultiHopConfig) -> Self {
+    pub fn new(config: MultiHopConfig, live_pool_cache: SharedLivePoolCache) -> Self {
         Self {
             config: RwLock::new(config),
             graph: PoolGraph::new(),
-            quote_provider: Arc::new(CachedQuoteProvider::new(Duration::from_secs(30))),
+            quote_provider: Arc::new(CachedQuoteProvider::new(
+                Duration::from_secs(30),
+                live_pool_cache,
+            )),
             token_state: RwLock::new(HashMap::new()),
             pool_mints: RwLock::new(HashMap::new()),
             searches_triggered: AtomicU64::new(0),
@@ -663,6 +807,12 @@ impl MultiHopArbitrage {
     pub fn is_enabled(&self) -> bool {
         self.config.read().enabled
     }
+
+    /// Seed trade-cache probe quotes from LivePoolCache (post-bootstrap cold-start).
+    pub fn warmup_quotes_from_live_pool_cache(&self) {
+        self.quote_provider
+            .warmup_from_live_pool_cache(QUOTE_WARMUP_TOP_N);
+    }
 }
 
 /// Stats for monitoring
@@ -715,6 +865,9 @@ impl QuoteProvider for Arc<CachedQuoteProvider> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::execution::live_pool_cache::{
+        create_shared_cache, CachedPoolState, RaydiumAmmState,
+    };
 
     #[test]
     fn test_multi_hop_config_default() {
@@ -728,11 +881,14 @@ mod tests {
 
     #[test]
     fn test_pool_upsert() {
-        let arb = MultiHopArbitrage::new(MultiHopConfig {
-            enabled: true,
-            min_liquidity_usd: 0.0,
-            ..Default::default()
-        });
+        let arb = MultiHopArbitrage::new(
+            MultiHopConfig {
+                enabled: true,
+                min_liquidity_usd: 0.0,
+                ..Default::default()
+            },
+            create_shared_cache(),
+        );
 
         arb.upsert_pool(
             "11111111111111111111111111111111",
@@ -749,8 +905,48 @@ mod tests {
     }
 
     #[test]
+    fn test_live_pool_cache_quote_without_trade() {
+        let cache = create_shared_cache();
+        let provider = CachedQuoteProvider::new(Duration::from_secs(30), cache.clone());
+
+        let wsol = Pubkey::from_str(WSOL_MINT).unwrap();
+        let token = Pubkey::new_unique();
+        let pool = Pubkey::new_unique();
+
+        cache.upsert(
+            pool,
+            CachedPoolState::RaydiumAmm(RaydiumAmmState {
+                base_mint: token,
+                quote_mint: wsol,
+                coin_vault: Pubkey::new_unique(),
+                pc_vault: Pubkey::new_unique(),
+                base_decimals: 9,
+                quote_decimals: 9,
+                coin_reserve: Some(10_000_000_000_000),
+                pc_reserve: Some(1_000_000_000_000),
+                market_id: Pubkey::new_unique(),
+                serum_bids: None,
+                serum_asks: None,
+                serum_event_queue: None,
+            }),
+            1,
+        );
+
+        let probe = PROBE_LAMPORTS;
+        let out = provider
+            .get_cached_probe_quote(&pool, DexType::RaydiumAmmV4, &wsol, &token, probe)
+            .expect("LivePoolCache quote expected");
+        let default_out = (probe as f64 * 0.99) as u64;
+        assert_ne!(
+            out, default_out,
+            "LivePoolCache quote must differ from conservative default"
+        );
+        assert!(out > 0);
+    }
+
+    #[test]
     fn test_cached_quote_provider() {
-        let provider = CachedQuoteProvider::new(Duration::from_secs(30));
+        let provider = CachedQuoteProvider::new(Duration::from_secs(30), create_shared_cache());
 
         let pool = Pubkey::new_unique();
         let input = Pubkey::new_unique();
@@ -767,10 +963,13 @@ mod tests {
 
     #[test]
     fn test_event_driven_disabled() {
-        let arb = MultiHopArbitrage::new(MultiHopConfig {
-            enabled: false, // Disabled
-            ..Default::default()
-        });
+        let arb = MultiHopArbitrage::new(
+            MultiHopConfig {
+                enabled: false, // Disabled
+                ..Default::default()
+            },
+            create_shared_cache(),
+        );
 
         let intents = arb.on_pool_price_update(
             "11111111111111111111111111111111",

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -1998,6 +1998,9 @@ async fn main() -> Result<()> {
         Some(client)
     };
 
+    let live_pool_cache = create_shared_cache();
+    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default(), live_pool_cache.clone());
+
     let ctx = Arc::new(ArbContext {
         run_id: run_id.clone(),
         config: RwLock::new(initial_config),
@@ -2014,10 +2017,9 @@ async fn main() -> Result<()> {
         last_market_event: RwLock::new(Instant::now()),
         vault_balances: RwLock::new(HashMap::new()),
         bin_arrays: RwLock::new(HashMap::new()),
-        live_pool_cache: create_shared_cache(),
+        live_pool_cache,
         known_pools: RwLock::new(HashSet::new()),
-        // Multi-hop arbitrage: disabled and shadow mode by default for safe rollout
-        multi_hop: MultiHopArbitrage::new(MultiHopConfig::default()),
+        multi_hop,
     });
 
     // Bootstrap SLAVE LivePoolCache from JetStream (same path as execution-engine).
@@ -2030,6 +2032,7 @@ async fn main() -> Result<()> {
                     &ctx.known_pools,
                     &ctx.multi_hop,
                 );
+                ctx.multi_hop.warmup_quotes_from_live_pool_cache();
                 let mh_stats = ctx.multi_hop.stats();
                 info!(
                     pools_recovered,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2383,6 +2383,9 @@ pub fn arb_two_hop_opportunity_inc() {
 pub static MULTI_HOP_RETURN_BPS_SATURATED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static MULTI_HOP_SHADOW_LOGGED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static MULTI_HOP_HOP_MISSING_QUOTE_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MULTI_HOP_QUOTE_FROM_CACHE_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MULTI_HOP_QUOTE_FROM_TRADE_CACHE_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 pub static MULTI_HOP_CYCLE_REJECTED_SANITY_EDGE_RATIO: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static MULTI_HOP_CYCLE_REJECTED_SANITY_PROFIT_CAP: Lazy<AtomicU64> =
@@ -2408,6 +2411,14 @@ pub fn multi_hop_shadow_logged_inc() {
 
 pub fn multi_hop_hop_missing_quote_inc() {
     MULTI_HOP_HOP_MISSING_QUOTE_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn multi_hop_quote_from_cache_inc() {
+    MULTI_HOP_QUOTE_FROM_CACHE_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn multi_hop_quote_from_trade_cache_inc() {
+    MULTI_HOP_QUOTE_FROM_TRADE_CACHE_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 pub fn multi_hop_cycle_rejected_sanity_inc(reason: MultiHopSanityRejectReason) {
@@ -4162,6 +4173,14 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "multi_hop_hop_missing_quote_total",
         MULTI_HOP_HOP_MISSING_QUOTE_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "multi_hop_quote_from_cache_total",
+        MULTI_HOP_QUOTE_FROM_CACHE_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "multi_hop_quote_from_trade_cache_total",
+        MULTI_HOP_QUOTE_FROM_TRADE_CACHE_TOTAL.load(Ordering::Relaxed)
     );
     out.push_str("multi_hop_cycle_rejected_sanity_total{reason=\"edge_ratio\"} ");
     out.push_str(

--- a/tests/arb_known_pools_sync.rs
+++ b/tests/arb_known_pools_sync.rs
@@ -22,7 +22,7 @@ fn empty_known_pools() -> RwLock<HashSet<String>> {
 fn balance_updated_only_populates_known_pools() {
     let cache = create_shared_cache();
     let known_pools = empty_known_pools();
-    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default());
+    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default(), cache.clone());
 
     let pool = Pubkey::new_unique().to_string();
     let base_mint = Pubkey::new_unique().to_string();
@@ -54,7 +54,7 @@ fn balance_updated_only_populates_known_pools() {
 fn pool_removed_evicts_known_pools_entry() {
     let cache = create_shared_cache();
     let known_pools = empty_known_pools();
-    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default());
+    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default(), cache.clone());
 
     let pool = Pubkey::new_unique().to_string();
     let base_mint = Pubkey::new_unique().to_string();
@@ -92,7 +92,7 @@ fn pool_removed_evicts_known_pools_entry() {
 fn pool_discovered_then_balance_updated_keeps_single_known_pools_entry() {
     let cache = create_shared_cache();
     let known_pools = empty_known_pools();
-    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default());
+    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default(), cache.clone());
 
     let pool = Pubkey::new_unique().to_string();
     let base_mint = Pubkey::new_unique().to_string();
@@ -136,7 +136,7 @@ fn pool_discovered_then_balance_updated_keeps_single_known_pools_entry() {
 fn balance_updated_upserts_multi_hop_idempotently() {
     let cache = create_shared_cache();
     let known_pools = empty_known_pools();
-    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default());
+    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default(), cache.clone());
 
     let pool = Pubkey::new_unique().to_string();
     let base_mint = Pubkey::new_unique().to_string();
@@ -169,7 +169,7 @@ fn balance_updated_upserts_multi_hop_idempotently() {
 fn populate_from_live_cache_matches_cache_len() {
     let cache = create_shared_cache();
     let known_pools = empty_known_pools();
-    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default());
+    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default(), cache.clone());
 
     let pool = Pubkey::new_unique().to_string();
     let update = PoolCacheUpdate::new_balance_updated(

--- a/tests/multi_hop_live_cache_quotes.rs
+++ b/tests/multi_hop_live_cache_quotes.rs
@@ -1,0 +1,76 @@
+//! Multi-hop quotes from LivePoolCache (no trade events required).
+
+use ironcrab::arbitrage::{
+    CachedQuoteProvider, DexType, PoolEdge, PoolGraph, PoolRanker, QuoteProvider, WSOL_MINT,
+};
+use ironcrab::execution::live_pool_cache::{create_shared_cache, CachedPoolState, RaydiumAmmState};
+use solana_sdk::pubkey::Pubkey;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+fn wsol() -> Pubkey {
+    Pubkey::from_str(WSOL_MINT).unwrap()
+}
+
+#[test]
+fn live_pool_cache_quotes_rank_both_directions_without_trades() {
+    let cache = create_shared_cache();
+    let provider = Arc::new(CachedQuoteProvider::new(
+        Duration::from_secs(30),
+        cache.clone(),
+    ));
+    let wsol_mint = wsol();
+    let token = Pubkey::new_unique();
+    let pool = Pubkey::new_unique();
+    let probe = 10_000_000u64;
+
+    cache.upsert(
+        pool,
+        CachedPoolState::RaydiumAmm(RaydiumAmmState {
+            base_mint: token,
+            quote_mint: wsol_mint,
+            coin_vault: Pubkey::new_unique(),
+            pc_vault: Pubkey::new_unique(),
+            base_decimals: 9,
+            quote_decimals: 9,
+            coin_reserve: Some(10_000_000_000_000),
+            pc_reserve: Some(1_000_000_000_000),
+            market_id: Pubkey::new_unique(),
+            serum_bids: None,
+            serum_asks: None,
+            serum_event_queue: None,
+        }),
+        1,
+    );
+
+    let graph = PoolGraph::new();
+    graph.upsert_pool(PoolEdge::new(
+        pool,
+        DexType::RaydiumAmmV4,
+        wsol_mint,
+        token,
+        500_000.0,
+        30,
+    ));
+
+    let ranker = PoolRanker::new(provider.clone());
+    assert!(
+        !ranker.rank_pools_from(&graph, &wsol_mint).is_empty(),
+        "WSOL→token should rank via LivePoolCache"
+    );
+    assert!(
+        !ranker.rank_pools_from(&graph, &token).is_empty(),
+        "token→WSOL should rank via LivePoolCache"
+    );
+
+    let default_out = (probe as f64 * 0.99) as u64;
+    let wsol_out = provider
+        .get_cached_probe_quote(&pool, DexType::RaydiumAmmV4, &wsol_mint, &token, probe)
+        .expect("WSOL→token quote");
+    assert_ne!(wsol_out, default_out);
+    let token_out = provider
+        .get_cached_probe_quote(&pool, DexType::RaydiumAmmV4, &token, &wsol_mint, probe)
+        .expect("token→WSOL quote");
+    assert_ne!(token_out, default_out);
+}

--- a/tests/multi_hop_sanity.rs
+++ b/tests/multi_hop_sanity.rs
@@ -107,6 +107,54 @@ fn find_cycles_never_emits_i32_max_return_bps() {
 }
 
 #[test]
+fn two_hop_sol_token_sol_plausible_return_bps() {
+    let graph = PoolGraph::new();
+    let mut mock = MockQuoteProvider::new();
+    let wsol = test_pubkey(0x01);
+    let token = test_pubkey(0x02);
+    let probe = 10_000_000u64;
+
+    let pool_out = test_pubkey(0x10);
+    let pool_back = test_pubkey(0x11);
+
+    graph.upsert_pool(PoolEdge::new(
+        pool_out,
+        DexType::RaydiumAmmV4,
+        wsol,
+        token,
+        500_000.0,
+        30,
+    ));
+    graph.upsert_pool(PoolEdge::new(
+        pool_back,
+        DexType::RaydiumAmmV4,
+        token,
+        wsol,
+        500_000.0,
+        30,
+    ));
+
+    // ~2% edge per hop → ~4% round-trip (before sanity caps)
+    mock.add_quote(pool_out, wsol, token, probe, 10_200_000);
+    mock.add_quote(pool_back, token, wsol, probe, 10_200_000);
+
+    let config = CycleFinderConfig {
+        min_profit_bps: 30,
+        base_mint: wsol,
+        max_hops: 3,
+        ..Default::default()
+    };
+    let finder = BeamCycleFinder::new(config, PoolRanker::new(mock));
+    let cycles = finder.find_cycles(&graph);
+
+    assert!(!cycles.is_empty(), "expected profitable 2-hop WSOL cycle");
+    let best = &cycles[0];
+    assert!(best.estimated_return_bps >= 30);
+    assert_ne!(best.estimated_return_bps, i32::MAX);
+    assert!(best.estimated_return_bps <= MAX_RETURN_BPS);
+}
+
+#[test]
 fn profit_to_return_bps_clamp_semantics() {
     let (bps, sat) = profit_to_return_bps(100.0);
     assert!(sat);


### PR DESCRIPTION
## Summary
- `CachedQuoteProvider` uses `quote_calculator::quote_output_amount` from SLAVE `LivePoolCache` before default edge_ratio 0.99
- Wires `SharedLivePoolCache` into `MultiHopArbitrage`; post-bootstrap quote warmup for top WSOL pools
- New metrics: `multi_hop_quote_from_cache_total`, `multi_hop_quote_from_trade_cache_total`
- Tests: live cache quotes without trades, plausible 2-hop SOL cycle return_bps

## Context
Post PR #210 graph was full (~90k pools) but `multi_hop_profitable=0` and `hop_missing_quote` ~2.59B because quotes were trade-cache-only.

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test
- [ ] Eval (Level 5) on CI
- [ ] Prod: `multi_hop_profitable` > 0, `[SHADOW]` logs, missing_quote rate drops

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how profitable multi-hop cycles are estimated at scale; wrong quotes could skew shadow/prod signals, but still uses the same SSOT cache as execution-engine with a conservative default on miss.
> 
> **Overview**
> **Multi-hop quotes no longer depend only on observed trades.** `CachedQuoteProvider` now takes the SLAVE `SharedLivePoolCache` and resolves hops in order: normalized trade cache → `quote_calculator::quote_output_amount` on Geyser-backed pool state (no RPC) → conservative `edge_ratio = 0.99` with `multi_hop_hop_missing_quote_total` incremented.
> 
> `MultiHopArbitrage` and `arb-strategy` share one `LivePoolCache` instance; after JetStream bootstrap, `warmup_quotes_from_live_pool_cache` seeds probe quotes for the top 1000 WSOL pools into the trade cache. `has_cached_quote` / probe paths treat live-cache quotes as valid when trade cache misses.
> 
> **Observability & tests:** Prometheus adds `multi_hop_quote_from_cache_total` and `multi_hop_quote_from_trade_cache_total`; docs describe quote priority. New/updated tests cover live-cache quoting without trades, `PoolRanker` both directions, and a plausible 2-hop WSOL cycle `return_bps`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b2e293958073a7bb1df0fd260916365b83421df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->