### PR TITLE
fix(market-data): account worker backlog — hot-pool relevance filter + md-state gate

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,13 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### ACCOUNT-WORKER-BACKLOG-PR230-FOLLOWUP: Account-Worker-Backlog + md-state Saturation (Post PR #230)
+**Datum**: 2026-06-21  
+**Problem** (Prod post-PR230 `6b0d5bd`, ~11h Killswitch): Global-Freeze behoben, aber struktureller Account-Worker-Backlog (`market_data_account_worker_queue_depth` ~34k, LOW-only) und md-state Drops (`geyser_tracking_enqueue_dropped_total` ~38M bei Queue-Cap 8192). Ingest ~457/s vs. Handler-Durchsatz ~245/s (2 Worker).  
+**Root Cause**: (1) `account_geyser_update_might_be_relevant` gab für **jeden** DEX-Program-Owner `true` zurück — widerspricht PR230 Hot-Pool-Intent. (2) `md_sidefx_process_live_pool_cache_account_update` enqueued bei jedem Pool-Parse 3 md-state Jobs ohne Hot-Pool-Gate. (3) Worker-Queue-Gauge: `inc` vor `send().await` + `pending_low` ohne sofortiges `dec` bei HIGH-preempt-LOW.  
+**Fix**: (1) Relevance-Filter: DEX Pool-State nur bei `is_hot_pool` / `pool_mint_map` / `high_priority_bonding_curves` / wallet-tracked Pump.fun. (2) md-sidefx: md-state Enqueues nur für Hot Pools; Cache-upsert bleibt. (3) `account_geyser_dispatch_priority_high`: `is_hot_pool` (inkl. Arb-LRU). (4) Metrik: `inc` nach erfolgreichem `send`; `dec` beim `low.recv()` vor `pending_low`. **Nicht**: Worker 2→8, Cap-Erhöhung allein, RPC, Non-Hot Vault-Coverage. **Invarianten**: I-4b, I-7, PR230 UnifiedHotPoolRegistry.  
+**Dateien**: `src/bin/market_data.rs`, `docs/BUGS_FIXES.md`
+
 ### PHASE-UNIFIED-HOT-POOL-REGISTRY: Prod Global-Freeze ~5s nach Restart (Subscription-Sync-Sturm)
 **Datum**: 2026-06-20  
 **Problem** (Prod `architecture-rebuild` @ `70fb34f`): Nach Restart ~5s Global-Freeze — TX/Account/`head_slot` still, `geyser_*_session_connected=1`. Parallele Momentum-`ActivePoolSet` + Arb-LRU/Reconcile + `tracking_changed`-Sync (Commit `65cff8a`) erzeugten Subscription-Sync-Sturm gegen Caps/LRU.  

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1715,7 +1715,7 @@ fn md_sidefx_process_live_pool_cache_account_update(w: &MdSidefxWorkerCtx, job: 
             return;
         }
 
