### PR TITLE
fix(ci): upgrade pyo3 0.24.2 → 0.29.0 — unblock cargo-audit (RUSTSEC-2026-0176/0177)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,15 +2244,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3405,37 +3396,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3443,9 +3429,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3455,13 +3441,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
@@ -8692,12 +8677,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unit-prefix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ legacy_sniper = []
 rpc_fallback = []
 
 [dependencies.pyo3]
-version = "0.24.2"
+version = "0.29"
 features = ["auto-initialize"]
 optional = true
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Entscheidung: Option A (Upgrade)

Nach Prüfung des Migrationsaufwands wurde **Option A** gewählt: pyo3 auf `0.29.0` upgraden statt die Advisories zu ignorieren.

**Begründung:** pyo3 ist als optionale Dependency für das `python`-Feature deklariert, aber es gibt **keinen direkten pyo3-API-Code** in `src/`. Der Upgrade war daher ein reiner Dependency-Bump ohne API-Migration — kein Grund für Option B (Advisory-Ignore).

## Problem

Seit 2026-06-11 schlägt `cargo audit --deny warnings` auf jedem PR und auf `architecture-rebuild` fehl:

- **RUSTSEC-2026-0176**: Out-of-bounds read in `PyList`/`PyTuple` iterators (>=0.24.0, <0.29.0)
- **RUSTSEC-2026-0177**: Missing `Sync` bound on `PyCFunction::new_closure` (<0.29.0)

## Änderung

- `Cargo.toml`: pyo3 `0.24.2` → `0.29`
- `Cargo.lock`: pyo3 + Subcrates auf `0.29.0` aktualisiert (`cargo update -p pyo3`)

## STOP-CHECK (durchgeführt)

1. **I-7 Hot Path RPC**: Keine Änderung — nur Dependency/CI
2. **Bestehendes Pattern**: N/A
3. **Architektur-Grenzen**: Keine Trading-Logik betroffen
4. **I-9 Simulation-Gate**: Keine Änderung
5. **Repo-Isolation**: Keine Eval-Tests gelesen

## Verifikation (lokal grün)

```
cargo fmt --check
cargo clippy -- -D warnings
cargo clippy --features python -- -D warnings
cargo test
cargo test --features python --lib --tests
cargo audit --deny warnings
```

## Scope

- Nur `Cargo.toml` + `Cargo.lock`
- Keine Änderungen an Trading-Logik, Audit-Policy oder `.cargo/audit.toml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dcfbeb5-82a8-44fb-bdf9-83d3b2a72726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dcfbeb5-82a8-44fb-bdf9-83d3b2a72726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

