### PR TITLE
fix(momentum): Phase4 positions wallet SSOT P1-P2-P4

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -1587,3 +1587,15 @@ BUY cost bevorzugt jetzt value_sol (fill_in) — die tatsächlich für den Swap 
 | **Betroffene Module** | `src/nats/arb_track_requests.rs`, `src/bin/market_data.rs`, `src/bin/arb_strategy.rs`, `src/metrics.rs` |
 | **Regression-Prüfung** | `cargo fmt`, `cargo clippy -D warnings`, `cargo test`, `phase3_*`; Eval Level 5. |
 | **Tags** | [arb-strategy, market-data, hybrid-rollback, phase3, i-4e, nats, track-worker, pr242] |
+
+---
+
+## HYBRID-PHASE4: Momentum Position/Wallet SSOT P1–P2–P4 (2026-06-25)
+
+| Symptom | Ghost positions / exit sizing drift when JetStream `WalletBalanceSnapshot` races with confirmed `ExecutionResult` fills. |
+|---------|-----------------------------------------------------------------------------------------------------------------------------|
+| **Root Cause** | Dual-path balance authority: Scope 57 preferred wallet snapshot over `PositionTracker` for exit sizing; snapshot `balance=0` could auto-close Live positions before SELL confirm. |
+| **Fix** | (P1) Audit `docs/PHASE4_BALANCE_SOURCE_AUDIT.md`. (P2) Confirmed BUY/SELL mutates `token_amount` only via `ExecutionResult`; snapshot hint-only + guarded zero-close for `WalletSnapshot` entry source. (P4) `momentum_wallet_balance_divergence_lamports{mint}` + `momentum_wallet_balance_divergence_total`. |
+| **Betroffene Module** | `src/bin/momentum_bot.rs`, `src/metrics.rs`, `docs/PHASE4_BALANCE_SOURCE_AUDIT.md` |
+| **Regression-Prüfung** | `cargo fmt`, `cargo clippy -D warnings`, `cargo test`, `cargo test phase4_`; Eval Level 5. |
+| **Tags** | [momentum-bot, hybrid-rollback, phase4, wallet-ssot, i-13, ghost-positions, pr-phase4] |

