### PR TITLE
perf(arbitrage): multi-hop search worker + quote-ready graph pruning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,3 +184,8 @@ name = "multi_hop_sanity"
 path = "tests/multi_hop_sanity.rs"
 required-features = ["test_helpers"]
 
+[[test]]
+name = "multi_hop_search_worker"
+path = "tests/multi_hop_search_worker.rs"
+required-features = ["test_helpers"]
+

--- a/src/arbitrage/arb_slave_sync.rs
+++ b/src/arbitrage/arb_slave_sync.rs
@@ -130,6 +130,7 @@ pub fn populate_arb_slave_from_live_pool_cache(
             liquidity_usd_from_state(&state),
             30,
         );
+        multi_hop.touch_live_pool_quote_ready(&pool_pk.to_string());
         count += 1;
     }
     ARB_KNOWN_POOLS_SYNCED_BOOTSTRAP.store(count as u64, Ordering::Relaxed);

--- a/src/arbitrage/mod.rs
+++ b/src/arbitrage/mod.rs
@@ -41,7 +41,8 @@ pub use arb_slave_sync::{
 };
 pub use cycle_finder::{BeamCycleFinder, CycleFinderConfig};
 pub use multi_hop_integration::{
-    CachedQuoteProvider, MultiHopArbitrage, MultiHopConfig, MultiHopStats, WSOL_MINT,
+    CachedQuoteProvider, MultiHopArbitrage, MultiHopConfig, MultiHopIntentBatch, MultiHopStats,
+    QuoteReadyIndex, WSOL_MINT,
 };
 pub use pool_graph::{GraphStats, PoolGraph};
 pub use pool_ranker::{PoolRanker, QuoteProvider, RankerConfig};

