### PR TITLE
feat(arb): Phase3 arb track_requests NATS + MD track-worker consumer

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -1575,3 +1575,15 @@ BUY cost bevorzugt jetzt value_sol (fill_in) — die tatsächlich für den Swap 
 | **Betroffene Module** | `src/bin/market_data.rs` |
 | **Regression-Prüfung** | `cargo fmt`, `cargo clippy -D warnings`, `cargo test`, `phase1_*`/`phase2a_*`/`phase2b_*`/`phase2c_*`; Eval Level 5 (separater Eval-PR für I-4c). |
 | **Tags** | [market-data, hybrid-rollback, phase2c, i-4c, md-state, arb, pr241] |
+
+---
+
+## HYBRID-PHASE3: Arb track_requests NATS + MD track-worker consumer (2026-06-25)
+
+| Symptom | Nach Phase 2c fehlten Arb-Geyser-Pins; arb-strategy Metrics HTTP :9803 timeout unter Last (2-hop sync im MarketEvent-Worker). |
+|---------|--------------------------------------------------------------------------------------------------------------------------------|
+| **Root Cause** | Arb-Pinning war strategy-owned noch nicht wieder angebunden; `handle_trade` / `check_arbitrage` blockierte den priorisierten MarketEvent-Worker synchron. |
+| **Fix** | (1) Neues Topic `ironcrab.v1.arb.track_requests` — arb-strategy publiziert, market-data subscribed + `md-track-worker` (`ApplyArbTrackRequests`). (2) Pool-zentrische Pins mit `GeyserPinReason::ArbMultiDex`, Wallet/Momentum geschützt. (3) Baseline-Reconcile ~60 s + inkrementelle `multi_dex`/`trade_signal` publishes. (4) 2-hop Detection auf dedizierten `arb_two_hop_worker` Channel (Scope D). |
+| **Betroffene Module** | `src/nats/arb_track_requests.rs`, `src/bin/market_data.rs`, `src/bin/arb_strategy.rs`, `src/metrics.rs` |
+| **Regression-Prüfung** | `cargo fmt`, `cargo clippy -D warnings`, `cargo test`, `phase3_*`; Eval Level 5. |
+| **Tags** | [arb-strategy, market-data, hybrid-rollback, phase3, i-4e, nats, track-worker, pr242] |

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -53,19 +53,21 @@ use ironcrab::metrics::{
     arb_two_hop_eligible_dexes_add, arb_two_hop_eligible_pools_by_dex_add,
     arb_two_hop_insufficient_subreason_inc, arb_two_hop_opportunity_inc, arb_two_hop_pool_gate_add,
     arb_two_hop_reject_subreason_inc, arb_two_hop_rejected_inc,
-    arb_two_hop_tracker_seeded_pools_add, serve_metrics, set_readiness_nats_connected,
-    ArbStrategyWarmupSkipReason, ArbTwoHopInsufficientSubreason, ArbTwoHopPoolGate,
-    ArbTwoHopRejectReason, ArbTwoHopRejectSubreason, MetricsComponent,
-    ARB_REJECTED_MISSING_ACCOUNTS, ARB_TRIANGLE_OPPORTUNITIES, INTENTS_GENERATED_TOTAL,
-    MARKET_EVENTS_CONSUMED_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL,
-    POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
+    arb_two_hop_tracker_seeded_pools_add, record_arb_track_requests_messages_total, serve_metrics,
+    set_readiness_nats_connected, wall_clock_unix_ms_now, ArbStrategyWarmupSkipReason,
+    ArbTwoHopInsufficientSubreason, ArbTwoHopPoolGate, ArbTwoHopRejectReason,
+    ArbTwoHopRejectSubreason, MetricsComponent, ARB_REJECTED_MISSING_ACCOUNTS,
+    ARB_TRIANGLE_OPPORTUNITIES, INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL,
+    NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE,
+    TOKENS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, pool_cache_live_fallback_consumer_config,
-    CONFIG_STREAM_NAME, STREAM_NAME,
+    ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackRemovedEntry, ArbTrackRemovedReason,
+    ArbTrackRequestsUpdate, CONFIG_STREAM_NAME, STREAM_NAME,
 };
 use ironcrab::nats::{NatsClient, NatsConfig};
-use ironcrab::nats::{TOPIC_MARKET_EVENTS, TOPIC_TRADE_INTENTS};
+use ironcrab::nats::{TOPIC_ARB_TRACK_REQUESTS, TOPIC_MARKET_EVENTS, TOPIC_TRADE_INTENTS};
 use ironcrab::solana::dex::meteora_bin_walker::{dlmm_fee_bps, walker_from_bins};
 use ironcrab::storage::{JsonlWriter, JsonlWriterConfig};
 use solana_sdk::pubkey::Pubkey;
@@ -75,6 +77,16 @@ const BUILD_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// NATS topic for config reload commands from control-plane (Core NATS fallback)
 const TOPIC_CONFIG_RELOAD: &str = "ironcrab.control.config.reload";
+
+/// Wire format version for `TOPIC_ARB_TRACK_REQUESTS`.
+const ARB_TRACK_REQUESTS_WIRE_VERSION: u32 = 1;
+/// Default cap for baseline reconcile `active[]` (configurable via `arb_track_baseline_max_pools`).
+const ARB_TRACK_BASELINE_MAX_POOLS_DEFAULT: usize = 500;
+/// Default baseline reconcile interval (configurable via `arb_track_reconcile_interval_secs`).
+const ARB_TRACK_RECONCILE_INTERVAL_SECS_DEFAULT: u64 = 60;
+
+/// Bounded queue for off-hot-loop 2-hop trade detection (Scope D).
+const ARB_TWO_HOP_WORKER_QUEUE_CAP: usize = 4096;
 
 // ============================================================================
 // Configuration
@@ -100,6 +112,10 @@ struct ArbConfig {
     intent_ttl_ms: u64,
     /// Enable 2-hop arbitrage (A→B on DEX1, B→A on DEX2). Default: true
     two_hop_enabled: bool,
+    /// Max pools in baseline reconcile snapshot. Default: 500.
+    arb_track_baseline_max_pools: usize,
+    /// Baseline reconcile publish interval in seconds. Default: 60.
+    arb_track_reconcile_interval_secs: u64,
 }
 
 impl Default for ArbConfig {
@@ -113,6 +129,8 @@ impl Default for ArbConfig {
             intent_cooldown_ms: 5000,             // 5s cooldown per pair
             intent_ttl_ms: 1000,                  // 1s TTL (Option C: fresh quotes in exec-engine)
             two_hop_enabled: true,                // 2-hop arb enabled by default
+            arb_track_baseline_max_pools: ARB_TRACK_BASELINE_MAX_POOLS_DEFAULT,
+            arb_track_reconcile_interval_secs: ARB_TRACK_RECONCILE_INTERVAL_SECS_DEFAULT,
         }
     }
 }
@@ -2296,6 +2314,63 @@ impl ArbLowEventCoalescer {
     }
 }
 
