### PR TITLE
P0: Meteora DLMM PoolStateUpdate / vault freshness (arb-pinned)

### DIFF
--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -345,6 +345,59 @@ fn vault_dlmm_sol_is_x(vault: &VaultBalanceCache) -> bool {
         .unwrap_or(vault.dlmm_sol_is_x)
 }
 
+/// H3: seed missing DLMM vault row from SLAVE cache on BinArrayUpdate (Geyser-only).
+fn try_seed_dlmm_vault_on_bin_update(
+    pool_address: &str,
+    update_slot: u64,
+    live_pool_cache: &SharedLivePoolCache,
+    vault_cache: &mut HashMap<String, VaultBalanceCache>,
+) {
+    if vault_cache.contains_key(pool_address) {
+        return;
+    }
+    let Ok(pool_pk) = Pubkey::from_str(pool_address) else {
+        return;
+    };
+    let Some(state) = live_pool_cache.get(&pool_pk) else {
+        return;
+    };
+    let CachedPoolState::Meteora(s) = state else {
+        return;
+    };
+    let x = s.token_x_mint.to_string();
+    let y = s.token_y_mint.to_string();
+    let (reserve_base, reserve_quote, dlmm_sol_is_x, dlmm_token_x_mint) = if y == NATIVE_SOL_MINT {
+        (
+            s.reserve_x_balance.unwrap_or(0),
+            s.reserve_y_balance.unwrap_or(0),
+            false,
+            Some(x),
+        )
+    } else if x == NATIVE_SOL_MINT {
+        (
+            s.reserve_y_balance.unwrap_or(0),
+            s.reserve_x_balance.unwrap_or(0),
+            true,
+            Some(x),
+        )
+    } else {
+        return;
+    };
+    vault_cache.insert(
+        pool_address.to_string(),
+        VaultBalanceCache {
+            reserve_base,
+            reserve_quote,
+            update_slot,
+            active_id: Some(s.active_id),
+            bin_step: Some(s.bin_step),
+            updated_at: Instant::now(),
+            dlmm_sol_is_x,
+            dlmm_token_x_mint,
+        },
+    );
+}
+
 /// Resolve on-chain `token_x_mint` for DLMM PoolStateUpdate (normalized base/quote ≠ token_x/y).
 fn resolve_dlmm_token_x_mint_for_pool_update(
     pool_address: &str,
@@ -3784,6 +3837,12 @@ impl ArbContext {
         let now = Instant::now();
         {
             let mut vault_cache = self.vault_balances.write();
+            try_seed_dlmm_vault_on_bin_update(
+                pool_address,
+                update_slot,
+                &self.live_pool_cache,
+                &mut vault_cache,
+            );
             if let Some(v) = vault_cache.get_mut(pool_address) {
                 v.updated_at = now;
             }
@@ -6948,7 +7007,9 @@ mod event_pipeline_tests {
 #[cfg(test)]
 mod two_hop_price_tests {
     use super::*;
-    use ironcrab::execution::live_pool_cache::{create_shared_cache, SharedLivePoolCache};
+    use ironcrab::execution::live_pool_cache::{
+        create_shared_cache, CachedPoolState, MeteoraState, SharedLivePoolCache,
+    };
     use ironcrab::ipc::PoolCacheUpdate;
     use rust_decimal::Decimal;
     use solana_sdk::pubkey::Pubkey;
@@ -7310,6 +7371,48 @@ mod two_hop_price_tests {
         };
         let max_age = Duration::from_millis(MAX_PRICE_AGE_MS);
         assert!(is_pool_price_fresh(&pool, Some(&vault), max_age));
+    }
+
+    #[test]
+    fn bin_array_update_seeds_missing_vault_from_live_cache() {
+        let cache = create_shared_cache();
+        let pool_pk = Pubkey::new_unique();
+        let token_mint = Pubkey::new_unique();
+        let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        cache.upsert(
+            pool_pk,
+            CachedPoolState::Meteora(MeteoraState {
+                token_x_mint: token_mint,
+                token_y_mint: sol,
+                reserve_x: Pubkey::new_unique(),
+                reserve_y: Pubkey::new_unique(),
+                active_id: 42,
+                bin_step: 25,
+                reserve_x_balance: Some(1_000_000),
+                reserve_y_balance: Some(2_000_000_000),
+            }),
+            10,
+        );
+        let ctx = test_arb_context(cache);
+        let pool_addr = pool_pk.to_string();
+        assert!(!ctx.vault_balances.read().contains_key(&pool_addr));
+
+        ctx.handle_bin_array_update(
+            &pool_addr,
+            0,
+            vec![BinData {
+                offset: 0,
+                amount_x: 1_000_000,
+                amount_y: 2_000_000_000,
+            }],
+            11,
+        );
+
+        let vaults = ctx.vault_balances.read();
+        let vault = vaults.get(&pool_addr).expect("vault must be seeded");
+        assert_eq!(vault.active_id, Some(42));
+        assert_eq!(vault.bin_step, Some(25));
+        assert!(vault.updated_at.elapsed() < Duration::from_secs(1));
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -79,8 +79,8 @@ use ironcrab::market_data::sidefx::{
 };
 use ironcrab::market_data::track::{
     arb_coalesce_try_send, explicit_subscription_has_new_keys, momentum_coalesce_try_send,
-    spawn_track_worker, ConsumerId, DesiredExplicitSet, TrackPinReason, TrackWorkerContext,
-    TrackWorkerSender,
+    spawn_track_worker, track_worker_try_enqueue, ConsumerId, DesiredExplicitSet, TrackPinReason,
+    TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -367,6 +367,7 @@ struct MarketDataSidefxHost {
     ctx: Arc<MarketDataContext>,
     publish_tx: Option<mpsc::Sender<AccountPathNatsJob>>,
     md_state: MdStateSender,
+    track_worker: TrackWorkerSender,
 }
 
 impl SidefxWorkerHost for MarketDataSidefxHost {
@@ -538,6 +539,23 @@ impl SidefxWorkerHost for MarketDataSidefxHost {
     fn note_trade_pool_lru_touches(&self, pool: Pubkey, scratch: &mut MdSidefxBurstScratch) {
         note_trade_pool_lru_touches_from_cache(&self.ctx, pool, scratch);
     }
+
+    fn is_hot_pool(&self, pool: &Pubkey) -> bool {
+        self.ctx.hot_pool_registry.is_hot_pool(*pool)
+    }
+
+    fn maybe_refresh_arb_dlmm_bin_window(&self, pool: Pubkey, new_active_id: i32) -> bool {
+        let changed = self
+            .ctx
+            .maybe_refresh_arb_dlmm_bin_window(pool, new_active_id);
+        if changed {
+            let _ = track_worker_try_enqueue(
+                &self.track_worker,
+                TrackWorkerCommand::ScheduleGeyserPushDebounced,
+            );
+        }
+        changed
+    }
 }
 
 /// Phase 5b: md-sidefx worker (delegates to `sidefx/worker.rs`).
@@ -545,11 +563,13 @@ fn spawn_md_sidefx_worker(
     ctx: Arc<MarketDataContext>,
     publish_tx: Option<mpsc::Sender<AccountPathNatsJob>>,
     md_state: MdStateSender,
+    track_worker: TrackWorkerSender,
 ) -> MdSidefxSender {
     let host = Arc::new(MarketDataSidefxHost {
         ctx,
         publish_tx,
         md_state,
+        track_worker,
     }) as Arc<dyn SidefxWorkerHost>;
     spawn_sidefx_worker(host, MARKET_DATA_MD_SIDEFX_QUEUE_CAP)
 }
@@ -1079,6 +1099,8 @@ struct MarketDataContext {
     last_momentum_snapshot_target: parking_lot::RwLock<Option<HashSet<(Pubkey, Pubkey)>>>,
     /// Phase 3: skip redundant arb snapshot reconcile when target pool set unchanged.
     last_arb_snapshot_target: parking_lot::RwLock<Option<HashSet<Pubkey>>>,
+    /// Last `active_id` used when registering DLMM bin-array window per pool (Fix B).
+    dlmm_registered_active_id: parking_lot::RwLock<HashMap<Pubkey, i32>>,
 }
 
 #[derive(Debug, Default)]
@@ -3068,6 +3090,85 @@ impl MarketDataContext {
         self.register_geyser_reserves_for_active_pool(pool, GeyserPinReason::ArbMultiDex)
     }
 
+    fn register_meteora_dlmm_bin_arrays(
+        &self,
+        pool: Pubkey,
+        active_id: i32,
+        bin_step: u16,
+        pin: GeyserPinReason,
+        now: Instant,
+    ) -> bool {
+        if !self.config.read().enable_meteora_dlmm {
+            return false;
+        }
+        let active_array_index = MeteoraDlmmSwapBuilder::bin_id_to_bin_array_index(active_id);
+        let mut bins_changed = false;
+        let mut new_bins: Vec<Pubkey> = Vec::new();
+        {
+            let mut bin_arrays = self.tracked_bin_arrays.write();
+            for offset in -3i64..=3i64 {
+                let index = active_array_index + offset;
+                if let Ok(pda) = MeteoraDlmmSwapBuilder::derive_bin_array_pda(&pool, index) {
+                    use std::collections::hash_map::Entry;
+                    match bin_arrays.entry(pda) {
+                        Entry::Vacant(e) => {
+                            e.insert(BinArrayInfo {
+                                pool_address: pool,
+                                bin_array_index: index,
+                                bin_step,
+                                last_used_at: now,
+                                pinned: false,
+                                pin: None,
+                            });
+                            bins_changed = true;
+                            new_bins.push(pda);
+                        }
+                        Entry::Occupied(mut e) => {
+                            let b = e.get_mut();
+                            if Self::geyser_pin_may_promote(b.pin, pin) {
+                                b.pinned = true;
+                                b.pin = Some(pin);
+                                b.bin_step = bin_step;
+                                bins_changed = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        for pda in new_bins {
+            self.geyser_lru_note_bin(pda, now);
+            self.pool_tracked_legs_note_bin(pool, pda);
+        }
+        if bins_changed {
+            self.dlmm_registered_active_id
+                .write()
+                .insert(pool, active_id);
+        }
+        bins_changed
+    }
+
+    /// Fix B: when arb-pinned DLMM `active_id` drifts, register new bin-array PDAs + Geyser push.
+    fn maybe_refresh_arb_dlmm_bin_window(&self, pool: Pubkey, new_active_id: i32) -> bool {
+        if !self.hot_pool_registry.pool_has_arb(pool) {
+            return false;
+        }
+        let prev = self.dlmm_registered_active_id.read().get(&pool).copied();
+        if prev == Some(new_active_id) {
+            return false;
+        }
+        let Some(CachedPoolState::Meteora(s)) = self.live_pool_cache.get(&pool) else {
+            return false;
+        };
+        self.register_meteora_dlmm_bin_arrays(
+            pool,
+            new_active_id,
+            s.bin_step,
+            GeyserPinReason::ArbMultiDex,
+            Instant::now(),
+        )
+    }
+
     fn register_geyser_reserves_impl(&self, pool: Pubkey, pin: GeyserPinReason) -> bool {
         let now = Instant::now();
         let enable_dlmm = self.config.read().enable_meteora_dlmm;
@@ -3088,38 +3189,8 @@ impl MarketDataContext {
 
         match &state {
             CachedPoolState::Meteora(s) if enable_dlmm => {
-                let active_id = s.active_id;
-                let active_array_index =
-                    MeteoraDlmmSwapBuilder::bin_id_to_bin_array_index(active_id);
-                let bin_step = s.bin_step;
-                {
-                    let mut bin_arrays = self.tracked_bin_arrays.write();
-                    let mut new_bins: Vec<Pubkey> = Vec::new();
-                    for offset in -3i64..=3i64 {
-                        let index = active_array_index + offset;
-                        if let Ok(pda) = MeteoraDlmmSwapBuilder::derive_bin_array_pda(&pool, index)
-                        {
-                            use std::collections::hash_map::Entry;
-                            if let Entry::Vacant(e) = bin_arrays.entry(pda) {
-                                e.insert(BinArrayInfo {
-                                    pool_address: pool,
-                                    bin_array_index: index,
-                                    bin_step,
-                                    last_used_at: now,
-                                    pinned: false,
-                                    pin: None,
-                                });
-                                bins_changed = true;
-                                new_bins.push(pda);
-                            }
-                        }
-                    }
-                    drop(bin_arrays);
-                    for pda in new_bins {
-                        self.geyser_lru_note_bin(pda, now);
-                        self.pool_tracked_legs_note_bin(pool, pda);
-                    }
-                }
+                bins_changed =
+                    self.register_meteora_dlmm_bin_arrays(pool, s.active_id, s.bin_step, pin, now);
             }
             CachedPoolState::RaydiumAmm(s) => {
                 let mut vaults = self.tracked_vaults.write();
@@ -5903,6 +5974,7 @@ async fn main() -> Result<()> {
         geyser_lru_index: parking_lot::Mutex::new(GeyserLruIndex::default()),
         last_momentum_snapshot_target: parking_lot::RwLock::new(None),
         last_arb_snapshot_target: parking_lot::RwLock::new(None),
+        dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -6483,14 +6555,8 @@ async fn account_path_enqueue_core_market_event(
     event: MarketEvent,
     trace: Option<MarketEventCorePublishTrace>,
 ) -> bool {
-    match &event.kind {
-        MarketEventKind::PoolStateUpdate { dex, .. } => {
-            ironcrab::metrics::market_data_pool_state_publish_inc(dex);
-        }
-        MarketEventKind::BinArrayUpdate { .. } => {
-            ironcrab::metrics::market_data_bin_array_publish_inc();
-        }
-        _ => {}
+    if matches!(&event.kind, MarketEventKind::BinArrayUpdate { .. }) {
+        ironcrab::metrics::market_data_bin_array_publish_inc();
     }
     publish_enqueue_core_market_event(publish_tx, nats, Some(ctx.as_ref()), event, trace).await
 }
@@ -7081,6 +7147,20 @@ async fn handle_geyser_account(
                             )
                             .await;
                         }
+                        if ctx
+                            .hot_pool_registry
+                            .is_hot_pool(bin_array_info.pool_address)
+                        {
+                            md_sidefx_try_enqueue(
+                                md_sidefx,
+                                MdSidefxCommand::DlmmPoolStatePublishSignal {
+                                    run_id: run_id.to_string(),
+                                    pool_address: bin_array_info.pool_address,
+                                    slot: account_update.slot,
+                                    grpc_recv_at: account_geyser_recv_at,
+                                },
+                            );
+                        }
                     }
                 }
                 Err(e) => {
@@ -7655,7 +7735,7 @@ async fn run_geyser_loop(
     let md_state = spawn_md_state_worker(
         Arc::clone(&ctx),
         tokio::runtime::Handle::current(),
-        track_worker,
+        track_worker.clone(),
     );
 
     // === P0: Wallet Balance Snapshot (Position Reconciliation) ===
@@ -7978,6 +8058,7 @@ async fn run_geyser_loop(
         Arc::clone(&ctx),
         account_publish_tx.clone(),
         md_state.clone(),
+        track_worker,
     );
 
     // Option A (MARKET-DATA-TX-INGEST-FAIRNESS): dedizierter Tokio-Task für Geyser-Txs.
@@ -8972,7 +9053,7 @@ async fn run_simulation_loop(
     let md_state = spawn_md_state_worker(
         Arc::clone(&ctx),
         tokio::runtime::Handle::current(),
-        track_worker,
+        track_worker.clone(),
     );
 
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
@@ -10430,6 +10511,7 @@ mod wallet_snapshot_stale_cleanup_tests {
             geyser_lru_index: parking_lot::Mutex::new(GeyserLruIndex::default()),
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
+            dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
         }
     }
 
@@ -10645,6 +10727,7 @@ mod wallet_tx_meta_balance_tests {
             geyser_lru_index: parking_lot::Mutex::new(GeyserLruIndex::default()),
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
+            dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
         })
     }
 
@@ -10992,19 +11075,22 @@ mod pr_b_geyser_tracking_tests {
     fn test_sidefx_host(
         ctx: &Arc<MarketDataContext>,
         md_state: MdStateSender,
+        track_worker: TrackWorkerSender,
     ) -> MarketDataSidefxHost {
         MarketDataSidefxHost {
             ctx: Arc::clone(ctx),
             publish_tx: None,
             md_state,
+            track_worker,
         }
     }
 
     fn test_spawn_md_sidefx(
         ctx: &Arc<MarketDataContext>,
         md_state: &MdStateSender,
+        track_worker: TrackWorkerSender,
     ) -> MdSidefxSender {
-        spawn_md_sidefx_worker(Arc::clone(ctx), None, md_state.clone())
+        spawn_md_sidefx_worker(Arc::clone(ctx), None, md_state.clone(), track_worker)
     }
 
     fn fill_md_state_queue(md_state: &MdStateSender) {
@@ -11065,7 +11151,7 @@ mod pr_b_geyser_tracking_tests {
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let (md_state, depth, md_state_rx) = test_md_state_sender_no_worker();
-        let worker = test_sidefx_host(&ctx, md_state.clone());
+        let worker = test_sidefx_host(&ctx, md_state.clone(), test_noop_track_worker_sender());
         let pool = Pubkey::new_unique();
         let base = Pubkey::new_unique();
         let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
@@ -11512,6 +11598,7 @@ mod pr_b_geyser_tracking_tests {
             geyser_lru_index: parking_lot::Mutex::new(GeyserLruIndex::default()),
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
+            dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
         })
     }
 
@@ -11583,6 +11670,7 @@ mod pr_b_geyser_tracking_tests {
             geyser_lru_index: parking_lot::Mutex::new(GeyserLruIndex::default()),
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
+            dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
         });
         (
             ctx,
@@ -12632,7 +12720,7 @@ mod pr_b_geyser_tracking_tests {
             grpc_recv_at: Instant::now(),
         };
         let md_state = test_spawn_md_state(&ctx);
-        let md_sidefx = test_spawn_md_sidefx(&ctx, &md_state);
+        let md_sidefx = test_spawn_md_sidefx(&ctx, &md_state, test_noop_track_worker_sender());
         let done = tokio::time::timeout(
             std::time::Duration::from_millis(150),
             handle_geyser_transaction(
@@ -12726,7 +12814,7 @@ mod pr_b_geyser_tracking_tests {
 
         let account_count = AtomicU64::new(0);
         let md_state = test_spawn_md_state(&ctx);
-        let md_sidefx = test_spawn_md_sidefx(&ctx, &md_state);
+        let md_sidefx = test_spawn_md_sidefx(&ctx, &md_state, test_noop_track_worker_sender());
         let update = GeyserAccountUpdate {
             pubkey: pool,
             owner: PUMPFUN_AMM_PROGRAM_OWNER,
@@ -13184,7 +13272,7 @@ mod pr_b_geyser_tracking_tests {
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let md_state = test_spawn_md_state(&ctx);
-        let md_sidefx = test_spawn_md_sidefx(&ctx, &md_state);
+        let md_sidefx = test_spawn_md_sidefx(&ctx, &md_state, test_noop_track_worker_sender());
         fill_md_state_queue(&md_state);
 
         let lock_ctx = Arc::clone(&ctx);
@@ -13269,7 +13357,7 @@ mod pr_b_geyser_tracking_tests {
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let md_state = test_spawn_md_state(&ctx);
-        let md_sidefx = test_spawn_md_sidefx(&ctx, &md_state);
+        let md_sidefx = test_spawn_md_sidefx(&ctx, &md_state, test_noop_track_worker_sender());
         fill_md_sidefx_queue(&md_sidefx);
 
         let lock_ctx = Arc::clone(&ctx);
@@ -13324,7 +13412,7 @@ mod pr_b_geyser_tracking_tests {
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let md_state = test_spawn_md_state(&ctx);
-        let md_sidefx = test_spawn_md_sidefx(&ctx, &md_state);
+        let md_sidefx = test_spawn_md_sidefx(&ctx, &md_state, test_noop_track_worker_sender());
 
         let pool = Pubkey::new_unique();
         let mint = "mint123".to_string();
@@ -13931,6 +14019,104 @@ mod pr_b_geyser_tracking_tests {
         );
     }
 
+    /// P0: coalesced DLMM PoolStateUpdate from bin/state signal uses MASTER cache.
+    #[test]
+    fn dlmm_pool_state_signal_coalesces_per_pool() {
+        use ironcrab::execution::live_pool_cache::{CachedPoolState, MeteoraState};
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let (md_state, _depth, _rx) = test_md_state_sender_no_worker();
+        let worker = test_sidefx_host(&ctx, md_state, test_noop_track_worker_sender());
+
+        let pool = Pubkey::new_unique();
+        let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::Meteora(MeteoraState {
+                token_x_mint: Pubkey::new_unique(),
+                token_y_mint: sol,
+                reserve_x: Pubkey::new_unique(),
+                reserve_y: Pubkey::new_unique(),
+                active_id: 7,
+                bin_step: 20,
+                reserve_x_balance: Some(500_000),
+                reserve_y_balance: Some(1_500_000_000),
+            }),
+            99,
+        );
+
+        let mut scratch = MdSidefxBurstScratch::new();
+        ironcrab::market_data::sidefx::handlers::md_sidefx_process_dlmm_pool_state_publish_signal(
+            &worker,
+            &MdSidefxCommand::DlmmPoolStatePublishSignal {
+                run_id: "run-test".into(),
+                pool_address: pool,
+                slot: 50,
+                grpc_recv_at: Instant::now(),
+            },
+            &mut scratch,
+        );
+        ironcrab::market_data::sidefx::handlers::md_sidefx_process_dlmm_pool_state_publish_signal(
+            &worker,
+            &MdSidefxCommand::DlmmPoolStatePublishSignal {
+                run_id: "run-test".into(),
+                pool_address: pool,
+                slot: 99,
+                grpc_recv_at: Instant::now(),
+            },
+            &mut scratch,
+        );
+        let signals = scratch.drain_dlmm_pool_state_signals();
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].1.slot, 99, "latest slot must win coalesce");
+    }
+
+    /// Fix B: arb-pinned DLMM re-registers bin arrays when active_id drifts.
+    #[test]
+    fn arb_dlmm_bin_window_refreshes_on_active_id_drift() {
+        use ironcrab::execution::live_pool_cache::{CachedPoolState, MeteoraState};
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::Meteora(MeteoraState {
+                token_x_mint: Pubkey::new_unique(),
+                token_y_mint: sol,
+                reserve_x: Pubkey::new_unique(),
+                reserve_y: Pubkey::new_unique(),
+                active_id: 10,
+                bin_step: 15,
+                reserve_x_balance: Some(1),
+                reserve_y_balance: Some(1),
+            }),
+            1,
+        );
+        assert!(ctx.register_geyser_reserves_for_arb_active_pool(pool));
+        let before = ctx.tracked_bin_arrays.read().len();
+        assert!(
+            !ctx.maybe_refresh_arb_dlmm_bin_window(pool, 10),
+            "same active_id must be idempotent"
+        );
+        assert_eq!(ctx.tracked_bin_arrays.read().len(), before);
+
+        assert!(ctx.maybe_refresh_arb_dlmm_bin_window(pool, 500));
+        assert!(
+            ctx.tracked_bin_arrays.read().len() >= before,
+            "new active_id must register additional bin-array PDAs"
+        );
+        assert_eq!(ctx.dlmm_registered_active_id.read().get(&pool), Some(&500));
+    }
+
     /// Phase1: snapshot-backed vault balance tick publishes paired reserves.
     #[test]
     fn phase1_vault_balance_tick_from_snapshot_publishes_pair() {
@@ -13939,7 +14125,7 @@ mod pr_b_geyser_tracking_tests {
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let (md_state, _depth, _rx) = test_md_state_sender_no_worker();
-        let worker = test_sidefx_host(&ctx, md_state);
+        let worker = test_sidefx_host(&ctx, md_state, test_noop_track_worker_sender());
 
         let pool = Pubkey::new_unique();
         let base_vault = Pubkey::new_unique();

--- a/src/market_data/publish/core.rs
+++ b/src/market_data/publish/core.rs
@@ -6,7 +6,7 @@ use crate::market_data::sidefx::host::{
     market_event_should_nats_core, MarketEventCorePublishTrace,
 };
 use crate::metrics::{
-    record_market_data_bonding_to_trade_slot_delta_slots,
+    market_data_pool_state_publish_inc, record_market_data_bonding_to_trade_slot_delta_slots,
     record_market_data_geyser_to_publish_on_success,
     record_market_data_trade_after_bonding_publish_ms, wall_clock_unix_ms_now,
     MARKET_DATA_LAST_TRADE_PUBLISH_TS_UNIX_MS, MARKET_EVENTS_MOMENTUM_FANOUT_PUBLISHED_TOTAL,
@@ -74,6 +74,9 @@ pub async fn publish_market_event_core_and_momentum_ex(
         Ok(true) => {
             NATS_MESSAGES_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
             MARKET_EVENTS_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+            if let MarketEventKind::PoolStateUpdate { dex, .. } = &event.kind {
+                market_data_pool_state_publish_inc(dex);
+            }
             if let Some(t) = trace {
                 record_market_data_geyser_to_publish_on_success(
                     t.recv_at,

--- a/src/market_data/sidefx/handlers.rs
+++ b/src/market_data/sidefx/handlers.rs
@@ -7,7 +7,7 @@ use super::pool_publish::{
     pool_cache_balance_fields_from_state, pump_amm_sell_layout_publish_state,
     raydium_cpmm_readiness_for_pool_cache_update, raydium_cpmm_vaults_for_pool_cache_update,
 };
-use super::worker::{MdSidefxBurstScratch, MdSidefxCommand};
+use super::worker::{DlmmPoolStateSignal, MdSidefxBurstScratch, MdSidefxCommand};
 use crate::execution::live_pool_cache::{
     meteora_cpmm_readiness_for_pool_cache_update, meteora_dlmm_readiness_for_pool_cache_update,
     orca_readiness_for_pool_cache_update, parse_pool_account,
@@ -19,6 +19,7 @@ use crate::ipc::{
     POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use crate::metrics::{
+    inc_market_data_pool_state_publish_skipped_balance_unchanged_total,
     record_market_data_bonding_curve_grpc_to_devwallet_ms,
     record_market_data_pool_mint_map_to_devwallet_ms, MarketDataLatencySegment,
 };
@@ -53,6 +54,104 @@ fn sidefx_host_enqueue_jetstream<T: serde::Serialize>(
         log_fail,
         bump_market_events_published_total,
     );
+}
+
+/// Build PoolStateUpdate from MASTER LivePoolCache (Geyser-only; no RPC).
+fn md_sidefx_build_pool_state_update_from_cache(
+    host: &dyn SidefxWorkerHost,
+    run_id: &str,
+    pool_pubkey: &Pubkey,
+    slot: u64,
+) -> Option<MarketEvent> {
+    let state = host.live_pool_cache().get(pool_pubkey)?;
+    let (base_mint, quote_mint, reserve_base, reserve_quote, dex) =
+        pool_cache_balance_fields_from_state(&state)?;
+    let (active_id, bin_step) = match &state {
+        CachedPoolState::Meteora(s) => (Some(s.active_id), Some(s.bin_step)),
+        _ => (None, None),
+    };
+    Some(MarketEvent::new(
+        "market-data",
+        host.build_version(),
+        run_id,
+        host.next_event_id(),
+        "geyser_dlmm_cache",
+        Some(slot),
+        MarketEventKind::PoolStateUpdate {
+            pool_address: pool_pubkey.to_string(),
+            dex: dex.to_string(),
+            reserve_base,
+            reserve_quote,
+            base_mint: base_mint.to_string(),
+            quote_mint: quote_mint.to_string(),
+            update_slot: slot,
+            active_id,
+            bin_step,
+        },
+    ))
+}
+
+fn md_sidefx_publish_pool_state_update_from_cache(
+    host: &dyn SidefxWorkerHost,
+    run_id: &str,
+    pool_pubkey: &Pubkey,
+    slot: u64,
+    grpc_recv_at: Instant,
+) -> bool {
+    let Some(state_event) =
+        md_sidefx_build_pool_state_update_from_cache(host, run_id, pool_pubkey, slot)
+    else {
+        return false;
+    };
+    host.write_market_event_jsonl(&state_event);
+    if host.nats_enabled() {
+        host.enqueue_core_market_event(
+            state_event,
+            Some(MarketEventCorePublishTrace {
+                recv_at: grpc_recv_at,
+                cold_path: false,
+                segment: MarketDataLatencySegment::Other,
+            }),
+        )
+    } else {
+        false
+    }
+}
+
+pub fn md_sidefx_flush_pending_dlmm_pool_state_publishes(
+    host: &dyn SidefxWorkerHost,
+    scratch: &mut MdSidefxBurstScratch,
+) {
+    let signals: Vec<(Pubkey, DlmmPoolStateSignal)> = scratch.drain_dlmm_pool_state_signals();
+    for (pool, signal) in signals {
+        if !host.is_hot_pool(&pool) {
+            continue;
+        }
+        let _ = md_sidefx_publish_pool_state_update_from_cache(
+            host,
+            &signal.run_id,
+            &pool,
+            signal.slot,
+            signal.grpc_recv_at,
+        );
+    }
+}
+
+pub fn md_sidefx_process_dlmm_pool_state_publish_signal(
+    _host: &dyn SidefxWorkerHost,
+    job: &MdSidefxCommand,
+    scratch: &mut MdSidefxBurstScratch,
+) {
+    let MdSidefxCommand::DlmmPoolStatePublishSignal {
+        run_id,
+        pool_address,
+        slot,
+        grpc_recv_at,
+    } = job
+    else {
+        return;
+    };
+    scratch.note_dlmm_pool_state_signal(*pool_address, run_id, *slot, *grpc_recv_at);
 }
 
 pub fn sidefx_maybe_emit_dev_wallet_after_pool_mint_map(
@@ -873,7 +972,7 @@ pub fn md_sidefx_process_live_pool_cache_mint_decimals(
 pub fn md_sidefx_process_live_pool_cache_account_update(
     host: &dyn SidefxWorkerHost,
     job: &MdSidefxCommand,
-    _scratch: &mut MdSidefxBurstScratch,
+    scratch: &mut MdSidefxBurstScratch,
 ) {
     let MdSidefxCommand::LivePoolCacheAccountUpdate {
         run_id,
@@ -887,6 +986,13 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
         return;
     };
     if let Some(mut cached_state) = parse_pool_account(owner, account_data) {
+        let prev_meteora_meta = host.live_pool_cache().get(pool_pubkey).and_then(|s| {
+            if let CachedPoolState::Meteora(m) = s {
+                Some((m.active_id, m.bin_step))
+            } else {
+                None
+            }
+        });
         // P2#7: Enrich PumpFun token_mint from pool_mint_map when parse returns default
         if let CachedPoolState::PumpFun(ref mut s) = &mut cached_state {
             if s.token_mint == Pubkey::default() {
@@ -912,6 +1018,21 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
             // Stale Geyser snapshot (e.g. HIGH/LOW queue reorder for same pubkey): skip downstream
             // JetStream / MarketEvent side effects so trading state cannot regress.
             return;
+        }
+
+        if let CachedPoolState::Meteora(ref s) = cached_state {
+            let meta_changed = match prev_meteora_meta {
+                None => host.is_hot_pool(pool_pubkey),
+                Some((prev_id, prev_step)) => prev_id != s.active_id || prev_step != s.bin_step,
+            };
+            if meta_changed && host.is_hot_pool(pool_pubkey) {
+                scratch.note_dlmm_pool_state_signal(*pool_pubkey, run_id, *slot, *grpc_recv_at);
+            }
+            if let Some((prev_id, _)) = prev_meteora_meta {
+                if prev_id != s.active_id {
+                    let _ = host.maybe_refresh_arb_dlmm_bin_window(*pool_pubkey, s.active_id);
+                }
+            }
         }
 
         // Phase1: sidefx only updates MASTER cache + JetStream; vault registration stays in md-state.
@@ -1283,6 +1404,7 @@ pub fn md_sidefx_process_vault_balance_tick(
         .last_balance
         .swap(*balance, std::sync::atomic::Ordering::Relaxed);
     if *balance == prev_balance {
+        inc_market_data_pool_state_publish_skipped_balance_unchanged_total();
         return;
     }
     scratch.note_vault_touch(*vault_pubkey);
@@ -1499,6 +1621,9 @@ pub fn md_sidefx_process_job(
         }
         MdSidefxCommand::TouchBinArrayTick { .. } => {
             md_sidefx_process_touch_bin_array_tick(host, job, scratch)
+        }
+        MdSidefxCommand::DlmmPoolStatePublishSignal { .. } => {
+            md_sidefx_process_dlmm_pool_state_publish_signal(host, job, scratch)
         }
         MdSidefxCommand::TradePoolLruTouch { .. } => {
             md_sidefx_process_trade_pool_lru_touch(host, job, scratch)

--- a/src/market_data/sidefx/host.rs
+++ b/src/market_data/sidefx/host.rs
@@ -71,6 +71,12 @@ pub trait SidefxWorkerHost: Send + Sync {
     fn vault_membership_view(&self, vault: &Pubkey) -> Option<SidefxVaultMembershipView>;
     fn snapshot_vault_pair_balances(&self, vault: &Pubkey, new_balance: u64) -> Option<(u64, u64)>;
     fn note_trade_pool_lru_touches(&self, pool: Pubkey, scratch: &mut MdSidefxBurstScratch);
+
+    /// True when pool is in momentum/arb hot set (arb-pinned DLMM PoolStateUpdate gate).
+    fn is_hot_pool(&self, pool: &Pubkey) -> bool;
+
+    /// Re-register DLMM bin-array window when arb-pinned pool `active_id` drifts (Fix B).
+    fn maybe_refresh_arb_dlmm_bin_window(&self, pool: Pubkey, new_active_id: i32) -> bool;
 }
 
 #[inline]

--- a/src/market_data/sidefx/worker.rs
+++ b/src/market_data/sidefx/worker.rs
@@ -93,6 +93,13 @@ pub enum MdSidefxCommand {
     },
     /// DLMM bin-array LRU touch off account ingest (coalesced in md-sidefx burst).
     TouchBinArrayTick { pda: Pubkey },
+    /// P0: coalesced PoolStateUpdate for hot Meteora DLMM pools (bin/state signal, no vault delta).
+    DlmmPoolStatePublishSignal {
+        run_id: String,
+        pool_address: Pubkey,
+        slot: u64,
+        grpc_recv_at: Instant,
+    },
     /// PR237: trade-path vault/bin LRU touch via sidefx scratch (replaces md-state TouchPool).
     TradePoolLruTouch { pool: Pubkey },
     /// Phase-R-R4b: `parse_pool_account` + LivePoolCache writes + PoolCacheUpdate publish off account ingest.
@@ -116,10 +123,19 @@ pub struct MdSidefxSender {
     pub queue_capacity: usize,
 }
 
+/// Per-burst coalesced DLMM pool-state publish signal (latest slot wins per pool).
+#[derive(Clone)]
+pub struct DlmmPoolStateSignal {
+    pub run_id: String,
+    pub slot: u64,
+    pub grpc_recv_at: Instant,
+}
+
 /// Per-burst scratch: LRU touches coalesced before md-state enqueue.
 pub struct MdSidefxBurstScratch {
     pending_vault_touches: HashSet<Pubkey>,
     pending_bin_array_touches: HashSet<Pubkey>,
+    pending_dlmm_pool_state_signals: HashMap<Pubkey, DlmmPoolStateSignal>,
 }
 
 impl Default for MdSidefxBurstScratch {
@@ -133,6 +149,7 @@ impl MdSidefxBurstScratch {
         Self {
             pending_vault_touches: HashSet::new(),
             pending_bin_array_touches: HashSet::new(),
+            pending_dlmm_pool_state_signals: HashMap::new(),
         }
     }
 
@@ -142,6 +159,32 @@ impl MdSidefxBurstScratch {
 
     pub fn note_bin_array_touch(&mut self, pda: Pubkey) {
         self.pending_bin_array_touches.insert(pda);
+    }
+
+    pub fn note_dlmm_pool_state_signal(
+        &mut self,
+        pool: Pubkey,
+        run_id: &str,
+        slot: u64,
+        grpc_recv_at: Instant,
+    ) {
+        match self.pending_dlmm_pool_state_signals.get(&pool) {
+            Some(existing) if existing.slot >= slot => {}
+            _ => {
+                self.pending_dlmm_pool_state_signals.insert(
+                    pool,
+                    DlmmPoolStateSignal {
+                        run_id: run_id.to_string(),
+                        slot,
+                        grpc_recv_at,
+                    },
+                );
+            }
+        }
+    }
+
+    pub fn drain_dlmm_pool_state_signals(&mut self) -> Vec<(Pubkey, DlmmPoolStateSignal)> {
+        self.pending_dlmm_pool_state_signals.drain().collect()
     }
 
     pub fn pending_vault_touches_contains(&self, vault: &Pubkey) -> bool {
@@ -164,6 +207,7 @@ pub fn md_sidefx_flush_pending_md_state_jobs(
     host: &dyn SidefxWorkerHost,
     scratch: &mut MdSidefxBurstScratch,
 ) {
+    super::handlers::md_sidefx_flush_pending_dlmm_pool_state_publishes(host, scratch);
     host.flush_lru_touches(scratch);
 }
 
@@ -203,6 +247,7 @@ pub fn md_sidefx_coalesce_key(job: &MdSidefxCommand) -> Option<Pubkey> {
         MdSidefxCommand::LivePoolCacheAccountUpdate { pool_pubkey, .. } => Some(*pool_pubkey),
         MdSidefxCommand::VaultBalanceTick { vault_pubkey, .. } => Some(*vault_pubkey),
         MdSidefxCommand::TouchBinArrayTick { pda } => Some(*pda),
+        MdSidefxCommand::DlmmPoolStatePublishSignal { pool_address, .. } => Some(*pool_address),
         MdSidefxCommand::TradePoolLruTouch { pool } => Some(*pool),
         _ => None,
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -403,6 +403,9 @@ pub static MARKET_DATA_POOL_STATE_PUBLISH_METEORA_CPMM: Lazy<AtomicU64> =
 pub static MARKET_DATA_POOL_STATE_PUBLISH_PUMPFUN: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static MARKET_DATA_POOL_STATE_PUBLISH_OTHER: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// VaultBalanceTick skipped because on-chain balance unchanged (H1 evidence).
+pub static MARKET_DATA_POOL_STATE_PUBLISH_SKIPPED_BALANCE_UNCHANGED: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// BinArrayUpdate published to Core NATS (Meteora DLMM only).
 pub static MARKET_DATA_BIN_ARRAY_PUBLISH_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
@@ -730,6 +733,11 @@ pub fn market_data_pool_state_publish_inc(dex: &str) {
         _ => &*MARKET_DATA_POOL_STATE_PUBLISH_OTHER,
     };
     counter.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_pool_state_publish_skipped_balance_unchanged_total() {
+    MARKET_DATA_POOL_STATE_PUBLISH_SKIPPED_BALANCE_UNCHANGED.fetch_add(1, Ordering::Relaxed);
 }
 
 pub fn market_data_bin_array_publish_inc() {
@@ -5454,6 +5462,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_balance_updated_from_cache_total",
         MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_pool_state_publish_skipped_total{reason=\"balance_unchanged\"}",
+        MARKET_DATA_POOL_STATE_PUBLISH_SKIPPED_BALANCE_UNCHANGED.load(Ordering::Relaxed)
     );
     out.push_str("market_data_pool_state_publish_total{dex=\"orca\"} ");
     out.push_str(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `stale_price` on the **meteora_dlmm** side of pump↔meteora multi-DEX 2-hop checks. Bins were flowing (~259k publishes) but `vault.updated_at` stayed stale (~404s avg) because `PoolStateUpdate` only fired on vault balance deltas.

## RCA (prod forensics, post-#256)

| Hypothesis | Layer | Finding | Verdict |
|------------|-------|---------|---------|
| **H1** | MD sidefx `VaultBalanceTick` | Early-return when `balance == prev_balance` → no `PoolStateUpdate` while DLMM price moves via bins/active_id | **Confirmed** (primary) |
| **H2** | MD Geyser bin pin | `active_id ± 3` registered once at pin; drift leaves new bin-array PDAs untracked | **Confirmed** (Fix B) |
| **H3** | Arb `handle_bin_array_update` | `updated_at` refresh only when `vault_balances` entry exists | **Confirmed** (Fix C) |
| **H4** | Metrics | `market_data_pool_state_publish_total` not incremented on sidefx/vault path | **Confirmed** (Fix D) |

## Changes

### Fix A — MD: coalesced `PoolStateUpdate` on DLMM bin/state signal
- After `BinArrayUpdate` publish for **hot/arb-pinned** pools → `DlmmPoolStatePublishSignal` on `md-sidefx`
- On Meteora LbPair cache upsert when `active_id`/`bin_step` changes → same signal
- Burst-coalesced flush builds `PoolStateUpdate` from **MASTER** `live_pool_cache` (Geyser-only, no RPC)

### Fix B — Arb-pinned DLMM bin window refresh
- `maybe_refresh_arb_dlmm_bin_window` re-registers `active_id ± 3` bin PDAs when `active_id` drifts
- Debounced `ScheduleGeyserPushDebounced` via existing track-worker pattern (I-4e)

### Fix C — Arb vault upsert on `BinArrayUpdate`
- `try_seed_dlmm_vault_on_bin_update`: seed missing `vault_balances` from `live_pool_cache` (SOL-quoted only, I-15)

### Fix D — Metrics
- `market_data_pool_state_publish_total{dex}` incremented on **successful** core NATS publish (`publish/core.rs`)
- `market_data_pool_state_publish_skipped_total{reason="balance_unchanged"}` on vault tick early-return (H1 evidence)

## STOP-CHECK

| Check | Result |
|-------|--------|
| I-7 Hot Path RPC | No new RPC; cache/Geyser-only |
| I-4 Geyser-first | MASTER cache authoritative |
| I-4e Arb track | Bin refresh uses track-worker debounced push |
| I-15 Non-SOL quote | Existing SOL-quote filter preserved |
| I-9 Simulation | Unchanged |

## Tests

- `dlmm_pool_state_signal_coalesces_per_pool`
- `arb_dlmm_bin_window_refreshes_on_active_id_drift`
- `bin_array_update_seeds_missing_vault_from_live_cache`
- Existing DLMM freshness tests still pass

## Post-deploy expectation

- `market_data_pool_state_publish_total{dex="meteora_dlmm"}` > 0
- `arb_price_freshness_age_ms` dlmm_meta bucket `le="30000"` rises
- `stale_price` rate for pump↔meteora pairs drops

**No deploy** in this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6366f34a-f49b-4e2e-9604-487df8b355c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6366f34a-f49b-4e2e-9604-487df8b355c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

