### PR TITLE
M2: 2-hop profit-first v2 (I-ARB-4..7)

### DIFF
--- a/src/arbitrage/mod.rs
+++ b/src/arbitrage/mod.rs
@@ -48,9 +48,12 @@ pub use multi_hop_integration::{
 pub use pool_graph::{GraphStats, PoolGraph};
 pub use pool_quote::{
     dlmm_marginal_price_plausible, dlmm_sol_output_from_bins, dlmm_token_output_from_bins,
-    flatten_bin_array_bins, quote_exact_in, quote_sol_per_token_for_screening, quotes_pairable,
-    round_trip_profit_lamports, DlmmBinArrays, PoolQuote, QuoteKind, QuotePoolInput, QuoteSide,
-    QuoteVaultInput, RoundTripLeg, DLMM_PROBE_SOL_LAMPORTS,
+    flatten_bin_array_bins, is_quote_fresh, quote_exact_in, quote_exact_in_with_freshness,
+    quote_sol_per_token_for_screening, quotes_pairable, round_trip_profit_lamports,
+    round_trip_profit_lamports_with_freshness, select_round_trip_pools, state_fingerprint,
+    DlmmBinArrays, PoolQuote, QuoteFreshnessConfig, QuoteKind, QuotePoolInput, QuoteSide,
+    QuoteVaultInput, RoundTripLeg, RoundTripPoolCandidate, RoundTripPoolSelection,
+    RoundTripSelectFailure, DLMM_PROBE_SOL_LAMPORTS, STATE_TTL_MS, TRADE_TTL_MS,
 };
 pub use pool_ranker::{PoolRanker, QuoteProvider, RankerConfig};
 pub use types::{

--- a/src/arbitrage/pool_quote.rs
+++ b/src/arbitrage/pool_quote.rs
@@ -5,7 +5,9 @@
 
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 use std::time::{Duration, Instant};
 
@@ -15,10 +17,59 @@ use crate::solana::dex::meteora_bin_walker::{dlmm_fee_bps, walker_from_bins};
 pub const NATIVE_SOL_MINT: &str = "So11111111111111111111111111111111111111112";
 /// Small SOL probe for DLMM marginal price / screening (0.01 SOL).
 pub const DLMM_PROBE_SOL_LAMPORTS: u64 = 10_000_000;
-/// Trade-implied quote TTL (v1 default 30s).
+/// Trade-implied quote TTL (v2 default 30s).
 pub const TRADE_TTL_MS: u64 = 30_000;
-/// Vault/bin state TTL when reserve snapshot unchanged (v1 default 120s).
+/// Vault/bin state TTL when reserve snapshot unchanged (v2 default 120s).
 pub const STATE_TTL_MS: u64 = 120_000;
+
+/// Configurable TTLs for quote freshness (I-ARB-4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QuoteFreshnessConfig {
+    pub trade_ttl_ms: u64,
+    pub state_ttl_ms: u64,
+}
+
+impl Default for QuoteFreshnessConfig {
+    fn default() -> Self {
+        Self {
+            trade_ttl_ms: TRADE_TTL_MS,
+            state_ttl_ms: STATE_TTL_MS,
+        }
+    }
+}
+
+/// Hash of vault reserve snapshot used for ExecutableMarginal freshness.
+pub fn state_fingerprint(vault: &QuoteVaultInput) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    vault.reserve_base.hash(&mut hasher);
+    vault.reserve_quote.hash(&mut hasher);
+    vault.active_id.hash(&mut hasher);
+    vault.bin_step.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// I-ARB-4: re-check quote freshness (trade TTL vs state fingerprint + state TTL).
+pub fn is_quote_fresh(
+    quote: &PoolQuote,
+    config: &QuoteFreshnessConfig,
+    current_vault: Option<&QuoteVaultInput>,
+    now: Instant,
+) -> bool {
+    match quote.kind {
+        QuoteKind::LastTradeMid => {
+            now.duration_since(quote.as_of_ts) <= Duration::from_millis(config.trade_ttl_ms)
+        }
+        QuoteKind::ExecutableMarginal => {
+            if now.duration_since(quote.as_of_ts) > Duration::from_millis(config.state_ttl_ms) {
+                return false;
+            }
+            match current_vault {
+                Some(vault) => state_fingerprint(vault) == quote.state_fingerprint,
+                None => true,
+            }
+        }
+    }
+}
 
 const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const USDT_MINT: &str = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
@@ -50,6 +101,8 @@ pub struct PoolQuote {
     pub as_of_slot: u64,
     pub as_of_ts: Instant,
     pub fresh: bool,
+    /// Vault reserve snapshot hash at quote time (ExecutableMarginal only).
+    pub state_fingerprint: u64,
     pub amount_in: u64,
     pub amount_out: u64,
 }
@@ -251,12 +304,12 @@ fn trade_mid_sol_per_token(pool: &QuotePoolInput) -> Option<Decimal> {
     }
 }
 