-        // PR169a: vault registration off hot path — single-writer tracking actor.
+        // PR169a + PR230: md-state tracking jobs only for execution-hot pools (bounded vault subs).
         if matches!(
             &cached_state,
             CachedPoolState::RaydiumCpmm(_)
@@ -1724,7 +1724,8 @@ fn md_sidefx_process_live_pool_cache_account_update(w: &MdSidefxWorkerCtx, job: 
                 | CachedPoolState::PumpAmm(_)
                 | CachedPoolState::Orca(_)
                 | CachedPoolState::RaydiumAmm(_)
-        ) {
+        ) && w.ctx.hot_pool_registry.is_hot_pool(*pool_pubkey)
+        {
             md_state_try_enqueue(
                 &w.md_state,
                 MdStateCommand::UpdateArbCoverageIndex { pool: *pool_pubkey },
@@ -11967,14 +11968,29 @@ fn account_geyser_update_might_be_relevant(
         return true;
     }
 
-    let o = u.owner;
-    o == RAYDIUM_AMM_V4_OWNER
-        || o == RAYDIUM_CPMM_OWNER
-        || o == ORCA_WHIRLPOOL_OWNER
-        || o == METEORA_CPMM_OWNER
-        || o == METEORA_DLMM_OWNER
-        || o == PUMPFUN_PROGRAM_OWNER
-        || o == PUMPFUN_AMM_PROGRAM_OWNER
+    if !account_geyser_update_is_dex_pool_owner(&u.owner) {
+        return false;
+    }
+
+    let pool_pk = u.pubkey;
+    if ctx.hot_pool_registry.is_hot_pool(pool_pk) {
+        return true;
+    }
+    let pool_str = pool_pk.to_string();
+    if ctx.pool_mint_map.read().contains_key(&pool_str) {
+        return true;
+    }
+    if ctx.high_priority_bonding_curves.read().contains(&pool_pk) {
+        return true;
+    }
+    if u.owner == PUMPFUN_PROGRAM_OWNER {
+        if let Some(CachedPoolState::PumpFun(s)) = ctx.live_pool_cache.get(&pool_pk) {
+            if ctx.wallet_tracks_mint_for_geyser(&s.token_mint) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Strategic HIGH admission for account worker sharding (ACCOUNT-PATH-TX-PARITY-CREATOR).
@@ -11994,7 +12010,7 @@ fn account_geyser_dispatch_priority_high(ctx: &MarketDataContext, u: &GeyserAcco
     if ctx.pool_mint_map.read().contains_key(&pool_str) {
         return true;
     }
-    if ctx.hot_pool_registry.pool_has_any_pin(pool_pk) {
+    if ctx.hot_pool_registry.is_hot_pool(pool_pk) {
         return true;
     }
     if ctx.wallet_tracks_mint_for_geyser(&pool_pk) {
@@ -12025,8 +12041,6 @@ async fn account_worker_recv_next(
             return Some(w);
         }
         if let Some(w) = pending_low.take() {
-            dec_market_data_account_low_priority_queue_depth();
-            dec_market_data_account_worker_queue_depth();
             return Some(w);
         }
         tokio::select! {
@@ -12044,8 +12058,6 @@ async fn account_worker_recv_next(
                         return Some(w);
                     }
                     if let Some(w) = pending_low.take() {
-                        dec_market_data_account_low_priority_queue_depth();
-                        dec_market_data_account_worker_queue_depth();
                         return Some(w);
                     }
                     if let Some(w) = low.recv().await {
@@ -12058,6 +12070,8 @@ async fn account_worker_recv_next(
             },
             l = low.recv() => match l {
                 Some(w) => {
+                    dec_market_data_account_low_priority_queue_depth();
+                    dec_market_data_account_worker_queue_depth();
                     pending_low = Some(w);
                     continue;
                 }
@@ -12068,8 +12082,6 @@ async fn account_worker_recv_next(
                         return Some(w);
                     }
                     if let Some(w) = pending_low.take() {
-                        dec_market_data_account_low_priority_queue_depth();
-                        dec_market_data_account_worker_queue_depth();
                         return Some(w);
                     }
                     return match high.recv().await {
@@ -13854,12 +13866,6 @@ async fn run_geyser_loop(
                     let shard = market_data_account_worker_shard(&account_update.pubkey);
                     let high =
                         account_geyser_dispatch_priority_high(&ctx_geyser_acc, &account_update);
-                    inc_market_data_account_worker_queue_depth();
-                    if high {
-                        inc_market_data_account_high_priority_queue_depth();
-                    } else {
-                        inc_market_data_account_low_priority_queue_depth();
-                    }
                     let send_res = if high {
                         worker_high_recv[shard]
                             .send(AccountWorkItem {
@@ -13875,13 +13881,14 @@ async fn run_geyser_loop(
                             })
                             .await
                     };
-                    if send_res.is_err() {
-                        dec_market_data_account_worker_queue_depth();
+                    if send_res.is_ok() {
+                        inc_market_data_account_worker_queue_depth();
                         if high {
-                            dec_market_data_account_high_priority_queue_depth();
+                            inc_market_data_account_high_priority_queue_depth();
                         } else {
-                            dec_market_data_account_low_priority_queue_depth();
+                            inc_market_data_account_low_priority_queue_depth();
                         }
+                    } else {
                         error!(
                             shard = shard,
                             "account worker queue closed; stopping Geyser account stream"
@@ -16376,6 +16383,83 @@ mod pr_b_geyser_tracking_tests {
         }
     }
 
+    fn test_md_state_sender_no_worker() -> (
+        MdStateSender,
+        Arc<AtomicUsize>,
+        std_mpsc::Receiver<MdStateCommand>,
+    ) {
+        let (tx, rx) = std_mpsc::sync_channel(MARKET_DATA_GEYSER_TRACKING_QUEUE_CAP);
+        let queue_depth = Arc::new(AtomicUsize::new(0));
+        let sender = MdStateSender {
+            tx,
+            queue_depth: Arc::clone(&queue_depth),
+            queue_capacity: MARKET_DATA_GEYSER_TRACKING_QUEUE_CAP,
+        };
+        (sender, queue_depth, rx)
+    }
+
+    fn test_raydium_cpmm_account_data(
+        token_0_mint: Pubkey,
+        token_1_mint: Pubkey,
+        token_0_vault: Pubkey,
+        token_1_vault: Pubkey,
+    ) -> Vec<u8> {
+        let mut data = vec![0u8; 1024];
+        data[8] = 1;
+        data[73..105].copy_from_slice(token_0_mint.as_ref());
+        data[105..137].copy_from_slice(token_1_mint.as_ref());
+        data[137..169].copy_from_slice(token_0_vault.as_ref());
+        data[169..201].copy_from_slice(token_1_vault.as_ref());
+        data
+    }
+
+    #[test]
+    fn md_sidefx_live_pool_cache_update_skips_md_state_for_non_hot_pool() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let (md_state, depth, _md_state_rx) = test_md_state_sender_no_worker();
+        let worker = MdSidefxWorkerCtx {
+            ctx: Arc::clone(&ctx),
+            publish_tx: None,
+            md_state,
+        };
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let account_data =
+            test_raydium_cpmm_account_data(base, quote, Pubkey::new_unique(), Pubkey::new_unique());
+        let job = MdSidefxCommand::LivePoolCacheAccountUpdate {
+            run_id: "test".into(),
+            pool_pubkey: pool,
+            owner: RAYDIUM_CPMM_OWNER,
+            account_data: account_data.clone(),
+            slot: 1,
+            grpc_recv_at: Instant::now(),
+        };
+        md_sidefx_process_live_pool_cache_account_update(&worker, &job);
+        assert_eq!(depth.load(Ordering::Relaxed), 0);
+        assert!(ctx.live_pool_cache.get(&pool).is_some());
+
+        ctx.hot_pool_registry.pin_pool(base, pool);
+        md_sidefx_process_live_pool_cache_account_update(
+            &worker,
+            &MdSidefxCommand::LivePoolCacheAccountUpdate {
+                run_id: "test".into(),
+                pool_pubkey: pool,
+                owner: RAYDIUM_CPMM_OWNER,
+                account_data,
+                slot: 2,
+                grpc_recv_at: Instant::now(),
+            },
+        );
+        assert!(
+            depth.load(Ordering::Relaxed) >= 2,
+            "hot pool must enqueue md-state tracking jobs"
+        );
+    }
+
     #[test]
     fn lru_eviction_prefers_oldest_unpinned_vault() {
         let a = Pubkey::new_unique();
@@ -17111,6 +17195,68 @@ mod pr_b_geyser_tracking_tests {
             !account_path_enqueue_core_market_event(Some(&tx), None, &ctx, mk_event(2), None,)
                 .await
         );
+    }
+
+    #[test]
+    fn account_geyser_update_might_be_relevant_non_hot_dex_pool_false() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let u = GeyserAccountUpdate {
+            pubkey: pool,
+            slot: 1,
+            owner: RAYDIUM_CPMM_OWNER,
+            data: vec![],
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        };
+        assert!(!account_geyser_update_might_be_relevant(&ctx, &u));
+        ctx.hot_pool_registry.pin_pool(base, pool);
+        assert!(account_geyser_update_might_be_relevant(&ctx, &u));
+    }
+
+    #[test]
+    fn account_geyser_update_might_be_relevant_pool_mint_map_without_hot_pin() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        ctx.pool_mint_map
+            .write()
+            .insert(pool.to_string(), Pubkey::new_unique().to_string());
+        let u = GeyserAccountUpdate {
+            pubkey: pool,
+            slot: 1,
+            owner: RAYDIUM_CPMM_OWNER,
+            data: vec![],
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        };
+        assert!(account_geyser_update_might_be_relevant(&ctx, &u));
+    }
+
+    #[test]
+    fn account_geyser_dispatch_high_when_arb_hot_pool_without_momentum_pin() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        ctx.hot_pool_registry
+            .promote_arb_pools(Pubkey::new_unique(), vec![pool]);
+        let u = GeyserAccountUpdate {
+            pubkey: pool,
+            slot: 1,
+            owner: RAYDIUM_CPMM_OWNER,
+            data: vec![],
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        };
+        assert!(account_geyser_dispatch_priority_high(&ctx, &u));
     }
 
     #[test]
@@ -18149,7 +18295,12 @@ mod pr_b_geyser_tracking_tests {
             inc_market_data_account_high_priority_queue_depth,
             inc_market_data_account_low_priority_queue_depth,
             inc_market_data_account_worker_queue_depth,
+            MARKET_DATA_ACCOUNT_HIGH_PRIORITY_QUEUE_DEPTH,
+            MARKET_DATA_ACCOUNT_LOW_PRIORITY_QUEUE_DEPTH, MARKET_DATA_ACCOUNT_WORKER_QUEUE_DEPTH,
         };
+        MARKET_DATA_ACCOUNT_WORKER_QUEUE_DEPTH.store(0, Ordering::Relaxed);
+        MARKET_DATA_ACCOUNT_HIGH_PRIORITY_QUEUE_DEPTH.store(0, Ordering::Relaxed);
+        MARKET_DATA_ACCOUNT_LOW_PRIORITY_QUEUE_DEPTH.store(0, Ordering::Relaxed);
         let (htx, mut hrx) = mpsc::channel(8);
         let (ltx, mut lrx) = mpsc::channel(8);
         let pool_h = Pubkey::new_unique();
@@ -18165,12 +18316,12 @@ mod pr_b_geyser_tracking_tests {
             },
             recv_at: Instant::now(),
         };
+        ltx.send(mk(pool_l)).await.unwrap();
         inc_market_data_account_low_priority_queue_depth();
         inc_market_data_account_worker_queue_depth();
-        ltx.send(mk(pool_l)).await.unwrap();
+        htx.send(mk(pool_h)).await.unwrap();
         inc_market_data_account_high_priority_queue_depth();
         inc_market_data_account_worker_queue_depth();
-        htx.send(mk(pool_h)).await.unwrap();
         drop(htx);
         drop(ltx);
         let w1 = account_worker_recv_next(&mut hrx, &mut lrx)
@@ -18182,6 +18333,18 @@ mod pr_b_geyser_tracking_tests {
             .expect("low item");
         assert_eq!(w2.update.pubkey, pool_l);
         assert!(account_worker_recv_next(&mut hrx, &mut lrx).await.is_none());
+        assert_eq!(
+            MARKET_DATA_ACCOUNT_WORKER_QUEUE_DEPTH.load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            MARKET_DATA_ACCOUNT_HIGH_PRIORITY_QUEUE_DEPTH.load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            MARKET_DATA_ACCOUNT_LOW_PRIORITY_QUEUE_DEPTH.load(Ordering::Relaxed),
+            0
+        );
     }
 
     #[test]
@@ -18997,6 +19160,20 @@ mod pr_b_geyser_tracking_tests {
         }
         let after = ctx.snapshot_explicit_subscription_pubkeys();
         assert!(!explicit_subscription_has_new_keys(&before, &after));
+    }
+
+    #[test]
+    fn md_state_coalesce_dedupes_ten_register_pool_vaults_from_account() {
+        let pool = Pubkey::new_unique();
+        let jobs: Vec<_> = (0..10)
+            .map(|_| MdStateCommand::RegisterPoolVaultsFromAccount { pool })
+            .collect();
+        let out = md_state_coalesce_jobs(jobs);
+        assert_eq!(out.len(), 1);
+        assert!(matches!(
+            out[0],
+            MdStateCommand::RegisterPoolVaultsFromAccount { .. }
+        ));
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -11984,8 +11984,9 @@ fn account_geyser_update_might_be_relevant(
         return true;
     }
     if u.owner == PUMPFUN_PROGRAM_OWNER {
-        if let Some(CachedPoolState::PumpFun(s)) = ctx.live_pool_cache.get(&pool_pk) {
-            if ctx.wallet_tracks_mint_for_geyser(&s.token_mint) {
+        for mint in ctx.tracked_wallet_mint_decimals.read().keys() {
+            let (bonding_curve, _) = PumpFunDex::derive_bonding_curve_static(mint);
+            if bonding_curve == pool_pk {
                 return true;
             }
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause (Prod post-PR #230 `6b0d5bd`, ~11h Killswitch)

Global-Freeze behoben, aber struktureller Account-Worker-Backlog und md-state Job-Drops:

| Metrik | Prod-Wert | Interpretation |
|--------|-----------|----------------|
| `market_data_account_early_drop_total` | **0** | Relevance-Filter verwirft nichts |
| `geyser_account_listener_account_updates_total` | **~457/s** | Hohe Account-Ingest-Rate |
| `market_data_account_handler_duration_us` avg | **~8,1 ms** | 2 Worker ⇒ ~245/s max Durchsatz |
| `market_data_account_worker_queue_depth` | **34.347** (steigend) | LOW-Backlog |
| `market_data_md_state_queue_depth` | **8192** (Cap) | Dauerhaft voll |
| `market_data_geyser_tracking_enqueue_dropped_total` | **~38.393.024** | md-state Drops massiv |

**Primärursachen:**
1. `account_geyser_update_might_be_relevant` gab für **jeden** DEX-Program-Owner `true` zurück — widerspricht PR230 UnifiedHotPoolRegistry (Vault/Tracking nur für Hot Pools).
2. `md_sidefx_process_live_pool_cache_account_update` enqueued bei jedem erfolgreichen Pool-Parse **3 md-state Jobs** ohne Hot-Pool-Gate.
3. Worker-Queue-Gauge: `inc` vor `send().await` + `pending_low` ohne sofortiges `dec` bei HIGH-preempt-LOW.

## Fixes (A–E aus Handoff)

### A) Relevance-Filter schärfen (P0)
DEX Pool-State-Accounts nur noch relevant bei `is_hot_pool`, `pool_mint_map`, `high_priority_bonding_curves`, oder wallet-getracktem Pump.fun-Bonding-Curve. Blindes `owner == RAYDIUM_* || ...` entfernt.

### B) md-sidefx Hot-Pool-Gate (P0)
`md_sidefx_process_live_pool_cache_account_update`: md-state Enqueues (`UpdateArbCoverageIndex`, `RegisterPoolVaultsFromAccount`, Arb-Reconcile) nur für Hot Pools. Cache-upsert bleibt.

### C) md_state_coalesce_jobs (P1)
`RegisterPoolVaultsFromAccount` war bereits dedupliziert; neuer Test mit 10× gleichem Pool.

### D) HIGH-Priority mit UnifiedHotPoolRegistry (P1)
`account_geyser_dispatch_priority_high`: `is_hot_pool` (inkl. Arb-LRU), nicht nur `pool_has_any_pin`.

### E) Metric-Fix (P1)
- Dispatch: `inc` nach erfolgreichem `send().await`
- Worker: `dec` beim `low.recv()` vor `pending_low` (kein Leak bei HIGH-preempt-LOW)

## Explizit NICHT geändert

- Keine Worker-Erhöhung 2→8
- Keine Cap-only-Lösung (`8192`, `5000`)
- Kein RPC im Hot Path
- Keine Non-Hot Vault-Geyser-Coverage

## Tests (`cargo test --bin market-data` — 123 passed)

1. `account_geyser_update_might_be_relevant_non_hot_dex_pool_false` — Non-Hot DEX pool ⇒ false; Hot pool ⇒ true
2. `account_geyser_update_might_be_relevant_pool_mint_map_without_hot_pin` — pool_mint_map bleibt relevant
3. `md_sidefx_live_pool_cache_update_skips_md_state_for_non_hot_pool` — Non-Hot upsert ⇒ keine md-state enqueues
4. `md_state_coalesce_dedupes_ten_register_pool_vaults_from_account` — 10× gleicher Pool ⇒ 1 Job
5. `account_worker_recv_next_prefers_high_queue` — HIGH preempt LOW, alle Gauges enden bei 0
6. `account_geyser_dispatch_high_when_arb_hot_pool_without_momentum_pin` — Arb-LRU HIGH dispatch

## Prod-Erwartung nach Deploy

```bash
curl -s localhost:9801/metrics | grep -E 'account_early_drop|account_worker_queue|md_state_queue|geyser_tracking_enqueue_dropped'
```

- `account_early_drop_total` > 0
- `account_worker_queue_depth` deutlich unter 20k und fallend/stabil
- `md_state_queue_depth` deutlich unter 8192
- `geyser_tracking_enqueue_dropped_total` rate ~ 0

## Dateien

- `src/bin/market_data.rs`
- `docs/BUGS_FIXES.md` — Eintrag `ACCOUNT-WORKER-BACKLOG-PR230-FOLLOWUP`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0958060-1de9-43f3-b112-89cd265bf48f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0958060-1de9-43f3-b112-89cd265bf48f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

