### PR TITLE
fix(arbitrage): Multi-Hop Quote-Gate + gezielte Subgraph-Suche

### DIFF
--- a/src/arbitrage/cycle_finder.rs
+++ b/src/arbitrage/cycle_finder.rs
@@ -18,7 +18,7 @@ use super::pool_graph::PoolGraph;
 use super::pool_ranker::{PoolRanker, QuoteProvider};
 use super::types::{ArbCycle, PoolEdge, SearchNode};
 use solana_sdk::pubkey::Pubkey;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 use std::str::FromStr;
 
 /// WSOL mint address (native mint)
@@ -74,8 +74,89 @@ impl<Q: QuoteProvider> BeamCycleFinder<Q> {
     ///
     /// Returns cycles sorted by estimated return (descending)
     pub fn find_cycles(&self, graph: &PoolGraph) -> Vec<ArbCycle> {
+        self.find_cycles_inner(graph, None)
+    }
+
+    /// Find cycles through affected tokens (targeted subgraph search).
+    ///
+    /// Only expands vertices within `max_hops` of the seed tokens and requires
+    /// found cycles to pass through at least one seed token.
+    pub fn find_cycles_through(
+        &self,
+        graph: &PoolGraph,
+        through_tokens: &[Pubkey],
+    ) -> Vec<ArbCycle> {
+        if through_tokens.is_empty() {
+            return vec![];
+        }
+
+        let seeds: Vec<Pubkey> = through_tokens
+            .iter()
+            .copied()
+            .filter(|t| graph.has_token(t))
+            .collect();
+        if seeds.is_empty() {
+            return vec![];
+        }
+
+        self.find_cycles_inner(graph, Some(&seeds))
+    }
+
+    /// BFS subgraph around seed tokens (plus base) within `max_hops`.
+    fn build_search_subgraph(&self, graph: &PoolGraph, seeds: &[Pubkey]) -> HashSet<Pubkey> {
+        let mut allowed = HashSet::new();
+        allowed.insert(self.config.base_mint);
+
+        let mut queue = VecDeque::new();
+        for &seed in seeds {
+            if graph.has_token(&seed) && allowed.insert(seed) {
+                queue.push_back((seed, 0usize));
+            }
+        }
+
+        while let Some((token, depth)) = queue.pop_front() {
+            if depth >= self.config.max_hops {
+                continue;
+            }
+            for (neighbor, _) in graph.neighbors(&token) {
+                if allowed.insert(neighbor) {
+                    queue.push_back((neighbor, depth + 1));
+                }
+            }
+        }
+
+        allowed
+    }
+
+    /// True when every hop has a fresh trade-cache or LivePoolCache quote.
+    fn cycle_all_hops_quoted(&self, cycle: &ArbCycle) -> bool {
+        for (hop_idx, pool_options) in cycle.pools.iter().enumerate() {
+            let input_mint = &cycle.path[hop_idx];
+            let output_mint = &cycle.path[hop_idx + 1];
+            let Some(primary) = pool_options.first() else {
+                return false;
+            };
+            if !self
+                .ranker
+                .hop_has_cached_quote(&primary.pool_address, input_mint, output_mint)
+            {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn find_cycles_inner(
+        &self,
+        graph: &PoolGraph,
+        through_tokens: Option<&[Pubkey]>,
+    ) -> Vec<ArbCycle> {
         let mut results = Vec::new();
         let min_profit_multiplier = 1.0 + (self.config.min_profit_bps as f64 / 10000.0);
+
+        let allowed_tokens = through_tokens.map(|seeds| self.build_search_subgraph(graph, seeds));
+        let required_tokens: Option<HashSet<Pubkey>> =
+            through_tokens.map(|seeds| seeds.iter().copied().collect());
 
         // Priority queue: max-heap by score
         let mut pq: BinaryHeap<SearchNode> = BinaryHeap::new();
@@ -92,7 +173,15 @@ impl<Q: QuoteProvider> BeamCycleFinder<Q> {
             // Check if we've found a cycle (back to base)
             if node.depth > 0 && node.token == self.config.base_mint {
                 if node.profit >= min_profit_multiplier {
+                    if let Some(required) = &required_tokens {
+                        if !node.path.iter().any(|t| required.contains(t)) {
+                            continue;
+                        }
+                    }
                     if let Some(cycle) = node.to_arb_cycle() {
+                        if !self.cycle_all_hops_quoted(&cycle) {
+                            continue;
+                        }
                         results.push(cycle);
                         if results.len() >= self.config.max_results {
                             break;
@@ -116,14 +205,21 @@ impl<Q: QuoteProvider> BeamCycleFinder<Q> {
                 continue; // Prune: even best case can't meet threshold
             }
 
-            // Get ranked neighbors
+            // Get ranked neighbors (pools without real quotes are skipped in ranker)
             let neighbors = self.ranker.rank_pools_from(graph, &node.token);
 
             for (next_token, ranked_pools) in neighbors {
-                // Skip if already visited (except returning to base at depth > 1)
+                // Skip if already visited (except returning to base at depth > 0)
                 let is_return_to_base = next_token == self.config.base_mint && node.depth > 0;
                 if !is_return_to_base && node.has_visited(&next_token) {
                     continue;
+                }
+
+                // Targeted search: stay within subgraph around affected tokens
+                if let Some(ref allowed) = allowed_tokens {
+                    if !is_return_to_base && !allowed.contains(&next_token) {
+                        continue;
+                    }
                 }
 
                 // Get top pools as alternatives (for execution fallback)
@@ -175,26 +271,6 @@ impl<Q: QuoteProvider> BeamCycleFinder<Q> {
         results.sort_by(|a, b| b.estimated_return_bps.cmp(&a.estimated_return_bps));
 
         results
-    }
-
-    /// Find cycles with a specific intermediate token (targeted search)
-    ///
-    /// Useful when you know a token might have an arbitrage opportunity
-    pub fn find_cycles_through(
-        &self,
-        graph: &PoolGraph,
-        intermediate_token: &Pubkey,
-    ) -> Vec<ArbCycle> {
-        // First check if there's a path: base -> intermediate -> base
-        if !graph.has_token(intermediate_token) {
-            return vec![];
-        }
-
-        // Get all cycles and filter
-        self.find_cycles(graph)
-            .into_iter()
-            .filter(|cycle| cycle.path.contains(intermediate_token))
-            .collect()
     }
 
     /// Quick check if any profitable cycle exists (for metrics/monitoring)
@@ -468,6 +544,131 @@ mod tests {
     }
 
     #[test]
+    fn test_cycle_with_missing_quote_hop_not_reported() {
+        let (graph, mut mock) = setup_triangle_graph();
+        let wsol = test_pubkey(0x01);
+        let pool_token_a_wsol = test_pubkey(0x12);
+        let token_a = test_pubkey(0x03);
+
+        // Remove quote for the final hop — path cannot be completed with real quotes
+        mock.remove_quote(pool_token_a_wsol, token_a, wsol);
+
+        let config = CycleFinderConfig {
+            min_profit_bps: 50,
+            base_mint: wsol,
+            ..Default::default()
+        };
+
+        let ranker = PoolRanker::new(mock);
+        let finder = BeamCycleFinder::new(config, ranker);
+
+        let cycles = finder.find_cycles(&graph);
+        assert!(
+            cycles.is_empty(),
+            "Cycle with a quote-less hop must not be reported"
+        );
+
+        // Sanity: profitable triangle exists when all quotes present
+        let (graph2, mock2) = setup_triangle_graph();
+        let finder2 = BeamCycleFinder::new(
+            CycleFinderConfig {
+                min_profit_bps: 50,
+                base_mint: wsol,
+                ..Default::default()
+            },
+            PoolRanker::new(mock2),
+        );
+        assert!(!finder2.find_cycles(&graph2).is_empty());
+    }
+
+    fn setup_local_triangle_plus_distant_chain() -> (PoolGraph, std::sync::Arc<MockQuoteProvider>) {
+        use std::sync::Arc;
+
+        let graph = PoolGraph::new();
+        let mut mock = MockQuoteProvider::new();
+        let wsol = test_pubkey(0x01);
+        let usdc = test_pubkey(0x02);
+        let token_a = test_pubkey(0x03);
+        let probe = 10_000_000u64;
+
+        let pool_wsol_usdc = test_pubkey(0x10);
+        let pool_usdc_token_a = test_pubkey(0x11);
+        let pool_token_a_wsol = test_pubkey(0x12);
+
+        graph.upsert_pool(make_edge(0x10, 0x01, 0x02, 1_000_000.0));
+        graph.upsert_pool(make_edge(0x11, 0x02, 0x03, 500_000.0));
+        graph.upsert_pool(make_edge(0x12, 0x03, 0x01, 300_000.0));
+
+        mock.add_quote(pool_wsol_usdc, wsol, usdc, probe, 9_900_000);
+        mock.add_quote(pool_usdc_token_a, usdc, token_a, probe, 10_200_000);
+        mock.add_quote(pool_token_a_wsol, token_a, wsol, probe, 10_200_000);
+        mock.add_quote(pool_wsol_usdc, usdc, wsol, probe, 9_900_000);
+        mock.add_quote(pool_usdc_token_a, token_a, usdc, probe, 9_800_000);
+        mock.add_quote(pool_token_a_wsol, wsol, token_a, probe, 9_800_000);
+
+        // Distant chain from WSOL (adds many probe lookups on full-graph search)
+        for i in 0..5 {
+            let from = if i == 0 { 0x01 } else { 0x20 + i - 1 };
+            let to = 0x20 + i;
+            let pool = 0x30 + i;
+            graph.upsert_pool(make_edge(pool, from, to, 50_000.0));
+            mock.add_quote(
+                test_pubkey(pool),
+                test_pubkey(from),
+                test_pubkey(to),
+                probe,
+                9_900_000,
+            );
+            mock.add_quote(
+                test_pubkey(pool),
+                test_pubkey(to),
+                test_pubkey(from),
+                probe,
+                9_900_000,
+            );
+        }
+
+        (graph, Arc::new(mock))
+    }
+
+    #[test]
+    fn test_find_cycles_through_limits_subgraph_probe_lookups() {
+        let (graph, mock) = setup_local_triangle_plus_distant_chain();
+        let token_a = test_pubkey(0x03);
+        let wsol = test_pubkey(0x01);
+
+        let config = CycleFinderConfig {
+            beam_width: 10,
+            max_hops: 4,
+            min_profit_bps: 50,
+            base_mint: wsol,
+            ..Default::default()
+        };
+
+        mock.reset_probe_lookup_count();
+        let finder_full = BeamCycleFinder::new(config.clone(), PoolRanker::new(mock.clone()));
+        let _ = finder_full.find_cycles(&graph);
+        let full_lookups = mock.probe_lookup_count();
+
+        mock.reset_probe_lookup_count();
+        let finder_targeted = BeamCycleFinder::new(config, PoolRanker::new(mock.clone()));
+        let targeted_cycles = finder_targeted.find_cycles_through(&graph, &[token_a]);
+        let targeted_lookups = mock.probe_lookup_count();
+
+        assert!(
+            targeted_lookups < full_lookups,
+            "Targeted search should probe fewer pools than full-graph search (targeted={targeted_lookups}, full={full_lookups})"
+        );
+        assert!(
+            !targeted_cycles.is_empty(),
+            "Should still find the local triangle through token_a"
+        );
+        for cycle in &targeted_cycles {
+            assert!(cycle.path.contains(&token_a));
+        }
+    }
+
+    #[test]
     fn test_finds_cycles_through_specific_token() {
         let (graph, mock) = setup_triangle_graph();
 
@@ -481,7 +682,7 @@ mod tests {
         let finder = BeamCycleFinder::new(config, ranker);
 
         // Search for cycles through USDC (0x02)
-        let cycles = finder.find_cycles_through(&graph, &test_pubkey(0x02));
+        let cycles = finder.find_cycles_through(&graph, &[test_pubkey(0x02)]);
 
         // Should find cycles containing USDC
         for cycle in &cycles {

--- a/src/arbitrage/cycle_finder.rs
+++ b/src/arbitrage/cycle_finder.rs
@@ -141,10 +141,12 @@ impl<Q: QuoteProvider> BeamCycleFinder<Q> {
             let Some(primary) = pool_options.first() else {
                 return false;
             };
-            if !self
-                .ranker
-                .hop_has_cached_quote(&primary.pool_address, input_mint, output_mint)
-            {
+            if !self.ranker.hop_has_cached_quote(
+                &primary.pool_address,
+                primary.dex,
+                input_mint,
+                output_mint,
+            ) {
                 return false;
             }
         }

--- a/src/arbitrage/cycle_finder.rs
+++ b/src/arbitrage/cycle_finder.rs
@@ -109,7 +109,8 @@ impl<Q: QuoteProvider> BeamCycleFinder<Q> {
 
         let mut queue = VecDeque::new();
         for &seed in seeds {
-            if graph.has_token(&seed) && allowed.insert(seed) {
+            if graph.has_token(&seed) {
+                allowed.insert(seed);
                 queue.push_back((seed, 0usize));
             }
         }

--- a/src/arbitrage/cycle_finder.rs
+++ b/src/arbitrage/cycle_finder.rs
@@ -105,15 +105,19 @@ impl<Q: QuoteProvider> BeamCycleFinder<Q> {
     /// BFS subgraph around seed tokens (plus base) within `max_hops`.
     fn build_search_subgraph(&self, graph: &PoolGraph, seeds: &[Pubkey]) -> HashSet<Pubkey> {
         let mut allowed = HashSet::new();
-        allowed.insert(self.config.base_mint);
-
         let mut queue = VecDeque::new();
+
         for &seed in seeds {
-            if graph.has_token(&seed) {
-                allowed.insert(seed);
-                queue.push_back((seed, 0usize));
+            if !graph.has_token(&seed) {
+                continue;
             }
+            allowed.insert(seed);
+            // Enqueue even when seed == base_mint (already in allowed from a prior seed).
+            queue.push_back((seed, 0usize));
         }
+
+        // Base is always reachable for cycle closing.
+        allowed.insert(self.config.base_mint);
 
         while let Some((token, depth)) = queue.pop_front() {
             if depth >= self.config.max_hops {
@@ -692,5 +696,38 @@ mod tests {
                 "Cycle should contain intermediate token"
             );
         }
+    }
+
+    #[test]
+    fn test_find_cycles_through_wsol_matches_find_cycles() {
+        let wsol = test_pubkey(0x01);
+
+        let config = CycleFinderConfig {
+            min_profit_bps: 50,
+            base_mint: wsol,
+            ..Default::default()
+        };
+
+        let (graph, mock) = setup_triangle_graph();
+        let finder_full = BeamCycleFinder::new(config.clone(), PoolRanker::new(mock));
+        let full_cycles = finder_full.find_cycles(&graph);
+
+        let (graph2, mock2) = setup_triangle_graph();
+        let finder_through = BeamCycleFinder::new(config, PoolRanker::new(mock2));
+        let through_cycles = finder_through.find_cycles_through(&graph2, &[wsol]);
+
+        assert!(
+            !full_cycles.is_empty(),
+            "Full-graph search should find cycles on triangle graph"
+        );
+        assert_eq!(
+            full_cycles.len(),
+            through_cycles.len(),
+            "WSOL-only targeted search should match full-graph cycle count"
+        );
+        assert_eq!(
+            full_cycles[0].estimated_return_bps, through_cycles[0].estimated_return_bps,
+            "Best cycle return should match between full and WSOL-targeted search"
+        );
     }
 }

--- a/src/arbitrage/multi_hop_integration.rs
+++ b/src/arbitrage/multi_hop_integration.rs
@@ -97,14 +97,12 @@ type QuoteCacheKey = (Pubkey, Pubkey, Pubkey);
 /// Cache value: (output_amount, timestamp)
 type QuoteCacheValue = (u64, Instant);
 
-/// Quote provider: trade-normalized cache, then LivePoolCache (Geyser), then conservative default.
+/// Quote provider: trade-normalized cache, then LivePoolCache (Geyser). No synthetic fallback.
 pub struct CachedQuoteProvider {
     /// Cache: (pool, input_mint, output_mint) -> (output_amount, timestamp)
     cache: RwLock<HashMap<QuoteCacheKey, QuoteCacheValue>>,
     /// Cache TTL
     cache_ttl: Duration,
-    /// Default edge ratio when no quote available (conservative)
-    default_edge_ratio: f64,
     /// SLAVE LivePoolCache (same SSOT as execution-engine) — no RPC on miss.
     live_pool_cache: SharedLivePoolCache,
 }
@@ -114,7 +112,6 @@ impl CachedQuoteProvider {
         Self {
             cache: RwLock::new(HashMap::new()),
             cache_ttl,
-            default_edge_ratio: 0.99, // Assume 1% loss when no data
             live_pool_cache,
         }
     }
@@ -311,7 +308,7 @@ impl QuoteProvider for CachedQuoteProvider {
         }
 
         multi_hop_hop_missing_quote_inc();
-        Some((amount_in as f64 * self.default_edge_ratio) as u64)
+        None
     }
 
     fn has_cached_quote(
@@ -494,9 +491,27 @@ impl MultiHopArbitrage {
             None => (input, output), // Fallback if not in index
         };
 
-        // Check cooldown and price change for both tokens
-        let tokens_to_search =
-            self.filter_tokens_for_search(&[mint_a, mint_b], normalized_price, &config);
+        // Per-mint directional price ratios (inverse for the output side of the trade)
+        let output_ratio = if output_amount > 0 {
+            (input_amount as u128 * 10_000 / output_amount as u128) as u64
+        } else {
+            return vec![];
+        };
+        let mut token_ratios = Vec::with_capacity(2);
+        for &mint in &[mint_a, mint_b] {
+            let ratio = if mint == input {
+                normalized_price
+            } else if mint == output {
+                output_ratio
+            } else {
+                continue;
+            };
+            if !token_ratios.iter().any(|(m, _)| *m == mint) {
+                token_ratios.push((mint, ratio));
+            }
+        }
+
+        let tokens_to_search = self.filter_tokens_for_search(&token_ratios, &config);
 
         if tokens_to_search.is_empty() {
             return vec![];
@@ -508,11 +523,10 @@ impl MultiHopArbitrage {
         self.search_from_tokens(&tokens_to_search, &config, component, build, run_id)
     }
 
-    /// Filter tokens that should be searched (cooldown + price change check)
+    /// Filter tokens that should be searched (cooldown + per-mint price change check)
     fn filter_tokens_for_search(
         &self,
-        tokens: &[Pubkey],
-        new_price_ratio: u64,
+        token_ratios: &[(Pubkey, u64)],
         config: &MultiHopConfig,
     ) -> Vec<Pubkey> {
         let now = Instant::now();
@@ -520,7 +534,7 @@ impl MultiHopArbitrage {
         let mut state = self.token_state.write();
         let mut result = Vec::new();
 
-        for &token in tokens {
+        for &(token, new_price_ratio) in token_ratios {
             let entry = state.entry(token).or_insert(TokenSearchState {
                 last_search: Instant::now() - cooldown, // Allow immediate first search
                 last_price_ratio: None,
@@ -534,7 +548,7 @@ impl MultiHopArbitrage {
                 continue;
             }
 
-            // Check price change threshold
+            // Check price change threshold (directional ratio for this mint)
             if let Some(last_ratio) = entry.last_price_ratio {
                 let change_bps = if last_ratio > 0 {
                     ((new_price_ratio as i64 - last_ratio as i64).abs() * 10_000
@@ -605,8 +619,8 @@ impl MultiHopArbitrage {
         let ranker = PoolRanker::with_config(ranker_config, self.quote_provider.clone());
         let finder = BeamCycleFinder::new(finder_config, ranker);
 
-        // Find cycles (searches from WSOL through the graph)
-        let cycles = finder.find_cycles(&self.graph);
+        // Targeted search: only expand subgraph around affected tokens
+        let cycles = finder.find_cycles_through(&self.graph, tokens);
         self.cycles_found
             .fetch_add(cycles.len() as u64, Ordering::Relaxed);
 
@@ -936,12 +950,28 @@ mod tests {
         let out = provider
             .get_cached_probe_quote(&pool, DexType::RaydiumAmmV4, &wsol, &token, probe)
             .expect("LivePoolCache quote expected");
-        let default_out = (probe as f64 * 0.99) as u64;
-        assert_ne!(
-            out, default_out,
-            "LivePoolCache quote must differ from conservative default"
-        );
         assert!(out > 0);
+    }
+
+    #[test]
+    fn test_get_quote_without_cache_returns_none() {
+        let provider = CachedQuoteProvider::new(Duration::from_secs(30), create_shared_cache());
+
+        let pool = Pubkey::new_unique();
+        let input = Pubkey::new_unique();
+        let output = Pubkey::new_unique();
+
+        let result = provider.get_quote(
+            &pool,
+            DexType::RaydiumAmmV4,
+            &input,
+            &output,
+            PROBE_LAMPORTS,
+        );
+        assert!(
+            result.is_none(),
+            "get_quote must return None without cache data"
+        );
     }
 
     #[test]

--- a/src/arbitrage/pool_ranker.rs
+++ b/src/arbitrage/pool_ranker.rs
@@ -235,14 +235,25 @@ impl<Q: QuoteProvider> PoolRanker<Q> {
     }
 
     /// Whether a fresh cached probe quote exists for this hop direction.
+    ///
+    /// Uses the same `probe_amount` as beam expansion (`rank_single_pool`) so the
+    /// final cycle gate cannot reject hops that were already ranked successfully.
     pub fn hop_has_cached_quote(
         &self,
         pool_address: &Pubkey,
+        dex: DexType,
         input_mint: &Pubkey,
         output_mint: &Pubkey,
     ) -> bool {
         self.quote_provider
-            .has_cached_quote(pool_address, input_mint, output_mint)
+            .get_cached_probe_quote(
+                pool_address,
+                dex,
+                input_mint,
+                output_mint,
+                self.config.probe_amount,
+            )
+            .is_some()
     }
 
     fn update_max_edge_ratios(&self, updates: Vec<(Pubkey, f64)>) {

--- a/src/arbitrage/pool_ranker.rs
+++ b/src/arbitrage/pool_ranker.rs
@@ -234,6 +234,17 @@ impl<Q: QuoteProvider> PoolRanker<Q> {
         self.max_edge_ratio.write().clear();
     }
 
+    /// Whether a fresh cached probe quote exists for this hop direction.
+    pub fn hop_has_cached_quote(
+        &self,
+        pool_address: &Pubkey,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+    ) -> bool {
+        self.quote_provider
+            .has_cached_quote(pool_address, input_mint, output_mint)
+    }
+
     fn update_max_edge_ratios(&self, updates: Vec<(Pubkey, f64)>) {
         if updates.is_empty() {
             return;
@@ -253,6 +264,8 @@ impl<Q: QuoteProvider> PoolRanker<Q> {
 #[cfg(any(test, feature = "test_helpers"))]
 pub struct MockQuoteProvider {
     quotes: HashMap<(Pubkey, Pubkey, Pubkey), u64>, // (pool, input, output) -> quote
+    /// Probe-quote lookups (for subgraph search tests).
+    probe_lookups: std::sync::atomic::AtomicU64,
 }
 
 #[cfg(any(test, feature = "test_helpers"))]
@@ -260,7 +273,18 @@ impl MockQuoteProvider {
     pub fn new() -> Self {
         Self {
             quotes: HashMap::new(),
+            probe_lookups: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    pub fn probe_lookup_count(&self) -> u64 {
+        self.probe_lookups
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn reset_probe_lookup_count(&self) {
+        self.probe_lookups
+            .store(0, std::sync::atomic::Ordering::Relaxed);
     }
 
     pub fn add_quote(
@@ -275,12 +299,50 @@ impl MockQuoteProvider {
         let _ = input_amount; // We ignore input amount for simplicity in mock
         self.quotes.insert((pool, input, output), output_amount);
     }
+
+    pub fn remove_quote(&mut self, pool: Pubkey, input: Pubkey, output: Pubkey) {
+        self.quotes.remove(&(pool, input, output));
+    }
 }
 
 #[cfg(any(test, feature = "test_helpers"))]
 impl Default for MockQuoteProvider {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(any(test, feature = "test_helpers"))]
+impl QuoteProvider for std::sync::Arc<MockQuoteProvider> {
+    fn get_quote(
+        &self,
+        pool_address: &Pubkey,
+        dex: DexType,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+        amount_in: u64,
+    ) -> Option<u64> {
+        (**self).get_quote(pool_address, dex, input_mint, output_mint, amount_in)
+    }
+
+    fn has_cached_quote(
+        &self,
+        pool_address: &Pubkey,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+    ) -> bool {
+        (**self).has_cached_quote(pool_address, input_mint, output_mint)
+    }
+
+    fn get_cached_probe_quote(
+        &self,
+        pool_address: &Pubkey,
+        dex: DexType,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+        amount_in: u64,
+    ) -> Option<u64> {
+        (**self).get_cached_probe_quote(pool_address, dex, input_mint, output_mint, amount_in)
     }
 }
 
@@ -297,6 +359,32 @@ impl QuoteProvider for MockQuoteProvider {
         self.quotes
             .get(&(*pool_address, *input_mint, *output_mint))
             .copied()
+    }
+
+    fn has_cached_quote(
+        &self,
+        pool_address: &Pubkey,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+    ) -> bool {
+        self.quotes
+            .contains_key(&(*pool_address, *input_mint, *output_mint))
+    }
+
+    fn get_cached_probe_quote(
+        &self,
+        pool_address: &Pubkey,
+        dex: DexType,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+        amount_in: u64,
+    ) -> Option<u64> {
+        self.probe_lookups
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if !self.has_cached_quote(pool_address, input_mint, output_mint) {
+            return None;
+        }
+        self.get_quote(pool_address, dex, input_mint, output_mint, amount_in)
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Behebt den Prod-Befund (219M `multi_hop_hop_missing_quote_total` / ~370k/s, >100% CPU im arb-strategy-Prozess): synthetische Quote-Fallbacks und Full-Graph-Beam-Search werden durch echte Quote-Gates und gezielte Subgraph-Suche ersetzt.

## Änderungen

1. **Quote-Fallback entfernt** (`multi_hop_integration.rs`): `CachedQuoteProvider::get_quote` gibt bei Miss `None` zurück (Zähler `multi_hop_hop_missing_quote_inc` bleibt). Feld `default_edge_ratio` entfernt.

2. **Beam-Expansion gegated** (`pool_ranker.rs`, `cycle_finder.rs`): Pools ohne echte Probe-Quote (Trade-Cache oder LivePoolCache) werden nicht expandiert. Zyklen werden nur gemeldet, wenn alle Hops `has_cached_quote` erfüllen.

3. **Gezielte Suche** (`multi_hop_integration.rs`, `cycle_finder.rs`): `search_from_tokens` nutzt `find_cycles_through` mit BFS-Subgraph um betroffene Tokens (max_hops). Kein `find_cycles(&graph)` Full-Graph mehr pro Preis-Update.

4. **Ratio pro Mint** (`multi_hop_integration.rs`): `filter_tokens_for_search` erhält pro Mint das richtungsbezogene Ratio (Input vs. Output der Trade-Richtung).

5. **Tests**: (a) `get_quote` ohne Cache → `None`, (b) Zyklus mit quote-losem Hop wird nicht gemeldet, (c) `find_cycles_through` weniger Probe-Lookups als Full-Graph.

## Invarianten

- Keine neuen RPC-Calls (I-7)
- LivePoolCache/Trade-Cache autoritativ im Hot Path (I-4, I-16)
- Keine synthetischen Quote-Werte (I-15)
- Öffentliche API von `MultiHopArbitrage` unverändert (`on_pool_price_update`, `search_from_tokens`, Konstruktoren)
- Keine Änderungen an `arb_strategy.rs`

## Verification

```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc017417-593b-44b1-a709-a63d8baaf717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc017417-593b-44b1-a709-a63d8baaf717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