--- a/src/arbitrage/multi_hop_integration.rs
+++ b/src/arbitrage/multi_hop_integration.rs
@@ -24,15 +24,18 @@ use crate::ipc::{
 use crate::metrics::{
     multi_hop_cycle_rejected_sanity_inc, multi_hop_hop_missing_quote_inc,
     multi_hop_quote_from_cache_inc, multi_hop_quote_from_trade_cache_inc,
-    multi_hop_return_bps_saturated_inc, multi_hop_shadow_logged_inc, MultiHopSanityRejectReason,
+    multi_hop_return_bps_saturated_inc, multi_hop_search_worker_queue_depth_set,
+    multi_hop_searches_coalesced_inc, multi_hop_shadow_logged_inc, MultiHopSanityRejectReason,
 };
 use parking_lot::RwLock;
 use solana_sdk::pubkey::Pubkey;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::sync::{mpsc, Notify};
+use tokio::task::JoinHandle;
 use tracing::{debug, info, trace, warn};
 
 /// WSOL mint (native SOL wrapped)
@@ -43,6 +46,49 @@ const PROBE_LAMPORTS: u64 = 10_000_000;
 
 /// Top-N WSOL pools to seed trade-cache quotes after JetStream bootstrap.
 const QUOTE_WARMUP_TOP_N: usize = 1000;
+
+/// Max dirty tokens queued before new mints are dropped (existing mints still coalesce).
+const MAX_DIRTY_TOKENS: usize = 10_000;
+
+/// Intents produced by the search worker (includes originating event metadata).
+#[derive(Debug, Clone)]
+pub struct MultiHopIntentBatch {
+    pub intents: Vec<TradeIntent>,
+    pub slot: Option<u64>,
+    pub seen_at_ms: u64,
+}
+
+/// Incrementally maintained set of pools with a fresh trade-cache or LivePoolCache quote.
+#[derive(Debug, Default)]
+pub struct QuoteReadyIndex {
+    pools: RwLock<HashSet<Pubkey>>,
+}
+
+impl QuoteReadyIndex {
+    pub fn mark_ready(&self, pool: Pubkey) {
+        self.pools.write().insert(pool);
+    }
+
+    pub fn remove(&self, pool: &Pubkey) {
+        self.pools.write().remove(pool);
+    }
+
+    pub fn contains(&self, pool: &Pubkey) -> bool {
+        self.pools.read().contains(pool)
+    }
+
+    pub fn snapshot(&self) -> HashSet<Pubkey> {
+        self.pools.read().clone()
+    }
+
+    pub fn len(&self) -> usize {
+        self.pools.read().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.pools.read().is_empty()
+    }
+}
 
 /// Multi-hop arbitrage configuration
 #[derive(Debug, Clone)]
@@ -105,6 +151,8 @@ pub struct CachedQuoteProvider {
     cache_ttl: Duration,
     /// SLAVE LivePoolCache (same SSOT as execution-engine) — no RPC on miss.
     live_pool_cache: SharedLivePoolCache,
+    /// Pools with at least one quotable direction (beam expansion pruning).
+    quote_ready: QuoteReadyIndex,
 }
 
 impl CachedQuoteProvider {
@@ -113,7 +161,51 @@ impl CachedQuoteProvider {
             cache: RwLock::new(HashMap::new()),
             cache_ttl,
             live_pool_cache,
+            quote_ready: QuoteReadyIndex::default(),
         }
+    }
+
+    pub fn quote_ready_index(&self) -> &QuoteReadyIndex {
+        &self.quote_ready
+    }
+
+    /// Mark pool ready when LivePoolCache gains reserves (incremental SSOT sync).
+    pub fn mark_ready_from_live_pool_cache(&self, pool_address: &Pubkey) {
+        let Some(state) = self.live_pool_cache.get(pool_address) else {
+            return;
+        };
+        let (mint_a, mint_b) = Self::mints_from_state(&state);
+        if self
+            .try_quote_from_live_pool_cache(pool_address, &mint_a, PROBE_LAMPORTS)
+            .is_some()
+            || self
+                .try_quote_from_live_pool_cache(pool_address, &mint_b, PROBE_LAMPORTS)
+                .is_some()
+        {
+            self.quote_ready.mark_ready(*pool_address);
+        }
+    }
+
+    fn pool_still_quote_ready(&self, pool: &Pubkey) -> bool {
+        let cache = self.cache.read();
+        let now = Instant::now();
+        if cache
+            .iter()
+            .any(|((p, _, _), (_, ts))| p == pool && now.duration_since(*ts) < self.cache_ttl)
+        {
+            return true;
+        }
+        drop(cache);
+
+        let Some(state) = self.live_pool_cache.get(pool) else {
+            return false;
+        };
+        let (mint_a, mint_b) = Self::mints_from_state(&state);
+        self.try_quote_from_live_pool_cache(pool, &mint_a, PROBE_LAMPORTS)
+            .is_some()
+            || self
+                .try_quote_from_live_pool_cache(pool, &mint_b, PROBE_LAMPORTS)
+                .is_some()
     }
 
     fn mints_from_state(state: &CachedPoolState) -> (Pubkey, Pubkey) {
@@ -224,11 +316,13 @@ impl CachedQuoteProvider {
             if let Some(out) = self.try_quote_from_live_pool_cache(&pool_pk, &wsol, PROBE_LAMPORTS)
             {
                 self.update_quote(pool_pk, wsol, other, PROBE_LAMPORTS, out);
+                self.quote_ready.mark_ready(pool_pk);
                 seeded += 1;
             }
             if let Some(out) = self.try_quote_from_live_pool_cache(&pool_pk, &other, PROBE_LAMPORTS)
             {
                 self.update_quote(pool_pk, other, wsol, PROBE_LAMPORTS, out);
+                self.quote_ready.mark_ready(pool_pk);
                 seeded += 1;
             }
         }
@@ -263,6 +357,7 @@ impl CachedQuoteProvider {
             (pool, input_mint, output_mint),
             (normalized_output, Instant::now()),
         );
+        self.quote_ready.mark_ready(pool);
     }
 
     /// Get cached edge ratio for a pool direction
@@ -309,6 +404,18 @@ impl QuoteProvider for CachedQuoteProvider {
 
         multi_hop_hop_missing_quote_inc();
         None
+    }
+
+    fn is_pool_quote_ready(&self, pool_address: &Pubkey) -> bool {
+        if !self.quote_ready.contains(pool_address) {
+            return false;
+        }
+        if self.pool_still_quote_ready(pool_address) {
+            true
+        } else {
+            self.quote_ready.remove(pool_address);
+            false
+        }
     }
 
     fn has_cached_quote(
@@ -360,6 +467,11 @@ pub struct MultiHopArbitrage {
     token_state: RwLock<HashMap<Pubkey, TokenSearchState>>,
     /// Pool -> (mint_a, mint_b) reverse index for quick lookup
     pool_mints: RwLock<HashMap<Pubkey, (Pubkey, Pubkey)>>,
+    /// Coalescing queue: latest price ratio per dirty token (search worker drains).
+    dirty_tokens: RwLock<HashMap<Pubkey, u64>>,
+    /// Latest trade event metadata (slot / ts) for intent publishing.
+    latest_event_meta: RwLock<(Option<u64>, u64)>,
+    search_notify: Arc<Notify>,
     /// Stats
     searches_triggered: AtomicU64,
     searches_skipped_cooldown: AtomicU64,
@@ -380,6 +492,9 @@ impl MultiHopArbitrage {
             )),
             token_state: RwLock::new(HashMap::new()),
             pool_mints: RwLock::new(HashMap::new()),
+            dirty_tokens: RwLock::new(HashMap::new()),
+            latest_event_meta: RwLock::new((None, 0)),
+            search_notify: Arc::new(Notify::new()),
             searches_triggered: AtomicU64::new(0),
             searches_skipped_cooldown: AtomicU64::new(0),
             searches_skipped_small_change: AtomicU64::new(0),
@@ -438,10 +553,158 @@ impl MultiHopArbitrage {
         }
     }
 
-    /// EVENT-DRIVEN: Called when a pool price updates (trade observed)
-    ///
-    /// This is the main entry point for cycle detection.
-    /// Returns intents if profitable cycles found (empty if shadow_mode).
+    /// Hot-path enqueue: update quote cache and coalesce dirty tokens (O(1), no search).
+    #[allow(clippy::too_many_arguments)]
+    pub fn enqueue_pool_price_update(
+        &self,
+        pool_address: &str,
+        input_mint: &str,
+        output_mint: &str,
+        input_amount: u64,
+        output_amount: u64,
+        event_slot: Option<u64>,
+        event_seen_at_ms: u64,
+    ) {
+        if !self.config.read().enabled {
+            return;
+        }
+
+        let pool = match Pubkey::from_str(pool_address) {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let input = match Pubkey::from_str(input_mint) {
+            Ok(m) => m,
+            Err(_) => return,
+        };
+        let output = match Pubkey::from_str(output_mint) {
+            Ok(m) => m,
+            Err(_) => return,
+        };
+
+        self.quote_provider
+            .update_quote(pool, input, output, input_amount, output_amount);
+        *self.latest_event_meta.write() = (event_slot, event_seen_at_ms);
+
+        if input_amount == 0 || output_amount == 0 {
+            return;
+        }
+
+        let normalized_price = (output_amount as u128 * 10_000 / input_amount as u128) as u64;
+        let (mint_a, mint_b) = match self.pool_mints.read().get(&pool) {
+            Some(&mints) => mints,
+            None => (input, output),
+        };
+
+        let output_ratio = (input_amount as u128 * 10_000 / output_amount as u128) as u64;
+        for &mint in &[mint_a, mint_b] {
+            let ratio = if mint == input {
+                normalized_price
+            } else if mint == output {
+                output_ratio
+            } else {
+                continue;
+            };
+            self.enqueue_dirty_token(mint, ratio);
+        }
+
+        self.search_notify.notify_one();
+    }
+
+    fn enqueue_dirty_token(&self, token: Pubkey, price_ratio: u64) {
+        let mut dirty = self.dirty_tokens.write();
+        if dirty.len() >= MAX_DIRTY_TOKENS && !dirty.contains_key(&token) {
+            return;
+        }
+        if dirty.insert(token, price_ratio).is_some() {
+            multi_hop_searches_coalesced_inc();
+        }
+        multi_hop_search_worker_queue_depth_set(dirty.len() as u64);
+    }
+
+    fn drain_dirty_tokens(&self) -> Vec<(Pubkey, u64)> {
+        let mut dirty = self.dirty_tokens.write();
+        if dirty.is_empty() {
+            return vec![];
+        }
+        let batch: Vec<_> = dirty.drain().collect();
+        multi_hop_search_worker_queue_depth_set(0);
+        batch
+    }
+
+    /// Worker batch: apply cooldown/price filters then run beam search.
+    fn process_dirty_batch(
+        &self,
+        component: &str,
+        build: &str,
+        run_id: &str,
+    ) -> MultiHopIntentBatch {
+        let config = self.config.read().clone();
+        let (slot, seen_at_ms) = *self.latest_event_meta.read();
+        if !config.enabled {
+            return MultiHopIntentBatch {
+                intents: vec![],
+                slot,
+                seen_at_ms,
+            };
+        }
+
+        let batch = self.drain_dirty_tokens();
+        if batch.is_empty() {
+            return MultiHopIntentBatch {
+                intents: vec![],
+                slot,
+                seen_at_ms,
+            };
+        }
+
+        let tokens_to_search = self.filter_tokens_for_search(&batch, &config);
+        if tokens_to_search.is_empty() {
+            return MultiHopIntentBatch {
+                intents: vec![],
+                slot,
+                seen_at_ms,
+            };
+        }
+
+        self.searches_triggered.fetch_add(1, Ordering::Relaxed);
+        let intents = self.search_from_tokens(&tokens_to_search, &config, component, build, run_id);
+        MultiHopIntentBatch {
+            intents,
+            slot,
+            seen_at_ms,
+        }
+    }
+
+    /// Dedicated search worker (decoupled from NATS event loop).
+    pub fn spawn_search_worker(
+        self: Arc<Self>,
+        intent_tx: mpsc::Sender<MultiHopIntentBatch>,
+        component: String,
+        build: String,
+        run_id: String,
+    ) -> JoinHandle<()> {
+        let notify = self.search_notify.clone();
+        tokio::spawn(async move {
+            loop {
+                notify.notified().await;
+                let batch = self.process_dirty_batch(&component, &build, &run_id);
+                if !batch.intents.is_empty() && intent_tx.send(batch).await.is_err() {
+                    break;
+                }
+            }
+        })
+    }
+
+    /// Incrementally mark pool quote-ready when LivePoolCache reserves update.
+    pub fn touch_live_pool_quote_ready(&self, pool_address: &str) {
+        if let Ok(pool) = Pubkey::from_str(pool_address) {
+            self.quote_provider.mark_ready_from_live_pool_cache(&pool);
+        }
+    }
+
+    /// Legacy synchronous entry (tests only).
+    #[cfg(test)]
     #[allow(clippy::too_many_arguments)]
     pub fn on_pool_price_update(
         &self,
@@ -454,73 +717,21 @@ impl MultiHopArbitrage {
         build: &str,
         run_id: &str,
     ) -> Vec<TradeIntent> {
-        let config = self.config.read().clone();
+        self.enqueue_pool_price_update(
+            pool_address,
+            input_mint,
+            output_mint,
+            input_amount,
+            output_amount,
+            None,
+            0,
+        );
+        self.process_dirty_batch(component, build, run_id).intents
+    }
 
-        if !config.enabled {
-            return vec![];
-        }
-
-        // Parse addresses
-        let pool = match Pubkey::from_str(pool_address) {
-            Ok(p) => p,
-            Err(_) => return vec![],
-        };
-        let input = match Pubkey::from_str(input_mint) {
-            Ok(m) => m,
-            Err(_) => return vec![],
-        };
-        let output = match Pubkey::from_str(output_mint) {
-            Ok(m) => m,
-            Err(_) => return vec![],
-        };
-
-        // Update quote cache
-        self.quote_provider
-            .update_quote(pool, input, output, input_amount, output_amount);
-
-        // Check if this is a significant price change
-        let normalized_price = if input_amount > 0 {
-            (output_amount as u128 * 10_000 / input_amount as u128) as u64
-        } else {
-            return vec![];
-        };
-
-        // Get the affected tokens (both sides of the pool)
-        let (mint_a, mint_b) = match self.pool_mints.read().get(&pool) {
-            Some(&mints) => mints,
-            None => (input, output), // Fallback if not in index
-        };
-
-        // Per-mint directional price ratios (inverse for the output side of the trade)
-        let output_ratio = if output_amount > 0 {
-            (input_amount as u128 * 10_000 / output_amount as u128) as u64
-        } else {
-            return vec![];
-        };
-        let mut token_ratios = Vec::with_capacity(2);
-        for &mint in &[mint_a, mint_b] {
-            let ratio = if mint == input {
-                normalized_price
-            } else if mint == output {
-                output_ratio
-            } else {
-                continue;
-            };
-            if !token_ratios.iter().any(|(m, _)| *m == mint) {
-                token_ratios.push((mint, ratio));
-            }
-        }
-
-        let tokens_to_search = self.filter_tokens_for_search(&token_ratios, &config);
-
-        if tokens_to_search.is_empty() {
-            return vec![];
-        }
-
-        self.searches_triggered.fetch_add(1, Ordering::Relaxed);
-
-        // Search for cycles starting from affected tokens
-        self.search_from_tokens(&tokens_to_search, &config, component, build, run_id)
+    #[cfg(test)]
+    pub fn dirty_token_count(&self) -> usize {
+        self.dirty_tokens.read().len()
     }
 
     /// Filter tokens that should be searched (cooldown + per-mint price change check)
@@ -864,6 +1075,10 @@ impl QuoteProvider for Arc<CachedQuoteProvider> {
         (**self).has_cached_quote(pool_address, input_mint, output_mint)
     }
 
+    fn is_pool_quote_ready(&self, pool_address: &Pubkey) -> bool {
+        (**self).is_pool_quote_ready(pool_address)
+    }
+
     fn get_cached_probe_quote(
         &self,
         pool_address: &Pubkey,
@@ -1014,5 +1229,82 @@ mod tests {
 
         assert!(intents.is_empty());
         assert_eq!(arb.stats().searches_triggered, 0);
+    }
+
+    #[test]
+    fn enqueue_does_not_search_synchronously() {
+        let arb = MultiHopArbitrage::new(
+            MultiHopConfig {
+                enabled: true,
+                min_liquidity_usd: 0.0,
+                min_price_change_bps: 0,
+                token_cooldown_ms: 0,
+                ..Default::default()
+            },
+            create_shared_cache(),
+        );
+
+        arb.upsert_pool(
+            "11111111111111111111111111111111",
+            "raydium",
+            WSOL_MINT,
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            100_000.0,
+            30,
+        );
+
+        arb.enqueue_pool_price_update(
+            "11111111111111111111111111111111",
+            WSOL_MINT,
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            1_000_000,
+            990_000,
+            None,
+            0,
+        );
+
+        assert!(arb.dirty_token_count() > 0);
+        assert_eq!(arb.stats().searches_triggered, 0);
+    }
+
+    #[test]
+    fn coalesced_dirty_tokens_produce_single_search() {
+        let arb = MultiHopArbitrage::new(
+            MultiHopConfig {
+                enabled: true,
+                min_liquidity_usd: 0.0,
+                min_price_change_bps: 0,
+                token_cooldown_ms: 0,
+                ..Default::default()
+            },
+            create_shared_cache(),
+        );
+
+        arb.upsert_pool(
+            "11111111111111111111111111111111111",
+            "raydium",
+            WSOL_MINT,
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            100_000.0,
+            30,
+        );
+
+        let usdc = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+        for i in 0..5 {
+            arb.enqueue_pool_price_update(
+                "11111111111111111111111111111111",
+                WSOL_MINT,
+                usdc,
+                1_000_000 + i,
+                990_000,
+                None,
+                0,
+            );
+        }
+
+        assert_eq!(arb.dirty_token_count(), 2, "WSOL + USDC dirty entries");
+        let _ = arb.process_dirty_batch("test", "0.1.0", "run");
+        assert_eq!(arb.stats().searches_triggered, 1);
+        assert_eq!(arb.dirty_token_count(), 0);
     }
 }

--- a/src/arbitrage/multi_hop_integration.rs
+++ b/src/arbitrage/multi_hop_integration.rs
@@ -47,6 +47,12 @@ const PROBE_LAMPORTS: u64 = 10_000_000;
 /// Top-N WSOL pools to seed trade-cache quotes after JetStream bootstrap.
 const QUOTE_WARMUP_TOP_N: usize = 1000;
 
+/// Hard cap on trade-cache entries after TTL sweep (evict oldest).
+const MAX_QUOTE_CACHE_ENTRIES: usize = 50_000;
+
+/// TTL sweep interval for the search worker (cold path).
+const QUOTE_CACHE_CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
+
 /// Max dirty tokens queued before new mints are dropped (existing mints still coalesce).
 const MAX_DIRTY_TOKENS: usize = 10_000;
 
@@ -75,10 +81,6 @@ impl QuoteReadyIndex {
 
     pub fn contains(&self, pool: &Pubkey) -> bool {
         self.pools.read().contains(pool)
-    }
-
-    pub fn snapshot(&self) -> HashSet<Pubkey> {
-        self.pools.read().clone()
     }
 
     pub fn len(&self) -> usize {
@@ -147,21 +149,26 @@ type QuoteCacheValue = (u64, Instant);
 pub struct CachedQuoteProvider {
     /// Cache: (pool, input_mint, output_mint) -> (output_amount, timestamp)
     cache: RwLock<HashMap<QuoteCacheKey, QuoteCacheValue>>,
+    /// pool -> (mint_a, mint_b) for O(1) freshness checks (no full-cache scan).
+    pool_mints: RwLock<HashMap<Pubkey, (Pubkey, Pubkey)>>,
     /// Cache TTL
     cache_ttl: Duration,
     /// SLAVE LivePoolCache (same SSOT as execution-engine) — no RPC on miss.
     live_pool_cache: SharedLivePoolCache,
     /// Pools with at least one quotable direction (beam expansion pruning).
     quote_ready: QuoteReadyIndex,
+    last_cleanup: RwLock<Instant>,
 }
 
 impl CachedQuoteProvider {
     pub fn new(cache_ttl: Duration, live_pool_cache: SharedLivePoolCache) -> Self {
         Self {
             cache: RwLock::new(HashMap::new()),
+            pool_mints: RwLock::new(HashMap::new()),
             cache_ttl,
             live_pool_cache,
             quote_ready: QuoteReadyIndex::default(),
+            last_cleanup: RwLock::new(Instant::now()),
         }
     }
 
@@ -186,16 +193,37 @@ impl CachedQuoteProvider {
         }
     }
 
-    fn pool_still_quote_ready(&self, pool: &Pubkey) -> bool {
-        let cache = self.cache.read();
-        let now = Instant::now();
-        if cache
-            .iter()
-            .any(|((p, _, _), (_, ts))| p == pool && now.duration_since(*ts) < self.cache_ttl)
-        {
-            return true;
+    fn resolve_pool_mints(&self, pool: &Pubkey) -> Option<(Pubkey, Pubkey)> {
+        if let Some(mints) = self.pool_mints.read().get(pool).copied() {
+            return Some(mints);
         }
-        drop(cache);
+        let state = self.live_pool_cache.get(pool)?;
+        Some(Self::mints_from_state(&state))
+    }
+
+    fn trade_direction_fresh(
+        &self,
+        cache: &HashMap<QuoteCacheKey, QuoteCacheValue>,
+        pool: Pubkey,
+        input_mint: Pubkey,
+        output_mint: Pubkey,
+        now: Instant,
+    ) -> bool {
+        cache
+            .get(&(pool, input_mint, output_mint))
+            .is_some_and(|(_, ts)| now.duration_since(*ts) < self.cache_ttl)
+    }
+
+    fn pool_still_quote_ready(&self, pool: &Pubkey) -> bool {
+        let now = Instant::now();
+        if let Some((mint_a, mint_b)) = self.resolve_pool_mints(pool) {
+            let cache = self.cache.read();
+            if self.trade_direction_fresh(&cache, *pool, mint_a, mint_b, now)
+                || self.trade_direction_fresh(&cache, *pool, mint_b, mint_a, now)
+            {
+                return true;
+            }
+        }
 
         let Some(state) = self.live_pool_cache.get(pool) else {
             return false;
@@ -352,11 +380,16 @@ impl CachedQuoteProvider {
             0
         };
 
+        self.pool_mints
+            .write()
+            .insert(pool, (input_mint, output_mint));
+
         let mut cache = self.cache.write();
         cache.insert(
             (pool, input_mint, output_mint),
             (normalized_output, Instant::now()),
         );
+        drop(cache);
         self.quote_ready.mark_ready(pool);
     }
 
@@ -375,12 +408,37 @@ impl CachedQuoteProvider {
             .map(|(out, ts)| (*out, ts.elapsed().as_millis() as u64))
     }
 
-    /// Clear stale entries
-    #[allow(dead_code)]
+    /// TTL sweep + bounded eviction (search worker cold path).
     pub fn cleanup(&self) {
         let mut cache = self.cache.write();
         let now = Instant::now();
         cache.retain(|_, (_, ts)| now.duration_since(*ts) < self.cache_ttl);
+
+        if cache.len() > MAX_QUOTE_CACHE_ENTRIES {
+            let mut entries: Vec<(QuoteCacheKey, Instant)> =
+                cache.iter().map(|(k, (_, ts))| (*k, *ts)).collect();
+            entries.sort_by_key(|(_, ts)| *ts);
+            let to_remove = cache.len().saturating_sub(MAX_QUOTE_CACHE_ENTRIES);
+            for (key, _) in entries.into_iter().take(to_remove) {
+                cache.remove(&key);
+            }
+        }
+    }
+
+    /// Periodic TTL sweep from the search worker (not hot path).
+    pub fn maybe_cleanup(&self) {
+        let should_run = {
+            let mut last = self.last_cleanup.write();
+            if last.elapsed() < QUOTE_CACHE_CLEANUP_INTERVAL {
+                false
+            } else {
+                *last = Instant::now();
+                true
+            }
+        };
+        if should_run {
+            self.cleanup();
+        }
     }
 }
 
@@ -639,6 +697,8 @@ impl MultiHopArbitrage {
         build: &str,
         run_id: &str,
     ) -> MultiHopIntentBatch {
+        self.quote_provider.maybe_cleanup();
+
         let config = self.config.read().clone();
         let (slot, seen_at_ms) = *self.latest_event_meta.read();
         if !config.enabled {
@@ -1265,6 +1325,42 @@ mod tests {
 
         assert!(arb.dirty_token_count() > 0);
         assert_eq!(arb.stats().searches_triggered, 0);
+    }
+
+    #[test]
+    fn pool_quote_ready_check_is_constant_per_pool() {
+        let provider = CachedQuoteProvider::new(Duration::from_secs(30), create_shared_cache());
+        let pool = Pubkey::new_unique();
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::new_unique();
+
+        provider.update_quote(pool, mint_a, mint_b, 1_000_000, 990_000);
+
+        for i in 0..5_000 {
+            let noise_pool = Pubkey::new_unique();
+            let noise_mint = Pubkey::new_unique();
+            provider.update_quote(
+                noise_pool,
+                noise_mint,
+                Pubkey::new_unique(),
+                1_000_000,
+                990_000 + i,
+            );
+        }
+
+        assert!(provider.is_pool_quote_ready(&pool));
+    }
+
+    #[test]
+    fn quote_cache_cleanup_evicts_stale_entries() {
+        let provider = CachedQuoteProvider::new(Duration::from_millis(1), create_shared_cache());
+        let pool = Pubkey::new_unique();
+        let input = Pubkey::new_unique();
+        let output = Pubkey::new_unique();
+        provider.update_quote(pool, input, output, 1_000_000, 990_000);
+        std::thread::sleep(Duration::from_millis(5));
+        provider.cleanup();
+        assert!(!provider.is_pool_quote_ready(&pool));
     }
 
     #[test]

--- a/src/arbitrage/multi_hop_integration.rs
+++ b/src/arbitrage/multi_hop_integration.rs
@@ -516,6 +516,13 @@ struct TokenSearchState {
     last_price_ratio: Option<u64>, // Normalized price for change detection
 }
 
+/// Coalesced dirty-token entry (price + originating event metadata).
+struct DirtyTokenEntry {
+    price_ratio: u64,
+    event_slot: Option<u64>,
+    event_seen_at_ms: u64,
+}
+
 /// Multi-hop arbitrage engine (Event-Driven)
 pub struct MultiHopArbitrage {
     config: RwLock<MultiHopConfig>,
@@ -526,9 +533,7 @@ pub struct MultiHopArbitrage {
     /// Pool -> (mint_a, mint_b) reverse index for quick lookup
     pool_mints: RwLock<HashMap<Pubkey, (Pubkey, Pubkey)>>,
     /// Coalescing queue: latest price ratio per dirty token (search worker drains).
-    dirty_tokens: RwLock<HashMap<Pubkey, u64>>,
-    /// Latest trade event metadata (slot / ts) for intent publishing.
-    latest_event_meta: RwLock<(Option<u64>, u64)>,
+    dirty_tokens: RwLock<HashMap<Pubkey, DirtyTokenEntry>>,
     search_notify: Arc<Notify>,
     /// Stats
     searches_triggered: AtomicU64,
@@ -551,7 +556,6 @@ impl MultiHopArbitrage {
             token_state: RwLock::new(HashMap::new()),
             pool_mints: RwLock::new(HashMap::new()),
             dirty_tokens: RwLock::new(HashMap::new()),
-            latest_event_meta: RwLock::new((None, 0)),
             search_notify: Arc::new(Notify::new()),
             searches_triggered: AtomicU64::new(0),
             searches_skipped_cooldown: AtomicU64::new(0),
@@ -642,7 +646,6 @@ impl MultiHopArbitrage {
 
         self.quote_provider
             .update_quote(pool, input, output, input_amount, output_amount);
-        *self.latest_event_meta.write() = (event_slot, event_seen_at_ms);
 
         if input_amount == 0 || output_amount == 0 {
             return;
@@ -663,24 +666,35 @@ impl MultiHopArbitrage {
             } else {
                 continue;
             };
-            self.enqueue_dirty_token(mint, ratio);
+            self.enqueue_dirty_token(mint, ratio, event_slot, event_seen_at_ms);
         }
 
         self.search_notify.notify_one();
     }
 
-    fn enqueue_dirty_token(&self, token: Pubkey, price_ratio: u64) {
+    fn enqueue_dirty_token(
+        &self,
+        token: Pubkey,
+        price_ratio: u64,
+        event_slot: Option<u64>,
+        event_seen_at_ms: u64,
+    ) {
         let mut dirty = self.dirty_tokens.write();
         if dirty.len() >= MAX_DIRTY_TOKENS && !dirty.contains_key(&token) {
             return;
         }
-        if dirty.insert(token, price_ratio).is_some() {
+        let entry = DirtyTokenEntry {
+            price_ratio,
+            event_slot,
+            event_seen_at_ms,
+        };
+        if dirty.insert(token, entry).is_some() {
             multi_hop_searches_coalesced_inc();
         }
         multi_hop_search_worker_queue_depth_set(dirty.len() as u64);
     }
 
-    fn drain_dirty_tokens(&self) -> Vec<(Pubkey, u64)> {
+    fn drain_dirty_tokens(&self) -> Vec<(Pubkey, DirtyTokenEntry)> {
         let mut dirty = self.dirty_tokens.write();
         if dirty.is_empty() {
             return vec![];
@@ -688,6 +702,19 @@ impl MultiHopArbitrage {
         let batch: Vec<_> = dirty.drain().collect();
         multi_hop_search_worker_queue_depth_set(0);
         batch
+    }
+
+    fn batch_event_meta_for_tokens(
+        batch: &[(Pubkey, DirtyTokenEntry)],
+        tokens: &[Pubkey],
+    ) -> (Option<u64>, u64) {
+        let token_set: HashSet<_> = tokens.iter().collect();
+        batch
+            .iter()
+            .filter(|(token, _)| token_set.contains(token))
+            .min_by_key(|(_, entry)| entry.event_seen_at_ms)
+            .map(|(_, entry)| (entry.event_slot, entry.event_seen_at_ms))
+            .unwrap_or((None, 0))
     }
 
     /// Worker batch: apply cooldown/price filters then run beam search.
@@ -700,25 +727,29 @@ impl MultiHopArbitrage {
         self.quote_provider.maybe_cleanup();
 
         let config = self.config.read().clone();
-        let (slot, seen_at_ms) = *self.latest_event_meta.read();
-        if !config.enabled {
-            return MultiHopIntentBatch {
-                intents: vec![],
-                slot,
-                seen_at_ms,
-            };
-        }
-
         let batch = self.drain_dirty_tokens();
         if batch.is_empty() {
             return MultiHopIntentBatch {
                 intents: vec![],
-                slot,
-                seen_at_ms,
+                slot: None,
+                seen_at_ms: 0,
             };
         }
 
-        let tokens_to_search = self.filter_tokens_for_search(&batch, &config);
+        if !config.enabled {
+            return MultiHopIntentBatch {
+                intents: vec![],
+                slot: None,
+                seen_at_ms: 0,
+            };
+        }
+
+        let token_ratios: Vec<(Pubkey, u64)> = batch
+            .iter()
+            .map(|(token, entry)| (*token, entry.price_ratio))
+            .collect();
+        let tokens_to_search = self.filter_tokens_for_search(&token_ratios, &config);
+        let (slot, seen_at_ms) = Self::batch_event_meta_for_tokens(&batch, &tokens_to_search);
         if tokens_to_search.is_empty() {
             return MultiHopIntentBatch {
                 intents: vec![],
@@ -750,7 +781,7 @@ impl MultiHopArbitrage {
                 notify.notified().await;
                 let batch = self.process_dirty_batch(&component, &build, &run_id);
                 if !batch.intents.is_empty() && intent_tx.send(batch).await.is_err() {
-                    break;
+                    warn!("Multi-hop search worker: intent channel closed, continuing search");
                 }
             }
         })

--- a/src/arbitrage/pool_graph.rs
+++ b/src/arbitrage/pool_graph.rs
@@ -86,28 +86,6 @@ impl PoolGraph {
         }
     }
 
-    /// Neighbors whose pools are all in `quote_ready` (beam expansion pruning).
-    pub fn neighbors_quote_ready(
-        &self,
-        mint: &Pubkey,
-        quote_ready: &std::collections::HashSet<Pubkey>,
-    ) -> Vec<(Pubkey, Vec<PoolEdge>)> {
-        self.neighbors(mint)
-            .into_iter()
-            .filter_map(|(neighbor, pools)| {
-                let filtered: Vec<PoolEdge> = pools
-                    .into_iter()
-                    .filter(|edge| quote_ready.contains(&edge.pool_address))
-                    .collect();
-                if filtered.is_empty() {
-                    None
-                } else {
-                    Some((neighbor, filtered))
-                }
-            })
-            .collect()
-    }
-
     /// Get all neighbors of a token with their pools
     ///
     /// Returns: Vec<(neighbor_mint, Vec<PoolEdge>)>

--- a/src/arbitrage/pool_graph.rs
+++ b/src/arbitrage/pool_graph.rs
@@ -86,6 +86,28 @@ impl PoolGraph {
         }
     }
 
+    /// Neighbors whose pools are all in `quote_ready` (beam expansion pruning).
+    pub fn neighbors_quote_ready(
+        &self,
+        mint: &Pubkey,
+        quote_ready: &std::collections::HashSet<Pubkey>,
+    ) -> Vec<(Pubkey, Vec<PoolEdge>)> {
+        self.neighbors(mint)
+            .into_iter()
+            .filter_map(|(neighbor, pools)| {
+                let filtered: Vec<PoolEdge> = pools
+                    .into_iter()
+                    .filter(|edge| quote_ready.contains(&edge.pool_address))
+                    .collect();
+                if filtered.is_empty() {
+                    None
+                } else {
+                    Some((neighbor, filtered))
+                }
+            })
+            .collect()
+    }
+
     /// Get all neighbors of a token with their pools
     ///
     /// Returns: Vec<(neighbor_mint, Vec<PoolEdge>)>

--- a/src/arbitrage/pool_ranker.rs
+++ b/src/arbitrage/pool_ranker.rs
@@ -77,6 +77,12 @@ pub trait QuoteProvider: Send + Sync {
         true
     }
 
+    /// Whether the pool is in the quote-ready set (beam expansion skips others).
+    /// Default `true` for mocks / providers without a ready index.
+    fn is_pool_quote_ready(&self, _pool_address: &Pubkey) -> bool {
+        true
+    }
+
     /// Fresh cached probe quote, or `None` if missing/stale.
     /// Default uses separate cache checks (fine for mocks); TTL caches should override.
     fn get_cached_probe_quote(
@@ -135,6 +141,9 @@ impl<Q: QuoteProvider> PoolRanker<Q> {
             let mut ranked_pools = Vec::with_capacity(pools.len());
 
             for edge in pools {
+                if !self.quote_provider.is_pool_quote_ready(&edge.pool_address) {
+                    continue;
+                }
                 if let Some(ranked) = self.rank_single_pool(&edge, input_mint, &output_mint) {
                     // Track max edge ratio for upper bound pruning
                     max_edge_updates.push((*input_mint, clamp_edge_ratio(ranked.edge_ratio)));
@@ -345,6 +354,10 @@ impl QuoteProvider for std::sync::Arc<MockQuoteProvider> {
         (**self).has_cached_quote(pool_address, input_mint, output_mint)
     }
 
+    fn is_pool_quote_ready(&self, pool_address: &Pubkey) -> bool {
+        (**self).is_pool_quote_ready(pool_address)
+    }
+
     fn get_cached_probe_quote(
         &self,
         pool_address: &Pubkey,
@@ -380,6 +393,10 @@ impl QuoteProvider for MockQuoteProvider {
     ) -> bool {
         self.quotes
             .contains_key(&(*pool_address, *input_mint, *output_mint))
+    }
+
+    fn is_pool_quote_ready(&self, pool_address: &Pubkey) -> bool {
+        self.quotes.keys().any(|(pool, _, _)| pool == pool_address)
     }
 
     fn get_cached_probe_quote(

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -23,12 +23,13 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 use ironcrab::arbitrage::{
     populate_arb_slave_from_live_pool_cache, sync_arb_slave_from_pool_cache_update,
-    MultiHopArbitrage, MultiHopConfig,
+    MultiHopArbitrage, MultiHopConfig, MultiHopIntentBatch,
 };
 use ironcrab::config::Config as AppConfig;
 use ironcrab::execution::live_pool_cache::{
@@ -1242,7 +1243,7 @@ struct ArbContext {
     // =========================================================================
     /// Multi-hop arbitrage engine for N-hop cycle detection.
     /// Disabled by default (shadow_mode=true). See docs/MULTI_HOP_ARBITRAGE.md
-    multi_hop: MultiHopArbitrage,
+    multi_hop: Arc<MultiHopArbitrage>,
 
     /// Per-mint last WARN time for "spread too large" deduplication.
     spread_too_large_warn_last: RwLock<HashMap<String, Instant>>,
@@ -2103,7 +2104,7 @@ impl ArbContext {
 
         let price = trade_implied_sol_per_token(sol_amount, token_amount, token_decimals);
 
-        info!(
+        trace!(
             pool = %pool_address,
             mint = %mint,
             sol_amount = sol_amount,
@@ -2179,7 +2180,7 @@ impl ArbContext {
         );
         pool.trade_count += 1;
         pool.last_update = Instant::now();
-        info!(
+        trace!(
             pool = %pool_address,
             mint = %mint,
             dex = %pool.dex,
@@ -2563,7 +2564,18 @@ async fn main() -> Result<()> {
     };
 
     let live_pool_cache = create_shared_cache();
-    let multi_hop = MultiHopArbitrage::new(MultiHopConfig::default(), live_pool_cache.clone());
+    let multi_hop = Arc::new(MultiHopArbitrage::new(
+        MultiHopConfig::default(),
+        live_pool_cache.clone(),
+    ));
+
+    let (multi_hop_intent_tx, mut multi_hop_intent_rx) = mpsc::channel::<MultiHopIntentBatch>(256);
+    let _multi_hop_search_worker = multi_hop.clone().spawn_search_worker(
+        multi_hop_intent_tx,
+        "arb-strategy".to_string(),
+        BUILD_VERSION.to_string(),
+        run_id.clone(),
+    );
 
     let ctx = Arc::new(ArbContext {
         run_id: run_id.clone(),
@@ -2753,6 +2765,41 @@ async fn main() -> Result<()> {
         None
     };
 
+    // Multi-hop intent publisher (decoupled from search worker)
+    let multi_hop_publish_ctx = ctx.clone();
+    tokio::spawn(async move {
+        while let Some(batch) = multi_hop_intent_rx.recv().await {
+            for mut intent in batch.intents {
+                if let Some(slot) = batch.slot {
+                    intent.metadata.insert("slot".to_string(), slot.to_string());
+                }
+                intent
+                    .metadata
+                    .insert("slot_seen_at_ms".to_string(), batch.seen_at_ms.to_string());
+                if let Err(e) = multi_hop_publish_ctx.jsonl_writer.write(&intent) {
+                    error!(error = %e, "Failed to write multi-hop intent to JSONL");
+                }
+                if let Some(ref nats) = multi_hop_publish_ctx.nats {
+                    if let Err(e) = nats.publish(TOPIC_TRADE_INTENTS, &intent).await {
+                        warn!(error = %e, "Failed to publish multi-hop intent");
+                    } else {
+                        NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                        INTENTS_GENERATED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                        multi_hop_publish_ctx
+                            .intents_generated
+                            .fetch_add(1, Ordering::Relaxed);
+                        info!(
+                            intent_id = %intent.intent_id,
+                            hops = intent.hop_count(),
+                            return_bps = intent.expected_roi_bps,
+                            "🎯 Multi-hop arb intent published"
+                        );
+                    }
+                }
+            }
+        }
+    });
+
     // Main event loop
     info!("Entering main event loop");
 
@@ -2905,9 +2952,11 @@ async fn main() -> Result<()> {
                                                 if sync_arb_slave_from_pool_cache_update(
                                                     &ctx.live_pool_cache,
                                                     &ctx.known_pools,
-                                                    &ctx.multi_hop,
+                                                    ctx.multi_hop.as_ref(),
                                                     &update,
                                                 ) {
+                                                    ctx.multi_hop
+                                                        .touch_live_pool_quote_ready(&update.pool_address);
                                                     ctx.seed_trackers_for_pool_cache_update(&update);
                                                     debug!(
                                                         pool = %update.pool_address,
@@ -3040,55 +3089,21 @@ async fn handle_market_event(ctx: &ArbContext, event: &MarketEvent) -> Option<Tr
             // Multi-hop: Event-driven cycle detection on every trade
             // This runs in parallel with the existing 2-hop detection
             if ctx.multi_hop.is_enabled() {
-                // Determine input/output mints based on trade direction
                 let (input_mint, output_mint) = if *is_buy {
-                    // Buy token: SOL -> Token
                     (NATIVE_SOL_MINT, mint.as_str())
                 } else {
-                    // Sell token: Token -> SOL
                     (mint.as_str(), NATIVE_SOL_MINT)
                 };
 
-                let multi_hop_intents = ctx.multi_hop.on_pool_price_update(
+                ctx.multi_hop.enqueue_pool_price_update(
                     pool_address,
                     input_mint,
                     output_mint,
                     *sol_amount,
                     *token_amount,
-                    "arb-strategy",
-                    BUILD_VERSION,
-                    &ctx.run_id,
+                    event.slot,
+                    event.header.ts_unix_ms,
                 );
-
-                // Publish any multi-hop intents found
-                for mut intent in multi_hop_intents {
-                    // K Phase 1: Slot-to-Send Latency - propagate slot from event
-                    if let Some(slot) = event.slot {
-                        intent.metadata.insert("slot".to_string(), slot.to_string());
-                    }
-                    intent.metadata.insert(
-                        "slot_seen_at_ms".to_string(),
-                        event.header.ts_unix_ms.to_string(),
-                    );
-                    if let Err(e) = ctx.jsonl_writer.write(&intent) {
-                        error!(error = %e, "Failed to write multi-hop intent to JSONL");
-                    }
-                    if let Some(ref nats) = ctx.nats {
-                        if let Err(e) = nats.publish(TOPIC_TRADE_INTENTS, &intent).await {
-                            warn!(error = %e, "Failed to publish multi-hop intent");
-                        } else {
-                            NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                            INTENTS_GENERATED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                            ctx.intents_generated.fetch_add(1, Ordering::Relaxed);
-                            info!(
-                                intent_id = %intent.intent_id,
-                                hops = intent.hop_count(),
-                                return_bps = intent.expected_roi_bps,
-                                "🎯 Multi-hop arb intent published"
-                            );
-                        }
-                    }
-                }
             }
 
             // Existing 2-hop arbitrage detection

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2454,6 +2454,8 @@ pub fn arb_two_hop_tracker_seeded_pools_add(count: u64) {
 pub static MULTI_HOP_RETURN_BPS_SATURATED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static MULTI_HOP_SHADOW_LOGGED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static MULTI_HOP_HOP_MISSING_QUOTE_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MULTI_HOP_SEARCH_WORKER_QUEUE_DEPTH: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MULTI_HOP_SEARCHES_COALESCED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static MULTI_HOP_QUOTE_FROM_CACHE_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static MULTI_HOP_QUOTE_FROM_TRADE_CACHE_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -2482,6 +2484,14 @@ pub fn multi_hop_shadow_logged_inc() {
 
 pub fn multi_hop_hop_missing_quote_inc() {
     MULTI_HOP_HOP_MISSING_QUOTE_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn multi_hop_search_worker_queue_depth_set(depth: u64) {
+    MULTI_HOP_SEARCH_WORKER_QUEUE_DEPTH.store(depth, Ordering::Relaxed);
+}
+
+pub fn multi_hop_searches_coalesced_inc() {
+    MULTI_HOP_SEARCHES_COALESCED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 pub fn multi_hop_quote_from_cache_inc() {
@@ -4387,6 +4397,14 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "multi_hop_hop_missing_quote_total",
         MULTI_HOP_HOP_MISSING_QUOTE_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "multi_hop_search_worker_queue_depth",
+        MULTI_HOP_SEARCH_WORKER_QUEUE_DEPTH.load(Ordering::Relaxed)
+    );
+    line!(
+        "multi_hop_searches_coalesced_total",
+        MULTI_HOP_SEARCHES_COALESCED_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "multi_hop_quote_from_cache_total",

--- a/tests/multi_hop_live_cache_quotes.rs
+++ b/tests/multi_hop_live_cache_quotes.rs
@@ -43,6 +43,7 @@ fn live_pool_cache_quotes_rank_both_directions_without_trades() {
         }),
         1,
     );
+    provider.mark_ready_from_live_pool_cache(&pool);
 
     let graph = PoolGraph::new();
     graph.upsert_pool(PoolEdge::new(

--- a/tests/multi_hop_search_worker.rs
+++ b/tests/multi_hop_search_worker.rs
@@ -1,0 +1,55 @@
+//! Multi-hop search worker coalescing and quote-ready beam pruning.
+
+use ironcrab::arbitrage::{DexType, MockQuoteProvider, PoolEdge, PoolGraph, PoolRanker, WSOL_MINT};
+use solana_sdk::pubkey::Pubkey;
+use std::str::FromStr;
+
+fn test_pubkey(byte: u8) -> Pubkey {
+    Pubkey::new_from_array([byte; 32])
+}
+
+#[test]
+fn expansion_skips_pools_outside_quote_ready_set() {
+    let graph = PoolGraph::new();
+    let mut mock = MockQuoteProvider::new();
+
+    let wsol = Pubkey::from_str(WSOL_MINT).unwrap();
+    let usdc = test_pubkey(0x02);
+    let token_a = test_pubkey(0x03);
+    let quoted_pool = test_pubkey(0x10);
+    let unquoted_pool = test_pubkey(0x11);
+    let probe = 10_000_000u64;
+
+    graph.upsert_pool(PoolEdge::new(
+        quoted_pool,
+        DexType::RaydiumAmmV4,
+        wsol,
+        usdc,
+        1_000_000.0,
+        30,
+    ));
+    graph.upsert_pool(PoolEdge::new(
+        unquoted_pool,
+        DexType::RaydiumAmmV4,
+        wsol,
+        token_a,
+        900_000.0,
+        30,
+    ));
+
+    mock.add_quote(quoted_pool, wsol, usdc, probe, 9_800_000);
+    let mock = std::sync::Arc::new(mock);
+    mock.reset_probe_lookup_count();
+    let ranker = PoolRanker::new(mock.clone());
+    let ranked = ranker.rank_pools_from(&graph, &wsol);
+
+    assert_eq!(ranked.len(), 1);
+    assert_eq!(ranked[0].0, usdc);
+    assert_eq!(ranked[0].1.len(), 1);
+    assert_eq!(ranked[0].1[0].edge.pool_address, quoted_pool);
+    assert!(
+        mock.probe_lookup_count() <= 2,
+        "only quote-ready pool should be probed, got {}",
+        mock.probe_lookup_count()
+    );
+}


### PR DESCRIPTION
## Summary
- Multi-Hop-Beam-Search aus dem NATS-Event-Loop in dedizierten Worker verlagert (coalescing dirty-token queue, latest-wins, bounded)
- QuoteReadyIndex: Beam-Expansion probt nur noch Pools mit echter Quote (Trade-Cache frisch oder LivePoolCache-Reserven) statt alle Edges zu enumerieren (~490k/s Miss-Lookups in Prod)
- Per-Trade-INFO-Logs (Trade-implied SOL per token / Pool comparable price updated) auf trace herabgestuft

## Kontext
Prod-Befund 2026-06-11 nach Deploy 1aeb6461: multi_hop_hop_missing_quote_total 739M/25min, arb-strategy >100% CPU, Heartbeats nur alle 2-3min. Handoff: docs/supervisor/handoff_multi_hop_worker_offload_quote_pruning.md (Eval-Repo).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how and when multi-hop intents are produced (async worker + channel) and which pools participate in search; behavior should match prior logic but timing/coalescing can shift opportunity detection under load.
> 
> **Overview**
> **Moves multi-hop beam search off the NATS trade hot path** into a background Tokio worker that drains a **coalesced dirty-token queue** (latest price per mint, bounded at 10k new mints). Trades only call `enqueue_pool_price_update` and wake the worker via `Notify`; intents flow through an `mpsc` channel to a separate publish task (JSONL/NATS + slot metadata).
> 
> Adds **`QuoteReadyIndex`** and `QuoteProvider::is_pool_quote_ready` so **`PoolRanker` skips pools without a fresh trade-cache or LivePoolCache probe quote**, cutting useless beam expansion. Quote cache gains **TTL sweeps, 50k entry cap**, and **`touch_live_pool_quote_ready`** on JetStream/bootstrap sync.
> 
> **Observability:** `multi_hop_search_worker_queue_depth` and `multi_hop_searches_coalesced_total`. Noisy per-trade **INFO** logs for trade-implied price are **trace**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39fa562257369d6e6e479dadd8119fb7572c91f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->