### PR TITLE
M1: pool_quote foundation + shadow metrics (I-ARB-1..3)

### DIFF
--- a/src/arbitrage/mod.rs
+++ b/src/arbitrage/mod.rs
@@ -31,6 +31,7 @@ pub mod arb_slave_sync;
 pub mod cycle_finder;
 pub mod multi_hop_integration;
 pub mod pool_graph;
+pub mod pool_quote;
 pub mod pool_ranker;
 pub mod types;
 
@@ -45,6 +46,12 @@ pub use multi_hop_integration::{
     QuoteReadyIndex, WSOL_MINT,
 };
 pub use pool_graph::{GraphStats, PoolGraph};
+pub use pool_quote::{
+    dlmm_marginal_price_plausible, dlmm_sol_output_from_bins, dlmm_token_output_from_bins,
+    flatten_bin_array_bins, quote_exact_in, quote_sol_per_token_for_screening, quotes_pairable,
+    round_trip_profit_lamports, DlmmBinArrays, PoolQuote, QuoteKind, QuotePoolInput, QuoteSide,
+    QuoteVaultInput, RoundTripLeg, DLMM_PROBE_SOL_LAMPORTS,
+};
 pub use pool_ranker::{PoolRanker, QuoteProvider, RankerConfig};
 pub use types::{
     clamp_edge_ratio, profit_to_return_bps, ArbCycle, DexType, ParseDexTypeError, PoolEdge,

--- a/src/arbitrage/pool_quote.rs
+++ b/src/arbitrage/pool_quote.rs
@@ -1,0 +1,714 @@
+//! Unified pool quote layer for profit-first arbitrage (M1).
+//!
+//! Contract: `Iron_crab-eval/docs/spec/ARB_QUOTE_CONTRACT.md`
+//! Legacy `comparable_price_sol_per_token` in arb-strategy remains authoritative until M5.
+
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+
+use crate::ipc::BinData;
+use crate::solana::dex::meteora_bin_walker::{dlmm_fee_bps, walker_from_bins};
+
+pub const NATIVE_SOL_MINT: &str = "So11111111111111111111111111111111111111112";
+/// Small SOL probe for DLMM marginal price / screening (0.01 SOL).
+pub const DLMM_PROBE_SOL_LAMPORTS: u64 = 10_000_000;
+/// Trade-implied quote TTL (v1 default 30s).
+pub const TRADE_TTL_MS: u64 = 30_000;
+/// Vault/bin state TTL when reserve snapshot unchanged (v1 default 120s).
+pub const STATE_TTL_MS: u64 = 120_000;
+
+const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const USDT_MINT: &str = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
+const STABLECOIN_MIN_SOL_PER_TOKEN: &str = "0.0001";
+const STABLECOIN_MAX_SOL_PER_TOKEN: &str = "1";
+const DLMM_MARGINAL_MAX_DEVIATION_FACTOR: u64 = 100;
+
+/// Quote provenance — cross-DEX pairing requires identical kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuoteKind {
+    ExecutableMarginal,
+    LastTradeMid,
+}
+
+/// Swap direction for `quote_exact_in`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuoteSide {
+    Buy,
+    Sell,
+}
+
+/// Executable or trade-mid quote for a single pool leg.
+#[derive(Debug, Clone)]
+pub struct PoolQuote {
+    pub pool_address: String,
+    pub dex: String,
+    pub kind: QuoteKind,
+    pub side: QuoteSide,
+    pub as_of_slot: u64,
+    pub as_of_ts: Instant,
+    pub fresh: bool,
+    pub amount_in: u64,
+    pub amount_out: u64,
+}
+
+/// Pool-level inputs for quoting (SOL-quoted pairs only).
+#[derive(Debug, Clone)]
+pub struct QuotePoolInput {
+    pub pool_address: String,
+    pub dex: String,
+    pub token_mint: String,
+    pub trade_price_buy: Option<Decimal>,
+    pub trade_price_sell: Option<Decimal>,
+    pub trade_updated_at: Instant,
+    pub has_reserve_data: bool,
+    pub token_decimals: u8,
+}
+
+/// Geyser vault / DLMM state for marginal quotes.
+#[derive(Debug, Clone)]
+pub struct QuoteVaultInput {
+    pub reserve_base: u64,
+    pub reserve_quote: u64,
+    pub update_slot: u64,
+    pub updated_at: Instant,
+    pub active_id: Option<i32>,
+    pub bin_step: Option<u16>,
+    pub dlmm_sol_is_x: bool,
+    pub dlmm_token_x_mint: Option<String>,
+}
+
+pub type DlmmBinArrays = HashMap<i64, Vec<BinData>>;
+
+/// True iff both quotes may be paired for cross-DEX round-trip screening.
+pub fn quotes_pairable(a: &PoolQuote, b: &PoolQuote) -> bool {
+    a.kind == b.kind
+}
+
+pub fn vault_dlmm_sol_is_x(vault: &QuoteVaultInput) -> bool {
+    vault
+        .dlmm_token_x_mint
+        .as_deref()
+        .map(|m| m == NATIVE_SOL_MINT)
+        .unwrap_or(vault.dlmm_sol_is_x)
+}
+
+pub fn flatten_bin_array_bins(arrays: &HashMap<i64, Vec<BinData>>) -> DlmmBinArrays {
+    arrays.clone()
+}
+
+fn flatten_bins_for_walker(bin_arrays: &HashMap<i64, Vec<BinData>>) -> Vec<(i32, u64, u64)> {
+    let mut all_bins: Vec<(i32, u64, u64)> = Vec::new();
+    for (array_idx, bins) in bin_arrays {
+        for bin in bins {
+            let bin_id = (*array_idx * 70 + bin.offset as i64) as i32;
+            all_bins.push((bin_id, bin.amount_x, bin.amount_y));
+        }
+    }
+    all_bins.sort_by_key(|(id, _, _)| *id);
+    all_bins
+}
+
+fn active_bin_present(active_id: i32, flat_bins: &[(i32, u64, u64)]) -> bool {
+    flat_bins.iter().any(|(id, _, _)| *id == active_id)
+}
+
+pub fn dlmm_marginal_price_plausible(
+    marginal: Decimal,
+    reserve_mid: Option<Decimal>,
+    trade_mid: Option<Decimal>,
+) -> bool {
+    let reference = match reserve_mid.or(trade_mid) {
+        Some(mid) if mid > Decimal::ZERO => mid,
+        _ => return true,
+    };
+    if marginal <= Decimal::ZERO {
+        return false;
+    }
+    let ratio = if marginal > reference {
+        marginal / reference
+    } else {
+        reference / marginal
+    };
+    ratio <= Decimal::from(DLMM_MARGINAL_MAX_DEVIATION_FACTOR)
+}
+
+/// DLMM token output via BinWalker (SOL → token).
+pub fn dlmm_token_output_from_bins(
+    active_id: i32,
+    bin_step: u16,
+    sol_in_lamports: u64,
+    bin_arrays: &HashMap<i64, Vec<BinData>>,
+    sol_is_x: bool,
+) -> Option<u64> {
+    if bin_arrays.is_empty() || sol_in_lamports == 0 {
+        return None;
+    }
+
+    let flat_bins = flatten_bins_for_walker(bin_arrays);
+    if !active_bin_present(active_id, &flat_bins) {
+        return None;
+    }
+
+    let walker = walker_from_bins(active_id, bin_step, &flat_bins);
+    let fee_bps = dlmm_fee_bps(bin_step);
+    let (amount_out, _, _) = if sol_is_x {
+        walker.quote_x_to_y(sol_in_lamports, fee_bps).ok()?
+    } else {
+        walker.quote_y_to_x(sol_in_lamports, fee_bps).ok()?
+    };
+    if amount_out == 0 {
+        return None;
+    }
+    Some(amount_out)
+}
+
+/// DLMM SOL output via BinWalker (token → SOL).
+pub fn dlmm_sol_output_from_bins(
+    active_id: i32,
+    bin_step: u16,
+    token_in: u64,
+    bin_arrays: &HashMap<i64, Vec<BinData>>,
+    sol_is_x: bool,
+) -> Option<u64> {
+    if bin_arrays.is_empty() || token_in == 0 {
+        return None;
+    }
+
+    let flat_bins = flatten_bins_for_walker(bin_arrays);
+    if !active_bin_present(active_id, &flat_bins) {
+        return None;
+    }
+
+    let walker = walker_from_bins(active_id, bin_step, &flat_bins);
+    let fee_bps = dlmm_fee_bps(bin_step);
+    let (amount_out, _, _) = if sol_is_x {
+        walker.quote_y_to_x(token_in, fee_bps).ok()?
+    } else {
+        walker.quote_x_to_y(token_in, fee_bps).ok()?
+    };
+    if amount_out == 0 {
+        return None;
+    }
+    Some(amount_out)
+}
+
+fn is_stablecoin_mint(mint: &str) -> bool {
+    mint == USDC_MINT || mint == USDT_MINT
+}
+
+fn is_plausible_sol_per_token_price(mint: &str, price: Decimal) -> bool {
+    if price <= Decimal::ZERO {
+        return false;
+    }
+    if is_stablecoin_mint(mint) {
+        let min = Decimal::from_str(STABLECOIN_MIN_SOL_PER_TOKEN).unwrap_or(Decimal::ZERO);
+        let max = Decimal::from_str(STABLECOIN_MAX_SOL_PER_TOKEN).unwrap_or(Decimal::ONE);
+        price >= min && price <= max
+    } else {
+        true
+    }
+}
+
+fn reserve_mid_sol_per_token(
+    reserve_base: u64,
+    reserve_quote: u64,
+    token_decimals: u8,
+) -> Option<Decimal> {
+    if reserve_base == 0 || reserve_quote == 0 {
+        return None;
+    }
+    let sol = Decimal::from(reserve_quote) / Decimal::from(1_000_000_000u64);
+    let token_divisor = 10u64.pow(token_decimals as u32);
+    let tokens = Decimal::from(reserve_base) / Decimal::from(token_divisor);
+    if tokens <= Decimal::ZERO {
+        return None;
+    }
+    Some(sol / tokens)
+}
+
+fn reserves_plausible(
+    reserve_base: u64,
+    reserve_quote: u64,
+    token_decimals: u8,
+    token_mint: &str,
+) -> bool {
+    reserve_base > 0
+        && reserve_quote > 0
+        && reserve_mid_sol_per_token(reserve_base, reserve_quote, token_decimals)
+            .is_some_and(|mid| is_plausible_sol_per_token_price(token_mint, mid))
+}
+
+fn trade_mid_sol_per_token(pool: &QuotePoolInput) -> Option<Decimal> {
+    match (pool.trade_price_buy, pool.trade_price_sell) {
+        (Some(buy), Some(sell)) if buy > Decimal::ZERO && sell > Decimal::ZERO => {
+            Some((buy + sell) / Decimal::from(2))
+        }
+        (Some(one), None) | (None, Some(one)) if one > Decimal::ZERO => Some(one),
+        _ => None,
+    }
+}
+
+fn trade_fresh(pool: &QuotePoolInput, now: Instant) -> bool {
+    now.duration_since(pool.trade_updated_at) <= Duration::from_millis(TRADE_TTL_MS)
+}
+
+fn state_fresh(vault: &QuoteVaultInput, now: Instant) -> bool {
+    now.duration_since(vault.updated_at) <= Duration::from_millis(STATE_TTL_MS)
+}
+
+fn cpmm_fee_bps(dex: &str) -> u64 {
+    match dex {
+        "pump_amm" => 100,
+        "orca" => 30,
+        _ => 25,
+    }
+}
+
+fn cpmm_amount_out(
+    reserve_in: u128,
+    reserve_out: u128,
+    amount_in: u64,
+    fee_bps: u64,
+) -> Option<u64> {
+    if reserve_in == 0 || reserve_out == 0 || amount_in == 0 {
+        return None;
+    }
+    let amount_in = amount_in as u128;
+    let fee_multiplier = 10000u128 - fee_bps as u128;
+    let amount_after_fee = amount_in.checked_mul(fee_multiplier)? / 10000;
+    if amount_after_fee == 0 {
+        return None;
+    }
+    let numerator = reserve_out.checked_mul(amount_after_fee)?;
+    let denominator = reserve_in.checked_add(amount_after_fee)?;
+    if denominator == 0 {
+        return None;
+    }
+    Some((numerator / denominator) as u64)
+}
+
+fn supports_cpmm(dex: &str) -> bool {
+    matches!(
+        dex,
+        "pump_amm" | "raydium" | "raydium_cpmm" | "orca" | "meteora_cpmm"
+    )
+}
+
+fn quote_side_from_mints(token_mint: &str, mint_in: &str, mint_out: &str) -> Option<QuoteSide> {
+    if mint_in == NATIVE_SOL_MINT && mint_out == token_mint {
+        Some(QuoteSide::Buy)
+    } else if mint_in == token_mint && mint_out == NATIVE_SOL_MINT {
+        Some(QuoteSide::Sell)
+    } else {
+        None
+    }
+}
+
+fn trade_implied_sol_per_token(sol_amount: u64, token_amount: u64, token_decimals: u8) -> Decimal {
+    let sol_dec = Decimal::from(sol_amount) / Decimal::from(1_000_000_000u64);
+    let token_divisor = 10u64.pow(token_decimals as u32);
+    let token_dec = Decimal::from(token_amount) / Decimal::from(token_divisor);
+    if token_dec <= Decimal::ZERO {
+        return Decimal::ZERO;
+    }
+    sol_dec / token_dec
+}
+
+fn tokens_from_trade_price(sol_lamports: u64, price: Decimal, token_decimals: u8) -> Option<u64> {
+    if price <= Decimal::ZERO || sol_lamports == 0 {
+        return None;
+    }
+    let sol = Decimal::from(sol_lamports) / Decimal::from(1_000_000_000u64);
+    let tokens_whole = sol / price;
+    let token_divisor = Decimal::from(10u64.pow(token_decimals as u32));
+    let raw = (tokens_whole * token_divisor).floor();
+    raw.to_u64()
+}
+
+fn sol_from_trade_price(token_raw: u64, price: Decimal, token_decimals: u8) -> Option<u64> {
+    if price <= Decimal::ZERO || token_raw == 0 {
+        return None;
+    }
+    let token_divisor = Decimal::from(10u64.pow(token_decimals as u32));
+    let tokens_whole = Decimal::from(token_raw) / token_divisor;
+    let sol = tokens_whole * price;
+    let lamports = (sol * Decimal::from(1_000_000_000u64)).floor();
+    lamports.to_u64().filter(|v| *v > 0)
+}
+
+fn executable_marginal_quote(
+    pool: &QuotePoolInput,
+    vault: &QuoteVaultInput,
+    dlmm_bins: Option<&DlmmBinArrays>,
+    side: QuoteSide,
+    amount_in: u64,
+    now: Instant,
+) -> Option<PoolQuote> {
+    if !state_fresh(vault, now) {
+        return None;
+    }
+
+    if pool.dex == "meteora_dlmm" {
+        let active_id = vault.active_id?;
+        let bin_step = vault.bin_step?;
+        let bins = dlmm_bins?;
+        let sol_is_x = vault_dlmm_sol_is_x(vault);
+        let amount_out = match side {
+            QuoteSide::Buy => {
+                dlmm_token_output_from_bins(active_id, bin_step, amount_in, bins, sol_is_x)?
+            }
+            QuoteSide::Sell => {
+                dlmm_sol_output_from_bins(active_id, bin_step, amount_in, bins, sol_is_x)?
+            }
+        };
+        let reserve_mid = reserves_plausible(
+            vault.reserve_base,
+            vault.reserve_quote,
+            pool.token_decimals,
+            &pool.token_mint,
+        )
+        .then(|| {
+            reserve_mid_sol_per_token(vault.reserve_base, vault.reserve_quote, pool.token_decimals)
+        })
+        .flatten();
+        let trade_mid = trade_mid_sol_per_token(pool)
+            .filter(|p| is_plausible_sol_per_token_price(&pool.token_mint, *p));
+        let marginal_price = match side {
+            QuoteSide::Buy => {
+                trade_implied_sol_per_token(amount_in, amount_out, pool.token_decimals)
+            }
+            QuoteSide::Sell => {
+                trade_implied_sol_per_token(amount_out, amount_in, pool.token_decimals)
+            }
+        };
+        if !dlmm_marginal_price_plausible(marginal_price, reserve_mid, trade_mid)
+            || !is_plausible_sol_per_token_price(&pool.token_mint, marginal_price)
+        {
+            return None;
+        }
+        return Some(PoolQuote {
+            pool_address: pool.pool_address.clone(),
+            dex: pool.dex.clone(),
+            kind: QuoteKind::ExecutableMarginal,
+            side,
+            as_of_slot: vault.update_slot,
+            as_of_ts: vault.updated_at,
+            fresh: true,
+            amount_in,
+            amount_out,
+        });
+    }
+
+    if !supports_cpmm(&pool.dex) {
+        return None;
+    }
+    if !reserves_plausible(
+        vault.reserve_base,
+        vault.reserve_quote,
+        pool.token_decimals,
+        &pool.token_mint,
+    ) {
+        return None;
+    }
+
+    let fee_bps = cpmm_fee_bps(&pool.dex);
+    let (reserve_in, reserve_out) = match side {
+        QuoteSide::Buy => (vault.reserve_quote as u128, vault.reserve_base as u128),
+        QuoteSide::Sell => (vault.reserve_base as u128, vault.reserve_quote as u128),
+    };
+    let amount_out = cpmm_amount_out(reserve_in, reserve_out, amount_in, fee_bps)?;
+    Some(PoolQuote {
+        pool_address: pool.pool_address.clone(),
+        dex: pool.dex.clone(),
+        kind: QuoteKind::ExecutableMarginal,
+        side,
+        as_of_slot: vault.update_slot,
+        as_of_ts: vault.updated_at,
+        fresh: true,
+        amount_in,
+        amount_out,
+    })
+}
+
+fn last_trade_mid_quote(
+    pool: &QuotePoolInput,
+    side: QuoteSide,
+    amount_in: u64,
+    now: Instant,
+) -> Option<PoolQuote> {
+    if !trade_fresh(pool, now) {
+        return None;
+    }
+    let price = match side {
+        QuoteSide::Buy => pool.trade_price_buy?,
+        QuoteSide::Sell => pool.trade_price_sell?,
+    };
+    if price <= Decimal::ZERO || !is_plausible_sol_per_token_price(&pool.token_mint, price) {
+        return None;
+    }
+    let amount_out = match side {
+        QuoteSide::Buy => tokens_from_trade_price(amount_in, price, pool.token_decimals)?,
+        QuoteSide::Sell => sol_from_trade_price(amount_in, price, pool.token_decimals)?,
+    };
+    Some(PoolQuote {
+        pool_address: pool.pool_address.clone(),
+        dex: pool.dex.clone(),
+        kind: QuoteKind::LastTradeMid,
+        side,
+        as_of_slot: 0,
+        as_of_ts: pool.trade_updated_at,
+        fresh: true,
+        amount_in,
+        amount_out,
+    })
+}
+
+/// Exact-in quote for SOL-quoted pools. Priority: ExecutableMarginal, then LastTradeMid.
+pub fn quote_exact_in(
+    pool: &QuotePoolInput,
+    vault: Option<&QuoteVaultInput>,
+    dlmm_bins: Option<&DlmmBinArrays>,
+    mint_in: &str,
+    mint_out: &str,
+    amount_in: u64,
+) -> Option<PoolQuote> {
+    if amount_in == 0 {
+        return None;
+    }
+    let side = quote_side_from_mints(&pool.token_mint, mint_in, mint_out)?;
+    let now = Instant::now();
+
+    if let Some(vault) = vault {
+        if let Some(q) = executable_marginal_quote(pool, vault, dlmm_bins, side, amount_in, now) {
+            return Some(q);
+        }
+    }
+
+    last_trade_mid_quote(pool, side, amount_in, now)
+}
+
+/// SOL per whole token for screening (marginal probe > reserve mid > trade mid).
+pub fn quote_sol_per_token_for_screening(
+    pool: &QuotePoolInput,
+    vault: Option<&QuoteVaultInput>,
+    dlmm_bins: Option<&DlmmBinArrays>,
+    side: QuoteSide,
+) -> Option<Decimal> {
+    let probe = match side {
+        QuoteSide::Buy => DLMM_PROBE_SOL_LAMPORTS,
+        QuoteSide::Sell => {
+            let buy_quote = quote_exact_in(
+                pool,
+                vault,
+                dlmm_bins,
+                NATIVE_SOL_MINT,
+                &pool.token_mint,
+                DLMM_PROBE_SOL_LAMPORTS,
+            )?;
+            buy_quote.amount_out
+        }
+    };
+
+    let quote = quote_exact_in(
+        pool,
+        vault,
+        dlmm_bins,
+        if side == QuoteSide::Buy {
+            NATIVE_SOL_MINT
+        } else {
+            &pool.token_mint
+        },
+        if side == QuoteSide::Buy {
+            &pool.token_mint
+        } else {
+            NATIVE_SOL_MINT
+        },
+        probe,
+    )?;
+
+    match side {
+        QuoteSide::Buy => Some(trade_implied_sol_per_token(
+            quote.amount_in,
+            quote.amount_out,
+            pool.token_decimals,
+        )),
+        QuoteSide::Sell => Some(trade_implied_sol_per_token(
+            quote.amount_out,
+            quote.amount_in,
+            pool.token_decimals,
+        )),
+    }
+}
+
+/// Leg inputs for round-trip profit screening.
+#[derive(Debug, Clone)]
+pub struct RoundTripLeg<'a> {
+    pub pool: &'a QuotePoolInput,
+    pub vault: Option<&'a QuoteVaultInput>,
+    pub dlmm_bins: Option<&'a DlmmBinArrays>,
+}
+
+/// Round-trip profit in lamports for a buy+sell pair (same QuoteKind required).
+pub fn round_trip_profit_lamports(
+    buy: &RoundTripLeg<'_>,
+    sell: &RoundTripLeg<'_>,
+    probe_sol_lamports: u64,
+    tx_cost_lamports: u64,
+) -> Option<i64> {
+    let buy_quote = quote_exact_in(
+        buy.pool,
+        buy.vault,
+        buy.dlmm_bins,
+        NATIVE_SOL_MINT,
+        &buy.pool.token_mint,
+        probe_sol_lamports,
+    )?;
+    let sell_quote = quote_exact_in(
+        sell.pool,
+        sell.vault,
+        sell.dlmm_bins,
+        &sell.pool.token_mint,
+        NATIVE_SOL_MINT,
+        buy_quote.amount_out,
+    )?;
+    if !quotes_pairable(&buy_quote, &sell_quote) {
+        return None;
+    }
+    let profit = sell_quote.amount_out as i64 - probe_sol_lamports as i64 - tx_cost_lamports as i64;
+    Some(profit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_pool(dex: &str, address: &str) -> QuotePoolInput {
+        QuotePoolInput {
+            pool_address: address.to_string(),
+            dex: dex.to_string(),
+            token_mint: "TokenMint11111111111111111111111111111111".to_string(),
+            trade_price_buy: None,
+            trade_price_sell: None,
+            trade_updated_at: Instant::now(),
+            has_reserve_data: true,
+            token_decimals: 6,
+        }
+    }
+
+    fn sample_vault(token_reserve: u64, sol_reserve: u64) -> QuoteVaultInput {
+        QuoteVaultInput {
+            reserve_base: token_reserve,
+            reserve_quote: sol_reserve,
+            update_slot: 1,
+            updated_at: Instant::now(),
+            active_id: None,
+            bin_step: None,
+            dlmm_sol_is_x: false,
+            dlmm_token_x_mint: None,
+        }
+    }
+
+    #[test]
+    fn pump_amm_cpmm_round_numbers() {
+        let pool = sample_pool("pump_amm", "pumpPool");
+        let vault = sample_vault(1_000_000_000_000, 1_000_000_000);
+        let sol_in = 100_000_000u64;
+        let quote = quote_exact_in(
+            &pool,
+            Some(&vault),
+            None,
+            NATIVE_SOL_MINT,
+            &pool.token_mint,
+            sol_in,
+        )
+        .expect("cpmm quote");
+        assert_eq!(quote.kind, QuoteKind::ExecutableMarginal);
+        assert_eq!(quote.side, QuoteSide::Buy);
+        assert!(quote.amount_out > 0);
+        assert!(quote.amount_out < vault.reserve_base);
+    }
+
+    #[test]
+    fn quotes_pairable_same_kind_only() {
+        let q_exec = PoolQuote {
+            pool_address: "a".into(),
+            dex: "orca".into(),
+            kind: QuoteKind::ExecutableMarginal,
+            side: QuoteSide::Buy,
+            as_of_slot: 1,
+            as_of_ts: Instant::now(),
+            fresh: true,
+            amount_in: 1,
+            amount_out: 2,
+        };
+        let q_trade = PoolQuote {
+            kind: QuoteKind::LastTradeMid,
+            ..q_exec.clone()
+        };
+        assert!(quotes_pairable(&q_exec, &q_exec));
+        assert!(!quotes_pairable(&q_exec, &q_trade));
+    }
+
+    #[test]
+    fn stale_trade_falls_back_to_none_without_reserves() {
+        let mut pool = sample_pool("pump_amm", "stale");
+        pool.trade_price_buy = Some(Decimal::new(1, 3));
+        pool.trade_price_sell = Some(Decimal::new(1, 3));
+        pool.trade_updated_at = Instant::now() - Duration::from_secs(60);
+        let quote = quote_exact_in(
+            &pool,
+            None,
+            None,
+            NATIVE_SOL_MINT,
+            &pool.token_mint,
+            DLMM_PROBE_SOL_LAMPORTS,
+        );
+        assert!(quote.is_none());
+    }
+
+    #[test]
+    fn dlmm_marginal_vs_reserve_mid_divergence_bounded() {
+        let active_id = 0i32;
+        let bin_step = 100u16;
+        let token_amount = 1_000_000_000_000u64;
+        let sol_amount = 1_000_000_000u64;
+        let array_index = active_id as i64 / 70;
+        let mut bins: DlmmBinArrays = HashMap::new();
+        bins.insert(
+            array_index,
+            vec![BinData {
+                offset: 0,
+                amount_x: token_amount,
+                amount_y: sol_amount,
+            }],
+        );
+        let pool = sample_pool("meteora_dlmm", "dlmm");
+        let vault = QuoteVaultInput {
+            reserve_base: token_amount,
+            reserve_quote: sol_amount,
+            update_slot: 1,
+            updated_at: Instant::now(),
+            active_id: Some(active_id),
+            bin_step: Some(bin_step),
+            dlmm_sol_is_x: false,
+            dlmm_token_x_mint: Some(pool.token_mint.clone()),
+        };
+        let reserve_mid =
+            reserve_mid_sol_per_token(token_amount, sol_amount, pool.token_decimals).unwrap();
+        let marginal_buy =
+            quote_sol_per_token_for_screening(&pool, Some(&vault), Some(&bins), QuoteSide::Buy)
+                .expect("marginal buy");
+        let ratio = if marginal_buy > reserve_mid {
+            marginal_buy / reserve_mid
+        } else {
+            reserve_mid / marginal_buy
+        };
+        assert!(
+            ratio <= Decimal::from(10),
+            "marginal vs reserve mid divergence too large: {ratio}"
+        );
+    }
+}

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -29,8 +29,11 @@ use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 use ironcrab::arbitrage::{
-    populate_arb_slave_from_live_pool_cache, sync_arb_slave_from_pool_cache_update,
-    MultiHopArbitrage, MultiHopConfig, MultiHopIntentBatch,
+    dlmm_marginal_price_plausible, dlmm_sol_output_from_bins, dlmm_token_output_from_bins,
+    populate_arb_slave_from_live_pool_cache, quote_exact_in, quotes_pairable,
+    round_trip_profit_lamports, sync_arb_slave_from_pool_cache_update, MultiHopArbitrage,
+    MultiHopConfig, MultiHopIntentBatch, QuotePoolInput, QuoteVaultInput, RoundTripLeg,
+    DLMM_PROBE_SOL_LAMPORTS,
 };
 use ironcrab::config::Config as AppConfig;
 use ironcrab::execution::live_pool_cache::{
@@ -61,8 +64,9 @@ use ironcrab::metrics::{
     arb_two_hop_eligible_pools_by_dex_add, arb_two_hop_insufficient_subreason_inc,
     arb_two_hop_opportunity_inc, arb_two_hop_pool_gate_add, arb_two_hop_reject_subreason_inc,
     arb_two_hop_rejected_inc, arb_two_hop_tracker_seeded_pools_add, record_arb_heartbeat_phase,
-    record_arb_price_freshness_stale_age_ms, record_arb_track_requests_messages_total,
-    record_arb_writer_lock_wait, serve_metrics, set_arb_pool_cache_apply_batch_size_gauge,
+    record_arb_price_freshness_stale_age_ms, record_arb_quote_shadow_round_trip,
+    record_arb_track_requests_messages_total, record_arb_writer_lock_wait, serve_metrics,
+    set_arb_pool_cache_apply_batch_size_gauge, set_arb_quote_shadow_legacy_spread_bps,
     set_arb_tracker_write_coalescer_pending, set_arb_tracker_write_queue_depth,
     set_arb_two_hop_blocked_on_apply_trade, set_readiness_nats_connected,
     tick_arb_heartbeat_seconds_since_last_finish, tick_arb_tracker_write_seconds_since_last_finish,
@@ -84,7 +88,6 @@ use ironcrab::nats::{
 };
 use ironcrab::nats::{NatsClient, NatsConfig};
 use ironcrab::nats::{TOPIC_ARB_TRACK_REQUESTS, TOPIC_MARKET_EVENTS, TOPIC_TRADE_INTENTS};
-use ironcrab::solana::dex::meteora_bin_walker::{dlmm_fee_bps, walker_from_bins};
 use ironcrab::storage::{JsonlWriter, JsonlWriterConfig};
 use solana_sdk::pubkey::Pubkey;
 
@@ -141,6 +144,8 @@ struct ArbConfig {
     arb_track_baseline_max_pools: usize,
     /// Baseline reconcile publish interval in seconds. Default: 60.
     arb_track_reconcile_interval_secs: u64,
+    /// Shadow pool_quote round-trip metrics (legacy path stays authoritative). Default: false.
+    arb_quote_shadow_mode: bool,
 }
 
 impl Default for ArbConfig {
@@ -156,6 +161,7 @@ impl Default for ArbConfig {
             two_hop_enabled: true,                // 2-hop arb enabled by default
             arb_track_baseline_max_pools: ARB_TRACK_BASELINE_MAX_POOLS_DEFAULT,
             arb_track_reconcile_interval_secs: ARB_TRACK_RECONCILE_INTERVAL_SECS_DEFAULT,
+            arb_quote_shadow_mode: false,
         }
     }
 }
@@ -224,11 +230,6 @@ const GEYSER_CONNECTION_TIMEOUT_SECS: u64 = 30;
 const MIN_TRADE_VOLUME_LAMPORTS: u64 = 100_000; // 0.0001 SOL minimum (filter dust)
 /// Max age for pool comparable prices used in 2-hop spread (aligns with Geyser health window).
 const MAX_PRICE_AGE_MS: u64 = 30_000;
-/// Small SOL probe for DLMM marginal price (0.01 SOL) — spread comparison only.
-const DLMM_PROBE_SOL_LAMPORTS: u64 = 10_000_000;
-/// Reject DLMM marginal price when it deviates more than this factor from reserve/trade mid.
-const DLMM_MARGINAL_MAX_DEVIATION_FACTOR: u64 = 100;
-/// Deduplicate per-mint "spread too large" WARN logs.
 const SPREAD_TOO_LARGE_WARN_COOLDOWN: Duration = Duration::from_secs(30);
 /// Rate limit for 2-hop eligibility diagnostic snapshots.
 const ELIGIBILITY_SNAPSHOT_COOLDOWN: Duration = Duration::from_secs(60);
@@ -320,23 +321,6 @@ fn trade_implied_sol_per_token(sol_amount: u64, token_amount: u64, token_decimal
     sol_dec / token_dec
 }
 
-fn flatten_bins_for_walker(bin_arrays: &HashMap<i64, Vec<BinData>>) -> Vec<(i32, u64, u64)> {
-    let mut all_bins: Vec<(i32, u64, u64)> = Vec::new();
-    for (array_idx, bins) in bin_arrays {
-        for bin in bins {
-            let bin_id = (*array_idx * 70 + bin.offset as i64) as i32;
-            all_bins.push((bin_id, bin.amount_x, bin.amount_y));
-        }
-    }
-    all_bins.sort_by_key(|(id, _, _)| *id);
-    all_bins
-}
-
-fn active_bin_present(active_id: i32, flat_bins: &[(i32, u64, u64)]) -> bool {
-    flat_bins.iter().any(|(id, _, _)| *id == active_id)
-}
-
-/// Derive whether on-chain token X is SOL (SSOT: Meteora `token_x_mint`).
 fn vault_dlmm_sol_is_x(vault: &VaultBalanceCache) -> bool {
     vault
         .dlmm_token_x_mint
@@ -428,86 +412,6 @@ fn trade_mid_sol_per_token(pool: &PoolState) -> Option<Decimal> {
         (Some(one), None) | (None, Some(one)) if one > Decimal::ZERO => Some(one),
         _ => None,
     }
-}
-
-fn dlmm_marginal_price_plausible(
-    marginal: Decimal,
-    reserve_mid: Option<Decimal>,
-    trade_mid: Option<Decimal>,
-) -> bool {
-    let reference = match reserve_mid.or(trade_mid) {
-        Some(mid) if mid > Decimal::ZERO => mid,
-        _ => return true,
-    };
-    if marginal <= Decimal::ZERO {
-        return false;
-    }
-    let ratio = if marginal > reference {
-        marginal / reference
-    } else {
-        reference / marginal
-    };
-    ratio <= Decimal::from(DLMM_MARGINAL_MAX_DEVIATION_FACTOR)
-}
-
-/// DLMM token output via BinWalker (shared by spread price + intent sizing).
-fn dlmm_token_output_from_bins(
-    active_id: i32,
-    bin_step: u16,
-    sol_in_lamports: u64,
-    bin_arrays: &HashMap<i64, Vec<BinData>>,
-    sol_is_x: bool,
-) -> Option<u64> {
-    if bin_arrays.is_empty() || sol_in_lamports == 0 {
-        return None;
-    }
-
-    let flat_bins = flatten_bins_for_walker(bin_arrays);
-    if !active_bin_present(active_id, &flat_bins) {
-        return None;
-    }
-
-    let walker = walker_from_bins(active_id, bin_step, &flat_bins);
-    let fee_bps = dlmm_fee_bps(bin_step);
-    let (amount_out, _, _) = if sol_is_x {
-        walker.quote_x_to_y(sol_in_lamports, fee_bps).ok()?
-    } else {
-        walker.quote_y_to_x(sol_in_lamports, fee_bps).ok()?
-    };
-    if amount_out == 0 {
-        return None;
-    }
-    Some(amount_out)
-}
-
-/// DLMM SOL output via BinWalker (token → SOL, sell-side marginal).
-fn dlmm_sol_output_from_bins(
-    active_id: i32,
-    bin_step: u16,
-    token_in: u64,
-    bin_arrays: &HashMap<i64, Vec<BinData>>,
-    sol_is_x: bool,
-) -> Option<u64> {
-    if bin_arrays.is_empty() || token_in == 0 {
-        return None;
-    }
-
-    let flat_bins = flatten_bins_for_walker(bin_arrays);
-    if !active_bin_present(active_id, &flat_bins) {
-        return None;
-    }
-
-    let walker = walker_from_bins(active_id, bin_step, &flat_bins);
-    let fee_bps = dlmm_fee_bps(bin_step);
-    let (amount_out, _, _) = if sol_is_x {
-        walker.quote_y_to_x(token_in, fee_bps).ok()?
-    } else {
-        walker.quote_x_to_y(token_in, fee_bps).ok()?
-    };
-    if amount_out == 0 {
-        return None;
-    }
-    Some(amount_out)
 }
 
 fn is_stablecoin_mint(mint: &str) -> bool {
@@ -1815,6 +1719,36 @@ struct ArbCheckContext<'a> {
     forensics: Option<&'a ArbEligibilityForensics>,
 }
 
+fn pool_state_to_quote_input(
+    pool: &PoolState,
+    token_mint: &str,
+    token_decimals: u8,
+) -> QuotePoolInput {
+    QuotePoolInput {
+        pool_address: pool.pool_address.clone(),
+        dex: pool.dex.clone(),
+        token_mint: token_mint.to_string(),
+        trade_price_buy: pool.trade_price_buy,
+        trade_price_sell: pool.trade_price_sell,
+        trade_updated_at: pool.last_update,
+        has_reserve_data: pool.has_reserve_data,
+        token_decimals,
+    }
+}
+
+fn vault_cache_to_quote_input(vault: &VaultBalanceCache) -> QuoteVaultInput {
+    QuoteVaultInput {
+        reserve_base: vault.reserve_base,
+        reserve_quote: vault.reserve_quote,
+        update_slot: vault.update_slot,
+        updated_at: vault.updated_at,
+        active_id: vault.active_id,
+        bin_step: vault.bin_step,
+        dlmm_sol_is_x: vault.dlmm_sol_is_x,
+        dlmm_token_x_mint: vault.dlmm_token_x_mint.clone(),
+    }
+}
+
 impl TokenArbTracker {
     fn new(base_mint: &str) -> Self {
         Self {
@@ -1947,6 +1881,112 @@ impl TokenArbTracker {
         }
     }
 
+    /// Shadow pool_quote round-trip (metrics only; does not affect legacy decisions).
+    fn run_arb_quote_shadow(
+        &self,
+        config: &ArbConfig,
+        known_pools: &HashSet<String>,
+        vault_balances: &HashMap<String, VaultBalanceCache>,
+        bin_arrays: &HashMap<String, HashMap<i64, BinArrayCache>>,
+        legacy_spread_bps: Option<i64>,
+    ) {
+        if !config.arb_quote_shadow_mode {
+            return;
+        }
+        let Some(token_decimals) = self.token_decimals else {
+            return;
+        };
+        let max_age = Duration::from_millis(MAX_PRICE_AGE_MS);
+        let probe_sol = config.max_position_lamports;
+        let mut best_profit: Option<i64> = None;
+        let mut saw_incompatible_kind = false;
+
+        let candidate_pools: Vec<&PoolState> = self
+            .pools
+            .values()
+            .filter(|p| known_pools.contains(&p.pool_address))
+            .filter(|p| is_known_dex_label(&p.dex))
+            .filter(|p| p.dex != "pumpfun")
+            .collect();
+
+        for buy_pool in &candidate_pools {
+            let buy_vault = vault_balances.get(&buy_pool.pool_address);
+            if !is_pool_price_fresh(buy_pool, buy_vault, max_age) {
+                continue;
+            }
+            let buy_input = pool_state_to_quote_input(buy_pool, &self.base_mint, token_decimals);
+            let buy_vault_q = buy_vault.map(vault_cache_to_quote_input);
+            let buy_bins = bin_arrays
+                .get(&buy_pool.pool_address)
+                .map(flatten_bin_array_cache);
+
+            for sell_pool in &candidate_pools {
+                if sell_pool.pool_address == buy_pool.pool_address || sell_pool.dex == buy_pool.dex
+                {
+                    continue;
+                }
+                let sell_vault = vault_balances.get(&sell_pool.pool_address);
+                if !is_pool_price_fresh(sell_pool, sell_vault, max_age) {
+                    continue;
+                }
+                let sell_input =
+                    pool_state_to_quote_input(sell_pool, &self.base_mint, token_decimals);
+                let sell_vault_q = sell_vault.map(vault_cache_to_quote_input);
+                let sell_bins = bin_arrays
+                    .get(&sell_pool.pool_address)
+                    .map(flatten_bin_array_cache);
+
+                if let Some(profit) = round_trip_profit_lamports(
+                    &RoundTripLeg {
+                        pool: &buy_input,
+                        vault: buy_vault_q.as_ref(),
+                        dlmm_bins: buy_bins.as_ref(),
+                    },
+                    &RoundTripLeg {
+                        pool: &sell_input,
+                        vault: sell_vault_q.as_ref(),
+                        dlmm_bins: sell_bins.as_ref(),
+                    },
+                    probe_sol,
+                    config.est_tx_cost_lamports,
+                ) {
+                    best_profit = Some(best_profit.map_or(profit, |b| b.max(profit)));
+                    continue;
+                }
+
+                let Some(buy_quote) = quote_exact_in(
+                    &buy_input,
+                    buy_vault_q.as_ref(),
+                    buy_bins.as_ref(),
+                    NATIVE_SOL_MINT,
+                    &self.base_mint,
+                    probe_sol,
+                ) else {
+                    continue;
+                };
+                let Some(sell_quote) = quote_exact_in(
+                    &sell_input,
+                    sell_vault_q.as_ref(),
+                    sell_bins.as_ref(),
+                    &self.base_mint,
+                    NATIVE_SOL_MINT,
+                    buy_quote.amount_out,
+                ) else {
+                    continue;
+                };
+                if !quotes_pairable(&buy_quote, &sell_quote) {
+                    saw_incompatible_kind = true;
+                }
+            }
+        }
+
+        record_arb_quote_shadow_round_trip(
+            best_profit.unwrap_or(0),
+            legacy_spread_bps,
+            saw_incompatible_kind && best_profit.is_none(),
+        );
+    }
+
     /// Check for arbitrage opportunity between DEXes
     /// Returns: Option<(buy_dex, sell_dex, spread_bps, estimated_profit_lamports)>
     fn check_arbitrage(
@@ -1970,6 +2010,8 @@ impl TokenArbTracker {
 
         let mut breakdown =
             self.build_eligibility_breakdown(known_pools, vault_balances, bin_arrays);
+
+        self.run_arb_quote_shadow(config, known_pools, vault_balances, bin_arrays, None);
 
         let Some(_token_decimals) = self.token_decimals else {
             debug!(
@@ -2123,6 +2165,9 @@ impl TokenArbTracker {
 
         let spread = (sell_price - buy_price) / buy_price * Decimal::from(10000);
         let spread_bps = spread.round().to_i64().unwrap_or(i64::MAX);
+        if config.arb_quote_shadow_mode {
+            set_arb_quote_shadow_legacy_spread_bps(spread_bps);
+        }
 
         if self.base_mint == NATIVE_SOL_MINT {
             debug!(
@@ -3310,6 +3355,15 @@ impl ArbContext {
                         }
                     } else {
                         rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
+                    }
+                }
+                "arb_quote_shadow_mode" => {
+                    if let Some(v) = value.as_bool() {
+                        config.arb_quote_shadow_mode = v;
+                        applied.push(key.clone());
+                        info!(key = %key, new_value = %v, "Config updated");
+                    } else {
+                        rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
                     }
                 }
                 // Skip multi_hop_* keys here - they're handled in the second loop below

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2989,6 +2989,22 @@ pub static ARB_TWO_HOP_OPPORTUNITIES: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::
 /// Pools seeded into TokenArbTracker from SLAVE LivePoolCache (reserve-mid, no Trade event).
 pub static ARB_TWO_HOP_TRACKER_SEEDED_POOLS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
+// --- pool_quote shadow (M1, default off) ---
+pub static ARB_QUOTE_SHADOW_ROUND_TRIP_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_QUOTE_SHADOW_INCOMPATIBLE_KIND_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_QUOTE_SHADOW_ROUND_TRIP_PROFIT_SUM: Lazy<AtomicI64> =
+    Lazy::new(|| AtomicI64::new(0));
+pub static ARB_QUOTE_SHADOW_ROUND_TRIP_PROFIT_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_QUOTE_SHADOW_LEGACY_SPREAD_BPS: Lazy<AtomicI64> = Lazy::new(|| AtomicI64::new(0));
+pub static ARB_QUOTE_SHADOW_V2_PROFIT_LAMPORTS: Lazy<AtomicI64> = Lazy::new(|| AtomicI64::new(0));
+
+const ARB_QUOTE_SHADOW_PROFIT_BUCKETS: [i64; 5] =
+    [0, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000];
+static ARB_QUOTE_SHADOW_PROFIT_BUCKET_COUNTS: Lazy<[AtomicU64; 5]> =
+    Lazy::new(|| std::array::from_fn(|_| AtomicU64::new(0)));
+
 // --- arb-strategy bootstrap / incremental warmup (low-cardinality) ---
 pub static ARB_STRATEGY_BOOTSTRAP_LIVE_POOL_CACHE_ROWS: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -3370,6 +3386,34 @@ pub fn arb_two_hop_rejected_inc(reason: ArbTwoHopRejectReason) {
 /// Increment `arb_two_hop_opportunities_total`.
 pub fn arb_two_hop_opportunity_inc() {
     ARB_TWO_HOP_OPPORTUNITIES.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record pool_quote shadow round-trip observation (legacy path unaffected).
+pub fn record_arb_quote_shadow_round_trip(
+    profit_lamports: i64,
+    legacy_spread_bps: Option<i64>,
+    incompatible_kind: bool,
+) {
+    ARB_QUOTE_SHADOW_ROUND_TRIP_TOTAL.fetch_add(1, Ordering::Relaxed);
+    if incompatible_kind {
+        ARB_QUOTE_SHADOW_INCOMPATIBLE_KIND_TOTAL.fetch_add(1, Ordering::Relaxed);
+    }
+    ARB_QUOTE_SHADOW_ROUND_TRIP_PROFIT_SUM.fetch_add(profit_lamports, Ordering::Relaxed);
+    ARB_QUOTE_SHADOW_ROUND_TRIP_PROFIT_COUNT.fetch_add(1, Ordering::Relaxed);
+    ARB_QUOTE_SHADOW_V2_PROFIT_LAMPORTS.store(profit_lamports, Ordering::Relaxed);
+    if let Some(spread) = legacy_spread_bps {
+        ARB_QUOTE_SHADOW_LEGACY_SPREAD_BPS.store(spread, Ordering::Relaxed);
+    }
+    for (i, bucket) in ARB_QUOTE_SHADOW_PROFIT_BUCKETS.iter().enumerate() {
+        if profit_lamports <= *bucket {
+            ARB_QUOTE_SHADOW_PROFIT_BUCKET_COUNTS[i].fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Update legacy spread gauge when shadow mode compares v1 vs v2.
+pub fn set_arb_quote_shadow_legacy_spread_bps(spread_bps: i64) {
+    ARB_QUOTE_SHADOW_LEGACY_SPREAD_BPS.store(spread_bps, Ordering::Relaxed);
 }
 
 /// Add to `arb_two_hop_tracker_seeded_pools_total` after SLAVE cache tracker seed.
@@ -6556,6 +6600,43 @@ async fn metrics_response() -> Response<Body> {
         "arb_two_hop_tracker_seeded_pools_total",
         ARB_TWO_HOP_TRACKER_SEEDED_POOLS.load(Ordering::Relaxed)
     );
+    line!(
+        "arb_quote_shadow_round_trip_total",
+        ARB_QUOTE_SHADOW_ROUND_TRIP_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_quote_shadow_incompatible_kind_total",
+        ARB_QUOTE_SHADOW_INCOMPATIBLE_KIND_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_quote_shadow_round_trip_profit_sum_lamports",
+        ARB_QUOTE_SHADOW_ROUND_TRIP_PROFIT_SUM.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_quote_shadow_round_trip_profit_count",
+        ARB_QUOTE_SHADOW_ROUND_TRIP_PROFIT_COUNT.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_quote_shadow_legacy_spread_bps",
+        ARB_QUOTE_SHADOW_LEGACY_SPREAD_BPS.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_quote_shadow_v2_profit_lamports",
+        ARB_QUOTE_SHADOW_V2_PROFIT_LAMPORTS.load(Ordering::Relaxed)
+    );
+    for (i, bucket) in ARB_QUOTE_SHADOW_PROFIT_BUCKETS.iter().enumerate() {
+        out.push_str(&format!(
+            "arb_quote_shadow_round_trip_profit_lamports_bucket{{le=\"{bucket}\"}} {}\n",
+            ARB_QUOTE_SHADOW_PROFIT_BUCKET_COUNTS[i].load(Ordering::Relaxed)
+        ));
+    }
+    out.push_str("arb_quote_shadow_round_trip_profit_lamports_bucket{le=\"+Inf\"} ");
+    out.push_str(
+        &ARB_QUOTE_SHADOW_ROUND_TRIP_PROFIT_COUNT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
     line!(
         "arb_strategy_bootstrap_live_pool_cache_rows",
         ARB_STRATEGY_BOOTSTRAP_LIVE_POOL_CACHE_ROWS.load(Ordering::Relaxed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Milestone M1 — Profit-First Arb Rebuild (Fundament)

Implements **I-ARB-1..3** from [plan_arb_profit_first_rebuild.md](https://github.com/Exploratorsclub/Iron_crab-eval/blob/main/docs/plans/plan_arb_profit_first_rebuild.md) per [ARB_QUOTE_CONTRACT.md](https://github.com/Exploratorsclub/Iron_crab-eval/blob/main/docs/spec/ARB_QUOTE_CONTRACT.md).

### I-ARB-1: `pool_quote.rs`
- New module `src/arbitrage/pool_quote.rs` exported from `arbitrage/mod.rs`
- Types: `QuoteKind` (`ExecutableMarginal`, `LastTradeMid`), `PoolQuote`, `QuoteSide`
- API: `quote_exact_in`, `quote_sol_per_token_for_screening`, `quotes_pairable`, `round_trip_profit_lamports`
- DEX support (SOL-quoted): pump_amm / raydium / orca / meteora_cpmm (CPMM on vault reserves), meteora_dlmm (bin-walker)
- DLMM helpers extracted from `arb_strategy`: `dlmm_token_output_from_bins`, `dlmm_sol_output_from_bins`, `DLMM_PROBE_SOL_LAMPORTS`, `dlmm_marginal_price_plausible`
- Freshness v1: trade TTL 30s, state TTL 120s — **no RPC**

### I-ARB-2: Unit tests
- `pump_amm` CPMM round numbers
- DLMM marginal vs reserve mid divergence bounded
- `quotes_pairable` same-kind pairing
- Stale trade → `None` without reserves
- Existing `comparable_price` tests in `arb_strategy` unchanged

### I-ARB-3: Shadow in `check_arbitrage`
- `ArbConfig.arb_quote_shadow_mode` (default **false**, control-plane key `arb_quote_shadow_mode`)
- Parallel round-trip profit via `pool_quote` for best fresh cross-DEX pair (same `QuoteKind`)
- Additive Prometheus metrics:
  - `arb_quote_shadow_round_trip_total`
  - `arb_quote_shadow_round_trip_profit_*` (sum/count/buckets)
  - `arb_quote_shadow_incompatible_kind_total`
  - `arb_quote_shadow_legacy_spread_bps` / `arb_quote_shadow_v2_profit_lamports` gauges
- **Legacy `check_arbitrage` spread/opportunity path unchanged and authoritative**

### STOP-CHECK (performed)
- No RPC added (I-7)
- Geyser vault/bin cache only (I-4, I-16)
- Shadow does not emit TradeIntents (I-9, I-17)
- Amounts explicit raw lamports/tokens (I-15)

### Verification
```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
cargo test pool_quote
```

Eval Level 5 CI expected green on merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac52dd24-ada8-4f53-86e8-1edef14d9852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac52dd24-ada8-4f53-86e8-1edef14d9852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

