### PR TITLE
fix(arb): comparable-price Orca/Meteora reserve orientation + data quality gates

### DIFF
--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -288,6 +288,28 @@ fn vault_dlmm_sol_is_x(vault: &VaultBalanceCache) -> bool {
         .unwrap_or(vault.dlmm_sol_is_x)
 }
 
+/// Resolve on-chain `token_x_mint` for DLMM PoolStateUpdate (normalized base/quote ≠ token_x/y).
+fn resolve_dlmm_token_x_mint_for_pool_update(
+    pool_address: &str,
+    vault_cache: &HashMap<String, VaultBalanceCache>,
+    live_pool_cache: &SharedLivePoolCache,
+) -> Option<String> {
+    if let Some(existing) = vault_cache
+        .get(pool_address)
+        .and_then(|v| v.dlmm_token_x_mint.clone())
+    {
+        return Some(existing);
+    }
+    let pool_pk = Pubkey::from_str(pool_address).ok()?;
+    live_pool_cache.get(&pool_pk).and_then(|state| {
+        if let CachedPoolState::Meteora(s) = state {
+            Some(s.token_x_mint.to_string())
+        } else {
+            None
+        }
+    })
+}
+
 fn trade_mid_sol_per_token(pool: &PoolState) -> Option<Decimal> {
     match (pool.trade_price_buy, pool.trade_price_sell) {
         (Some(buy), Some(sell)) if buy > Decimal::ZERO && sell > Decimal::ZERO => {
@@ -2234,7 +2256,7 @@ impl ArbContext {
         }
         let is_new = !cache.contains_key(pool_address);
         let dlmm_token_x_mint = if dex == "meteora_dlmm" {
-            Some(base_mint.to_string())
+            resolve_dlmm_token_x_mint_for_pool_update(pool_address, &cache, &self.live_pool_cache)
         } else {
             cache
                 .get(pool_address)

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -20,6 +20,7 @@ use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -61,7 +62,6 @@ use ironcrab::nats::{TOPIC_MARKET_EVENTS, TOPIC_TRADE_INTENTS};
 use ironcrab::solana::dex::meteora_bin_walker::{dlmm_fee_bps, walker_from_bins};
 use ironcrab::storage::{JsonlWriter, JsonlWriterConfig};
 use solana_sdk::pubkey::Pubkey;
-use std::str::FromStr;
 
 /// Build version for decision records
 const BUILD_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -164,6 +164,9 @@ const USDT_MINT: &str = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
 // Maximum reasonable spread before considering it a data error
 const MAX_REASONABLE_SPREAD_BPS: i64 = 1000; // 10%
 const STABLECOIN_MAX_SPREAD_BPS: i64 = 200; // 2% for stablecoins
+/// Broad stablecoin comparable-price guard (SOL per 1 whole token); not a hardcoded SOL/USD peg.
+const STABLECOIN_MIN_SOL_PER_TOKEN: &str = "0.0001";
+const STABLECOIN_MAX_SOL_PER_TOKEN: &str = "1";
 /// Geyser connection is considered broken if no MarketEvent received for this duration.
 /// This is NOT about individual pool staleness - it's about connection health.
 /// If Geyser is connected but a pool has no updates, the data IS current (pool is inactive).
@@ -375,6 +378,36 @@ fn dlmm_sol_output_from_bins(
     Some(amount_out)
 }
 
+fn is_stablecoin_mint(mint: &str) -> bool {
+    mint == USDC_MINT || mint == USDT_MINT
+}
+
+/// Reject obviously wrong side/decimal comparable prices (stablecoins only).
+fn is_plausible_sol_per_token_price(mint: &str, price: Decimal) -> bool {
+    if price <= Decimal::ZERO {
+        return false;
+    }
+    if is_stablecoin_mint(mint) {
+        let min = Decimal::from_str(STABLECOIN_MIN_SOL_PER_TOKEN).unwrap_or(Decimal::ZERO);
+        let max = Decimal::from_str(STABLECOIN_MAX_SOL_PER_TOKEN).unwrap_or(Decimal::ONE);
+        price >= min && price <= max
+    } else {
+        true
+    }
+}
+
+fn reserves_plausible_for_comparable_price(
+    reserve_base: u64,
+    reserve_quote: u64,
+    token_decimals: u8,
+    token_mint: &str,
+) -> bool {
+    reserve_base > 0
+        && reserve_quote > 0
+        && reserve_mid_sol_per_token(reserve_base, reserve_quote, token_decimals)
+            .is_some_and(|mid| is_plausible_sol_per_token_price(token_mint, mid))
+}
+
 /// Map on-chain base/quote reserves to token-base + SOL-quote for comparable pricing.
 fn sol_quoted_vault_reserves(
     base_mint: &str,
@@ -388,6 +421,22 @@ fn sol_quoted_vault_reserves(
         (reserve_quote, reserve_base)
     } else {
         (reserve_base, reserve_quote)
+    }
+}
+
+/// Explicit Orca WSOL-side mapping: vault_a/vault_b → (token_reserve, sol_reserve).
+fn orca_sol_quoted_vault_reserves(
+    token_mint_a: &str,
+    token_mint_b: &str,
+    vault_a_balance: u64,
+    vault_b_balance: u64,
+) -> Option<(u64, u64)> {
+    if token_mint_a == NATIVE_SOL_MINT {
+        Some((vault_b_balance, vault_a_balance))
+    } else if token_mint_b == NATIVE_SOL_MINT {
+        Some((vault_a_balance, vault_b_balance))
+    } else {
+        None
     }
 }
 
@@ -421,20 +470,33 @@ fn is_pool_price_fresh(
 fn comparable_price_sol_per_token(
     pool: &PoolState,
     vault_reserves: Option<(u64, u64)>,
-    token_decimals: u8,
+    token_decimals: Option<u8>,
+    token_mint: &str,
     vault_cache: Option<&VaultBalanceCache>,
     dlmm_bin_arrays: Option<&HashMap<i64, BinArrayCache>>,
     side: ComparablePriceSide,
 ) -> Option<Decimal> {
+    let token_decimals = token_decimals?;
+
     if pool.dex == "meteora_dlmm" {
         if let (Some(vault), Some(arrays)) = (vault_cache, dlmm_bin_arrays) {
             if let (Some(active_id), Some(bin_step)) = (vault.active_id, vault.bin_step) {
                 let flat = flatten_bin_array_cache(arrays);
                 let sol_is_x = vault_dlmm_sol_is_x(vault);
                 let reserve_mid = vault_reserves.and_then(|(base, quote)| {
-                    reserve_mid_sol_per_token(base, quote, token_decimals)
+                    if reserves_plausible_for_comparable_price(
+                        base,
+                        quote,
+                        token_decimals,
+                        token_mint,
+                    ) {
+                        reserve_mid_sol_per_token(base, quote, token_decimals)
+                    } else {
+                        None
+                    }
                 });
-                let trade_mid = trade_mid_sol_per_token(pool);
+                let trade_mid = trade_mid_sol_per_token(pool)
+                    .filter(|p| is_plausible_sol_per_token_price(token_mint, *p));
                 let marginal = match side {
                     ComparablePriceSide::Buy => dlmm_token_output_from_bins(
                         active_id,
@@ -468,7 +530,9 @@ fn comparable_price_sol_per_token(
                     }),
                 };
                 if let Some(price) = marginal.filter(|p| *p > Decimal::ZERO) {
-                    if dlmm_marginal_price_plausible(price, reserve_mid, trade_mid) {
+                    if dlmm_marginal_price_plausible(price, reserve_mid, trade_mid)
+                        && is_plausible_sol_per_token_price(token_mint, price)
+                    {
                         return Some(price);
                     }
                     DLMM_MARGINAL_PRICE_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
@@ -478,15 +542,35 @@ fn comparable_price_sol_per_token(
     }
 
     if let Some((reserve_base, reserve_quote)) = vault_reserves {
-        if let Some(mid) = reserve_mid_sol_per_token(reserve_base, reserve_quote, token_decimals) {
-            return Some(mid);
+        if reserves_plausible_for_comparable_price(
+            reserve_base,
+            reserve_quote,
+            token_decimals,
+            token_mint,
+        ) {
+            if let Some(mid) =
+                reserve_mid_sol_per_token(reserve_base, reserve_quote, token_decimals)
+            {
+                return Some(mid);
+            }
         }
     }
     match (pool.trade_price_buy, pool.trade_price_sell) {
         (Some(buy), Some(sell)) if buy > Decimal::ZERO && sell > Decimal::ZERO => {
-            Some((buy + sell) / Decimal::from(2))
+            let mid = (buy + sell) / Decimal::from(2);
+            if is_plausible_sol_per_token_price(token_mint, mid) {
+                Some(mid)
+            } else {
+                None
+            }
         }
-        (Some(one), None) | (None, Some(one)) if one > Decimal::ZERO => Some(one),
+        (Some(one), None) | (None, Some(one)) if one > Decimal::ZERO => {
+            if is_plausible_sol_per_token_price(token_mint, one) {
+                Some(one)
+            } else {
+                None
+            }
+        }
         _ => None,
     }
 }
@@ -502,13 +586,14 @@ fn sol_quoted_pool_seed(state: &CachedPoolState) -> Option<SolQuotedPoolSeed> {
             let mint_b = s.token_mint_b.to_string();
             let va = s.vault_a_balance?;
             let vb = s.vault_b_balance?;
-            if mint_b == NATIVE_SOL_MINT {
-                Some((mint_a, va, vb, None, None))
-            } else if mint_a == NATIVE_SOL_MINT {
-                Some((mint_b, vb, va, None, None))
+            let (reserve_base, reserve_quote) =
+                orca_sol_quoted_vault_reserves(&mint_a, &mint_b, va, vb)?;
+            let token_mint = if mint_a == NATIVE_SOL_MINT {
+                mint_b
             } else {
-                None
-            }
+                mint_a
+            };
+            Some((token_mint, reserve_base, reserve_quote, None, None))
         }
         CachedPoolState::RaydiumAmm(s) => {
             let base = s.base_mint.to_string();
@@ -657,10 +742,19 @@ fn seed_one_pool_from_live_cache(
     let tracker = trackers
         .entry(mint.to_string())
         .or_insert_with(|| TokenArbTracker::new(mint));
-    let token_decimals = tracker.token_decimals.unwrap_or(6);
     let liquidity_sol = Decimal::from(eff_reserve_quote) / Decimal::from(1_000_000_000u64);
-    let reserve_price =
-        reserve_mid_sol_per_token(eff_reserve_base, eff_reserve_quote, token_decimals);
+    let reserve_price = tracker.token_decimals.and_then(|token_decimals| {
+        if reserves_plausible_for_comparable_price(
+            eff_reserve_base,
+            eff_reserve_quote,
+            token_decimals,
+            mint,
+        ) {
+            reserve_mid_sol_per_token(eff_reserve_base, eff_reserve_quote, token_decimals)
+        } else {
+            None
+        }
+    });
     let (trade_price_buy, trade_price_sell, trade_count, dex_accounts) = tracker
         .pools
         .get(&pool_addr)
@@ -694,7 +788,8 @@ fn seed_one_pool_from_live_cache(
     let last_price = comparable_price_sol_per_token(
         &seed_pool,
         Some((eff_reserve_base, eff_reserve_quote)),
-        token_decimals,
+        tracker.token_decimals,
+        mint,
         vault_entry,
         dlmm_bins,
         ComparablePriceSide::Buy,
@@ -892,6 +987,7 @@ impl TokenArbTracker {
         vault_balances: &HashMap<String, VaultBalanceCache>,
         bin_arrays: &HashMap<String, HashMap<i64, BinArrayCache>>,
         spread_warn_last: &RwLock<HashMap<String, Instant>>,
+        data_quality_rejects: &AtomicU64,
     ) -> Option<ArbOpportunity> {
         // Check if 2-hop arbitrage is enabled
         if !config.two_hop_enabled {
@@ -902,7 +998,14 @@ impl TokenArbTracker {
             return None;
         }
 
-        let token_decimals = self.token_decimals.unwrap_or(6);
+        let Some(token_decimals) = self.token_decimals else {
+            debug!(
+                mint = %self.base_mint,
+                "Arb check: token decimals unknown — no synthetic fallback"
+            );
+            arb_two_hop_rejected_inc(ArbTwoHopRejectReason::NoComparablePrice);
+            return None;
+        };
 
         // Build comparable prices per pool (buy-side for cheapest, sell-side for highest bid)
         let mut best_buy: Option<(&PoolState, Decimal)> = None;
@@ -928,7 +1031,8 @@ impl TokenArbTracker {
             let buy_price = comparable_price_sol_per_token(
                 pool,
                 vault_reserves,
-                token_decimals,
+                Some(token_decimals),
+                &self.base_mint,
                 vault_entry,
                 dlmm_bins,
                 ComparablePriceSide::Buy,
@@ -936,7 +1040,8 @@ impl TokenArbTracker {
             let sell_price = comparable_price_sol_per_token(
                 pool,
                 vault_reserves,
-                token_decimals,
+                Some(token_decimals),
+                &self.base_mint,
                 vault_entry,
                 dlmm_bins,
                 ComparablePriceSide::Sell,
@@ -946,11 +1051,21 @@ impl TokenArbTracker {
             }
             eligible_pools += 1;
             if let Some(price) = buy_price.filter(|p| *p > Decimal::ZERO) {
+                if !is_plausible_sol_per_token_price(&self.base_mint, price) {
+                    data_quality_rejects.fetch_add(1, Ordering::Relaxed);
+                    arb_two_hop_rejected_inc(ArbTwoHopRejectReason::DataQuality);
+                    continue;
+                }
                 if best_buy.is_none() || price < best_buy.unwrap().1 {
                     best_buy = Some((pool, price));
                 }
             }
             if let Some(price) = sell_price.filter(|p| *p > Decimal::ZERO) {
+                if !is_plausible_sol_per_token_price(&self.base_mint, price) {
+                    data_quality_rejects.fetch_add(1, Ordering::Relaxed);
+                    arb_two_hop_rejected_inc(ArbTwoHopRejectReason::DataQuality);
+                    continue;
+                }
                 if best_sell.is_none() || price > best_sell.unwrap().1 {
                     best_sell = Some((pool, price));
                 }
@@ -969,6 +1084,14 @@ impl TokenArbTracker {
 
         let (buy_pool, buy_price) = best_buy?;
         let (sell_pool, sell_price) = best_sell?;
+
+        if !is_plausible_sol_per_token_price(&self.base_mint, buy_price)
+            || !is_plausible_sol_per_token_price(&self.base_mint, sell_price)
+        {
+            data_quality_rejects.fetch_add(1, Ordering::Relaxed);
+            arb_two_hop_rejected_inc(ArbTwoHopRejectReason::DataQuality);
+            return None;
+        }
 
         // Staleness: trade-implied or Geyser reserve data must be fresh
         let max_age = Duration::from_millis(MAX_PRICE_AGE_MS);
@@ -2159,11 +2282,19 @@ impl ArbContext {
                 pool.liquidity_sol = liquidity_sol;
                 pool.has_reserve_data = reserve_base > 0 && reserve_quote > 0;
                 pool.last_update = Instant::now();
-                let token_decimals = tracker.token_decimals.unwrap_or(6);
-                if let Some(mid) =
-                    reserve_mid_sol_per_token(reserve_base, reserve_quote, token_decimals)
-                {
-                    pool.last_price = Some(mid);
+                if let Some(token_decimals) = tracker.token_decimals {
+                    if reserves_plausible_for_comparable_price(
+                        reserve_base,
+                        reserve_quote,
+                        token_decimals,
+                        &tracker.base_mint,
+                    ) {
+                        if let Some(mid) =
+                            reserve_mid_sol_per_token(reserve_base, reserve_quote, token_decimals)
+                        {
+                            pool.last_price = Some(mid);
+                        }
+                    }
                 }
             }
         }
@@ -2494,7 +2625,8 @@ impl ArbContext {
         pool.last_price = comparable_price_sol_per_token(
             pool,
             vault_reserves,
-            token_decimals,
+            Some(token_decimals),
+            mint,
             vault_entry.as_ref(),
             dlmm_bins.as_ref(),
             ComparablePriceSide::Buy,
@@ -2530,6 +2662,7 @@ impl ArbContext {
             &vault_balances,
             &bin_arrays,
             &self.spread_too_large_warn_last,
+            &self.data_quality_rejects,
         ) {
             // Check cooldown
             let cooldown = Duration::from_millis(config.intent_cooldown_ms);
@@ -3877,7 +4010,8 @@ mod two_hop_price_tests {
         let p_a = comparable_price_sol_per_token(
             &pool_a,
             Some(reserves),
-            6,
+            Some(6),
+            "TokenMint11111111111111111111111111111111",
             Some(&vault),
             None,
             ComparablePriceSide::Buy,
@@ -3886,7 +4020,8 @@ mod two_hop_price_tests {
         let p_b = comparable_price_sol_per_token(
             &pool_b,
             Some(reserves),
-            6,
+            Some(6),
+            "TokenMint11111111111111111111111111111111",
             Some(&vault),
             None,
             ComparablePriceSide::Buy,
@@ -3906,9 +4041,16 @@ mod two_hop_price_tests {
         let buy_price = trade_implied_sol_per_token(2_000_000_000, 1_000_000_000_000, 6);
         let sell_price = trade_implied_sol_per_token(500_000_000, 1_000_000_000_000, 6);
         let pool = sample_pool("orca", "poolO", Some(buy_price), Some(sell_price));
-        let mid =
-            comparable_price_sol_per_token(&pool, None, 6, None, None, ComparablePriceSide::Buy)
-                .unwrap();
+        let mid = comparable_price_sol_per_token(
+            &pool,
+            None,
+            Some(6),
+            "TokenMint11111111111111111111111111111111",
+            None,
+            None,
+            ComparablePriceSide::Buy,
+        )
+        .unwrap();
         let naive_spread_bps = ((buy_price - sell_price) / sell_price * Decimal::from(10000))
             .round()
             .to_i64()
@@ -3960,7 +4102,8 @@ mod two_hop_price_tests {
             let p_dlmm = comparable_price_sol_per_token(
                 &dlmm_pool,
                 Some((reserve_base, reserve_quote)),
-                token_decimals,
+                Some(token_decimals),
+                USDC_MINT,
                 Some(&vault),
                 Some(&bin_arrays),
                 ComparablePriceSide::Buy,
@@ -3969,7 +4112,8 @@ mod two_hop_price_tests {
             let p_orca = comparable_price_sol_per_token(
                 &orca_pool,
                 Some((reserve_base, reserve_quote)),
-                token_decimals,
+                Some(token_decimals),
+                USDC_MINT,
                 Some(&vault),
                 None,
                 ComparablePriceSide::Buy,
@@ -4033,7 +4177,8 @@ mod two_hop_price_tests {
         let price = comparable_price_sol_per_token(
             &dlmm_pool,
             Some((reserve_base, reserve_quote)),
-            6,
+            Some(6),
+            USDC_MINT,
             Some(&vault),
             Some(&bin_arrays),
             ComparablePriceSide::Buy,
@@ -4116,19 +4261,22 @@ mod two_hop_price_tests {
         known_pools.insert(pool_a.to_string());
         known_pools.insert(pool_b.to_string());
 
-        let tracker = trackers.get(&mint_str).unwrap();
+        let tracker = trackers.get_mut(&mint_str).unwrap();
+        tracker.token_decimals = Some(6);
         assert_eq!(tracker.pools.len(), 2);
         assert_eq!(tracker.pool_count_on_distinct_dexes(), 2);
 
         let config = ArbConfig::default();
         let bin_arrays: HashMap<String, HashMap<i64, BinArrayCache>> = HashMap::new();
         let spread_warn_last = RwLock::new(HashMap::new());
+        let data_quality_rejects = AtomicU64::new(0);
         let opp = tracker.check_arbitrage(
             &config,
             &known_pools,
             &vault_balances,
             &bin_arrays,
             &spread_warn_last,
+            &data_quality_rejects,
         );
         // Same reserves → spread ~0, rejected by spread_below_min not insufficient_pools
         assert!(
@@ -4284,6 +4432,191 @@ mod two_hop_price_tests {
         assert!(!tracker.pools.contains_key(&pool_b.to_string()));
         assert!(vault_balances.contains_key(&pool_a.to_string()));
         assert!(!vault_balances.contains_key(&pool_b.to_string()));
+    }
+
+    #[test]
+    fn orca_wsol_usdc_mint_a_sol_comparable_price_sane() {
+        let sol_lamports = 1_000_000_000u64;
+        let usdc_raw = 65_000_000u64;
+        let (token_reserve, sol_reserve) =
+            orca_sol_quoted_vault_reserves(NATIVE_SOL_MINT, USDC_MINT, sol_lamports, usdc_raw)
+                .expect("WSOL/USDC Orca pool");
+        assert_eq!(token_reserve, usdc_raw);
+        assert_eq!(sol_reserve, sol_lamports);
+
+        let price = reserve_mid_sol_per_token(token_reserve, sol_reserve, 6).unwrap();
+        let expected = Decimal::from(1u64) / Decimal::from(65u64);
+        let ratio = if price > expected {
+            price / expected
+        } else {
+            expected / price
+        };
+        assert!(
+            ratio <= Decimal::from(2),
+            "price {price} should be near 1/65 SOL/USDC, not 1e-7 or 0.026"
+        );
+        assert!(is_plausible_sol_per_token_price(USDC_MINT, price));
+    }
+
+    #[test]
+    fn orca_usdc_wsol_swapped_orientation_same_price() {
+        let sol_lamports = 1_000_000_000u64;
+        let usdc_raw = 65_000_000u64;
+        let price_a =
+            orca_sol_quoted_vault_reserves(NATIVE_SOL_MINT, USDC_MINT, sol_lamports, usdc_raw)
+                .and_then(|(tb, tq)| reserve_mid_sol_per_token(tb, tq, 6));
+        let price_b =
+            orca_sol_quoted_vault_reserves(USDC_MINT, NATIVE_SOL_MINT, usdc_raw, sol_lamports)
+                .and_then(|(tb, tq)| reserve_mid_sol_per_token(tb, tq, 6));
+        assert_eq!(price_a, price_b);
+    }
+
+    #[test]
+    fn orca_and_dlmm_realistic_reserves_no_spread_too_large() {
+        let reserve_base = 65_000_000u64;
+        let reserve_quote = 1_000_000_000u64;
+        let active_id: i32 = 0;
+        let bin_step: u16 = 10;
+        let (bin_arrays, vault, token_decimals) =
+            usdc_sol_dlmm_fixture(false, reserve_base, reserve_quote, active_id, bin_step);
+
+        let dlmm_pool = sample_pool("meteora_dlmm", "dlmmUsdc", None, None);
+        let orca_pool = sample_pool("orca", "orcaUsdc", None, None);
+        let p_dlmm = comparable_price_sol_per_token(
+            &dlmm_pool,
+            Some((reserve_base, reserve_quote)),
+            Some(token_decimals),
+            USDC_MINT,
+            Some(&vault),
+            Some(&bin_arrays),
+            ComparablePriceSide::Buy,
+        )
+        .unwrap();
+        let p_orca = comparable_price_sol_per_token(
+            &orca_pool,
+            Some((reserve_base, reserve_quote)),
+            Some(token_decimals),
+            USDC_MINT,
+            Some(&vault),
+            None,
+            ComparablePriceSide::Buy,
+        )
+        .unwrap();
+        let spread_bps = ((p_orca - p_dlmm) / p_dlmm * Decimal::from(10000))
+            .abs()
+            .round()
+            .to_i64()
+            .unwrap();
+        assert!(
+            spread_bps < STABLECOIN_MAX_SPREAD_BPS,
+            "realistic Orca/DLMM reserves should not trip spread_too_large ({spread_bps} bps)"
+        );
+    }
+
+    #[test]
+    fn prod_like_swapped_reserves_rejected_not_spread_too_large() {
+        let sol_in_base = 1_000_000_000u64;
+        let usdc_in_quote = 65_000_000u64;
+        assert!(!reserves_plausible_for_comparable_price(
+            sol_in_base,
+            usdc_in_quote,
+            6,
+            USDC_MINT
+        ));
+
+        let pool = sample_pool("orca", "orcaSwapped", None, None);
+        let price = comparable_price_sol_per_token(
+            &pool,
+            Some((sol_in_base, usdc_in_quote)),
+            Some(6),
+            USDC_MINT,
+            None,
+            None,
+            ComparablePriceSide::Buy,
+        );
+        assert!(
+            price.is_none(),
+            "prod-like swapped reserves must not produce comparable price"
+        );
+
+        let before_spread =
+            ironcrab::metrics::ARB_TWO_HOP_REJECTED_SPREAD_TOO_LARGE.load(Ordering::Relaxed);
+        let mut tracker = TokenArbTracker::new(USDC_MINT);
+        tracker.token_decimals = Some(6);
+        tracker.upsert_pool(pool);
+        let mut known_pools = HashSet::new();
+        known_pools.insert("orcaSwapped".to_string());
+        let opp = tracker.check_arbitrage(
+            &ArbConfig::default(),
+            &known_pools,
+            &HashMap::from([(
+                "orcaSwapped".to_string(),
+                VaultBalanceCache {
+                    reserve_base: sol_in_base,
+                    reserve_quote: usdc_in_quote,
+                    update_slot: 1,
+                    active_id: None,
+                    bin_step: None,
+                    updated_at: Instant::now(),
+                    dlmm_sol_is_x: false,
+                    dlmm_token_x_mint: None,
+                },
+            )]),
+            &HashMap::new(),
+            &RwLock::new(HashMap::new()),
+            &AtomicU64::new(0),
+        );
+        assert!(opp.is_none());
+        assert_eq!(
+            ironcrab::metrics::ARB_TWO_HOP_REJECTED_SPREAD_TOO_LARGE.load(Ordering::Relaxed),
+            before_spread
+        );
+    }
+
+    #[test]
+    fn stablecoin_out_of_range_trade_mid_rejected() {
+        let bad_buy = Decimal::from_str("0.000000094").unwrap();
+        let bad_sell = Decimal::from_str("5.0").unwrap();
+        assert!(!is_plausible_sol_per_token_price(USDC_MINT, bad_buy));
+        assert!(!is_plausible_sol_per_token_price(USDC_MINT, bad_sell));
+
+        let pool = sample_pool("orca", "orcaBad", Some(bad_buy), Some(bad_sell));
+        let buy = comparable_price_sol_per_token(
+            &pool,
+            None,
+            Some(6),
+            USDC_MINT,
+            None,
+            None,
+            ComparablePriceSide::Buy,
+        );
+        let sell = comparable_price_sol_per_token(
+            &pool,
+            None,
+            Some(6),
+            USDC_MINT,
+            None,
+            None,
+            ComparablePriceSide::Sell,
+        );
+        assert!(buy.is_none());
+        assert!(sell.is_none());
+    }
+
+    #[test]
+    fn missing_decimals_no_synthetic_reserve_mid() {
+        let pool = sample_pool("orca", "orcaNoDec", None, None);
+        let reserves = (65_000_000u64, 1_000_000_000u64);
+        let price = comparable_price_sol_per_token(
+            &pool,
+            Some(reserves),
+            None,
+            USDC_MINT,
+            None,
+            None,
+            ComparablePriceSide::Buy,
+        );
+        assert!(price.is_none(), "must not assume 6 decimals when unknown");
     }
 }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4353,7 +4353,14 @@ impl MarketDataContext {
 
         if enable_meteora_dlmm {
             if let CachedPoolState::Meteora(s) = cached_state {
-                if admit(s.token_x_mint, s.token_y_mint) {
+                let (base_mint_v, quote_mint_v, base_vault, quote_vault) =
+                    cpmm_token_mints_and_vaults_sol_normalized(
+                        s.token_x_mint,
+                        s.token_y_mint,
+                        s.reserve_x,
+                        s.reserve_y,
+                    );
+                if admit(base_mint_v, quote_mint_v) {
                     let mut vaults = self.tracked_vaults.write();
                     insert_tracked_vault_pair(
                         &mut vaults,
@@ -4362,15 +4369,43 @@ impl MarketDataContext {
                             pool,
                             now,
                             dex: "meteora_dlmm",
-                            base_mint: s.token_x_mint,
-                            quote_mint: s.token_y_mint,
-                            base_vault: s.reserve_x,
-                            quote_vault: s.reserve_y,
+                            base_mint: base_mint_v,
+                            quote_mint: quote_mint_v,
+                            base_vault,
+                            quote_vault,
                             active_id: Some(s.active_id),
                             bin_step: Some(s.bin_step),
                         },
                     );
                 }
+            }
+        }
+
+        if let CachedPoolState::Orca(s) = cached_state {
+            let (base_mint_v, quote_mint_v, base_vault, quote_vault) =
+                cpmm_token_mints_and_vaults_sol_normalized(
+                    s.token_mint_a,
+                    s.token_mint_b,
+                    s.token_vault_a,
+                    s.token_vault_b,
+                );
+            if admit(base_mint_v, quote_mint_v) {
+                let mut vaults = self.tracked_vaults.write();
+                insert_tracked_vault_pair(
+                    &mut vaults,
+                    &mut vaults_changed,
+                    TrackedVaultPairInsert {
+                        pool,
+                        now,
+                        dex: "orca",
+                        base_mint: base_mint_v,
+                        quote_mint: quote_mint_v,
+                        base_vault,
+                        quote_vault,
+                        active_id: None,
+                        bin_step: None,
+                    },
+                );
             }
         }
 
@@ -4486,44 +4521,6 @@ impl MarketDataContext {
                             });
                         }
                     }
-                }
-            }
-            CachedPoolState::Orca(s) => {
-                let dex_str = "orca".to_string();
-                {
-                    let mut vaults = self.tracked_vaults.write();
-                    vaults.entry(s.token_vault_a).or_insert_with(|| {
-                        vaults_changed = true;
-                        VaultInfo {
-                            pool_address: pool,
-                            dex: dex_str.clone(),
-                            base_mint: s.token_mint_a,
-                            quote_mint: s.token_mint_b,
-                            is_base_vault: true,
-                            last_balance: std::sync::atomic::AtomicU64::new(0),
-                            last_used_at: now,
-                            pinned: false,
-                            pin: None,
-                            active_id: None,
-                            bin_step: None,
-                        }
-                    });
-                    vaults.entry(s.token_vault_b).or_insert_with(|| {
-                        vaults_changed = true;
-                        VaultInfo {
-                            pool_address: pool,
-                            dex: dex_str,
-                            base_mint: s.token_mint_a,
-                            quote_mint: s.token_mint_b,
-                            is_base_vault: false,
-                            last_balance: std::sync::atomic::AtomicU64::new(0),
-                            last_used_at: now,
-                            pinned: false,
-                            pin: None,
-                            active_id: None,
-                            bin_step: None,
-                        }
-                    });
                 }
             }
             CachedPoolState::RaydiumAmm(s) => {

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -44,11 +44,11 @@ use ironcrab::ipc::{
     POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY,
     POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_ONCHAIN_MINTS_KEY,
     POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY, POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY,
-    POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY, POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY,
-    POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY, POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY,
-    POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY,
-    POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY,
-    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY, POOL_CACHE_UPDATE_ORCA_ONCHAIN_MINTS_KEY,
+    POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY,
+    POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY, POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY,
+    POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY,
+    POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -2533,12 +2533,21 @@ fn meteora_cpmm_onchain_mints_for_pool_cache_update(s: &MeteoraCpmmState) -> Str
     format!("{},{}", s.token_0_mint, s.token_1_mint)
 }
 
+/// On-chain `token_mint_a,token_mint_b` for SLAVE bootstrap when JetStream uses normalized base/quote.
+fn orca_onchain_mints_for_pool_cache_update(s: &OrcaWhirlpoolState) -> String {
+    format!("{},{}", s.token_mint_a, s.token_mint_b)
+}
+
 /// Orca Whirlpool: PoolCacheUpdate metadata keys for SLAVE bootstrap (BalanceUpdated + PoolDiscovered).
 fn orca_metadata_for_pool_cache_update(s: &OrcaWhirlpoolState) -> HashMap<String, String> {
     let mut meta = HashMap::new();
     meta.insert(
         POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY.to_string(),
         format!("{},{}", s.token_vault_a, s.token_vault_b),
+    );
+    meta.insert(
+        POOL_CACHE_UPDATE_ORCA_ONCHAIN_MINTS_KEY.to_string(),
+        orca_onchain_mints_for_pool_cache_update(s),
     );
     meta.insert(
         POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY.to_string(),

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -42,12 +42,13 @@ use ironcrab::ipc::{
     ExecutionStatus, IntentTier, MarketEvent, MarketEventKind, PoolCacheUpdate,
     PriorityFeePercentiles, NATIVE_SOL_MINT, POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY,
     POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY,
-    POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY,
-    POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY,
-    POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY,
-    POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY, POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY,
-    POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY,
-    POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_ONCHAIN_MINTS_KEY,
+    POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY, POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY,
+    POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY, POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY,
+    POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY, POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY,
+    POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY,
+    POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY,
+    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -2578,12 +2579,21 @@ fn orca_metadata_for_pool_cache_update(s: &OrcaWhirlpoolState) -> HashMap<String
     meta
 }
 
+/// On-chain `token_x_mint,token_y_mint` for SLAVE bootstrap when JetStream uses normalized base/quote.
+fn meteora_dlmm_onchain_mints_for_pool_cache_update(s: &MeteoraState) -> String {
+    format!("{},{}", s.token_x_mint, s.token_y_mint)
+}
+
 /// Meteora DLMM: vault pubkeys + static pool fields for JetStream / SLAVE bootstrap.
 fn meteora_dlmm_metadata_for_pool_cache_update(s: &MeteoraState) -> HashMap<String, String> {
     let mut meta = HashMap::new();
     meta.insert(
         POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY.to_string(),
         format!("{},{}", s.reserve_x, s.reserve_y),
+    );
+    meta.insert(
+        POOL_CACHE_UPDATE_METEORA_DLMM_ONCHAIN_MINTS_KEY.to_string(),
+        meteora_dlmm_onchain_mints_for_pool_cache_update(s),
     );
     meta.insert(
         POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY.to_string(),

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -28,12 +28,12 @@ use crate::ipc::{
     PoolCacheUpdate, PoolCacheUpdateType, NATIVE_SOL_MINT,
     POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY, POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY,
     POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY,
-    POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY, POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY,
-    POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY, POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY,
-    POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY, POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY,
-    POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY,
-    POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY,
-    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    POOL_CACHE_UPDATE_METEORA_DLMM_ONCHAIN_MINTS_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY,
+    POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY,
+    POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY,
+    POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY, POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY,
+    POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY,
+    POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use crate::nats::{slave_consumer_config, NatsClient, STREAM_NAME};
 
@@ -46,10 +46,18 @@ fn extract_reserves(state: &CachedPoolState) -> (u64, u64) {
         ),
         CachedPoolState::RaydiumAmm(s) => (s.coin_reserve.unwrap_or(0), s.pc_reserve.unwrap_or(0)),
         CachedPoolState::RaydiumCpmm(s) => (s.reserve_0.unwrap_or(0), s.reserve_1.unwrap_or(0)),
-        CachedPoolState::Meteora(s) => (
-            s.reserve_x_balance.unwrap_or(0),
-            s.reserve_y_balance.unwrap_or(0),
-        ),
+        CachedPoolState::Meteora(s) => {
+            let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap_or_default();
+            let rx = s.reserve_x_balance.unwrap_or(0);
+            let ry = s.reserve_y_balance.unwrap_or(0);
+            if s.token_y_mint == sol {
+                (rx, ry)
+            } else if s.token_x_mint == sol {
+                (ry, rx)
+            } else {
+                (rx, ry)
+            }
+        }
         CachedPoolState::PumpAmm(s) => (s.base_reserve.unwrap_or(0), s.quote_reserve.unwrap_or(0)),
         CachedPoolState::PumpFun(s) => (s.virtual_token_reserves, s.virtual_sol_reserves),
         CachedPoolState::MeteoraCpmm(s) => {
@@ -238,15 +246,36 @@ fn build_minimal_pool_state_with_reserves(
                 .and_then(|s| s.parse::<u16>().ok())
                 .unwrap_or(0);
 
+            let (token_x_mint, token_y_mint, reserve_x_balance, reserve_y_balance) = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_METEORA_DLMM_ONCHAIN_MINTS_KEY))
+                .and_then(|s| {
+                    let mut it = s.split(',').filter_map(|a| Pubkey::from_str(a.trim()).ok());
+                    match (it.next(), it.next()) {
+                        (Some(tx), Some(ty)) => Some((tx, ty)),
+                        _ => None,
+                    }
+                })
+                .map(|(tx, ty)| {
+                    let (rx, ry) = if tx == base_mint && ty == quote_mint {
+                        (base_reserve, quote_reserve)
+                    } else if tx == quote_mint && ty == base_mint {
+                        (quote_reserve, base_reserve)
+                    } else {
+                        (base_reserve, quote_reserve)
+                    };
+                    (tx, ty, rx, ry)
+                })
+                .unwrap_or((base_mint, quote_mint, base_reserve, quote_reserve));
+
             CachedPoolState::Meteora(MeteoraState {
-                token_x_mint: base_mint,
-                token_y_mint: quote_mint,
+                token_x_mint,
+                token_y_mint,
                 reserve_x,
                 reserve_y,
                 active_id,
                 bin_step,
-                reserve_x_balance: Some(base_reserve),
-                reserve_y_balance: Some(quote_reserve),
+                reserve_x_balance: Some(reserve_x_balance),
+                reserve_y_balance: Some(reserve_y_balance),
             })
         }
         "meteora_cpmm" => {
@@ -963,6 +992,34 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 if update.dex == "meteora_dlmm" {
                     let um = update.metadata.as_ref();
                     if let CachedPoolState::Meteora(ref mut new_m) = minimal_state {
+                        let update_has_onchain_mints = um
+                            .and_then(|m| m.get(POOL_CACHE_UPDATE_METEORA_DLMM_ONCHAIN_MINTS_KEY))
+                            .is_some();
+                        if !update_has_onchain_mints {
+                            if let Some(CachedPoolState::Meteora(ex)) = existing.as_ref() {
+                                new_m.token_x_mint = ex.token_x_mint;
+                                new_m.token_y_mint = ex.token_y_mint;
+                                if let (Ok(up_base), Ok(up_quote)) = (
+                                    Pubkey::from_str(&update.base_mint),
+                                    Pubkey::from_str(&update.quote_mint),
+                                ) {
+                                    new_m.reserve_x_balance = if ex.token_x_mint == up_base {
+                                        Some(base_reserve)
+                                    } else if ex.token_x_mint == up_quote {
+                                        Some(quote_reserve)
+                                    } else {
+                                        new_m.reserve_x_balance
+                                    };
+                                    new_m.reserve_y_balance = if ex.token_y_mint == up_base {
+                                        Some(base_reserve)
+                                    } else if ex.token_y_mint == up_quote {
+                                        Some(quote_reserve)
+                                    } else {
+                                        new_m.reserve_y_balance
+                                    };
+                                }
+                            }
+                        }
                         if let Some(CachedPoolState::Meteora(ex)) = existing.as_ref() {
                             if new_m.reserve_x == Pubkey::default()
                                 && ex.reserve_x != Pubkey::default()

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -30,10 +30,11 @@ use crate::ipc::{
     POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_BIN_STEP_KEY,
     POOL_CACHE_UPDATE_METEORA_DLMM_ONCHAIN_MINTS_KEY, POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY,
     POOL_CACHE_UPDATE_ORCA_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_LIQUIDITY_KEY,
-    POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY, POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY,
-    POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY, POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY,
-    POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY,
-    POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    POOL_CACHE_UPDATE_ORCA_ONCHAIN_MINTS_KEY, POOL_CACHE_UPDATE_ORCA_PROTOCOL_FEE_RATE_KEY,
+    POOL_CACHE_UPDATE_ORCA_SQRT_PRICE_KEY, POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY,
+    POOL_CACHE_UPDATE_ORCA_TICK_SPACING_KEY, POOL_CACHE_UPDATE_ORCA_TOKEN_A_PROGRAM_KEY,
+    POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY, POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY,
+    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use crate::nats::{slave_consumer_config, NatsClient, STREAM_NAME};
 
@@ -161,9 +162,36 @@ fn build_minimal_pool_state_with_reserves(
                 .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY))
                 .and_then(|s| Pubkey::from_str(s.trim()).ok());
 
+            let (token_mint_a, token_mint_b, vault_a_balance, vault_b_balance) = meta
+                .and_then(|m| m.get(POOL_CACHE_UPDATE_ORCA_ONCHAIN_MINTS_KEY))
+                .and_then(|s| {
+                    let mut it = s.split(',').filter_map(|a| Pubkey::from_str(a.trim()).ok());
+                    match (it.next(), it.next()) {
+                        (Some(ma), Some(mb)) => Some((ma, mb)),
+                        _ => None,
+                    }
+                })
+                .map(|(ma, mb)| {
+                    let (va, vb) = orca_map_normalized_reserves_to_vault_balances(
+                        ma,
+                        mb,
+                        base_mint,
+                        quote_mint,
+                        base_reserve,
+                        quote_reserve,
+                    );
+                    (ma, mb, va, vb)
+                })
+                .unwrap_or((
+                    base_mint,
+                    quote_mint,
+                    Some(base_reserve),
+                    Some(quote_reserve),
+                ));
+
             CachedPoolState::Orca(OrcaWhirlpoolState {
-                token_mint_a: base_mint,
-                token_mint_b: quote_mint,
+                token_mint_a,
+                token_mint_b,
                 token_vault_a,
                 token_vault_b,
                 tick_current_index,
@@ -172,8 +200,8 @@ fn build_minimal_pool_state_with_reserves(
                 fee_rate,
                 protocol_fee_rate,
                 tick_spacing,
-                vault_a_balance: Some(base_reserve),
-                vault_b_balance: Some(quote_reserve),
+                vault_a_balance,
+                vault_b_balance,
                 token_a_program,
                 token_b_program,
             })
@@ -2902,6 +2930,51 @@ mod tests {
             "merge must not downgrade Ready to Observed for Orca"
         );
         assert_eq!(cache.orca_readiness(&pool), Some(DexPoolReadiness::Ready));
+    }
+
+    #[test]
+    fn test_orca_balance_updated_bootstrap_maps_normalized_reserves_when_sol_is_token_a() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let usdc = Pubkey::new_unique();
+        let sol = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let va = Pubkey::new_unique();
+        let vb = Pubkey::new_unique();
+
+        let mut meta = std::collections::HashMap::new();
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY.to_string(),
+            format!("{va},{vb}"),
+        );
+        meta.insert(
+            POOL_CACHE_UPDATE_ORCA_ONCHAIN_MINTS_KEY.to_string(),
+            format!("{sol},{usdc}"),
+        );
+
+        let mut update = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "orca".to_string(),
+            usdc.to_string(),
+            sol.to_string(),
+            66_000_000,
+            1_100_000_000,
+            2,
+        );
+        update.metadata = Some(meta);
+        assert!(apply_pool_cache_update(&cache, &update));
+
+        let state = cache.get(&pool).expect("orca pool");
+        if let CachedPoolState::Orca(s) = state {
+            assert_eq!(s.token_mint_a, sol);
+            assert_eq!(s.token_mint_b, usdc);
+            assert_eq!(s.vault_a_balance, Some(1_100_000_000));
+            assert_eq!(s.vault_b_balance, Some(66_000_000));
+        } else {
+            panic!("expected Orca state");
+        }
     }
 
     #[test]

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -78,6 +78,24 @@ pub fn build_minimal_pool_state(update: &PoolCacheUpdate) -> Option<(Pubkey, Cac
     build_minimal_pool_state_with_reserves(update, update.base_reserve, update.quote_reserve)
 }
 
+/// Map normalized JetStream reserves onto on-chain Orca vault_a/vault_b balances.
+fn orca_map_normalized_reserves_to_vault_balances(
+    onchain_mint_a: Pubkey,
+    onchain_mint_b: Pubkey,
+    normalized_base: Pubkey,
+    normalized_quote: Pubkey,
+    base_reserve: u64,
+    quote_reserve: u64,
+) -> (Option<u64>, Option<u64>) {
+    if onchain_mint_a == normalized_base && onchain_mint_b == normalized_quote {
+        (Some(base_reserve), Some(quote_reserve))
+    } else if onchain_mint_a == normalized_quote && onchain_mint_b == normalized_base {
+        (Some(quote_reserve), Some(base_reserve))
+    } else {
+        (Some(base_reserve), Some(quote_reserve))
+    }
+}
+
 /// Build minimal state with explicit reserves (used for BalanceUpdated merge).
 fn build_minimal_pool_state_with_reserves(
     update: &PoolCacheUpdate,
@@ -863,6 +881,23 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                     let um = update.metadata.as_ref();
                     if let CachedPoolState::Orca(ref mut new_o) = minimal_state {
                         if let Some(CachedPoolState::Orca(ex)) = existing.as_ref() {
+                            new_o.token_mint_a = ex.token_mint_a;
+                            new_o.token_mint_b = ex.token_mint_b;
+                            if let (Ok(up_base), Ok(up_quote)) = (
+                                Pubkey::from_str(&update.base_mint),
+                                Pubkey::from_str(&update.quote_mint),
+                            ) {
+                                let (va, vb) = orca_map_normalized_reserves_to_vault_balances(
+                                    ex.token_mint_a,
+                                    ex.token_mint_b,
+                                    up_base,
+                                    up_quote,
+                                    base_reserve,
+                                    quote_reserve,
+                                );
+                                new_o.vault_a_balance = va;
+                                new_o.vault_b_balance = vb;
+                            }
                             if new_o.token_vault_a == Pubkey::default()
                                 && ex.token_vault_a != Pubkey::default()
                             {
@@ -2810,5 +2845,60 @@ mod tests {
             "merge must not downgrade Ready to Observed for Orca"
         );
         assert_eq!(cache.orca_readiness(&pool), Some(DexPoolReadiness::Ready));
+    }
+
+    #[test]
+    fn test_orca_balance_updated_maps_normalized_reserves_when_sol_is_token_a() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let usdc = Pubkey::new_unique();
+        let sol = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let va = Pubkey::new_unique();
+        let vb = Pubkey::new_unique();
+
+        cache.upsert(
+            pool,
+            CachedPoolState::Orca(OrcaWhirlpoolState {
+                token_mint_a: sol,
+                token_mint_b: usdc,
+                token_vault_a: va,
+                token_vault_b: vb,
+                tick_current_index: 0,
+                sqrt_price: 1,
+                liquidity: 1,
+                fee_rate: 1,
+                protocol_fee_rate: 1,
+                tick_spacing: 64,
+                vault_a_balance: Some(1_000_000_000),
+                vault_b_balance: Some(65_000_000),
+                token_a_program: None,
+                token_b_program: None,
+            }),
+            1,
+        );
+
+        let update = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "orca".to_string(),
+            usdc.to_string(),
+            sol.to_string(),
+            66_000_000,
+            1_100_000_000,
+            2,
+        );
+        assert!(apply_pool_cache_update(&cache, &update));
+
+        let state = cache.get(&pool).expect("orca pool");
+        if let CachedPoolState::Orca(s) = state {
+            assert_eq!(s.token_mint_a, sol);
+            assert_eq!(s.token_mint_b, usdc);
+            assert_eq!(s.vault_a_balance, Some(1_100_000_000));
+            assert_eq!(s.vault_b_balance, Some(66_000_000));
+        } else {
+            panic!("expected Orca state");
+        }
     }
 }

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -2898,10 +2898,17 @@ pub const POOL_CACHE_UPDATE_ORCA_TOKEN_B_PROGRAM_KEY: &str = "orca_token_b_progr
 
 /// Meteora DLMM: `reserve_x_vault,reserve_y_vault` (comma-separated base58).
 ///
-/// Order matches on-chain LB pair layout (`token_x_mint` / `token_y_mint`), which is the same as
-/// [`PoolCacheUpdate::base_mint`] / [`PoolCacheUpdate::quote_mint`] for Meteora DLMM publishes from
-/// market-data (`token_x` → base, `token_y` → quote).
+/// Order matches on-chain LB pair layout (`reserve_x` / `reserve_y` vault ATAs), **not** normalized
+/// JetStream `base_mint` / `quote_mint` (token-as-base, SOL-as-quote when present).
 pub const POOL_CACHE_UPDATE_METEORA_DLMM_VAULTS_KEY: &str = "meteora_dlmm_vaults";
+
+/// Metadata key for Meteora DLMM: `token_x_mint,token_y_mint` (comma-separated base58), **on-chain**
+/// LB pair order (not normalized base/quote).
+///
+/// Lets SLAVE `build_minimal_pool_state` map JetStream `base_reserve`/`quote_reserve` (normalized:
+/// non-SOL base first) onto the correct `reserve_x_balance`/`reserve_y_balance` even when SOL is
+/// token_x on-chain.
+pub const POOL_CACHE_UPDATE_METEORA_DLMM_ONCHAIN_MINTS_KEY: &str = "meteora_dlmm_onchain_mints";
 
 /// Meteora DLMM: active bin id from pool account (decimal string, signed i32).
 pub const POOL_CACHE_UPDATE_METEORA_DLMM_ACTIVE_ID_KEY: &str = "meteora_dlmm_active_id";

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -2879,10 +2879,17 @@ pub const POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY: &str = "meteora_cpmm
 
 /// Metadata key for Orca Whirlpool: `token_vault_a,token_vault_b` (comma-separated base58).
 ///
-/// Order matches on-chain Whirlpool layout (`token_mint_a` / `token_mint_b` on the pool), which is
-/// the same order as [`PoolCacheUpdate::base_mint`] / [`PoolCacheUpdate::quote_mint`] for Orca
-/// publishes from market-data (token A then token B).
+/// Order matches on-chain Whirlpool layout (`token_mint_a` / `token_mint_b` on the pool), **not**
+/// normalized JetStream `base_mint` / `quote_mint`.
 pub const POOL_CACHE_UPDATE_ORCA_WHIRLPOOL_VAULTS_KEY: &str = "orca_whirlpool_vaults";
+
+/// Metadata key for Orca Whirlpool: `token_mint_a,token_mint_b` (comma-separated base58), **on-chain**
+/// Whirlpool order (not normalized base/quote).
+///
+/// Lets SLAVE `build_minimal_pool_state` map JetStream `base_reserve`/`quote_reserve` (normalized:
+/// non-SOL base first) onto the correct `vault_a_balance`/`vault_b_balance` even when SOL is
+/// `token_mint_a` on-chain.
+pub const POOL_CACHE_UPDATE_ORCA_ONCHAIN_MINTS_KEY: &str = "orca_onchain_mints";
 
 /// Orca Whirlpool static fields from the pool account (Geyser parse), as decimal strings in metadata.
 pub const POOL_CACHE_UPDATE_ORCA_TICK_CURRENT_INDEX_KEY: &str = "orca_tick_current_index";

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2448,6 +2448,7 @@ pub static ARB_TWO_HOP_REJECTED_STALE_PRICE: Lazy<AtomicU64> = Lazy::new(|| Atom
 pub static ARB_TWO_HOP_REJECTED_NO_COMPARABLE_PRICE: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TWO_HOP_REJECTED_NATIVE_SOL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_REJECTED_DATA_QUALITY: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
 /// Rejection reason for 2-hop cross-DEX arb checks (Prometheus label `reason`).
 #[derive(Debug, Clone, Copy)]
@@ -2461,6 +2462,7 @@ pub enum ArbTwoHopRejectReason {
     StalePrice,
     NoComparablePrice,
     NativeSol,
+    DataQuality,
 }
 
 /// Increment `arb_two_hop_rejected_total{reason=...}` for the given rejection.
@@ -2475,6 +2477,7 @@ pub fn arb_two_hop_rejected_inc(reason: ArbTwoHopRejectReason) {
         ArbTwoHopRejectReason::StalePrice => &*ARB_TWO_HOP_REJECTED_STALE_PRICE,
         ArbTwoHopRejectReason::NoComparablePrice => &*ARB_TWO_HOP_REJECTED_NO_COMPARABLE_PRICE,
         ArbTwoHopRejectReason::NativeSol => &*ARB_TWO_HOP_REJECTED_NATIVE_SOL,
+        ArbTwoHopRejectReason::DataQuality => &*ARB_TWO_HOP_REJECTED_DATA_QUALITY,
     };
     counter.fetch_add(1, Ordering::Relaxed);
 }
@@ -4522,6 +4525,13 @@ async fn metrics_response() -> Response<Body> {
     out.push_str("arb_two_hop_rejected_total{reason=\"native_sol\"} ");
     out.push_str(
         &ARB_TWO_HOP_REJECTED_NATIVE_SOL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_rejected_total{reason=\"data_quality\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECTED_DATA_QUALITY
             .load(Ordering::Relaxed)
             .to_string(),
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the 2-hop comparable-price path for USDC Orca ↔ Meteora DLMM after prod logs showed absurd spreads (`buy_price≈9.4e-8`, `sell_price≈0.027`, `spread_too_large`).

**Root cause:** Orca vault tracking used raw on-chain `token_mint_a/b` without SOL normalization. SOL lamports could land in `reserve_base` and be divided with token decimals → prices orders of magnitude too low.

## Changes

### `market_data.rs`
- Orca + Meteora DLMM vault registration now uses `cpmm_token_mints_and_vaults_sol_normalized` + `insert_tracked_vault_pair` (same pattern as Raydium CPMM).
- `PoolStateUpdate` / `PoolCacheUpdate` consistently emit `reserve_base` = token raw, `reserve_quote` = SOL lamports.

### `arb_strategy.rs`
- Explicit `orca_sol_quoted_vault_reserves` for WSOL-side mapping.
- No `unwrap_or(6)` for reserve-mid without known decimals.
- Stablecoin plausibility gate: 0.0001–1 SOL per token (USDC/USDT).
- Implausible prices → `arb_two_hop_rejected_total{reason="data_quality"}` instead of `spread_too_large`.
- Reserve-mid only when both sides > 0, decimals known, and price is plausible.

### `pool_cache_sync.rs`
- Orca `BalanceUpdated` maps normalized JetStream reserves onto on-chain `vault_a`/`vault_b` when WSOL is `token_mint_a`.

### `metrics.rs`
- New reject reason: `data_quality`.

## Regression tests

1. Orca WSOL/USDC (`token_mint_a=WSOL`, 1 SOL / ~65 USDC) → price ≈ 1/65 SOL/USDC
2. Swapped Orca orientation → same price
3. Orca + DLMM realistic reserves → no `spread_too_large`
4. Prod-like swapped reserves → rejected, not `spread_too_large`
5. Missing decimals → no synthetic 6-decimal fallback

## CI / local verification

```
cargo fmt --check   ✅
cargo clippy -- -D warnings   ✅
cargo test   ✅ (436+ tests)
```

## Invariants

- No new RPC in hot path (I-7)
- No threshold loosening (`max_spread` unchanged)
- Geyser-first reserve data preserved (I-4, I-16)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-102a9ffd-803d-43af-94c7-c5c90835dfa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-102a9ffd-803d-43af-94c7-c5c90835dfa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

