### PR TITLE
feat(arb-strategy): 2-hop eligibility forensics + multi-hop quote readiness

### DIFF
--- a/src/arbitrage/multi_hop_integration.rs
+++ b/src/arbitrage/multi_hop_integration.rs
@@ -442,6 +442,11 @@ impl CachedQuoteProvider {
             self.cleanup();
         }
     }
+
+    /// Read-only quote-ready probe for metrics/diagnostics (does not evict stale index entries).
+    pub fn probe_pool_quote_ready(&self, pool_address: &Pubkey) -> bool {
+        self.quote_ready.contains(pool_address) && self.pool_still_quote_ready(pool_address)
+    }
 }
 
 impl QuoteProvider for CachedQuoteProvider {
@@ -934,7 +939,10 @@ impl MultiHopArbitrage {
                 let quote_ready_neighbors = neighbors
                     .iter()
                     .flat_map(|(_, edges)| edges)
-                    .filter(|edge| self.quote_provider.is_pool_quote_ready(&edge.pool_address))
+                    .filter(|edge| {
+                        self.quote_provider
+                            .probe_pool_quote_ready(&edge.pool_address)
+                    })
                     .count();
                 if quote_ready_neighbors < 2 {
                     multi_hop_search_no_quote_neighbors_inc();
@@ -1161,7 +1169,7 @@ impl MultiHopArbitrage {
             .iter()
             .filter(|(pool, (mint_a, mint_b))| {
                 (*mint_a == wsol || *mint_b == wsol)
-                    && self.quote_provider.is_pool_quote_ready(pool)
+                    && self.quote_provider.probe_pool_quote_ready(pool)
             })
             .count() as u64;
         multi_hop_quote_ready_wsol_edge_pools_set(wsol_edge);

--- a/src/arbitrage/multi_hop_integration.rs
+++ b/src/arbitrage/multi_hop_integration.rs
@@ -24,8 +24,10 @@ use crate::ipc::{
 use crate::metrics::{
     multi_hop_cycle_rejected_sanity_inc, multi_hop_hop_missing_quote_inc,
     multi_hop_quote_from_cache_inc, multi_hop_quote_from_trade_cache_inc,
-    multi_hop_return_bps_saturated_inc, multi_hop_search_worker_queue_depth_set,
-    multi_hop_searches_coalesced_inc, multi_hop_shadow_logged_inc, MultiHopSanityRejectReason,
+    multi_hop_quote_ready_pools_set, multi_hop_quote_ready_wsol_edge_pools_set,
+    multi_hop_return_bps_saturated_inc, multi_hop_search_no_quote_neighbors_inc,
+    multi_hop_search_worker_queue_depth_set, multi_hop_searches_coalesced_inc,
+    multi_hop_shadow_logged_inc, MultiHopSanityRejectReason,
 };
 use parking_lot::RwLock;
 use solana_sdk::pubkey::Pubkey;
@@ -926,6 +928,20 @@ impl MultiHopArbitrage {
         self.cycles_found
             .fetch_add(cycles.len() as u64, Ordering::Relaxed);
 
+        if cycles.is_empty() {
+            for token in tokens {
+                let neighbors = self.graph.neighbors(token);
+                let quote_ready_neighbors = neighbors
+                    .iter()
+                    .flat_map(|(_, edges)| edges)
+                    .filter(|edge| self.quote_provider.is_pool_quote_ready(&edge.pool_address))
+                    .count();
+                if quote_ready_neighbors < 2 {
+                    multi_hop_search_no_quote_neighbors_inc();
+                }
+            }
+        }
+
         // Filter: trustworthy profit estimate + min threshold
         let profitable: Vec<_> = cycles
             .into_iter()
@@ -1128,6 +1144,27 @@ impl MultiHopArbitrage {
     pub fn warmup_quotes_from_live_pool_cache(&self) {
         self.quote_provider
             .warmup_from_live_pool_cache(QUOTE_WARMUP_TOP_N);
+    }
+
+    /// Publish quote-readiness gauges for Prometheus (no algorithm change).
+    pub fn refresh_quote_readiness_metrics(&self) {
+        let ready_total = self.quote_provider.quote_ready_index().len() as u64;
+        multi_hop_quote_ready_pools_set(ready_total);
+
+        let wsol = match Pubkey::from_str(WSOL_MINT) {
+            Ok(w) => w,
+            Err(_) => return,
+        };
+        let wsol_edge = self
+            .pool_mints
+            .read()
+            .iter()
+            .filter(|(pool, (mint_a, mint_b))| {
+                (*mint_a == wsol || *mint_b == wsol)
+                    && self.quote_provider.is_pool_quote_ready(pool)
+            })
+            .count() as u64;
+        multi_hop_quote_ready_wsol_edge_pools_set(wsol_edge);
     }
 }
 

--- a/src/arbitrage/multi_hop_integration.rs
+++ b/src/arbitrage/multi_hop_integration.rs
@@ -92,6 +92,10 @@ impl QuoteReadyIndex {
     pub fn is_empty(&self) -> bool {
         self.pools.read().is_empty()
     }
+
+    pub fn snapshot_keys(&self) -> Vec<Pubkey> {
+        self.pools.read().iter().copied().collect()
+    }
 }
 
 /// Multi-hop arbitrage configuration
@@ -446,6 +450,14 @@ impl CachedQuoteProvider {
     /// Read-only quote-ready probe for metrics/diagnostics (does not evict stale index entries).
     pub fn probe_pool_quote_ready(&self, pool_address: &Pubkey) -> bool {
         self.quote_ready.contains(pool_address) && self.pool_still_quote_ready(pool_address)
+    }
+
+    /// Count pools that remain quote-ready after freshness probe; evicts stale index entries.
+    pub fn count_fresh_quote_ready_pools(&self) -> u64 {
+        let keys = self.quote_ready.snapshot_keys();
+        keys.iter()
+            .filter(|pool| self.is_pool_quote_ready(pool))
+            .count() as u64
     }
 }
 
@@ -1156,7 +1168,7 @@ impl MultiHopArbitrage {
 
     /// Publish quote-readiness gauges for Prometheus (no algorithm change).
     pub fn refresh_quote_readiness_metrics(&self) {
-        let ready_total = self.quote_provider.quote_ready_index().len() as u64;
+        let ready_total = self.quote_provider.count_fresh_quote_ready_pools();
         multi_hop_quote_ready_pools_set(ready_total);
 
         let wsol = match Pubkey::from_str(WSOL_MINT) {
@@ -1340,6 +1352,22 @@ mod tests {
 
         let out = result.unwrap();
         assert!(out > 9_700_000 && out < 9_900_000, "Got {out}");
+    }
+
+    #[test]
+    fn count_fresh_quote_ready_pools_excludes_stale_index_entries() {
+        let provider = CachedQuoteProvider::new(Duration::from_secs(30), create_shared_cache());
+        let fresh_pool = Pubkey::new_unique();
+        let stale_pool = Pubkey::new_unique();
+        let input = Pubkey::new_unique();
+        let output = Pubkey::new_unique();
+
+        provider.update_quote(fresh_pool, input, output, 1_000_000, 980_000);
+        provider.quote_ready_index().mark_ready(stale_pool);
+
+        assert_eq!(provider.quote_ready_index().len(), 2);
+        assert_eq!(provider.count_fresh_quote_ready_pools(), 1);
+        assert_eq!(provider.quote_ready_index().len(), 1);
     }
 
     #[test]

--- a/src/arbitrage/multi_hop_integration.rs
+++ b/src/arbitrage/multi_hop_integration.rs
@@ -844,6 +844,18 @@ impl MultiHopArbitrage {
         self.dirty_tokens.read().len()
     }
 
+    #[cfg(test)]
+    pub(crate) fn search_from_tokens_for_test(
+        &self,
+        tokens: &[Pubkey],
+        config: &MultiHopConfig,
+        component: &str,
+        build: &str,
+        run_id: &str,
+    ) -> Vec<TradeIntent> {
+        self.search_from_tokens(tokens, config, component, build, run_id)
+    }
+
     /// Filter tokens that should be searched (cooldown + per-mint price change check)
     fn filter_tokens_for_search(
         &self,
@@ -946,6 +958,7 @@ impl MultiHopArbitrage {
             .fetch_add(cycles.len() as u64, Ordering::Relaxed);
 
         if cycles.is_empty() {
+            let mut search_lacked_quote_neighbors = false;
             for token in tokens {
                 let neighbors = self.graph.neighbors(token);
                 let quote_ready_neighbors = neighbors
@@ -957,8 +970,12 @@ impl MultiHopArbitrage {
                     })
                     .count();
                 if quote_ready_neighbors < 2 {
-                    multi_hop_search_no_quote_neighbors_inc();
+                    search_lacked_quote_neighbors = true;
+                    break;
                 }
+            }
+            if search_lacked_quote_neighbors {
+                multi_hop_search_no_quote_neighbors_inc();
             }
         }
 
@@ -1352,6 +1369,65 @@ mod tests {
 
         let out = result.unwrap();
         assert!(out > 9_700_000 && out < 9_900_000, "Got {out}");
+    }
+
+    #[test]
+    fn search_from_tokens_increments_no_quote_neighbors_once_per_search() {
+        use crate::metrics::MULTI_HOP_SEARCH_NO_QUOTE_NEIGHBORS_TOTAL;
+        use std::sync::atomic::Ordering;
+
+        let before = MULTI_HOP_SEARCH_NO_QUOTE_NEIGHBORS_TOTAL.load(Ordering::Relaxed);
+        let arb = MultiHopArbitrage::new(
+            MultiHopConfig {
+                enabled: true,
+                min_liquidity_usd: 0.0,
+                min_profit_bps: i32::MAX,
+                ..Default::default()
+            },
+            create_shared_cache(),
+        );
+
+        let token_a = Pubkey::new_unique();
+        let token_b = Pubkey::new_unique();
+        let pool_a = Pubkey::new_unique();
+        let pool_b = Pubkey::new_unique();
+
+        arb.upsert_pool(
+            &pool_a.to_string(),
+            "raydium",
+            WSOL_MINT,
+            &token_a.to_string(),
+            100_000.0,
+            30,
+        );
+        arb.upsert_pool(
+            &pool_b.to_string(),
+            "raydium",
+            WSOL_MINT,
+            &token_b.to_string(),
+            100_000.0,
+            30,
+        );
+
+        let config = MultiHopConfig {
+            enabled: true,
+            min_liquidity_usd: 0.0,
+            min_profit_bps: i32::MAX,
+            ..Default::default()
+        };
+        let _ = arb.search_from_tokens_for_test(
+            &[token_a, token_b],
+            &config,
+            "test",
+            "0.1.0",
+            "test-run",
+        );
+
+        assert_eq!(
+            MULTI_HOP_SEARCH_NO_QUOTE_NEIGHBORS_TOTAL.load(Ordering::Relaxed),
+            before + 1,
+            "coalesced multi-token search should increment no-quote-neighbors once"
+        );
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -48,9 +48,10 @@ use ironcrab::metrics::{
     arb_subscriber_low_processed_inc, arb_subscriber_low_queue_depth_set,
     arb_subscriber_pool_created_skipped_inc, arb_two_hop_eligible_dexes_add,
     arb_two_hop_eligible_pools_by_dex_add, arb_two_hop_insufficient_subreason_inc,
-    arb_two_hop_opportunity_inc, arb_two_hop_pool_gate_add, arb_two_hop_rejected_inc,
-    arb_two_hop_tracker_seeded_pools_add, serve_metrics, set_readiness_nats_connected,
-    ArbTwoHopInsufficientSubreason, ArbTwoHopPoolGate, ArbTwoHopRejectReason, MetricsComponent,
+    arb_two_hop_opportunity_inc, arb_two_hop_pool_gate_add, arb_two_hop_reject_subreason_inc,
+    arb_two_hop_rejected_inc, arb_two_hop_tracker_seeded_pools_add, serve_metrics,
+    set_readiness_nats_connected, ArbTwoHopInsufficientSubreason, ArbTwoHopPoolGate,
+    ArbTwoHopRejectReason, ArbTwoHopRejectSubreason, MetricsComponent,
     ARB_REJECTED_MISSING_ACCOUNTS, ARB_TRIANGLE_OPPORTUNITIES, INTENTS_GENERATED_TOTAL,
     MARKET_EVENTS_CONSUMED_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL,
     POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
@@ -604,6 +605,44 @@ fn comparable_price_sol_per_token(
     }
 }
 
+#[cfg(test)]
+thread_local! {
+    static COMPARABLE_PRICE_CALLS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn reset_comparable_price_call_count() {
+    COMPARABLE_PRICE_CALLS.with(|c| c.set(0));
+}
+
+#[cfg(test)]
+fn comparable_price_call_count() -> u64 {
+    COMPARABLE_PRICE_CALLS.with(|c| c.get())
+}
+
+/// Single eligibility-path entry for comparable price (counted in tests).
+fn comparable_price_for_eligibility(
+    pool: &PoolState,
+    vault_reserves: Option<(u64, u64)>,
+    token_decimals: Option<u8>,
+    token_mint: &str,
+    vault_cache: Option<&VaultBalanceCache>,
+    dlmm_bin_arrays: Option<&HashMap<i64, BinArrayCache>>,
+    side: ComparablePriceSide,
+) -> Option<Decimal> {
+    #[cfg(test)]
+    COMPARABLE_PRICE_CALLS.with(|c| c.set(c.get().saturating_add(1)));
+    comparable_price_sol_per_token(
+        pool,
+        vault_reserves,
+        token_decimals,
+        token_mint,
+        vault_cache,
+        dlmm_bin_arrays,
+        side,
+    )
+}
+
 /// SOL-quoted pool seed: (token_mint, reserve_base, reserve_quote_sol, active_id, bin_step).
 type SolQuotedPoolSeed = (String, u64, u64, Option<i32>, Option<u16>);
 
@@ -976,6 +1015,10 @@ struct PoolEligibilityRow {
     has_trade_mid: bool,
     has_decimals: bool,
     fresh: bool,
+    buy_price: Option<Decimal>,
+    sell_price: Option<Decimal>,
+    buy_plausible: bool,
+    sell_plausible: bool,
     comparable_price_present: bool,
     comparable_price_plausible: bool,
     eligible: bool,
@@ -996,7 +1039,7 @@ struct MintEligibilityBreakdown {
     eligible_pools: usize,
     eligible_dexes: usize,
     eligible_by_dex: HashMap<String, usize>,
-    reject_subreason: Option<ArbTwoHopInsufficientSubreason>,
+    reject_subreason: Option<ArbTwoHopRejectSubreason>,
     pool_rows: Vec<PoolEligibilityRow>,
 }
 
@@ -1022,16 +1065,16 @@ impl ArbEligibilityForensics {
         };
         if !matches!(
             subreason,
-            ArbTwoHopInsufficientSubreason::StalePrice
-                | ArbTwoHopInsufficientSubreason::NotKnownPool
-                | ArbTwoHopInsufficientSubreason::MissingDecimals
-                | ArbTwoHopInsufficientSubreason::MissingReserves
-                | ArbTwoHopInsufficientSubreason::MissingTradePrice
-                | ArbTwoHopInsufficientSubreason::NoComparablePrice
-                | ArbTwoHopInsufficientSubreason::SameDexOnly
-                | ArbTwoHopInsufficientSubreason::ImplausiblePrice
-                | ArbTwoHopInsufficientSubreason::OnlyOneEligiblePool
-                | ArbTwoHopInsufficientSubreason::OnlyOneEligibleDex
+            ArbTwoHopRejectSubreason::StalePrice
+                | ArbTwoHopRejectSubreason::NotKnownPool
+                | ArbTwoHopRejectSubreason::MissingDecimals
+                | ArbTwoHopRejectSubreason::MissingReserves
+                | ArbTwoHopRejectSubreason::MissingTradePrice
+                | ArbTwoHopRejectSubreason::NoComparablePrice
+                | ArbTwoHopRejectSubreason::SameDexOnly
+                | ArbTwoHopRejectSubreason::ImplausiblePrice
+                | ArbTwoHopRejectSubreason::OnlyOneEligiblePool
+                | ArbTwoHopRejectSubreason::OnlyOneEligibleDex
         ) {
             return;
         }
@@ -1154,17 +1197,19 @@ fn record_eligibility_metrics(breakdown: &MintEligibilityBreakdown) {
     for (dex, count) in &breakdown.eligible_by_dex {
         arb_two_hop_eligible_pools_by_dex_add(dex, *count as u64);
     }
-    if let Some(subreason) = breakdown.reject_subreason {
-        arb_two_hop_insufficient_subreason_inc(subreason);
-    }
+}
+
+fn record_insufficient_subreason(reason: ArbTwoHopInsufficientSubreason) {
+    arb_two_hop_insufficient_subreason_inc(reason);
+}
+
+fn record_reject_subreason(reason: ArbTwoHopRejectSubreason) {
+    arb_two_hop_reject_subreason_inc(reason);
 }
 
 fn determine_insufficient_subreason(
     breakdown: &MintEligibilityBreakdown,
 ) -> ArbTwoHopInsufficientSubreason {
-    if breakdown.has_decimals == 0 && breakdown.candidate_pools_total > 0 {
-        return ArbTwoHopInsufficientSubreason::MissingDecimals;
-    }
     if breakdown.eligible_pools == 1 {
         return ArbTwoHopInsufficientSubreason::OnlyOneEligiblePool;
     }
@@ -1174,9 +1219,6 @@ fn determine_insufficient_subreason(
     if breakdown.known_pools < 2 && breakdown.candidate_pools_total >= 2 {
         return ArbTwoHopInsufficientSubreason::NotKnownPool;
     }
-    if breakdown.comparable_price_present >= 2 && breakdown.comparable_price_plausible < 2 {
-        return ArbTwoHopInsufficientSubreason::ImplausiblePrice;
-    }
     if breakdown.comparable_price_present == 0 {
         if breakdown.has_reserve_data == 0 && breakdown.has_trade_mid == 0 {
             return ArbTwoHopInsufficientSubreason::MissingReserves;
@@ -1185,9 +1227,6 @@ fn determine_insufficient_subreason(
             return ArbTwoHopInsufficientSubreason::MissingTradePrice;
         }
         return ArbTwoHopInsufficientSubreason::NoComparablePrice;
-    }
-    if breakdown.comparable_price_plausible == 0 {
-        return ArbTwoHopInsufficientSubreason::ImplausiblePrice;
     }
     ArbTwoHopInsufficientSubreason::NoComparablePrice
 }
@@ -1215,7 +1254,7 @@ fn analyze_pool_eligibility(
     let vault_reserves = vault_entry.map(|c| (c.reserve_base, c.reserve_quote));
     let dlmm_bins = bin_arrays.get(&pool.pool_address);
     let buy_price = if known && has_decimals {
-        comparable_price_sol_per_token(
+        comparable_price_for_eligibility(
             pool,
             vault_reserves,
             token_decimals,
@@ -1228,7 +1267,7 @@ fn analyze_pool_eligibility(
         None
     };
     let sell_price = if known && has_decimals {
-        comparable_price_sol_per_token(
+        comparable_price_for_eligibility(
             pool,
             vault_reserves,
             token_decimals,
@@ -1260,6 +1299,10 @@ fn analyze_pool_eligibility(
         has_trade_mid,
         has_decimals,
         fresh,
+        buy_price,
+        sell_price,
+        buy_plausible,
+        sell_plausible,
         comparable_price_present,
         comparable_price_plausible,
         eligible,
@@ -1397,6 +1440,9 @@ impl TokenArbTracker {
         forensics: Option<&ArbEligibilityForensics>,
     ) {
         record_eligibility_metrics(&breakdown);
+        if let Some(subreason) = breakdown.reject_subreason {
+            record_reject_subreason(subreason);
+        }
         if let Some(collector) = forensics {
             collector.record(breakdown);
         }
@@ -1426,12 +1472,12 @@ impl TokenArbTracker {
         let mut breakdown =
             self.build_eligibility_breakdown(known_pools, vault_balances, bin_arrays);
 
-        let Some(token_decimals) = self.token_decimals else {
+        let Some(_token_decimals) = self.token_decimals else {
             debug!(
                 mint = %self.base_mint,
                 "Arb check: token decimals unknown — no synthetic fallback"
             );
-            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::MissingDecimals);
+            breakdown.reject_subreason = Some(ArbTwoHopRejectSubreason::MissingDecimals);
             self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::NoComparablePrice);
             return None;
@@ -1440,49 +1486,19 @@ impl TokenArbTracker {
         let max_age = Duration::from_millis(MAX_PRICE_AGE_MS);
         let mut best_buy: Option<(&PoolState, Decimal)> = None;
         let mut best_sell: Option<(&PoolState, Decimal)> = None;
-        let mut eligible_pools = 0usize;
 
-        for pool in self.pools.values() {
-            let is_known_dex = is_known_dex_label(&pool.dex);
-            let in_master_cache = known_pools.contains(&pool.pool_address);
-            if !is_known_dex || !in_master_cache {
-                if is_known_dex && !in_master_cache {
-                    debug!(
-                        pool = %pool.pool_address,
-                        dex = %pool.dex,
-                        mint = %self.base_mint,
-                        "Pool filtered: not in market-data MASTER cache (parse_pool_account failed)"
-                    );
-                }
+        for row in &breakdown.pool_rows {
+            if !row.known {
                 continue;
             }
-            let vault_entry = vault_balances.get(&pool.pool_address);
-            let vault_reserves = vault_entry.map(|c| (c.reserve_base, c.reserve_quote));
-            let dlmm_bins = bin_arrays.get(&pool.pool_address);
-            let buy_price = comparable_price_sol_per_token(
-                pool,
-                vault_reserves,
-                Some(token_decimals),
-                &self.base_mint,
-                vault_entry,
-                dlmm_bins,
-                ComparablePriceSide::Buy,
-            );
-            let sell_price = comparable_price_sol_per_token(
-                pool,
-                vault_reserves,
-                Some(token_decimals),
-                &self.base_mint,
-                vault_entry,
-                dlmm_bins,
-                ComparablePriceSide::Sell,
-            );
-            if buy_price.is_none() && sell_price.is_none() {
+            let Some(pool) = self.pools.get(&row.pool_address) else {
+                continue;
+            };
+            if !row.comparable_price_present {
                 continue;
             }
-            eligible_pools += 1;
-            if let Some(price) = buy_price.filter(|p| *p > Decimal::ZERO) {
-                if !is_plausible_sol_per_token_price(&self.base_mint, price) {
+            if let Some(price) = row.buy_price.filter(|p| *p > Decimal::ZERO) {
+                if !row.buy_plausible {
                     data_quality_rejects.fetch_add(1, Ordering::Relaxed);
                     arb_two_hop_rejected_inc(ArbTwoHopRejectReason::DataQuality);
                     continue;
@@ -1491,8 +1507,8 @@ impl TokenArbTracker {
                     best_buy = Some((pool, price));
                 }
             }
-            if let Some(price) = sell_price.filter(|p| *p > Decimal::ZERO) {
-                if !is_plausible_sol_per_token_price(&self.base_mint, price) {
+            if let Some(price) = row.sell_price.filter(|p| *p > Decimal::ZERO) {
+                if !row.sell_plausible {
                     data_quality_rejects.fetch_add(1, Ordering::Relaxed);
                     arb_two_hop_rejected_inc(ArbTwoHopRejectReason::DataQuality);
                     continue;
@@ -1503,25 +1519,32 @@ impl TokenArbTracker {
             }
         }
 
+        let eligible_pools = breakdown.eligible_pools;
+
         if eligible_pools < 2 {
             debug!(
                 mint = %self.base_mint,
                 pools = eligible_pools,
                 "Arb check: insufficient pools with comparable prices"
             );
-            breakdown.reject_subreason = Some(determine_insufficient_subreason(&breakdown));
-            self.emit_eligibility_forensics(breakdown, forensics);
+            let insufficient = determine_insufficient_subreason(&breakdown);
+            breakdown.reject_subreason = Some(insufficient.into());
+            record_eligibility_metrics(&breakdown);
+            record_insufficient_subreason(insufficient);
+            if let Some(collector) = forensics {
+                collector.record(breakdown);
+            }
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::InsufficientPools);
             return None;
         }
 
         let Some((buy_pool, buy_price)) = best_buy else {
-            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::ImplausiblePrice);
+            breakdown.reject_subreason = Some(ArbTwoHopRejectSubreason::ImplausiblePrice);
             self.emit_eligibility_forensics(breakdown, forensics);
             return None;
         };
         let Some((sell_pool, sell_price)) = best_sell else {
-            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::ImplausiblePrice);
+            breakdown.reject_subreason = Some(ArbTwoHopRejectSubreason::ImplausiblePrice);
             self.emit_eligibility_forensics(breakdown, forensics);
             return None;
         };
@@ -1530,7 +1553,7 @@ impl TokenArbTracker {
             || !is_plausible_sol_per_token_price(&self.base_mint, sell_price)
         {
             data_quality_rejects.fetch_add(1, Ordering::Relaxed);
-            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::ImplausiblePrice);
+            breakdown.reject_subreason = Some(ArbTwoHopRejectSubreason::ImplausiblePrice);
             self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::DataQuality);
             return None;
@@ -1548,7 +1571,7 @@ impl TokenArbTracker {
                 max_age_ms = MAX_PRICE_AGE_MS,
                 "Arb check rejected: stale comparable price"
             );
-            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::StalePrice);
+            breakdown.reject_subreason = Some(ArbTwoHopRejectSubreason::StalePrice);
             self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::StalePrice);
             return None;
@@ -1560,7 +1583,7 @@ impl TokenArbTracker {
                 dex = %buy_pool.dex,
                 "Arb check rejected: same DEX for buy/sell"
             );
-            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::SameDexOnly);
+            breakdown.reject_subreason = Some(ArbTwoHopRejectSubreason::SameDexOnly);
             self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::SameDex);
             return None;
@@ -5125,8 +5148,7 @@ mod two_hop_price_tests {
 
     #[test]
     fn forensics_same_dex_only_when_both_pools_on_one_dex() {
-        let before =
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY.load(Ordering::Relaxed);
+        let before = ironcrab::metrics::ARB_TWO_HOP_REJECT_SAME_DEX_ONLY.load(Ordering::Relaxed);
         let reserves = (1_000_000_000_000u64, 1_000_000_000u64);
         let mint = "TokenMint22222222222222222222222222222222";
         let mut tracker = TokenArbTracker::new(mint);
@@ -5148,15 +5170,13 @@ mod two_hop_price_tests {
             check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics).is_none()
         );
         assert!(
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY.load(Ordering::Relaxed)
-                > before
+            ironcrab::metrics::ARB_TWO_HOP_REJECT_SAME_DEX_ONLY.load(Ordering::Relaxed) > before
         );
     }
 
     #[test]
     fn forensics_stale_price_when_one_dex_stale() {
-        let before =
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE.load(Ordering::Relaxed);
+        let before = ironcrab::metrics::ARB_TWO_HOP_REJECT_STALE_PRICE.load(Ordering::Relaxed);
         let mint = "TokenMint33333333333333333333333333333333";
         let mut tracker = TokenArbTracker::new(mint);
         tracker.token_decimals = Some(6);
@@ -5194,16 +5214,12 @@ mod two_hop_price_tests {
         assert!(
             check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics).is_none()
         );
-        assert!(
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE.load(Ordering::Relaxed)
-                > before
-        );
+        assert!(ironcrab::metrics::ARB_TWO_HOP_REJECT_STALE_PRICE.load(Ordering::Relaxed) > before);
     }
 
     #[test]
     fn forensics_missing_decimals_subreason() {
-        let before =
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS.load(Ordering::Relaxed);
+        let before = ironcrab::metrics::ARB_TWO_HOP_REJECT_MISSING_DECIMALS.load(Ordering::Relaxed);
         let reserves = (1_000_000_000_000u64, 1_000_000_000u64);
         let mut tracker = TokenArbTracker::new("TokenMint44444444444444444444444444444444");
         tracker.upsert_pool(sample_pool("orca", "poolA", None, None));
@@ -5222,8 +5238,7 @@ mod two_hop_price_tests {
             check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics).is_none()
         );
         assert!(
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS.load(Ordering::Relaxed)
-                > before
+            ironcrab::metrics::ARB_TWO_HOP_REJECT_MISSING_DECIMALS.load(Ordering::Relaxed) > before
         );
     }
 
@@ -5264,29 +5279,52 @@ mod two_hop_price_tests {
     }
 
     #[test]
-    fn determine_implausible_subreason_when_comparable_not_plausible() {
+    fn determine_insufficient_subreason_when_no_comparable_price() {
         let breakdown = MintEligibilityBreakdown {
             mint: USDC_MINT.to_string(),
             candidate_pools_total: 2,
             known_pools: 2,
             fresh_price: 2,
             has_reserve_data: 0,
-            has_trade_mid: 2,
+            has_trade_mid: 0,
             has_decimals: 2,
-            comparable_price_present: 2,
+            comparable_price_present: 0,
             comparable_price_plausible: 0,
-            eligible_pools: 2,
-            eligible_dexes: 2,
-            eligible_by_dex: HashMap::from([
-                ("orca".to_string(), 1),
-                ("meteora_dlmm".to_string(), 1),
-            ]),
+            eligible_pools: 0,
+            eligible_dexes: 0,
+            eligible_by_dex: HashMap::new(),
             reject_subreason: None,
             pool_rows: vec![],
         };
         assert_eq!(
             determine_insufficient_subreason(&breakdown),
-            ArbTwoHopInsufficientSubreason::ImplausiblePrice
+            ArbTwoHopInsufficientSubreason::MissingReserves
+        );
+    }
+
+    #[test]
+    fn check_arbitrage_computes_comparable_price_once_per_pool_side() {
+        reset_comparable_price_call_count();
+        let reserves = (1_000_000_000_000u64, 1_000_000_000u64);
+        let mut tracker = TokenArbTracker::new("TokenMint66666666666666666666666666666666");
+        tracker.token_decimals = Some(6);
+        tracker.upsert_pool(sample_pool("orca", "poolA", None, None));
+        tracker.upsert_pool(sample_pool("pump_amm", "poolB", None, None));
+
+        let mut known_pools = HashSet::new();
+        known_pools.insert("poolA".to_string());
+        known_pools.insert("poolB".to_string());
+        let vault_balances = HashMap::from([
+            ("poolA".to_string(), vault(reserves.0, reserves.1)),
+            ("poolB".to_string(), vault(reserves.0, reserves.1)),
+        ]);
+
+        let forensics = ArbEligibilityForensics::new();
+        let _ = check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics);
+        assert_eq!(
+            comparable_price_call_count(),
+            4,
+            "buy+sell once per known pool"
         );
     }
 

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -1062,9 +1062,9 @@ impl ArbEligibilityForensics {
 
         let mut ranked: Vec<MintEligibilityBreakdown> = pending.drain().map(|(_, b)| b).collect();
         ranked.sort_by(|a, b| {
-            b.eligible_pools
-                .cmp(&a.eligible_pools)
-                .then_with(|| a.candidate_pools_total.cmp(&b.candidate_pools_total))
+            a.eligible_pools
+                .cmp(&b.eligible_pools)
+                .then_with(|| b.candidate_pools_total.cmp(&a.candidate_pools_total))
         });
         ranked.truncate(ELIGIBILITY_SNAPSHOT_TOP_N);
 
@@ -1153,9 +1153,6 @@ fn record_eligibility_metrics(breakdown: &MintEligibilityBreakdown) {
     arb_two_hop_eligible_dexes_add(breakdown.eligible_dexes as u64);
     for (dex, count) in &breakdown.eligible_by_dex {
         arb_two_hop_eligible_pools_by_dex_add(dex, *count as u64);
-    }
-    if let Some(subreason) = breakdown.reject_subreason {
-        arb_two_hop_insufficient_subreason_inc(subreason);
     }
 }
 
@@ -1510,6 +1507,9 @@ impl TokenArbTracker {
                 "Arb check: insufficient pools with comparable prices"
             );
             breakdown.reject_subreason = Some(determine_insufficient_subreason(&breakdown));
+            if let Some(subreason) = breakdown.reject_subreason {
+                arb_two_hop_insufficient_subreason_inc(subreason);
+            }
             self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::InsufficientPools);
             return None;
@@ -5127,8 +5127,10 @@ mod two_hop_price_tests {
 
     #[test]
     fn forensics_same_dex_only_when_both_pools_on_one_dex() {
-        let before =
+        let before_subreason =
             ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY.load(Ordering::Relaxed);
+        let before_reject =
+            ironcrab::metrics::ARB_TWO_HOP_REJECTED_SAME_DEX.load(Ordering::Relaxed);
         let reserves = (1_000_000_000_000u64, 1_000_000_000u64);
         let mint = "TokenMint22222222222222222222222222222222";
         let mut tracker = TokenArbTracker::new(mint);
@@ -5150,15 +5152,21 @@ mod two_hop_price_tests {
             check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics).is_none()
         );
         assert!(
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY.load(Ordering::Relaxed)
-                > before
+            ironcrab::metrics::ARB_TWO_HOP_REJECTED_SAME_DEX.load(Ordering::Relaxed)
+                > before_reject
+        );
+        assert_eq!(
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY.load(Ordering::Relaxed),
+            before_subreason
         );
     }
 
     #[test]
     fn forensics_stale_price_when_one_dex_stale() {
-        let before =
+        let before_subreason =
             ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE.load(Ordering::Relaxed);
+        let before_reject =
+            ironcrab::metrics::ARB_TWO_HOP_REJECTED_STALE_PRICE.load(Ordering::Relaxed);
         let mint = "TokenMint33333333333333333333333333333333";
         let mut tracker = TokenArbTracker::new(mint);
         tracker.token_decimals = Some(6);
@@ -5197,15 +5205,21 @@ mod two_hop_price_tests {
             check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics).is_none()
         );
         assert!(
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE.load(Ordering::Relaxed)
-                > before
+            ironcrab::metrics::ARB_TWO_HOP_REJECTED_STALE_PRICE.load(Ordering::Relaxed)
+                > before_reject
+        );
+        assert_eq!(
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE.load(Ordering::Relaxed),
+            before_subreason
         );
     }
 
     #[test]
     fn forensics_missing_decimals_subreason() {
-        let before =
+        let before_subreason =
             ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS.load(Ordering::Relaxed);
+        let before_reject =
+            ironcrab::metrics::ARB_TWO_HOP_REJECTED_NO_COMPARABLE_PRICE.load(Ordering::Relaxed);
         let reserves = (1_000_000_000_000u64, 1_000_000_000u64);
         let mut tracker = TokenArbTracker::new("TokenMint44444444444444444444444444444444");
         tracker.upsert_pool(sample_pool("orca", "poolA", None, None));
@@ -5224,8 +5238,12 @@ mod two_hop_price_tests {
             check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics).is_none()
         );
         assert!(
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS.load(Ordering::Relaxed)
-                > before
+            ironcrab::metrics::ARB_TWO_HOP_REJECTED_NO_COMPARABLE_PRICE.load(Ordering::Relaxed)
+                > before_reject
+        );
+        assert_eq!(
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS.load(Ordering::Relaxed),
+            before_subreason
         );
     }
 

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -1092,11 +1092,12 @@ impl ArbEligibilityForensics {
     }
 
     fn maybe_emit_snapshot(&self) -> bool {
-        let mut last = self.last_snapshot.write();
-        if last.elapsed() < ELIGIBILITY_SNAPSHOT_COOLDOWN {
-            return false;
+        {
+            let last = self.last_snapshot.read();
+            if last.elapsed() < ELIGIBILITY_SNAPSHOT_COOLDOWN {
+                return false;
+            }
         }
-        *last = Instant::now();
 
         let mut pending = self.pending.write();
         if pending.is_empty() {
@@ -1150,6 +1151,7 @@ impl ArbEligibilityForensics {
             pending.remove(&entry.mint);
         }
 
+        *self.last_snapshot.write() = Instant::now();
         self.snapshots_emitted.fetch_add(1, Ordering::Relaxed);
         true
     }
@@ -5402,6 +5404,32 @@ mod two_hop_price_tests {
             4,
             "buy+sell once per known pool"
         );
+    }
+
+    #[test]
+    fn eligibility_snapshot_empty_pending_does_not_reset_cooldown() {
+        let forensics = ArbEligibilityForensics::new();
+        forensics.force_snapshot_ready();
+
+        assert!(!forensics.maybe_emit_snapshot());
+        assert_eq!(forensics.snapshots_emitted_count(), 0);
+
+        let reserves = (1_000_000_000_000u64, 1_000_000_000u64);
+        let mut tracker = TokenArbTracker::new("TokenMint33333333333333333333333333333333");
+        tracker.token_decimals = Some(6);
+        tracker.upsert_pool(sample_pool("orca", "poolOnly", None, None));
+
+        let mut known_pools = HashSet::new();
+        known_pools.insert("poolOnly".to_string());
+        let vault_balances =
+            HashMap::from([("poolOnly".to_string(), vault(reserves.0, reserves.1))]);
+
+        let _ = check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics);
+        assert!(
+            forensics.maybe_emit_snapshot(),
+            "empty pending must not advance cooldown; mint should snapshot immediately"
+        );
+        assert_eq!(forensics.snapshots_emitted_count(), 1);
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -46,12 +46,14 @@ use ironcrab::metrics::{
     arb_subscriber_high_processed_inc, arb_subscriber_high_queue_depth_set,
     arb_subscriber_low_coalesced_inc, arb_subscriber_low_dropped_inc,
     arb_subscriber_low_processed_inc, arb_subscriber_low_queue_depth_set,
-    arb_subscriber_pool_created_skipped_inc, arb_two_hop_opportunity_inc, arb_two_hop_rejected_inc,
+    arb_subscriber_pool_created_skipped_inc, arb_two_hop_eligible_dexes_add,
+    arb_two_hop_eligible_pools_by_dex_add, arb_two_hop_insufficient_subreason_inc,
+    arb_two_hop_opportunity_inc, arb_two_hop_pool_gate_add, arb_two_hop_rejected_inc,
     arb_two_hop_tracker_seeded_pools_add, serve_metrics, set_readiness_nats_connected,
-    ArbTwoHopRejectReason, MetricsComponent, ARB_REJECTED_MISSING_ACCOUNTS,
-    ARB_TRIANGLE_OPPORTUNITIES, INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL,
-    NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE,
-    TOKENS_TRACKED_GAUGE,
+    ArbTwoHopInsufficientSubreason, ArbTwoHopPoolGate, ArbTwoHopRejectReason, MetricsComponent,
+    ARB_REJECTED_MISSING_ACCOUNTS, ARB_TRIANGLE_OPPORTUNITIES, INTENTS_GENERATED_TOTAL,
+    MARKET_EVENTS_CONSUMED_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL,
+    POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, pool_cache_live_fallback_consumer_config,
@@ -180,6 +182,11 @@ const DLMM_PROBE_SOL_LAMPORTS: u64 = 10_000_000;
 const DLMM_MARGINAL_MAX_DEVIATION_FACTOR: u64 = 100;
 /// Deduplicate per-mint "spread too large" WARN logs.
 const SPREAD_TOO_LARGE_WARN_COOLDOWN: Duration = Duration::from_secs(30);
+/// Rate limit for 2-hop eligibility diagnostic snapshots.
+const ELIGIBILITY_SNAPSHOT_COOLDOWN: Duration = Duration::from_secs(60);
+const ELIGIBILITY_SNAPSHOT_TOP_N: usize = 10;
+const ELIGIBILITY_SNAPSHOT_POOL_ROWS: usize = 5;
+const ELIGIBILITY_PENDING_CAP: usize = 256;
 
 /// Bounded HIGH-priority MarketEvent queue (Trade + active-pool state updates).
 const ARB_HIGH_EVENT_QUEUE_CAP: usize = 8192;
@@ -959,6 +966,313 @@ struct TokenArbTracker {
     last_intent_time: Option<Instant>,
 }
 
+/// Per-pool row for 2-hop eligibility forensics (bounded, no dynamic Prometheus labels).
+#[derive(Debug, Clone)]
+struct PoolEligibilityRow {
+    pool_address: String,
+    dex: String,
+    known: bool,
+    has_reserve_data: bool,
+    has_trade_mid: bool,
+    has_decimals: bool,
+    fresh: bool,
+    comparable_price_present: bool,
+    comparable_price_plausible: bool,
+    eligible: bool,
+}
+
+/// Aggregated mint-level eligibility breakdown for metrics + snapshots.
+#[derive(Debug, Clone)]
+struct MintEligibilityBreakdown {
+    mint: String,
+    candidate_pools_total: usize,
+    known_pools: usize,
+    fresh_price: usize,
+    has_reserve_data: usize,
+    has_trade_mid: usize,
+    has_decimals: usize,
+    comparable_price_present: usize,
+    comparable_price_plausible: usize,
+    eligible_pools: usize,
+    eligible_dexes: usize,
+    eligible_by_dex: HashMap<String, usize>,
+    reject_subreason: Option<ArbTwoHopInsufficientSubreason>,
+    pool_rows: Vec<PoolEligibilityRow>,
+}
+
+/// Rate-limited collector for top offending mints (insufficient_pools / stale_price).
+struct ArbEligibilityForensics {
+    last_snapshot: RwLock<Instant>,
+    pending: RwLock<HashMap<String, MintEligibilityBreakdown>>,
+    snapshots_emitted: AtomicU64,
+}
+
+impl ArbEligibilityForensics {
+    fn new() -> Self {
+        Self {
+            last_snapshot: RwLock::new(Instant::now()),
+            pending: RwLock::new(HashMap::new()),
+            snapshots_emitted: AtomicU64::new(0),
+        }
+    }
+
+    fn record(&self, breakdown: MintEligibilityBreakdown) {
+        let Some(subreason) = breakdown.reject_subreason else {
+            return;
+        };
+        if !matches!(
+            subreason,
+            ArbTwoHopInsufficientSubreason::StalePrice
+                | ArbTwoHopInsufficientSubreason::NotKnownPool
+                | ArbTwoHopInsufficientSubreason::MissingDecimals
+                | ArbTwoHopInsufficientSubreason::MissingReserves
+                | ArbTwoHopInsufficientSubreason::MissingTradePrice
+                | ArbTwoHopInsufficientSubreason::NoComparablePrice
+                | ArbTwoHopInsufficientSubreason::SameDexOnly
+                | ArbTwoHopInsufficientSubreason::ImplausiblePrice
+                | ArbTwoHopInsufficientSubreason::OnlyOneEligiblePool
+                | ArbTwoHopInsufficientSubreason::OnlyOneEligibleDex
+        ) {
+            return;
+        }
+
+        let mut pending = self.pending.write();
+        pending.insert(breakdown.mint.clone(), breakdown);
+        if pending.len() > ELIGIBILITY_PENDING_CAP {
+            let drop_key = pending
+                .keys()
+                .next()
+                .cloned()
+                .expect("pending non-empty after cap exceeded");
+            pending.remove(&drop_key);
+        }
+    }
+
+    fn maybe_emit_snapshot(&self) -> bool {
+        let mut last = self.last_snapshot.write();
+        if last.elapsed() < ELIGIBILITY_SNAPSHOT_COOLDOWN {
+            return false;
+        }
+        *last = Instant::now();
+
+        let mut pending = self.pending.write();
+        if pending.is_empty() {
+            return false;
+        }
+
+        let mut ranked: Vec<MintEligibilityBreakdown> = pending.drain().map(|(_, b)| b).collect();
+        ranked.sort_by(|a, b| {
+            b.eligible_pools
+                .cmp(&a.eligible_pools)
+                .then_with(|| a.candidate_pools_total.cmp(&b.candidate_pools_total))
+        });
+        ranked.truncate(ELIGIBILITY_SNAPSHOT_TOP_N);
+
+        for entry in &ranked {
+            let top_pools: Vec<_> = entry
+                .pool_rows
+                .iter()
+                .take(ELIGIBILITY_SNAPSHOT_POOL_ROWS)
+                .map(|row| {
+                    serde_json::json!({
+                        "pool": row.pool_address,
+                        "dex": row.dex,
+                        "known": row.known,
+                        "has_reserve_data": row.has_reserve_data,
+                        "has_trade_mid": row.has_trade_mid,
+                        "has_decimals": row.has_decimals,
+                        "fresh": row.fresh,
+                        "comparable_price_present": row.comparable_price_present,
+                        "comparable_price_plausible": row.comparable_price_plausible,
+                    })
+                })
+                .collect();
+
+            info!(
+                kind = "arb_two_hop_eligibility_snapshot",
+                mint = %entry.mint,
+                total_pools = entry.candidate_pools_total,
+                eligible_pools = entry.eligible_pools,
+                eligible_dexes = entry.eligible_dexes,
+                reject_subreason = ?entry.reject_subreason,
+                top_pools = %serde_json::to_string(&top_pools).unwrap_or_else(|_| "[]".to_string()),
+                "2-hop eligibility forensics snapshot"
+            );
+        }
+
+        self.snapshots_emitted.fetch_add(1, Ordering::Relaxed);
+        true
+    }
+
+    #[cfg(test)]
+    fn snapshots_emitted_count(&self) -> u64 {
+        self.snapshots_emitted.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    fn force_snapshot_ready(&self) {
+        *self.last_snapshot.write() =
+            Instant::now() - ELIGIBILITY_SNAPSHOT_COOLDOWN - Duration::from_secs(1);
+    }
+}
+
+fn record_eligibility_metrics(breakdown: &MintEligibilityBreakdown) {
+    arb_two_hop_pool_gate_add(
+        ArbTwoHopPoolGate::CandidatePools,
+        breakdown.candidate_pools_total as u64,
+    );
+    arb_two_hop_pool_gate_add(
+        ArbTwoHopPoolGate::InKnownPools,
+        breakdown.known_pools as u64,
+    );
+    arb_two_hop_pool_gate_add(ArbTwoHopPoolGate::FreshPrice, breakdown.fresh_price as u64);
+    arb_two_hop_pool_gate_add(
+        ArbTwoHopPoolGate::HasReserveData,
+        breakdown.has_reserve_data as u64,
+    );
+    arb_two_hop_pool_gate_add(
+        ArbTwoHopPoolGate::HasTradeMid,
+        breakdown.has_trade_mid as u64,
+    );
+    arb_two_hop_pool_gate_add(
+        ArbTwoHopPoolGate::HasDecimals,
+        breakdown.has_decimals as u64,
+    );
+    arb_two_hop_pool_gate_add(
+        ArbTwoHopPoolGate::ComparablePricePresent,
+        breakdown.comparable_price_present as u64,
+    );
+    arb_two_hop_pool_gate_add(
+        ArbTwoHopPoolGate::ComparablePricePlausible,
+        breakdown.comparable_price_plausible as u64,
+    );
+    arb_two_hop_pool_gate_add(
+        ArbTwoHopPoolGate::EligiblePools,
+        breakdown.eligible_pools as u64,
+    );
+    arb_two_hop_eligible_dexes_add(breakdown.eligible_dexes as u64);
+    for (dex, count) in &breakdown.eligible_by_dex {
+        arb_two_hop_eligible_pools_by_dex_add(dex, *count as u64);
+    }
+    if let Some(subreason) = breakdown.reject_subreason {
+        arb_two_hop_insufficient_subreason_inc(subreason);
+    }
+}
+
+fn determine_insufficient_subreason(
+    breakdown: &MintEligibilityBreakdown,
+) -> ArbTwoHopInsufficientSubreason {
+    if breakdown.has_decimals == 0 && breakdown.candidate_pools_total > 0 {
+        return ArbTwoHopInsufficientSubreason::MissingDecimals;
+    }
+    if breakdown.eligible_pools == 1 {
+        return ArbTwoHopInsufficientSubreason::OnlyOneEligiblePool;
+    }
+    if breakdown.eligible_pools >= 2 && breakdown.eligible_dexes < 2 {
+        return ArbTwoHopInsufficientSubreason::OnlyOneEligibleDex;
+    }
+    if breakdown.known_pools < 2 && breakdown.candidate_pools_total >= 2 {
+        return ArbTwoHopInsufficientSubreason::NotKnownPool;
+    }
+    if breakdown.comparable_price_present >= 2 && breakdown.comparable_price_plausible < 2 {
+        return ArbTwoHopInsufficientSubreason::ImplausiblePrice;
+    }
+    if breakdown.comparable_price_present == 0 {
+        if breakdown.has_reserve_data == 0 && breakdown.has_trade_mid == 0 {
+            return ArbTwoHopInsufficientSubreason::MissingReserves;
+        }
+        if breakdown.has_trade_mid == 0 {
+            return ArbTwoHopInsufficientSubreason::MissingTradePrice;
+        }
+        return ArbTwoHopInsufficientSubreason::NoComparablePrice;
+    }
+    if breakdown.comparable_price_plausible == 0 {
+        return ArbTwoHopInsufficientSubreason::ImplausiblePrice;
+    }
+    ArbTwoHopInsufficientSubreason::NoComparablePrice
+}
+
+fn analyze_pool_eligibility(
+    pool: &PoolState,
+    base_mint: &str,
+    known_pools: &HashSet<String>,
+    token_decimals: Option<u8>,
+    vault_balances: &HashMap<String, VaultBalanceCache>,
+    bin_arrays: &HashMap<String, HashMap<i64, BinArrayCache>>,
+    max_age: Duration,
+) -> PoolEligibilityRow {
+    let is_known_dex = is_known_dex_label(&pool.dex);
+    let known = is_known_dex && known_pools.contains(&pool.pool_address);
+    let vault_entry = vault_balances.get(&pool.pool_address);
+    let has_reserve_data = pool.has_reserve_data
+        || vault_entry
+            .map(|v| v.reserve_base > 0 && v.reserve_quote > 0)
+            .unwrap_or(false);
+    let has_trade_mid = trade_mid_sol_per_token(pool).is_some();
+    let has_decimals = token_decimals.is_some();
+    let fresh = known && is_pool_price_fresh(pool, vault_entry, max_age);
+
+    let vault_reserves = vault_entry.map(|c| (c.reserve_base, c.reserve_quote));
+    let dlmm_bins = bin_arrays.get(&pool.pool_address);
+    let buy_price = if known && has_decimals {
+        comparable_price_sol_per_token(
+            pool,
+            vault_reserves,
+            token_decimals,
+            base_mint,
+            vault_entry,
+            dlmm_bins,
+            ComparablePriceSide::Buy,
+        )
+    } else {
+        None
+    };
+    let sell_price = if known && has_decimals {
+        comparable_price_sol_per_token(
+            pool,
+            vault_reserves,
+            token_decimals,
+            base_mint,
+            vault_entry,
+            dlmm_bins,
+            ComparablePriceSide::Sell,
+        )
+    } else {
+        None
+    };
+    let comparable_price_present = buy_price.is_some() || sell_price.is_some();
+    let buy_plausible = buy_price
+        .filter(|p| *p > Decimal::ZERO)
+        .map(|p| is_plausible_sol_per_token_price(base_mint, p))
+        .unwrap_or(false);
+    let sell_plausible = sell_price
+        .filter(|p| *p > Decimal::ZERO)
+        .map(|p| is_plausible_sol_per_token_price(base_mint, p))
+        .unwrap_or(false);
+    let comparable_price_plausible = comparable_price_present && (buy_plausible || sell_plausible);
+    let eligible = known && comparable_price_present;
+
+    PoolEligibilityRow {
+        pool_address: pool.pool_address.clone(),
+        dex: pool.dex.clone(),
+        known,
+        has_reserve_data,
+        has_trade_mid,
+        has_decimals,
+        fresh,
+        comparable_price_present,
+        comparable_price_plausible,
+        eligible,
+    }
+}
+
+/// Ancillary inputs for `check_arbitrage` (keeps signature within clippy limits).
+struct ArbCheckContext<'a> {
+    spread_warn_last: &'a RwLock<HashMap<String, Instant>>,
+    data_quality_rejects: &'a AtomicU64,
+    forensics: Option<&'a ArbEligibilityForensics>,
+}
+
 impl TokenArbTracker {
     fn new(base_mint: &str) -> Self {
         Self {
@@ -1000,6 +1314,94 @@ impl TokenArbTracker {
         dexes.len()
     }
 
+    fn build_eligibility_breakdown(
+        &self,
+        known_pools: &HashSet<String>,
+        vault_balances: &HashMap<String, VaultBalanceCache>,
+        bin_arrays: &HashMap<String, HashMap<i64, BinArrayCache>>,
+    ) -> MintEligibilityBreakdown {
+        let max_age = Duration::from_millis(MAX_PRICE_AGE_MS);
+        let mut pool_rows = Vec::with_capacity(self.pools.len());
+        let mut known_pools_count = 0usize;
+        let mut fresh_price = 0usize;
+        let mut has_reserve_data = 0usize;
+        let mut has_trade_mid = 0usize;
+        let mut has_decimals = 0usize;
+        let mut comparable_price_present = 0usize;
+        let mut comparable_price_plausible = 0usize;
+
+        for pool in self.pools.values() {
+            let row = analyze_pool_eligibility(
+                pool,
+                &self.base_mint,
+                known_pools,
+                self.token_decimals,
+                vault_balances,
+                bin_arrays,
+                max_age,
+            );
+            if row.known {
+                known_pools_count += 1;
+            }
+            if row.fresh {
+                fresh_price += 1;
+            }
+            if row.has_reserve_data {
+                has_reserve_data += 1;
+            }
+            if row.has_trade_mid {
+                has_trade_mid += 1;
+            }
+            if row.has_decimals {
+                has_decimals += 1;
+            }
+            if row.comparable_price_present {
+                comparable_price_present += 1;
+            }
+            if row.comparable_price_plausible {
+                comparable_price_plausible += 1;
+            }
+            pool_rows.push(row);
+        }
+
+        let mut eligible_by_dex: HashMap<String, usize> = HashMap::new();
+        let mut eligible_pools = 0usize;
+        for row in &pool_rows {
+            if row.eligible {
+                eligible_pools += 1;
+                *eligible_by_dex.entry(row.dex.clone()).or_default() += 1;
+            }
+        }
+
+        MintEligibilityBreakdown {
+            mint: self.base_mint.clone(),
+            candidate_pools_total: pool_rows.len(),
+            known_pools: known_pools_count,
+            fresh_price,
+            has_reserve_data,
+            has_trade_mid,
+            has_decimals,
+            comparable_price_present,
+            comparable_price_plausible,
+            eligible_pools,
+            eligible_dexes: eligible_by_dex.len(),
+            eligible_by_dex,
+            reject_subreason: None,
+            pool_rows,
+        }
+    }
+
+    fn emit_eligibility_forensics(
+        &self,
+        breakdown: MintEligibilityBreakdown,
+        forensics: Option<&ArbEligibilityForensics>,
+    ) {
+        record_eligibility_metrics(&breakdown);
+        if let Some(collector) = forensics {
+            collector.record(breakdown);
+        }
+    }
+
     /// Check for arbitrage opportunity between DEXes
     /// Returns: Option<(buy_dex, sell_dex, spread_bps, estimated_profit_lamports)>
     fn check_arbitrage(
@@ -1008,10 +1410,11 @@ impl TokenArbTracker {
         known_pools: &HashSet<String>,
         vault_balances: &HashMap<String, VaultBalanceCache>,
         bin_arrays: &HashMap<String, HashMap<i64, BinArrayCache>>,
-        spread_warn_last: &RwLock<HashMap<String, Instant>>,
-        data_quality_rejects: &AtomicU64,
+        check_ctx: &ArbCheckContext<'_>,
     ) -> Option<ArbOpportunity> {
-        // Check if 2-hop arbitrage is enabled
+        let spread_warn_last = check_ctx.spread_warn_last;
+        let data_quality_rejects = check_ctx.data_quality_rejects;
+        let forensics = check_ctx.forensics;
         if !config.two_hop_enabled {
             debug!(
                 mint = %self.base_mint,
@@ -1020,19 +1423,25 @@ impl TokenArbTracker {
             return None;
         }
 
+        let mut breakdown =
+            self.build_eligibility_breakdown(known_pools, vault_balances, bin_arrays);
+
         let Some(token_decimals) = self.token_decimals else {
             debug!(
                 mint = %self.base_mint,
                 "Arb check: token decimals unknown — no synthetic fallback"
             );
+            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::MissingDecimals);
+            self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::NoComparablePrice);
             return None;
         };
 
-        // Build comparable prices per pool (buy-side for cheapest, sell-side for highest bid)
+        let max_age = Duration::from_millis(MAX_PRICE_AGE_MS);
         let mut best_buy: Option<(&PoolState, Decimal)> = None;
         let mut best_sell: Option<(&PoolState, Decimal)> = None;
         let mut eligible_pools = 0usize;
+
         for pool in self.pools.values() {
             let is_known_dex = is_known_dex_label(&pool.dex);
             let in_master_cache = known_pools.contains(&pool.pool_address);
@@ -1100,23 +1509,33 @@ impl TokenArbTracker {
                 pools = eligible_pools,
                 "Arb check: insufficient pools with comparable prices"
             );
+            breakdown.reject_subreason = Some(determine_insufficient_subreason(&breakdown));
+            self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::InsufficientPools);
             return None;
         }
 
-        let (buy_pool, buy_price) = best_buy?;
-        let (sell_pool, sell_price) = best_sell?;
+        let Some((buy_pool, buy_price)) = best_buy else {
+            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::ImplausiblePrice);
+            self.emit_eligibility_forensics(breakdown, forensics);
+            return None;
+        };
+        let Some((sell_pool, sell_price)) = best_sell else {
+            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::ImplausiblePrice);
+            self.emit_eligibility_forensics(breakdown, forensics);
+            return None;
+        };
 
         if !is_plausible_sol_per_token_price(&self.base_mint, buy_price)
             || !is_plausible_sol_per_token_price(&self.base_mint, sell_price)
         {
             data_quality_rejects.fetch_add(1, Ordering::Relaxed);
+            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::ImplausiblePrice);
+            self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::DataQuality);
             return None;
         }
 
-        // Staleness: trade-implied or Geyser reserve data must be fresh
-        let max_age = Duration::from_millis(MAX_PRICE_AGE_MS);
         let buy_vault = vault_balances.get(&buy_pool.pool_address);
         let sell_vault = vault_balances.get(&sell_pool.pool_address);
         if !is_pool_price_fresh(buy_pool, buy_vault, max_age)
@@ -1129,22 +1548,24 @@ impl TokenArbTracker {
                 max_age_ms = MAX_PRICE_AGE_MS,
                 "Arb check rejected: stale comparable price"
             );
+            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::StalePrice);
+            self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::StalePrice);
             return None;
         }
 
-        // Don't arb same DEX
         if buy_pool.dex == sell_pool.dex {
             debug!(
                 mint = %self.base_mint,
                 dex = %buy_pool.dex,
                 "Arb check rejected: same DEX for buy/sell"
             );
+            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::SameDexOnly);
+            self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::SameDex);
             return None;
         }
 
-        // CRITICAL: Exclude pumpfun (bonding curve) from ALL arbitrage!
         if buy_pool.dex == "pumpfun" || sell_pool.dex == "pumpfun" {
             debug!(
                 mint = %self.base_mint,
@@ -1152,39 +1573,29 @@ impl TokenArbTracker {
                 sell_dex = %sell_pool.dex,
                 "Arb check rejected: pumpfun (bonding curve) has no other pools to arb against"
             );
+            record_eligibility_metrics(&breakdown);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::Pumpfun);
             return None;
         }
 
-        // Calculate spread in bps
-        // spread = (sell_price - buy_price) / buy_price * 10000
         if buy_price <= Decimal::ZERO {
+            record_eligibility_metrics(&breakdown);
             return None;
         }
 
         let spread = (sell_price - buy_price) / buy_price * Decimal::from(10000);
-        // Convert to i64, handling large spreads correctly
         let spread_bps = spread.round().to_i64().unwrap_or(i64::MAX);
 
-        // DATA QUALITY FILTERS
-
-        // Filter 1: Exclude Native SOL arbitrage (these are wrap/unwrap, not real arb)
         if self.base_mint == NATIVE_SOL_MINT {
             debug!(
                 mint = %self.base_mint,
                 "Arb check rejected: Native SOL trades are wrap/unwrap, not arbitrage"
             );
+            record_eligibility_metrics(&breakdown);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::NativeSol);
             return None;
         }
 
-        // NOTE: Per-pool staleness check REMOVED.
-        // Geyser streams directly from validator - if pool has no updates, that means:
-        // - Pool is inactive (no trades/events), data IS current
-        // - RPC would have same or older data
-        // Geyser connection health is checked globally in ArbContext::is_geyser_connection_healthy()
-
-        // Filter 2: Sanity check for unrealistic spreads
         let max_spread = if self.base_mint == USDC_MINT || self.base_mint == USDT_MINT {
             STABLECOIN_MAX_SPREAD_BPS
         } else {
@@ -1215,6 +1626,7 @@ impl TokenArbTracker {
                     "Arb check rejected: spread too large (likely data error)"
                 );
             }
+            record_eligibility_metrics(&breakdown);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::SpreadTooLarge);
             return None;
         }
@@ -1230,34 +1642,28 @@ impl TokenArbTracker {
                 min_spread = config.min_spread_bps,
                 "Arb check rejected: spread below minimum"
             );
+            record_eligibility_metrics(&breakdown);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::SpreadBelowMin);
             return None;
         }
 
-        // Estimate profit
-        // Use smaller liquidity pool as constraint (fallback to max_position if liquidity unknown)
         let max_trade_sol =
             if buy_pool.liquidity_sol > Decimal::ZERO && sell_pool.liquidity_sol > Decimal::ZERO {
                 buy_pool.liquidity_sol.min(sell_pool.liquidity_sol).min(
                     Decimal::from(config.max_position_lamports) / Decimal::from(1_000_000_000u64),
                 )
             } else {
-                // Liquidity unknown (trade-based pools) - use max_position as conservative estimate
                 Decimal::from(config.max_position_lamports) / Decimal::from(1_000_000_000u64)
             };
 
-        // Gross profit = trade_amount * spread_pct
         let gross_profit = max_trade_sol * (spread / Decimal::from(10000));
-        // Convert to lamports using proper Decimal methods
         let gross_profit_lamports = (gross_profit * Decimal::from(1_000_000_000u64))
             .round()
             .to_u64()
             .unwrap_or(0);
 
-        // Net profit after tx costs
         let net_profit = gross_profit_lamports.saturating_sub(config.est_tx_cost_lamports);
 
-        // 5× profit penalty only when BOTH sides lack Geyser reserve data and SOL liquidity
         let buy_liquidity_unknown =
             !buy_pool.has_reserve_data && buy_pool.liquidity_sol <= Decimal::ZERO;
         let sell_liquidity_unknown =
@@ -1296,10 +1702,12 @@ impl TokenArbTracker {
                 sell_liquidity_known = !sell_liquidity_unknown,
                 "Arb check rejected: profit below minimum"
             );
+            record_eligibility_metrics(&breakdown);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::ProfitBelowMin);
             return None;
         }
 
+        record_eligibility_metrics(&breakdown);
         arb_two_hop_opportunity_inc();
 
         let trade_amount_lamports = (max_trade_sol * Decimal::from(1_000_000_000u64))
@@ -1704,6 +2112,9 @@ struct ArbContext {
 
     /// Per-mint last WARN time for "spread too large" deduplication.
     spread_too_large_warn_last: RwLock<HashMap<String, Instant>>,
+
+    /// Bounded 2-hop eligibility forensics (rate-limited snapshots).
+    eligibility_forensics: ArbEligibilityForensics,
 }
 
 /// Cached vault balances from PoolStateUpdate events
@@ -2683,8 +3094,11 @@ impl ArbContext {
             &known_pools,
             &vault_balances,
             &bin_arrays,
-            &self.spread_too_large_warn_last,
-            &self.data_quality_rejects,
+            &ArbCheckContext {
+                spread_warn_last: &self.spread_too_large_warn_last,
+                data_quality_rejects: &self.data_quality_rejects,
+                forensics: Some(&self.eligibility_forensics),
+            },
         ) {
             // Check cooldown
             let cooldown = Duration::from_millis(config.intent_cooldown_ms);
@@ -3075,6 +3489,7 @@ async fn main() -> Result<()> {
         known_pools: RwLock::new(HashSet::new()),
         multi_hop,
         spread_too_large_warn_last: RwLock::new(HashMap::new()),
+        eligibility_forensics: ArbEligibilityForensics::new(),
     });
 
     // Bootstrap SLAVE LivePoolCache from JetStream (same path as execution-engine).
@@ -3439,6 +3854,8 @@ async fn main() -> Result<()> {
 
                 let known_pools_count = ctx.known_pools.read().len();
                 let multi_hop_stats = ctx.multi_hop.stats();
+                ctx.multi_hop.refresh_quote_readiness_metrics();
+                ctx.eligibility_forensics.maybe_emit_snapshot();
 
                 // Prometheus: publish current gauges for this process
                 POOLS_TRACKED_GAUGE.store(ctx.pools_tracked.load(Ordering::Relaxed), Ordering::Relaxed);
@@ -4297,8 +4714,11 @@ mod two_hop_price_tests {
             &known_pools,
             &vault_balances,
             &bin_arrays,
-            &spread_warn_last,
-            &data_quality_rejects,
+            &ArbCheckContext {
+                spread_warn_last: &spread_warn_last,
+                data_quality_rejects: &data_quality_rejects,
+                forensics: None,
+            },
         );
         // Same reserves → spread ~0, rejected by spread_below_min not insufficient_pools
         assert!(
@@ -4568,6 +4988,8 @@ mod two_hop_price_tests {
         tracker.upsert_pool(pool);
         let mut known_pools = HashSet::new();
         known_pools.insert("orcaSwapped".to_string());
+        let spread_warn_last = RwLock::new(HashMap::new());
+        let data_quality_rejects = AtomicU64::new(0);
         let opp = tracker.check_arbitrage(
             &ArbConfig::default(),
             &known_pools,
@@ -4585,8 +5007,11 @@ mod two_hop_price_tests {
                 },
             )]),
             &HashMap::new(),
-            &RwLock::new(HashMap::new()),
-            &AtomicU64::new(0),
+            &ArbCheckContext {
+                spread_warn_last: &spread_warn_last,
+                data_quality_rejects: &data_quality_rejects,
+                forensics: None,
+            },
         );
         assert!(opp.is_none());
         assert_eq!(
@@ -4639,6 +5064,253 @@ mod two_hop_price_tests {
             ComparablePriceSide::Buy,
         );
         assert!(price.is_none(), "must not assume 6 decimals when unknown");
+    }
+
+    fn check_with_forensics(
+        tracker: &TokenArbTracker,
+        known_pools: &HashSet<String>,
+        vault_balances: &HashMap<String, VaultBalanceCache>,
+        forensics: &ArbEligibilityForensics,
+    ) -> Option<ArbOpportunity> {
+        let spread_warn_last = RwLock::new(HashMap::new());
+        let data_quality_rejects = AtomicU64::new(0);
+        tracker.check_arbitrage(
+            &ArbConfig::default(),
+            known_pools,
+            vault_balances,
+            &HashMap::new(),
+            &ArbCheckContext {
+                spread_warn_last: &spread_warn_last,
+                data_quality_rejects: &data_quality_rejects,
+                forensics: Some(forensics),
+            },
+        )
+    }
+
+    fn vault(reserve_base: u64, reserve_quote: u64) -> VaultBalanceCache {
+        sample_vault(reserve_base, reserve_quote, None, None, false, None)
+    }
+
+    #[test]
+    fn forensics_not_known_pool_when_only_one_in_master_cache() {
+        let before =
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_NOT_KNOWN_POOL.load(Ordering::Relaxed);
+        let reserves = (1_000_000_000_000u64, 1_000_000_000u64);
+        let mut tracker = TokenArbTracker::new("TokenMint11111111111111111111111111111111");
+        tracker.token_decimals = Some(6);
+        tracker.upsert_pool(sample_pool("orca", "poolKnown", None, None));
+        tracker.upsert_pool(sample_pool("pump_amm", "poolUnknown", None, None));
+
+        let mut known_pools = HashSet::new();
+        known_pools.insert("poolKnown".to_string());
+
+        let vault_balances = HashMap::from([
+            ("poolKnown".to_string(), vault(reserves.0, reserves.1)),
+            ("poolUnknown".to_string(), vault(reserves.0, reserves.1)),
+        ]);
+
+        let forensics = ArbEligibilityForensics::new();
+        assert!(
+            check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics).is_none()
+        );
+        assert!(
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_POOL
+                .load(Ordering::Relaxed)
+                > before
+                || ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_NOT_KNOWN_POOL
+                    .load(Ordering::Relaxed)
+                    > before
+        );
+    }
+
+    #[test]
+    fn forensics_same_dex_only_when_both_pools_on_one_dex() {
+        let before =
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY.load(Ordering::Relaxed);
+        let reserves = (1_000_000_000_000u64, 1_000_000_000u64);
+        let mint = "TokenMint22222222222222222222222222222222";
+        let mut tracker = TokenArbTracker::new(mint);
+        tracker.token_decimals = Some(6);
+        tracker.upsert_pool(sample_pool("orca", "poolA", None, None));
+        tracker.upsert_pool(sample_pool("orca", "poolB", None, None));
+
+        let mut known_pools = HashSet::new();
+        known_pools.insert("poolA".to_string());
+        known_pools.insert("poolB".to_string());
+
+        let vault_balances = HashMap::from([
+            ("poolA".to_string(), vault(reserves.0, reserves.1)),
+            ("poolB".to_string(), vault(reserves.0, reserves.1)),
+        ]);
+
+        let forensics = ArbEligibilityForensics::new();
+        assert!(
+            check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics).is_none()
+        );
+        assert!(
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY.load(Ordering::Relaxed)
+                > before
+        );
+    }
+
+    #[test]
+    fn forensics_stale_price_when_one_dex_stale() {
+        let before =
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE.load(Ordering::Relaxed);
+        let mint = "TokenMint33333333333333333333333333333333";
+        let mut tracker = TokenArbTracker::new(mint);
+        tracker.token_decimals = Some(6);
+        tracker.upsert_pool(PoolState {
+            has_reserve_data: true,
+            ..sample_pool("orca", "poolFresh", None, None)
+        });
+        tracker.upsert_pool(PoolState {
+            has_reserve_data: true,
+            last_update: Instant::now() - Duration::from_millis(MAX_PRICE_AGE_MS + 5_000),
+            ..sample_pool("pump_amm", "poolStale", None, None)
+        });
+
+        let mut known_pools = HashSet::new();
+        known_pools.insert("poolFresh".to_string());
+        known_pools.insert("poolStale".to_string());
+
+        let vault_balances = HashMap::from([
+            (
+                "poolFresh".to_string(),
+                vault(1_000_000_000_000, 1_000_000_000),
+            ),
+            (
+                "poolStale".to_string(),
+                VaultBalanceCache {
+                    reserve_base: 500_000_000_000,
+                    reserve_quote: 1_000_000_000,
+                    updated_at: Instant::now() - Duration::from_millis(MAX_PRICE_AGE_MS + 5_000),
+                    ..vault(500_000_000_000, 1_000_000_000)
+                },
+            ),
+        ]);
+
+        let forensics = ArbEligibilityForensics::new();
+        assert!(
+            check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics).is_none()
+        );
+        assert!(
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE.load(Ordering::Relaxed)
+                > before
+        );
+    }
+
+    #[test]
+    fn forensics_missing_decimals_subreason() {
+        let before =
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS.load(Ordering::Relaxed);
+        let reserves = (1_000_000_000_000u64, 1_000_000_000u64);
+        let mut tracker = TokenArbTracker::new("TokenMint44444444444444444444444444444444");
+        tracker.upsert_pool(sample_pool("orca", "poolA", None, None));
+        tracker.upsert_pool(sample_pool("pump_amm", "poolB", None, None));
+
+        let mut known_pools = HashSet::new();
+        known_pools.insert("poolA".to_string());
+        known_pools.insert("poolB".to_string());
+        let vault_balances = HashMap::from([
+            ("poolA".to_string(), vault(reserves.0, reserves.1)),
+            ("poolB".to_string(), vault(reserves.0, reserves.1)),
+        ]);
+
+        let forensics = ArbEligibilityForensics::new();
+        assert!(
+            check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics).is_none()
+        );
+        assert!(
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS.load(Ordering::Relaxed)
+                > before
+        );
+    }
+
+    #[test]
+    fn forensics_implausible_stablecoin_not_spread_too_large() {
+        let spread_before =
+            ironcrab::metrics::ARB_TWO_HOP_REJECTED_SPREAD_TOO_LARGE.load(Ordering::Relaxed);
+        let insufficient_before =
+            ironcrab::metrics::ARB_TWO_HOP_REJECTED_INSUFFICIENT_POOLS.load(Ordering::Relaxed);
+
+        let sol_in_base = 1_000_000_000u64;
+        let usdc_in_quote = 65_000_000u64;
+        let mut tracker = TokenArbTracker::new(USDC_MINT);
+        tracker.token_decimals = Some(6);
+        tracker.upsert_pool(sample_pool("orca", "orcaBad", None, None));
+        tracker.upsert_pool(sample_pool("meteora_dlmm", "dlmmBad", None, None));
+
+        let mut known_pools = HashSet::new();
+        known_pools.insert("orcaBad".to_string());
+        known_pools.insert("dlmmBad".to_string());
+        let vault_balances = HashMap::from([
+            ("orcaBad".to_string(), vault(sol_in_base, usdc_in_quote)),
+            ("dlmmBad".to_string(), vault(sol_in_base, usdc_in_quote)),
+        ]);
+
+        let forensics = ArbEligibilityForensics::new();
+        assert!(
+            check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics).is_none()
+        );
+        assert_eq!(
+            ironcrab::metrics::ARB_TWO_HOP_REJECTED_SPREAD_TOO_LARGE.load(Ordering::Relaxed),
+            spread_before
+        );
+        assert!(
+            ironcrab::metrics::ARB_TWO_HOP_REJECTED_INSUFFICIENT_POOLS.load(Ordering::Relaxed)
+                > insufficient_before
+        );
+    }
+
+    #[test]
+    fn determine_implausible_subreason_when_comparable_not_plausible() {
+        let breakdown = MintEligibilityBreakdown {
+            mint: USDC_MINT.to_string(),
+            candidate_pools_total: 2,
+            known_pools: 2,
+            fresh_price: 2,
+            has_reserve_data: 0,
+            has_trade_mid: 2,
+            has_decimals: 2,
+            comparable_price_present: 2,
+            comparable_price_plausible: 0,
+            eligible_pools: 2,
+            eligible_dexes: 2,
+            eligible_by_dex: HashMap::from([
+                ("orca".to_string(), 1),
+                ("meteora_dlmm".to_string(), 1),
+            ]),
+            reject_subreason: None,
+            pool_rows: vec![],
+        };
+        assert_eq!(
+            determine_insufficient_subreason(&breakdown),
+            ArbTwoHopInsufficientSubreason::ImplausiblePrice
+        );
+    }
+
+    #[test]
+    fn eligibility_snapshot_rate_limited_to_once_per_60s() {
+        let forensics = ArbEligibilityForensics::new();
+        let reserves = (1_000_000_000_000u64, 1_000_000_000u64);
+        let mut tracker = TokenArbTracker::new("TokenMint55555555555555555555555555555555");
+        tracker.token_decimals = Some(6);
+        tracker.upsert_pool(sample_pool("orca", "poolOnly", None, None));
+
+        let mut known_pools = HashSet::new();
+        known_pools.insert("poolOnly".to_string());
+        let vault_balances =
+            HashMap::from([("poolOnly".to_string(), vault(reserves.0, reserves.1))]);
+
+        forensics.force_snapshot_ready();
+        let _ = check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics);
+        assert!(forensics.maybe_emit_snapshot());
+        assert_eq!(forensics.snapshots_emitted_count(), 1);
+
+        let _ = check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics);
+        assert!(!forensics.maybe_emit_snapshot());
+        assert_eq!(forensics.snapshots_emitted_count(), 1);
     }
 }
 

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -979,6 +979,8 @@ struct PoolEligibilityRow {
     comparable_price_present: bool,
     comparable_price_plausible: bool,
     eligible: bool,
+    buy_price: Option<Decimal>,
+    sell_price: Option<Decimal>,
 }
 
 /// Aggregated mint-level eligibility breakdown for metrics + snapshots.
@@ -1156,6 +1158,14 @@ fn record_eligibility_metrics(breakdown: &MintEligibilityBreakdown) {
     }
 }
 
+fn set_reject_subreason(
+    breakdown: &mut MintEligibilityBreakdown,
+    subreason: ArbTwoHopInsufficientSubreason,
+) {
+    breakdown.reject_subreason = Some(subreason);
+    arb_two_hop_insufficient_subreason_inc(subreason);
+}
+
 fn determine_insufficient_subreason(
     breakdown: &MintEligibilityBreakdown,
 ) -> ArbTwoHopInsufficientSubreason {
@@ -1260,6 +1270,8 @@ fn analyze_pool_eligibility(
         comparable_price_present,
         comparable_price_plausible,
         eligible,
+        buy_price,
+        sell_price,
     }
 }
 
@@ -1423,12 +1435,15 @@ impl TokenArbTracker {
         let mut breakdown =
             self.build_eligibility_breakdown(known_pools, vault_balances, bin_arrays);
 
-        let Some(token_decimals) = self.token_decimals else {
+        let Some(_token_decimals) = self.token_decimals else {
             debug!(
                 mint = %self.base_mint,
                 "Arb check: token decimals unknown — no synthetic fallback"
             );
-            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::MissingDecimals);
+            set_reject_subreason(
+                &mut breakdown,
+                ArbTwoHopInsufficientSubreason::MissingDecimals,
+            );
             self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::NoComparablePrice);
             return None;
@@ -1439,42 +1454,24 @@ impl TokenArbTracker {
         let mut best_sell: Option<(&PoolState, Decimal)> = None;
         let mut eligible_pools = 0usize;
 
-        for pool in self.pools.values() {
-            let is_known_dex = is_known_dex_label(&pool.dex);
-            let in_master_cache = known_pools.contains(&pool.pool_address);
-            if !is_known_dex || !in_master_cache {
-                if is_known_dex && !in_master_cache {
+        for row in &breakdown.pool_rows {
+            if !row.known {
+                if is_known_dex_label(&row.dex) {
                     debug!(
-                        pool = %pool.pool_address,
-                        dex = %pool.dex,
+                        pool = %row.pool_address,
+                        dex = %row.dex,
                         mint = %self.base_mint,
                         "Pool filtered: not in market-data MASTER cache (parse_pool_account failed)"
                     );
                 }
                 continue;
             }
-            let vault_entry = vault_balances.get(&pool.pool_address);
-            let vault_reserves = vault_entry.map(|c| (c.reserve_base, c.reserve_quote));
-            let dlmm_bins = bin_arrays.get(&pool.pool_address);
-            let buy_price = comparable_price_sol_per_token(
-                pool,
-                vault_reserves,
-                Some(token_decimals),
-                &self.base_mint,
-                vault_entry,
-                dlmm_bins,
-                ComparablePriceSide::Buy,
-            );
-            let sell_price = comparable_price_sol_per_token(
-                pool,
-                vault_reserves,
-                Some(token_decimals),
-                &self.base_mint,
-                vault_entry,
-                dlmm_bins,
-                ComparablePriceSide::Sell,
-            );
-            if buy_price.is_none() && sell_price.is_none() {
+            let Some(pool) = self.pools.get(&row.pool_address) else {
+                continue;
+            };
+            let buy_price = row.buy_price;
+            let sell_price = row.sell_price;
+            if !row.comparable_price_present {
                 continue;
             }
             eligible_pools += 1;
@@ -1506,23 +1503,27 @@ impl TokenArbTracker {
                 pools = eligible_pools,
                 "Arb check: insufficient pools with comparable prices"
             );
-            breakdown.reject_subreason = Some(determine_insufficient_subreason(&breakdown));
-            if let Some(subreason) = breakdown.reject_subreason {
-                arb_two_hop_insufficient_subreason_inc(subreason);
-            }
+            let subreason = determine_insufficient_subreason(&breakdown);
+            set_reject_subreason(&mut breakdown, subreason);
             self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::InsufficientPools);
             return None;
         }
 
         let Some((buy_pool, buy_price)) = best_buy else {
-            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::ImplausiblePrice);
+            set_reject_subreason(
+                &mut breakdown,
+                ArbTwoHopInsufficientSubreason::ImplausiblePrice,
+            );
             self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::DataQuality);
             return None;
         };
         let Some((sell_pool, sell_price)) = best_sell else {
-            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::ImplausiblePrice);
+            set_reject_subreason(
+                &mut breakdown,
+                ArbTwoHopInsufficientSubreason::ImplausiblePrice,
+            );
             self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::DataQuality);
             return None;
@@ -1532,7 +1533,10 @@ impl TokenArbTracker {
             || !is_plausible_sol_per_token_price(&self.base_mint, sell_price)
         {
             data_quality_rejects.fetch_add(1, Ordering::Relaxed);
-            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::ImplausiblePrice);
+            set_reject_subreason(
+                &mut breakdown,
+                ArbTwoHopInsufficientSubreason::ImplausiblePrice,
+            );
             self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::DataQuality);
             return None;
@@ -1550,7 +1554,7 @@ impl TokenArbTracker {
                 max_age_ms = MAX_PRICE_AGE_MS,
                 "Arb check rejected: stale comparable price"
             );
-            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::StalePrice);
+            set_reject_subreason(&mut breakdown, ArbTwoHopInsufficientSubreason::StalePrice);
             self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::StalePrice);
             return None;
@@ -1562,7 +1566,12 @@ impl TokenArbTracker {
                 dex = %buy_pool.dex,
                 "Arb check rejected: same DEX for buy/sell"
             );
-            breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::SameDexOnly);
+            let subreason = if breakdown.eligible_dexes < 2 {
+                ArbTwoHopInsufficientSubreason::OnlyOneEligibleDex
+            } else {
+                ArbTwoHopInsufficientSubreason::SameDexOnly
+            };
+            set_reject_subreason(&mut breakdown, subreason);
             self.emit_eligibility_forensics(breakdown, forensics);
             arb_two_hop_rejected_inc(ArbTwoHopRejectReason::SameDex);
             return None;
@@ -5127,8 +5136,8 @@ mod two_hop_price_tests {
 
     #[test]
     fn forensics_same_dex_only_when_both_pools_on_one_dex() {
-        let before_subreason =
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY.load(Ordering::Relaxed);
+        let before_subreason = ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_DEX
+            .load(Ordering::Relaxed);
         let before_reject =
             ironcrab::metrics::ARB_TWO_HOP_REJECTED_SAME_DEX.load(Ordering::Relaxed);
         let reserves = (1_000_000_000_000u64, 1_000_000_000u64);
@@ -5155,9 +5164,10 @@ mod two_hop_price_tests {
             ironcrab::metrics::ARB_TWO_HOP_REJECTED_SAME_DEX.load(Ordering::Relaxed)
                 > before_reject
         );
-        assert_eq!(
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY.load(Ordering::Relaxed),
-            before_subreason
+        assert!(
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_DEX
+                .load(Ordering::Relaxed)
+                > before_subreason
         );
     }
 
@@ -5208,9 +5218,9 @@ mod two_hop_price_tests {
             ironcrab::metrics::ARB_TWO_HOP_REJECTED_STALE_PRICE.load(Ordering::Relaxed)
                 > before_reject
         );
-        assert_eq!(
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE.load(Ordering::Relaxed),
-            before_subreason
+        assert!(
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE.load(Ordering::Relaxed)
+                > before_subreason
         );
     }
 
@@ -5241,9 +5251,9 @@ mod two_hop_price_tests {
             ironcrab::metrics::ARB_TWO_HOP_REJECTED_NO_COMPARABLE_PRICE.load(Ordering::Relaxed)
                 > before_reject
         );
-        assert_eq!(
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS.load(Ordering::Relaxed),
-            before_subreason
+        assert!(
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS.load(Ordering::Relaxed)
+                > before_subreason
         );
     }
 

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -1103,15 +1103,18 @@ impl ArbEligibilityForensics {
             return false;
         }
 
-        let mut ranked: Vec<MintEligibilityBreakdown> = pending.drain().map(|(_, b)| b).collect();
+        let mut ranked: Vec<MintEligibilityBreakdown> = pending.values().cloned().collect();
         ranked.sort_by(|a, b| {
             b.eligible_pools
                 .cmp(&a.eligible_pools)
                 .then_with(|| a.candidate_pools_total.cmp(&b.candidate_pools_total))
         });
-        ranked.truncate(ELIGIBILITY_SNAPSHOT_TOP_N);
+        let logged: Vec<MintEligibilityBreakdown> = ranked
+            .into_iter()
+            .take(ELIGIBILITY_SNAPSHOT_TOP_N)
+            .collect();
 
-        for entry in &ranked {
+        for entry in &logged {
             let top_pools: Vec<_> = entry
                 .pool_rows
                 .iter()
@@ -1143,8 +1146,17 @@ impl ArbEligibilityForensics {
             );
         }
 
+        for entry in &logged {
+            pending.remove(&entry.mint);
+        }
+
         self.snapshots_emitted.fetch_add(1, Ordering::Relaxed);
         true
+    }
+
+    #[cfg(test)]
+    fn pending_mint_count(&self) -> usize {
+        self.pending.read().len()
     }
 
     #[cfg(test)]
@@ -1210,12 +1222,6 @@ fn record_reject_subreason(reason: ArbTwoHopRejectSubreason) {
 fn determine_insufficient_subreason(
     breakdown: &MintEligibilityBreakdown,
 ) -> ArbTwoHopInsufficientSubreason {
-    if breakdown.eligible_pools == 1 {
-        return ArbTwoHopInsufficientSubreason::OnlyOneEligiblePool;
-    }
-    if breakdown.eligible_pools >= 2 && breakdown.eligible_dexes < 2 {
-        return ArbTwoHopInsufficientSubreason::OnlyOneEligibleDex;
-    }
     if breakdown.known_pools < 2 && breakdown.candidate_pools_total >= 2 {
         return ArbTwoHopInsufficientSubreason::NotKnownPool;
     }
@@ -1227,6 +1233,18 @@ fn determine_insufficient_subreason(
             return ArbTwoHopInsufficientSubreason::MissingTradePrice;
         }
         return ArbTwoHopInsufficientSubreason::NoComparablePrice;
+    }
+    if breakdown.known_pools >= 2
+        && breakdown.has_decimals < breakdown.known_pools
+        && breakdown.eligible_pools < 2
+    {
+        return ArbTwoHopInsufficientSubreason::NoComparablePrice;
+    }
+    if breakdown.eligible_pools == 1 {
+        return ArbTwoHopInsufficientSubreason::OnlyOneEligiblePool;
+    }
+    if breakdown.eligible_pools >= 2 && breakdown.eligible_dexes < 2 {
+        return ArbTwoHopInsufficientSubreason::OnlyOneEligibleDex;
     }
     ArbTwoHopInsufficientSubreason::NoComparablePrice
 }
@@ -5126,7 +5144,7 @@ mod two_hop_price_tests {
 
     #[test]
     fn forensics_not_known_pool_when_only_one_in_master_cache() {
-        let before =
+        let before_known =
             ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_NOT_KNOWN_POOL.load(Ordering::Relaxed);
         let reserves = (1_000_000_000_000u64, 1_000_000_000u64);
         let mut tracker = TokenArbTracker::new("TokenMint11111111111111111111111111111111");
@@ -5147,12 +5165,8 @@ mod two_hop_price_tests {
             check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics).is_none()
         );
         assert!(
-            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_POOL
-                .load(Ordering::Relaxed)
-                > before
-                || ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_NOT_KNOWN_POOL
-                    .load(Ordering::Relaxed)
-                    > before
+            ironcrab::metrics::ARB_TWO_HOP_INSUFFICIENT_NOT_KNOWN_POOL.load(Ordering::Relaxed)
+                > before_known
         );
     }
 
@@ -5309,6 +5323,58 @@ mod two_hop_price_tests {
         assert_eq!(
             determine_insufficient_subreason(&breakdown),
             ArbTwoHopInsufficientSubreason::MissingReserves
+        );
+    }
+
+    #[test]
+    fn determine_insufficient_subreason_prefers_not_known_pool_over_only_one_eligible() {
+        let breakdown = MintEligibilityBreakdown {
+            mint: "TokenMint11111111111111111111111111111111".to_string(),
+            candidate_pools_total: 2,
+            known_pools: 1,
+            fresh_price: 2,
+            has_reserve_data: 2,
+            has_trade_mid: 0,
+            has_decimals: 2,
+            comparable_price_present: 1,
+            comparable_price_plausible: 1,
+            eligible_pools: 1,
+            eligible_dexes: 1,
+            eligible_by_dex: HashMap::new(),
+            reject_subreason: None,
+            pool_rows: vec![],
+        };
+        assert_eq!(
+            determine_insufficient_subreason(&breakdown),
+            ArbTwoHopInsufficientSubreason::NotKnownPool
+        );
+    }
+
+    #[test]
+    fn eligibility_snapshot_retains_pending_mints_beyond_top_n() {
+        let forensics = ArbEligibilityForensics::new();
+        let reserves = (1_000_000_000_000u64, 1_000_000_000u64);
+
+        for i in 0..11 {
+            let mint = format!("TokenMint{i:032}");
+            let pool = format!("pool{i}");
+            let mut tracker = TokenArbTracker::new(&mint);
+            tracker.token_decimals = Some(6);
+            tracker.upsert_pool(sample_pool("orca", &pool, None, None));
+            let mut known_pools = HashSet::new();
+            known_pools.insert(pool.clone());
+            let vault_balances = HashMap::from([(pool, vault(reserves.0, reserves.1))]);
+            let _ = check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics);
+        }
+
+        assert_eq!(forensics.pending_mint_count(), 11);
+        forensics.force_snapshot_ready();
+        assert!(forensics.maybe_emit_snapshot());
+        assert_eq!(forensics.snapshots_emitted_count(), 1);
+        assert_eq!(
+            forensics.pending_mint_count(),
+            1,
+            "only top 10 logged mints should be removed from pending"
         );
     }
 

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -1518,11 +1518,13 @@ impl TokenArbTracker {
         let Some((buy_pool, buy_price)) = best_buy else {
             breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::ImplausiblePrice);
             self.emit_eligibility_forensics(breakdown, forensics);
+            arb_two_hop_rejected_inc(ArbTwoHopRejectReason::DataQuality);
             return None;
         };
         let Some((sell_pool, sell_price)) = best_sell else {
             breakdown.reject_subreason = Some(ArbTwoHopInsufficientSubreason::ImplausiblePrice);
             self.emit_eligibility_forensics(breakdown, forensics);
+            arb_two_hop_rejected_inc(ArbTwoHopRejectReason::DataQuality);
             return None;
         };
 

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -1228,6 +1228,9 @@ fn determine_insufficient_subreason(
         return ArbTwoHopInsufficientSubreason::NotKnownPool;
     }
     if breakdown.comparable_price_present == 0 {
+        if breakdown.has_reserve_data > 0 {
+            return ArbTwoHopInsufficientSubreason::NoComparablePrice;
+        }
         if breakdown.has_reserve_data == 0 && breakdown.has_trade_mid == 0 {
             return ArbTwoHopInsufficientSubreason::MissingReserves;
         }
@@ -5301,6 +5304,30 @@ mod two_hop_price_tests {
         assert!(
             ironcrab::metrics::ARB_TWO_HOP_REJECTED_INSUFFICIENT_POOLS.load(Ordering::Relaxed)
                 > insufficient_before
+        );
+    }
+
+    #[test]
+    fn determine_insufficient_subreason_reserve_data_without_trade_mid_is_no_comparable_price() {
+        let breakdown = MintEligibilityBreakdown {
+            mint: USDC_MINT.to_string(),
+            candidate_pools_total: 2,
+            known_pools: 2,
+            fresh_price: 2,
+            has_reserve_data: 2,
+            has_trade_mid: 0,
+            has_decimals: 2,
+            comparable_price_present: 0,
+            comparable_price_plausible: 0,
+            eligible_pools: 0,
+            eligible_dexes: 0,
+            eligible_by_dex: HashMap::new(),
+            reject_subreason: None,
+            pool_rows: vec![],
+        };
+        assert_eq!(
+            determine_insufficient_subreason(&breakdown),
+            ArbTwoHopInsufficientSubreason::NoComparablePrice
         );
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2496,6 +2496,17 @@ pub fn arb_two_hop_tracker_seeded_pools_add(count: u64) {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArbTwoHopInsufficientSubreason {
     NotKnownPool,
+    MissingReserves,
+    MissingTradePrice,
+    NoComparablePrice,
+    OnlyOneEligiblePool,
+    OnlyOneEligibleDex,
+}
+
+/// Diagnostic sub-reason for any 2-hop reject path (low-cardinality `reason` label).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArbTwoHopRejectSubreason {
+    NotKnownPool,
     MissingDecimals,
     MissingReserves,
     MissingTradePrice,
@@ -2505,6 +2516,19 @@ pub enum ArbTwoHopInsufficientSubreason {
     ImplausiblePrice,
     OnlyOneEligiblePool,
     OnlyOneEligibleDex,
+}
+
+impl From<ArbTwoHopInsufficientSubreason> for ArbTwoHopRejectSubreason {
+    fn from(reason: ArbTwoHopInsufficientSubreason) -> Self {
+        match reason {
+            ArbTwoHopInsufficientSubreason::NotKnownPool => Self::NotKnownPool,
+            ArbTwoHopInsufficientSubreason::MissingReserves => Self::MissingReserves,
+            ArbTwoHopInsufficientSubreason::MissingTradePrice => Self::MissingTradePrice,
+            ArbTwoHopInsufficientSubreason::NoComparablePrice => Self::NoComparablePrice,
+            ArbTwoHopInsufficientSubreason::OnlyOneEligiblePool => Self::OnlyOneEligiblePool,
+            ArbTwoHopInsufficientSubreason::OnlyOneEligibleDex => Self::OnlyOneEligibleDex,
+        }
+    }
 }
 
 pub static ARB_TWO_HOP_INSUFFICIENT_NOT_KNOWN_POOL: Lazy<AtomicU64> =
@@ -2527,13 +2551,25 @@ pub static ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_POOL: Lazy<AtomicU64> =
 pub static ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_DEX: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
-/// Increment `arb_two_hop_insufficient_subreason_total{reason=...}` once per mint rejection.
+pub static ARB_TWO_HOP_REJECT_NOT_KNOWN_POOL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_REJECT_MISSING_DECIMALS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_REJECT_MISSING_RESERVES: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_REJECT_MISSING_TRADE_PRICE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_REJECT_NO_COMPARABLE_PRICE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_REJECT_STALE_PRICE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_REJECT_SAME_DEX_ONLY: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_REJECT_IMPLAUSIBLE_PRICE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_REJECT_ONLY_ONE_ELIGIBLE_POOL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_REJECT_ONLY_ONE_ELIGIBLE_DEX: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Increment `arb_two_hop_insufficient_subreason_total{reason=...}` for insufficient_pools only.
 pub fn arb_two_hop_insufficient_subreason_inc(reason: ArbTwoHopInsufficientSubreason) {
     let counter = match reason {
         ArbTwoHopInsufficientSubreason::NotKnownPool => &*ARB_TWO_HOP_INSUFFICIENT_NOT_KNOWN_POOL,
-        ArbTwoHopInsufficientSubreason::MissingDecimals => {
-            &*ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS
-        }
         ArbTwoHopInsufficientSubreason::MissingReserves => {
             &*ARB_TWO_HOP_INSUFFICIENT_MISSING_RESERVES
         }
@@ -2543,17 +2579,32 @@ pub fn arb_two_hop_insufficient_subreason_inc(reason: ArbTwoHopInsufficientSubre
         ArbTwoHopInsufficientSubreason::NoComparablePrice => {
             &*ARB_TWO_HOP_INSUFFICIENT_NO_COMPARABLE_PRICE
         }
-        ArbTwoHopInsufficientSubreason::StalePrice => &*ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE,
-        ArbTwoHopInsufficientSubreason::SameDexOnly => &*ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY,
-        ArbTwoHopInsufficientSubreason::ImplausiblePrice => {
-            &*ARB_TWO_HOP_INSUFFICIENT_IMPLAUSIBLE_PRICE
-        }
         ArbTwoHopInsufficientSubreason::OnlyOneEligiblePool => {
             &*ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_POOL
         }
         ArbTwoHopInsufficientSubreason::OnlyOneEligibleDex => {
             &*ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_DEX
         }
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+    arb_two_hop_reject_subreason_inc(reason.into());
+}
+
+/// Increment `arb_two_hop_reject_subreason_total{reason=...}` for any documented reject subreason.
+pub fn arb_two_hop_reject_subreason_inc(reason: ArbTwoHopRejectSubreason) {
+    let counter = match reason {
+        ArbTwoHopRejectSubreason::NotKnownPool => &*ARB_TWO_HOP_REJECT_NOT_KNOWN_POOL,
+        ArbTwoHopRejectSubreason::MissingDecimals => &*ARB_TWO_HOP_REJECT_MISSING_DECIMALS,
+        ArbTwoHopRejectSubreason::MissingReserves => &*ARB_TWO_HOP_REJECT_MISSING_RESERVES,
+        ArbTwoHopRejectSubreason::MissingTradePrice => &*ARB_TWO_HOP_REJECT_MISSING_TRADE_PRICE,
+        ArbTwoHopRejectSubreason::NoComparablePrice => &*ARB_TWO_HOP_REJECT_NO_COMPARABLE_PRICE,
+        ArbTwoHopRejectSubreason::StalePrice => &*ARB_TWO_HOP_REJECT_STALE_PRICE,
+        ArbTwoHopRejectSubreason::SameDexOnly => &*ARB_TWO_HOP_REJECT_SAME_DEX_ONLY,
+        ArbTwoHopRejectSubreason::ImplausiblePrice => &*ARB_TWO_HOP_REJECT_IMPLAUSIBLE_PRICE,
+        ArbTwoHopRejectSubreason::OnlyOneEligiblePool => {
+            &*ARB_TWO_HOP_REJECT_ONLY_ONE_ELIGIBLE_POOL
+        }
+        ArbTwoHopRejectSubreason::OnlyOneEligibleDex => &*ARB_TWO_HOP_REJECT_ONLY_ONE_ELIGIBLE_DEX,
     };
     counter.fetch_add(1, Ordering::Relaxed);
 }
@@ -4763,6 +4814,76 @@ async fn metrics_response() -> Response<Body> {
     out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"only_one_eligible_dex\"} ");
     out.push_str(
         &ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_DEX
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"not_known_pool\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_NOT_KNOWN_POOL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"missing_decimals\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_MISSING_DECIMALS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"missing_reserves\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_MISSING_RESERVES
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"missing_trade_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_MISSING_TRADE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"no_comparable_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_NO_COMPARABLE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"stale_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_STALE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"same_dex_only\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_SAME_DEX_ONLY
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"implausible_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_IMPLAUSIBLE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"only_one_eligible_pool\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_ONLY_ONE_ELIGIBLE_POOL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"only_one_eligible_dex\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_ONLY_ONE_ELIGIBLE_DEX
             .load(Ordering::Relaxed)
             .to_string(),
     );

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2533,18 +2533,11 @@ impl From<ArbTwoHopInsufficientSubreason> for ArbTwoHopRejectSubreason {
 
 pub static ARB_TWO_HOP_INSUFFICIENT_NOT_KNOWN_POOL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
-pub static ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS: Lazy<AtomicU64> =
-    Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TWO_HOP_INSUFFICIENT_MISSING_RESERVES: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TWO_HOP_INSUFFICIENT_MISSING_TRADE_PRICE: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TWO_HOP_INSUFFICIENT_NO_COMPARABLE_PRICE: Lazy<AtomicU64> =
-    Lazy::new(|| AtomicU64::new(0));
-pub static ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
-pub static ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY: Lazy<AtomicU64> =
-    Lazy::new(|| AtomicU64::new(0));
-pub static ARB_TWO_HOP_INSUFFICIENT_IMPLAUSIBLE_PRICE: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_POOL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -2588,6 +2581,124 @@ pub fn arb_two_hop_insufficient_subreason_inc(reason: ArbTwoHopInsufficientSubre
     };
     counter.fetch_add(1, Ordering::Relaxed);
     arb_two_hop_reject_subreason_inc(reason.into());
+}
+
+fn append_arb_two_hop_insufficient_subreason_total(out: &mut String) {
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"not_known_pool\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_NOT_KNOWN_POOL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"missing_reserves\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_MISSING_RESERVES
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"missing_trade_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_MISSING_TRADE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"no_comparable_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_NO_COMPARABLE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"only_one_eligible_pool\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_POOL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"only_one_eligible_dex\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_DEX
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+}
+
+fn append_arb_two_hop_reject_subreason_total(out: &mut String) {
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"not_known_pool\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_NOT_KNOWN_POOL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"missing_decimals\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_MISSING_DECIMALS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"missing_reserves\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_MISSING_RESERVES
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"missing_trade_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_MISSING_TRADE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"no_comparable_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_NO_COMPARABLE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"stale_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_STALE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"same_dex_only\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_SAME_DEX_ONLY
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"implausible_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_IMPLAUSIBLE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"only_one_eligible_pool\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_ONLY_ONE_ELIGIBLE_POOL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_reject_subreason_total{reason=\"only_one_eligible_dex\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_REJECT_ONLY_ONE_ELIGIBLE_DEX
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
 }
 
 /// Increment `arb_two_hop_reject_subreason_total{reason=...}` for any documented reject subreason.
@@ -4748,146 +4859,8 @@ async fn metrics_response() -> Response<Body> {
             .to_string(),
     );
     out.push('\n');
-    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"not_known_pool\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_INSUFFICIENT_NOT_KNOWN_POOL
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"missing_decimals\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"missing_reserves\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_INSUFFICIENT_MISSING_RESERVES
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"missing_trade_price\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_INSUFFICIENT_MISSING_TRADE_PRICE
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"no_comparable_price\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_INSUFFICIENT_NO_COMPARABLE_PRICE
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"stale_price\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"same_dex_only\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"implausible_price\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_INSUFFICIENT_IMPLAUSIBLE_PRICE
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"only_one_eligible_pool\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_POOL
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"only_one_eligible_dex\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_DEX
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_reject_subreason_total{reason=\"not_known_pool\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_REJECT_NOT_KNOWN_POOL
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_reject_subreason_total{reason=\"missing_decimals\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_REJECT_MISSING_DECIMALS
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_reject_subreason_total{reason=\"missing_reserves\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_REJECT_MISSING_RESERVES
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_reject_subreason_total{reason=\"missing_trade_price\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_REJECT_MISSING_TRADE_PRICE
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_reject_subreason_total{reason=\"no_comparable_price\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_REJECT_NO_COMPARABLE_PRICE
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_reject_subreason_total{reason=\"stale_price\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_REJECT_STALE_PRICE
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_reject_subreason_total{reason=\"same_dex_only\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_REJECT_SAME_DEX_ONLY
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_reject_subreason_total{reason=\"implausible_price\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_REJECT_IMPLAUSIBLE_PRICE
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_reject_subreason_total{reason=\"only_one_eligible_pool\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_REJECT_ONLY_ONE_ELIGIBLE_POOL
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
-    out.push_str("arb_two_hop_reject_subreason_total{reason=\"only_one_eligible_dex\"} ");
-    out.push_str(
-        &ARB_TWO_HOP_REJECT_ONLY_ONE_ELIGIBLE_DEX
-            .load(Ordering::Relaxed)
-            .to_string(),
-    );
-    out.push('\n');
+    append_arb_two_hop_insufficient_subreason_total(&mut out);
+    append_arb_two_hop_reject_subreason_total(&mut out);
     out.push_str("arb_two_hop_pool_gate_pools_total{gate=\"candidate_pools\"} ");
     out.push_str(
         &ARB_TWO_HOP_GATE_CANDIDATE_POOLS
@@ -5855,5 +5828,61 @@ mod momentum_latency_metrics_tests {
             MOMENTUM_CORE_MARKET_EVENTS_INGEST_CONSECUTIVE_CAP_HIT_STREAK.load(Ordering::Relaxed),
             0
         );
+    }
+}
+
+#[cfg(test)]
+mod arb_two_hop_subreason_metrics_tests {
+    use super::*;
+
+    #[test]
+    fn insufficient_subreason_prometheus_exposes_only_incrementable_labels() {
+        let mut out = String::new();
+        append_arb_two_hop_insufficient_subreason_total(&mut out);
+
+        for label in [
+            "not_known_pool",
+            "missing_reserves",
+            "missing_trade_price",
+            "no_comparable_price",
+            "only_one_eligible_pool",
+            "only_one_eligible_dex",
+        ] {
+            assert!(
+                out.contains(&format!("reason=\"{label}\"")),
+                "missing insufficient label {label}"
+            );
+        }
+        for label in [
+            "missing_decimals",
+            "stale_price",
+            "same_dex_only",
+            "implausible_price",
+        ] {
+            assert!(
+                !out.contains(&format!("reason=\"{label}\"")),
+                "insufficient metric must not expose {label}"
+            );
+        }
+    }
+
+    #[test]
+    fn reject_subreason_prometheus_exposes_generic_reject_labels() {
+        let mut out = String::new();
+        append_arb_two_hop_reject_subreason_total(&mut out);
+
+        for label in [
+            "missing_decimals",
+            "stale_price",
+            "same_dex_only",
+            "implausible_price",
+            "not_known_pool",
+            "missing_reserves",
+        ] {
+            assert!(
+                out.contains(&format!("reason=\"{label}\"")),
+                "missing reject label {label}"
+            );
+        }
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2492,6 +2492,151 @@ pub fn arb_two_hop_tracker_seeded_pools_add(count: u64) {
     ARB_TWO_HOP_TRACKER_SEEDED_POOLS.fetch_add(count, Ordering::Relaxed);
 }
 
+/// Sub-reason when a mint hits the `insufficient_pools` gate (low-cardinality `reason` label).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArbTwoHopInsufficientSubreason {
+    NotKnownPool,
+    MissingDecimals,
+    MissingReserves,
+    MissingTradePrice,
+    NoComparablePrice,
+    StalePrice,
+    SameDexOnly,
+    ImplausiblePrice,
+    OnlyOneEligiblePool,
+    OnlyOneEligibleDex,
+}
+
+pub static ARB_TWO_HOP_INSUFFICIENT_NOT_KNOWN_POOL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_INSUFFICIENT_MISSING_RESERVES: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_INSUFFICIENT_MISSING_TRADE_PRICE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_INSUFFICIENT_NO_COMPARABLE_PRICE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_INSUFFICIENT_IMPLAUSIBLE_PRICE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_POOL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_DEX: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Increment `arb_two_hop_insufficient_subreason_total{reason=...}` once per mint rejection.
+pub fn arb_two_hop_insufficient_subreason_inc(reason: ArbTwoHopInsufficientSubreason) {
+    let counter = match reason {
+        ArbTwoHopInsufficientSubreason::NotKnownPool => &*ARB_TWO_HOP_INSUFFICIENT_NOT_KNOWN_POOL,
+        ArbTwoHopInsufficientSubreason::MissingDecimals => {
+            &*ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS
+        }
+        ArbTwoHopInsufficientSubreason::MissingReserves => {
+            &*ARB_TWO_HOP_INSUFFICIENT_MISSING_RESERVES
+        }
+        ArbTwoHopInsufficientSubreason::MissingTradePrice => {
+            &*ARB_TWO_HOP_INSUFFICIENT_MISSING_TRADE_PRICE
+        }
+        ArbTwoHopInsufficientSubreason::NoComparablePrice => {
+            &*ARB_TWO_HOP_INSUFFICIENT_NO_COMPARABLE_PRICE
+        }
+        ArbTwoHopInsufficientSubreason::StalePrice => &*ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE,
+        ArbTwoHopInsufficientSubreason::SameDexOnly => &*ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY,
+        ArbTwoHopInsufficientSubreason::ImplausiblePrice => {
+            &*ARB_TWO_HOP_INSUFFICIENT_IMPLAUSIBLE_PRICE
+        }
+        ArbTwoHopInsufficientSubreason::OnlyOneEligiblePool => {
+            &*ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_POOL
+        }
+        ArbTwoHopInsufficientSubreason::OnlyOneEligibleDex => {
+            &*ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_DEX
+        }
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Pool-gate stages aggregated across 2-hop eligibility checks (`gate` label).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArbTwoHopPoolGate {
+    CandidatePools,
+    InKnownPools,
+    FreshPrice,
+    HasReserveData,
+    HasTradeMid,
+    HasDecimals,
+    ComparablePricePresent,
+    ComparablePricePlausible,
+    EligiblePools,
+}
+
+pub static ARB_TWO_HOP_GATE_CANDIDATE_POOLS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_GATE_IN_KNOWN_POOLS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_GATE_FRESH_PRICE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_GATE_HAS_RESERVE_DATA: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_GATE_HAS_TRADE_MID: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_GATE_HAS_DECIMALS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_GATE_COMPARABLE_PRICE_PRESENT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_GATE_COMPARABLE_PRICE_PLAUSIBLE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_GATE_ELIGIBLE_POOLS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_ELIGIBLE_DEXES_CHECKS_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_ELIGIBLE_ORCA: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_ELIGIBLE_METEORA_DLMM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_ELIGIBLE_PUMP_AMM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_ELIGIBLE_RAYDIUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_ELIGIBLE_RAYDIUM_CPMM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_ELIGIBLE_PUMPFUN: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// Add pool counts from one mint eligibility check to gate aggregate counters.
+pub fn arb_two_hop_pool_gate_add(gate: ArbTwoHopPoolGate, count: u64) {
+    if count == 0 {
+        return;
+    }
+    let counter = match gate {
+        ArbTwoHopPoolGate::CandidatePools => &*ARB_TWO_HOP_GATE_CANDIDATE_POOLS,
+        ArbTwoHopPoolGate::InKnownPools => &*ARB_TWO_HOP_GATE_IN_KNOWN_POOLS,
+        ArbTwoHopPoolGate::FreshPrice => &*ARB_TWO_HOP_GATE_FRESH_PRICE,
+        ArbTwoHopPoolGate::HasReserveData => &*ARB_TWO_HOP_GATE_HAS_RESERVE_DATA,
+        ArbTwoHopPoolGate::HasTradeMid => &*ARB_TWO_HOP_GATE_HAS_TRADE_MID,
+        ArbTwoHopPoolGate::HasDecimals => &*ARB_TWO_HOP_GATE_HAS_DECIMALS,
+        ArbTwoHopPoolGate::ComparablePricePresent => &*ARB_TWO_HOP_GATE_COMPARABLE_PRICE_PRESENT,
+        ArbTwoHopPoolGate::ComparablePricePlausible => {
+            &*ARB_TWO_HOP_GATE_COMPARABLE_PRICE_PLAUSIBLE
+        }
+        ArbTwoHopPoolGate::EligiblePools => &*ARB_TWO_HOP_GATE_ELIGIBLE_POOLS,
+    };
+    counter.fetch_add(count, Ordering::Relaxed);
+}
+
+/// Add distinct eligible DEX count from one mint check.
+pub fn arb_two_hop_eligible_dexes_add(count: u64) {
+    if count > 0 {
+        ARB_TWO_HOP_ELIGIBLE_DEXES_CHECKS_TOTAL.fetch_add(count, Ordering::Relaxed);
+    }
+}
+
+/// Add eligible pool count per DEX from one mint check (fixed DEX labels only).
+pub fn arb_two_hop_eligible_pools_by_dex_add(dex: &str, count: u64) {
+    if count == 0 {
+        return;
+    }
+    let counter = match dex {
+        "orca" => &*ARB_TWO_HOP_ELIGIBLE_ORCA,
+        "meteora_dlmm" => &*ARB_TWO_HOP_ELIGIBLE_METEORA_DLMM,
+        "pump_amm" => &*ARB_TWO_HOP_ELIGIBLE_PUMP_AMM,
+        "raydium" => &*ARB_TWO_HOP_ELIGIBLE_RAYDIUM,
+        "raydium_cpmm" => &*ARB_TWO_HOP_ELIGIBLE_RAYDIUM_CPMM,
+        "pumpfun" => &*ARB_TWO_HOP_ELIGIBLE_PUMPFUN,
+        _ => return,
+    };
+    counter.fetch_add(count, Ordering::Relaxed);
+}
+
 // --- Arb-strategy MarketEvent subscriber pipeline ---
 pub static ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static ARB_SUBSCRIBER_LOW_QUEUE_DEPTH: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -2545,6 +2690,22 @@ pub static MULTI_HOP_CYCLE_REJECTED_SANITY_PROFIT_CAP: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static MULTI_HOP_CYCLE_REJECTED_SANITY_RETURN_BPS_CAP: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+pub static MULTI_HOP_QUOTE_READY_POOLS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MULTI_HOP_QUOTE_READY_WSOL_EDGE_POOLS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MULTI_HOP_SEARCH_NO_QUOTE_NEIGHBORS_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+pub fn multi_hop_quote_ready_pools_set(count: u64) {
+    MULTI_HOP_QUOTE_READY_POOLS.store(count, Ordering::Relaxed);
+}
+
+pub fn multi_hop_quote_ready_wsol_edge_pools_set(count: u64) {
+    MULTI_HOP_QUOTE_READY_WSOL_EDGE_POOLS.store(count, Ordering::Relaxed);
+}
+
+pub fn multi_hop_search_no_quote_neighbors_inc() {
+    MULTI_HOP_SEARCH_NO_QUOTE_NEIGHBORS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
 
 /// Sanity rejection reason for multi-hop cycles (Prometheus label `reason`).
 #[derive(Debug, Clone, Copy)]
@@ -4536,6 +4697,185 @@ async fn metrics_response() -> Response<Body> {
             .to_string(),
     );
     out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"not_known_pool\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_NOT_KNOWN_POOL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"missing_decimals\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_MISSING_DECIMALS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"missing_reserves\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_MISSING_RESERVES
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"missing_trade_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_MISSING_TRADE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"no_comparable_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_NO_COMPARABLE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"stale_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_STALE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"same_dex_only\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_SAME_DEX_ONLY
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"implausible_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_IMPLAUSIBLE_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"only_one_eligible_pool\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_POOL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_insufficient_subreason_total{reason=\"only_one_eligible_dex\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_INSUFFICIENT_ONLY_ONE_ELIGIBLE_DEX
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_pool_gate_pools_total{gate=\"candidate_pools\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_GATE_CANDIDATE_POOLS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_pool_gate_pools_total{gate=\"known_pools\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_GATE_IN_KNOWN_POOLS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_pool_gate_pools_total{gate=\"fresh_price\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_GATE_FRESH_PRICE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_pool_gate_pools_total{gate=\"has_reserve_data\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_GATE_HAS_RESERVE_DATA
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_pool_gate_pools_total{gate=\"has_trade_mid\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_GATE_HAS_TRADE_MID
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_pool_gate_pools_total{gate=\"has_decimals\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_GATE_HAS_DECIMALS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_pool_gate_pools_total{gate=\"comparable_price_present\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_GATE_COMPARABLE_PRICE_PRESENT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_pool_gate_pools_total{gate=\"comparable_price_plausible\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_GATE_COMPARABLE_PRICE_PLAUSIBLE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_pool_gate_pools_total{gate=\"eligible_pools\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_GATE_ELIGIBLE_POOLS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    line!(
+        "arb_two_hop_eligible_dexes_checks_total",
+        ARB_TWO_HOP_ELIGIBLE_DEXES_CHECKS_TOTAL.load(Ordering::Relaxed)
+    );
+    out.push_str("arb_two_hop_eligible_pools_by_dex_total{dex=\"orca\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_ELIGIBLE_ORCA
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_eligible_pools_by_dex_total{dex=\"meteora_dlmm\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_ELIGIBLE_METEORA_DLMM
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_eligible_pools_by_dex_total{dex=\"pump_amm\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_ELIGIBLE_PUMP_AMM
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_eligible_pools_by_dex_total{dex=\"raydium\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_ELIGIBLE_RAYDIUM
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_eligible_pools_by_dex_total{dex=\"raydium_cpmm\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_ELIGIBLE_RAYDIUM_CPMM
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_eligible_pools_by_dex_total{dex=\"pumpfun\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_ELIGIBLE_PUMPFUN
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
     line!(
         "multi_hop_return_bps_saturated_total",
         MULTI_HOP_RETURN_BPS_SATURATED_TOTAL.load(Ordering::Relaxed)
@@ -4585,6 +4925,18 @@ async fn metrics_response() -> Response<Body> {
             .to_string(),
     );
     out.push('\n');
+    line!(
+        "multi_hop_quote_ready_pools_total",
+        MULTI_HOP_QUOTE_READY_POOLS.load(Ordering::Relaxed)
+    );
+    line!(
+        "multi_hop_quote_ready_wsol_edge_pools_total",
+        MULTI_HOP_QUOTE_READY_WSOL_EDGE_POOLS.load(Ordering::Relaxed)
+    );
+    line!(
+        "multi_hop_search_no_quote_neighbors_total",
+        MULTI_HOP_SEARCH_NO_QUOTE_NEIGHBORS_TOTAL.load(Ordering::Relaxed)
+    );
     line!(
         "cycle_partial_examined_total",
         CYCLE_PARTIAL_EXAMINED.load(Ordering::Relaxed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds bounded, low-cardinality diagnostics to explain why 2-hop arb mints hit `insufficient_pools`, `same_dex`, and `stale_price` without changing spread/profit thresholds or hot-path RPC behavior.

## Prod question answered

**Why are there 3362 `insufficient_pools` rejects but zero intents?**

The coarse counters only show the final gate. This PR adds per-gate pool aggregates and subreason counters so prod can distinguish, for example:
- pools tracked but not in `known_pools` (`not_known_pool`)
- missing decimals / reserves / trade mid / comparable price
- only one eligible pool or DEX (`only_one_eligible_pool`, `only_one_eligible_dex`, `same_dex_only`)
- stale comparable prices on otherwise eligible pairs

Rate-limited structured snapshots (`kind=arb_two_hop_eligibility_snapshot`, max 1×/60s, top 10 mints) provide concrete pool rows for the worst offenders.

## New Prometheus metrics

### 2-hop eligibility
- `arb_two_hop_insufficient_subreason_total{reason=...}` — 10 fixed subreasons
- `arb_two_hop_pool_gate_pools_total{gate=...}` — cumulative pool counts per gate stage
- `arb_two_hop_eligible_dexes_checks_total`
- `arb_two_hop_eligible_pools_by_dex_total{dex=orca|meteora_dlmm|pump_amm|raydium|raydium_cpmm|pumpfun}`

### Multi-hop quote readiness (diagnostics only, no algorithm change)
- `multi_hop_quote_ready_pools_total` (gauge)
- `multi_hop_quote_ready_wsol_edge_pools_total` (gauge)
- `multi_hop_search_no_quote_neighbors_total` — dirty-token searches that find no cycles and have <2 quote-ready neighbor pools

## Decisions enabled by this data

1. **If `not_known_pool` dominates** → focus on market-data MASTER cache / `known_pools` sync, not spread tuning.
2. **If `missing_decimals` / `missing_reserves` / `missing_trade_price` dominate** → fix upstream MarketEvent / SLAVE seed coverage for specific DEX types.
3. **If `only_one_eligible_dex` / `same_dex_only` dominate** → token universe issue (single-DEX coverage), not execution.
4. **If `stale_price` dominates** → Geyser freshness / vault update path for otherwise valid pairs.
5. **If multi-hop `quote_ready` is low vs graph pools** → quote-cache warm-up / LivePoolCache readiness, explaining `multi_hop_hop_missing_quote_total`.

## Implementation notes

- Forensics run inside existing `check_arbitrage` path; gate counters are additive sums per check (no mint/pool labels).
- Snapshots emitted from heartbeat via `ArbEligibilityForensics::maybe_emit_snapshot()` (60s cooldown).
- Multi-hop gauges refreshed on heartbeat via `MultiHopArbitrage::refresh_quote_readiness_metrics()`.

## Tests

- `not_known_pool` / `only_one_eligible_pool` when one pool missing from MASTER cache
- `same_dex_only` when both eligible pools share a DEX
- `stale_price` when cross-DEX pair has stale sell-side vault
- `missing_decimals` when token decimals unknown
- swapped stablecoin reserves → `insufficient_pools`, not `spread_too_large`
- snapshot rate limit: at most one emit per 60s window

## Verification

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-627cb07b-1249-4482-83c3-f937ef299218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-627cb07b-1249-4482-83c3-f937ef299218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