+/// Off-hot-loop 2-hop detection job (Scope D).
+#[derive(Debug, Clone)]
+struct ArbTwoHopTradeJob {
+    pool_address: String,
+    mint: String,
+    quote_mint: String,
+    sol_amount: u64,
+    token_amount: u64,
+    token_decimals: u8,
+    is_buy: bool,
+    dex: String,
+    slot: Option<u64>,
+    ts_unix_ms: u64,
+}
+
+fn spawn_arb_two_hop_worker(ctx: Arc<ArbContext>, mut rx: mpsc::Receiver<ArbTwoHopTradeJob>) {
+    tokio::spawn(async move {
+        while let Some(job) = rx.recv().await {
+            let two_hop_enabled = ctx.config.read().two_hop_enabled;
+            if !two_hop_enabled {
+                continue;
+            }
+            if let Some(opp) = ctx.handle_trade(
+                &job.pool_address,
+                &job.mint,
+                &job.quote_mint,
+                job.sol_amount,
+                job.token_amount,
+                job.token_decimals,
+                job.is_buy,
+                &job.dex,
+            ) {
+                ARB_TRIANGLE_OPPORTUNITIES.fetch_add(1, Ordering::Relaxed);
+                info!(
+                    mint = %opp.base_mint,
+                    buy_dex = %opp.buy_dex,
+                    sell_dex = %opp.sell_dex,
+                    spread_bps = opp.spread_bps,
+                    profit_lamports = opp.estimated_profit_lamports,
+                    "🔥 Arbitrage opportunity detected (two-hop worker)"
+                );
+                ctx.publish_arb_trade_signal_track_pins(&opp.buy_pool, &opp.sell_pool);
+                if let Some(mut intent) = create_arb_intent(&ctx, &opp) {
+                    if let Some(slot) = job.slot {
+                        intent.metadata.insert("slot".to_string(), slot.to_string());
+                    }
+                    intent
+                        .metadata
+                        .insert("slot_seen_at_ms".to_string(), job.ts_unix_ms.to_string());
+                    publish_arb_intent(&ctx, &intent).await;
+                }
+            }
+        }
+        info!("arb-strategy two-hop worker stopped");
+    });
+}
+
 async fn publish_arb_intent(ctx: &ArbContext, intent: &TradeIntent) {
     if let Err(e) = ctx.jsonl_writer.write(intent) {
         error!(error = %e, "Failed to write intent to JSONL");
@@ -2508,6 +2583,13 @@ struct ArbContext {
 
     /// Bounded 2-hop eligibility forensics (rate-limited snapshots).
     eligibility_forensics: ArbEligibilityForensics,
+
+    /// Phase 3: pools published as active via `TOPIC_ARB_TRACK_REQUESTS`.
+    arb_pinned_pools: RwLock<HashSet<String>>,
+    /// Phase 3: count of track_requests publishes (heartbeat).
+    arb_track_published: AtomicU64,
+    /// Scope D: enqueue-only sender for off-hot-loop 2-hop detection.
+    two_hop_tx: mpsc::Sender<ArbTwoHopTradeJob>,
 }
 
 /// Cached vault balances from PoolStateUpdate events
@@ -2667,6 +2749,32 @@ impl ArbContext {
                         info!(key = %key, new_value = %v, "Config updated");
                     } else {
                         rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
+                    }
+                }
+                "arb_track_baseline_max_pools" => {
+                    if let Some(v) = value.as_u64() {
+                        if v > 0 && v <= 10_000 {
+                            config.arb_track_baseline_max_pools = v as usize;
+                            applied.push(key.clone());
+                            info!(key = %key, new_value = %v, "Config updated");
+                        } else {
+                            rejected.push((key.clone(), "Must be 1-10000".to_string()));
+                        }
+                    } else {
+                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
+                    }
+                }
+                "arb_track_reconcile_interval_secs" => {
+                    if let Some(v) = value.as_u64() {
+                        if (10..=3_600).contains(&v) {
+                            config.arb_track_reconcile_interval_secs = v;
+                            applied.push(key.clone());
+                            info!(key = %key, new_value = %v, "Config updated");
+                        } else {
+                            rejected.push((key.clone(), "Must be 10-3600".to_string()));
+                        }
+                    } else {
+                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
                     }
                 }
                 // Skip multi_hop_* keys here - they're handled in the second loop below
@@ -3546,6 +3654,152 @@ impl ArbContext {
         let trackers = self.trackers.read();
         trackers.get(mint).and_then(|t| t.token_program.clone())
     }
+
+    fn spawn_publish_arb_track_requests(
+        self: &Arc<Self>,
+        active: Vec<ArbTrackActiveEntry>,
+        removed: Vec<ArbTrackRemovedEntry>,
+        reconcile: bool,
+    ) {
+        if active.is_empty() && removed.is_empty() && !reconcile {
+            return;
+        }
+        let Some(nats_src) = self.nats.as_ref() else {
+            return;
+        };
+        let nats = nats_src.clone_for_spawned_publish();
+        let update = ArbTrackRequestsUpdate {
+            version: ARB_TRACK_REQUESTS_WIRE_VERSION,
+            ts_unix_ms: wall_clock_unix_ms_now(),
+            active,
+            removed,
+            reconcile,
+        };
+        record_arb_track_requests_messages_total();
+        self.arb_track_published.fetch_add(1, Ordering::Relaxed);
+        tokio::spawn(async move {
+            if let Err(e) = nats.publish(TOPIC_ARB_TRACK_REQUESTS, &update).await {
+                warn!(
+                    error = %e,
+                    topic = TOPIC_ARB_TRACK_REQUESTS,
+                    "ArbTrackRequests NATS publish failed"
+                );
+            }
+        });
+    }
+
+    fn collect_arb_track_baseline_active(&self) -> Vec<ArbTrackActiveEntry> {
+        let trackers = self.trackers.read();
+        let max_pools = self.config.read().arb_track_baseline_max_pools;
+        let mut seen = HashSet::new();
+        let mut out = Vec::new();
+        for tracker in trackers.values() {
+            if tracker.pool_count_on_distinct_dexes() < 2 {
+                continue;
+            }
+            for pool in tracker.pools.keys() {
+                if seen.len() >= max_pools {
+                    return out;
+                }
+                if seen.insert(pool.clone()) {
+                    out.push(ArbTrackActiveEntry {
+                        pool: pool.clone(),
+                        reason: ArbTrackActiveReason::Baseline,
+                    });
+                }
+            }
+        }
+        out
+    }
+
+    fn reconcile_arb_track_baseline_publish(self: &Arc<Self>) {
+        if self.nats.is_none() {
+            return;
+        }
+        let active = self.collect_arb_track_baseline_active();
+        {
+            let mut pinned = self.arb_pinned_pools.write();
+            pinned.clear();
+            for a in &active {
+                pinned.insert(a.pool.clone());
+            }
+        }
+        self.spawn_publish_arb_track_requests(active, Vec::new(), true);
+    }
+
+    fn maybe_publish_arb_track_incremental_for_mint(self: &Arc<Self>, mint: &str) {
+        let trackers = self.trackers.read();
+        let Some(tracker) = trackers.get(mint) else {
+            return;
+        };
+        if tracker.pool_count_on_distinct_dexes() < 2 {
+            return;
+        }
+        let mut active = Vec::new();
+        let mut pinned = self.arb_pinned_pools.write();
+        for pool in tracker.pools.keys() {
+            if pinned.insert(pool.clone()) {
+                active.push(ArbTrackActiveEntry {
+                    pool: pool.clone(),
+                    reason: ArbTrackActiveReason::MultiDex,
+                });
+            }
+        }
+        drop(pinned);
+        drop(trackers);
+        if !active.is_empty() {
+            self.spawn_publish_arb_track_requests(active, Vec::new(), false);
+        }
+    }
+
+    fn publish_arb_trade_signal_track_pins(self: &Arc<Self>, buy_pool: &str, sell_pool: &str) {
+        if self.nats.is_none() {
+            return;
+        }
+        let mut active = Vec::new();
+        let mut pinned = self.arb_pinned_pools.write();
+        for pool in [buy_pool, sell_pool] {
+            if pinned.insert(pool.to_string()) {
+                active.push(ArbTrackActiveEntry {
+                    pool: pool.to_string(),
+                    reason: ArbTrackActiveReason::TradeSignal,
+                });
+            }
+        }
+        drop(pinned);
+        if !active.is_empty() {
+            self.spawn_publish_arb_track_requests(active, Vec::new(), false);
+        }
+    }
+
+    fn prune_arb_track_stale_pools(self: &Arc<Self>) {
+        if self.nats.is_none() {
+            return;
+        }
+        let trackers = self.trackers.read();
+        let mut still_active: HashSet<String> = HashSet::new();
+        for tracker in trackers.values() {
+            if tracker.pool_count_on_distinct_dexes() >= 2 {
+                still_active.extend(tracker.pools.keys().cloned());
+            }
+        }
+        drop(trackers);
+        let mut removed = Vec::new();
+        let mut pinned = self.arb_pinned_pools.write();
+        for pool in pinned.clone().into_iter() {
+            if !still_active.contains(&pool) {
+                pinned.remove(&pool);
+                removed.push(ArbTrackRemovedEntry {
+                    pool,
+                    reason: ArbTrackRemovedReason::Stale,
+                });
+            }
+        }
+        drop(pinned);
+        if !removed.is_empty() {
+            self.spawn_publish_arb_track_requests(Vec::new(), removed, false);
+        }
+    }
 }
 
 // ============================================================================
@@ -3878,6 +4132,8 @@ async fn main() -> Result<()> {
         run_id.clone(),
     );
 
