### PR TITLE
fix: Arb event-pipeline stall + Momentum ghost positions (prod hotfix)

### DIFF
--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -43,7 +43,7 @@ use ironcrab::ipc::{
     TradeResources, TradeSide, TradingRegime,
 };
 use ironcrab::metrics::{
-    arb_event_worker_stall_inc, arb_strategy_bootstrap_skip_inc, arb_strategy_bootstrap_warmup_set,
+    arb_strategy_bootstrap_skip_inc, arb_strategy_bootstrap_warmup_set,
     arb_strategy_pool_cache_update_seeded_inc, arb_strategy_pool_cache_update_seen_inc,
     arb_strategy_pool_cache_update_skip_no_seed_inc,
     arb_strategy_pool_cache_update_skip_non_arb_quote_inc, arb_subscriber_high_dropped_inc,
@@ -218,8 +218,6 @@ const ARB_HIGH_EVENT_QUEUE_CAP: usize = 8192;
 const ARB_LOW_COALESCER_CAP: usize = 2048;
 /// Heartbeat warns when HIGH queue depth exceeds this fraction of capacity.
 const ARB_HIGH_QUEUE_WARN_PCT: u64 = 80;
-/// Max time a HIGH-priority market-event may block the worker before stall accounting.
-const ARB_EVENT_WORKER_HIGH_TIMEOUT: Duration = Duration::from_secs(5);
 
 static DLMM_MARGINAL_PRICE_REJECTED_TOTAL: AtomicU64 = AtomicU64::new(0);
 
@@ -2441,32 +2439,14 @@ async fn process_arb_market_event(
     event: MarketEvent,
     priority: ArbEventPriority,
 ) {
-    let process = async {
-        MARKET_EVENTS_CONSUMED_TOTAL.fetch_add(1, Ordering::Relaxed);
-        match priority {
-            ArbEventPriority::High => arb_subscriber_high_processed_inc(),
-            ArbEventPriority::Low => arb_subscriber_low_processed_inc(),
-        }
+    MARKET_EVENTS_CONSUMED_TOTAL.fetch_add(1, Ordering::Relaxed);
+    match priority {
+        ArbEventPriority::High => arb_subscriber_high_processed_inc(),
+        ArbEventPriority::Low => arb_subscriber_low_processed_inc(),
+    }
 
-        if let Some(intent) = handle_market_event(ctx, &event).await {
-            publish_arb_intent(ctx, &intent).await;
-        }
-    };
-
-    if priority == ArbEventPriority::High {
-        match tokio::time::timeout(ARB_EVENT_WORKER_HIGH_TIMEOUT, process).await {
-            Ok(()) => {}
-            Err(_) => {
-                arb_event_worker_stall_inc();
-                warn!(
-                    timeout_secs = ARB_EVENT_WORKER_HIGH_TIMEOUT.as_secs(),
-                    event_id = %event.event_id,
-                    "arb HIGH market-event worker timed out (continuing pipeline)"
-                );
-            }
-        }
-    } else {
-        process.await;
+    if let Some(intent) = handle_market_event(ctx, &event).await {
+        publish_arb_intent(ctx, &intent).await;
     }
 }
 
@@ -3290,27 +3270,42 @@ impl ArbContext {
                 "Vault balances updated"
             );
         }
+        drop(cache);
 
         // Mirror SOL liquidity + reserve flag into per-mint pool trackers (Geyser-only, no RPC)
         let liquidity_sol = Decimal::from(reserve_quote) / Decimal::from(1_000_000_000u64);
+        let mints_with_pool: Vec<String> = self
+            .trackers
+            .read()
+            .iter()
+            .filter(|(_, tracker)| tracker.pools.contains_key(pool_address))
+            .map(|(mint, _)| mint.clone())
+            .collect();
+        if mints_with_pool.is_empty() {
+            return;
+        }
         let mut trackers = self.trackers.write();
-        for tracker in trackers.values_mut() {
-            if let Some(pool) = tracker.pools.get_mut(pool_address) {
-                pool.liquidity_sol = liquidity_sol;
-                pool.has_reserve_data = reserve_base > 0 && reserve_quote > 0;
-                pool.last_update = Instant::now();
-                if let Some(token_decimals) = tracker.token_decimals {
-                    if reserves_plausible_for_comparable_price(
-                        reserve_base,
-                        reserve_quote,
-                        token_decimals,
-                        &tracker.base_mint,
-                    ) {
-                        if let Some(mid) =
-                            reserve_mid_sol_per_token(reserve_base, reserve_quote, token_decimals)
-                        {
-                            pool.last_price = Some(mid);
-                        }
+        for mint in mints_with_pool {
+            let Some(tracker) = trackers.get_mut(&mint) else {
+                continue;
+            };
+            let Some(pool) = tracker.pools.get_mut(pool_address) else {
+                continue;
+            };
+            pool.liquidity_sol = liquidity_sol;
+            pool.has_reserve_data = reserve_base > 0 && reserve_quote > 0;
+            pool.last_update = Instant::now();
+            if let Some(token_decimals) = tracker.token_decimals {
+                if reserves_plausible_for_comparable_price(
+                    reserve_base,
+                    reserve_quote,
+                    token_decimals,
+                    &tracker.base_mint,
+                ) {
+                    if let Some(mid) =
+                        reserve_mid_sol_per_token(reserve_base, reserve_quote, token_decimals)
+                    {
+                        pool.last_price = Some(mid);
                     }
                 }
             }

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -43,23 +43,24 @@ use ironcrab::ipc::{
     TradeResources, TradeSide, TradingRegime,
 };
 use ironcrab::metrics::{
-    arb_strategy_bootstrap_skip_inc, arb_strategy_bootstrap_warmup_set,
+    arb_event_worker_stall_inc, arb_strategy_bootstrap_skip_inc, arb_strategy_bootstrap_warmup_set,
     arb_strategy_pool_cache_update_seeded_inc, arb_strategy_pool_cache_update_seen_inc,
     arb_strategy_pool_cache_update_skip_no_seed_inc,
-    arb_strategy_pool_cache_update_skip_non_arb_quote_inc, arb_subscriber_high_processed_inc,
-    arb_subscriber_high_queue_depth_set, arb_subscriber_low_coalesced_inc,
-    arb_subscriber_low_dropped_inc, arb_subscriber_low_processed_inc,
-    arb_subscriber_low_queue_depth_set, arb_subscriber_pool_created_skipped_inc,
-    arb_two_hop_eligible_dexes_add, arb_two_hop_eligible_pools_by_dex_add,
-    arb_two_hop_insufficient_subreason_inc, arb_two_hop_opportunity_inc, arb_two_hop_pool_gate_add,
-    arb_two_hop_reject_subreason_inc, arb_two_hop_rejected_inc,
-    arb_two_hop_tracker_seeded_pools_add, record_arb_track_requests_messages_total, serve_metrics,
-    set_readiness_nats_connected, wall_clock_unix_ms_now, ArbStrategyWarmupSkipReason,
-    ArbTwoHopInsufficientSubreason, ArbTwoHopPoolGate, ArbTwoHopRejectReason,
-    ArbTwoHopRejectSubreason, MetricsComponent, ARB_REJECTED_MISSING_ACCOUNTS,
-    ARB_TRIANGLE_OPPORTUNITIES, INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL,
-    NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE,
-    TOKENS_TRACKED_GAUGE,
+    arb_strategy_pool_cache_update_skip_non_arb_quote_inc, arb_subscriber_high_dropped_inc,
+    arb_subscriber_high_processed_inc, arb_subscriber_high_queue_depth_set,
+    arb_subscriber_low_coalesced_inc, arb_subscriber_low_dropped_inc,
+    arb_subscriber_low_processed_inc, arb_subscriber_low_queue_depth_set,
+    arb_subscriber_pool_created_skipped_inc, arb_two_hop_eligible_dexes_add,
+    arb_two_hop_eligible_pools_by_dex_add, arb_two_hop_insufficient_subreason_inc,
+    arb_two_hop_opportunity_inc, arb_two_hop_pool_gate_add, arb_two_hop_reject_subreason_inc,
+    arb_two_hop_rejected_inc, arb_two_hop_tracker_seeded_pools_add,
+    record_arb_track_requests_messages_total, serve_metrics, set_readiness_nats_connected,
+    wall_clock_unix_ms_now, ArbStrategyWarmupSkipReason, ArbTwoHopInsufficientSubreason,
+    ArbTwoHopPoolGate, ArbTwoHopRejectReason, ArbTwoHopRejectSubreason, MetricsComponent,
+    ARB_REJECTED_MISSING_ACCOUNTS, ARB_SUBSCRIBER_HIGH_PROCESSED_TOTAL,
+    ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH, ARB_TRIANGLE_OPPORTUNITIES, INTENTS_GENERATED_TOTAL,
+    MARKET_EVENTS_CONSUMED_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL,
+    POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, pool_cache_live_fallback_consumer_config,
@@ -215,6 +216,10 @@ const ELIGIBILITY_PENDING_CAP: usize = 256;
 const ARB_HIGH_EVENT_QUEUE_CAP: usize = 8192;
 /// Max distinct LOW-priority pool keys coalesced before latest-wins eviction.
 const ARB_LOW_COALESCER_CAP: usize = 2048;
+/// Heartbeat warns when HIGH queue depth exceeds this fraction of capacity.
+const ARB_HIGH_QUEUE_WARN_PCT: u64 = 80;
+/// Max time a HIGH-priority market-event may block the worker before stall accounting.
+const ARB_EVENT_WORKER_HIGH_TIMEOUT: Duration = Duration::from_secs(5);
 
 static DLMM_MARGINAL_PRICE_REJECTED_TOTAL: AtomicU64 = AtomicU64::new(0);
 
@@ -1348,7 +1353,7 @@ struct PoolState {
 }
 
 /// Tracks same token across multiple DEXes
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct TokenArbTracker {
     base_mint: String,
     /// Pool states keyed by pool_address (multiple pools per DEX allowed)
@@ -2314,6 +2319,44 @@ impl ArbLowEventCoalescer {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HighEnqueueOutcome {
+    Enqueued,
+    DowngradedToLow,
+    Dropped,
+    ChannelClosed,
+}
+
+/// Non-blocking HIGH ingress: never block the NATS reader on a full queue.
+fn try_enqueue_high_priority(
+    high_tx: &mpsc::Sender<MarketEvent>,
+    low_coalescer: &parking_lot::Mutex<ArbLowEventCoalescer>,
+    low_notify: &tokio::sync::Notify,
+    event: MarketEvent,
+) -> HighEnqueueOutcome {
+    let depth = ARB_HIGH_EVENT_QUEUE_CAP.saturating_sub(high_tx.capacity());
+    arb_subscriber_high_queue_depth_set(depth as u64);
+
+    match high_tx.try_send(event) {
+        Ok(()) => HighEnqueueOutcome::Enqueued,
+        Err(tokio::sync::mpsc::error::TrySendError::Full(event)) => {
+            if market_event_pool_key(&event).is_some() {
+                let mut coalescer = low_coalescer.lock();
+                coalescer.insert(event, ARB_LOW_COALESCER_CAP);
+                arb_subscriber_low_queue_depth_set(coalescer.len() as u64);
+                drop(coalescer);
+                low_notify.notify_one();
+                arb_subscriber_high_dropped_inc();
+                HighEnqueueOutcome::DowngradedToLow
+            } else {
+                arb_subscriber_high_dropped_inc();
+                HighEnqueueOutcome::Dropped
+            }
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => HighEnqueueOutcome::ChannelClosed,
+    }
+}
+
 /// Off-hot-loop 2-hop detection job (Scope D).
 #[derive(Debug, Clone)]
 struct ArbTwoHopTradeJob {
@@ -2398,14 +2441,32 @@ async fn process_arb_market_event(
     event: MarketEvent,
     priority: ArbEventPriority,
 ) {
-    MARKET_EVENTS_CONSUMED_TOTAL.fetch_add(1, Ordering::Relaxed);
-    match priority {
-        ArbEventPriority::High => arb_subscriber_high_processed_inc(),
-        ArbEventPriority::Low => arb_subscriber_low_processed_inc(),
-    }
+    let process = async {
+        MARKET_EVENTS_CONSUMED_TOTAL.fetch_add(1, Ordering::Relaxed);
+        match priority {
+            ArbEventPriority::High => arb_subscriber_high_processed_inc(),
+            ArbEventPriority::Low => arb_subscriber_low_processed_inc(),
+        }
 
-    if let Some(intent) = handle_market_event(ctx, &event).await {
-        publish_arb_intent(ctx, &intent).await;
+        if let Some(intent) = handle_market_event(ctx, &event).await {
+            publish_arb_intent(ctx, &intent).await;
+        }
+    };
+
+    if priority == ArbEventPriority::High {
+        match tokio::time::timeout(ARB_EVENT_WORKER_HIGH_TIMEOUT, process).await {
+            Ok(()) => {}
+            Err(_) => {
+                arb_event_worker_stall_inc();
+                warn!(
+                    timeout_secs = ARB_EVENT_WORKER_HIGH_TIMEOUT.as_secs(),
+                    event_id = %event.event_id,
+                    "arb HIGH market-event worker timed out (continuing pipeline)"
+                );
+            }
+        }
+    } else {
+        process.await;
     }
 }
 
@@ -2443,13 +2504,19 @@ fn spawn_arb_market_event_pipeline(
 
             match priority {
                 ArbEventPriority::High => {
-                    let depth = ARB_HIGH_EVENT_QUEUE_CAP.saturating_sub(high_tx.capacity());
-                    arb_subscriber_high_queue_depth_set(depth as u64);
-                    if high_tx.try_send(event.clone()).is_err()
-                        && high_tx.send(event).await.is_err()
-                    {
-                        warn!("arb-strategy HIGH event queue closed; stopping NATS reader");
-                        break;
+                    match try_enqueue_high_priority(
+                        &high_tx,
+                        &reader_coalescer,
+                        &reader_notify,
+                        event,
+                    ) {
+                        HighEnqueueOutcome::ChannelClosed => {
+                            warn!("arb-strategy HIGH event queue closed; stopping NATS reader");
+                            break;
+                        }
+                        HighEnqueueOutcome::Enqueued
+                        | HighEnqueueOutcome::DowngradedToLow
+                        | HighEnqueueOutcome::Dropped => {}
                     }
                     arb_subscriber_high_queue_depth_set(
                         ARB_HIGH_EVENT_QUEUE_CAP.saturating_sub(high_tx.capacity()) as u64,
@@ -3518,81 +3585,8 @@ impl ArbContext {
         );
 
         let config = self.config.read().clone();
-        let mut trackers = self.trackers.write();
-
-        // Get or create tracker for this mint
-        let tracker = trackers.entry(mint.to_string()).or_insert_with(|| {
-            info!(mint = %mint, "Creating tracker from Trade event (no PoolCreated)");
-            TokenArbTracker {
-                base_mint: mint.to_string(),
-                pools: HashMap::new(),
-                pool_accounts: HashMap::new(),
-                token_program: None,
-                token_decimals: None,
-                last_intent_time: None,
-            }
-        });
-
-        tracker.token_decimals = Some(token_decimals);
-
-        let effective_dex = if !dex.is_empty() && dex != "unknown" {
-            dex.to_string()
-        } else {
-            pool_address.to_string()
-        };
-
-        let pool = tracker
-            .pools
-            .entry(pool_address.to_string())
-            .or_insert_with(|| {
-                info!(pool = %pool_address, mint = %mint, dex = %effective_dex, "Creating pool from Trade event");
-                PoolState {
-                    pool_address: pool_address.to_string(),
-                    dex: effective_dex.clone(),
-                    liquidity_sol: Decimal::ZERO,
-                    has_reserve_data: false,
-                    last_price: None,
-                    trade_price_buy: None,
-                    trade_price_sell: None,
-                    trade_count: 0,
-                    last_update: Instant::now(),
-                    dex_accounts: None,
-                }
-            });
-
-        if is_buy {
-            pool.trade_price_buy = Some(price);
-        } else {
-            pool.trade_price_sell = Some(price);
-        }
-        let vault_reserves = self
-            .vault_balances
-            .read()
-            .get(pool_address)
-            .map(|c| (c.reserve_base, c.reserve_quote));
-        let vault_entry = self.vault_balances.read().get(pool_address).cloned();
-        let dlmm_bins = self.bin_arrays.read().get(pool_address).cloned();
-        pool.last_price = comparable_price_sol_per_token(
-            pool,
-            vault_reserves,
-            Some(token_decimals),
-            mint,
-            vault_entry.as_ref(),
-            dlmm_bins.as_ref(),
-            ComparablePriceSide::Buy,
-        );
-        pool.trade_count += 1;
-        pool.last_update = Instant::now();
-        trace!(
-            pool = %pool_address,
-            mint = %mint,
-            dex = %pool.dex,
-            comparable_price = ?pool.last_price,
-            "Pool comparable price updated"
-        );
 
         // Global Geyser connection health check (replaces per-pool staleness)
-        // If no MarketEvents received for 30s, connection is broken - don't trade
         if !self.is_geyser_connection_healthy() {
             warn!(
                 mint = %mint,
@@ -3602,11 +3596,87 @@ impl ArbContext {
             return None;
         }
 
-        // Check for arbitrage opportunity (with known_pools filter)
+        let vault_reserves = self
+            .vault_balances
+            .read()
+            .get(pool_address)
+            .map(|c| (c.reserve_base, c.reserve_quote));
+        let vault_entry = self.vault_balances.read().get(pool_address).cloned();
+        let dlmm_bins = self.bin_arrays.read().get(pool_address).cloned();
+
+        let tracker_snapshot = {
+            let mut trackers = self.trackers.write();
+
+            let tracker = trackers.entry(mint.to_string()).or_insert_with(|| {
+                info!(mint = %mint, "Creating tracker from Trade event (no PoolCreated)");
+                TokenArbTracker {
+                    base_mint: mint.to_string(),
+                    pools: HashMap::new(),
+                    pool_accounts: HashMap::new(),
+                    token_program: None,
+                    token_decimals: None,
+                    last_intent_time: None,
+                }
+            });
+
+            tracker.token_decimals = Some(token_decimals);
+
+            let effective_dex = if !dex.is_empty() && dex != "unknown" {
+                dex.to_string()
+            } else {
+                pool_address.to_string()
+            };
+
+            let pool = tracker
+                .pools
+                .entry(pool_address.to_string())
+                .or_insert_with(|| {
+                    info!(pool = %pool_address, mint = %mint, dex = %effective_dex, "Creating pool from Trade event");
+                    PoolState {
+                        pool_address: pool_address.to_string(),
+                        dex: effective_dex.clone(),
+                        liquidity_sol: Decimal::ZERO,
+                        has_reserve_data: false,
+                        last_price: None,
+                        trade_price_buy: None,
+                        trade_price_sell: None,
+                        trade_count: 0,
+                        last_update: Instant::now(),
+                        dex_accounts: None,
+                    }
+                });
+
+            if is_buy {
+                pool.trade_price_buy = Some(price);
+            } else {
+                pool.trade_price_sell = Some(price);
+            }
+            pool.last_price = comparable_price_sol_per_token(
+                pool,
+                vault_reserves,
+                Some(token_decimals),
+                mint,
+                vault_entry.as_ref(),
+                dlmm_bins.as_ref(),
+                ComparablePriceSide::Buy,
+            );
+            pool.trade_count += 1;
+            pool.last_update = Instant::now();
+            trace!(
+                pool = %pool_address,
+                mint = %mint,
+                dex = %pool.dex,
+                comparable_price = ?pool.last_price,
+                "Pool comparable price updated"
+            );
+
+            tracker.clone()
+        };
+
         let known_pools = self.known_pools.read();
         let vault_balances = self.vault_balances.read();
         let bin_arrays = self.bin_arrays.read();
-        if let Some(opp) = tracker.check_arbitrage(
+        let opp = tracker_snapshot.check_arbitrage(
             &config,
             &known_pools,
             &vault_balances,
@@ -3616,21 +3686,20 @@ impl ArbContext {
                 data_quality_rejects: &self.data_quality_rejects,
                 forensics: Some(&self.eligibility_forensics),
             },
-        ) {
-            // Check cooldown
-            let cooldown = Duration::from_millis(config.intent_cooldown_ms);
-            if let Some(last_time) = tracker.last_intent_time {
-                if last_time.elapsed() < cooldown {
-                    return None;
-                }
-            }
+        )?;
 
-            tracker.last_intent_time = Some(Instant::now());
-            self.opportunities_found.fetch_add(1, Ordering::Relaxed);
-            return Some(opp);
+        let cooldown = Duration::from_millis(config.intent_cooldown_ms);
+        let mut trackers = self.trackers.write();
+        let tracker = trackers.get_mut(mint)?;
+        if let Some(last_time) = tracker.last_intent_time {
+            if last_time.elapsed() < cooldown {
+                return None;
+            }
         }
 
-        None
+        tracker.last_intent_time = Some(Instant::now());
+        self.opportunities_found.fetch_add(1, Ordering::Relaxed);
+        Some(opp)
     }
 
     /// Get pool accounts for both buy and sell pools
@@ -4397,6 +4466,8 @@ async fn main() -> Result<()> {
     let mut arb_track_reconcile_interval =
         tokio::time::interval(Duration::from_secs(arb_reconcile_secs.max(10)));
     arb_track_reconcile_interval.tick().await;
+    let mut last_heartbeat_events_received = 0u64;
+    let mut last_heartbeat_high_processed = 0u64;
 
     loop {
         tokio::select! {
@@ -4568,8 +4639,37 @@ async fn main() -> Result<()> {
                 ctx.prune_arb_track_stale_pools();
                 TOKENS_TRACKED_GAUGE.store(trackers.len() as u64, Ordering::Relaxed);
 
+                let high_queue_depth = ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH.load(Ordering::Relaxed);
+                let high_processed = ARB_SUBSCRIBER_HIGH_PROCESSED_TOTAL.load(Ordering::Relaxed);
+                let events_received = ctx.events_received.load(Ordering::Relaxed);
+                let high_queue_cap = ARB_HIGH_EVENT_QUEUE_CAP as u64;
+                if high_queue_depth.saturating_mul(100) / high_queue_cap.max(1)
+                    >= ARB_HIGH_QUEUE_WARN_PCT
+                {
+                    warn!(
+                        high_queue_depth,
+                        high_queue_cap,
+                        high_processed,
+                        "arb HIGH event queue above 80% capacity"
+                    );
+                }
+                let events_delta = events_received.saturating_sub(last_heartbeat_events_received);
+                let high_processed_delta =
+                    high_processed.saturating_sub(last_heartbeat_high_processed);
+                if events_delta > 0 && high_processed_delta == 0 && high_queue_depth > high_queue_cap / 2
+                {
+                    warn!(
+                        events_delta,
+                        high_queue_depth,
+                        high_processed,
+                        "arb event pipeline may be stalled (events received but HIGH queue not draining)"
+                    );
+                }
+                last_heartbeat_events_received = events_received;
+                last_heartbeat_high_processed = high_processed;
+
                 info!(
-                    events_received = ctx.events_received.load(Ordering::Relaxed),
+                    events_received,
                     pools_tracked = ctx.pools_tracked.load(Ordering::Relaxed),
                     tokens_tracked = trackers.len(),
                     multi_dex_tokens = multi_dex_tokens,
@@ -4587,6 +4687,8 @@ async fn main() -> Result<()> {
                     multi_hop_enabled = ctx.multi_hop.is_enabled(),
                     arb_track_requests_published =
                         ctx.arb_track_published.load(Ordering::Relaxed),
+                    high_queue_depth,
+                    high_processed,
                     "arb-strategy heartbeat (SLAVE cache sync from market-data MASTER)"
                 );
             }
@@ -5041,6 +5143,65 @@ mod event_pipeline_tests {
         tx.try_send(event)
             .expect("HIGH trade must enqueue without drop");
         assert!(rx.try_recv().is_ok());
+    }
+
+    #[test]
+    fn high_priority_channel_drops_or_downgrades_when_full_instead_of_blocking() {
+        let (tx, _rx) = mpsc::channel::<MarketEvent>(2);
+        let coalescer = parking_lot::Mutex::new(ArbLowEventCoalescer::new());
+        let notify = tokio::sync::Notify::new();
+
+        let trade_a = sample_trade_event("pool-trade-a");
+        let trade_b = sample_trade_event("pool-trade-b");
+        let pool_state_event = MarketEvent::new(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            "evt-psu-full".to_string(),
+            "geyser",
+            Some(1),
+            MarketEventKind::PoolStateUpdate {
+                pool_address: "pool-known-full".to_string(),
+                dex: "orca".to_string(),
+                reserve_base: 1,
+                reserve_quote: 1,
+                update_slot: 1,
+                active_id: None,
+                bin_step: None,
+                base_mint: NATIVE_SOL_MINT.to_string(),
+                quote_mint: "TokenMint11111111111111111111111111111111".to_string(),
+            },
+        );
+
+        assert_eq!(
+            try_enqueue_high_priority(&tx, &coalescer, &notify, trade_a),
+            HighEnqueueOutcome::Enqueued
+        );
+        assert_eq!(
+            try_enqueue_high_priority(&tx, &coalescer, &notify, trade_b),
+            HighEnqueueOutcome::Enqueued
+        );
+        assert_eq!(tx.capacity(), 0, "HIGH channel must be full");
+
+        let before_dropped =
+            ironcrab::metrics::ARB_SUBSCRIBER_HIGH_DROPPED_TOTAL.load(Ordering::Relaxed);
+        assert_eq!(
+            try_enqueue_high_priority(&tx, &coalescer, &notify, pool_state_event),
+            HighEnqueueOutcome::DowngradedToLow
+        );
+        assert_eq!(tx.capacity(), 0);
+        assert_eq!(coalescer.lock().len(), 1);
+        assert!(
+            ironcrab::metrics::ARB_SUBSCRIBER_HIGH_DROPPED_TOTAL.load(Ordering::Relaxed)
+                > before_dropped
+        );
+
+        let trade_overflow = sample_trade_event("pool-trade-overflow");
+        assert_eq!(
+            try_enqueue_high_priority(&tx, &coalescer, &notify, trade_overflow),
+            HighEnqueueOutcome::DowngradedToLow
+        );
+        assert_eq!(coalescer.lock().len(), 2);
     }
 }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -5593,6 +5593,16 @@ async fn publish_wallet_snapshot(
         "✅ Wallet snapshot bootstrap published (RPC: getMultipleAccounts + startup owner-scan)"
     );
 
+    if is_periodic {
+        ironcrab::metrics::market_data_wallet_snapshot_periodic_published_inc();
+        info!(
+            wallet = %wallet_str,
+            mints_in_wallet = mints_in_wallet.len(),
+            is_periodic = true,
+            "📸 Periodic wallet snapshot published"
+        );
+    }
+
     Ok(())
 }
 
@@ -7641,6 +7651,20 @@ async fn run_geyser_loop(
         return Ok(());
     }
 
+    let wallet_snapshot_periodic_secs = std::env::var("IRONCRAB_WALLET_SNAPSHOT_PERIODIC_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|secs| *secs >= 60)
+        .unwrap_or(600);
+    let mut wallet_snapshot_periodic_interval = tokio::time::interval(
+        std::time::Duration::from_secs(wallet_snapshot_periodic_secs),
+    );
+    wallet_snapshot_periodic_interval.tick().await;
+    info!(
+        interval_secs = wallet_snapshot_periodic_secs,
+        "Periodic wallet snapshot timer enabled (cold path)"
+    );
+
     // Mint metadata fetch pipeline:
     // - We add mints to `tracked_mints` when we see them via tx/pool discovery.
     // - Mint accounts often *never change*, so relying on a future Geyser account update
@@ -8750,6 +8774,30 @@ async fn run_geyser_loop(
                             warn!(error = %e, "Failed to deserialize ConfigUpdate");
                         }
                     }
+                }
+            }
+
+            // Periodic wallet snapshot (cold path) for momentum ghost reconciliation.
+            _ = wallet_snapshot_periodic_interval.tick() => {
+                if let Some(ref tracked_wallet) = ctx.tracked_wallet {
+                    let ctx_spawn = Arc::clone(&ctx);
+                    let rpc_spawn = Arc::clone(&rpc);
+                    let md_state_spawn = md_state.clone();
+                    let wallet = tracked_wallet.wallet;
+                    tokio::spawn(async move {
+                        if let Err(e) = publish_wallet_snapshot(
+                            &ctx_spawn,
+                            &rpc_spawn,
+                            &wallet,
+                            true,
+                            false,
+                            &md_state_spawn,
+                        )
+                        .await
+                        {
+                            warn!(error = %e, "Periodic wallet snapshot publish failed");
+                        }
+                    });
                 }
             }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4777,6 +4777,115 @@ mod execution_result_sell_close_tests {
 /// background task so the caller can reach the main loop and systemd watchdog pings before slow
 /// cold-path RPC completes. When true (`wallet_snapshot_only`), verification is awaited so the
 /// one-shot process exits with work finished.
+async fn publish_wallet_snapshot_stale_jetstream_cleanup(
+    ctx: &MarketDataContext,
+    nats: &NatsClient,
+    wallet_str: &str,
+    published_mint_set: &HashSet<String>,
+) {
+    use async_nats::jetstream;
+    use futures::StreamExt;
+
+    let js = jetstream::new(nats.client().clone());
+    let Ok(stream) = js.get_stream(WALLET_SNAPSHOT_STREAM_NAME).await else {
+        debug!(
+            stream = WALLET_SNAPSHOT_STREAM_NAME,
+            "Stale cleanup: WALLET_SNAPSHOT stream not found"
+        );
+        return;
+    };
+
+    let mut cleanup_consumer_config = wallet_snapshot_consumer_config();
+    cleanup_consumer_config.filter_subject = format!("ironcrab.wallet_snapshot.{}.*", wallet_str);
+    let Ok(consumer) = stream.create_consumer(cleanup_consumer_config).await else {
+        warn!("Stale cleanup: failed to create consumer");
+        return;
+    };
+
+    let mut stale_cleaned = 0usize;
+    let mut total_checked = 0usize;
+
+    loop {
+        let Ok(mut messages) = consumer.fetch().max_messages(500).messages().await else {
+            warn!("Stale cleanup: fetch failed");
+            break;
+        };
+
+        let mut batch_count = 0usize;
+
+        while let Some(msg) = messages.next().await {
+            let Ok(msg) = msg else {
+                warn!("Stale cleanup: error fetching message");
+                continue;
+            };
+
+            batch_count += 1;
+            total_checked += 1;
+
+            let Ok(event) = serde_json::from_slice::<MarketEvent>(&msg.payload) else {
+                let _ = msg.ack().await;
+                continue;
+            };
+
+            if let MarketEventKind::WalletBalanceSnapshot {
+                mint,
+                balance_raw,
+                decimals,
+                token_program: tp,
+            } = &event.kind
+            {
+                if mint != WSOL_MINT && *balance_raw > 0 && !published_mint_set.contains(mint) {
+                    let override_event = MarketEvent::new(
+                        "market-data",
+                        BUILD_VERSION,
+                        &ctx.run_id,
+                        format!("wallet_snapshot_stale_cleanup_{}", mint),
+                        "wallet_bootstrap_stale_cleanup",
+                        None,
+                        MarketEventKind::WalletBalanceSnapshot {
+                            mint: mint.clone(),
+                            balance_raw: 0,
+                            decimals: *decimals,
+                            token_program: tp.clone(),
+                        },
+                    );
+
+                    let subject = wallet_snapshot_subject(wallet_str, mint);
+                    if let Err(e) = nats.jetstream_publish(&subject, &override_event).await {
+                        warn!(error = %e, mint = %mint, "Stale cleanup: failed to publish zero-balance override to JetStream");
+                    }
+
+                    stale_cleaned += 1;
+                    info!(
+                        mint = %mint,
+                        old_balance = *balance_raw,
+                        "Stale cleanup: cleared ghost position (ATA no longer exists, balance → 0)"
+                    );
+                }
+            }
+
+            let _ = msg.ack().await;
+        }
+
+        if batch_count < 500 {
+            break;
+        }
+    }
+
+    if stale_cleaned > 0 {
+        info!(
+            stale_cleaned,
+            total_checked, "✅ Stale JetStream cleanup: cleared ghost positions from previous runs"
+        );
+    } else if total_checked > 0 {
+        debug!(
+            total_checked,
+            published = published_mint_set.len(),
+            "Stale cleanup: no ghost positions found (all entries are fresh)"
+        );
+    }
+}
+
 async fn publish_wallet_snapshot(
     ctx: &Arc<MarketDataContext>,
     rpc: &Arc<SolanaRpc>,
@@ -4906,20 +5015,19 @@ async fn publish_wallet_snapshot(
         // Token holdings will be learned event-driven (ExecutionResults + Geyser).
     }
 
-    // 1.5) Owner-Scan Discovery: getTokenAccountsByOwner (startup only)
+    // 1.5) Owner-Scan Discovery: getTokenAccountsByOwner (bootstrap + periodic cold path)
     //
     // JetStream only knows mints that were previously tracked. If the bot was offline and
     // tokens were bought externally (Phantom, Jupiter) or a previous run had broken ATA
     // tracking, those mints won't be in JetStream.
     //
     // This owner-scan discovers ALL token accounts in the wallet, merges them with known
-    // mints, and ensures the startup snapshot reflects the true on-chain wallet state.
-    // This is a legitimate startup-only RPC call (2 calls: SPL Token + Token-2022).
-    // It runs at every startup but NOT for periodic refreshes.
-    // Capture WSOL balance from owner-scan for JetStream bootstrap (set inside if !is_periodic)
+    // mints, and ensures the snapshot reflects the true on-chain wallet state.
+    // Cold-path RPC (2 calls: SPL Token + Token-2022) — allowed on startup and periodic timer.
+    // Capture WSOL balance from owner-scan for JetStream bootstrap (startup SOL/WSOL publish only).
     let mut bootstrap_wsol_balance: Option<u64> = None;
 
-    if !is_periodic {
+    {
         use solana_client::rpc_request::TokenAccountsFilter;
 
         let mut discovered_from_owner_scan: Vec<(Pubkey, u64, Pubkey)> = Vec::new(); // (mint, balance, token_program)
@@ -5225,139 +5333,21 @@ async fn publish_wallet_snapshot(
         ctx.write_market_event_jsonl(&event);
     }
 
-    // 2.5) Stale JetStream Cleanup: Override ghost entries not covered by bootstrap.
+    // 2.5) Stale JetStream Cleanup: Override ghost entries not covered by bootstrap/periodic scan.
     //
-    // MAX_BOOTSTRAP_MINTS limits how many mints are processed above.
     // JetStream may contain entries for mints that were sold/closed in previous runs,
-    // but never got their zero-balance override because they exceeded the cap.
-    // This step reads ALL remaining JetStream entries and publishes zero-balance
-    // overrides for any non-zero mints not already covered. No additional RPC calls.
-    if !is_periodic {
-        if let Some(ref nats) = ctx.nats {
-            let published_mint_set: HashSet<String> =
-                known_mints.iter().map(|m| m.to_string()).collect();
-
-            let js = jetstream::new(nats.client().clone());
-            match js.get_stream(WALLET_SNAPSHOT_STREAM_NAME).await {
-                Ok(stream) => {
-                    let mut cleanup_consumer_config = wallet_snapshot_consumer_config();
-                    cleanup_consumer_config.filter_subject =
-                        format!("ironcrab.wallet_snapshot.{}.*", wallet_str);
-                    match stream.create_consumer(cleanup_consumer_config).await {
-                        Ok(consumer) => {
-                            let mut stale_cleaned = 0usize;
-                            let mut total_checked = 0usize;
-
-                            loop {
-                                let mut messages =
-                                    match consumer.fetch().max_messages(500).messages().await {
-                                        Ok(m) => m,
-                                        Err(e) => {
-                                            warn!(error = %e, "Stale cleanup: fetch failed");
-                                            break;
-                                        }
-                                    };
-
-                                let mut batch_count = 0usize;
-
-                                while let Some(msg) = messages.next().await {
-                                    let msg = match msg {
-                                        Ok(m) => m,
-                                        Err(e) => {
-                                            warn!(error = %e, "Stale cleanup: error fetching message");
-                                            continue;
-                                        }
-                                    };
-
-                                    batch_count += 1;
-                                    total_checked += 1;
-
-                                    let event: MarketEvent =
-                                        match serde_json::from_slice(&msg.payload) {
-                                            Ok(e) => e,
-                                            Err(_) => {
-                                                let _ = msg.ack().await;
-                                                continue;
-                                            }
-                                        };
-
-                                    if let MarketEventKind::WalletBalanceSnapshot {
-                                        mint,
-                                        balance_raw,
-                                        decimals,
-                                        token_program: tp,
-                                    } = &event.kind
-                                    {
-                                        if mint != WSOL_MINT
-                                            && *balance_raw > 0
-                                            && !published_mint_set.contains(mint)
-                                        {
-                                            // Stale entry: publish zero-balance override
-                                            let override_event = MarketEvent::new(
-                                                "market-data",
-                                                BUILD_VERSION,
-                                                &ctx.run_id,
-                                                format!("wallet_snapshot_stale_cleanup_{}", mint),
-                                                "wallet_bootstrap_stale_cleanup",
-                                                None,
-                                                MarketEventKind::WalletBalanceSnapshot {
-                                                    mint: mint.clone(),
-                                                    balance_raw: 0,
-                                                    decimals: *decimals,
-                                                    token_program: tp.clone(),
-                                                },
-                                            );
-
-                                            let subject =
-                                                wallet_snapshot_subject(&wallet_str, mint);
-                                            if let Err(e) = nats
-                                                .jetstream_publish(&subject, &override_event)
-                                                .await
-                                            {
-                                                warn!(error = %e, mint = %mint, "Stale cleanup: failed to publish zero-balance override to JetStream");
-                                            }
-
-                                            stale_cleaned += 1;
-                                            info!(
-                                                mint = %mint,
-                                                old_balance = *balance_raw,
-                                                "Stale cleanup: cleared ghost position (ATA no longer exists, balance → 0)"
-                                            );
-                                        }
-                                    }
-
-                                    let _ = msg.ack().await;
-                                }
-
-                                if batch_count < 500 {
-                                    break;
-                                }
-                            }
-
-                            if stale_cleaned > 0 {
-                                info!(
-                                    stale_cleaned,
-                                    total_checked,
-                                    "✅ Stale JetStream cleanup: cleared ghost positions from previous runs"
-                                );
-                            } else if total_checked > 0 {
-                                debug!(
-                                    total_checked,
-                                    published = published_mint_set.len(),
-                                    "Stale cleanup: no ghost positions found (all entries are fresh)"
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            warn!(error = %e, "Stale cleanup: failed to create consumer");
-                        }
-                    }
-                }
-                Err(e) => {
-                    debug!(error = %e, "Stale cleanup: WALLET_SNAPSHOT stream not found");
-                }
-            }
-        }
+    // but never got their zero-balance override. Publish zero-balance overrides for any
+    // non-zero mints not already covered. No additional RPC calls.
+    if let Some(ref nats) = ctx.nats {
+        let published_mint_set: HashSet<String> =
+            known_mints.iter().map(|m| m.to_string()).collect();
+        publish_wallet_snapshot_stale_jetstream_cleanup(
+            ctx.as_ref(),
+            nats,
+            &wallet_str,
+            &published_mint_set,
+        )
+        .await;
     }
 
     // 3) Update tracked wallet accounts for Geyser subscription (wallet + WSOL + token ATAs).

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -9131,11 +9131,133 @@ async fn recover_positions_from_jsonl(
     Ok(positions)
 }
 
+fn record_wallet_snapshot_latest(
+    latest_by_mint: &mut HashMap<String, (u64, u64)>,
+    mint: &str,
+    balance_raw: u64,
+    ts_unix_ms: u64,
+) {
+    if is_non_tradeable_momentum_mint(mint) {
+        return;
+    }
+    latest_by_mint
+        .entry(mint.to_string())
+        .and_modify(|(bal, prev_ts)| {
+            if ts_unix_ms >= *prev_ts {
+                *bal = balance_raw;
+                *prev_ts = ts_unix_ms;
+            }
+        })
+        .or_insert((balance_raw, ts_unix_ms));
+}
+
+fn mint_has_positive_wallet_balance(
+    mint: &str,
+    latest_by_mint: &HashMap<String, (u64, u64)>,
+) -> bool {
+    latest_by_mint.get(mint).is_some_and(|(bal, _)| *bal > 0)
+}
+
+/// Preload latest per-mint wallet balances from JetStream (last-write-wins on `ts_unix_ms`).
+async fn fetch_latest_wallet_balance_hints_from_jetstream(
+    nats: &NatsClient,
+) -> HashMap<String, u64> {
+    use async_nats::jetstream;
+    use futures::StreamExt;
+
+    let jetstream = jetstream::new(nats.client().clone());
+    let Ok(stream) = jetstream.get_stream(WALLET_SNAPSHOT_STREAM_NAME).await else {
+        return HashMap::new();
+    };
+    let Ok(consumer) = stream
+        .create_consumer(wallet_snapshot_consumer_config())
+        .await
+    else {
+        return HashMap::new();
+    };
+
+    let mut latest_by_mint: HashMap<String, (u64, u64)> = HashMap::new();
+    let batch_size = 1000;
+
+    loop {
+        let Ok(mut messages) = consumer.fetch().max_messages(batch_size).messages().await else {
+            break;
+        };
+        let mut batch_count = 0;
+
+        while let Some(msg) = messages.next().await {
+            let Ok(msg) = msg else { continue };
+            batch_count += 1;
+
+            let Ok(event) = serde_json::from_slice::<MarketEvent>(&msg.payload) else {
+                let _ = msg.ack().await;
+                continue;
+            };
+
+            if let MarketEventKind::WalletBalanceSnapshot {
+                mint, balance_raw, ..
+            } = &event.kind
+            {
+                record_wallet_snapshot_latest(
+                    &mut latest_by_mint,
+                    mint,
+                    *balance_raw,
+                    event.header.ts_unix_ms,
+                );
+            }
+
+            let _ = msg.ack().await;
+        }
+
+        if batch_count < batch_size {
+            break;
+        }
+    }
+
+    latest_by_mint
+        .into_iter()
+        .map(|(mint, (balance, _))| (mint, balance))
+        .collect()
+}
+
+async fn startup_wallet_ghost_reconciliation(ctx: &Arc<MomentumContext>) {
+    let mints_in_wallet: Vec<String> = ctx
+        .latest_wallet_balance_raw_by_mint
+        .read()
+        .iter()
+        .filter(|(mint, balance)| **balance > 0 && !is_non_tradeable_momentum_mint(mint))
+        .map(|(mint, _)| mint.clone())
+        .collect();
+
+    if ctx.latest_wallet_balance_raw_by_mint.read().is_empty() {
+        debug!("startup wallet reconciliation skipped: no JetStream wallet hints loaded");
+        return;
+    }
+
+    let wallet = std::env::var("IRONCRAB_WALLET_PUBKEY").unwrap_or_default();
+    let event = MarketEvent::new(
+        "momentum-bot",
+        BUILD_VERSION,
+        &ctx.run_id,
+        "wallet_snapshot_complete_startup".to_string(),
+        "startup_reconcile",
+        None,
+        MarketEventKind::WalletSnapshotComplete {
+            mints_in_wallet,
+            wallet,
+            is_periodic: false,
+        },
+    );
+
+    if let Err(e) = process_market_event(ctx, &event, false).await {
+        warn!(error = %e, "startup WalletSnapshotComplete reconciliation failed");
+    }
+}
+
 /// Bootstrap WalletBalanceSnapshot events from JetStream (race-free recovery)
 async fn bootstrap_wallet_snapshot_from_jetstream(ctx: &Arc<MomentumContext>) -> Result<usize> {
     use async_nats::jetstream;
     use futures::StreamExt;
-    use std::collections::HashSet;
 
     let Some(ref nats_client) = ctx.nats else {
         return Ok(0);
@@ -9158,7 +9280,7 @@ async fn bootstrap_wallet_snapshot_from_jetstream(ctx: &Arc<MomentumContext>) ->
         .create_consumer(wallet_snapshot_consumer_config())
         .await?;
     let mut recovered = 0usize;
-    let mut snapshot_mints: HashSet<String> = HashSet::new();
+    let mut latest_by_mint: HashMap<String, (u64, u64)> = HashMap::new();
     let batch_size = 1000;
 
     loop {
@@ -9187,8 +9309,16 @@ async fn bootstrap_wallet_snapshot_from_jetstream(ctx: &Arc<MomentumContext>) ->
                 }
             };
 
-            if let MarketEventKind::WalletBalanceSnapshot { mint, .. } = &event.kind {
-                snapshot_mints.insert(mint.clone());
+            if let MarketEventKind::WalletBalanceSnapshot {
+                mint, balance_raw, ..
+            } = &event.kind
+            {
+                record_wallet_snapshot_latest(
+                    &mut latest_by_mint,
+                    mint,
+                    *balance_raw,
+                    event.header.ts_unix_ms,
+                );
                 // JetStream bootstrap/replay: do not mix historical `ts_unix_ms` into
                 // `momentum_event_to_ingest_ms` (live Core NATS ingest SLO only).
                 let ingest_t0 = Instant::now();
@@ -9218,21 +9348,18 @@ async fn bootstrap_wallet_snapshot_from_jetstream(ctx: &Arc<MomentumContext>) ->
 
     if recovered > 0 {
         info!(recovered, "✅ Wallet snapshots recovered from JetStream");
+    }
 
+    if !latest_by_mint.is_empty() {
         let mut positions = ctx.positions.write();
-        let mut removed = 0usize;
-        positions.retain(|mint, _| {
-            let keep = snapshot_mints.contains(mint);
-            if !keep {
-                removed += 1;
-            }
-            keep
-        });
+        let before = positions.len();
+        positions.retain(|mint, _| mint_has_positive_wallet_balance(mint, &latest_by_mint));
+        let removed = before.saturating_sub(positions.len());
         if removed > 0 {
             info!(
                 removed,
                 remaining = positions.len(),
-                "🧹 Closed positions not present in wallet snapshot"
+                "🧹 Closed positions with latest JetStream wallet balance = 0"
             );
         }
     }
@@ -9383,6 +9510,18 @@ async fn main() -> Result<()> {
     // FIX: Probe + Scale must be aggregated. JSONL sums ALL BUY fills (probe+scale) from
     // execution_results. KV can be stale (saved after probe, before scale processed).
     // Merge: JSONL authoritative for token_amount when available; KV for rest.
+    let wallet_balance_hints = if let Some(ref nats_client) = nats {
+        fetch_latest_wallet_balance_hints_from_jetstream(nats_client).await
+    } else {
+        HashMap::new()
+    };
+    if !wallet_balance_hints.is_empty() {
+        info!(
+            count = wallet_balance_hints.len(),
+            "Preloaded latest JetStream wallet balance hints for position recovery gate"
+        );
+    }
+
     let recovered_positions = {
         let mut kv_positions = HashMap::new();
         let mut jsonl_positions = HashMap::new();
@@ -9430,7 +9569,19 @@ async fn main() -> Result<()> {
         // Merge: JSONL authoritative (sums probe+scale from execution_results). KV for mints not in JSONL.
         let mut positions = HashMap::new();
         let mut merged_count = 0u32;
+        let mut jsonl_skipped_wallet_zero = 0u32;
         for (mint, jsonl_tracker) in &jsonl_positions {
+            if wallet_balance_hints
+                .get(mint)
+                .is_some_and(|balance| *balance == 0)
+            {
+                jsonl_skipped_wallet_zero += 1;
+                info!(
+                    mint = %mint,
+                    "Skipping JSONL position recovery: latest JetStream wallet balance is 0"
+                );
+                continue;
+            }
             let mut tracker = jsonl_tracker.clone();
             if let Some(kv_tracker) = kv_positions.get(mint) {
                 // Both sources: prefer JSONL — it sums ALL BUY fills (probe+scale).
@@ -9455,7 +9606,19 @@ async fn main() -> Result<()> {
             }
             positions.insert(mint.clone(), tracker);
         }
+        if jsonl_skipped_wallet_zero > 0 {
+            info!(
+                skipped = jsonl_skipped_wallet_zero,
+                "JSONL ghost positions skipped via JetStream wallet-zero gate"
+            );
+        }
         for (mint, kv_tracker) in kv_positions {
+            if wallet_balance_hints
+                .get(&mint)
+                .is_some_and(|balance| *balance == 0)
+            {
+                continue;
+            }
             positions.entry(mint).or_insert(kv_tracker);
         }
         if merged_count > 0 {
@@ -9548,6 +9711,8 @@ async fn main() -> Result<()> {
             debug!("No wallet snapshots recovered from JetStream");
         }
     }
+
+    startup_wallet_ghost_reconciliation(&ctx).await;
 
     // Open positions: request authoritative pool rows from market-data (bounded, deduped; no RPC here).
     ctx.schedule_open_position_pool_recoveries("startup").await;

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -9158,22 +9158,45 @@ fn mint_has_positive_wallet_balance(
     latest_by_mint.get(mint).is_some_and(|(bal, _)| *bal > 0)
 }
 
+/// Result of JetStream wallet-hint preload for JSONL/KV recovery gating.
+#[derive(Debug, Clone)]
+struct WalletHintPreload {
+    hints: HashMap<String, u64>,
+    /// True when the wallet snapshot stream was read (even if no per-mint hints).
+    stream_loaded: bool,
+}
+
+/// When stream preload succeeded: block recovery unless latest hint balance > 0.
+fn wallet_hint_blocks_position_recovery(preload: &WalletHintPreload, mint: &str) -> bool {
+    if !preload.stream_loaded {
+        return false;
+    }
+    preload
+        .hints
+        .get(mint)
+        .is_none_or(|balance| *balance == 0)
+}
+
 /// Preload latest per-mint wallet balances from JetStream (last-write-wins on `ts_unix_ms`).
-async fn fetch_latest_wallet_balance_hints_from_jetstream(
-    nats: &NatsClient,
-) -> HashMap<String, u64> {
+async fn fetch_latest_wallet_balance_hints_from_jetstream(nats: &NatsClient) -> WalletHintPreload {
     use async_nats::jetstream;
     use futures::StreamExt;
 
     let jetstream = jetstream::new(nats.client().clone());
     let Ok(stream) = jetstream.get_stream(WALLET_SNAPSHOT_STREAM_NAME).await else {
-        return HashMap::new();
+        return WalletHintPreload {
+            hints: HashMap::new(),
+            stream_loaded: false,
+        };
     };
     let Ok(consumer) = stream
         .create_consumer(wallet_snapshot_consumer_config())
         .await
     else {
-        return HashMap::new();
+        return WalletHintPreload {
+            hints: HashMap::new(),
+            stream_loaded: false,
+        };
     };
 
     let mut latest_by_mint: HashMap<String, (u64, u64)> = HashMap::new();
@@ -9214,10 +9237,13 @@ async fn fetch_latest_wallet_balance_hints_from_jetstream(
         }
     }
 
-    latest_by_mint
-        .into_iter()
-        .map(|(mint, (balance, _))| (mint, balance))
-        .collect()
+    WalletHintPreload {
+        hints: latest_by_mint
+            .into_iter()
+            .map(|(mint, (balance, _))| (mint, balance))
+            .collect(),
+        stream_loaded: true,
+    }
 }
 
 async fn startup_wallet_ghost_reconciliation(ctx: &Arc<MomentumContext>) {
@@ -9510,14 +9536,17 @@ async fn main() -> Result<()> {
     // FIX: Probe + Scale must be aggregated. JSONL sums ALL BUY fills (probe+scale) from
     // execution_results. KV can be stale (saved after probe, before scale processed).
     // Merge: JSONL authoritative for token_amount when available; KV for rest.
-    let wallet_balance_hints = if let Some(ref nats_client) = nats {
+    let wallet_hint_preload = if let Some(ref nats_client) = nats {
         fetch_latest_wallet_balance_hints_from_jetstream(nats_client).await
     } else {
-        HashMap::new()
+        WalletHintPreload {
+            hints: HashMap::new(),
+            stream_loaded: false,
+        }
     };
-    if !wallet_balance_hints.is_empty() {
+    if wallet_hint_preload.stream_loaded {
         info!(
-            count = wallet_balance_hints.len(),
+            count = wallet_hint_preload.hints.len(),
             "Preloaded latest JetStream wallet balance hints for position recovery gate"
         );
     }
@@ -9569,16 +9598,14 @@ async fn main() -> Result<()> {
         // Merge: JSONL authoritative (sums probe+scale from execution_results). KV for mints not in JSONL.
         let mut positions = HashMap::new();
         let mut merged_count = 0u32;
-        let mut jsonl_skipped_wallet_zero = 0u32;
+        let mut jsonl_skipped_wallet_gate = 0u32;
         for (mint, jsonl_tracker) in &jsonl_positions {
-            if wallet_balance_hints
-                .get(mint)
-                .is_some_and(|balance| *balance == 0)
-            {
-                jsonl_skipped_wallet_zero += 1;
+            if wallet_hint_blocks_position_recovery(&wallet_hint_preload, mint) {
+                jsonl_skipped_wallet_gate += 1;
                 info!(
                     mint = %mint,
-                    "Skipping JSONL position recovery: latest JetStream wallet balance is 0"
+                    hint_balance = ?wallet_hint_preload.hints.get(mint),
+                    "Skipping JSONL position recovery: JetStream wallet hint missing or zero"
                 );
                 continue;
             }
@@ -9606,17 +9633,14 @@ async fn main() -> Result<()> {
             }
             positions.insert(mint.clone(), tracker);
         }
-        if jsonl_skipped_wallet_zero > 0 {
+        if jsonl_skipped_wallet_gate > 0 {
             info!(
-                skipped = jsonl_skipped_wallet_zero,
-                "JSONL ghost positions skipped via JetStream wallet-zero gate"
+                skipped = jsonl_skipped_wallet_gate,
+                "JSONL ghost positions skipped via JetStream wallet-hint gate"
             );
         }
         for (mint, kv_tracker) in kv_positions {
-            if wallet_balance_hints
-                .get(&mint)
-                .is_some_and(|balance| *balance == 0)
-            {
+            if wallet_hint_blocks_position_recovery(&wallet_hint_preload, &mint) {
                 continue;
             }
             positions.entry(mint).or_insert(kv_tracker);
@@ -12796,6 +12820,38 @@ mod tests {
         assert!(matches!(
             trackers.get(&sk).unwrap().state,
             TrackerState::PositionOpenProbe { .. }
+        ));
+    }
+
+    #[test]
+    fn wallet_hint_blocks_position_recovery_when_missing_or_zero() {
+        let loaded = WalletHintPreload {
+            stream_loaded: true,
+            hints: HashMap::from([
+                ("GhostMint1111111111111111111111111111111".to_string(), 0),
+                ("LiveMint11111111111111111111111111111111".to_string(), 42),
+            ]),
+        };
+        assert!(wallet_hint_blocks_position_recovery(
+            &loaded,
+            "GhostMint1111111111111111111111111111111"
+        ));
+        assert!(wallet_hint_blocks_position_recovery(
+            &loaded,
+            "MissingMint111111111111111111111111111111"
+        ));
+        assert!(!wallet_hint_blocks_position_recovery(
+            &loaded,
+            "LiveMint11111111111111111111111111111111"
+        ));
+
+        let unavailable = WalletHintPreload {
+            stream_loaded: false,
+            hints: HashMap::new(),
+        };
+        assert!(!wallet_hint_blocks_position_recovery(
+            &unavailable,
+            "AnyMint111111111111111111111111111111111"
         ));
     }
 

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -9171,10 +9171,7 @@ fn wallet_hint_blocks_position_recovery(preload: &WalletHintPreload, mint: &str)
     if !preload.stream_loaded {
         return false;
     }
-    preload
-        .hints
-        .get(mint)
-        .is_none_or(|balance| *balance == 0)
+    preload.hints.get(mint).is_none_or(|balance| *balance == 0)
 }
 
 /// Preload latest per-mint wallet balances from JetStream (last-write-wins on `ts_unix_ms`).

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3341,6 +3341,8 @@ pub static ARB_SUBSCRIBER_LOW_COALESCED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| At
 pub static ARB_SUBSCRIBER_LOW_DROPPED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static ARB_SUBSCRIBER_POOL_CREATED_SKIPPED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+pub static ARB_SUBSCRIBER_HIGH_DROPPED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_EVENT_WORKER_STALL_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
 pub fn arb_subscriber_high_queue_depth_set(depth: u64) {
     ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH.store(depth, Ordering::Relaxed);
@@ -3368,6 +3370,21 @@ pub fn arb_subscriber_low_dropped_inc() {
 
 pub fn arb_subscriber_pool_created_skipped_inc() {
     ARB_SUBSCRIBER_POOL_CREATED_SKIPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn arb_subscriber_high_dropped_inc() {
+    ARB_SUBSCRIBER_HIGH_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn arb_event_worker_stall_inc() {
+    ARB_EVENT_WORKER_STALL_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub static MARKET_DATA_WALLET_SNAPSHOT_PERIODIC_PUBLISHED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+pub fn market_data_wallet_snapshot_periodic_published_inc() {
+    MARKET_DATA_WALLET_SNAPSHOT_PERIODIC_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 // --- Multi-hop shadow / cycle sanity (arb-strategy) ---
@@ -4312,6 +4329,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "momentum_active_pools_messages_total",
         MOMENTUM_ACTIVE_POOLS_MESSAGES_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_wallet_snapshot_periodic_published_total",
+        MARKET_DATA_WALLET_SNAPSHOT_PERIODIC_PUBLISHED_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_momentum_active_pool_messages_total",
@@ -5634,6 +5655,14 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "arb_subscriber_pool_created_skipped_total",
         ARB_SUBSCRIBER_POOL_CREATED_SKIPPED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_subscriber_high_dropped_total",
+        ARB_SUBSCRIBER_HIGH_DROPPED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_event_worker_stall_total",
+        ARB_EVENT_WORKER_STALL_TOTAL.load(Ordering::Relaxed)
     );
     out.push_str("arb_two_hop_rejected_total{reason=\"spread_too_large\"} ");
     out.push_str(


### PR DESCRIPTION
## Summary
- **P0 Arb:** Non-blocking HIGH queue ingress, shrunk `trackers.write()` scope in `handle_trade`, 5s HIGH worker timeout, stall/queue observability.
- **P1 Momentum:** Bootstrap retain uses latest wallet balance per mint; JSONL recovery skips wallet-zero mints; startup reconciliation before immediate exits.
- **P1 MD:** Periodic wallet snapshot timer (default 10min, cold path).

## Prod context
Post Phase-5e deploy: Arb frozen after ~33 events (HIGH queue @ cap); Momentum ghost TIME_EXIT from JSONL recovery overriding wallet reconciliation.

## Test plan
- [ ] CI: fmt, clippy, test
- [ ] After deploy: Arb `market_events_consumed` delta > 0 over 60s
- [ ] Momentum restart with empty wallet → `open_positions=0` without MD restart
- [ ] Kill-switch remains active until send path verified