### PR TITLE
Sim/Send-Vereinheitlichung: VersionedTransaction (I-9)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -13083,10 +13083,7 @@ mod execution_engine_tests {
         data.extend_from_slice(&lamports.to_le_bytes());
         Instruction {
             program_id: solana_system_program::id(),
-            accounts: vec![
-                AccountMeta::new(*from, true),
-                AccountMeta::new(*to, false),
-            ],
+            accounts: vec![AccountMeta::new(*from, true), AccountMeta::new(*to, false)],
             data,
         }
     }

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -12140,6 +12140,18 @@ fn check_versioned_tx_size(tx: &VersionedTransaction) -> Result<(), String> {
     Ok(())
 }
 
+/// Build + size-gate the unsigned TX used for simulation (same form as send, no RPC yet).
+fn prepare_unsigned_versioned_tx_for_simulation(
+    wallet_pubkey: &Pubkey,
+    plan: &tx_builder::TxPlan,
+    blockhash: Hash,
+    alt: Option<&ironcrab::solana::address_lookup_table::LoadedAlt>,
+) -> Result<VersionedTransaction, String> {
+    let tx = build_unsigned_versioned_tx(wallet_pubkey, plan, blockhash, alt)?;
+    check_versioned_tx_size(&tx)?;
+    Ok(tx)
+}
+
 /// Real RPC simulation (RS-3.1).
 ///
 /// Notes:
@@ -12163,7 +12175,7 @@ async fn simulate_transaction(
         }
     };
 