+    let (two_hop_tx, two_hop_rx) = mpsc::channel::<ArbTwoHopTradeJob>(ARB_TWO_HOP_WORKER_QUEUE_CAP);
+
     let ctx = Arc::new(ArbContext {
         run_id: run_id.clone(),
         config: RwLock::new(initial_config),
@@ -3899,7 +4155,12 @@ async fn main() -> Result<()> {
         multi_hop,
         spread_too_large_warn_last: RwLock::new(HashMap::new()),
         eligibility_forensics: ArbEligibilityForensics::new(),
+        arb_pinned_pools: RwLock::new(HashSet::new()),
+        arb_track_published: AtomicU64::new(0),
+        two_hop_tx,
     });
+
+    spawn_arb_two_hop_worker(Arc::clone(&ctx), two_hop_rx);
 
     // Bootstrap SLAVE LivePoolCache from JetStream (same path as execution-engine).
     // Consumer is returned for reuse in the main loop (FIX-12 — no second LastPerSubject replay).
@@ -4132,6 +4393,10 @@ async fn main() -> Result<()> {
     let config_js_consumer_opt = config_js_consumer;
     let pool_cache_consumer_opt = pool_cache_consumer;
     let mut heartbeat_interval = tokio::time::interval(Duration::from_secs(60));
+    let arb_reconcile_secs = ctx.config.read().arb_track_reconcile_interval_secs;
+    let mut arb_track_reconcile_interval =
+        tokio::time::interval(Duration::from_secs(arb_reconcile_secs.max(10)));
+    arb_track_reconcile_interval.tick().await;
 
     loop {
         tokio::select! {
@@ -4244,6 +4509,14 @@ async fn main() -> Result<()> {
                                                     if ctx.seed_trackers_for_pool_cache_update(&update)
                                                     {
                                                         arb_strategy_pool_cache_update_seeded_inc();
+                                                        if let Some(mint) = arb_tracked_token_mint(
+                                                            &update.base_mint,
+                                                            &update.quote_mint,
+                                                        ) {
+                                                            ctx.maybe_publish_arb_track_incremental_for_mint(
+                                                                mint,
+                                                            );
+                                                        }
                                                     } else {
                                                         arb_strategy_pool_cache_update_skip_no_seed_inc();
                                                     }
@@ -4292,6 +4565,7 @@ async fn main() -> Result<()> {
                 ctx.multi_hop.refresh_quote_readiness_metrics();
                 ctx.eligibility_forensics.maybe_emit_snapshot();
                 ctx.sync_pools_tracked_gauge();
+                ctx.prune_arb_track_stale_pools();
                 TOKENS_TRACKED_GAUGE.store(trackers.len() as u64, Ordering::Relaxed);
 
                 info!(
@@ -4304,17 +4578,22 @@ async fn main() -> Result<()> {
                     intents_generated = ctx.intents_generated.load(Ordering::Relaxed),
                     intents_written = records,
                     bytes_written = bytes,
-                    // Data quality metrics
                     zero_amount_trades = ctx.zero_amount_trades.load(Ordering::Relaxed),
                     data_quality_rejects = ctx.data_quality_rejects.load(Ordering::Relaxed),
-                    // Multi-hop stats
                     multi_hop_vertices = multi_hop_stats.graph_vertices,
                     multi_hop_pools = multi_hop_stats.graph_pools,
                     multi_hop_cycles_found = multi_hop_stats.cycles_found,
                     multi_hop_profitable = multi_hop_stats.cycles_profitable,
                     multi_hop_enabled = ctx.multi_hop.is_enabled(),
+                    arb_track_requests_published =
+                        ctx.arb_track_published.load(Ordering::Relaxed),
                     "arb-strategy heartbeat (SLAVE cache sync from market-data MASTER)"
                 );
+            }
+
+            // Phase 3: baseline arb track_requests reconcile (strategy-owned pins).
+            _ = arb_track_reconcile_interval.tick() => {
+                ctx.reconcile_arb_track_baseline_publish();
             }
 
             _ = &mut shutdown => {
@@ -4394,42 +4673,25 @@ async fn handle_market_event(ctx: &ArbContext, event: &MarketEvent) -> Option<Tr
                 );
             }
 
-            // Existing 2-hop arbitrage detection
-            if let Some(opp) = ctx.handle_trade(
-                pool_address,
-                mint,
-                quote_mint,
-                *sol_amount,
-                *token_amount,
-                *token_decimals,
-                *is_buy,
-                dex,
-            ) {
-                // Prometheus: count arbitrage opportunities detected
-                ARB_TRIANGLE_OPPORTUNITIES.fetch_add(1, Ordering::Relaxed);
-                info!(
-                    mint = %opp.base_mint,
-                    buy_dex = %opp.buy_dex,
-                    sell_dex = %opp.sell_dex,
-                    spread_bps = opp.spread_bps,
-                    profit_lamports = opp.estimated_profit_lamports,
-                    "🔥 Arbitrage opportunity detected!"
-                );
-                // create_arb_intent returns None if pump_amm is used but DexPoolAccounts are missing
-                create_arb_intent(ctx, &opp).map(|mut intent| {
-                    // K Phase 1: Slot-to-Send Latency - propagate slot from event
-                    if let Some(slot) = event.slot {
-                        intent.metadata.insert("slot".to_string(), slot.to_string());
-                    }
-                    intent.metadata.insert(
-                        "slot_seen_at_ms".to_string(),
-                        event.header.ts_unix_ms.to_string(),
-                    );
-                    intent
-                })
-            } else {
-                None
+            // Scope D: 2-hop detection off the prioritized market-event worker.
+            if ctx.config.read().two_hop_enabled {
+                let job = ArbTwoHopTradeJob {
+                    pool_address: pool_address.clone(),
+                    mint: mint.clone(),
+                    quote_mint: quote_mint.clone(),
+                    sol_amount: *sol_amount,
+                    token_amount: *token_amount,
+                    token_decimals: *token_decimals,
+                    is_buy: *is_buy,
+                    dex: dex.clone(),
+                    slot: event.slot,
+                    ts_unix_ms: event.header.ts_unix_ms,
+                };
+                if ctx.two_hop_tx.try_send(job).is_err() {
+                    debug!("arb two-hop worker queue full; dropping trade detection job");
+                }
             }
+            None
         }
 
         // Handle DexPoolAccounts - cache for deterministic IX building (NO RPC in execution-engine)
@@ -4865,6 +5127,12 @@ mod two_hop_price_tests {
             )),
             spread_too_large_warn_last: RwLock::new(HashMap::new()),
             eligibility_forensics: ArbEligibilityForensics::new(),
+            arb_pinned_pools: RwLock::new(HashSet::new()),
+            arb_track_published: AtomicU64::new(0),
+            two_hop_tx: {
+                let (tx, _rx) = mpsc::channel(1);
+                tx
+            },
         }
     }
 
@@ -6231,6 +6499,25 @@ mod two_hop_price_tests {
         let _ = check_with_forensics(&tracker, &known_pools, &vault_balances, &forensics);
         assert!(!forensics.maybe_emit_snapshot());
         assert_eq!(forensics.snapshots_emitted_count(), 1);
+    }
+
+    #[test]
+    fn phase3_arb_track_requests_publish_serializes_reconcile_flag() {
+        let update = ArbTrackRequestsUpdate {
+            version: ARB_TRACK_REQUESTS_WIRE_VERSION,
+            ts_unix_ms: 1_700_000_000,
+            active: vec![ArbTrackActiveEntry {
+                pool: "Pool111111111111111111111111111111111111111".to_string(),
+                reason: ArbTrackActiveReason::Baseline,
+            }],
+            removed: vec![],
+            reconcile: true,
+        };
+        let json = serde_json::to_string(&update).expect("serialize");
+        assert!(json.contains("\"reconcile\":true"));
+        let back: ArbTrackRequestsUpdate = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.reconcile);
+        assert_eq!(back.active.len(), 1);
     }
 }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -61,6 +61,9 @@ use ironcrab::metrics::{
     inc_market_data_account_low_priority_queue_depth,
     inc_market_data_account_publish_enqueue_dropped_total,
     inc_market_data_account_publish_queue_depth, inc_market_data_account_worker_queue_depth,
+    inc_market_data_arb_track_coalesced_batches_total,
+    inc_market_data_arb_track_coalesced_messages_total,
+    inc_market_data_arb_track_worker_enqueue_dropped_total,
     inc_market_data_balance_updated_from_cache_total,
     inc_market_data_discovery_deferred_md_state_pressure_total,
     inc_market_data_geyser_sync_partial_total, inc_market_data_geyser_sync_skipped_no_delta_total,
@@ -87,6 +90,7 @@ use ironcrab::metrics::{
     record_market_data_account_publish_worker_job_duration_us,
     record_market_data_account_publish_worker_reconnect,
     record_market_data_account_publish_worker_stall,
+    record_market_data_arb_track_requests_messages_total,
     record_market_data_bonding_curve_grpc_to_devwallet_ms,
     record_market_data_bonding_to_trade_slot_delta_slots,
     record_market_data_geyser_merge_coalesced_total,
@@ -102,15 +106,15 @@ use ironcrab::metrics::{
     record_market_data_tx_handler_processed, serve_metrics,
     set_market_data_account_broadcast_queue_depth,
     set_market_data_account_publish_worker_last_success_unix_ms,
-    set_market_data_account_worker_count, set_market_data_geyser_explicit_set_size,
-    set_market_data_geyser_merge_pending, set_market_data_geyser_sync_pending,
-    set_market_data_geyser_tracking_queue_depth, set_market_data_hot_pool_registry_pools_gauge,
-    set_market_data_md_sidefx_queue_depth, set_market_data_md_state_burst_in_progress,
-    set_market_data_md_state_deferred_jobs_len, set_market_data_md_state_evict_pending,
-    set_market_data_md_state_queue_depth, set_market_data_momentum_active_pool_pins_gauge,
-    set_market_data_track_worker_queue_depth, set_market_data_tx_broadcast_queue_depth,
-    set_readiness_control_sub_active, set_readiness_mode, set_readiness_nats_connected,
-    touch_market_data_global_ingest_progress,
+    set_market_data_account_worker_count, set_market_data_arb_pinned_pools_gauge,
+    set_market_data_geyser_explicit_set_size, set_market_data_geyser_merge_pending,
+    set_market_data_geyser_sync_pending, set_market_data_geyser_tracking_queue_depth,
+    set_market_data_hot_pool_registry_pools_gauge, set_market_data_md_sidefx_queue_depth,
+    set_market_data_md_state_burst_in_progress, set_market_data_md_state_deferred_jobs_len,
+    set_market_data_md_state_evict_pending, set_market_data_md_state_queue_depth,
+    set_market_data_momentum_active_pool_pins_gauge, set_market_data_track_worker_queue_depth,
+    set_market_data_tx_broadcast_queue_depth, set_readiness_control_sub_active, set_readiness_mode,
+    set_readiness_nats_connected, touch_market_data_global_ingest_progress,
     touch_market_data_tracked_membership_snapshot_refresh, update_readiness_market_data_current,
     wall_clock_unix_ms_now, GeyserTrackedEvictKind, MarketDataLatencySegment, MetricsComponent,
     MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS, MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS,
@@ -122,9 +126,10 @@ use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
     ensure_pool_cache_stream, ensure_wallet_snapshot_stream, ensure_wallet_tx_confirm_stream,
     execution_results_consumer_config, pool_subject, wallet_snapshot_consumer_config,
-    wallet_snapshot_subject, wallet_tx_confirm_subject, MomentumActivePoolEntry,
-    MomentumActivePoolsUpdate, MomentumRemovedPoolEntry, NatsClient, NatsConfig,
-    CONFIG_STREAM_NAME, EXECUTION_RESULTS_STREAM_NAME, TOPIC_CONTROL_REQUESTS,
+    wallet_snapshot_subject, wallet_tx_confirm_subject, ArbTrackActiveEntry, ArbTrackRemovedEntry,
+    ArbTrackRequestsUpdate, MomentumActivePoolEntry, MomentumActivePoolsUpdate,
+    MomentumRemovedPoolEntry, NatsClient, NatsConfig, CONFIG_STREAM_NAME,
+    EXECUTION_RESULTS_STREAM_NAME, TOPIC_ARB_TRACK_REQUESTS, TOPIC_CONTROL_REQUESTS,
     TOPIC_CONTROL_RESPONSES, TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS,
     TOPIC_MOMENTUM_ACTIVE_POOLS, TOPIC_MOMENTUM_MARKET_EVENTS, TOPIC_PRIORITY_FEE_SAMPLES,
     WALLET_SNAPSHOT_STREAM_NAME,
@@ -207,6 +212,11 @@ const MARKET_DATA_MOMENTUM_COALESCE_CHANNEL_CAP: usize = 512;
 /// PR169c: chunk large momentum applies so the tracking actor yields to ingest tasks.
 const MARKET_DATA_MOMENTUM_APPLY_CHUNK_THRESHOLD: usize = 32;
 const MARKET_DATA_MOMENTUM_APPLY_CHUNK_SIZE: usize = 16;
+/// Phase 3: bounded channel for arb track updates before track-worker coalesce.
+const MARKET_DATA_ARB_COALESCE_CHANNEL_CAP: usize = 512;
+/// Phase 3: chunk large arb track applies on md-track-worker.
+const MARKET_DATA_ARB_APPLY_CHUNK_THRESHOLD: usize = 32;
+const MARKET_DATA_ARB_APPLY_CHUNK_SIZE: usize = 16;
 /// Phase 2a: track-worker Geyser push coalesce window (I-4d prep).
 const MARKET_DATA_TRACK_WORKER_COALESCE_MS: u64 = 500;
 /// Phase 2a: bounded queue for md-track-worker commands.
@@ -538,6 +548,141 @@ fn apply_momentum_active_pools_on_track_worker(
     batch_dirty
 }
 
+/// Phase 3: merge a burst of arb track updates into one payload equivalent to sequential applies.
+fn merge_arb_track_requests_updates(
+    updates: &[ArbTrackRequestsUpdate],
+) -> Option<ArbTrackRequestsUpdate> {
+    if updates.is_empty() {
+        return None;
+    }
+    let mut active_map: HashMap<String, ArbTrackActiveEntry> = HashMap::new();
+    let mut removed_map: HashMap<String, ArbTrackRemovedEntry> = HashMap::new();
+    let mut saw_reconcile = false;
+    let mut max_version = 0u32;
+    let mut max_ts = 0u64;
+
+    for update in updates {
+        max_version = max_version.max(update.version);
+        max_ts = max_ts.max(update.ts_unix_ms);
+        if update.reconcile {
+            saw_reconcile = true;
+            let target: HashSet<String> = update.active.iter().map(|a| a.pool.clone()).collect();
+            for key in active_map.keys().cloned().collect::<Vec<_>>() {
+                if !target.contains(&key) {
+                    active_map.remove(&key);
+                    removed_map.remove(&key);
+                }
+            }
+            active_map.clear();
+            for r in &update.removed {
+                let key = r.pool.clone();
+                active_map.remove(&key);
+                removed_map.insert(key, r.clone());
+            }
+            for a in &update.active {
+                let key = a.pool.clone();
+                removed_map.remove(&key);
+                active_map.insert(key, a.clone());
+            }
+        } else {
+            for r in &update.removed {
+                let key = r.pool.clone();
+                active_map.remove(&key);
+                removed_map.insert(key, r.clone());
+            }
+            for a in &update.active {
+                let key = a.pool.clone();
+                removed_map.remove(&key);
+                active_map.insert(key, a.clone());
+            }
+        }
+    }
+
+    for key in active_map.keys().cloned().collect::<Vec<_>>() {
+        removed_map.remove(&key);
+    }
+
+    Some(ArbTrackRequestsUpdate {
+        version: max_version,
+        ts_unix_ms: max_ts,
+        active: active_map.into_values().collect(),
+        removed: removed_map.into_values().collect(),
+        reconcile: saw_reconcile,
+    })
+}
+
+fn arb_coalesce_try_send(
+    tx: &mpsc::Sender<ArbTrackRequestsUpdate>,
+    update: ArbTrackRequestsUpdate,
+) {
+    inc_market_data_arb_track_coalesced_messages_total();
+    if tx.try_send(update).is_err() {
+        warn!("arb track coalesce channel full; dropping ArbTrackRequestsUpdate");
+    }
+}
+
+fn spawn_arb_tracking_coalescer(
+    ctx: Arc<MarketDataContext>,
+    track_worker: TrackWorkerSender,
+) -> mpsc::Sender<ArbTrackRequestsUpdate> {
+    let (coalesce_tx, mut coalesce_rx) =
+        mpsc::channel::<ArbTrackRequestsUpdate>(MARKET_DATA_ARB_COALESCE_CHANNEL_CAP);
+    tokio::spawn(async move {
+        while let Some(first) = coalesce_rx.recv().await {
+            let mut pending = vec![first];
+            while let Ok(more) = coalesce_rx.try_recv() {
+                pending.push(more);
+            }
+            let debounce_ms = ctx.geyser_sync_batch_debounce_ms();
+            tokio::time::sleep(Duration::from_millis(debounce_ms)).await;
+            while let Ok(more) = coalesce_rx.try_recv() {
+                pending.push(more);
+            }
+            if let Some(merged) = merge_arb_track_requests_updates(&pending) {
+                inc_market_data_arb_track_coalesced_batches_total();
+                if !track_worker_try_enqueue(
+                    &track_worker,
+                    TrackWorkerCommand::ApplyArbTrackRequests(merged),
+                ) {
+                    inc_market_data_arb_track_worker_enqueue_dropped_total();
+                }
+            }
+            pending.clear();
+        }
+    });
+    coalesce_tx
+}
+
+/// Phase 3: sync arb track apply on `md-track-worker` thread (no Tokio yield).
+fn apply_arb_track_requests_on_track_worker(
+    ctx: &Arc<MarketDataContext>,
+    update: ArbTrackRequestsUpdate,
+) -> bool {
+    let item_count = update.active.len() + update.removed.len();
+    if item_count <= MARKET_DATA_ARB_APPLY_CHUNK_THRESHOLD {
+        return ctx.apply_arb_track_requests_update(&update);
+    }
+    record_market_data_arb_track_requests_messages_total();
+    let mut batch_dirty = false;
+    if update.reconcile {
+        batch_dirty |= ctx.apply_arb_snapshot_reconcile(&update.active);
+        std::thread::yield_now();
+    }
+    for chunk in update.removed.chunks(MARKET_DATA_ARB_APPLY_CHUNK_SIZE) {
+        batch_dirty |= ctx.apply_arb_removed_entries(chunk);
+        std::thread::yield_now();
+    }
+    for chunk in update.active.chunks(MARKET_DATA_ARB_APPLY_CHUNK_SIZE) {
+        batch_dirty |= ctx.apply_arb_active_entries(chunk);
+        std::thread::yield_now();
+    }
+    if !batch_dirty {
+        ctx.refresh_geyser_pins_gauge();
+    }
+    set_market_data_arb_pinned_pools_gauge(ctx.hot_pool_registry.arb_pool_count());
+    batch_dirty
+}
+
 fn md_state_dec_queue_depth(queue_depth: &AtomicUsize) {
     let mut cur = queue_depth.load(Ordering::Relaxed);
     while cur > 0 {
@@ -562,6 +707,7 @@ fn explicit_subscription_has_new_keys(before: &HashSet<Pubkey>, after: &HashSet<
 /// Phase 2a: commands for the `md-track-worker` OS thread (DesiredExplicitSet + coalesced Geyser push).
 enum TrackWorkerCommand {
     ApplyMomentumActivePools(MomentumActivePoolsUpdate),
+    ApplyArbTrackRequests(ArbTrackRequestsUpdate),
     ApplyWalletPin {
         mint: Pubkey,
     },
@@ -642,6 +788,9 @@ fn track_worker_process_command(ctx: &Arc<MarketDataContext>, job: TrackWorkerCo
     match job {
         TrackWorkerCommand::ApplyMomentumActivePools(update) => {
             apply_momentum_active_pools_on_track_worker(ctx, update)
+        }
+        TrackWorkerCommand::ApplyArbTrackRequests(update) => {
+            apply_arb_track_requests_on_track_worker(ctx, update)
         }
         TrackWorkerCommand::ApplyWalletPin { mint } => {
             ctx.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::Wallet))
@@ -3316,10 +3465,9 @@ fn pump_amm_control_response_for_ensure_publish(
 enum GeyserPinReason {
     /// Wallet bootstrap / execution-result mint tracking — never LRU-evicted.
     Wallet,
-    /// Momentum active pool (PR-D will populate); never LRU-evicted.
+    /// Momentum active pool (PR-D); never LRU-evicted by lower tiers.
     MomentumActive,
-    /// Legacy arb pin tier (read-only after Phase 2c; no new MD pins).
-    #[allow(dead_code)]
+    /// Arb strategy multi-DEX pool pin (Phase 3 track_requests).
     ArbMultiDex,
 }
 
@@ -3340,10 +3488,11 @@ impl Default for MintTrackInfo {
     }
 }
 
-/// Unified hot-pool registry: momentum active pools (Phase 2c: arb path removed).
+/// Unified hot-pool registry: momentum `(mint, pool)` rows + arb pool-centric pins.
 #[derive(Debug)]
 struct UnifiedHotPoolRegistry {
     momentum_pairs: parking_lot::RwLock<std::collections::HashSet<(Pubkey, Pubkey)>>,
+    arb_pools: parking_lot::RwLock<std::collections::HashSet<Pubkey>>,
 }
 
 #[allow(dead_code)]
@@ -3351,6 +3500,7 @@ impl UnifiedHotPoolRegistry {
     fn new() -> Self {
         Self {
             momentum_pairs: parking_lot::RwLock::new(std::collections::HashSet::new()),
+            arb_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
         }
     }
 
@@ -3360,6 +3510,26 @@ impl UnifiedHotPoolRegistry {
 
     fn unpin_pool(&self, mint: Pubkey, pool: Pubkey) {
         self.momentum_pairs.write().remove(&(mint, pool));
+    }
+
+    fn pin_arb_pool(&self, pool: Pubkey) {
+        self.arb_pools.write().insert(pool);
+    }
+
+    fn unpin_arb_pool(&self, pool: Pubkey) {
+        self.arb_pools.write().remove(&pool);
+    }
+
+    fn pool_has_arb(&self, pool: Pubkey) -> bool {
+        self.arb_pools.read().contains(&pool)
+    }
+
+    fn snapshot_arb_pools(&self) -> HashSet<Pubkey> {
+        self.arb_pools.read().clone()
+    }
+
+    fn arb_pool_count(&self) -> usize {
+        self.arb_pools.read().len()
     }
 
     #[allow(dead_code)]
@@ -3384,9 +3554,9 @@ impl UnifiedHotPoolRegistry {
         self.momentum_pairs.read().clone()
     }
 
-    /// Pool is in the execution hot set (momentum active only after Phase 2c).
+    /// Pool is in the execution hot set (momentum active and/or arb track pin).
     fn is_hot_pool(&self, pool: Pubkey) -> bool {
-        self.pool_has_any_pin(pool)
+        self.pool_has_momentum(pool) || self.pool_has_arb(pool)
     }
 
     fn pool_has_momentum(&self, pool: Pubkey) -> bool {
@@ -3679,6 +3849,8 @@ struct MarketDataContext {
     geyser_lru_index: parking_lot::Mutex<GeyserLruIndex>,
     /// PR235: skip redundant momentum snapshot reconcile when target set unchanged.
     last_momentum_snapshot_target: parking_lot::RwLock<Option<HashSet<(Pubkey, Pubkey)>>>,
+    /// Phase 3: skip redundant arb snapshot reconcile when target pool set unchanged.
+    last_arb_snapshot_target: parking_lot::RwLock<Option<HashSet<Pubkey>>>,
 }
 
 #[derive(Debug, Default)]
@@ -4466,10 +4638,12 @@ impl MarketDataContext {
 
     fn refresh_hot_pool_registry_gauges(&self) {
         let momentum = self.hot_pool_registry.hot_pool_count_momentum();
+        let arb = self.hot_pool_registry.arb_pool_count();
         set_market_data_hot_pool_registry_pools_gauge("momentum", momentum);
-        set_market_data_hot_pool_registry_pools_gauge("arb", 0);
+        set_market_data_hot_pool_registry_pools_gauge("arb", arb);
         set_market_data_hot_pool_registry_pools_gauge("both", 0);
         set_market_data_momentum_active_pool_pins_gauge(self.hot_pool_registry.pair_count());
+        set_market_data_arb_pinned_pools_gauge(arb);
     }
 
     /// PR237 + Phase1: rebuild ingest/sidefx snapshot from authoritative md-state maps.
@@ -5250,7 +5424,7 @@ impl MarketDataContext {
             return false;
         }
         let before_keys = self.snapshot_explicit_subscription_pubkeys();
-        self.register_geyser_reserves_impl(pool);
+        self.register_geyser_reserves_impl(pool, GeyserPinReason::MomentumActive);
         explicit_subscription_has_new_keys(
             &before_keys,
             &self.snapshot_explicit_subscription_pubkeys(),
@@ -5443,21 +5617,30 @@ impl MarketDataContext {
         )
     }
 
-    /// PR-D: explicit vault/bin subscriptions for momentum active `(mint, pool)` when cache has layout.
-    /// Returns whether any tracked set changed. Caller must [`Self::sync_geyser_tracked_accounts`].
-    fn register_geyser_reserves_for_momentum_active_pool(&self, pool: Pubkey) -> bool {
+    /// PR-D / Phase 3: explicit vault/bin subscriptions when cache has layout.
+    /// Returns whether any tracked set changed. Caller schedules debounced Geyser push.
+    fn register_geyser_reserves_for_active_pool(&self, pool: Pubkey, pin: GeyserPinReason) -> bool {
         if self.live_pool_cache.get(&pool).is_none() {
             debug!(
                 run_id = %self.run_id,
                 pool = %pool,
-                "Momentum active pool: LivePoolCache miss — pin may still be recorded; reserve registration deferred"
+                pin = ?pin,
+                "Active pool pin: LivePoolCache miss — registry row kept; reserve registration deferred"
             );
             return false;
         }
-        self.register_geyser_reserves_impl(pool)
+        self.register_geyser_reserves_impl(pool, pin)
     }
 
-    fn register_geyser_reserves_impl(&self, pool: Pubkey) -> bool {
+    fn register_geyser_reserves_for_momentum_active_pool(&self, pool: Pubkey) -> bool {
+        self.register_geyser_reserves_for_active_pool(pool, GeyserPinReason::MomentumActive)
+    }
+
+    fn register_geyser_reserves_for_arb_active_pool(&self, pool: Pubkey) -> bool {
+        self.register_geyser_reserves_for_active_pool(pool, GeyserPinReason::ArbMultiDex)
+    }
+
+    fn register_geyser_reserves_impl(&self, pool: Pubkey, pin: GeyserPinReason) -> bool {
         let now = Instant::now();
         let enable_dlmm = self.config.read().enable_meteora_dlmm;
         let enable_meteora_cpmm = self.config.read().enable_meteora_cpmm;
@@ -5535,12 +5718,9 @@ impl MarketDataContext {
         {
             let mut vaults = self.tracked_vaults.write();
             for v in vaults.values_mut() {
-                if v.pool_address == pool
-                    && v.pin != Some(GeyserPinReason::Wallet)
-                    && (!v.pinned || v.pin != Some(GeyserPinReason::MomentumActive))
-                {
+                if v.pool_address == pool && Self::geyser_pin_may_promote(v.pin, pin) {
                     v.pinned = true;
-                    v.pin = Some(GeyserPinReason::MomentumActive);
+                    v.pin = Some(pin);
                     vaults_changed = true;
                 }
             }
@@ -5548,26 +5728,34 @@ impl MarketDataContext {
         {
             let mut bins = self.tracked_bin_arrays.write();
             for b in bins.values_mut() {
-                if b.pool_address == pool
-                    && b.pin != Some(GeyserPinReason::Wallet)
-                    && (!b.pinned || b.pin != Some(GeyserPinReason::MomentumActive))
-                {
+                if b.pool_address == pool && Self::geyser_pin_may_promote(b.pin, pin) {
                     b.pinned = true;
-                    b.pin = Some(GeyserPinReason::MomentumActive);
+                    b.pin = Some(pin);
                     bins_changed = true;
                 }
             }
         }
         if let Some((a, b)) = pool_mints_for_geyser_explicit_tracking(&state) {
-            if self.track_mint_for_geyser_metadata(a, Some(GeyserPinReason::MomentumActive)) {
+            if self.track_mint_for_geyser_metadata(a, Some(pin)) {
                 mints_changed = true;
             }
-            if self.track_mint_for_geyser_metadata(b, Some(GeyserPinReason::MomentumActive)) {
+            if self.track_mint_for_geyser_metadata(b, Some(pin)) {
                 mints_changed = true;
             }
         }
 
         vaults_changed || bins_changed || mints_changed
+    }
+
+    fn geyser_pin_may_promote(current: Option<GeyserPinReason>, target: GeyserPinReason) -> bool {
+        match target {
+            GeyserPinReason::Wallet => current != Some(GeyserPinReason::Wallet),
+            GeyserPinReason::MomentumActive => current != Some(GeyserPinReason::Wallet),
+            GeyserPinReason::ArbMultiDex => !matches!(
+                current,
+                Some(GeyserPinReason::Wallet) | Some(GeyserPinReason::MomentumActive)
+            ),
+        }
     }
 
     /// PR-D / PR169b: apply momentum-bot active pool pin updates (actor-only writer; caller schedules sync).
@@ -5733,6 +5921,147 @@ impl MarketDataContext {
                     info.pinned = false;
                     info.pin = None;
                     changed = true;
+                }
+            }
+        }
+        changed
+    }
+
+    /// Phase 3: apply arb-strategy track_requests pin updates (md-track-worker only).
+    fn apply_arb_track_requests_update(&self, update: &ArbTrackRequestsUpdate) -> bool {
+        record_market_data_arb_track_requests_messages_total();
+        let mut batch_dirty = false;
+        if update.reconcile {
+            batch_dirty |= self.apply_arb_snapshot_reconcile(&update.active);
+        }
+        batch_dirty |= self.apply_arb_removed_entries(&update.removed);
+        batch_dirty |= self.apply_arb_active_entries(&update.active);
+        if !batch_dirty {
+            self.refresh_geyser_pins_gauge();
+        }
+        set_market_data_arb_pinned_pools_gauge(self.hot_pool_registry.arb_pool_count());
+        batch_dirty
+    }
+
+    fn apply_arb_snapshot_reconcile(&self, active: &[ArbTrackActiveEntry]) -> bool {
+        let mut target: HashSet<Pubkey> = HashSet::new();
+        for a in active {
+            let Ok(pool_pk) = Pubkey::from_str(a.pool.trim()) else {
+                warn!(pool = %a.pool, "ArbTrackRequestsUpdate.active (snapshot): invalid pool");
+                continue;
+            };
+            target.insert(pool_pk);
+        }
+        {
+            let mut last = self.last_arb_snapshot_target.write();
+            if last.as_ref() == Some(&target) {
+                return false;
+            }
+            *last = Some(target.clone());
+        }
+        let mut batch_dirty = false;
+        let before = self.hot_pool_registry.snapshot_arb_pools();
+        for pool in before.difference(&target) {
+            if self.clear_arb_geyser_reserves_for_pool(*pool) {
+                batch_dirty = true;
+            }
+        }
+        batch_dirty
+    }
+
+    fn apply_arb_removed_entries(&self, removed: &[ArbTrackRemovedEntry]) -> bool {
+        let mut batch_dirty = false;
+        for r in removed {
+            let Ok(pool_pk) = Pubkey::from_str(r.pool.trim()) else {
+                warn!(pool = %r.pool, "ArbTrackRequestsUpdate.removed: invalid pool");
+                continue;
+            };
+            if self.clear_arb_geyser_reserves_for_pool(pool_pk) {
+                batch_dirty = true;
+            }
+        }
+        batch_dirty
+    }
+
+    fn apply_arb_active_entries(&self, active: &[ArbTrackActiveEntry]) -> bool {
+        let mut batch_dirty = false;
+        for a in active {
+            let Ok(pool_pk) = Pubkey::from_str(a.pool.trim()) else {
+                warn!(pool = %a.pool, "ArbTrackRequestsUpdate.active: invalid pool");
+                continue;
+            };
+            self.hot_pool_registry.pin_arb_pool(pool_pk);
+            if self.register_geyser_reserves_for_arb_active_pool(pool_pk) {
+                batch_dirty = true;
+            }
+            let _ = &a.reason;
+        }
+        batch_dirty
+    }
+
+    fn arb_pool_leg_mint_still_required_by_other_pool(&self, mint: Pubkey) -> bool {
+        for pool_pk in self.hot_pool_registry.snapshot_arb_pools() {
+            match self.live_pool_cache.get(&pool_pk) {
+                Some(state) => {
+                    if let Some((a, b)) = pool_mints_for_geyser_explicit_tracking(&state) {
+                        if a == mint || b == mint {
+                            return true;
+                        }
+                    }
+                }
+                None => return true,
+            }
+        }
+        false
+    }
+
+    /// Clear Arb consumer pins for one pool; never demotes [`GeyserPinReason::Wallet`] or Momentum.
+    fn clear_arb_geyser_reserves_for_pool(&self, pool: Pubkey) -> bool {
+        self.hot_pool_registry.unpin_arb_pool(pool);
+        let mut changed = false;
+        if !self.hot_pool_registry.pool_has_arb(pool)
+            && !self.hot_pool_registry.pool_has_any_pin(pool)
+        {
+            {
+                let mut vaults = self.tracked_vaults.write();
+                for v in vaults.values_mut() {
+                    if v.pool_address == pool && v.pin == Some(GeyserPinReason::ArbMultiDex) {
+                        v.pin = None;
+                        v.pinned = false;
+                        changed = true;
+                    }
+                }
+            }
+            {
+                let mut bins = self.tracked_bin_arrays.write();
+                for b in bins.values_mut() {
+                    if b.pool_address == pool && b.pin == Some(GeyserPinReason::ArbMultiDex) {
+                        b.pin = None;
+                        b.pinned = false;
+                        changed = true;
+                    }
+                }
+            }
+            if let Some(state) = self.live_pool_cache.get(&pool) {
+                if let Some((leg_a, leg_b)) = pool_mints_for_geyser_explicit_tracking(&state) {
+                    for leg in [leg_a, leg_b] {
+                        if self.wallet_tracks_mint_for_geyser(&leg) {
+                            continue;
+                        }
+                        if self.momentum_pool_leg_mint_still_required_by_other_pool(leg)
+                            || self.arb_pool_leg_mint_still_required_by_other_pool(leg)
+                        {
+                            continue;
+                        }
+                        let mut m = self.tracked_mints.write();
+                        if let Some(info) = m.get_mut(&leg) {
+                            if info.pin == Some(GeyserPinReason::ArbMultiDex) {
+                                info.pinned = false;
+                                info.pin = None;
+                                changed = true;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -10482,6 +10811,7 @@ async fn main() -> Result<()> {
         pending_geyser_evict: AtomicBool::new(false),
         geyser_lru_index: parking_lot::Mutex::new(GeyserLruIndex::default()),
         last_momentum_snapshot_target: parking_lot::RwLock::new(None),
+        last_arb_snapshot_target: parking_lot::RwLock::new(None),
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -13574,6 +13904,8 @@ async fn run_geyser_loop(
     // PR169c / Phase-2b: coalesce momentum NATS bursts before md-track-worker.
     let momentum_coalesce_tx =
         spawn_momentum_tracking_coalescer(Arc::clone(&ctx), track_worker.clone());
+    // Phase 3: coalesce arb track_requests before md-track-worker.
+    let arb_coalesce_tx = spawn_arb_tracking_coalescer(Arc::clone(&ctx), track_worker.clone());
     let md_state = spawn_md_state_worker(
         Arc::clone(&ctx),
         tokio::runtime::Handle::current(),
@@ -13774,6 +14106,29 @@ async fn run_geyser_loop(
                     error = %e,
                     topic = TOPIC_MOMENTUM_ACTIVE_POOLS,
                     "Failed to subscribe to MomentumActivePools (momentum reserve pins disabled)"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    // Phase 3: arb-strategy pool pin stream (core NATS).
+    let mut arb_track_requests_sub = if let Some(ref nats) = ctx.nats {
+        match nats.subscribe(TOPIC_ARB_TRACK_REQUESTS).await {
+            Ok(sub) => {
+                info!(
+                    topic = TOPIC_ARB_TRACK_REQUESTS,
+                    "Subscribed to ArbTrackRequests (Geyser pin stream)"
+                );
+                Some(sub)
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    topic = TOPIC_ARB_TRACK_REQUESTS,
+                    "Failed to subscribe to ArbTrackRequests (arb reserve pins disabled)"
                 );
                 None
             }
@@ -14650,6 +15005,26 @@ async fn run_geyser_loop(
                 }
             }
 
+            // Phase 3: Arb track_requests pin stream (core NATS).
+            msg = async {
+                if let Some(ref mut sub) = arb_track_requests_sub {
+                    sub.next().await
+                } else {
+                    std::future::pending::<Option<ironcrab::nats::NatsMessage>>().await
+                }
+            } => {
+                if let Some(nats_msg) = msg {
+                    match serde_json::from_slice::<ArbTrackRequestsUpdate>(&nats_msg.payload) {
+                        Ok(update) => {
+                            arb_coalesce_try_send(&arb_coalesce_tx, update);
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "Failed to deserialize ArbTrackRequestsUpdate");
+                        }
+                    }
+                }
+            }
+
             // P1: Handle Config Updates (Runtime Configuration via UI)
             msg = async {
                 if let Some(ref mut sub) = config_subscription {
@@ -14776,6 +15151,28 @@ async fn run_simulation_loop(
         None
     };
 
+    let mut arb_track_requests_sub = if let Some(ref nats) = ctx.nats {
+        match nats.subscribe(TOPIC_ARB_TRACK_REQUESTS).await {
+            Ok(sub) => {
+                info!(
+                    topic = TOPIC_ARB_TRACK_REQUESTS,
+                    "Simulation mode: Subscribed to ArbTrackRequests"
+                );
+                Some(sub)
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    topic = TOPIC_ARB_TRACK_REQUESTS,
+                    "Simulation mode: Failed to subscribe to ArbTrackRequests"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let mut pump_inner = PumpFunAmmDex::new_with_cache(
         Arc::clone(&rpc),
         ctx.live_pool_cache.clone(),
@@ -14787,6 +15184,7 @@ async fn run_simulation_loop(
     let track_worker = spawn_track_worker(Arc::clone(&ctx));
     let momentum_coalesce_tx =
         spawn_momentum_tracking_coalescer(Arc::clone(&ctx), track_worker.clone());
+    let arb_coalesce_tx = spawn_arb_tracking_coalescer(Arc::clone(&ctx), track_worker.clone());
     let md_state = spawn_md_state_worker(
         Arc::clone(&ctx),
         tokio::runtime::Handle::current(),
@@ -15094,6 +15492,26 @@ async fn run_simulation_loop(
                         }
                         Err(e) => {
                             warn!(error = %e, "Failed to deserialize MomentumActivePoolsUpdate (simulation)");
+                        }
+                    }
+                }
+            }
+
+            // Phase 3: Arb track_requests pin stream (simulation / tests).
+            msg = async {
+                if let Some(ref mut sub) = arb_track_requests_sub {
+                    sub.next().await
+                } else {
+                    std::future::pending::<Option<ironcrab::nats::NatsMessage>>().await
+                }
+            } => {
+                if let Some(nats_msg) = msg {
+                    match serde_json::from_slice::<ArbTrackRequestsUpdate>(&nats_msg.payload) {
+                        Ok(update) => {
+                            arb_coalesce_try_send(&arb_coalesce_tx, update);
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "Failed to deserialize ArbTrackRequestsUpdate (simulation)");
                         }
                     }
                 }
@@ -16188,6 +16606,7 @@ mod wallet_tx_meta_balance_tests {
             pending_geyser_evict: AtomicBool::new(false),
             geyser_lru_index: parking_lot::Mutex::new(GeyserLruIndex::default()),
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
+            last_arb_snapshot_target: parking_lot::RwLock::new(None),
         })
     }
 
@@ -17051,6 +17470,7 @@ mod pr_b_geyser_tracking_tests {
             pending_geyser_evict: AtomicBool::new(false),
             geyser_lru_index: parking_lot::Mutex::new(GeyserLruIndex::default()),
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
+            last_arb_snapshot_target: parking_lot::RwLock::new(None),
         })
     }
 
@@ -17121,6 +17541,7 @@ mod pr_b_geyser_tracking_tests {
             pending_geyser_evict: AtomicBool::new(false),
             geyser_lru_index: parking_lot::Mutex::new(GeyserLruIndex::default()),
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
+            last_arb_snapshot_target: parking_lot::RwLock::new(None),
         });
         (
             ctx,
@@ -19796,5 +20217,103 @@ mod pr_b_geyser_tracking_tests {
         let block = &src[enum_start..enum_end];
         assert!(!block.contains("ArbMultiDexReconcile"));
         assert!(!block.contains("UpdateArbCoverageIndex"));
+    }
+
+    #[test]
+    fn phase3_arb_track_requests_nats_uses_track_worker_not_md_state() {
+        let src = include_str!("market_data.rs");
+        let prod_src = src
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production source section");
+        assert!(
+            !prod_src.contains("MdStateCommand::ApplyArbTrackRequests"),
+            "arb track must not enqueue MdStateCommand::ApplyArbTrackRequests"
+        );
+        let coalescer_start = prod_src
+            .find("fn spawn_arb_tracking_coalescer")
+            .expect("spawn_arb_tracking_coalescer");
+        let coalescer_body = &prod_src[coalescer_start..coalescer_start.saturating_add(2500)];
+        assert!(
+            coalescer_body.contains("track_worker_try_enqueue"),
+            "arb coalescer must enqueue track-worker"
+        );
+        assert!(
+            !coalescer_body.contains("md_state_try_enqueue"),
+            "arb coalescer must not touch md-state enqueue"
+        );
+        assert!(
+            !prod_src.contains(".publish(TOPIC_ARB_TRACK_REQUESTS"),
+            "market-data must not publish TOPIC_ARB_TRACK_REQUESTS"
+        );
+    }
+
+    #[test]
+    fn phase3_apply_arb_track_requests_respects_wallet_pins() {
+        use ironcrab::nats::{
+            ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackRemovedEntry, ArbTrackRequestsUpdate,
+        };
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            1,
+        );
+
+        ctx.apply_arb_track_requests_update(&ArbTrackRequestsUpdate {
+            version: 1,
+            ts_unix_ms: 1,
+            active: vec![ArbTrackActiveEntry {
+                pool: pool.to_string(),
+                reason: ArbTrackActiveReason::Baseline,
+            }],
+            removed: vec![],
+            reconcile: false,
+        });
+
+        {
+            let mut vs = ctx.tracked_vaults.write();
+            if let Some(v) = vs.get_mut(&pc_vault) {
+                v.pin = Some(GeyserPinReason::Wallet);
+                v.pinned = true;
+            }
+        }
+
+        ctx.apply_arb_track_requests_update(&ArbTrackRequestsUpdate {
+            version: 1,
+            ts_unix_ms: 2,
+            active: vec![],
+            removed: vec![ArbTrackRemovedEntry {
+                pool: pool.to_string(),
+                reason: ironcrab::nats::ArbTrackRemovedReason::Cooldown,
+            }],
+            reconcile: false,
+        });
+
+        let vs = ctx.tracked_vaults.read();
+        assert_eq!(vs.get(&coin_vault).and_then(|v| v.pin), None);
+        assert!(!vs.get(&coin_vault).is_some_and(|v| v.pinned));
+        assert_eq!(
+            vs.get(&pc_vault).and_then(|v| v.pin),
+            Some(GeyserPinReason::Wallet)
+        );
+        assert!(vs.get(&pc_vault).is_some_and(|v| v.pinned));
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -286,6 +286,17 @@ pub static MARKET_DATA_MOMENTUM_COALESCED_MESSAGES_TOTAL: Lazy<AtomicU64> =
 /// Merged `ApplyMomentumActivePools` batches enqueued to the tracking actor (PR169c).
 pub static MARKET_DATA_MOMENTUM_COALESCED_BATCHES_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// arb-strategy published `ArbTrackRequestsUpdate` payloads (Phase 3).
+pub static ARB_TRACK_REQUESTS_MESSAGES_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// market-data applied `ArbTrackRequestsUpdate` from core NATS (Phase 3).
+pub static MARKET_DATA_ARB_TRACK_REQUESTS_MESSAGES_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// NATS arb track updates absorbed by the pre-track-worker coalescer (Phase 3).
+pub static MARKET_DATA_ARB_TRACK_COALESCED_MESSAGES_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Merged `ApplyArbTrackRequests` batches enqueued to md-track-worker (Phase 3).
+pub static MARKET_DATA_ARB_TRACK_COALESCED_BATCHES_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// Vaults registered via arb multi-dex admission (no momentum pin).
 pub static MARKET_DATA_ARB_REGISTERED_VAULTS_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -484,6 +495,31 @@ pub fn inc_market_data_momentum_coalesced_messages_total() {
 #[inline]
 pub fn inc_market_data_momentum_coalesced_batches_total() {
     MARKET_DATA_MOMENTUM_COALESCED_BATCHES_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_arb_track_requests_messages_total() {
+    ARB_TRACK_REQUESTS_MESSAGES_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_market_data_arb_track_requests_messages_total() {
+    MARKET_DATA_ARB_TRACK_REQUESTS_MESSAGES_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_arb_track_coalesced_messages_total() {
+    MARKET_DATA_ARB_TRACK_COALESCED_MESSAGES_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_arb_track_coalesced_batches_total() {
+    MARKET_DATA_ARB_TRACK_COALESCED_BATCHES_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_arb_track_worker_enqueue_dropped_total() {
+    MARKET_DATA_ARB_TRACK_WORKER_ENQUEUE_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -764,6 +800,9 @@ pub static MARKET_DATA_TX_DEFERRED_DROPPED_TOTAL: Lazy<AtomicU64> = Lazy::new(||
 pub static MARKET_DATA_TRACK_WORKER_QUEUE_DEPTH: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// Phase-2b: momentum active pools enqueue dropped on full track-worker queue.
 pub static MARKET_DATA_MOMENTUM_TRACK_WORKER_ENQUEUE_DROPPED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Phase 3: arb track requests enqueue dropped on full track-worker queue.
+pub static MARKET_DATA_ARB_TRACK_WORKER_ENQUEUE_DROPPED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
 /// PR169a: single-writer Geyser tracking actor queue depth (gauge).
@@ -4260,6 +4299,22 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_momentum_coalesced_batches_total",
         MARKET_DATA_MOMENTUM_COALESCED_BATCHES_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_track_requests_messages_total",
+        ARB_TRACK_REQUESTS_MESSAGES_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_arb_track_requests_messages_total",
+        MARKET_DATA_ARB_TRACK_REQUESTS_MESSAGES_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_arb_track_coalesced_messages_total",
+        MARKET_DATA_ARB_TRACK_COALESCED_MESSAGES_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_arb_track_coalesced_batches_total",
+        MARKET_DATA_ARB_TRACK_COALESCED_BATCHES_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_arb_registered_vaults_total",

--- a/src/nats/arb_track_requests.rs
+++ b/src/nats/arb_track_requests.rs
@@ -1,0 +1,82 @@
+//! Core NATS fire-and-forget messages: arb-strategy → market-data Geyser pool pins (Phase 3).
+//!
+//! Spec: `Iron_crab-eval/docs/spec/ARB_TRACK_REQUESTS.md` (eval repo; wire format stable here).
+
+use serde::{Deserialize, Serialize};
+
+/// Wire payload for `ironcrab.v1.arb.track_requests` ([`crate::nats::topics::TOPIC_ARB_TRACK_REQUESTS`]).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArbTrackRequestsUpdate {
+    pub version: u32,
+    pub ts_unix_ms: u64,
+    pub active: Vec<ArbTrackActiveEntry>,
+    pub removed: Vec<ArbTrackRemovedEntry>,
+    /// When true, `active` is the authoritative full Arb pool set: market-data unpins any pool
+    /// it still holds under the Arb consumer that is not listed in `active`.
+    #[serde(default)]
+    pub reconcile: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArbTrackActiveEntry {
+    pub pool: String,
+    pub reason: ArbTrackActiveReason,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ArbTrackActiveReason {
+    Baseline,
+    MultiDex,
+    TradeSignal,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArbTrackRemovedEntry {
+    pub pool: String,
+    pub reason: ArbTrackRemovedReason,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ArbTrackRemovedReason {
+    Cooldown,
+    Stale,
+    Budget,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arb_track_requests_update_roundtrip_json() {
+        let u = ArbTrackRequestsUpdate {
+            version: 1,
+            ts_unix_ms: 1_700_000_000,
+            active: vec![ArbTrackActiveEntry {
+                pool: "Pool111111111111111111111111111111111111111".to_string(),
+                reason: ArbTrackActiveReason::MultiDex,
+            }],
+            removed: vec![ArbTrackRemovedEntry {
+                pool: "Pool222222222222222222222222222222222222222".to_string(),
+                reason: ArbTrackRemovedReason::Cooldown,
+            }],
+            reconcile: true,
+        };
+        let json = serde_json::to_string(&u).expect("serialize");
+        let back: ArbTrackRequestsUpdate = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(u, back);
+        assert!(back.reconcile);
+        assert!(json.contains("\"reason\":\"multi_dex\""));
+        assert!(json.contains("\"reason\":\"cooldown\""));
+        assert!(json.contains("\"reconcile\":true"));
+    }
+
+    #[test]
+    fn arb_track_requests_update_deserializes_without_reconcile_field() {
+        let json = r#"{"version":1,"ts_unix_ms":1,"active":[],"removed":[]}"#;
+        let u: ArbTrackRequestsUpdate = serde_json::from_str(json).expect("deserialize");
+        assert!(!u.reconcile);
+    }
+}

--- a/src/nats/mod.rs
+++ b/src/nats/mod.rs
@@ -9,11 +9,13 @@
 //! - ControlRequests (control-plane ↔ execution-engine)
 //! - PoolCacheUpdates (market-data → execution-engine + arb-strategy via JetStream)
 
+pub mod arb_track_requests;
 pub mod client;
 pub mod jetstream;
 pub mod momentum_active_pools;
 pub mod topics;
 
+pub use arb_track_requests::*;
 pub use client::*;
 pub use jetstream::*;
 pub use momentum_active_pools::*;

--- a/src/nats/topics.rs
+++ b/src/nats/topics.rs
@@ -18,6 +18,9 @@ pub const TOPIC_MOMENTUM_MARKET_EVENTS: &str = "ironcrab.v1.market_events.moment
 /// Momentum active pool lifecycle (mint+pool pins for Geyser reserve subscription; PR-D).
 pub const TOPIC_MOMENTUM_ACTIVE_POOLS: &str = "ironcrab.v1.momentum.active_pools";
 
+/// Arb strategy-owned Geyser pool pins (pool-centric; Phase 3 hybrid rollback).
+pub const TOPIC_ARB_TRACK_REQUESTS: &str = "ironcrab.v1.arb.track_requests";
+
 /// Trade intents from strategy bots
 pub const TOPIC_TRADE_INTENTS: &str = "ironcrab.v1.trade_intents";
 
@@ -145,6 +148,14 @@ mod tests {
         assert!(TOPIC_MOMENTUM_ACTIVE_POOLS.contains(TOPIC_VERSION));
         assert!(TOPIC_MOMENTUM_ACTIVE_POOLS.contains("momentum"));
         assert!(TOPIC_MOMENTUM_ACTIVE_POOLS.contains("active_pools"));
+    }
+
+    #[test]
+    fn test_arb_track_requests_topic_versioned() {
+        assert!(TOPIC_ARB_TRACK_REQUESTS.starts_with(TOPIC_PREFIX));
+        assert!(TOPIC_ARB_TRACK_REQUESTS.contains(TOPIC_VERSION));
+        assert!(TOPIC_ARB_TRACK_REQUESTS.contains("arb"));
+        assert!(TOPIC_ARB_TRACK_REQUESTS.contains("track_requests"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Hybrid Plan Phase 3** — strategy-owned Arb Geyser pins via NATS, symmetric to Momentum Phase 2b.

### Scope A — Wire format
- New `src/nats/arb_track_requests.rs` with `ArbTrackRequestsUpdate`, active/removed entries, reason enums, `reconcile` flag
- `TOPIC_ARB_TRACK_REQUESTS = ironcrab.v1.arb.track_requests`

### Scope B — market-data consumer
- NATS subscribe + coalesce channel → `track_worker_try_enqueue(ApplyArbTrackRequests)`
- Pool-centric apply on `md-track-worker`: reconcile snapshot, active pins (`ArbMultiDex`), removed with wallet/momentum protection
- Extended `UnifiedHotPoolRegistry` with `arb_pools` set
- **No** `md_state` enqueue for Arb

### Scope C — arb-strategy publisher
- `spawn_publish_arb_track_requests` (async NATS publish)
- Baseline reconcile timer (~60s default, configurable)
- Incremental `multi_dex` on pool-cache seed; `trade_signal` on 2-hop opportunity

### Scope D — 2-hop off hot loop
- Dedicated `arb_two_hop_worker` channel; MarketEvent worker only enqueues trade jobs
- `multi_hop.enqueue_pool_price_update` unchanged (enqueue-only)

### Scope E — Tests + docs
- `phase3_arb_track_requests_nats_uses_track_worker_not_md_state`
- `phase3_apply_arb_track_requests_respects_wallet_pins`
- `phase3_arb_track_requests_publish_serializes_reconcile_flag`
- `HYBRID-PHASE3` entry in `docs/BUGS_FIXES.md`

## STOP-CHECK (performed)
- **I-7**: No RPC in track-worker / NATS subscriber / Geyser ingest hot path; LivePoolCache miss → debug + deferred
- **Pattern**: Mirrors momentum coalesce + `md-track-worker` apply
- **I-9**: No simulation-gate changes
- **Level-5**: No eval test reads

## Verification
```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
cargo test --bin market-data phase3_
cargo test --bin arb-strategy phase3_
```

Eval Level 5 runs in Impl CI against sibling eval.

**No deploy** in this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-680eec25-ff9e-4657-9d90-0ba516865a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-680eec25-ff9e-4657-9d90-0ba516865a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

