### PR TITLE
feat(execution-engine): segment intent delivery latency into three histograms

### DIFF
--- a/docs/RUNBOOK_PROD.md
+++ b/docs/RUNBOOK_PROD.md
@@ -285,6 +285,9 @@ histogram_quantile(0.50, sum(rate(market_data_geyser_to_publish_ms_trade_bucket[
 | D | `momentum_intent_header_to_publish_ms_*` | Intent-Header-Zeit bis JetStream-TradeIntent-Publish |
 | E | `momentum_publish_to_intent_ms_*` | Kausales Event-`ts_unix_ms` bis Intent-Header (Momentum-intern) |
 | F | `execution_intent_header_to_receive_ms_*` | Intent-Header bis erster Zeile `process_intent` |
+| F1 | `execution_intent_jetstream_to_channel_ms_*` | JetStream-Deserialisierung bis erfolgreicher `intent_tx.send` (Fetch-Task) |
+| F2 | `execution_intent_channel_wait_ms_*` | Channel-Enqueue bis `intent_rx.recv` im Main-Loop (Channel + `select!`-Wartezeit) |
+| F3 | `execution_engine_interval_tick_duration_ms_*` | Wall-Zeit des `interval.tick`-Arms nach Task-Drain (PoolCache + WalletSnapshot JetStream-Batches) |
 | G | `execution_process_intent_us_*` | Gesamtdauer `process_intent` (Mikrosekunden) |
 | H | `execution_intent_to_confirm_ms_*` | Intent-Header bis bestätigtes On-Chain-Outcome |
 | I | `execution_slot_lag_at_send_slots_*` | `cached_blockhash.slot` minus Intent-Metadaten-`slot` nach erfolgreichem Send |
@@ -295,6 +298,8 @@ Beispiel **rate()** über 5m (Namen an eueren `job`/Labels anpassen):
 histogram_quantile(0.99, sum(rate(momentum_intent_header_to_publish_ms_bucket[5m])) by (le))
 histogram_quantile(0.99, sum(rate(execution_process_intent_us_bucket[5m])) by (le)) / 1e6
 ```
+
+**Intent-Delivery-Segmentierung (execution-engine):** F1 + F2 + JetStream-Fetch-Latenz (nicht histogrammiert) erklaeren approx. den Gesamtweg bis F. Hohes F3 bei gleichzeitig hohem F2 deutet auf `interval.tick`-Starvation hin (Main-Loop blockiert durch PoolCache/WalletSnapshot-Batches). Hohes F1 bei niedrigem F2 deutet auf JetStream-Fetch-/Consumer-Verzoegerung hin.
 
 ### PumpSwap Async-Healing Metrics
 

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -45,7 +45,7 @@ use solana_sdk::{
 use solana_transaction_status::{
     EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding, UiTransactionTokenBalance,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -74,9 +74,11 @@ use ironcrab::ipc::{
 };
 use ironcrab::ipc::{ControlRequest, ControlRequestKind, ControlResponse, ControlResponseStatus};
 use ironcrab::metrics::{
-    record_execution_process_intent_us, record_execution_slot_lag_at_send_slots,
-    record_recent_trade, record_tx_confirmed_slot_delta_slots, record_tx_priority_fee_source,
-    record_tx_rebroadcast, record_tx_rebroadcast_during_confirm_ms, record_tx_rebroadcast_method,
+    record_execution_engine_interval_tick_duration_ms, record_execution_intent_channel_wait_ms,
+    record_execution_intent_jetstream_to_channel_ms, record_execution_process_intent_us,
+    record_execution_slot_lag_at_send_slots, record_recent_trade,
+    record_tx_confirmed_slot_delta_slots, record_tx_priority_fee_source, record_tx_rebroadcast,
+    record_tx_rebroadcast_during_confirm_ms, record_tx_rebroadcast_method,
     record_tx_send_to_confirm_ms, record_tx_slot_to_send_ms, serve_metrics,
     set_readiness_control_response_sub_active, set_readiness_control_sub_active,
     set_readiness_mode, set_readiness_nats_connected, set_readiness_state_paths_initialized,
@@ -6757,6 +6759,72 @@ async fn create_wallet_tx_confirm_live_consumer(
     }
 }
 
+const INTENT_CHANNEL_ENQUEUE_TRACKER_CAP: usize = 256;
+
+/// Sidecar map: channel enqueue wall time keyed by `intent_id` (not on-wire; cap 256, LRU evict).
+struct IntentChannelEnqueueTracker {
+    inner: std::sync::Mutex<IntentChannelEnqueueState>,
+}
+
+struct IntentChannelEnqueueState {
+    enqueue_ms_by_id: HashMap<String, u64>,
+    insertion_order: VecDeque<String>,
+}
+
+impl Default for IntentChannelEnqueueTracker {
+    fn default() -> Self {
+        Self {
+            inner: std::sync::Mutex::new(IntentChannelEnqueueState {
+                enqueue_ms_by_id: HashMap::new(),
+                insertion_order: VecDeque::new(),
+            }),
+        }
+    }
+}
+
+impl IntentChannelEnqueueTracker {
+    fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    fn record_enqueue(&self, intent_id: String, enqueue_ms: u64) {
+        let mut state = self
+            .inner
+            .lock()
+            .expect("IntentChannelEnqueueTracker lock poisoned");
+        if let Some(entry) = state.enqueue_ms_by_id.get_mut(&intent_id) {
+            *entry = enqueue_ms;
+            return;
+        }
+        while state.enqueue_ms_by_id.len() >= INTENT_CHANNEL_ENQUEUE_TRACKER_CAP {
+            if let Some(oldest) = state.insertion_order.pop_front() {
+                state.enqueue_ms_by_id.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+        state.insertion_order.push_back(intent_id.clone());
+        state.enqueue_ms_by_id.insert(intent_id, enqueue_ms);
+    }
+
+    fn take_and_record_channel_wait(&self, intent_id: &str, now_ms: u64) {
+        let enqueue_ms = {
+            let mut state = self
+                .inner
+                .lock()
+                .expect("IntentChannelEnqueueTracker lock poisoned");
+            let Some(enqueue_ms) = state.enqueue_ms_by_id.remove(intent_id) else {
+                return;
+            };
+            if let Some(pos) = state.insertion_order.iter().position(|id| id == intent_id) {
+                state.insertion_order.remove(pos);
+            }
+            enqueue_ms
+        };
+        record_execution_intent_channel_wait_ms(now_ms.saturating_sub(enqueue_ms));
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize tracing
@@ -7827,10 +7895,12 @@ async fn main() -> Result<()> {
     let (intent_tx, mut intent_rx) = tokio::sync::mpsc::channel::<TradeIntent>(100);
     let (control_tx, mut control_rx) = tokio::sync::mpsc::channel::<ControlRequest>(10);
     let (config_tx, mut config_rx) = tokio::sync::mpsc::channel::<ConfigUpdate>(10);
+    let intent_channel_enqueue_tracker = IntentChannelEnqueueTracker::new();
 
     // Spawn dedicated task for TradeIntents JetStream consumer
     if let Some(intent_consumer) = intent_js_consumer {
         let tx = intent_tx.clone();
+        let enqueue_tracker = Arc::clone(&intent_channel_enqueue_tracker);
         tokio::spawn(async move {
             use futures::StreamExt;
             loop {
@@ -7846,10 +7916,17 @@ async fn main() -> Result<()> {
                             if let Ok(msg) = msg_result {
                                 match serde_json::from_slice::<TradeIntent>(&msg.payload) {
                                     Ok(intent) => {
+                                        let deser_done_ms = wall_clock_unix_ms_now();
+                                        let intent_id = intent.intent_id.clone();
                                         if tx.send(intent).await.is_err() {
                                             warn!("TradeIntent channel closed, stopping JetStream consumer");
                                             return;
                                         }
+                                        let enqueue_ms = wall_clock_unix_ms_now();
+                                        record_execution_intent_jetstream_to_channel_ms(
+                                            enqueue_ms.saturating_sub(deser_done_ms),
+                                        );
+                                        enqueue_tracker.record_enqueue(intent_id, enqueue_ms);
                                         if let Err(e) = msg.ack().await {
                                             warn!(error = %e, "Failed to ack trade intent");
                                         }
@@ -8325,6 +8402,9 @@ async fn main() -> Result<()> {
         tokio::select! {
             // FIX-31: Spawn intent processing as a parallel task (was: blocking await)
             Some(intent) = intent_rx.recv() => {
+                let recv_ms = wall_clock_unix_ms_now();
+                intent_channel_enqueue_tracker
+                    .take_and_record_channel_wait(&intent.intent_id, recv_ms);
                 info!(intent_id = %intent.intent_id, source = %intent.source, "Received TradeIntent from NATS");
                 let ctx_clone = Arc::clone(&ctx);
                 let sem = Arc::clone(&ctx.intent_semaphore);
@@ -8550,6 +8630,8 @@ async fn main() -> Result<()> {
                     }
                 }
 
+                let interval_tick_block_started_ms = wall_clock_unix_ms_now();
+
                 // Keep /ready fresh even when no intents flow.
                 ironcrab::metrics::record_activity();
 
@@ -8693,6 +8775,10 @@ async fn main() -> Result<()> {
                         }
                     }
                 }
+
+                record_execution_engine_interval_tick_duration_ms(
+                    wall_clock_unix_ms_now().saturating_sub(interval_tick_block_started_ms),
+                );
 
                 // MVP/dev convenience: simulate receiving a test intent once when running dry-run
                 // *without* NATS (so local dev still does something).

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2576,6 +2576,25 @@ fn reset_momentum_latency_metrics_for_test() {
     MOMENTUM_CORE_MARKET_EVENTS_PROCESSED_OTHER_TOTAL.store(0, Ordering::Relaxed);
 }
 
+#[cfg(test)]
+fn reset_execution_intent_delivery_segment_metrics_for_test() {
+    for c in EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_BUCKET_COUNTS.iter() {
+        c.store(0, Ordering::Relaxed);
+    }
+    EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_SUM.store(0, Ordering::Relaxed);
+    EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_COUNT.store(0, Ordering::Relaxed);
+    for c in EXECUTION_INTENT_CHANNEL_WAIT_MS_BUCKET_COUNTS.iter() {
+        c.store(0, Ordering::Relaxed);
+    }
+    EXECUTION_INTENT_CHANNEL_WAIT_MS_SUM.store(0, Ordering::Relaxed);
+    EXECUTION_INTENT_CHANNEL_WAIT_MS_COUNT.store(0, Ordering::Relaxed);
+    for c in EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_BUCKET_COUNTS.iter() {
+        c.store(0, Ordering::Relaxed);
+    }
+    EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_SUM.store(0, Ordering::Relaxed);
+    EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_COUNT.store(0, Ordering::Relaxed);
+}
+
 // --- execution-engine service metrics ---
 pub static INTENTS_RECEIVED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static INTENTS_EXECUTED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -2679,6 +2698,43 @@ pub static EXECUTION_INTENT_TO_CONFIRM_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = 
 });
 pub static EXECUTION_INTENT_TO_CONFIRM_MS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static EXECUTION_INTENT_TO_CONFIRM_MS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// JetStream fetch task: TradeIntent deserialize → successful `intent_tx.send` (ms).
+pub static EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+pub static EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// `intent_tx.send` enqueue → main-loop `intent_rx.recv` (channel + select! wait, ms).
+pub static EXECUTION_INTENT_CHANNEL_WAIT_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+pub static EXECUTION_INTENT_CHANNEL_WAIT_MS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static EXECUTION_INTENT_CHANNEL_WAIT_MS_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Wall time of PoolCache + WalletSnapshot JetStream batch block in `interval.tick` arm (ms).
+pub static EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+pub static EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 pub static EXECUTION_PROCESS_INTENT_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
     EXECUTION_PROCESS_INTENT_US_BUCKETS
@@ -3992,6 +4048,45 @@ pub fn record_tx_slot_to_send_ms(ms: u64) {
             break;
         }
     }
+}
+
+/// JetStream fetch task: TradeIntent deserialize → successful channel enqueue (ms).
+#[inline]
+pub fn record_execution_intent_jetstream_to_channel_ms(ms: u64) {
+    record_histogram_u64_into(
+        EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS,
+        EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_BUCKET_COUNTS.as_slice(),
+        &EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_SUM,
+        &EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_COUNT,
+        ms,
+        MOMENTUM_LATENCY_MS_SUM_CAP,
+    );
+}
+
+/// Channel enqueue → main-loop `intent_rx.recv` before `process_intent` spawn (ms).
+#[inline]
+pub fn record_execution_intent_channel_wait_ms(ms: u64) {
+    record_histogram_u64_into(
+        EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS,
+        EXECUTION_INTENT_CHANNEL_WAIT_MS_BUCKET_COUNTS.as_slice(),
+        &EXECUTION_INTENT_CHANNEL_WAIT_MS_SUM,
+        &EXECUTION_INTENT_CHANNEL_WAIT_MS_COUNT,
+        ms,
+        MOMENTUM_LATENCY_MS_SUM_CAP,
+    );
+}
+
+/// PoolCache + WalletSnapshot JetStream batch work inside `interval.tick` (ms).
+#[inline]
+pub fn record_execution_engine_interval_tick_duration_ms(ms: u64) {
+    record_histogram_u64_into(
+        EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS,
+        EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_BUCKET_COUNTS.as_slice(),
+        &EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_SUM,
+        &EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_COUNT,
+        ms,
+        MOMENTUM_LATENCY_MS_SUM_CAP,
+    );
 }
 
 /// `TradeIntent.header.ts_unix_ms` → first line of `process_intent` (JetStream / consumer skew).
@@ -5338,6 +5433,30 @@ async fn metrics_response() -> Response<Body> {
         &TX_REBROADCAST_DURING_CONFIRM_MS_BUCKET_COUNTS,
         &TX_REBROADCAST_DURING_CONFIRM_MS_SUM,
         &TX_REBROADCAST_DURING_CONFIRM_MS_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "execution_intent_jetstream_to_channel_ms",
+        EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS,
+        &EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_BUCKET_COUNTS,
+        &EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_SUM,
+        &EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "execution_intent_channel_wait_ms",
+        EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS,
+        &EXECUTION_INTENT_CHANNEL_WAIT_MS_BUCKET_COUNTS,
+        &EXECUTION_INTENT_CHANNEL_WAIT_MS_SUM,
+        &EXECUTION_INTENT_CHANNEL_WAIT_MS_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "execution_engine_interval_tick_duration_ms",
+        EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS,
+        &EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_BUCKET_COUNTS,
+        &EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_SUM,
+        &EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_COUNT,
     );
     append_momentum_latency_histogram_prometheus(
         &mut out,
@@ -6748,6 +6867,44 @@ mod momentum_latency_metrics_tests {
         assert_eq!(
             MOMENTUM_CORE_MARKET_EVENTS_INGEST_CONSECUTIVE_CAP_HIT_STREAK.load(Ordering::Relaxed),
             0
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn execution_intent_delivery_segment_histograms_record_known_delta() {
+        reset_execution_intent_delivery_segment_metrics_for_test();
+        record_execution_intent_jetstream_to_channel_ms(42);
+        record_execution_intent_channel_wait_ms(1_500);
+        record_execution_engine_interval_tick_duration_ms(250);
+
+        assert_eq!(
+            EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_COUNT.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            EXECUTION_INTENT_JETSTREAM_TO_CHANNEL_MS_SUM.load(Ordering::Relaxed),
+            42
+        );
+        assert_eq!(
+            EXECUTION_INTENT_CHANNEL_WAIT_MS_COUNT.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            EXECUTION_INTENT_CHANNEL_WAIT_MS_SUM.load(Ordering::Relaxed),
+            1_500
+        );
+        assert_eq!(
+            EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_COUNT.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            EXECUTION_ENGINE_INTERVAL_TICK_DURATION_MS_SUM.load(Ordering::Relaxed),
+            250
+        );
+        assert_eq!(
+            EXECUTION_INTENT_CHANNEL_WAIT_MS_BUCKET_COUNTS[9].load(Ordering::Relaxed),
+            1
         );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds three Prometheus histograms to decompose the prod-observed end-to-end latency `execution_intent_header_to_receive_ms` into attributable segments. **Observability only — no behavior changes.**

### New metrics (`:9804/metrics`)

| Metric | Segment |
|--------|---------|
| `execution_intent_jetstream_to_channel_ms` | JetStream deserialize → successful `intent_tx.send` (fetch task) |
| `execution_intent_channel_wait_ms` | Channel enqueue → `intent_rx.recv` in main loop (channel + `select!` wait) |
| `execution_engine_interval_tick_duration_ms` | Wall time in `interval.tick` arm after task drain (readiness + PoolCache + WalletSnapshot batches) |

### Implementation notes

- Enqueue timestamps stored in an internal sidecar map (`IntentChannelEnqueueTracker`, cap 256, LRU evict) — not in `TradeIntent.metadata` (wire contract preserved).
- Buckets match existing `execution_intent_header_to_receive_ms` / momentum latency sets (ms, up to 60_000).
- RUNBOOK updated with segments F1–F3 and interpretation guidance.

### STOP-CHECK

- **I-7:** No RPC — wall-clock timestamps only
- **I-9 / I-12:** Unchanged
- **I-23:** No new NATS subjects

## Files changed

- `src/metrics.rs` — histogram statics, recording fns, Prometheus export, unit test
- `src/bin/execution_engine.rs` — instrumentation at fetch task, main recv, interval.tick
- `docs/RUNBOOK_PROD.md` — segment documentation

## Verification

```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```

All green locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d1655c9-a0e4-4024-bed0-cd4a30f55fc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d1655c9-a0e4-4024-bed0-cd4a30f55fc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