--- a/docs/PHASE4_BALANCE_SOURCE_AUDIT.md
+++ b/docs/PHASE4_BALANCE_SOURCE_AUDIT.md
@@ -1,0 +1,50 @@
+# Phase 4 — Balance / Position Source Audit (P1)
+
+**Plan:** `Iron_crab-eval/docs/plans/plan_hybrid_rollback_tracking_architecture_20260623.md` §6.2–6.3  
+**Datum:** 2026-06-25  
+**Scope:** `momentum_bot.rs` — Strategy-Position (`PositionTracker`) vs JetStream `WalletBalanceSnapshot`
+
+## SSOT-Ziel (Plan §6.2)
+
+| Concern | SSOT |
+|---------|------|
+| On-chain Wallet Balance | JetStream `WalletBalanceSnapshot` + Geyser (market-data publiziert) |
+| Offene Position (Strategy) | `PositionTracker` + **bestätigte** `ExecutionResult` fills |
+| Pool-Preis | Trades / PoolCache mit I-13 (`source_pool == position.pool`) |
+
+**P2-Regel:** Geyser/JetStream-Snapshot ist **Hint / Plausibilität / Divergence-Metrik** — darf bestätigte `token_amount` nicht rückwärts überschreiben. Ausnahme: explizite Cold/Bootstrap-Pfade (Orphan, Wallet-Reconcile).
+
+## Mutations- und Lese-Sites
+
+| Site (fn/Modul) | Liest/Mutiert | Aktuelle Quelle | Soll-SSOT | P2-Aktion |
+|-----------------|---------------|-----------------|-----------|-----------|
+| `handle_execution_result` — BUY `Confirmed` (pending path) | Mutiert `PositionTracker.token_amount` via `open_position` | `ExecutionResult.fill_out.raw`, `fill_in` / `wallet_sol_delta` für SOL | ExecutionResult | **Behalten** — SSOT; nach Confirm Hint-Cache auf Fill setzen |
+| `handle_execution_result` — SELL `Confirmed` (pending path) | Reduziert `token_amount` oder `close_position` | `ExecutionResult.fill_in.raw` (sold), partial vs full | ExecutionResult | **Behalten** — SSOT; Hint-Cache auf `remaining` / remove |
+| `handle_execution_result` — Orphan BUY `Confirmed` | `open_position` scale-in / new | `fill_out.raw`, routing aus Position/TokenTracker/metadata | ExecutionResult | **Behalten** — Cold recovery; idempotent via `orphaned_recovered_intent_ids` |
+| `handle_execution_result` — Liquidation SELL `Confirmed` | `close_position` | External EE intent; kein pending | ExecutionResult (EE) | **Behalten** — Regression only (I-24d) |
+| `open_position` | `token_amount` add / new `PositionTracker` | Caller params (aus ExecutionResult im Live-Pfad) | ExecutionResult | **Behalten** — einzige Live-Mutations-API |
+| `close_position` | Entfernt Position | Caller (SELL confirm / guarded snapshot) | ExecutionResult (Live) | **Behalten**; Divergence-Gauge für Mint clearen |
+| `resolve_exit_token_amount_raw` | Liest sizing für SELL-Intent | War: JetStream-Snapshot bevorzugt (Scope 57) | Position `token_amount` (confirmed) | **P2:** Overlay SSOT; Snapshot nur Fallback + Divergence |
+| `cache_wallet_balance_snapshot_raw` | Schreibt `latest_wallet_balance_raw_by_mint` | JetStream / ExecutionResult Hint | Hint only | **Behalten** — kein direktes Position-Overwrite |
+| `process_market_event` — `WalletBalanceSnapshot` balance > 0, Position existiert | Liest Position; cache Snapshot | Snapshot + Position verify log | Position SSOT | **P2:** Divergence-Metrik; **kein** `token_amount`-Write |
+| `process_market_event` — `WalletBalanceSnapshot` balance = 0 | `close_position` (auto) | Snapshot zero | ExecutionResult für `Live` | **P2:** Auto-close nur `WalletSnapshot`-Entry oder kein pending SELL |
+| `process_market_event` — `WalletBalanceSnapshot` balance > 0, keine Position | `build_reconciled_position` / `orphaned_mints` | Snapshot + pool registry | Snapshot (Cold bootstrap) | **Behalten** — dokumentiert Cold Path |
+| `process_market_event` — `WalletSnapshotComplete` | Ghost cleanup `positions.remove` | Wallet scan mint set | Cold reconcile | **Behalten** — Grace 90s; kein Hot-Path-RPC |
+| `bootstrap_wallet_snapshot_from_jetstream` | Replay Snapshots; `positions.retain` | JetStream replay | Cold bootstrap | **Behalten** — Startup only |
+| `register_pool` / `try_orphan_reconcile` | `build_reconciled_position` | `orphaned_mints` + Snapshot balance | Cold bootstrap | **Behalten** |
+| `build_reconciled_position` | Neue Position `token_amount = balance_raw` | Wallet snapshot + `mint_pools` | Snapshot (Cold) | **Behalten** — `entry_source = WalletSnapshot` |
+| `recover_positions_from_jsonl` + KV merge (startup) | `token_amount` merge | JSONL ExecutionResults > KV | ExecutionResult (Cold) | **Behalten** — bereits JSONL-authoritative |
+| `check_for_exits` / `publish_sell_intent` | Liest `token_amount` via `resolve_exit_token_amount_raw` | Position + Hint | Position SSOT | **P2** via `resolve_exit_token_amount_raw` |
+| **execution-engine** `LockManager` (`set_available_token_balance`, `add_available_token_balance`) | EE token balance für Locks / max_open | ExecutionResult confirm + Geyser snapshot | EE: ExecutionResult SSOT (parallel P2 in EE) | **Nicht in diesem PR** — Momentum hat keinen LockManager; Metrik vergleicht Position vs Snapshot |
+
+## Divergence-Metrik (P4)
+
+`momentum_wallet_balance_divergence_lamports{mint}` — signed `position.token_amount - snapshot.balance_raw` für offene Positionen; `momentum_wallet_balance_divergence_total` bei neuem Drift-Event.
+
+Cardinality: nur Mints mit offener Position und `divergence != 0`.
+
+## Referenzen
+
+- KNOWN_BUG_PATTERNS #5 (Ghost Positions) — dual-path balance updates
+- FIX-17 — `fill_in` / `fill_out` Kette für entry_price und sizing
+- Scope 57 Kommentar `latest_wallet_balance_raw_by_mint` — nach P2: Hint, nicht Authority für confirmed size

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -3240,7 +3240,8 @@ struct MomentumContext {
     /// Scope 56: in-memory idempotency for duplicate JetStream / replayed ExecutionResults
     /// on the orphaned-BUY path (no durable store in this scope).
     orphaned_recovered_intent_ids: parking_lot::RwLock<BoundedIntentIdCache>,
-    /// Scope 57: latest JetStream `WalletBalanceSnapshot` per mint (authority hint for exit sizing; I-7 no RPC).
+    /// Phase 4 P2: latest JetStream `WalletBalanceSnapshot` per mint — **hint / plausibility only**
+    /// (I-7 no RPC). Confirmed position `token_amount` comes from `ExecutionResult`, not snapshot.
     latest_wallet_balance_raw_by_mint: parking_lot::RwLock<HashMap<String, u64>>,
     /// Stats — **unique mints** with at least one pool-scoped tracker row (not one increment per pool row).
     tokens_tracked: std::sync::atomic::AtomicU64,
@@ -5803,6 +5804,8 @@ impl MomentumContext {
             self.flush_momentum_active_pool_publish_queue();
         }
 
+        ironcrab::metrics::clear_momentum_wallet_balance_divergence_for_mint(mint);
+
         // Delete from KV asynchronously (fire-and-forget)
         let ctx = Arc::clone(self);
         tokio::spawn(async move {
@@ -6951,7 +6954,38 @@ impl MomentumContext {
             .insert(mint.to_string(), balance_raw);
     }
 
-    /// Scope 57 interim exit sizing (PA-5 follow-up): prefer JetStream wallet snapshot when overlay drifts.
+    fn has_pending_sell_for_mint(&self, mint: &str) -> bool {
+        self.pending_intents
+            .read()
+            .values()
+            .any(|p| p.mint == mint && matches!(p.side, TradeSide::Sell))
+    }
+
+    /// Phase 4 P4: record signed drift between confirmed position size and wallet snapshot hint.
+    fn record_wallet_balance_divergence_if_any(
+        &self,
+        mint: &str,
+        position_balance_raw: u64,
+        snapshot_balance_raw: u64,
+    ) {
+        if position_balance_raw == snapshot_balance_raw {
+            ironcrab::metrics::clear_momentum_wallet_balance_divergence_for_mint(mint);
+            return;
+        }
+        let signed = i64::try_from(position_balance_raw as i128 - snapshot_balance_raw as i128)
+            .unwrap_or(i64::MAX);
+        ironcrab::metrics::set_momentum_wallet_balance_divergence_lamports(mint, signed);
+        ironcrab::metrics::record_momentum_wallet_balance_divergence_total();
+        warn!(
+            mint = %mint,
+            position_balance_raw,
+            snapshot_balance_raw,
+            signed_delta_raw = signed,
+            "Wallet balance divergence: confirmed position size != JetStream snapshot hint"
+        );
+    }
+
+    /// Phase 4 P2: confirmed `PositionTracker.token_amount` is SSOT for exit sizing; snapshot is hint.
     fn resolve_exit_token_amount_raw(&self, mint: &str, hint_amount: u64) -> u64 {
         let overlay = self
             .positions
@@ -6961,18 +6995,26 @@ impl MomentumContext {
             .filter(|t| *t > 0)
             .unwrap_or(hint_amount);
 
-        match self
+        let snapshot = self
             .latest_wallet_balance_raw_by_mint
             .read()
             .get(mint)
             .copied()
-            .filter(|a| *a > 0)
-        {
-            Some(auth) => auth,
-            None => {
-                ironcrab::metrics::record_momentum_exit_amount_overlay_only_total();
-                overlay
+            .filter(|a| *a > 0);
+
+        if overlay > 0 {
+            if let Some(snap) = snapshot {
+                self.record_wallet_balance_divergence_if_any(mint, overlay, snap);
+            } else {
+                ironcrab::metrics::clear_momentum_wallet_balance_divergence_for_mint(mint);
             }
+            overlay
+        } else if let Some(snap) = snapshot {
+            ironcrab::metrics::record_momentum_exit_amount_overlay_only_total();
+            snap
+        } else {
+            ironcrab::metrics::record_momentum_exit_amount_overlay_only_total();
+            overlay
         }
     }
 
@@ -7572,6 +7614,7 @@ impl MomentumContext {
                             entry_confirmed_slot: entry_confirmed_slot_from_execution(result),
                             initial_bonding,
                         });
+                        self.cache_wallet_balance_snapshot_raw(&pending.mint, token_amount);
                         let ctx_exit = Arc::clone(self);
                         tokio::spawn(async move {
                             ctx_exit.process_exit_signals(None).await;
@@ -7679,6 +7722,9 @@ impl MomentumContext {
                                 realized_pnl_pct = format!("{:.2}%", realized_pnl_pct),
                                 "✅ SELL CONFIRMED - Closing position"
                             );
+                            self.latest_wallet_balance_raw_by_mint
+                                .write()
+                                .remove(&pending.mint);
                             self.close_position(&pending.mint);
                         }
                     }
@@ -18021,6 +18067,8 @@ mod tests {
     }
 
     /// Scope 57: exit sizing prefers JetStream wallet snapshot when overlay understates holdings.
+    /// Phase 4 P2 supersedes Scope 57: confirmed `PositionTracker.token_amount` is exit SSOT;
+    /// wallet snapshot is hint-only (divergence metric), not authority when overlay is smaller.
     #[tokio::test]
     async fn scope57_exit_amount_uses_wallet_authority_when_overlay_smaller() {
         let tmp = TempDir::new().expect("tempdir");
@@ -18068,8 +18116,8 @@ mod tests {
         let line = content.lines().last().expect("intent line");
         let intent: TradeIntent = serde_json::from_str(line).expect("parse TradeIntent");
         assert_eq!(
-            intent.required_capital.raw, wallet_total,
-            "exit must use wallet authority when overlay is probe-only"
+            intent.required_capital.raw, probe_only,
+            "Phase 4: exit must use confirmed position overlay, not wallet snapshot hint"
         );
     }
 
@@ -18807,6 +18855,155 @@ mod tests {
         assert_eq!(applied, 1);
         let pos = ctx.positions.read().get(mint).unwrap().clone();
         assert_eq!(pos.last_price_slot, 201);
+    }
+
+    fn wallet_balance_snapshot_event(mint: &str, balance_raw: u64, decimals: u8) -> MarketEvent {
+        MarketEvent {
+            header: RecordHeader::new("test", BUILD_VERSION, "run-test"),
+            event_id: format!("wbs-{mint}-{balance_raw}"),
+            source: "market-data".into(),
+            slot: Some(1),
+            kind: MarketEventKind::WalletBalanceSnapshot {
+                mint: mint.to_string(),
+                balance_raw,
+                decimals,
+                token_program: SPL_TOKEN_PROGRAM.to_string(),
+            },
+        }
+    }
+
+    /// Phase 4 P2: confirmed BUY fill_out is SSOT; a later Geyser snapshot must not resize the position.
+    #[tokio::test]
+    async fn phase4_confirmed_buy_size_from_execution_result_not_geyser_snapshot() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+
+        let mint = "Phase4BuyMintttttttttttttttttttttttttttttt";
+        let pool = "Phase4BuyPoolttttttttttttttttttttttttttttt";
+        ctx.register_pool(mint, pool, "raydium", 1);
+        ctx.register_buy_intent(
+            "buy-phase4-001",
+            mint,
+            pool,
+            "raydium",
+            1_000_000,
+            Some(EntryKind::Probe),
+        );
+
+        let confirmed_fill_raw = 5_432_100u64;
+        let stale_snapshot_raw = 9_999_999u64;
+        let result = ExecutionResult {
+            header: RecordHeader::new("test", BUILD_VERSION, "run-test"),
+            execution_id: "ex-phase4-buy".to_string(),
+            decision_id: "dec-phase4-buy".to_string(),
+            intent_id: "buy-phase4-001".to_string(),
+            source: "momentum-bot".to_string(),
+            token_mint: Some(mint.to_string()),
+            signature: Some("sig-phase4-buy".to_string()),
+            bundle_id: None,
+            status: ExecutionStatus::Confirmed,
+            fill_in: Some(ExplicitAmount::new(1_000_000, 9)),
+            fill_out: Some(ExplicitAmount::new(confirmed_fill_raw, 6)),
+            fill_status: Some(FillStatus::Complete),
+            fill_unavailable_reason: None,
+            confirmed_slot: Some(42),
+            block_time_unix_ms: None,
+            fees: None,
+            pnl: None,
+            wallet_sol_delta_lamports: Some(-1_000_000),
+            error_message: None,
+            error_code: None,
+            latency_ms: Some(1),
+            metadata: std::collections::HashMap::new(),
+        };
+
+        Arc::clone(&ctx).handle_execution_result(&result);
+        assert_eq!(
+            ctx.positions.read().get(mint).unwrap().token_amount,
+            confirmed_fill_raw
+        );
+
+        process_market_event(
+            &ctx,
+            &wallet_balance_snapshot_event(mint, stale_snapshot_raw, 6),
+            false,
+        )
+        .await
+        .expect("wallet snapshot");
+
+        assert_eq!(
+            ctx.positions.read().get(mint).unwrap().token_amount,
+            confirmed_fill_raw,
+            "stale JetStream snapshot must not overwrite confirmed BUY fill size"
+        );
+        assert_eq!(
+            ctx.resolve_exit_token_amount_raw(mint, confirmed_fill_raw),
+            confirmed_fill_raw,
+            "exit sizing must follow confirmed position, not snapshot hint"
+        );
+    }
+
+    /// Phase 4 P2: wallet snapshot is hint-only for existing Live positions (no clobber / no zero-close).
+    #[tokio::test]
+    async fn phase4_wallet_snapshot_does_not_clobber_confirmed_position_balance() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+
+        let mint = "Phase4ClobMintttttttttttttttttttttttttttttt";
+        let pool = "Phase4ClobPoolttttttttttttttttttttttttttttt";
+        let confirmed_raw = 2_000_000u64;
+        let drift_snapshot_raw = 9_000_000u64;
+
+        ctx.open_position(OpenPositionParams {
+            mint,
+            pool,
+            dex: "raydium",
+            entry_price: 1.0,
+            token_decimals: 6,
+            token_amount: confirmed_raw,
+            sol_invested: 1_000_000,
+            token_program: None,
+            creator: None,
+            entry_confirmed_slot: 10,
+            initial_bonding: None,
+        });
+
+        process_market_event(
+            &ctx,
+            &wallet_balance_snapshot_event(mint, drift_snapshot_raw, 6),
+            false,
+        )
+        .await
+        .expect("wallet snapshot drift");
+
+        assert_eq!(
+            ctx.positions.read().get(mint).unwrap().token_amount,
+            confirmed_raw,
+            "snapshot must not overwrite confirmed position token_amount"
+        );
+        assert_eq!(
+            ctx.resolve_exit_token_amount_raw(mint, confirmed_raw),
+            confirmed_raw
+        );
+        assert!(
+            ctx.positions.read().contains_key(mint),
+            "Live position must remain open when snapshot drifts higher"
+        );
+
+        process_market_event(&ctx, &wallet_balance_snapshot_event(mint, 0, 6), false)
+            .await
+            .expect("wallet snapshot zero");
+
+        assert!(
+            ctx.positions.read().contains_key(mint),
+            "Live position must not auto-close on snapshot zero — close only via ExecutionResult"
+        );
+        assert_eq!(
+            ctx.positions.read().get(mint).unwrap().token_amount,
+            confirmed_raw
+        );
     }
 }
 
@@ -19710,19 +19907,48 @@ async fn process_market_event(
 
             if *balance_raw == 0 {
                 ctx.latest_wallet_balance_raw_by_mint.write().remove(mint);
-                // Remove ghost position if wallet balance is zero
-                let was_tracked = {
-                    let mut positions = ctx.positions.write();
-                    positions.remove(mint).is_some()
+                let close_decision = {
+                    let positions = ctx.positions.read();
+                    match positions.get(mint) {
+                        None => (false, false),
+                        Some(pos) => {
+                            let allow_snapshot_zero_close = pos.entry_source
+                                == PositionEntrySource::WalletSnapshot
+                                && !ctx.has_pending_sell_for_mint(mint);
+                            (true, allow_snapshot_zero_close)
+                        }
+                    }
                 };
-                // FIX-35: Also remove from orphaned_mints if it was waiting for reconciliation
-                ctx.orphaned_mints.write().remove(mint);
-                if was_tracked {
-                    info!(
-                        mint = %mint,
-                        "🧹 Position auto-closed: WalletBalanceSnapshot shows balance=0 (manual sale or external transfer)"
-                    );
-                    ctx.delete_position_from_kv(mint).await;
+                if close_decision.1 {
+                    let should_delete_kv = {
+                        let mut positions = ctx.positions.write();
+                        if positions.remove(mint).is_some() {
+                            info!(
+                                mint = %mint,
+                                "🧹 Position auto-closed: WalletBalanceSnapshot shows balance=0 (wallet-reconciled position)"
+                            );
+                            true
+                        } else {
+                            false
+                        }
+                    };
+                    if should_delete_kv {
+                        ctx.orphaned_mints.write().remove(mint);
+                        ironcrab::metrics::clear_momentum_wallet_balance_divergence_for_mint(mint);
+                        ctx.delete_position_from_kv(mint).await;
+                    }
+                } else if close_decision.0 {
+                    if let Some(pos) = ctx.positions.read().get(mint) {
+                        if pos.token_amount > 0 {
+                            ctx.record_wallet_balance_divergence_if_any(mint, pos.token_amount, 0);
+                            debug!(
+                                mint = %mint,
+                                position_balance_raw = pos.token_amount,
+                                "WalletBalanceSnapshot balance=0 ignored for Live position — awaiting ExecutionResult close"
+                            );
+                        }
+                    }
+                    ctx.orphaned_mints.write().remove(mint);
                 } else {
                     debug!(
                         mint = %mint,
@@ -19733,10 +19959,17 @@ async fn process_market_event(
                 // Position exists in wallet - verify we're tracking it
                 let has_position = { ctx.positions.read().contains_key(mint) };
                 if has_position {
+                    if let Some(pos) = ctx.positions.read().get(mint) {
+                        ctx.record_wallet_balance_divergence_if_any(
+                            mint,
+                            pos.token_amount,
+                            *balance_raw,
+                        );
+                    }
                     debug!(
                         mint = %mint,
                         balance_raw = *balance_raw,
-                        "✅ WalletBalanceSnapshot: position verified in wallet"
+                        "✅ WalletBalanceSnapshot: position verified in wallet (hint only; no size overwrite)"
                     );
                 } else if let Some(reconciled) =
                     ctx.build_reconciled_position(mint, *balance_raw, *decimals)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2,7 +2,7 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request, Response, Server};
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, AtomicU64, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
@@ -2086,6 +2086,35 @@ pub fn record_momentum_orphan_scale_in_recovery_total() {
 #[inline]
 pub fn record_momentum_exit_amount_overlay_only_total() {
     MOMENTUM_EXIT_AMOUNT_OVERLAY_ONLY_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Per-mint signed divergence: `position.token_amount_raw - wallet_snapshot.balance_raw`.
+/// Cardinality bounded to open positions with non-zero drift (pruned on close / align).
+pub static MOMENTUM_WALLET_BALANCE_DIVERGENCE_BY_MINT: Lazy<RwLock<HashMap<String, i64>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+pub static MOMENTUM_WALLET_BALANCE_DIVERGENCE_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn set_momentum_wallet_balance_divergence_lamports(mint: &str, signed_raw_delta: i64) {
+    let mut map = MOMENTUM_WALLET_BALANCE_DIVERGENCE_BY_MINT.write();
+    if signed_raw_delta == 0 {
+        map.remove(mint);
+    } else {
+        map.insert(mint.to_string(), signed_raw_delta);
+    }
+}
+
+#[inline]
+pub fn clear_momentum_wallet_balance_divergence_for_mint(mint: &str) {
+    MOMENTUM_WALLET_BALANCE_DIVERGENCE_BY_MINT
+        .write()
+        .remove(mint);
+}
+
+#[inline]
+pub fn record_momentum_wallet_balance_divergence_total() {
+    MOMENTUM_WALLET_BALANCE_DIVERGENCE_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Scale-in gate blocked reason (Prometheus label `reason`).
@@ -4864,6 +4893,17 @@ async fn metrics_response() -> Response<Body> {
         "momentum_exit_amount_overlay_only_total",
         MOMENTUM_EXIT_AMOUNT_OVERLAY_ONLY_TOTAL.load(Ordering::Relaxed)
     );
+    line!(
+        "momentum_wallet_balance_divergence_total",
+        MOMENTUM_WALLET_BALANCE_DIVERGENCE_TOTAL.load(Ordering::Relaxed)
+    );
+    for (mint, delta) in MOMENTUM_WALLET_BALANCE_DIVERGENCE_BY_MINT.read().iter() {
+        out.push_str("momentum_wallet_balance_divergence_lamports{mint=\"");
+        out.push_str(mint);
+        out.push_str("\"} ");
+        out.push_str(&delta.to_string());
+        out.push('\n');
+    }
     out.push_str("momentum_scale_in_gate_blocked_total{reason=\"missing_probe_state\"} ");
     out.push_str(
         &MOMENTUM_SCALE_IN_GATE_BLOCKED_MISSING_PROBE_STATE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 4 fixes Momentum ↔ Wallet coherence per hybrid rollback plan §6.3.

### P1 — Audit
- New `docs/PHASE4_BALANCE_SOURCE_AUDIT.md` listing all balance read/mutation sites with target SSOT and P2 actions.

### P2 — ExecutionResult as mutations SSOT
- Confirmed BUY/SELL mutates `PositionTracker.token_amount` only via `ExecutionResult` (`fill_out` / `fill_in`).
- `resolve_exit_token_amount_raw` prefers confirmed position overlay; JetStream snapshot is hint/plausibility only.
- `WalletBalanceSnapshot` no longer clobbers Live position size; `balance=0` auto-close only for `WalletSnapshot` entry source (cold reconcile).
- Hint cache updated from ExecutionResult on BUY confirm; cleared on full SELL confirm.

### P4 — Divergence metric
- `momentum_wallet_balance_divergence_lamports{mint}` — signed `position - snapshot` for open positions.
- `momentum_wallet_balance_divergence_total` counter on drift events.

## Tests
- `phase4_confirmed_buy_size_from_execution_result_not_geyser_snapshot`
- `phase4_wallet_snapshot_does_not_clobber_confirmed_position_balance`
- Updated Scope 57 exit test to reflect P2 (position SSOT over snapshot hint)

## Verification
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅
- `cargo test phase4_` ✅ (2 tests)

## STOP-CHECK
- I-7: No RPC added to hot path
- I-9: Simulation gate untouched
- Scope: `momentum_bot.rs`, `metrics.rs`, docs only — no `market_data.rs`

## Docs
- `docs/BUGS_FIXES.md` — HYBRID-PHASE4 entry

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec97c7f4-8acc-4b23-8641-6aed44cf3e32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec97c7f4-8acc-4b23-8641-6aed44cf3e32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