-fn trade_fresh(pool: &QuotePoolInput, now: Instant) -> bool {
-    now.duration_since(pool.trade_updated_at) <= Duration::from_millis(TRADE_TTL_MS)
+fn trade_fresh(pool: &QuotePoolInput, now: Instant, trade_ttl_ms: u64) -> bool {
+    now.duration_since(pool.trade_updated_at) <= Duration::from_millis(trade_ttl_ms)
 }
 
-fn state_fresh(vault: &QuoteVaultInput, now: Instant) -> bool {
-    now.duration_since(vault.updated_at) <= Duration::from_millis(STATE_TTL_MS)
+fn state_fresh(vault: &QuoteVaultInput, now: Instant, state_ttl_ms: u64) -> bool {
+    now.duration_since(vault.updated_at) <= Duration::from_millis(state_ttl_ms)
 }
 
 fn cpmm_fee_bps(dex: &str) -> u64 {
@@ -346,10 +399,13 @@ fn executable_marginal_quote(
     side: QuoteSide,
     amount_in: u64,
     now: Instant,
+    freshness: &QuoteFreshnessConfig,
 ) -> Option<PoolQuote> {
-    if !state_fresh(vault, now) {
+    if !state_fresh(vault, now, freshness.state_ttl_ms) {
         return None;
     }
+
+    let fingerprint = state_fingerprint(vault);
 
     if pool.dex == "meteora_dlmm" {
         let active_id = vault.active_id?;
@@ -397,6 +453,7 @@ fn executable_marginal_quote(
             as_of_slot: vault.update_slot,
             as_of_ts: vault.updated_at,
             fresh: true,
+            state_fingerprint: fingerprint,
             amount_in,
             amount_out,
         });
@@ -428,6 +485,7 @@ fn executable_marginal_quote(
         as_of_slot: vault.update_slot,
         as_of_ts: vault.updated_at,
         fresh: true,
+        state_fingerprint: fingerprint,
         amount_in,
         amount_out,
     })
@@ -438,8 +496,9 @@ fn last_trade_mid_quote(
     side: QuoteSide,
     amount_in: u64,
     now: Instant,
+    freshness: &QuoteFreshnessConfig,
 ) -> Option<PoolQuote> {
-    if !trade_fresh(pool, now) {
+    if !trade_fresh(pool, now, freshness.trade_ttl_ms) {
         return None;
     }
     let price = match side {
@@ -461,6 +520,7 @@ fn last_trade_mid_quote(
         as_of_slot: 0,
         as_of_ts: pool.trade_updated_at,
         fresh: true,
+        state_fingerprint: 0,
         amount_in,
         amount_out,
     })
@@ -475,6 +535,27 @@ pub fn quote_exact_in(
     mint_out: &str,
     amount_in: u64,
 ) -> Option<PoolQuote> {
+    quote_exact_in_with_freshness(
+        pool,
+        vault,
+        dlmm_bins,
+        mint_in,
+        mint_out,
+        amount_in,
+        &QuoteFreshnessConfig::default(),
+    )
+}
+
+/// Exact-in quote with configurable freshness TTLs.
+pub fn quote_exact_in_with_freshness(
+    pool: &QuotePoolInput,
+    vault: Option<&QuoteVaultInput>,
+    dlmm_bins: Option<&DlmmBinArrays>,
+    mint_in: &str,
+    mint_out: &str,
+    amount_in: u64,
+    freshness: &QuoteFreshnessConfig,
+) -> Option<PoolQuote> {
     if amount_in == 0 {
         return None;
     }
@@ -482,12 +563,14 @@ pub fn quote_exact_in(
     let now = Instant::now();
 
     if let Some(vault) = vault {
-        if let Some(q) = executable_marginal_quote(pool, vault, dlmm_bins, side, amount_in, now) {
+        if let Some(q) =
+            executable_marginal_quote(pool, vault, dlmm_bins, side, amount_in, now, freshness)
+        {
             return Some(q);
         }
     }
 
-    last_trade_mid_quote(pool, side, amount_in, now)
+    last_trade_mid_quote(pool, side, amount_in, now, freshness)
 }
 
 /// SOL per whole token for screening (marginal probe > reserve mid > trade mid).
@@ -558,27 +641,208 @@ pub fn round_trip_profit_lamports(
     probe_sol_lamports: u64,
     tx_cost_lamports: u64,
 ) -> Option<i64> {
-    let buy_quote = quote_exact_in(
+    round_trip_profit_lamports_with_freshness(
+        buy,
+        sell,
+        probe_sol_lamports,
+        tx_cost_lamports,
+        &QuoteFreshnessConfig::default(),
+    )
+}
+
+/// Round-trip profit with configurable freshness TTLs.
+pub fn round_trip_profit_lamports_with_freshness(
+    buy: &RoundTripLeg<'_>,
+    sell: &RoundTripLeg<'_>,
+    probe_sol_lamports: u64,
+    tx_cost_lamports: u64,
+    freshness: &QuoteFreshnessConfig,
+) -> Option<i64> {
+    let now = Instant::now();
+    let buy_quote = quote_exact_in_with_freshness(
         buy.pool,
         buy.vault,
         buy.dlmm_bins,
         NATIVE_SOL_MINT,
         &buy.pool.token_mint,
         probe_sol_lamports,
+        freshness,
     )?;
-    let sell_quote = quote_exact_in(
+    if !is_quote_fresh(&buy_quote, freshness, buy.vault, now) {
+        return None;
+    }
+    let sell_quote = quote_exact_in_with_freshness(
         sell.pool,
         sell.vault,
         sell.dlmm_bins,
         &sell.pool.token_mint,
         NATIVE_SOL_MINT,
         buy_quote.amount_out,
+        freshness,
     )?;
+    if !is_quote_fresh(&sell_quote, freshness, sell.vault, now) {
+        return None;
+    }
     if !quotes_pairable(&buy_quote, &sell_quote) {
         return None;
     }
     let profit = sell_quote.amount_out as i64 - probe_sol_lamports as i64 - tx_cost_lamports as i64;
     Some(profit)
+}
+
+/// Candidate pool for round-trip selection (I-ARB-5).
+pub struct RoundTripPoolCandidate<'a> {
+    pub pool: &'a QuotePoolInput,
+    pub vault: Option<&'a QuoteVaultInput>,
+    pub dlmm_bins: Option<&'a DlmmBinArrays>,
+    pub dex: &'a str,
+}
+
+/// Selected buy/sell pools with executable quotes.
+#[derive(Debug, Clone)]
+pub struct RoundTripPoolSelection {
+    pub buy_pool_address: String,
+    pub buy_dex: String,
+    pub sell_pool_address: String,
+    pub sell_dex: String,
+    pub buy_quote: PoolQuote,
+    pub sell_quote: PoolQuote,
+}
+
+/// Failure reason for `select_round_trip_pools`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoundTripSelectFailure {
+    InsufficientPools,
+    IncompatibleQuoteKind,
+    QuoteStale,
+}
+
+fn sol_per_token_from_buy_quote(quote: &PoolQuote, token_decimals: u8) -> Decimal {
+    trade_implied_sol_per_token(quote.amount_in, quote.amount_out, token_decimals)
+}
+
+fn sol_per_token_from_sell_quote(quote: &PoolQuote, token_decimals: u8) -> Decimal {
+    trade_implied_sol_per_token(quote.amount_out, quote.amount_in, token_decimals)
+}
+
+/// I-ARB-5: per-DEX best buy + cross-DEX best sell with matching QuoteKind.
+pub fn select_round_trip_pools(
+    candidates: &[RoundTripPoolCandidate<'_>],
+    probe_lamports: u64,
+    freshness: &QuoteFreshnessConfig,
+) -> Result<RoundTripPoolSelection, RoundTripSelectFailure> {
+    if candidates.len() < 2 {
+        return Err(RoundTripSelectFailure::InsufficientPools);
+    }
+
+    let now = Instant::now();
+    let token_decimals = candidates
+        .first()
+        .map(|c| c.pool.token_decimals)
+        .unwrap_or(6);
+
+    struct BuyCandidate<'a> {
+        candidate: &'a RoundTripPoolCandidate<'a>,
+        quote: PoolQuote,
+        sol_per_token: Decimal,
+    }
+
+    let mut best_buy: Option<BuyCandidate<'_>> = None;
+    for candidate in candidates {
+        let buy_quote = quote_exact_in_with_freshness(
+            candidate.pool,
+            candidate.vault,
+            candidate.dlmm_bins,
+            NATIVE_SOL_MINT,
+            &candidate.pool.token_mint,
+            probe_lamports,
+            freshness,
+        );
+        let Some(buy_quote) = buy_quote else {
+            continue;
+        };
+        if !is_quote_fresh(&buy_quote, freshness, candidate.vault, now) {
+            continue;
+        }
+        let sol_per_token = sol_per_token_from_buy_quote(&buy_quote, token_decimals);
+        if sol_per_token <= Decimal::ZERO {
+            continue;
+        }
+        let replace = match &best_buy {
+            None => true,
+            Some(current) => sol_per_token < current.sol_per_token,
+        };
+        if replace {
+            best_buy = Some(BuyCandidate {
+                candidate,
+                quote: buy_quote,
+                sol_per_token,
+            });
+        }
+    }
+
+    let Some(best_buy) = best_buy else {
+        return Err(RoundTripSelectFailure::InsufficientPools);
+    };
+
+    let mut best_sell: Option<BuyCandidate<'_>> = None;
+    let mut saw_incompatible_kind = false;
+
+    for candidate in candidates {
+        if candidate.dex == best_buy.candidate.dex {
+            continue;
+        }
+        let sell_quote = quote_exact_in_with_freshness(
+            candidate.pool,
+            candidate.vault,
+            candidate.dlmm_bins,
+            &candidate.pool.token_mint,
+            NATIVE_SOL_MINT,
+            best_buy.quote.amount_out,
+            freshness,
+        );
+        let Some(sell_quote) = sell_quote else {
+            continue;
+        };
+        if !is_quote_fresh(&sell_quote, freshness, candidate.vault, now) {
+            continue;
+        }
+        if !quotes_pairable(&best_buy.quote, &sell_quote) {
+            saw_incompatible_kind = true;
+            continue;
+        }
+        let sol_per_token = sol_per_token_from_sell_quote(&sell_quote, token_decimals);
+        if sol_per_token <= Decimal::ZERO {
+            continue;
+        }
+        let replace = match &best_sell {
+            None => true,
+            Some(current) => sol_per_token > current.sol_per_token,
+        };
+        if replace {
+            best_sell = Some(BuyCandidate {
+                candidate,
+                quote: sell_quote,
+                sol_per_token,
+            });
+        }
+    }
+
+    let Some(best_sell) = best_sell else {
+        if saw_incompatible_kind {
+            return Err(RoundTripSelectFailure::IncompatibleQuoteKind);
+        }
+        return Err(RoundTripSelectFailure::InsufficientPools);
+    };
+
+    Ok(RoundTripPoolSelection {
+        buy_pool_address: best_buy.candidate.pool.pool_address.clone(),
+        buy_dex: best_buy.candidate.dex.to_string(),
+        sell_pool_address: best_sell.candidate.pool.pool_address.clone(),
+        sell_dex: best_sell.candidate.dex.to_string(),
+        buy_quote: best_buy.quote,
+        sell_quote: best_sell.quote,
+    })
 }
 
 #[cfg(test)]
@@ -641,6 +905,7 @@ mod tests {
             as_of_slot: 1,
             as_of_ts: Instant::now(),
             fresh: true,
+            state_fingerprint: 42,
             amount_in: 1,
             amount_out: 2,
         };
@@ -710,5 +975,81 @@ mod tests {
             ratio <= Decimal::from(10),
             "marginal vs reserve mid divergence too large: {ratio}"
         );
+    }
+
+    #[test]
+    fn is_quote_fresh_trade_ttl_expires() {
+        let config = QuoteFreshnessConfig::default();
+        let quote = PoolQuote {
+            pool_address: "p".into(),
+            dex: "orca".into(),
+            kind: QuoteKind::LastTradeMid,
+            side: QuoteSide::Buy,
+            as_of_slot: 0,
+            as_of_ts: Instant::now() - Duration::from_secs(60),
+            fresh: false,
+            state_fingerprint: 0,
+            amount_in: 1,
+            amount_out: 2,
+        };
+        assert!(!is_quote_fresh(&quote, &config, None, Instant::now()));
+    }
+
+    #[test]
+    fn is_quote_fresh_state_fingerprint_mismatch() {
+        let config = QuoteFreshnessConfig::default();
+        let vault = sample_vault(1_000_000_000_000, 1_000_000_000);
+        let fingerprint = state_fingerprint(&vault);
+        let quote = PoolQuote {
+            pool_address: "p".into(),
+            dex: "orca".into(),
+            kind: QuoteKind::ExecutableMarginal,
+            side: QuoteSide::Buy,
+            as_of_slot: 1,
+            as_of_ts: Instant::now(),
+            fresh: true,
+            state_fingerprint: fingerprint,
+            amount_in: 1,
+            amount_out: 2,
+        };
+        let mut changed_vault = vault.clone();
+        changed_vault.reserve_base += 1;
+        assert!(!is_quote_fresh(
+            &quote,
+            &config,
+            Some(&changed_vault),
+            Instant::now()
+        ));
+    }
+
+    #[test]
+    fn select_round_trip_pools_picks_cross_dex_pair() {
+        let pool_a = sample_pool("orca", "poolA");
+        let pool_b = sample_pool("pump_amm", "poolB");
+        let vault_a = sample_vault(1_000_000_000_000, 900_000_000);
+        let vault_b = sample_vault(1_000_000_000_000, 1_100_000_000);
+        let candidates = [
+            RoundTripPoolCandidate {
+                pool: &pool_a,
+                vault: Some(&vault_a),
+                dlmm_bins: None,
+                dex: "orca",
+            },
+            RoundTripPoolCandidate {
+                pool: &pool_b,
+                vault: Some(&vault_b),
+                dlmm_bins: None,
+                dex: "pump_amm",
+            },
+        ];
+        let selection = select_round_trip_pools(
+            &candidates,
+            DLMM_PROBE_SOL_LAMPORTS,
+            &QuoteFreshnessConfig::default(),
+        )
+        .expect("cross-dex selection");
+        assert_eq!(selection.buy_pool_address, "poolA");
+        assert_eq!(selection.sell_pool_address, "poolB");
+        assert_eq!(selection.buy_quote.kind, selection.sell_quote.kind);
     }
 }

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -31,8 +31,9 @@ use uuid::Uuid;
 use ironcrab::arbitrage::{
     dlmm_marginal_price_plausible, dlmm_sol_output_from_bins, dlmm_token_output_from_bins,
     populate_arb_slave_from_live_pool_cache, quote_exact_in, quotes_pairable,
-    round_trip_profit_lamports, sync_arb_slave_from_pool_cache_update, MultiHopArbitrage,
-    MultiHopConfig, MultiHopIntentBatch, QuotePoolInput, QuoteVaultInput, RoundTripLeg,
+    round_trip_profit_lamports, select_round_trip_pools, sync_arb_slave_from_pool_cache_update,
+    MultiHopArbitrage, MultiHopConfig, MultiHopIntentBatch, QuoteFreshnessConfig, QuotePoolInput,
+    QuoteVaultInput, RoundTripLeg, RoundTripPoolCandidate, RoundTripSelectFailure,
     DLMM_PROBE_SOL_LAMPORTS,
 };
 use ironcrab::config::Config as AppConfig;
@@ -63,23 +64,25 @@ use ironcrab::metrics::{
     arb_tracker_write_stall_watchdog_inc, arb_two_hop_eligible_dexes_add,
     arb_two_hop_eligible_pools_by_dex_add, arb_two_hop_insufficient_subreason_inc,
     arb_two_hop_opportunity_inc, arb_two_hop_pool_gate_add, arb_two_hop_reject_subreason_inc,
-    arb_two_hop_rejected_inc, arb_two_hop_tracker_seeded_pools_add, record_arb_heartbeat_phase,
-    record_arb_price_freshness_stale_age_ms, record_arb_quote_shadow_round_trip,
-    record_arb_track_requests_messages_total, record_arb_writer_lock_wait, serve_metrics,
-    set_arb_pool_cache_apply_batch_size_gauge, set_arb_quote_shadow_legacy_spread_bps,
-    set_arb_tracker_write_coalescer_pending, set_arb_tracker_write_queue_depth,
-    set_arb_two_hop_blocked_on_apply_trade, set_readiness_nats_connected,
-    tick_arb_heartbeat_seconds_since_last_finish, tick_arb_tracker_write_seconds_since_last_finish,
-    wall_clock_unix_ms_now, ArbHeartbeatPhase, ArbStrategyWarmupSkipReason, ArbTrackerWriteJobType,
-    ArbTwoHopInsufficientSubreason, ArbTwoHopPoolGate, ArbTwoHopRejectReason,
-    ArbTwoHopRejectSubreason, ArbWriterLockKind, MetricsComponent,
-    ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH, ARB_REJECTED_MISSING_ACCOUNTS,
-    ARB_SUBSCRIBER_HIGH_PROCESSED_TOTAL, ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH,
-    ARB_TRACKER_WRITE_COALESCER_PENDING, ARB_TRACKER_WRITE_CURRENT_JOB_STARTED_UNIX_MS,
-    ARB_TRACKER_WRITE_CURRENT_JOB_TYPE, ARB_TRACKER_WRITE_QUEUE_DEPTH,
-    ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH, ARB_TRIANGLE_OPPORTUNITIES,
-    INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
-    NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
+    arb_two_hop_rejected_inc, arb_two_hop_tracker_seeded_pools_add,
+    arb_two_hop_v2_incompatible_kind_inc, arb_two_hop_v2_rejected_inc, arb_two_hop_v2_screen_inc,
+    record_arb_heartbeat_phase, record_arb_price_freshness_stale_age_ms,
+    record_arb_quote_shadow_round_trip, record_arb_track_requests_messages_total,
+    record_arb_writer_lock_wait, serve_metrics, set_arb_pool_cache_apply_batch_size_gauge,
+    set_arb_quote_shadow_legacy_spread_bps, set_arb_tracker_write_coalescer_pending,
+    set_arb_tracker_write_queue_depth, set_arb_two_hop_blocked_on_apply_trade,
+    set_readiness_nats_connected, tick_arb_heartbeat_seconds_since_last_finish,
+    tick_arb_tracker_write_seconds_since_last_finish, wall_clock_unix_ms_now, ArbHeartbeatPhase,
+    ArbStrategyWarmupSkipReason, ArbTrackerWriteJobType, ArbTwoHopInsufficientSubreason,
+    ArbTwoHopPoolGate, ArbTwoHopRejectReason, ArbTwoHopRejectSubreason, ArbTwoHopV2RejectReason,
+    ArbWriterLockKind, MetricsComponent, ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH,
+    ARB_REJECTED_MISSING_ACCOUNTS, ARB_SUBSCRIBER_HIGH_PROCESSED_TOTAL,
+    ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH, ARB_TRACKER_WRITE_COALESCER_PENDING,
+    ARB_TRACKER_WRITE_CURRENT_JOB_STARTED_UNIX_MS, ARB_TRACKER_WRITE_CURRENT_JOB_TYPE,
+    ARB_TRACKER_WRITE_QUEUE_DEPTH, ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH,
+    ARB_TRIANGLE_OPPORTUNITIES, INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL,
+    NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE,
+    TOKENS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     arb_strategy_pool_cache_live_consumer_config, config_consumer_config, config_subject,
@@ -146,6 +149,14 @@ struct ArbConfig {
     arb_track_reconcile_interval_secs: u64,
     /// Shadow pool_quote round-trip metrics (legacy path stays authoritative). Default: false.
     arb_quote_shadow_mode: bool,
+    /// Profit-first 2-hop v2 (round-trip quotes). Default: false.
+    arb_two_hop_v2_enabled: bool,
+    /// SOL probe for v2 round-trip screening. Default: 10_000_000 (0.01 SOL).
+    arb_probe_lamports: u64,
+    /// LastTradeMid quote TTL for v2 freshness. Default: 30_000 ms.
+    arb_quote_trade_ttl_ms: u64,
+    /// ExecutableMarginal state TTL for v2 freshness. Default: 120_000 ms.
+    arb_quote_state_ttl_ms: u64,
 }
 
 impl Default for ArbConfig {
@@ -162,6 +173,10 @@ impl Default for ArbConfig {
             arb_track_baseline_max_pools: ARB_TRACK_BASELINE_MAX_POOLS_DEFAULT,
             arb_track_reconcile_interval_secs: ARB_TRACK_RECONCILE_INTERVAL_SECS_DEFAULT,
             arb_quote_shadow_mode: false,
+            arb_two_hop_v2_enabled: false,
+            arb_probe_lamports: DLMM_PROBE_SOL_LAMPORTS,
+            arb_quote_trade_ttl_ms: 30_000,
+            arb_quote_state_ttl_ms: 120_000,
         }
     }
 }
@@ -1368,6 +1383,14 @@ struct PoolState {
     dex_accounts: Option<Vec<String>>,
 }
 
+/// Owned pool inputs for v2 round-trip selection (avoids dangling refs to temporaries).
+type OwnedRoundTripCandidate = (
+    QuotePoolInput,
+    Option<QuoteVaultInput>,
+    Option<HashMap<i64, Vec<BinData>>>,
+    String,
+);
+
 /// Tracks same token across multiple DEXes
 #[derive(Debug, Clone)]
 struct TokenArbTracker {
@@ -1987,6 +2010,184 @@ impl TokenArbTracker {
         );
     }
 
+    fn quote_freshness_config(config: &ArbConfig) -> QuoteFreshnessConfig {
+        QuoteFreshnessConfig {
+            trade_ttl_ms: config.arb_quote_trade_ttl_ms,
+            state_ttl_ms: config.arb_quote_state_ttl_ms,
+        }
+    }
+
+    fn build_round_trip_candidates(
+        &self,
+        known_pools: &HashSet<String>,
+        vault_balances: &HashMap<String, VaultBalanceCache>,
+        bin_arrays: &HashMap<String, HashMap<i64, BinArrayCache>>,
+        token_decimals: u8,
+    ) -> Vec<OwnedRoundTripCandidate> {
+        self.pools
+            .values()
+            .filter(|p| known_pools.contains(&p.pool_address))
+            .filter(|p| is_known_dex_label(&p.dex))
+            .filter(|p| p.dex != "pumpfun")
+            .map(|pool| {
+                let vault = vault_balances
+                    .get(&pool.pool_address)
+                    .map(vault_cache_to_quote_input);
+                let bins = bin_arrays
+                    .get(&pool.pool_address)
+                    .map(flatten_bin_array_cache);
+                (
+                    pool_state_to_quote_input(pool, &self.base_mint, token_decimals),
+                    vault,
+                    bins,
+                    pool.dex.clone(),
+                )
+            })
+            .collect()
+    }
+
+    /// I-ARB-6: profit-first 2-hop via round-trip quotes (no legacy mid-spread gates).
+    fn check_arbitrage_v2(
+        &self,
+        config: &ArbConfig,
+        known_pools: &HashSet<String>,
+        vault_balances: &HashMap<String, VaultBalanceCache>,
+        bin_arrays: &HashMap<String, HashMap<i64, BinArrayCache>>,
+    ) -> Option<ArbOpportunity> {
+        arb_two_hop_v2_screen_inc();
+
+        if !config.two_hop_enabled {
+            return None;
+        }
+
+        let token_decimals = self.token_decimals?;
+
+        if self.base_mint == NATIVE_SOL_MINT {
+            arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::RoundTripUnprofitable);
+            return None;
+        }
+
+        let freshness = Self::quote_freshness_config(config);
+        let probe = config.arb_probe_lamports;
+        let owned_candidates = self.build_round_trip_candidates(
+            known_pools,
+            vault_balances,
+            bin_arrays,
+            token_decimals,
+        );
+        let candidates: Vec<RoundTripPoolCandidate<'_>> = owned_candidates
+            .iter()
+            .map(|(pool, vault, bins, dex)| RoundTripPoolCandidate {
+                pool,
+                vault: vault.as_ref(),
+                dlmm_bins: bins.as_ref(),
+                dex,
+            })
+            .collect();
+
+        let selection = match select_round_trip_pools(&candidates, probe, &freshness) {
+            Ok(selection) => selection,
+            Err(RoundTripSelectFailure::InsufficientPools) => {
+                arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::InsufficientPools);
+                return None;
+            }
+            Err(RoundTripSelectFailure::QuoteStale) => {
+                arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::QuoteStale);
+                return None;
+            }
+            Err(RoundTripSelectFailure::IncompatibleQuoteKind) => {
+                arb_two_hop_v2_incompatible_kind_inc();
+                arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::IncompatibleQuoteKind);
+                return None;
+            }
+        };
+
+        let buy_pool = self.pools.get(&selection.buy_pool_address)?;
+        let sell_pool = self.pools.get(&selection.sell_pool_address)?;
+
+        let max_trade_sol =
+            if buy_pool.liquidity_sol > Decimal::ZERO && sell_pool.liquidity_sol > Decimal::ZERO {
+                buy_pool.liquidity_sol.min(sell_pool.liquidity_sol).min(
+                    Decimal::from(config.max_position_lamports) / Decimal::from(1_000_000_000u64),
+                )
+            } else {
+                Decimal::from(config.max_position_lamports) / Decimal::from(1_000_000_000u64)
+            };
+        let trade_amount_lamports = (max_trade_sol * Decimal::from(1_000_000_000u64))
+            .to_string()
+            .parse::<u64>()
+            .unwrap_or(config.max_position_lamports)
+            .max(probe);
+
+        let profit_lamports = selection.sell_quote.amount_out as i64
+            - probe as i64
+            - config.est_tx_cost_lamports as i64;
+
+        let buy_liquidity_unknown =
+            !buy_pool.has_reserve_data && buy_pool.liquidity_sol <= Decimal::ZERO;
+        let sell_liquidity_unknown =
+            !sell_pool.has_reserve_data && sell_pool.liquidity_sol <= Decimal::ZERO;
+        let effective_min_profit = if buy_liquidity_unknown && sell_liquidity_unknown {
+            config.min_profit_lamports * 5
+        } else {
+            config.min_profit_lamports
+        };
+
+        let spread_bps = if probe > 0 {
+            let gross = selection.sell_quote.amount_out as i64 - probe as i64;
+            (gross * 10_000 / probe as i64).clamp(i64::MIN, i64::MAX) as i32
+        } else {
+            0
+        };
+
+        let max_spread = if self.base_mint == USDC_MINT || self.base_mint == USDT_MINT {
+            STABLECOIN_MAX_SPREAD_BPS
+        } else {
+            MAX_REASONABLE_SPREAD_BPS
+        };
+
+        if spread_bps as i64 > max_spread || spread_bps < config.min_spread_bps as i32 {
+            arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::RoundTripUnprofitable);
+            return None;
+        }
+
+        if profit_lamports < effective_min_profit as i64 {
+            arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::RoundTripUnprofitable);
+            return None;
+        }
+
+        let buy_price = Decimal::from(selection.buy_quote.amount_in)
+            / Decimal::from(1_000_000_000u64)
+            / (Decimal::from(selection.buy_quote.amount_out)
+                / Decimal::from(10u64.pow(token_decimals as u32)));
+        let sell_price = Decimal::from(selection.sell_quote.amount_out)
+            / Decimal::from(1_000_000_000u64)
+            / (Decimal::from(selection.sell_quote.amount_in)
+                / Decimal::from(10u64.pow(token_decimals as u32)));
+
+        arb_two_hop_opportunity_inc();
+
+        let scale = if probe > 0 {
+            trade_amount_lamports as i128 / probe as i128
+        } else {
+            1
+        };
+        let estimated_profit_lamports = (profit_lamports as i128 * scale).max(0) as u64;
+
+        Some(ArbOpportunity {
+            base_mint: self.base_mint.clone(),
+            buy_dex: selection.buy_dex,
+            buy_pool: selection.buy_pool_address,
+            buy_price,
+            sell_dex: selection.sell_dex,
+            sell_pool: selection.sell_pool_address,
+            sell_price,
+            spread_bps: spread_bps.max(0) as u32,
+            trade_amount_lamports,
+            estimated_profit_lamports,
+        })
+    }
+
     /// Check for arbitrage opportunity between DEXes
     /// Returns: Option<(buy_dex, sell_dex, spread_bps, estimated_profit_lamports)>
     fn check_arbitrage(
@@ -1997,6 +2198,10 @@ impl TokenArbTracker {
         bin_arrays: &HashMap<String, HashMap<i64, BinArrayCache>>,
         check_ctx: &ArbCheckContext<'_>,
     ) -> Option<ArbOpportunity> {
+        if config.arb_two_hop_v2_enabled {
+            return self.check_arbitrage_v2(config, known_pools, vault_balances, bin_arrays);
+        }
+
         let spread_warn_last = check_ctx.spread_warn_last;
         let data_quality_rejects = check_ctx.data_quality_rejects;
         let forensics = check_ctx.forensics;
@@ -3364,6 +3569,54 @@ impl ArbContext {
                         info!(key = %key, new_value = %v, "Config updated");
                     } else {
                         rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
+                    }
+                }
+                "arb_two_hop_v2_enabled" => {
+                    if let Some(v) = value.as_bool() {
+                        config.arb_two_hop_v2_enabled = v;
+                        applied.push(key.clone());
+                        info!(key = %key, new_value = %v, "Config updated");
+                    } else {
+                        rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
+                    }
+                }
+                "arb_probe_lamports" => {
+                    if let Some(v) = value.as_u64() {
+                        if v > 0 {
+                            config.arb_probe_lamports = v;
+                            applied.push(key.clone());
+                            info!(key = %key, new_value = %v, "Config updated");
+                        } else {
+                            rejected.push((key.clone(), "Must be > 0".to_string()));
+                        }
+                    } else {
+                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
+                    }
+                }
+                "arb_quote_trade_ttl_ms" => {
+                    if let Some(v) = value.as_u64() {
+                        if v > 0 {
+                            config.arb_quote_trade_ttl_ms = v;
+                            applied.push(key.clone());
+                            info!(key = %key, new_value = %v, "Config updated");
+                        } else {
+                            rejected.push((key.clone(), "Must be > 0".to_string()));
+                        }
+                    } else {
+                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
+                    }
+                }
+                "arb_quote_state_ttl_ms" => {
+                    if let Some(v) = value.as_u64() {
+                        if v > 0 {
+                            config.arb_quote_state_ttl_ms = v;
+                            applied.push(key.clone());
+                            info!(key = %key, new_value = %v, "Config updated");
+                        } else {
+                            rejected.push((key.clone(), "Must be > 0".to_string()));
+                        }
+                    } else {
+                        rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
                     }
                 }
                 // Skip multi_hop_* keys here - they're handled in the second loop below
@@ -7608,6 +7861,87 @@ mod two_hop_price_tests {
             "expected spread_below_min or similar, not insufficient_pools"
         );
         assert_eq!(tracker.pools.len(), 2);
+    }
+
+    #[test]
+    fn check_arbitrage_v2_uses_round_trip_not_legacy_mids() {
+        let cache = create_shared_cache();
+        let token_mint = Pubkey::new_unique();
+        let pool_a = Pubkey::new_unique();
+        let pool_b = Pubkey::new_unique();
+        let mint_str = token_mint.to_string();
+
+        let update_orca = PoolCacheUpdate::new_balance_updated(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            pool_a.to_string(),
+            "orca".to_string(),
+            mint_str.clone(),
+            NATIVE_SOL_MINT.to_string(),
+            1_000_000_000_000,
+            980_000_000,
+            1,
+        );
+        let update_pump = PoolCacheUpdate::new_balance_updated(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            pool_b.to_string(),
+            "pump_amm".to_string(),
+            mint_str.clone(),
+            NATIVE_SOL_MINT.to_string(),
+            1_000_000_000_000,
+            1_020_000_000,
+            2,
+        );
+        ironcrab::execution::pool_cache_sync::apply_pool_cache_update(&cache, &update_orca);
+        ironcrab::execution::pool_cache_sync::apply_pool_cache_update(&cache, &update_pump);
+
+        let mut trackers = HashMap::new();
+        let mut vault_balances = HashMap::new();
+        seed_token_tracker_from_live_pool_cache(
+            &mint_str,
+            &cache,
+            &mut trackers,
+            &mut vault_balances,
+            None,
+        );
+
+        let mut known_pools = HashSet::new();
+        known_pools.insert(pool_a.to_string());
+        known_pools.insert(pool_b.to_string());
+
+        let tracker = trackers.get_mut(&mint_str).unwrap();
+        tracker.token_decimals = Some(6);
+        assert_eq!(tracker.pools.len(), 2, "expected two seeded pools");
+        assert_eq!(vault_balances.len(), 2, "expected two vault entries");
+
+        let mut config = ArbConfig::default();
+        config.arb_two_hop_v2_enabled = true;
+        config.min_spread_bps = 1;
+        config.min_profit_lamports = 1;
+        config.est_tx_cost_lamports = 1;
+
+        let bin_arrays: HashMap<String, HashMap<i64, BinArrayCache>> = HashMap::new();
+        let spread_warn_last = RwLock::new(HashMap::new());
+        let data_quality_rejects = AtomicU64::new(0);
+        let opp = tracker.check_arbitrage(
+            &config,
+            &known_pools,
+            &vault_balances,
+            &bin_arrays,
+            &ArbCheckContext {
+                spread_warn_last: &spread_warn_last,
+                data_quality_rejects: &data_quality_rejects,
+                forensics: None,
+            },
+        );
+        let opp = opp.expect("v2 round-trip should find cross-dex edge");
+        assert_eq!(opp.buy_pool, pool_a.to_string());
+        assert_eq!(opp.sell_pool, pool_b.to_string());
+        assert!(opp.spread_bps > 0);
+        assert!(opp.estimated_profit_lamports > 0);
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -7917,11 +7917,13 @@ mod two_hop_price_tests {
         assert_eq!(tracker.pools.len(), 2, "expected two seeded pools");
         assert_eq!(vault_balances.len(), 2, "expected two vault entries");
 
-        let mut config = ArbConfig::default();
-        config.arb_two_hop_v2_enabled = true;
-        config.min_spread_bps = 1;
-        config.min_profit_lamports = 1;
-        config.est_tx_cost_lamports = 1;
+        let config = ArbConfig {
+            arb_two_hop_v2_enabled: true,
+            min_spread_bps: 1,
+            min_profit_lamports: 1,
+            est_tx_cost_lamports: 1,
+            ..Default::default()
+        };
 
         let bin_arrays: HashMap<String, HashMap<i64, BinArrayCache>> = HashMap::new();
         let spread_warn_last = RwLock::new(HashMap::new());

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3005,6 +3005,18 @@ const ARB_QUOTE_SHADOW_PROFIT_BUCKETS: [i64; 5] =
 static ARB_QUOTE_SHADOW_PROFIT_BUCKET_COUNTS: Lazy<[AtomicU64; 5]> =
     Lazy::new(|| std::array::from_fn(|_| AtomicU64::new(0)));
 
+// --- 2-hop profit-first v2 (M2, default off) ---
+pub static ARB_TWO_HOP_V2_SCREEN_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_INCOMPATIBLE_KIND_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_UNPROFITABLE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_REJECTED_QUOTE_STALE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_REJECTED_INCOMPATIBLE_QUOTE_KIND: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_REJECTED_INSUFFICIENT_POOLS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 // --- arb-strategy bootstrap / incremental warmup (low-cardinality) ---
 pub static ARB_STRATEGY_BOOTSTRAP_LIVE_POOL_CACHE_ROWS: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -3414,6 +3426,40 @@ pub fn record_arb_quote_shadow_round_trip(
 /// Update legacy spread gauge when shadow mode compares v1 vs v2.
 pub fn set_arb_quote_shadow_legacy_spread_bps(spread_bps: i64) {
     ARB_QUOTE_SHADOW_LEGACY_SPREAD_BPS.store(spread_bps, Ordering::Relaxed);
+}
+
+/// Rejection reason for `arb_two_hop_v2_rejected_total{reason=...}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArbTwoHopV2RejectReason {
+    RoundTripUnprofitable,
+    QuoteStale,
+    IncompatibleQuoteKind,
+    InsufficientPools,
+}
+
+/// Increment `arb_two_hop_v2_screen_total`.
+pub fn arb_two_hop_v2_screen_inc() {
+    ARB_TWO_HOP_V2_SCREEN_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Increment `arb_two_hop_v2_incompatible_kind_total`.
+pub fn arb_two_hop_v2_incompatible_kind_inc() {
+    ARB_TWO_HOP_V2_INCOMPATIBLE_KIND_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Increment `arb_two_hop_v2_rejected_total{reason=...}`.
+pub fn arb_two_hop_v2_rejected_inc(reason: ArbTwoHopV2RejectReason) {
+    let counter = match reason {
+        ArbTwoHopV2RejectReason::RoundTripUnprofitable => {
+            &*ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_UNPROFITABLE
+        }
+        ArbTwoHopV2RejectReason::QuoteStale => &*ARB_TWO_HOP_V2_REJECTED_QUOTE_STALE,
+        ArbTwoHopV2RejectReason::IncompatibleQuoteKind => {
+            &*ARB_TWO_HOP_V2_REJECTED_INCOMPATIBLE_QUOTE_KIND
+        }
+        ArbTwoHopV2RejectReason::InsufficientPools => &*ARB_TWO_HOP_V2_REJECTED_INSUFFICIENT_POOLS,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Add to `arb_two_hop_tracker_seeded_pools_total` after SLAVE cache tracker seed.
@@ -6633,6 +6679,42 @@ async fn metrics_response() -> Response<Body> {
     out.push_str("arb_quote_shadow_round_trip_profit_lamports_bucket{le=\"+Inf\"} ");
     out.push_str(
         &ARB_QUOTE_SHADOW_ROUND_TRIP_PROFIT_COUNT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    line!(
+        "arb_two_hop_v2_screen_total",
+        ARB_TWO_HOP_V2_SCREEN_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_two_hop_v2_incompatible_kind_total",
+        ARB_TWO_HOP_V2_INCOMPATIBLE_KIND_TOTAL.load(Ordering::Relaxed)
+    );
+    out.push_str("arb_two_hop_v2_rejected_total{reason=\"round_trip_unprofitable\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_UNPROFITABLE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_rejected_total{reason=\"quote_stale\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_REJECTED_QUOTE_STALE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_rejected_total{reason=\"incompatible_quote_kind\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_REJECTED_INCOMPATIBLE_QUOTE_KIND
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_rejected_total{reason=\"insufficient_pools\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_REJECTED_INSUFFICIENT_POOLS
             .load(Ordering::Relaxed)
             .to_string(),
     );


### PR DESCRIPTION
## Summary
Milestone M2 — Profit-first 2-hop Cross-DEX (plan_arb_profit_first_rebuild.md).

- **I-ARB-4:** Freshness v2 (state fingerprint, trade/state TTL, as_of_slot)
- **I-ARB-5:** `select_round_trip_pools` — fresh + same QuoteKind, per-DEX selection
- **I-ARB-6:** `check_arbitrage_v2` — Round-Trip SOL→Token→SOL, no legacy mid spread
- **I-ARB-7:** `arb_two_hop_v2_enabled` (default false) + control plane keys

Legacy `check_arbitrage` unchanged when flag false.

## Test plan
- [ ] cargo fmt/clippy/test
- [ ] Eval Level 5 CI
- [ ] Do not enable `arb_two_hop_v2_enabled` on prod until M2 batch merged + soak plan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how 2-hop opportunities are detected when v2 is enabled (trade execution path); default-off limits blast radius, but mis-tuned TTLs or early prod enablement could miss or mis-rank arbs.
> 
> **Overview**
> **Profit-first 2-hop v2 (M2)** extends the pool quote layer and gates a new arb path behind **`arb_two_hop_v2_enabled`** (default **false**); legacy `check_arbitrage` is unchanged when the flag is off.
> 
> **Quote freshness (I-ARB-4):** `QuoteFreshnessConfig`, vault **`state_fingerprint`** on `PoolQuote`, and **`is_quote_fresh`** (trade TTL vs state TTL + fingerprint). Quoting and round-trip profit helpers gain **`_with_freshness`** variants wired to configurable TTLs.
> 
> **Round-trip selection (I-ARB-5):** **`select_round_trip_pools`** picks the best buy across candidates and the best **cross-DEX** sell with matching **`QuoteKind`**, skipping stale quotes.
> 
> **Strategy (I-ARB-6/7):** When v2 is enabled, **`check_arbitrage_v2`** screens SOL→token→SOL via probe quotes and selection (no legacy mid-spread gates), with hot-reload keys for probe size and TTLs. **Prometheus** counters for v2 screens and reject reasons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 392cd13992abf4bac73262ce3f083339e7be5471. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->