-    let tx_result = build_unsigned_versioned_tx(
+    let tx_result = prepare_unsigned_versioned_tx_for_simulation(
         &wallet_pubkey,
         plan,
         blockhash,
@@ -13036,11 +13048,11 @@ async fn spawn_rebroadcast_loop(
 mod execution_engine_tests {
     use super::{
         apply_scope48_confirmed_sell_execution_metadata, build_signed_versioned_tx,
-        build_unsigned_versioned_tx, check_versioned_tx_size,
-        cold_path_dex_sim_failure_triggers_discovery_recovery, is_cold_path_recovery_sell,
-        is_pump_amm_structural_sim_error, is_pumpfun_bonding_curve_structural_sim_error,
-        is_regular_momentum_hot_path_sell, liquidation_pumpfun_sell_preference,
-        liquidation_store_multi_pool_fallback_metadata, max_open_positions_buy_gate,
+        build_unsigned_versioned_tx, cold_path_dex_sim_failure_triggers_discovery_recovery,
+        is_cold_path_recovery_sell, is_pump_amm_structural_sim_error,
+        is_pumpfun_bonding_curve_structural_sim_error, is_regular_momentum_hot_path_sell,
+        liquidation_pumpfun_sell_preference, liquidation_store_multi_pool_fallback_metadata,
+        max_open_positions_buy_gate, prepare_unsigned_versioned_tx_for_simulation,
         pump_amm_hint_pool_cache_usable_for_tx_plan_builder,
         pump_amm_hot_path_quote_not_ready_detail, pump_amm_liquidation_discovery_force_refresh,
         pump_amm_liquidation_quote_timeout_str, pump_amm_pool_market_hint_merge,
@@ -13130,9 +13142,7 @@ mod execution_engine_tests {
         assert!(matches!(unsigned.message, VersionedMessage::V0(_)));
     }
 
-    #[test]
-    fn tx_size_check_rejects_oversized_serialized_transaction() {
-        let wallet = Keypair::new();
+    fn oversized_legacy_tx_plan(wallet: &Keypair) -> (TxPlan, Hash) {
         let blockhash = Hash::new_unique();
         let mut instructions = Vec::new();
         for _ in 0..40 {
@@ -13142,10 +13152,27 @@ mod execution_engine_tests {
                 1,
             ));
         }
-        let plan = TxPlan { instructions };
+        (TxPlan { instructions }, blockhash)
+    }
+
+    #[test]
+    fn tx_size_check_rejects_oversized_serialized_transaction_on_send_path() {
+        let wallet = Keypair::new();
+        let (plan, blockhash) = oversized_legacy_tx_plan(&wallet);
         let tx = build_signed_versioned_tx(&wallet.pubkey(), &plan, blockhash, None, &[&wallet])
             .unwrap();
-        let err = check_versioned_tx_size(&tx).expect_err("oversized legacy tx should be rejected");
+        let err = super::check_versioned_tx_size(&tx)
+            .expect_err("oversized legacy tx should be rejected on send");
+        assert!(err.starts_with("tx_too_large:"));
+    }
+
+    #[test]
+    fn oversized_tx_rejected_before_simulation() {
+        let wallet = Keypair::new();
+        let (plan, blockhash) = oversized_legacy_tx_plan(&wallet);
+        let err =
+            prepare_unsigned_versioned_tx_for_simulation(&wallet.pubkey(), &plan, blockhash, None)
+                .expect_err("oversized legacy tx should be rejected before simulation RPC");
         assert!(err.starts_with("tx_too_large:"));
     }
 

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -37,7 +37,11 @@ use solana_message::{v0, AddressLookupTableAccount, VersionedMessage};
 use solana_sdk::bs58;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
-use solana_sdk::transaction::Transaction;
+use solana_sdk::{
+    hash::Hash,
+    signature::Signer,
+    transaction::{Transaction, VersionedTransaction},
+};
 use solana_transaction_status::{
     EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding, UiTransactionTokenBalance,
 };
@@ -10810,7 +10814,7 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
     let mut bundle_id: Option<String> = None;
     let mut send_signature: Option<String> = None;
     let mut send_method_used: Option<String> = None;
-    let mut sent_tx: Option<Transaction> = None;
+    let mut sent_tx: Option<VersionedTransaction> = None;
     let mut sent_anything = false;
     let mut send_failed = false;
     let mut slot_at_send: Option<u64> = None;
@@ -11093,7 +11097,7 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                     record_tx_priority_fee_source(priority_fee_selection.source);
                     send_signature = Some(result.signature.clone());
                     send_method_used = Some(result.method.clone());
-                    sent_tx = Some(result.tx);
+                    sent_tx = Some(result.vtx);
                     checks.push(CheckResult {
                         check_name: "send".to_string(),
                         passed: true,
@@ -12064,79 +12068,107 @@ async fn emit_sim_failed_decision(
     Err(anyhow::anyhow!("Simulation failed: {}", sim_error_str))
 }
 
+/// Solana wire-format size limit for serialized transactions.
+const MAX_SERIALIZED_TX_BYTES: usize = 1232;
+
+/// Build the versioned message shared by simulation and send.
+///
+/// v0+ALT when an ALT is configured, otherwise legacy.
+fn build_versioned_message(
+    wallet_pubkey: &Pubkey,
+    plan: &tx_builder::TxPlan,
+    blockhash: Hash,
+    alt: Option<&ironcrab::solana::address_lookup_table::LoadedAlt>,
+) -> Result<VersionedMessage, String> {
+    if let Some(alt) = alt {
+        let alt_account = AddressLookupTableAccount {
+            key: alt.address,
+            addresses: alt.accounts.clone(),
+        };
+        v0::Message::try_compile(wallet_pubkey, &plan.instructions, &[alt_account], blockhash)
+            .map(VersionedMessage::V0)
+            .map_err(|e| format!("v0_compile_error:{e}"))
+    } else {
+        let message = solana_sdk::message::Message::new_with_blockhash(
+            &plan.instructions,
+            Some(wallet_pubkey),
+            &blockhash,
+        );
+        Ok(VersionedMessage::Legacy(message))
+    }
+}
+
+/// Unsigned versioned transaction for RPC simulation (`sig_verify=false`).
+fn build_unsigned_versioned_tx(
+    wallet_pubkey: &Pubkey,
+    plan: &tx_builder::TxPlan,
+    blockhash: Hash,
+    alt: Option<&ironcrab::solana::address_lookup_table::LoadedAlt>,
+) -> Result<VersionedTransaction, String> {
+    let message = build_versioned_message(wallet_pubkey, plan, blockhash, alt)?;
+    Ok(VersionedTransaction {
+        signatures: vec![Signature::default()],
+        message,
+    })
+}
+
+/// Signed versioned transaction for send and rebroadcast.
+fn build_signed_versioned_tx(
+    wallet_pubkey: &Pubkey,
+    plan: &tx_builder::TxPlan,
+    blockhash: Hash,
+    alt: Option<&ironcrab::solana::address_lookup_table::LoadedAlt>,
+    signers: &[&dyn Signer],
+) -> Result<VersionedTransaction, String> {
+    let message = build_versioned_message(wallet_pubkey, plan, blockhash, alt)?;
+    VersionedTransaction::try_new(message, signers).map_err(|e| format!("sign_error:{e}"))
+}
+
+fn versioned_tx_serialized_len(tx: &VersionedTransaction) -> Result<usize, String> {
+    bincode::serialize(tx)
+        .map(|bytes| bytes.len())
+        .map_err(|e| format!("serialize_error:{e}"))
+}
+
+fn check_versioned_tx_size(tx: &VersionedTransaction) -> Result<(), String> {
+    let size = versioned_tx_serialized_len(tx)?;
+    if size > MAX_SERIALIZED_TX_BYTES {
+        return Err(format!(
+            "tx_too_large:{size}_bytes_max_{MAX_SERIALIZED_TX_BYTES}"
+        ));
+    }
+    Ok(())
+}
+
 /// Real RPC simulation (RS-3.1).
 ///
 /// Notes:
 /// - Uses `sig_verify=false` (unsigned tx is fine for simulation).
 /// - Uses `replace_recent_blockhash=true` so simulation does not depend on blockhash freshness.
-/// - Uses Versioned Transaction (v0) with Address Lookup Table if configured.
+/// - Uses the same message form as send (v0+ALT or legacy).
 async fn simulate_transaction(
     ctx: &ExecutionContext,
     wallet_pubkey: Pubkey,
     plan: &tx_builder::TxPlan,
 ) -> SimulationResult {
-    use solana_sdk::transaction::VersionedTransaction;
-
-    // Build Versioned Transaction with ALT if available
-    let tx_result: Result<VersionedTransaction, String> =
-        if let Some(ref alt) = ctx.address_lookup_table {
-            // Use v0 message with ALT for size reduction
-            let alt_account = AddressLookupTableAccount {
-                key: alt.address,
-                addresses: alt.accounts.clone(),
+    let blockhash = match ctx.get_latest_blockhash().await {
+        Ok(hash) => hash,
+        Err(e) => {
+            return SimulationResult {
+                success: false,
+                error_code: Some(format!("blockhash_error:{e}")),
+                logs_preview: None,
+                compute_units_consumed: None,
             };
+        }
+    };
 
-            // Get a recent blockhash (Geyser cache → RPC fallback)
-            let blockhash = match ctx.get_latest_blockhash().await {
-                Ok(hash) => hash,
-                Err(e) => {
-                    return SimulationResult {
-                        success: false,
-                        error_code: Some(format!("blockhash_error:{e}")),
-                        logs_preview: None,
-                        compute_units_consumed: None,
-                    };
-                }
-            };
-
-            match v0::Message::try_compile(
-                &wallet_pubkey,
-                &plan.instructions,
-                &[alt_account],
-                blockhash,
-            ) {
-                Ok(message) => {
-                    let versioned_message = VersionedMessage::V0(message);
-                    // Create unsigned versioned transaction
-                    Ok(VersionedTransaction {
-                        signatures: vec![solana_sdk::signature::Signature::default()],
-                        message: versioned_message,
-                    })
-                }
-                Err(e) => Err(format!("v0_compile_error:{e}")),
-            }
-        } else {
-            // Fallback to legacy transaction (will fail if too large)
-            let blockhash = match ctx.get_latest_blockhash().await {
-                Ok(hash) => hash,
-                Err(e) => {
-                    return SimulationResult {
-                        success: false,
-                        error_code: Some(format!("blockhash_error:{e}")),
-                        logs_preview: None,
-                        compute_units_consumed: None,
-                    };
-                }
-            };
-            let message = solana_sdk::message::Message::new_with_blockhash(
-                &plan.instructions,
-                Some(&wallet_pubkey),
-                &blockhash,
-            );
-            Ok(VersionedTransaction::from(Transaction::new_unsigned(
-                message,
-            )))
-        };
+    let tx_result = build_unsigned_versioned_tx(
+        &wallet_pubkey,
+        plan,
+        blockhash,
+        ctx.address_lookup_table.as_ref(),
+    );
 
     let tx = match tx_result {
         Ok(tx) => tx,
@@ -12209,9 +12241,6 @@ async fn send_transaction_rpc(
     skip_preflight: bool,
     preflight_commitment: Option<CommitmentLevel>,
 ) -> std::result::Result<String, String> {
-    use solana_sdk::message::{v0, VersionedMessage};
-    use solana_sdk::transaction::VersionedTransaction;
-
     TX_SEND_ATTEMPTS_TOTAL.fetch_add(1, Ordering::Relaxed);
     let treasury = ctx
         .treasury
@@ -12221,35 +12250,14 @@ async fn send_transaction_rpc(
     let signer = treasury.signer_ref();
     let blockhash = ctx.get_latest_blockhash().await?;
 
-    // Build Versioned Transaction with ALT if available
-    let tx: VersionedTransaction = if let Some(ref alt) = ctx.address_lookup_table {
-        // Use v0 message with ALT for size reduction
-        let alt_account = AddressLookupTableAccount {
-            key: alt.address,
-            addresses: alt.accounts.clone(),
-        };
-
-        let message = v0::Message::try_compile(
-            &wallet_pubkey,
-            &plan.instructions,
-            &[alt_account],
-            blockhash,
-        )
-        .map_err(|e| format!("v0_compile_error:{e}"))?;
-
-        let versioned_message = VersionedMessage::V0(message);
-        VersionedTransaction::try_new(versioned_message, &[signer])
-            .map_err(|e| format!("v0_sign_error:{e}"))?
-    } else {
-        // Fallback to legacy transaction
-        let legacy_tx = Transaction::new_signed_with_payer(
-            &plan.instructions,
-            Some(&wallet_pubkey),
-            &[signer],
-            blockhash,
-        );
-        VersionedTransaction::from(legacy_tx)
-    };
+    let tx = build_signed_versioned_tx(
+        &wallet_pubkey,
+        plan,
+        blockhash,
+        ctx.address_lookup_table.as_ref(),
+        &[signer],
+    )?;
+    check_versioned_tx_size(&tx)?;
 
     let config = RpcSendTransactionConfig {
         skip_preflight,
@@ -12270,8 +12278,8 @@ async fn send_transaction_rpc(
 /// Send transaction result with method tracking
 struct SendTxResult {
     signature: String,
-    method: String,  // "tpu", "jito", "rpc"
-    tx: Transaction, // signed legacy transaction (for rebroadcast during confirm)
+    method: String,            // "tpu", "jito", "rpc"
+    vtx: VersionedTransaction, // exact signed TX for rebroadcast during confirm
     slot_at_send: u64,
 }
 
@@ -12298,18 +12306,22 @@ async fn send_transaction_with_fallback(
     let signer = treasury.signer_ref();
     let blockhash_for_send = ctx.get_latest_blockhash_for_send().await?;
 
-    // Build legacy Transaction for TxSender (TxSender handles signing internally for TPU)
-    // Note: We sign here because TxSender.send_with_fallback() expects a signed Transaction
-    let tx = Transaction::new_signed_with_payer(
-        &plan.instructions,
-        Some(&wallet_pubkey),
-        &[signer],
+    // Same message form as simulation: v0+ALT when configured, else legacy.
+    let vtx = build_signed_versioned_tx(
+        &wallet_pubkey,
+        plan,
         blockhash_for_send.hash,
-    );
+        ctx.address_lookup_table.as_ref(),
+        &[signer],
+    )?;
+    check_versioned_tx_size(&vtx)?;
 
     // If TxSender is available, use it for the fallback chain
     if let Some(ref tx_sender) = ctx.tx_sender {
-        match tx_sender.send_with_fallback(&tx, require_bundle).await {
+        match tx_sender
+            .send_versioned_with_fallback(&vtx, require_bundle)
+            .await
+        {
             Ok(result) => {
                 let method_str = result.method.to_string();
                 info!(
@@ -12322,7 +12334,7 @@ async fn send_transaction_with_fallback(
                 return Ok(SendTxResult {
                     signature: result.signature.to_string(),
                     method: method_str,
-                    tx,
+                    vtx,
                     slot_at_send: blockhash_for_send.slot,
                 });
             }
@@ -12346,18 +12358,11 @@ async fn send_transaction_with_fallback(
     // Reuse the *exact* signed transaction we are sending as `sent_tx` for any rebroadcasts
     // during confirmation polling. Creating a new Transaction here could change the signature
     // (e.g. if blockhash changes or signing is not perfectly deterministic).
-    let versioned = solana_sdk::transaction::VersionedTransaction::from(tx.clone());
-
-    match ctx
-        .rpc
-        .rpc
-        .send_transaction_with_config(&versioned, config)
-        .await
-    {
+    match ctx.rpc.rpc.send_transaction_with_config(&vtx, config).await {
         Ok(sig) => Ok(SendTxResult {
             signature: sig.to_string(),
             method: "rpc".into(),
-            tx,
+            vtx,
             slot_at_send: blockhash_for_send.slot,
         }),
         Err(e) => Err(format!("rpc_error:{e}")),
@@ -12681,7 +12686,7 @@ async fn confirm_signature_status(
     ctx: &ExecutionContext,
     signature_base58: &str,
     timeout_ms: u64,
-    rebroadcast_tx: Option<&Transaction>,
+    rebroadcast_tx: Option<&VersionedTransaction>,
     pre_registered_rx: Option<tokio::sync::oneshot::Receiver<WalletTxConfirmNotify>>,
     slot_at_send: Option<u64>,
 ) -> std::result::Result<(ConfirmOutcome, u32), String> {
@@ -12928,7 +12933,7 @@ async fn spawn_rebroadcast_loop(
     tx_sender: Option<Arc<TxSender>>,
     rebroadcast_use_tpu: bool,
     signature_base58: &str,
-    tx: Transaction,
+    vtx: VersionedTransaction,
     deadline: Duration,
     interval_ms: u64,
     max_rebroadcasts: u32,
@@ -12947,7 +12952,7 @@ async fn spawn_rebroadcast_loop(
 
         if rebroadcast_use_tpu {
             if let Some(ref sender) = tx_sender {
-                match sender.send_tpu_then_rpc(&tx).await {
+                match sender.send_versioned_tpu_then_rpc(&vtx).await {
                     Ok(result) => {
                         rebroadcasts += 1;
                         rebroadcast_count.store(rebroadcasts, Ordering::Relaxed);
@@ -12987,7 +12992,6 @@ async fn spawn_rebroadcast_loop(
                 min_context_slot: None,
             };
 
-            let vtx = solana_sdk::transaction::VersionedTransaction::from(tx.clone());
             match rpc.rpc.send_transaction_with_config(&vtx, cfg).await {
                 Ok(sig) => {
                     rebroadcasts += 1;
@@ -13031,7 +13035,8 @@ async fn spawn_rebroadcast_loop(
 #[cfg(test)]
 mod execution_engine_tests {
     use super::{
-        apply_scope48_confirmed_sell_execution_metadata,
+        apply_scope48_confirmed_sell_execution_metadata, build_signed_versioned_tx,
+        build_unsigned_versioned_tx, check_versioned_tx_size,
         cold_path_dex_sim_failure_triggers_discovery_recovery, is_cold_path_recovery_sell,
         is_pump_amm_structural_sim_error, is_pumpfun_bonding_curve_structural_sim_error,
         is_regular_momentum_hot_path_sell, liquidation_pumpfun_sell_preference,
@@ -13052,18 +13057,100 @@ mod execution_engine_tests {
         CachedPoolState, LivePoolCache, MeteoraState, PumpAmmState, PumpFunState,
     };
     use ironcrab::execution::pool_cache_sync::apply_pool_cache_update;
+    use ironcrab::execution::tx_builder::TxPlan;
     use ironcrab::ipc::{
         ControlResponse, ControlResponseStatus, DexPoolReadiness, ExecutionResult, ExecutionStatus,
         ExplicitAmount, IntentOrigin, IntentTier, PoolCacheUpdate, TradeIntent, TradeResources,
         TradeSide, TradingRegime,
     };
+    use ironcrab::solana::address_lookup_table::LoadedAlt;
     use ironcrab::solana::dex::pumpfun::PumpFunDex;
     use ironcrab::storage::locks::{LockHolder, LockManager, LockResult};
     use parking_lot::Mutex as ParkingMutex;
-    use solana_sdk::pubkey::Pubkey;
+    use solana_message::VersionedMessage;
+    use solana_sdk::{
+        hash::Hash,
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+    };
     use std::collections::HashMap;
     use std::str::FromStr;
     use std::time::Instant;
+
+    fn test_system_transfer(from: &Pubkey, to: &Pubkey, lamports: u64) -> Instruction {
+        let mut data = vec![2, 0, 0, 0];
+        data.extend_from_slice(&lamports.to_le_bytes());
+        Instruction {
+            program_id: solana_system_program::id(),
+            accounts: vec![
+                AccountMeta::new(*from, true),
+                AccountMeta::new(*to, false),
+            ],
+            data,
+        }
+    }
+
+    #[test]
+    fn sim_and_send_share_identical_message_without_alt() {
+        let wallet = Keypair::new();
+        let blockhash = Hash::new_unique();
+        let recipient = Pubkey::new_unique();
+        let plan = TxPlan {
+            instructions: vec![test_system_transfer(&wallet.pubkey(), &recipient, 1)],
+        };
+
+        let unsigned = build_unsigned_versioned_tx(&wallet.pubkey(), &plan, blockhash, None)
+            .expect("unsigned legacy tx");
+        let signed =
+            build_signed_versioned_tx(&wallet.pubkey(), &plan, blockhash, None, &[&wallet])
+                .expect("signed legacy tx");
+
+        assert_eq!(unsigned.message, signed.message);
+        assert!(matches!(unsigned.message, VersionedMessage::Legacy(_)));
+    }
+
+    #[test]
+    fn sim_and_send_share_identical_message_with_alt() {
+        let wallet = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        let blockhash = Hash::new_unique();
+        let alt = LoadedAlt {
+            address: Pubkey::new_unique(),
+            accounts: vec![recipient],
+        };
+        let plan = TxPlan {
+            instructions: vec![test_system_transfer(&wallet.pubkey(), &recipient, 1)],
+        };
+
+        let unsigned = build_unsigned_versioned_tx(&wallet.pubkey(), &plan, blockhash, Some(&alt))
+            .expect("unsigned v0 tx");
+        let signed =
+            build_signed_versioned_tx(&wallet.pubkey(), &plan, blockhash, Some(&alt), &[&wallet])
+                .expect("signed v0 tx");
+
+        assert_eq!(unsigned.message, signed.message);
+        assert!(matches!(unsigned.message, VersionedMessage::V0(_)));
+    }
+
+    #[test]
+    fn tx_size_check_rejects_oversized_serialized_transaction() {
+        let wallet = Keypair::new();
+        let blockhash = Hash::new_unique();
+        let mut instructions = Vec::new();
+        for _ in 0..40 {
+            instructions.push(test_system_transfer(
+                &wallet.pubkey(),
+                &Pubkey::new_unique(),
+                1,
+            ));
+        }
+        let plan = TxPlan { instructions };
+        let tx = build_signed_versioned_tx(&wallet.pubkey(), &plan, blockhash, None, &[&wallet])
+            .unwrap();
+        let err = check_versioned_tx_size(&tx).expect_err("oversized legacy tx should be rejected");
+        assert!(err.starts_with("tx_too_large:"));
+    }
 
     #[test]
     fn max_open_positions_gate_rejects_when_lock_manager_exceeds_metadata() {

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -12194,6 +12194,15 @@ async fn simulate_transaction(
         }
     };
 
+    if let Err(e) = check_versioned_tx_size(&tx) {
+        return SimulationResult {
+            success: false,
+            error_code: Some(e),
+            logs_preview: None,
+            compute_units_consumed: None,
+        };
+    }
+
     let cfg = RpcSimulateTransactionConfig {
         sig_verify: false,
         replace_recent_blockhash: true,

--- a/src/solana/tpu_client.rs
+++ b/src/solana/tpu_client.rs
@@ -25,7 +25,10 @@
 //! - This module provides health checks and automatic reconnection
 
 use anyhow::Result;
-use solana_sdk::{signature::Signature, transaction::Transaction};
+use solana_sdk::{
+    signature::Signature,
+    transaction::{Transaction, VersionedTransaction},
+};
 use std::sync::Arc;
 
 #[cfg(not(windows))]
@@ -174,6 +177,32 @@ impl TpuSubmitter {
 
         // try_send_transaction returns TransportResult
         match client.try_send_transaction(tx) {
+            Ok(()) => {
+                self.consecutive_failures
+                    .store(0, std::sync::atomic::Ordering::Relaxed);
+                Ok(signature)
+            }
+            Err(e) => {
+                self.consecutive_failures
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                Err(TpuError::SendFailed(format!("{:?}", e)))
+            }
+        }
+    }
+
+    /// Send a versioned transaction (v0+ALT or legacy) via TPU Direct wire format.
+    pub async fn send_versioned_transaction(
+        &self,
+        tx: &VersionedTransaction,
+    ) -> Result<Signature, TpuError> {
+        let guard = self.tpu_client.read().await;
+        let client = guard.as_ref().ok_or(TpuError::NotInitialized)?;
+
+        let signature = tx.signatures.first().copied().unwrap_or_default();
+        let wire_transaction =
+            bincode::serialize(tx).map_err(|e| TpuError::SendFailed(format!("serialize: {e}")))?;
+
+        match client.try_send_wire_transaction(wire_transaction) {
             Ok(()) => {
                 self.consecutive_failures
                     .store(0, std::sync::atomic::Ordering::Relaxed);
@@ -336,6 +365,13 @@ impl TpuSubmitter {
     }
 
     pub async fn send_transaction(&self, _tx: &Transaction) -> Result<Signature, TpuError> {
+        Err(TpuError::NotSupported)
+    }
+
+    pub async fn send_versioned_transaction(
+        &self,
+        _tx: &VersionedTransaction,
+    ) -> Result<Signature, TpuError> {
         Err(TpuError::NotSupported)
     }
 

--- a/src/solana/tx_sender.rs
+++ b/src/solana/tx_sender.rs
@@ -19,7 +19,10 @@ use crate::solana::tpu_client::{TpuError, TpuSubmitter, TpuSubmitterConfig};
 use anyhow::Result;
 use solana_client::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
-use solana_sdk::{signature::Signature, transaction::Transaction};
+use solana_sdk::{
+    signature::Signature,
+    transaction::{Transaction, VersionedTransaction},
+};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -209,6 +212,32 @@ impl TxSender {
         self.send_sequential(tx).await
     }
 
+    /// Send a versioned transaction with automatic fallback (TPU / RPC).
+    ///
+    /// Legacy `Transaction` callers should keep using [`Self::send_with_fallback`].
+    pub async fn send_versioned_with_fallback(
+        &self,
+        tx: &VersionedTransaction,
+        require_bundle: bool,
+    ) -> Result<SendResult, SendError> {
+        if require_bundle && (self.config.skip_tpu_for_bundles || self.jito.is_none()) {
+            return self
+                .send_via_jito_versioned(tx)
+                .await
+                .map(|(sig, bundle_id)| SendResult {
+                    signature: sig,
+                    method: SendMethod::JitoBundle,
+                    bundle_id: Some(bundle_id),
+                });
+        }
+
+        if self.config.parallel_send && self.tpu.is_some() {
+            return self.send_versioned_parallel(tx).await;
+        }
+
+        self.send_versioned_sequential(tx).await
+    }
+
     /// Rebroadcast-safe send: TPU and/or RPC only, never Jito.
     ///
     /// Used during confirmation wait where rebroadcast must mirror the
@@ -234,6 +263,37 @@ impl TxSender {
         }
 
         self.send_via_rpc(tx).await.map(|sig| SendResult {
+            signature: sig,
+            method: SendMethod::Rpc,
+            bundle_id: None,
+        })
+    }
+
+    /// Rebroadcast-safe versioned send: TPU and/or RPC only, never Jito.
+    pub async fn send_versioned_tpu_then_rpc(
+        &self,
+        tx: &VersionedTransaction,
+    ) -> Result<SendResult, SendError> {
+        if self.config.parallel_send && self.tpu.is_some() {
+            return self.send_versioned_parallel(tx).await;
+        }
+
+        if self.tpu.is_some() {
+            match self.send_versioned_via_tpu(tx).await {
+                Ok(sig) => {
+                    return Ok(SendResult {
+                        signature: sig,
+                        method: SendMethod::TpuDirect,
+                        bundle_id: None,
+                    });
+                }
+                Err(e) => {
+                    warn!(error = %e, "Rebroadcast: TPU failed, falling back to RPC");
+                }
+            }
+        }
+
+        self.send_versioned_via_rpc(tx).await.map(|sig| SendResult {
             signature: sig,
             method: SendMethod::Rpc,
             bundle_id: None,
@@ -374,6 +434,122 @@ impl TxSender {
         Err(last_error.unwrap_or(SendError::NoMethodAvailable))
     }
 
+    /// Sequential send with fallback chain for versioned transactions.
+    async fn send_versioned_sequential(
+        &self,
+        tx: &VersionedTransaction,
+    ) -> Result<SendResult, SendError> {
+        let methods: Vec<&str> = std::iter::once(self.config.primary_method.as_str())
+            .chain(self.config.fallback_chain.iter().map(|s| s.as_str()))
+            .collect();
+
+        debug!(methods = ?methods, "Versioned TX send method chain (sequential)");
+
+        let mut last_error: Option<SendError> = None;
+
+        for method in methods {
+            let result = match method {
+                "tpu" => self.send_versioned_via_tpu(tx).await.map(|sig| SendResult {
+                    signature: sig,
+                    method: SendMethod::TpuDirect,
+                    bundle_id: None,
+                }),
+                "jito" => self
+                    .send_via_jito_versioned(tx)
+                    .await
+                    .map(|(sig, bundle_id)| SendResult {
+                        signature: sig,
+                        method: SendMethod::JitoBundle,
+                        bundle_id: Some(bundle_id),
+                    }),
+                "rpc" => self.send_versioned_via_rpc(tx).await.map(|sig| SendResult {
+                    signature: sig,
+                    method: SendMethod::Rpc,
+                    bundle_id: None,
+                }),
+                _ => {
+                    warn!(method = method, "Unknown send method, skipping");
+                    continue;
+                }
+            };
+
+            match result {
+                Ok(send_result) => {
+                    info!(
+                        signature = %send_result.signature,
+                        method = %send_result.method,
+                        "Versioned TX sent successfully"
+                    );
+                    return Ok(send_result);
+                }
+                Err(e) => {
+                    warn!(
+                        method = method,
+                        error = %e,
+                        "Versioned send method failed, trying next"
+                    );
+                    last_error = Some(e);
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or(SendError::NoMethodAvailable))
+    }
+
+    /// Send versioned TX via TPU and RPC in parallel. First success wins.
+    async fn send_versioned_parallel(
+        &self,
+        tx: &VersionedTransaction,
+    ) -> Result<SendResult, SendError> {
+        debug!("Parallel send: TPU + RPC simultaneously (versioned)");
+
+        let tx_clone = tx.clone();
+        let tpu_future = async {
+            match self.send_versioned_via_tpu(tx).await {
+                Ok(sig) => Some((sig, SendMethod::TpuDirect)),
+                Err(e) => {
+                    warn!(error = %e, "Parallel send: TPU failed");
+                    None
+                }
+            }
+        };
+
+        let rpc_future = async {
+            match self.send_versioned_via_rpc(&tx_clone).await {
+                Ok(sig) => Some((sig, SendMethod::Rpc)),
+                Err(e) => {
+                    warn!(error = %e, "Parallel send: RPC failed");
+                    None
+                }
+            }
+        };
+
+        let (tpu_result, rpc_result) = tokio::join!(tpu_future, rpc_future);
+
+        info!(
+            tpu_ok = tpu_result.is_some(),
+            rpc_ok = rpc_result.is_some(),
+            "Parallel versioned send results collected"
+        );
+
+        match (tpu_result, rpc_result) {
+            (Some((sig, method)), _) => Ok(SendResult {
+                signature: sig,
+                method,
+                bundle_id: None,
+            }),
+            (None, Some((sig, method))) => Ok(SendResult {
+                signature: sig,
+                method,
+                bundle_id: None,
+            }),
+            (None, None) => {
+                error!("Parallel send: Both TPU and RPC failed (versioned)");
+                Err(SendError::AllMethodsFailed)
+            }
+        }
+    }
+
     /// Send via TPU Direct
     async fn send_via_tpu(&self, tx: &Transaction) -> Result<Signature, SendError> {
         let tpu = self
@@ -434,7 +610,66 @@ impl TxSender {
         Err(SendError::TpuError("Max retries exceeded".into()))
     }
 
-    /// Send via Jito bundle
+    /// Send a versioned transaction via TPU Direct.
+    async fn send_versioned_via_tpu(
+        &self,
+        tx: &VersionedTransaction,
+    ) -> Result<Signature, SendError> {
+        let tpu = self
+            .tpu
+            .as_ref()
+            .ok_or(SendError::MethodNotConfigured("tpu"))?;
+
+        if let Err(e) = tpu.check_leader_cache_health() {
+            warn!(error = %e, "Leader cache stale, attempting reconnect");
+            if tpu.can_reconnect(15_000) {
+                if let Err(reconnect_err) = tpu.reconnect().await {
+                    warn!(error = %reconnect_err, "TPU reconnect failed, continuing with stale cache");
+                }
+            }
+        }
+
+        if tpu.should_reconnect(self.config.tpu_reconnect_failure_threshold) {
+            warn!(
+                consecutive_failures = tpu.consecutive_failures(),
+                threshold = self.config.tpu_reconnect_failure_threshold,
+                "TPU client has many failures, attempting reconnect"
+            );
+            if tpu.can_reconnect(15_000) {
+                if let Err(e) = tpu.reconnect().await {
+                    warn!(error = %e, "TPU reconnect failed");
+                }
+            }
+        }
+
+        let timeout_duration = Duration::from_millis(self.config.method_timeout_ms);
+
+        for attempt in 0..self.config.retries_per_method {
+            let result = timeout(timeout_duration, tpu.send_versioned_transaction(tx)).await;
+
+            match result {
+                Ok(Ok(signature)) => return Ok(signature),
+                Ok(Err(e)) => {
+                    if attempt + 1 < self.config.retries_per_method {
+                        debug!(attempt = attempt, error = %e, "TPU versioned send failed, retrying");
+                    } else {
+                        return Err(SendError::TpuError(e.to_string()));
+                    }
+                }
+                Err(_) => {
+                    if attempt + 1 < self.config.retries_per_method {
+                        debug!(attempt = attempt, "TPU versioned send timed out, retrying");
+                    } else {
+                        return Err(SendError::Timeout("tpu"));
+                    }
+                }
+            }
+        }
+
+        Err(SendError::TpuError("Max retries exceeded".into()))
+    }
+
+    /// Send via Jito bundle (legacy transaction)
     async fn send_via_jito(&self, tx: &Transaction) -> Result<(Signature, String), SendError> {
         let jito = self
             .jito
@@ -442,7 +677,6 @@ impl TxSender {
             .ok_or(SendError::MethodNotConfigured("jito"))?;
 
         let signature = tx.signatures.first().copied().unwrap_or_default();
-
         let timeout_duration = Duration::from_millis(self.config.method_timeout_ms);
 
         for attempt in 0..self.config.retries_per_method {
@@ -464,6 +698,51 @@ impl TxSender {
                 Err(_) => {
                     if attempt + 1 < self.config.retries_per_method {
                         debug!(attempt = attempt, "Jito send timed out, retrying");
+                    } else {
+                        return Err(SendError::Timeout("jito"));
+                    }
+                }
+            }
+        }
+
+        Err(SendError::JitoError("Max retries exceeded".into()))
+    }
+
+    /// Send via Jito bundle (versioned transaction)
+    async fn send_via_jito_versioned(
+        &self,
+        tx: &VersionedTransaction,
+    ) -> Result<(Signature, String), SendError> {
+        let jito = self
+            .jito
+            .as_ref()
+            .ok_or(SendError::MethodNotConfigured("jito"))?;
+
+        let signature = tx.signatures.first().copied().unwrap_or_default();
+        let timeout_duration = Duration::from_millis(self.config.method_timeout_ms);
+
+        for attempt in 0..self.config.retries_per_method {
+            let result = timeout(
+                timeout_duration,
+                jito.send_versioned_bundle(std::slice::from_ref(tx)),
+            )
+            .await;
+
+            match result {
+                Ok(Ok(bundle_id)) => {
+                    info!(bundle_id = %bundle_id, "Jito versioned bundle submitted");
+                    return Ok((signature, bundle_id));
+                }
+                Ok(Err(e)) => {
+                    if attempt + 1 < self.config.retries_per_method {
+                        debug!(attempt = attempt, error = %e, "Jito versioned send failed, retrying");
+                    } else {
+                        return Err(SendError::JitoError(e.to_string()));
+                    }
+                }
+                Err(_) => {
+                    if attempt + 1 < self.config.retries_per_method {
+                        debug!(attempt = attempt, "Jito versioned send timed out, retrying");
                     } else {
                         return Err(SendError::Timeout("jito"));
                     }
@@ -516,6 +795,58 @@ impl TxSender {
                 Err(_) => {
                     if attempt + 1 < self.config.retries_per_method {
                         debug!(attempt = attempt, "RPC send timed out, retrying");
+                    } else {
+                        return Err(SendError::Timeout("rpc"));
+                    }
+                }
+            }
+        }
+
+        Err(SendError::RpcError("Max retries exceeded".into()))
+    }
+
+    /// Send a versioned transaction via RPC sendTransaction.
+    async fn send_versioned_via_rpc(
+        &self,
+        tx: &VersionedTransaction,
+    ) -> Result<Signature, SendError> {
+        let timeout_duration = Duration::from_millis(self.config.method_timeout_ms);
+
+        for attempt in 0..self.config.retries_per_method {
+            let rpc = Arc::clone(&self.rpc);
+            let tx_clone = tx.clone();
+
+            let result = timeout(
+                timeout_duration,
+                tokio::task::spawn_blocking(move || {
+                    rpc.send_transaction_with_config(
+                        &tx_clone,
+                        solana_client::rpc_config::RpcSendTransactionConfig {
+                            skip_preflight: true,
+                            preflight_commitment: Some(CommitmentConfig::confirmed().commitment),
+                            max_retries: Some(0),
+                            ..Default::default()
+                        },
+                    )
+                }),
+            )
+            .await;
+
+            match result {
+                Ok(Ok(Ok(signature))) => return Ok(signature),
+                Ok(Ok(Err(e))) => {
+                    if attempt + 1 < self.config.retries_per_method {
+                        debug!(attempt = attempt, error = %e, "RPC versioned send failed, retrying");
+                    } else {
+                        return Err(SendError::RpcError(e.to_string()));
+                    }
+                }
+                Ok(Err(e)) => {
+                    return Err(SendError::RpcError(format!("Task join error: {}", e)));
+                }
+                Err(_) => {
+                    if attempt + 1 < self.config.retries_per_method {
+                        debug!(attempt = attempt, "RPC versioned send timed out, retrying");
                     } else {
                         return Err(SendError::Timeout("rpc"));
                     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Behebt das Format-Mismatch zwischen Simulation und Send im `execution-engine`: Beide Pfade nutzen jetzt denselben gemeinsamen TX-Build (`build_versioned_message` / `build_signed_versioned_tx`).

- **v0+ALT** wenn Address Lookup Table konfiguriert ist
- **Legacy** sonst
- Simulierte und gesendete TX haben dieselbe Message-Form (nur Blockhash darf bei Sim via `replace_recent_blockhash=true` abweichen)

## Änderungen

### `execution_engine.rs`
- Gemeinsame Build-Hilfsfunktionen extrahiert aus dem bisherigen Sim-Pfad
- `simulate_transaction` und `send_transaction_with_fallback` / `send_transaction_rpc` nutzen dieselbe Logik
- Größen-Check vor Send: serialisierte TX muss ≤ 1232 Bytes sein (`tx_too_large:…` → Reject, kein Send-Versuch)
- `SendTxResult` speichert `VersionedTransaction` für exakte Rebroadcasts während Confirm
- Unit-Tests: Sim/Send Message-Parität mit und ohne ALT, Size-Check

### `tx_sender.rs`
- Neue Methoden: `send_versioned_with_fallback`, `send_versioned_tpu_then_rpc`
- Versioned-Pfade für TPU, RPC und Jito (parallel + sequential unverändert in Semantik)

### `tpu_client.rs` (notwendige Ergänzung für TPU-Wire-Send)
- `send_versioned_transaction` via `try_send_wire_transaction`

## Invarianten

- **I-9**: Sim und Send verwenden dieselbe Transaktionsform → Simulate-gated bleibt wirksam
- **I-7**: Keine neuen Hot-Path-RPC-Calls
- Lock-Handling, Confirm-Pfad, Fee-Logik, Rebroadcast-Regeln (TPU+RPC, kein Jito-Rebroadcast) unverändert

## Tests

```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```

Alle grün lokal.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a407d125-3d4b-4f1a-9b60-beab5add2d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a407d125-3d4b-4f1a-9b60-beab5add2d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

