### PR TITLE
feat(arb-strategy): Tracker-Write Stall Forensics — Phase 1 Instrumentierung

### DIFF
--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -4666,7 +4666,7 @@ fn maybe_arb_tracker_write_stall_watchdog_warn(queue_cap: usize) {
     let secs_since_finish = ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH.load(Ordering::Relaxed);
     let queue_depth = ARB_TRACKER_WRITE_QUEUE_DEPTH.load(Ordering::Relaxed);
     let threshold = (queue_cap as u64 * 90) / 100;
-    if secs_since_finish <= 30 || queue_depth < threshold {
+    if queue_depth < threshold {
         return;
     }
 
@@ -4678,6 +4678,20 @@ fn maybe_arb_tracker_write_stall_watchdog_warn(queue_cap: usize) {
     } else {
         0
     };
+    let stuck_in_job = current_job_type > 0 && job_duration_secs > 30;
+    let not_finishing = secs_since_finish > 30;
+    if !stuck_in_job && !not_finishing {
+        return;
+    }
+
+    let stall_kind = if stuck_in_job && not_finishing {
+        "writer stuck in job and not finishing jobs"
+    } else if stuck_in_job {
+        "writer stuck in job"
+    } else {
+        "writer not finishing jobs"
+    };
+
     let coalescer_pending = ARB_TRACKER_WRITE_COALESCER_PENDING.load(Ordering::Relaxed);
     let flush_lost_pool_state =
         arb_tracker_write_coalescer_flush_lost_total(ArbTrackerWriteJobType::PoolStateUpdate);
@@ -4686,6 +4700,7 @@ fn maybe_arb_tracker_write_stall_watchdog_warn(queue_cap: usize) {
     let heartbeat_secs = ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH.load(Ordering::Relaxed);
 
     warn!(
+        stall_kind,
         current_job_type,
         job_duration_secs,
         queue_depth,
@@ -4695,7 +4710,7 @@ fn maybe_arb_tracker_write_stall_watchdog_warn(queue_cap: usize) {
         flush_lost_dex_accounts,
         secs_since_finish,
         heartbeat_secs_since_finish = heartbeat_secs,
-        "arb tracker write stall watchdog: writer idle while queue near capacity"
+        "arb tracker write stall watchdog"
     );
     arb_tracker_write_stall_watchdog_inc();
 }
@@ -5247,20 +5262,14 @@ async fn main() -> Result<()> {
             _ = heartbeat_interval.tick() => {
                 tick_arb_heartbeat_seconds_since_last_finish();
 
-                let phase_start = Instant::now();
                 let (records, bytes) = ctx.jsonl_writer.stats();
-                let (tokens_tracked, multi_dex_tokens) = {
-                    let trackers = ctx.trackers.read();
-                    let multi_dex_tokens = trackers
-                        .values()
-                        .filter(|t| t.pool_count_on_distinct_dexes() >= 2)
-                        .count();
-                    (trackers.len(), multi_dex_tokens)
-                };
-                record_arb_heartbeat_phase(
-                    ArbHeartbeatPhase::TrackersRead,
-                    phase_start.elapsed(),
-                );
+                // RCA parity with #253: hold trackers.read() across slow heartbeat steps.
+                let trackers_read_start = Instant::now();
+                let trackers = ctx.trackers.read();
+                let multi_dex_tokens = trackers
+                    .values()
+                    .filter(|t| t.pool_count_on_distinct_dexes() >= 2)
+                    .count();
 
                 let known_pools_count = ctx.known_pools.read().len();
                 let multi_hop_stats = ctx.multi_hop.stats();
@@ -5278,7 +5287,7 @@ async fn main() -> Result<()> {
                 ctx.prune_arb_track_stale_pools();
                 record_arb_heartbeat_phase(ArbHeartbeatPhase::Prune, phase_start.elapsed());
 
-                TOKENS_TRACKED_GAUGE.store(tokens_tracked as u64, Ordering::Relaxed);
+                TOKENS_TRACKED_GAUGE.store(trackers.len() as u64, Ordering::Relaxed);
 
                 let high_queue_depth = ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH.load(Ordering::Relaxed);
                 let high_processed = ARB_SUBSCRIBER_HIGH_PROCESSED_TOTAL.load(Ordering::Relaxed);
@@ -5336,7 +5345,7 @@ async fn main() -> Result<()> {
                     market_events_consumed,
                     market_events_consumed_delta = consumed_delta,
                     pools_tracked = ctx.pools_tracked.load(Ordering::Relaxed),
-                    tokens_tracked,
+                    tokens_tracked = trackers.len(),
                     multi_dex_tokens,
                     known_pools = known_pools_count,
                     opportunities_found = ctx.opportunities_found.load(Ordering::Relaxed),
@@ -5357,6 +5366,10 @@ async fn main() -> Result<()> {
                     "arb-strategy heartbeat (SLAVE cache sync from market-data MASTER)"
                 );
                 record_arb_heartbeat_phase(ArbHeartbeatPhase::InfoLog, phase_start.elapsed());
+                record_arb_heartbeat_phase(
+                    ArbHeartbeatPhase::TrackersRead,
+                    trackers_read_start.elapsed(),
+                );
                 arb_heartbeat_finished();
             }
 

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -43,7 +43,7 @@ use ironcrab::ipc::{
     TradeResources, TradeSide, TradingRegime,
 };
 use ironcrab::metrics::{
-    arb_pool_cache_apply_batches_inc, arb_pool_cache_updates_applied_add,
+    arb_heartbeat_finished, arb_pool_cache_apply_batches_inc, arb_pool_cache_updates_applied_add,
     arb_strategy_bootstrap_skip_inc, arb_strategy_bootstrap_warmup_set,
     arb_strategy_pool_cache_update_seeded_inc, arb_strategy_pool_cache_update_seen_inc,
     arb_strategy_pool_cache_update_skip_no_seed_inc,
@@ -52,20 +52,28 @@ use ironcrab::metrics::{
     arb_subscriber_low_coalesced_inc, arb_subscriber_low_dropped_inc,
     arb_subscriber_low_processed_inc, arb_subscriber_low_queue_depth_set,
     arb_subscriber_pool_created_skipped_inc, arb_tracker_write_coalesced_flushed_inc,
-    arb_tracker_write_coalesced_inc, arb_tracker_write_enqueue_dropped_inc,
-    arb_tracker_write_job_processed_inc, arb_two_hop_eligible_dexes_add,
+    arb_tracker_write_coalesced_inc, arb_tracker_write_coalescer_flush_lost_inc,
+    arb_tracker_write_coalescer_flush_lost_total, arb_tracker_write_enqueue_dropped_inc,
+    arb_tracker_write_init_worker_state, arb_tracker_write_job_finished,
+    arb_tracker_write_job_processed_inc, arb_tracker_write_job_started,
+    arb_tracker_write_stall_watchdog_inc, arb_two_hop_eligible_dexes_add,
     arb_two_hop_eligible_pools_by_dex_add, arb_two_hop_insufficient_subreason_inc,
     arb_two_hop_opportunity_inc, arb_two_hop_pool_gate_add, arb_two_hop_reject_subreason_inc,
-    arb_two_hop_rejected_inc, arb_two_hop_tracker_seeded_pools_add,
-    record_arb_track_requests_messages_total, serve_metrics,
-    set_arb_pool_cache_apply_batch_size_gauge, set_arb_tracker_write_queue_depth,
-    set_readiness_nats_connected, wall_clock_unix_ms_now, ArbStrategyWarmupSkipReason,
-    ArbTrackerWriteJobType, ArbTwoHopInsufficientSubreason, ArbTwoHopPoolGate,
-    ArbTwoHopRejectReason, ArbTwoHopRejectSubreason, MetricsComponent,
-    ARB_REJECTED_MISSING_ACCOUNTS, ARB_SUBSCRIBER_HIGH_PROCESSED_TOTAL,
-    ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH, ARB_TRIANGLE_OPPORTUNITIES, INTENTS_GENERATED_TOTAL,
-    MARKET_EVENTS_CONSUMED_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL,
-    POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
+    arb_two_hop_rejected_inc, arb_two_hop_tracker_seeded_pools_add, record_arb_heartbeat_phase,
+    record_arb_track_requests_messages_total, record_arb_writer_lock_wait, serve_metrics,
+    set_arb_pool_cache_apply_batch_size_gauge, set_arb_tracker_write_coalescer_pending,
+    set_arb_tracker_write_queue_depth, set_arb_two_hop_blocked_on_apply_trade,
+    set_readiness_nats_connected, tick_arb_heartbeat_seconds_since_last_finish,
+    tick_arb_tracker_write_seconds_since_last_finish, wall_clock_unix_ms_now, ArbHeartbeatPhase,
+    ArbStrategyWarmupSkipReason, ArbTrackerWriteJobType, ArbTwoHopInsufficientSubreason,
+    ArbTwoHopPoolGate, ArbTwoHopRejectReason, ArbTwoHopRejectSubreason, ArbWriterLockKind,
+    MetricsComponent, ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH, ARB_REJECTED_MISSING_ACCOUNTS,
+    ARB_SUBSCRIBER_HIGH_PROCESSED_TOTAL, ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH,
+    ARB_TRACKER_WRITE_COALESCER_PENDING, ARB_TRACKER_WRITE_CURRENT_JOB_STARTED_UNIX_MS,
+    ARB_TRACKER_WRITE_CURRENT_JOB_TYPE, ARB_TRACKER_WRITE_QUEUE_DEPTH,
+    ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH, ARB_TRIANGLE_OPPORTUNITIES,
+    INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
+    NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, pool_cache_live_fallback_consumer_config,
@@ -2446,11 +2454,15 @@ impl ArbTrackerWriteCoalescer {
         for (_, job) in self.pool_state_updates.drain() {
             if handle.try_enqueue(job, ArbTrackerWriteJobType::PoolStateUpdate) {
                 arb_tracker_write_coalesced_flushed_inc();
+            } else {
+                arb_tracker_write_coalescer_flush_lost_inc(ArbTrackerWriteJobType::PoolStateUpdate);
             }
         }
         for (_, job) in self.dex_pool_accounts.drain() {
             if handle.try_enqueue(job, ArbTrackerWriteJobType::DexPoolAccounts) {
                 arb_tracker_write_coalesced_flushed_inc();
+            } else {
+                arb_tracker_write_coalescer_flush_lost_inc(ArbTrackerWriteJobType::DexPoolAccounts);
             }
         }
     }
@@ -2626,10 +2638,15 @@ fn spawn_arb_two_hop_worker(ctx: Arc<ArbContext>, mut rx: mpsc::Receiver<ArbTwoH
                 debug!("Dropped ApplyTrade (tracker-write queue full)");
                 continue;
             }
+            set_arb_two_hop_blocked_on_apply_trade(true);
             let apply_result = match reply_rx.await {
                 Ok(Some(result)) => result,
-                _ => continue,
+                _ => {
+                    set_arb_two_hop_blocked_on_apply_trade(false);
+                    continue;
+                }
             };
+            set_arb_two_hop_blocked_on_apply_trade(false);
             let intent_cooldown_ms = apply_result.config.intent_cooldown_ms;
             let mint = apply_result.mint.clone();
             let ctx_for_check = Arc::clone(&ctx);
@@ -2992,6 +3009,7 @@ impl ArbContext {
             quote_mint,
             ARB_TRACKER_WRITE_COALESCER_CAP,
         );
+        set_arb_tracker_write_coalescer_pending(coalescer.pending_len() as u64);
     }
 
     fn coalesce_dex_pool_accounts(
@@ -3009,11 +3027,13 @@ impl ArbContext {
             accounts,
             ARB_TRACKER_WRITE_COALESCER_CAP,
         );
+        set_arb_tracker_write_coalescer_pending(coalescer.pending_len() as u64);
     }
 
     fn flush_tracker_write_coalescer(&self) {
         let mut coalescer = self.tracker_write_coalescer.lock();
         coalescer.flush(&self.tracker_write);
+        set_arb_tracker_write_coalescer_pending(coalescer.pending_len() as u64);
     }
 
     /// Check if the Geyser connection is healthy.
@@ -3514,8 +3534,12 @@ impl ArbContext {
         if mint == NATIVE_SOL_MINT || is_stablecoin_mint(mint) {
             return false;
         }
+        let trackers_wait = Instant::now();
         let mut trackers = self.trackers.write();
+        record_arb_writer_lock_wait(ArbWriterLockKind::TrackersWrite, trackers_wait.elapsed());
+        let vault_wait = Instant::now();
         let mut vault_balances = self.vault_balances.write();
+        record_arb_writer_lock_wait(ArbWriterLockKind::VaultBalancesWrite, vault_wait.elapsed());
         let seeded = seed_token_tracker_from_live_pool_cache(
             mint,
             &self.live_pool_cache,
@@ -3561,7 +3585,9 @@ impl ArbContext {
         }
         let (reserve_base, reserve_quote) =
             sol_quoted_vault_reserves(base_mint, quote_mint, reserve_base, reserve_quote);
+        let vault_wait = Instant::now();
         let mut cache = self.vault_balances.write();
+        record_arb_writer_lock_wait(ArbWriterLockKind::VaultBalancesWrite, vault_wait.elapsed());
         let should_update_vault = match cache.get(pool_address) {
             Some(existing) => update_slot >= existing.update_slot,
             None => true,
@@ -3614,17 +3640,22 @@ impl ArbContext {
 
         // Mirror SOL liquidity + reserve flag into per-mint pool trackers (Geyser-only, no RPC)
         let liquidity_sol = Decimal::from(reserve_quote) / Decimal::from(1_000_000_000u64);
-        let mints_with_pool: Vec<String> = self
-            .trackers
-            .read()
-            .iter()
-            .filter(|(_, tracker)| tracker.pools.contains_key(pool_address))
-            .map(|(mint, _)| mint.clone())
-            .collect();
+        let read_wait = Instant::now();
+        let mints_with_pool: Vec<String> = {
+            let trackers = self.trackers.read();
+            record_arb_writer_lock_wait(ArbWriterLockKind::TrackersRead, read_wait.elapsed());
+            trackers
+                .iter()
+                .filter(|(_, tracker)| tracker.pools.contains_key(pool_address))
+                .map(|(mint, _)| mint.clone())
+                .collect()
+        };
         if mints_with_pool.is_empty() {
             return;
         }
+        let write_wait = Instant::now();
         let mut trackers = self.trackers.write();
+        record_arb_writer_lock_wait(ArbWriterLockKind::TrackersWrite, write_wait.elapsed());
         for mint in mints_with_pool {
             let Some(tracker) = trackers.get_mut(&mint) else {
                 continue;
@@ -4516,117 +4547,177 @@ fn apply_pool_cache_jetstream_message(ctx: &ArbContext, update: PoolCacheUpdate)
     }
 }
 
+fn arb_tracker_write_job_type(job: &ArbTrackerWriteJob) -> ArbTrackerWriteJobType {
+    match job {
+        ArbTrackerWriteJob::SeedPoolCache { .. } => ArbTrackerWriteJobType::SeedPoolCache,
+        ArbTrackerWriteJob::ApplyTrade { .. } => ArbTrackerWriteJobType::ApplyTrade,
+        ArbTrackerWriteJob::FinalizeOpportunity { .. } => {
+            ArbTrackerWriteJobType::FinalizeOpportunity
+        }
+        ArbTrackerWriteJob::PoolCreated { .. } => ArbTrackerWriteJobType::PoolCreated,
+        ArbTrackerWriteJob::DexPoolAccounts { .. } => ArbTrackerWriteJobType::DexPoolAccounts,
+        ArbTrackerWriteJob::TokenMintInfo { .. } => ArbTrackerWriteJobType::TokenMintInfo,
+        ArbTrackerWriteJob::PoolStateUpdate { .. } => ArbTrackerWriteJobType::PoolStateUpdate,
+    }
+}
+
+fn process_arb_tracker_write_job(ctx: Arc<ArbContext>, job: ArbTrackerWriteJob) {
+    let job_type = arb_tracker_write_job_type(&job);
+    arb_tracker_write_job_started(job_type);
+    let started = Instant::now();
+
+    match job {
+        ArbTrackerWriteJob::SeedPoolCache { update } => {
+            if ctx.seed_trackers_for_pool_cache_update(&update) {
+                arb_strategy_pool_cache_update_seeded_inc();
+                if let Some(mint) = arb_tracked_token_mint(&update.base_mint, &update.quote_mint) {
+                    ctx.maybe_publish_arb_track_incremental_for_mint(mint);
+                }
+            } else {
+                arb_strategy_pool_cache_update_skip_no_seed_inc();
+            }
+        }
+        ArbTrackerWriteJob::ApplyTrade { job, reply } => {
+            let result = ctx
+                .apply_trade_to_tracker(
+                    &job.pool_address,
+                    &job.mint,
+                    &job.quote_mint,
+                    job.sol_amount,
+                    job.token_amount,
+                    job.token_decimals,
+                    job.is_buy,
+                    &job.dex,
+                )
+                .map(|(tracker_snapshot, config)| ApplyTradeResult {
+                    tracker_snapshot,
+                    config,
+                    mint: job.mint.clone(),
+                    vault_balances: ctx.vault_balances.read().clone(),
+                    bin_arrays: ctx.bin_arrays.read().clone(),
+                });
+            let _ = reply.send(result);
+        }
+        ArbTrackerWriteJob::FinalizeOpportunity {
+            mint,
+            intent_cooldown_ms,
+            opp,
+            reply,
+        } => {
+            let finalized = ctx.finalize_trade_opportunity(&mint, intent_cooldown_ms, opp);
+            let _ = reply.send(finalized);
+        }
+        ArbTrackerWriteJob::PoolCreated {
+            pool_address,
+            base_mint,
+            quote_mint,
+            dex,
+            liquidity_sol,
+        } => {
+            ctx.handle_pool_created(&pool_address, &base_mint, &quote_mint, &dex, liquidity_sol);
+        }
+        ArbTrackerWriteJob::DexPoolAccounts {
+            pool_address,
+            base_mint,
+            quote_mint,
+            accounts,
+        } => {
+            ctx.handle_dex_pool_accounts(&pool_address, &base_mint, &quote_mint, accounts);
+        }
+        ArbTrackerWriteJob::TokenMintInfo {
+            mint,
+            token_program,
+        } => {
+            ctx.handle_token_mint_info(&mint, &token_program);
+        }
+        ArbTrackerWriteJob::PoolStateUpdate {
+            pool_address,
+            dex,
+            reserve_base,
+            reserve_quote,
+            update_slot,
+            active_id,
+            bin_step,
+            base_mint,
+            quote_mint,
+        } => {
+            ctx.handle_pool_state_update(
+                &pool_address,
+                &dex,
+                reserve_base,
+                reserve_quote,
+                update_slot,
+                active_id,
+                bin_step,
+                &base_mint,
+                &quote_mint,
+            );
+        }
+    }
+
+    arb_tracker_write_job_finished(job_type, started.elapsed());
+    arb_tracker_write_job_processed_inc(job_type);
+}
+
+fn maybe_arb_tracker_write_stall_watchdog_warn(queue_cap: usize) {
+    tick_arb_tracker_write_seconds_since_last_finish();
+    tick_arb_heartbeat_seconds_since_last_finish();
+
+    let secs_since_finish = ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH.load(Ordering::Relaxed);
+    let queue_depth = ARB_TRACKER_WRITE_QUEUE_DEPTH.load(Ordering::Relaxed);
+    let threshold = (queue_cap as u64 * 90) / 100;
+    if secs_since_finish <= 30 || queue_depth < threshold {
+        return;
+    }
+
+    let current_job_type = ARB_TRACKER_WRITE_CURRENT_JOB_TYPE.load(Ordering::Relaxed);
+    let job_started_ms = ARB_TRACKER_WRITE_CURRENT_JOB_STARTED_UNIX_MS.load(Ordering::Relaxed);
+    let now_ms = wall_clock_unix_ms_now();
+    let job_duration_secs = if job_started_ms > 0 {
+        now_ms.saturating_sub(job_started_ms) / 1000
+    } else {
+        0
+    };
+    let coalescer_pending = ARB_TRACKER_WRITE_COALESCER_PENDING.load(Ordering::Relaxed);
+    let flush_lost_pool_state =
+        arb_tracker_write_coalescer_flush_lost_total(ArbTrackerWriteJobType::PoolStateUpdate);
+    let flush_lost_dex_accounts =
+        arb_tracker_write_coalescer_flush_lost_total(ArbTrackerWriteJobType::DexPoolAccounts);
+    let heartbeat_secs = ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH.load(Ordering::Relaxed);
+
+    warn!(
+        current_job_type,
+        job_duration_secs,
+        queue_depth,
+        queue_cap = queue_cap as u64,
+        coalescer_pending,
+        flush_lost_pool_state,
+        flush_lost_dex_accounts,
+        secs_since_finish,
+        heartbeat_secs_since_finish = heartbeat_secs,
+        "arb tracker write stall watchdog: writer idle while queue near capacity"
+    );
+    arb_tracker_write_stall_watchdog_inc();
+}
+
 fn spawn_arb_tracker_write_worker(
     ctx: Arc<ArbContext>,
     mut rx: mpsc::Receiver<ArbTrackerWriteJob>,
 ) {
+    arb_tracker_write_init_worker_state();
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            maybe_arb_tracker_write_stall_watchdog_warn(ARB_TRACKER_WRITE_QUEUE_CAP);
+        }
+    });
+
     tokio::spawn(async move {
         while let Some(job) = rx.recv().await {
-            match job {
-                ArbTrackerWriteJob::SeedPoolCache { update } => {
-                    if ctx.seed_trackers_for_pool_cache_update(&update) {
-                        arb_strategy_pool_cache_update_seeded_inc();
-                        if let Some(mint) =
-                            arb_tracked_token_mint(&update.base_mint, &update.quote_mint)
-                        {
-                            ctx.maybe_publish_arb_track_incremental_for_mint(mint);
-                        }
-                    } else {
-                        arb_strategy_pool_cache_update_skip_no_seed_inc();
-                    }
-                    arb_tracker_write_job_processed_inc(ArbTrackerWriteJobType::SeedPoolCache);
-                }
-                ArbTrackerWriteJob::ApplyTrade { job, reply } => {
-                    let result = ctx
-                        .apply_trade_to_tracker(
-                            &job.pool_address,
-                            &job.mint,
-                            &job.quote_mint,
-                            job.sol_amount,
-                            job.token_amount,
-                            job.token_decimals,
-                            job.is_buy,
-                            &job.dex,
-                        )
-                        .map(|(tracker_snapshot, config)| ApplyTradeResult {
-                            tracker_snapshot,
-                            config,
-                            mint: job.mint.clone(),
-                            vault_balances: ctx.vault_balances.read().clone(),
-                            bin_arrays: ctx.bin_arrays.read().clone(),
-                        });
-                    let _ = reply.send(result);
-                    arb_tracker_write_job_processed_inc(ArbTrackerWriteJobType::ApplyTrade);
-                }
-                ArbTrackerWriteJob::FinalizeOpportunity {
-                    mint,
-                    intent_cooldown_ms,
-                    opp,
-                    reply,
-                } => {
-                    let finalized = ctx.finalize_trade_opportunity(&mint, intent_cooldown_ms, opp);
-                    let _ = reply.send(finalized);
-                    arb_tracker_write_job_processed_inc(
-                        ArbTrackerWriteJobType::FinalizeOpportunity,
-                    );
-                }
-                ArbTrackerWriteJob::PoolCreated {
-                    pool_address,
-                    base_mint,
-                    quote_mint,
-                    dex,
-                    liquidity_sol,
-                } => {
-                    ctx.handle_pool_created(
-                        &pool_address,
-                        &base_mint,
-                        &quote_mint,
-                        &dex,
-                        liquidity_sol,
-                    );
-                    arb_tracker_write_job_processed_inc(ArbTrackerWriteJobType::PoolCreated);
-                }
-                ArbTrackerWriteJob::DexPoolAccounts {
-                    pool_address,
-                    base_mint,
-                    quote_mint,
-                    accounts,
-                } => {
-                    ctx.handle_dex_pool_accounts(&pool_address, &base_mint, &quote_mint, accounts);
-                    arb_tracker_write_job_processed_inc(ArbTrackerWriteJobType::DexPoolAccounts);
-                }
-                ArbTrackerWriteJob::TokenMintInfo {
-                    mint,
-                    token_program,
-                } => {
-                    ctx.handle_token_mint_info(&mint, &token_program);
-                    arb_tracker_write_job_processed_inc(ArbTrackerWriteJobType::TokenMintInfo);
-                }
-                ArbTrackerWriteJob::PoolStateUpdate {
-                    pool_address,
-                    dex,
-                    reserve_base,
-                    reserve_quote,
-                    update_slot,
-                    active_id,
-                    bin_step,
-                    base_mint,
-                    quote_mint,
-                } => {
-                    ctx.handle_pool_state_update(
-                        &pool_address,
-                        &dex,
-                        reserve_base,
-                        reserve_quote,
-                        update_slot,
-                        active_id,
-                        bin_step,
-                        &base_mint,
-                        &quote_mint,
-                    );
-                    arb_tracker_write_job_processed_inc(ArbTrackerWriteJobType::PoolStateUpdate);
-                }
-            }
+            process_arb_tracker_write_job(Arc::clone(&ctx), job);
             ctx.tracker_write.record_queue_depth();
         }
         info!("arb-strategy tracker write worker stopped");
@@ -5154,20 +5245,40 @@ async fn main() -> Result<()> {
 
             // Heartbeat
             _ = heartbeat_interval.tick() => {
+                tick_arb_heartbeat_seconds_since_last_finish();
+
+                let phase_start = Instant::now();
                 let (records, bytes) = ctx.jsonl_writer.stats();
-                let trackers = ctx.trackers.read();
-                let multi_dex_tokens = trackers
-                    .values()
-                    .filter(|t| t.pool_count_on_distinct_dexes() >= 2)
-                    .count();
+                let (tokens_tracked, multi_dex_tokens) = {
+                    let trackers = ctx.trackers.read();
+                    let multi_dex_tokens = trackers
+                        .values()
+                        .filter(|t| t.pool_count_on_distinct_dexes() >= 2)
+                        .count();
+                    (trackers.len(), multi_dex_tokens)
+                };
+                record_arb_heartbeat_phase(
+                    ArbHeartbeatPhase::TrackersRead,
+                    phase_start.elapsed(),
+                );
 
                 let known_pools_count = ctx.known_pools.read().len();
                 let multi_hop_stats = ctx.multi_hop.stats();
                 ctx.multi_hop.refresh_quote_readiness_metrics();
+
+                let phase_start = Instant::now();
                 ctx.eligibility_forensics.maybe_emit_snapshot();
+                record_arb_heartbeat_phase(ArbHeartbeatPhase::MaybeEmit, phase_start.elapsed());
+
+                let phase_start = Instant::now();
                 ctx.sync_pools_tracked_gauge();
+                record_arb_heartbeat_phase(ArbHeartbeatPhase::SyncPools, phase_start.elapsed());
+
+                let phase_start = Instant::now();
                 ctx.prune_arb_track_stale_pools();
-                TOKENS_TRACKED_GAUGE.store(trackers.len() as u64, Ordering::Relaxed);
+                record_arb_heartbeat_phase(ArbHeartbeatPhase::Prune, phase_start.elapsed());
+
+                TOKENS_TRACKED_GAUGE.store(tokens_tracked as u64, Ordering::Relaxed);
 
                 let high_queue_depth = ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH.load(Ordering::Relaxed);
                 let high_processed = ARB_SUBSCRIBER_HIGH_PROCESSED_TOTAL.load(Ordering::Relaxed);
@@ -5219,13 +5330,14 @@ async fn main() -> Result<()> {
                 last_heartbeat_high_processed = high_processed;
                 last_heartbeat_market_events_consumed = market_events_consumed;
 
+                let phase_start = Instant::now();
                 info!(
                     events_received,
                     market_events_consumed,
                     market_events_consumed_delta = consumed_delta,
                     pools_tracked = ctx.pools_tracked.load(Ordering::Relaxed),
-                    tokens_tracked = trackers.len(),
-                    multi_dex_tokens = multi_dex_tokens,
+                    tokens_tracked,
+                    multi_dex_tokens,
                     known_pools = known_pools_count,
                     opportunities_found = ctx.opportunities_found.load(Ordering::Relaxed),
                     intents_generated = ctx.intents_generated.load(Ordering::Relaxed),
@@ -5244,6 +5356,8 @@ async fn main() -> Result<()> {
                     high_processed,
                     "arb-strategy heartbeat (SLAVE cache sync from market-data MASTER)"
                 );
+                record_arb_heartbeat_phase(ArbHeartbeatPhase::InfoLog, phase_start.elapsed());
+                arb_heartbeat_finished();
             }
 
             // Phase 3: baseline arb track_requests reconcile (strategy-owned pins).
@@ -6205,6 +6319,221 @@ mod event_pipeline_tests {
             ticks >= 5,
             "expected heartbeat to tick under PoolCache burst + trade load, got {ticks}"
         );
+    }
+
+    #[test]
+    fn tracker_write_coalescer_flush_increments_lost_when_queue_full() {
+        use ironcrab::metrics::{
+            arb_tracker_write_coalescer_flush_lost_total, ArbTrackerWriteJobType,
+        };
+
+        let (tx, _rx) = mpsc::channel::<ArbTrackerWriteJob>(1);
+        let handle = ArbTrackerWriteHandle { tx, capacity: 1 };
+        assert!(handle.try_enqueue(
+            ArbTrackerWriteJob::TokenMintInfo {
+                mint: "TokenMint11111111111111111111111111111111".to_string(),
+                token_program: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string(),
+            },
+            ArbTrackerWriteJobType::TokenMintInfo,
+        ));
+
+        let mut coalescer = ArbTrackerWriteCoalescer::new();
+        coalescer.insert_pool_state_update(
+            "pool-full".to_string(),
+            "raydium".to_string(),
+            1,
+            1,
+            1,
+            None,
+            None,
+            NATIVE_SOL_MINT.to_string(),
+            "TokenMint11111111111111111111111111111111".to_string(),
+            16,
+        );
+
+        let before =
+            arb_tracker_write_coalescer_flush_lost_total(ArbTrackerWriteJobType::PoolStateUpdate);
+        coalescer.flush(&handle);
+        let after =
+            arb_tracker_write_coalescer_flush_lost_total(ArbTrackerWriteJobType::PoolStateUpdate);
+        assert!(
+            after > before,
+            "coalescer flush on full queue must increment flush_lost counter"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn writer_job_duration_histogram_recorded() {
+        use ironcrab::execution::live_pool_cache::create_shared_cache;
+        use ironcrab::metrics::{
+            arb_tracker_write_job_duration_count, arb_tracker_write_job_finished_total,
+            ArbTrackerWriteJobType,
+        };
+
+        let live_pool_cache = create_shared_cache();
+        let log_dir = std::env::temp_dir().join(format!("arb_job_hist_{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&log_dir).expect("test log dir");
+        let jsonl_writer =
+            JsonlWriter::new(JsonlWriterConfig::new("arb_job_hist").with_log_dir(log_dir))
+                .expect("jsonl writer");
+        let (tracker_write_tx, tracker_write_rx) = mpsc::channel::<ArbTrackerWriteJob>(8);
+        let tracker_write = ArbTrackerWriteHandle {
+            tx: tracker_write_tx,
+            capacity: 8,
+        };
+        let (two_hop_tx, _two_hop_rx) = mpsc::channel::<ArbTwoHopTradeJob>(1);
+
+        let ctx = Arc::new(ArbContext {
+            run_id: TEST_RUN.to_string(),
+            config: RwLock::new(ArbConfig::default()),
+            nats: None,
+            jsonl_writer,
+            trackers: RwLock::new(HashMap::new()),
+            events_received: AtomicU64::new(0),
+            pools_tracked: AtomicU64::new(0),
+            opportunities_found: AtomicU64::new(0),
+            intents_generated: AtomicU64::new(0),
+            intent_counter: AtomicU64::new(0),
+            zero_amount_trades: AtomicU64::new(0),
+            data_quality_rejects: AtomicU64::new(0),
+            last_market_event: RwLock::new(Instant::now()),
+            vault_balances: RwLock::new(HashMap::new()),
+            bin_arrays: RwLock::new(HashMap::new()),
+            live_pool_cache,
+            known_pools: RwLock::new(HashSet::new()),
+            multi_hop: Arc::new(MultiHopArbitrage::new(
+                MultiHopConfig::default(),
+                create_shared_cache(),
+            )),
+            spread_too_large_warn_last: RwLock::new(HashMap::new()),
+            eligibility_forensics: ArbEligibilityForensics::new(),
+            arb_pinned_pools: RwLock::new(HashSet::new()),
+            arb_track_published: AtomicU64::new(0),
+            two_hop_tx,
+            tracker_write,
+            tracker_write_coalescer: parking_lot::Mutex::new(ArbTrackerWriteCoalescer::new()),
+        });
+        spawn_arb_tracker_write_worker(ctx.clone(), tracker_write_rx);
+
+        ctx.tracker_write
+            .enqueue(
+                ArbTrackerWriteJob::TokenMintInfo {
+                    mint: "TokenMint11111111111111111111111111111111".to_string(),
+                    token_program: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string(),
+                },
+                ArbTrackerWriteJobType::TokenMintInfo,
+            )
+            .await;
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if arb_tracker_write_job_finished_total(ArbTrackerWriteJobType::TokenMintInfo) > 0 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("writer job did not finish in time");
+
+        assert!(
+            arb_tracker_write_job_duration_count(ArbTrackerWriteJobType::TokenMintInfo) > 0,
+            "writer job duration histogram must record finished jobs"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn heartbeat_read_lock_contention_blocks_writer_pool_state() {
+        use ironcrab::execution::live_pool_cache::create_shared_cache;
+        use ironcrab::metrics::{arb_writer_lock_wait_count, ArbWriterLockKind};
+
+        let live_pool_cache = create_shared_cache();
+        let log_dir = std::env::temp_dir().join(format!("arb_stall_repro_{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&log_dir).expect("test log dir");
+        let jsonl_writer =
+            JsonlWriter::new(JsonlWriterConfig::new("arb_stall_repro").with_log_dir(log_dir))
+                .expect("jsonl writer");
+        let (tracker_write_tx, tracker_write_rx) = mpsc::channel::<ArbTrackerWriteJob>(8);
+        let tracker_write = ArbTrackerWriteHandle {
+            tx: tracker_write_tx,
+            capacity: 8,
+        };
+        let (two_hop_tx, _two_hop_rx) = mpsc::channel::<ArbTwoHopTradeJob>(1);
+
+        let ctx = Arc::new(ArbContext {
+            run_id: TEST_RUN.to_string(),
+            config: RwLock::new(ArbConfig::default()),
+            nats: None,
+            jsonl_writer,
+            trackers: RwLock::new(HashMap::new()),
+            events_received: AtomicU64::new(0),
+            pools_tracked: AtomicU64::new(0),
+            opportunities_found: AtomicU64::new(0),
+            intents_generated: AtomicU64::new(0),
+            intent_counter: AtomicU64::new(0),
+            zero_amount_trades: AtomicU64::new(0),
+            data_quality_rejects: AtomicU64::new(0),
+            last_market_event: RwLock::new(Instant::now()),
+            vault_balances: RwLock::new(HashMap::new()),
+            bin_arrays: RwLock::new(HashMap::new()),
+            live_pool_cache,
+            known_pools: RwLock::new(HashSet::new()),
+            multi_hop: Arc::new(MultiHopArbitrage::new(
+                MultiHopConfig::default(),
+                create_shared_cache(),
+            )),
+            spread_too_large_warn_last: RwLock::new(HashMap::new()),
+            eligibility_forensics: ArbEligibilityForensics::new(),
+            arb_pinned_pools: RwLock::new(HashSet::new()),
+            arb_track_published: AtomicU64::new(0),
+            two_hop_tx,
+            tracker_write,
+            tracker_write_coalescer: parking_lot::Mutex::new(ArbTrackerWriteCoalescer::new()),
+        });
+        spawn_arb_tracker_write_worker(ctx.clone(), tracker_write_rx);
+
+        let pool = "pool-stall-repro";
+        let mint = "TokenMint11111111111111111111111111111111";
+        ctx.handle_pool_created(pool, mint, NATIVE_SOL_MINT, "raydium", Decimal::ONE);
+
+        let contention_ctx = ctx.clone();
+        let contention = std::thread::spawn(move || {
+            let _read_guard = contention_ctx.trackers.read();
+            std::thread::sleep(Duration::from_millis(400));
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let write_ctx = ctx.clone();
+        let writer = tokio::spawn(async move {
+            write_ctx
+                .tracker_write
+                .enqueue(
+                    ArbTrackerWriteJob::PoolStateUpdate {
+                        pool_address: pool.to_string(),
+                        dex: "raydium".to_string(),
+                        reserve_base: 5_000_000,
+                        reserve_quote: 10_000_000_000,
+                        update_slot: 99,
+                        active_id: None,
+                        bin_step: None,
+                        base_mint: NATIVE_SOL_MINT.to_string(),
+                        quote_mint: mint.to_string(),
+                    },
+                    ArbTrackerWriteJobType::PoolStateUpdate,
+                )
+                .await;
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            arb_writer_lock_wait_count(ArbWriterLockKind::TrackersWrite) > 0
+                || arb_writer_lock_wait_count(ArbWriterLockKind::TrackersRead) > 0,
+            "writer must observe lock wait while heartbeat-style read lock is held"
+        );
+
+        writer.await.expect("writer enqueue task panicked");
+        contention.join().expect("contention thread panicked");
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -5,7 +5,7 @@ use parking_lot::RwLock;
 use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, AtomicU64, Ordering};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 /// Recent trade record for dashboard display
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -3021,6 +3021,258 @@ pub enum ArbTrackerWriteJobType {
     FinalizeOpportunity,
 }
 
+impl ArbTrackerWriteJobType {
+    pub const COUNT: usize = 7;
+
+    pub fn index(self) -> usize {
+        match self {
+            Self::PoolStateUpdate => 0,
+            Self::ApplyTrade => 1,
+            Self::PoolCreated => 2,
+            Self::DexPoolAccounts => 3,
+            Self::TokenMintInfo => 4,
+            Self::SeedPoolCache => 5,
+            Self::FinalizeOpportunity => 6,
+        }
+    }
+
+    pub fn as_numeric(self) -> u64 {
+        (self.index() + 1) as u64
+    }
+
+    pub fn prometheus_label(self) -> &'static str {
+        match self {
+            Self::PoolStateUpdate => "pool_state_update",
+            Self::ApplyTrade => "apply_trade",
+            Self::PoolCreated => "pool_created",
+            Self::DexPoolAccounts => "dex_pool_accounts",
+            Self::TokenMintInfo => "token_mint_info",
+            Self::SeedPoolCache => "seed_pool_cache",
+            Self::FinalizeOpportunity => "finalize_opportunity",
+        }
+    }
+
+    pub fn all() -> [Self; Self::COUNT] {
+        [
+            Self::PoolStateUpdate,
+            Self::ApplyTrade,
+            Self::PoolCreated,
+            Self::DexPoolAccounts,
+            Self::TokenMintInfo,
+            Self::SeedPoolCache,
+            Self::FinalizeOpportunity,
+        ]
+    }
+}
+
+/// Writer job duration histogram buckets (nanoseconds).
+const ARB_TRACKER_WRITE_JOB_DURATION_NS_BUCKETS: &[u64] = &[
+    1_000_000,
+    5_000_000,
+    10_000_000,
+    25_000_000,
+    50_000_000,
+    100_000_000,
+    250_000_000,
+    500_000_000,
+    1_000_000_000,
+    2_500_000_000,
+    5_000_000_000,
+    10_000_000_000,
+    30_000_000_000,
+    60_000_000_000,
+];
+
+struct ArbTrackerWriteJobDurationHist {
+    bucket_counts: Vec<AtomicU64>,
+    sum_ns: AtomicU64,
+    count: AtomicU64,
+}
+
+impl ArbTrackerWriteJobDurationHist {
+    fn new() -> Self {
+        Self {
+            bucket_counts: ARB_TRACKER_WRITE_JOB_DURATION_NS_BUCKETS
+                .iter()
+                .map(|_| AtomicU64::new(0))
+                .collect(),
+            sum_ns: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+        }
+    }
+
+    fn record(&self, duration_ns: u64) {
+        record_histogram_u64_into(
+            ARB_TRACKER_WRITE_JOB_DURATION_NS_BUCKETS,
+            &self.bucket_counts,
+            &self.sum_ns,
+            &self.count,
+            duration_ns,
+            u64::MAX,
+        );
+    }
+}
+
+fn new_arb_tracker_write_job_duration_hists(
+) -> [ArbTrackerWriteJobDurationHist; ArbTrackerWriteJobType::COUNT] {
+    std::array::from_fn(|_| ArbTrackerWriteJobDurationHist::new())
+}
+
+static ARB_TRACKER_WRITE_JOB_STARTED: Lazy<[AtomicU64; ArbTrackerWriteJobType::COUNT]> =
+    Lazy::new(|| std::array::from_fn(|_| AtomicU64::new(0)));
+static ARB_TRACKER_WRITE_JOB_FINISHED: Lazy<[AtomicU64; ArbTrackerWriteJobType::COUNT]> =
+    Lazy::new(|| std::array::from_fn(|_| AtomicU64::new(0)));
+static ARB_TRACKER_WRITE_JOB_DURATION: Lazy<
+    [ArbTrackerWriteJobDurationHist; ArbTrackerWriteJobType::COUNT],
+> = Lazy::new(new_arb_tracker_write_job_duration_hists);
+
+pub static ARB_TRACKER_WRITE_LAST_JOB_TYPE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACKER_WRITE_CURRENT_JOB_TYPE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACKER_WRITE_CURRENT_JOB_STARTED_UNIX_MS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACKER_WRITE_LAST_FINISH_UNIX_MS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+static ARB_TRACKER_WRITE_COALESCER_FLUSH_LOST: Lazy<[AtomicU64; ArbTrackerWriteJobType::COUNT]> =
+    Lazy::new(|| std::array::from_fn(|_| AtomicU64::new(0)));
+pub static ARB_TRACKER_WRITE_COALESCER_PENDING: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_BLOCKED_ON_APPLY_TRADE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACKER_WRITE_STALL_WATCHDOG_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Lock kinds observed during tracker-write jobs (Prometheus label `lock`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArbWriterLockKind {
+    TrackersRead,
+    TrackersWrite,
+    VaultBalancesWrite,
+}
+
+impl ArbWriterLockKind {
+    fn index(self) -> usize {
+        match self {
+            Self::TrackersRead => 0,
+            Self::TrackersWrite => 1,
+            Self::VaultBalancesWrite => 2,
+        }
+    }
+
+    fn prometheus_label(self) -> &'static str {
+        match self {
+            Self::TrackersRead => "trackers_read",
+            Self::TrackersWrite => "trackers_write",
+            Self::VaultBalancesWrite => "vault_balances_write",
+        }
+    }
+
+    const COUNT: usize = 3;
+}
+
+struct ArbWriterLockWaitHist {
+    bucket_counts: Vec<AtomicU64>,
+    sum_ns: AtomicU64,
+    count: AtomicU64,
+}
+
+impl ArbWriterLockWaitHist {
+    fn new() -> Self {
+        Self {
+            bucket_counts: ARB_TRACKER_WRITE_JOB_DURATION_NS_BUCKETS
+                .iter()
+                .map(|_| AtomicU64::new(0))
+                .collect(),
+            sum_ns: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+        }
+    }
+
+    fn record(&self, wait_ns: u64) {
+        record_histogram_u64_into(
+            ARB_TRACKER_WRITE_JOB_DURATION_NS_BUCKETS,
+            &self.bucket_counts,
+            &self.sum_ns,
+            &self.count,
+            wait_ns,
+            u64::MAX,
+        );
+    }
+}
+
+static ARB_TRACKER_WRITE_LOCK_WAIT: Lazy<[ArbWriterLockWaitHist; ArbWriterLockKind::COUNT]> =
+    Lazy::new(|| std::array::from_fn(|_| ArbWriterLockWaitHist::new()));
+
+/// Heartbeat sub-phases for stall forensics (Prometheus label `phase`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArbHeartbeatPhase {
+    TrackersRead,
+    MaybeEmit,
+    SyncPools,
+    Prune,
+    InfoLog,
+}
+
+impl ArbHeartbeatPhase {
+    fn index(self) -> usize {
+        match self {
+            Self::TrackersRead => 0,
+            Self::MaybeEmit => 1,
+            Self::SyncPools => 2,
+            Self::Prune => 3,
+            Self::InfoLog => 4,
+        }
+    }
+
+    fn prometheus_label(self) -> &'static str {
+        match self {
+            Self::TrackersRead => "trackers_read",
+            Self::MaybeEmit => "maybe_emit",
+            Self::SyncPools => "sync_pools",
+            Self::Prune => "prune",
+            Self::InfoLog => "info_log",
+        }
+    }
+
+    const COUNT: usize = 5;
+}
+
+struct ArbHeartbeatPhaseDurationHist {
+    bucket_counts: Vec<AtomicU64>,
+    sum_ns: AtomicU64,
+    count: AtomicU64,
+}
+
+impl ArbHeartbeatPhaseDurationHist {
+    fn new() -> Self {
+        Self {
+            bucket_counts: ARB_TRACKER_WRITE_JOB_DURATION_NS_BUCKETS
+                .iter()
+                .map(|_| AtomicU64::new(0))
+                .collect(),
+            sum_ns: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+        }
+    }
+
+    fn record(&self, duration_ns: u64) {
+        record_histogram_u64_into(
+            ARB_TRACKER_WRITE_JOB_DURATION_NS_BUCKETS,
+            &self.bucket_counts,
+            &self.sum_ns,
+            &self.count,
+            duration_ns,
+            u64::MAX,
+        );
+    }
+}
+
+static ARB_HEARTBEAT_PHASE_DURATION: Lazy<
+    [ArbHeartbeatPhaseDurationHist; ArbHeartbeatPhase::COUNT],
+> = Lazy::new(|| std::array::from_fn(|_| ArbHeartbeatPhaseDurationHist::new()));
+pub static ARB_HEARTBEAT_LAST_FINISH_UNIX_MS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 /// 2-hop reject breakdown (arb-strategy `check_arbitrage`)
 pub static ARB_TWO_HOP_REJECTED_SPREAD_TOO_LARGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TWO_HOP_REJECTED_SPREAD_BELOW_MIN: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -3188,6 +3440,105 @@ pub fn arb_tracker_write_coalesced_flushed_inc() {
 
 pub fn set_arb_tracker_write_queue_depth(depth: u64) {
     ARB_TRACKER_WRITE_QUEUE_DEPTH.store(depth, Ordering::Relaxed);
+}
+
+pub fn arb_tracker_write_init_worker_state() {
+    let now = wall_clock_unix_ms_now();
+    ARB_TRACKER_WRITE_LAST_FINISH_UNIX_MS.store(now, Ordering::Relaxed);
+    ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH.store(0, Ordering::Relaxed);
+}
+
+pub fn arb_tracker_write_job_started(job_type: ArbTrackerWriteJobType) {
+    ARB_TRACKER_WRITE_JOB_STARTED[job_type.index()].fetch_add(1, Ordering::Relaxed);
+    ARB_TRACKER_WRITE_LAST_JOB_TYPE.store(job_type.as_numeric(), Ordering::Relaxed);
+    ARB_TRACKER_WRITE_CURRENT_JOB_TYPE.store(job_type.as_numeric(), Ordering::Relaxed);
+    ARB_TRACKER_WRITE_CURRENT_JOB_STARTED_UNIX_MS
+        .store(wall_clock_unix_ms_now(), Ordering::Relaxed);
+}
+
+pub fn arb_tracker_write_job_finished(job_type: ArbTrackerWriteJobType, duration: Duration) {
+    let idx = job_type.index();
+    ARB_TRACKER_WRITE_JOB_FINISHED[idx].fetch_add(1, Ordering::Relaxed);
+    ARB_TRACKER_WRITE_JOB_DURATION[idx].record(duration.as_nanos() as u64);
+    let now = wall_clock_unix_ms_now();
+    ARB_TRACKER_WRITE_LAST_FINISH_UNIX_MS.store(now, Ordering::Relaxed);
+    ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH.store(0, Ordering::Relaxed);
+    ARB_TRACKER_WRITE_CURRENT_JOB_TYPE.store(0, Ordering::Relaxed);
+    ARB_TRACKER_WRITE_CURRENT_JOB_STARTED_UNIX_MS.store(0, Ordering::Relaxed);
+}
+
+pub fn tick_arb_tracker_write_seconds_since_last_finish() {
+    let last = ARB_TRACKER_WRITE_LAST_FINISH_UNIX_MS.load(Ordering::Relaxed);
+    if last == 0 {
+        return;
+    }
+    let now = wall_clock_unix_ms_now();
+    let secs = now.saturating_sub(last) / 1000;
+    ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH.store(secs, Ordering::Relaxed);
+}
+
+pub fn arb_tracker_write_job_started_total(job_type: ArbTrackerWriteJobType) -> u64 {
+    ARB_TRACKER_WRITE_JOB_STARTED[job_type.index()].load(Ordering::Relaxed)
+}
+
+pub fn arb_tracker_write_job_finished_total(job_type: ArbTrackerWriteJobType) -> u64 {
+    ARB_TRACKER_WRITE_JOB_FINISHED[job_type.index()].load(Ordering::Relaxed)
+}
+
+pub fn arb_tracker_write_job_duration_count(job_type: ArbTrackerWriteJobType) -> u64 {
+    ARB_TRACKER_WRITE_JOB_DURATION[job_type.index()]
+        .count
+        .load(Ordering::Relaxed)
+}
+
+pub fn arb_tracker_write_coalescer_flush_lost_inc(job_type: ArbTrackerWriteJobType) {
+    ARB_TRACKER_WRITE_COALESCER_FLUSH_LOST[job_type.index()].fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn arb_tracker_write_coalescer_flush_lost_total(job_type: ArbTrackerWriteJobType) -> u64 {
+    ARB_TRACKER_WRITE_COALESCER_FLUSH_LOST[job_type.index()].load(Ordering::Relaxed)
+}
+
+pub fn set_arb_tracker_write_coalescer_pending(pending: u64) {
+    ARB_TRACKER_WRITE_COALESCER_PENDING.store(pending, Ordering::Relaxed);
+}
+
+pub fn set_arb_two_hop_blocked_on_apply_trade(blocked: bool) {
+    ARB_TWO_HOP_BLOCKED_ON_APPLY_TRADE.store(u64::from(blocked), Ordering::Relaxed);
+}
+
+pub fn arb_tracker_write_stall_watchdog_inc() {
+    ARB_TRACKER_WRITE_STALL_WATCHDOG_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn record_arb_writer_lock_wait(lock: ArbWriterLockKind, wait: Duration) {
+    ARB_TRACKER_WRITE_LOCK_WAIT[lock.index()].record(wait.as_nanos() as u64);
+}
+
+pub fn arb_writer_lock_wait_count(lock: ArbWriterLockKind) -> u64 {
+    ARB_TRACKER_WRITE_LOCK_WAIT[lock.index()]
+        .count
+        .load(Ordering::Relaxed)
+}
+
+pub fn record_arb_heartbeat_phase(phase: ArbHeartbeatPhase, duration: Duration) {
+    ARB_HEARTBEAT_PHASE_DURATION[phase.index()].record(duration.as_nanos() as u64);
+}
+
+pub fn arb_heartbeat_finished() {
+    let now = wall_clock_unix_ms_now();
+    ARB_HEARTBEAT_LAST_FINISH_UNIX_MS.store(now, Ordering::Relaxed);
+    ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH.store(0, Ordering::Relaxed);
+}
+
+pub fn tick_arb_heartbeat_seconds_since_last_finish() {
+    let last = ARB_HEARTBEAT_LAST_FINISH_UNIX_MS.load(Ordering::Relaxed);
+    if last == 0 {
+        return;
+    }
+    let now = wall_clock_unix_ms_now();
+    let secs = now.saturating_sub(last) / 1000;
+    ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH.store(secs, Ordering::Relaxed);
 }
 
 /// Sub-reason when a mint hits the `insufficient_pools` gate (low-cardinality `reason` label).
@@ -4258,6 +4609,39 @@ fn append_momentum_latency_histogram_prometheus(
     out.push_str(&format!("{}_bucket{{le=\"+Inf\"}} {}\n", metric, c));
     out.push_str(&format!("{}_sum {}\n", metric, s));
     out.push_str(&format!("{}_count {}\n", metric, c));
+}
+
+/// Append `_bucket{le=...}`, `_sum`, `_count` lines (same layout as `tx_slot_to_send_ms`).
+#[allow(clippy::too_many_arguments)]
+fn append_labeled_duration_seconds_histogram(
+    out: &mut String,
+    metric: &str,
+    label_key: &str,
+    label_value: &str,
+    buckets_ns: &[u64],
+    bucket_counts: &[AtomicU64],
+    sum: &AtomicU64,
+    count: &AtomicU64,
+) {
+    let c = count.load(Ordering::Relaxed);
+    let s = sum.load(Ordering::Relaxed);
+    for (i, b) in buckets_ns.iter().enumerate() {
+        let v = bucket_counts[i].load(Ordering::Relaxed);
+        out.push_str(&format!(
+            "{metric}_bucket{{{label_key}=\"{label_value}\",le=\"{}\"}} {v}\n",
+            (*b as f64) / 1e9
+        ));
+    }
+    out.push_str(&format!(
+        "{metric}_bucket{{{label_key}=\"{label_value}\",le=\"+Inf\"}} {c}\n"
+    ));
+    out.push_str(&format!(
+        "{metric}_sum{{{label_key}=\"{label_value}\"}} {}\n",
+        (s as f64) / 1e9
+    ));
+    out.push_str(&format!(
+        "{metric}_count{{{label_key}=\"{label_value}\"}} {c}\n"
+    ));
 }
 
 async fn metrics_response() -> Response<Body> {
@@ -5982,6 +6366,101 @@ async fn metrics_response() -> Response<Body> {
             .to_string(),
     );
     out.push('\n');
+    for job_type in ArbTrackerWriteJobType::all() {
+        out.push_str(&format!(
+            "arb_tracker_write_job_started_total{{job_type=\"{}\"}} {}\n",
+            job_type.prometheus_label(),
+            ARB_TRACKER_WRITE_JOB_STARTED[job_type.index()].load(Ordering::Relaxed)
+        ));
+    }
+    for job_type in ArbTrackerWriteJobType::all() {
+        out.push_str(&format!(
+            "arb_tracker_write_job_finished_total{{job_type=\"{}\"}} {}\n",
+            job_type.prometheus_label(),
+            ARB_TRACKER_WRITE_JOB_FINISHED[job_type.index()].load(Ordering::Relaxed)
+        ));
+    }
+    for job_type in ArbTrackerWriteJobType::all() {
+        append_labeled_duration_seconds_histogram(
+            &mut out,
+            "arb_tracker_write_job_duration_seconds",
+            "job_type",
+            job_type.prometheus_label(),
+            ARB_TRACKER_WRITE_JOB_DURATION_NS_BUCKETS,
+            &ARB_TRACKER_WRITE_JOB_DURATION[job_type.index()].bucket_counts,
+            &ARB_TRACKER_WRITE_JOB_DURATION[job_type.index()].sum_ns,
+            &ARB_TRACKER_WRITE_JOB_DURATION[job_type.index()].count,
+        );
+    }
+    line!(
+        "arb_tracker_write_last_job_type",
+        ARB_TRACKER_WRITE_LAST_JOB_TYPE.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_tracker_write_seconds_since_last_finish",
+        ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_tracker_write_current_job_type",
+        ARB_TRACKER_WRITE_CURRENT_JOB_TYPE.load(Ordering::Relaxed)
+    );
+    for job_type in ArbTrackerWriteJobType::all() {
+        out.push_str(&format!(
+            "arb_tracker_write_coalescer_flush_lost_total{{job_type=\"{}\"}} {}\n",
+            job_type.prometheus_label(),
+            ARB_TRACKER_WRITE_COALESCER_FLUSH_LOST[job_type.index()].load(Ordering::Relaxed)
+        ));
+    }
+    line!(
+        "arb_tracker_write_coalescer_pending",
+        ARB_TRACKER_WRITE_COALESCER_PENDING.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_two_hop_blocked_on_apply_trade",
+        ARB_TWO_HOP_BLOCKED_ON_APPLY_TRADE.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_tracker_write_stall_watchdog_total",
+        ARB_TRACKER_WRITE_STALL_WATCHDOG_TOTAL.load(Ordering::Relaxed)
+    );
+    for lock in [
+        ArbWriterLockKind::TrackersRead,
+        ArbWriterLockKind::TrackersWrite,
+        ArbWriterLockKind::VaultBalancesWrite,
+    ] {
+        append_labeled_duration_seconds_histogram(
+            &mut out,
+            "arb_tracker_write_lock_wait_seconds",
+            "lock",
+            lock.prometheus_label(),
+            ARB_TRACKER_WRITE_JOB_DURATION_NS_BUCKETS,
+            &ARB_TRACKER_WRITE_LOCK_WAIT[lock.index()].bucket_counts,
+            &ARB_TRACKER_WRITE_LOCK_WAIT[lock.index()].sum_ns,
+            &ARB_TRACKER_WRITE_LOCK_WAIT[lock.index()].count,
+        );
+    }
+    for phase in [
+        ArbHeartbeatPhase::TrackersRead,
+        ArbHeartbeatPhase::MaybeEmit,
+        ArbHeartbeatPhase::SyncPools,
+        ArbHeartbeatPhase::Prune,
+        ArbHeartbeatPhase::InfoLog,
+    ] {
+        append_labeled_duration_seconds_histogram(
+            &mut out,
+            "arb_heartbeat_phase_duration_seconds",
+            "phase",
+            phase.prometheus_label(),
+            ARB_TRACKER_WRITE_JOB_DURATION_NS_BUCKETS,
+            &ARB_HEARTBEAT_PHASE_DURATION[phase.index()].bucket_counts,
+            &ARB_HEARTBEAT_PHASE_DURATION[phase.index()].sum_ns,
+            &ARB_HEARTBEAT_PHASE_DURATION[phase.index()].count,
+        );
+    }
+    line!(
+        "arb_heartbeat_seconds_since_last_finish",
+        ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH.load(Ordering::Relaxed)
+    );
     line!(
         "arb_subscriber_high_queue_depth",
         ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH.load(Ordering::Relaxed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ziel

Beweisbare Instrumentierung für den **initialen Writer-Stall** nach PR #253. **Kein Verhaltens-Fix** — nur Metriken, Logs, Watchdog und Repro-Tests.

## Supervisor-Review Follow-up

### Finding 1 — Heartbeat scope shrink **revertiert** (RCA-Parität)
Der initiale Entwurf kürzte `trackers.read()` vor `maybe_emit_snapshot` — das hätte H2-Contention in Prod **maskiert**. Revert bewusst: Heartbeat hält `trackers.read()` wieder über alle langsamen Schritte wie in #253 (`maybe_emit`, `sync_pools`, `prune`, `info!`). Metrik `arb_heartbeat_phase_duration_seconds{phase="trackers_read"}` erfasst die **volle** Read-Guard-Dauer bis zum Drop.

### Finding 3 — Stall-Watchdog erweitert
Zusätzliche Trigger-Bedingung bei Queue > 90%:
- `secs_since_last_finish > 30` → `stall_kind="writer not finishing jobs"`
- `job_duration_secs > 30` (aktiver Job) → `stall_kind="writer stuck in job"`
- Beides → `"writer stuck in job and not finishing jobs"`

## Phase 1 — Instrumentierung

### A. Writer-Job-Lifecycle
- `arb_tracker_write_job_started_total{job_type}`
- `arb_tracker_write_job_finished_total{job_type}`
- `arb_tracker_write_job_duration_seconds{job_type}` (Histogram)
- `arb_tracker_write_last_job_type` / `seconds_since_last_finish` / `current_job_type`

### B. Lock-Wait + Heartbeat-Phasen
- `arb_tracker_write_lock_wait_seconds{lock=...}`
- `arb_heartbeat_phase_duration_seconds{phase=trackers_read|maybe_emit|sync_pools|prune|info_log}`

### C. Coalescer / Flush
- `arb_tracker_write_coalescer_flush_lost_total{job_type}`
- `arb_tracker_write_coalescer_pending`

### D. two-hop
- `arb_two_hop_blocked_on_apply_trade`

### E. Stall-Watchdog
- 30s-Intervall, Queue > 90%, differenziertes `stall_kind` + `warn!`

## Phase 2 — Repro-Tests
- `tracker_write_coalescer_flush_increments_lost_when_queue_full`
- `writer_job_duration_histogram_recorded`
- `heartbeat_read_lock_contention_blocks_writer_pool_state`

## Hypothesen-Tabelle (Metrik-Zuordnung für Prod)

| ID | Hypothese | Bestätigen würde | Widerlegen würde |
|----|-----------|------------------|------------------|
| H1 | Writer hängt **in** Job | `stall_kind=writer stuck in job`; `job_duration_seconds` p99 hoch | Kein langer aktiver Job-Typ |
| H2 | Heartbeat `trackers.read()` blockiert Writer | `lock_wait_seconds{trackers_write}` spike; `heartbeat_phase_duration_seconds{trackers_read}` hoch | Kurze TrackersRead-Phase ohne Write-Wait |
| H3 | two-hop auf `reply_rx` | `two_hop_blocked_on_apply_trade=1` dauerhaft | Gauge=0 trotz Stall |
| H4 | Coalescer flush loss | `coalescer_flush_lost_total` steigt bei voller Queue | Flush-Lost=0 |
| H5 | Writer-Task beendet | Alle Metriken stagnieren, kein `current_job_type` | Watchdog zeigt aktiven Job |

## Phase 3
**Nicht in diesem PR** — Fix folgt nach Prod-Evidenz.

## STOP-CHECK
- I-7: Keine RPC ✓ | Single-Writer unverändert ✓ | I-9 unverändert ✓

## CI
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`

## Prod-Verifikation (nach Deploy)
```bash
curl -s http://127.0.0.1:9803/metrics | grep -E 'arb_tracker_write_job_|coalescer_flush_lost|stall_watchdog|heartbeat_phase|two_hop_blocked'
journalctl -u arb-strategy --since "10 min ago" | grep -iE 'tracker write stall|stall_kind|blocked_on_apply'
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-182cdc29-2253-4b4b-a9ad-3229fd0d20ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-182cdc29-2253-4b4b-a9ad-3229fd0d20ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

