### PR TITLE
M3: Multi-hop unified PoolQuote (I-ARB-8..9)

### DIFF
--- a/src/arbitrage/mod.rs
+++ b/src/arbitrage/mod.rs
@@ -48,12 +48,14 @@ pub use multi_hop_integration::{
 pub use pool_graph::{GraphStats, PoolGraph};
 pub use pool_quote::{
     dlmm_marginal_price_plausible, dlmm_sol_output_from_bins, dlmm_token_output_from_bins,
-    flatten_bin_array_bins, is_quote_fresh, quote_exact_in, quote_exact_in_with_freshness,
-    quote_sol_per_token_for_screening, quotes_pairable, round_trip_profit_lamports,
-    round_trip_profit_lamports_with_freshness, select_round_trip_pools, state_fingerprint,
-    DlmmBinArrays, PoolQuote, QuoteFreshnessConfig, QuoteKind, QuotePoolInput, QuoteSide,
-    QuoteVaultInput, RoundTripLeg, RoundTripPoolCandidate, RoundTripPoolSelection,
-    RoundTripSelectFailure, DLMM_PROBE_SOL_LAMPORTS, STATE_TTL_MS, TRADE_TTL_MS,
+    flatten_bin_array_bins, is_quote_fresh, is_usable_quote_kind, quote_exact_in,
+    quote_exact_in_with_freshness, quote_from_cached_pool, quote_sol_per_token_for_screening,
+    quotes_pairable, round_trip_profit_lamports, round_trip_profit_lamports_with_freshness,
+    select_round_trip_pools, sol_quoted_seed_from_cached_state, state_fingerprint,
+    token_decimals_from_cached_state, DlmmBinArrays, PoolQuote, QuoteFreshnessConfig, QuoteKind,
+    QuotePoolInput, QuoteSide, QuoteVaultInput, RoundTripLeg, RoundTripPoolCandidate,
+    RoundTripPoolSelection, RoundTripSelectFailure, SolQuotedPoolSeed, DLMM_PROBE_SOL_LAMPORTS,
+    STATE_TTL_MS, TRADE_TTL_MS,
 };
 pub use pool_ranker::{PoolRanker, QuoteProvider, RankerConfig};
 pub use types::{

--- a/src/arbitrage/multi_hop_integration.rs
+++ b/src/arbitrage/multi_hop_integration.rs
@@ -12,18 +12,19 @@
 //! This is event-driven, NOT interval-based, to minimize latency.
 
 use crate::arbitrage::{
-    ArbCycle, BeamCycleFinder, CycleFinderConfig, DexType, PoolEdge, PoolGraph, PoolRanker,
-    QuoteProvider, RankerConfig, MAX_RETURN_BPS,
+    is_usable_quote_kind, quote_from_cached_pool, token_decimals_from_cached_state, ArbCycle,
+    BeamCycleFinder, CycleFinderConfig, DexType, DlmmBinArrays, PoolEdge, PoolGraph, PoolQuote,
+    PoolRanker, QuoteFreshnessConfig, QuoteKind, QuoteProvider, RankerConfig, MAX_RETURN_BPS,
 };
 use crate::execution::live_pool_cache::{CachedPoolState, SharedLivePoolCache};
-use crate::execution::quote_calculator;
+use crate::ipc::BinData;
 use crate::ipc::{
     ExplicitAmount, IntentOrigin, IntentTier, PoolAlternative, RecordHeader, SwapHop, TradeIntent,
     TradeResources, TradeSide, TradingRegime,
 };
 use crate::metrics::{
     multi_hop_cycle_rejected_sanity_inc, multi_hop_hop_missing_quote_inc,
-    multi_hop_quote_from_cache_inc, multi_hop_quote_from_trade_cache_inc,
+    multi_hop_quote_from_pool_quote_inc, multi_hop_quote_from_trade_cache_inc,
     multi_hop_quote_ready_pools_set, multi_hop_quote_ready_wsol_edge_pools_set,
     multi_hop_return_bps_saturated_inc, multi_hop_search_no_quote_neighbors_inc,
     multi_hop_search_worker_queue_depth_set, multi_hop_searches_coalesced_inc,
@@ -151,7 +152,7 @@ type QuoteCacheKey = (Pubkey, Pubkey, Pubkey);
 /// Cache value: (output_amount, timestamp)
 type QuoteCacheValue = (u64, Instant);
 
-/// Quote provider: trade-normalized cache, then LivePoolCache (Geyser). No synthetic fallback.
+/// Quote provider: trade-normalized cache, then LivePoolCache via `pool_quote` (Geyser). No synthetic fallback.
 pub struct CachedQuoteProvider {
     /// Cache: (pool, input_mint, output_mint) -> (output_amount, timestamp)
     cache: RwLock<HashMap<QuoteCacheKey, QuoteCacheValue>>,
@@ -161,6 +162,10 @@ pub struct CachedQuoteProvider {
     cache_ttl: Duration,
     /// SLAVE LivePoolCache (same SSOT as execution-engine) — no RPC on miss.
     live_pool_cache: SharedLivePoolCache,
+    /// Meteora DLMM bin arrays (Geyser); optional until wired from market events.
+    dlmm_bin_arrays: RwLock<HashMap<Pubkey, DlmmBinArrays>>,
+    /// Freshness TTLs aligned with 2-hop v2 defaults.
+    quote_freshness: QuoteFreshnessConfig,
     /// Pools with at least one quotable direction (beam expansion pruning).
     quote_ready: QuoteReadyIndex,
     last_cleanup: RwLock<Instant>,
@@ -173,30 +178,80 @@ impl CachedQuoteProvider {
             pool_mints: RwLock::new(HashMap::new()),
             cache_ttl,
             live_pool_cache,
+            dlmm_bin_arrays: RwLock::new(HashMap::new()),
+            quote_freshness: QuoteFreshnessConfig {
+                trade_ttl_ms: cache_ttl.as_millis() as u64,
+                ..QuoteFreshnessConfig::default()
+            },
             quote_ready: QuoteReadyIndex::default(),
             last_cleanup: RwLock::new(Instant::now()),
         }
+    }
+
+    /// Ingest Meteora DLMM bin array updates (Geyser). Enables ExecutableMarginal DLMM quotes.
+    pub fn update_dlmm_bin_array(&self, pool: Pubkey, array_index: i64, bins: Vec<BinData>) {
+        if bins.is_empty() {
+            return;
+        }
+        self.dlmm_bin_arrays
+            .write()
+            .entry(pool)
+            .or_default()
+            .insert(array_index, bins);
+    }
+
+    fn dlmm_bins_for_pool(&self, pool: &Pubkey) -> Option<DlmmBinArrays> {
+        let arrays = self.dlmm_bin_arrays.read();
+        let bins = arrays.get(pool)?;
+        (!bins.is_empty()).then(|| bins.clone())
+    }
+
+    fn resolve_token_decimals(&self, state: &CachedPoolState, token_mint: &Pubkey) -> u8 {
+        self.live_pool_cache
+            .get_mint_decimals(token_mint)
+            .unwrap_or_else(|| token_decimals_from_cached_state(state, token_mint))
     }
 
     pub fn quote_ready_index(&self) -> &QuoteReadyIndex {
         &self.quote_ready
     }
 
-    /// Mark pool ready when LivePoolCache gains reserves (incremental SSOT sync).
+    /// Mark pool ready when LivePoolCache yields ExecutableMarginal or fresh trade-cache quote.
     pub fn mark_ready_from_live_pool_cache(&self, pool_address: &Pubkey) {
         let Some(state) = self.live_pool_cache.get(pool_address) else {
             return;
         };
         let (mint_a, mint_b) = Self::mints_from_state(&state);
-        if self
-            .try_quote_from_live_pool_cache(pool_address, &mint_a, PROBE_LAMPORTS)
-            .is_some()
-            || self
-                .try_quote_from_live_pool_cache(pool_address, &mint_b, PROBE_LAMPORTS)
-                .is_some()
+        if self.direction_quotable(pool_address, &state, &mint_a, &mint_b)
+            || self.direction_quotable(pool_address, &state, &mint_b, &mint_a)
         {
             self.quote_ready.mark_ready(*pool_address);
         }
+    }
+
+    fn direction_quotable(
+        &self,
+        pool: &Pubkey,
+        state: &CachedPoolState,
+        mint_in: &Pubkey,
+        mint_out: &Pubkey,
+    ) -> bool {
+        if self.trade_direction_fresh_probe(*pool, *mint_in, *mint_out) {
+            return true;
+        }
+        self.try_pool_quote_from_live_pool_cache(pool, state, mint_in, mint_out, PROBE_LAMPORTS)
+            .is_some_and(|q| is_usable_quote_kind(q.kind))
+    }
+
+    fn trade_direction_fresh_probe(
+        &self,
+        pool: Pubkey,
+        input_mint: Pubkey,
+        output_mint: Pubkey,
+    ) -> bool {
+        let now = Instant::now();
+        let cache = self.cache.read();
+        self.trade_direction_fresh(&cache, pool, input_mint, output_mint, now)
     }
 
     fn resolve_pool_mints(&self, pool: &Pubkey) -> Option<(Pubkey, Pubkey)> {
@@ -235,11 +290,8 @@ impl CachedQuoteProvider {
             return false;
         };
         let (mint_a, mint_b) = Self::mints_from_state(&state);
-        self.try_quote_from_live_pool_cache(pool, &mint_a, PROBE_LAMPORTS)
-            .is_some()
-            || self
-                .try_quote_from_live_pool_cache(pool, &mint_b, PROBE_LAMPORTS)
-                .is_some()
+        self.direction_quotable(pool, &state, &mint_a, &mint_b)
+            || self.direction_quotable(pool, &state, &mint_b, &mint_a)
     }
 
     fn mints_from_state(state: &CachedPoolState) -> (Pubkey, Pubkey) {
@@ -281,26 +333,96 @@ impl CachedQuoteProvider {
         sol_side.max(10_000.0)
     }
 
-    fn try_quote_from_live_pool_cache(
+    fn try_pool_quote_from_live_pool_cache(
+        &self,
+        pool_address: &Pubkey,
+        state: &CachedPoolState,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+        amount_in: u64,
+    ) -> Option<PoolQuote> {
+        let (state, slot, age_ms) = self
+            .live_pool_cache
+            .get_with_metadata(pool_address)
+            .unwrap_or((state.clone(), 0, 0));
+        let updated_at = Instant::now()
+            .checked_sub(Duration::from_millis(age_ms))
+            .unwrap_or_else(Instant::now);
+        let wsol = Pubkey::from_str(WSOL_MINT).ok()?;
+        let token_mint = if *input_mint == wsol {
+            *output_mint
+        } else {
+            *input_mint
+        };
+        let token_decimals = self.resolve_token_decimals(&state, &token_mint);
+        let dlmm_bins = self.dlmm_bins_for_pool(pool_address);
+        let quote = quote_from_cached_pool(
+            &state,
+            &pool_address.to_string(),
+            &input_mint.to_string(),
+            &output_mint.to_string(),
+            amount_in,
+            dlmm_bins.as_ref(),
+            slot,
+            updated_at,
+            token_decimals,
+            &self.quote_freshness,
+        )?;
+        (quote.amount_out > 0).then_some(quote)
+    }
+
+    fn quote_output_from_live_pool_cache(
         &self,
         pool_address: &Pubkey,
         input_mint: &Pubkey,
+        output_mint: &Pubkey,
         amount_in: u64,
     ) -> Option<u64> {
         let state = self.live_pool_cache.get(pool_address)?;
-        let out = quote_calculator::quote_output_amount(&state, amount_in, input_mint).ok()?;
-        (out > 0).then_some(out)
+        let quote = self.try_pool_quote_from_live_pool_cache(
+            pool_address,
+            &state,
+            input_mint,
+            output_mint,
+            amount_in,
+        )?;
+        multi_hop_quote_from_pool_quote_inc();
+        Some(quote.amount_out)
     }
 
-    fn quote_from_live_pool_cache(
+    fn prefer_pool_quote_then_trade_cache(
         &self,
         pool_address: &Pubkey,
         input_mint: &Pubkey,
+        output_mint: &Pubkey,
         amount_in: u64,
     ) -> Option<u64> {
-        let out = self.try_quote_from_live_pool_cache(pool_address, input_mint, amount_in)?;
-        multi_hop_quote_from_cache_inc();
-        Some(out)
+        let pool_quote = self.live_pool_cache.get(pool_address).and_then(|state| {
+            self.try_pool_quote_from_live_pool_cache(
+                pool_address,
+                &state,
+                input_mint,
+                output_mint,
+                amount_in,
+            )
+        });
+        if let Some(ref q) = pool_quote {
+            if q.kind == QuoteKind::ExecutableMarginal {
+                multi_hop_quote_from_pool_quote_inc();
+                return Some(q.amount_out);
+            }
+        }
+        if let Some(out) = self.trade_cache_quote(pool_address, input_mint, output_mint, amount_in)
+        {
+            return Some(out);
+        }
+        if let Some(q) = pool_quote {
+            if is_usable_quote_kind(q.kind) {
+                multi_hop_quote_from_pool_quote_inc();
+                return Some(q.amount_out);
+            }
+        }
+        None
     }
 
     fn trade_cache_quote(
@@ -347,13 +469,15 @@ impl CachedQuoteProvider {
             let (mint_a, mint_b) = Self::mints_from_state(&state);
             let other = if mint_a == wsol { mint_b } else { mint_a };
 
-            if let Some(out) = self.try_quote_from_live_pool_cache(&pool_pk, &wsol, PROBE_LAMPORTS)
+            if let Some(out) =
+                self.quote_output_from_live_pool_cache(&pool_pk, &wsol, &other, PROBE_LAMPORTS)
             {
                 self.update_quote(pool_pk, wsol, other, PROBE_LAMPORTS, out);
                 self.quote_ready.mark_ready(pool_pk);
                 seeded += 1;
             }
-            if let Some(out) = self.try_quote_from_live_pool_cache(&pool_pk, &other, PROBE_LAMPORTS)
+            if let Some(out) =
+                self.quote_output_from_live_pool_cache(&pool_pk, &other, &wsol, PROBE_LAMPORTS)
             {
                 self.update_quote(pool_pk, other, wsol, PROBE_LAMPORTS, out);
                 self.quote_ready.mark_ready(pool_pk);
@@ -470,16 +594,18 @@ impl QuoteProvider for CachedQuoteProvider {
         output_mint: &Pubkey,
         amount_in: u64,
     ) -> Option<u64> {
-        if let Some(out) = self.trade_cache_quote(pool_address, input_mint, output_mint, amount_in)
-        {
+        if let Some(out) = self.prefer_pool_quote_then_trade_cache(
+            pool_address,
+            input_mint,
+            output_mint,
+            amount_in,
+        ) {
             return Some(out);
         }
 
-        if let Some(out) = self.quote_from_live_pool_cache(pool_address, input_mint, amount_in) {
-            return Some(out);
+        if self.quote_ready.contains(pool_address) {
+            multi_hop_hop_missing_quote_inc();
         }
-
-        multi_hop_hop_missing_quote_inc();
         None
     }
 
@@ -508,8 +634,17 @@ impl QuoteProvider for CachedQuoteProvider {
         {
             return true;
         }
-        self.try_quote_from_live_pool_cache(pool_address, input_mint, PROBE_LAMPORTS)
-            .is_some()
+        let Some(state) = self.live_pool_cache.get(pool_address) else {
+            return false;
+        };
+        self.try_pool_quote_from_live_pool_cache(
+            pool_address,
+            &state,
+            input_mint,
+            output_mint,
+            PROBE_LAMPORTS,
+        )
+        .is_some_and(|q| is_usable_quote_kind(q.kind))
     }
 
     fn get_cached_probe_quote(
@@ -520,12 +655,7 @@ impl QuoteProvider for CachedQuoteProvider {
         output_mint: &Pubkey,
         amount_in: u64,
     ) -> Option<u64> {
-        if let Some(out) = self.trade_cache_quote(pool_address, input_mint, output_mint, amount_in)
-        {
-            return Some(out);
-        }
-
-        self.quote_from_live_pool_cache(pool_address, input_mint, amount_in)
+        self.prefer_pool_quote_then_trade_cache(pool_address, input_mint, output_mint, amount_in)
     }
 }
 
@@ -1260,8 +1390,9 @@ impl QuoteProvider for Arc<CachedQuoteProvider> {
 mod tests {
     use super::*;
     use crate::execution::live_pool_cache::{
-        create_shared_cache, CachedPoolState, RaydiumAmmState,
+        create_shared_cache, CachedPoolState, MeteoraState, RaydiumAmmState,
     };
+    use crate::ipc::BinData;
     use serial_test::serial;
 
     #[test]
@@ -1330,8 +1461,66 @@ mod tests {
         let probe = PROBE_LAMPORTS;
         let out = provider
             .get_cached_probe_quote(&pool, DexType::RaydiumAmmV4, &wsol, &token, probe)
-            .expect("LivePoolCache quote expected");
+            .expect("pool_quote LivePoolCache quote expected");
         assert!(out > 0);
+        provider.mark_ready_from_live_pool_cache(&pool);
+        assert!(provider.is_pool_quote_ready(&pool));
+    }
+
+    #[test]
+    fn dlmm_multi_hop_uses_bin_walker_not_cp_approx() {
+        let cache = create_shared_cache();
+        let provider = CachedQuoteProvider::new(Duration::from_secs(30), cache.clone());
+
+        let wsol = Pubkey::from_str(WSOL_MINT).unwrap();
+        let token = Pubkey::new_unique();
+        let pool = Pubkey::new_unique();
+        let active_id = 0i32;
+        let bin_step = 100u16;
+        let token_amount = 500_000_000_000u64;
+        let sol_amount = 2_000_000_000u64;
+
+        cache.upsert(
+            pool,
+            CachedPoolState::Meteora(MeteoraState {
+                token_x_mint: token,
+                token_y_mint: wsol,
+                reserve_x: Pubkey::new_unique(),
+                reserve_y: Pubkey::new_unique(),
+                active_id,
+                bin_step,
+                reserve_x_balance: Some(1_000_000_000_000),
+                reserve_y_balance: Some(500_000_000),
+            }),
+            1,
+        );
+        provider.update_dlmm_bin_array(
+            pool,
+            active_id as i64 / 70,
+            vec![BinData {
+                offset: 0,
+                amount_x: token_amount,
+                amount_y: sol_amount,
+            }],
+        );
+
+        let out = provider
+            .get_cached_probe_quote(&pool, DexType::MeteoraDlmm, &wsol, &token, PROBE_LAMPORTS)
+            .expect("DLMM bin-walker quote expected");
+        let cp_approx = {
+            let fee_bps = 100u64;
+            let ri = sol_amount as u128;
+            let ro = token_amount as u128;
+            let a = PROBE_LAMPORTS as u128;
+            let after_fee = a * (10000 - fee_bps as u128) / 10000;
+            ((after_fee * ro) / (ri + after_fee)) as u64
+        };
+        assert_ne!(
+            out, cp_approx,
+            "bin walker must differ from reserve CP approx"
+        );
+        provider.mark_ready_from_live_pool_cache(&pool);
+        assert!(provider.is_pool_quote_ready(&pool));
     }
 
     #[test]

--- a/src/arbitrage/pool_quote.rs
+++ b/src/arbitrage/pool_quote.rs
@@ -11,8 +11,10 @@ use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 use std::time::{Duration, Instant};
 
+use crate::execution::live_pool_cache::{CachedPoolState, MeteoraState};
 use crate::ipc::BinData;
 use crate::solana::dex::meteora_bin_walker::{dlmm_fee_bps, walker_from_bins};
+use solana_sdk::pubkey::Pubkey;
 
 pub const NATIVE_SOL_MINT: &str = "So11111111111111111111111111111111111111112";
 /// Small SOL probe for DLMM marginal price / screening (0.01 SOL).
@@ -526,6 +528,450 @@ fn last_trade_mid_quote(
     })
 }
 
+/// SOL-quoted token reserves extracted from [`CachedPoolState`] (base = token, quote = SOL).
+#[derive(Debug, Clone)]
+pub struct SolQuotedPoolSeed {
+    pub token_mint: String,
+    pub reserve_base: u64,
+    pub reserve_quote: u64,
+    pub active_id: Option<i32>,
+    pub bin_step: Option<u16>,
+    pub dlmm_token_x_mint: Option<String>,
+}
+
+/// True when a quote may drive beam expansion / quote-ready index.
+pub fn is_usable_quote_kind(kind: QuoteKind) -> bool {
+    matches!(
+        kind,
+        QuoteKind::ExecutableMarginal | QuoteKind::LastTradeMid
+    )
+}
+
+fn orca_sol_quoted_vault_reserves(
+    mint_a: &str,
+    mint_b: &str,
+    vault_a: u64,
+    vault_b: u64,
+) -> Option<(u64, u64)> {
+    if mint_a == NATIVE_SOL_MINT {
+        Some((vault_b, vault_a))
+    } else if mint_b == NATIVE_SOL_MINT {
+        Some((vault_a, vault_b))
+    } else {
+        None
+    }
+}
+
+/// Map SLAVE [`CachedPoolState`] to SOL-quoted reserves for `quote_exact_in`.
+pub fn sol_quoted_seed_from_cached_state(state: &CachedPoolState) -> Option<SolQuotedPoolSeed> {
+    match state {
+        CachedPoolState::Orca(s) => {
+            let mint_a = s.token_mint_a.to_string();
+            let mint_b = s.token_mint_b.to_string();
+            let va = s.vault_a_balance?;
+            let vb = s.vault_b_balance?;
+            let (reserve_base, reserve_quote) =
+                orca_sol_quoted_vault_reserves(&mint_a, &mint_b, va, vb)?;
+            let token_mint = if mint_a == NATIVE_SOL_MINT {
+                mint_b
+            } else {
+                mint_a
+            };
+            Some(SolQuotedPoolSeed {
+                token_mint,
+                reserve_base,
+                reserve_quote,
+                active_id: None,
+                bin_step: None,
+                dlmm_token_x_mint: None,
+            })
+        }
+        CachedPoolState::RaydiumAmm(s) => {
+            let base = s.base_mint.to_string();
+            let quote = s.quote_mint.to_string();
+            let cr = s.coin_reserve?;
+            let pr = s.pc_reserve?;
+            if quote == NATIVE_SOL_MINT {
+                Some(SolQuotedPoolSeed {
+                    token_mint: base,
+                    reserve_base: cr,
+                    reserve_quote: pr,
+                    active_id: None,
+                    bin_step: None,
+                    dlmm_token_x_mint: None,
+                })
+            } else if base == NATIVE_SOL_MINT {
+                Some(SolQuotedPoolSeed {
+                    token_mint: quote,
+                    reserve_base: pr,
+                    reserve_quote: cr,
+                    active_id: None,
+                    bin_step: None,
+                    dlmm_token_x_mint: None,
+                })
+            } else {
+                None
+            }
+        }
+        CachedPoolState::RaydiumCpmm(s) => {
+            let t0 = s.token_0_mint.to_string();
+            let t1 = s.token_1_mint.to_string();
+            let r0 = s.reserve_0?;
+            let r1 = s.reserve_1?;
+            if t1 == NATIVE_SOL_MINT {
+                Some(SolQuotedPoolSeed {
+                    token_mint: t0,
+                    reserve_base: r0,
+                    reserve_quote: r1,
+                    active_id: None,
+                    bin_step: None,
+                    dlmm_token_x_mint: None,
+                })
+            } else if t0 == NATIVE_SOL_MINT {
+                Some(SolQuotedPoolSeed {
+                    token_mint: t1,
+                    reserve_base: r1,
+                    reserve_quote: r0,
+                    active_id: None,
+                    bin_step: None,
+                    dlmm_token_x_mint: None,
+                })
+            } else {
+                None
+            }
+        }
+        CachedPoolState::Meteora(s) => sol_quoted_seed_from_meteora_dlmm(s),
+        CachedPoolState::MeteoraCpmm(s) => {
+            let t0 = s.token_0_mint.to_string();
+            let t1 = s.token_1_mint.to_string();
+            if t1 == NATIVE_SOL_MINT {
+                Some(SolQuotedPoolSeed {
+                    token_mint: t0,
+                    reserve_base: s.reserve_0,
+                    reserve_quote: s.reserve_1,
+                    active_id: None,
+                    bin_step: None,
+                    dlmm_token_x_mint: None,
+                })
+            } else if t0 == NATIVE_SOL_MINT {
+                Some(SolQuotedPoolSeed {
+                    token_mint: t1,
+                    reserve_base: s.reserve_1,
+                    reserve_quote: s.reserve_0,
+                    active_id: None,
+                    bin_step: None,
+                    dlmm_token_x_mint: None,
+                })
+            } else {
+                None
+            }
+        }
+        CachedPoolState::PumpAmm(s) => {
+            let base = s.base_mint.to_string();
+            let quote = s.quote_mint.to_string();
+            let br = s.base_reserve?;
+            let qr = s.quote_reserve?;
+            if quote == NATIVE_SOL_MINT {
+                Some(SolQuotedPoolSeed {
+                    token_mint: base,
+                    reserve_base: br,
+                    reserve_quote: qr,
+                    active_id: None,
+                    bin_step: None,
+                    dlmm_token_x_mint: None,
+                })
+            } else if base == NATIVE_SOL_MINT {
+                Some(SolQuotedPoolSeed {
+                    token_mint: quote,
+                    reserve_base: qr,
+                    reserve_quote: br,
+                    active_id: None,
+                    bin_step: None,
+                    dlmm_token_x_mint: None,
+                })
+            } else {
+                None
+            }
+        }
+        CachedPoolState::PumpFun(s) => {
+            let mint = s.token_mint.to_string();
+            if mint == NATIVE_SOL_MINT {
+                return None;
+            }
+            let token_r = s.virtual_token_reserves;
+            let sol_r = s.virtual_sol_reserves;
+            (token_r > 0 && sol_r > 0).then_some(SolQuotedPoolSeed {
+                token_mint: mint,
+                reserve_base: token_r,
+                reserve_quote: sol_r,
+                active_id: None,
+                bin_step: None,
+                dlmm_token_x_mint: None,
+            })
+        }
+    }
+}
+
+fn sol_quoted_seed_from_meteora_dlmm(s: &MeteoraState) -> Option<SolQuotedPoolSeed> {
+    let x = s.token_x_mint.to_string();
+    let y = s.token_y_mint.to_string();
+    let rx = s.reserve_x_balance?;
+    let ry = s.reserve_y_balance?;
+    if y == NATIVE_SOL_MINT {
+        Some(SolQuotedPoolSeed {
+            token_mint: x.clone(),
+            reserve_base: rx,
+            reserve_quote: ry,
+            active_id: Some(s.active_id),
+            bin_step: Some(s.bin_step),
+            dlmm_token_x_mint: Some(x),
+        })
+    } else if x == NATIVE_SOL_MINT {
+        Some(SolQuotedPoolSeed {
+            token_mint: y.clone(),
+            reserve_base: ry,
+            reserve_quote: rx,
+            active_id: Some(s.active_id),
+            bin_step: Some(s.bin_step),
+            dlmm_token_x_mint: Some(x),
+        })
+    } else {
+        None
+    }
+}
+
+fn cached_pool_inputs(
+    state: &CachedPoolState,
+    pool_address: &str,
+    seed: &SolQuotedPoolSeed,
+    slot: u64,
+    updated_at: Instant,
+    token_decimals: u8,
+) -> (QuotePoolInput, QuoteVaultInput) {
+    let pool_input = QuotePoolInput {
+        pool_address: pool_address.to_string(),
+        dex: state.dex_name().to_string(),
+        token_mint: seed.token_mint.clone(),
+        trade_price_buy: None,
+        trade_price_sell: None,
+        trade_updated_at: updated_at,
+        has_reserve_data: seed.reserve_base > 0 && seed.reserve_quote > 0,
+        token_decimals,
+    };
+    let vault_input = QuoteVaultInput {
+        reserve_base: seed.reserve_base,
+        reserve_quote: seed.reserve_quote,
+        update_slot: slot,
+        updated_at,
+        active_id: seed.active_id,
+        bin_step: seed.bin_step,
+        dlmm_sol_is_x: seed.dlmm_token_x_mint.as_deref() == Some(NATIVE_SOL_MINT),
+        dlmm_token_x_mint: seed.dlmm_token_x_mint.clone(),
+    };
+    (pool_input, vault_input)
+}
+
+fn hop_mints_match_sol_seed(seed: &SolQuotedPoolSeed, mint_in: &str, mint_out: &str) -> bool {
+    (mint_in == NATIVE_SOL_MINT && mint_out == seed.token_mint)
+        || (mint_out == NATIVE_SOL_MINT && mint_in == seed.token_mint)
+}
+
+fn cpmm_hop_from_cached_state(
+    state: &CachedPoolState,
+    pool_address: &str,
+    mint_in: &str,
+    mint_out: &str,
+    amount_in: u64,
+    slot: u64,
+    updated_at: Instant,
+) -> Option<PoolQuote> {
+    if state.dex_name() == "meteora_dlmm" {
+        return None;
+    }
+    let (reserve_in, reserve_out, dex) = match state {
+        CachedPoolState::Orca(s) => {
+            let a = s.token_mint_a.to_string();
+            let b = s.token_mint_b.to_string();
+            let va = s.vault_a_balance?;
+            let vb = s.vault_b_balance?;
+            if mint_in == a && mint_out == b {
+                (va as u128, vb as u128, "orca")
+            } else if mint_in == b && mint_out == a {
+                (vb as u128, va as u128, "orca")
+            } else {
+                return None;
+            }
+        }
+        CachedPoolState::RaydiumAmm(s) => {
+            let base = s.base_mint.to_string();
+            let quote = s.quote_mint.to_string();
+            let cr = s.coin_reserve?;
+            let pr = s.pc_reserve?;
+            if mint_in == base && mint_out == quote {
+                (cr as u128, pr as u128, "raydium")
+            } else if mint_in == quote && mint_out == base {
+                (pr as u128, cr as u128, "raydium")
+            } else {
+                return None;
+            }
+        }
+        CachedPoolState::RaydiumCpmm(s) => {
+            let t0 = s.token_0_mint.to_string();
+            let t1 = s.token_1_mint.to_string();
+            let r0 = s.reserve_0?;
+            let r1 = s.reserve_1?;
+            if mint_in == t0 && mint_out == t1 {
+                (r0 as u128, r1 as u128, "raydium_cpmm")
+            } else if mint_in == t1 && mint_out == t0 {
+                (r1 as u128, r0 as u128, "raydium_cpmm")
+            } else {
+                return None;
+            }
+        }
+        CachedPoolState::MeteoraCpmm(s) => {
+            let t0 = s.token_0_mint.to_string();
+            let t1 = s.token_1_mint.to_string();
+            if mint_in == t0 && mint_out == t1 {
+                (s.reserve_0 as u128, s.reserve_1 as u128, "meteora_cpmm")
+            } else if mint_in == t1 && mint_out == t0 {
+                (s.reserve_1 as u128, s.reserve_0 as u128, "meteora_cpmm")
+            } else {
+                return None;
+            }
+        }
+        CachedPoolState::PumpAmm(s) => {
+            let base = s.base_mint.to_string();
+            let quote = s.quote_mint.to_string();
+            let br = s.base_reserve?;
+            let qr = s.quote_reserve?;
+            if mint_in == base && mint_out == quote {
+                (br as u128, qr as u128, "pump_amm")
+            } else if mint_in == quote && mint_out == base {
+                (qr as u128, br as u128, "pump_amm")
+            } else {
+                return None;
+            }
+        }
+        CachedPoolState::PumpFun(s) => {
+            let mint = s.token_mint.to_string();
+            if mint_in == NATIVE_SOL_MINT && mint_out == mint {
+                (
+                    s.virtual_sol_reserves as u128,
+                    s.virtual_token_reserves as u128,
+                    "pumpfun",
+                )
+            } else if mint_in == mint && mint_out == NATIVE_SOL_MINT {
+                (
+                    s.virtual_token_reserves as u128,
+                    s.virtual_sol_reserves as u128,
+                    "pumpfun",
+                )
+            } else {
+                return None;
+            }
+        }
+        CachedPoolState::Meteora(_) => return None,
+    };
+    if !supports_cpmm(dex) && dex != "pumpfun" {
+        return None;
+    }
+    let fee_bps = cpmm_fee_bps(dex);
+    let amount_out = cpmm_amount_out(reserve_in, reserve_out, amount_in, fee_bps)?;
+    Some(PoolQuote {
+        pool_address: pool_address.to_string(),
+        dex: dex.to_string(),
+        kind: QuoteKind::ExecutableMarginal,
+        side: quote_side_for_token_hop(mint_in, mint_out),
+        as_of_slot: slot,
+        as_of_ts: updated_at,
+        fresh: true,
+        state_fingerprint: 0,
+        amount_in,
+        amount_out,
+    })
+}
+
+fn quote_side_for_token_hop(_mint_in: &str, mint_out: &str) -> QuoteSide {
+    if mint_out == NATIVE_SOL_MINT {
+        QuoteSide::Sell
+    } else {
+        QuoteSide::Buy
+    }
+}
+
+/// Unified exact-in quote from SLAVE [`CachedPoolState`] (multi-hop + 2-hop SSOT).
+///
+/// SOL-quoted hops delegate to [`quote_exact_in_with_freshness`] (DLMM uses bin walker).
+/// Token-token hops on CPMM DEXes use reserve math from the same module (no `quote_calculator` CP DLMM).
+#[allow(clippy::too_many_arguments)]
+pub fn quote_from_cached_pool(
+    state: &CachedPoolState,
+    pool_address: &str,
+    mint_in: &str,
+    mint_out: &str,
+    amount_in: u64,
+    dlmm_bins: Option<&DlmmBinArrays>,
+    slot: u64,
+    updated_at: Instant,
+    token_decimals: u8,
+    freshness: &QuoteFreshnessConfig,
+) -> Option<PoolQuote> {
+    if amount_in == 0 {
+        return None;
+    }
+    if mint_in == NATIVE_SOL_MINT || mint_out == NATIVE_SOL_MINT {
+        let seed = sol_quoted_seed_from_cached_state(state)?;
+        if !hop_mints_match_sol_seed(&seed, mint_in, mint_out) {
+            return None;
+        }
+        let (pool_input, vault_input) =
+            cached_pool_inputs(state, pool_address, &seed, slot, updated_at, token_decimals);
+        return quote_exact_in_with_freshness(
+            &pool_input,
+            Some(&vault_input),
+            dlmm_bins,
+            mint_in,
+            mint_out,
+            amount_in,
+            freshness,
+        );
+    }
+    cpmm_hop_from_cached_state(
+        state,
+        pool_address,
+        mint_in,
+        mint_out,
+        amount_in,
+        slot,
+        updated_at,
+    )
+}
+
+/// Token decimals from cache state when mint-decimals map has no entry.
+pub fn token_decimals_from_cached_state(state: &CachedPoolState, token_mint: &Pubkey) -> u8 {
+    match state {
+        CachedPoolState::RaydiumAmm(s) => {
+            if s.base_mint == *token_mint && s.base_decimals > 0 {
+                s.base_decimals
+            } else if s.quote_mint == *token_mint && s.quote_decimals > 0 {
+                s.quote_decimals
+            } else {
+                6
+            }
+        }
+        CachedPoolState::MeteoraCpmm(s) => {
+            if s.token_0_mint == *token_mint && s.mint_0_decimals > 0 {
+                s.mint_0_decimals
+            } else if s.token_1_mint == *token_mint && s.mint_1_decimals > 0 {
+                s.mint_1_decimals
+            } else {
+                6
+            }
+        }
+        _ => 6,
+    }
+}
+
 /// Exact-in quote for SOL-quoted pools. Priority: ExecutableMarginal, then LastTradeMid.
 pub fn quote_exact_in(
     pool: &QuotePoolInput,
@@ -1020,6 +1466,65 @@ mod tests {
             Some(&changed_vault),
             Instant::now()
         ));
+    }
+
+    #[test]
+    fn dlmm_cached_pool_quote_uses_bin_walker_not_reserve_ratio() {
+        let active_id = 0i32;
+        let bin_step = 100u16;
+        let token_amount = 500_000_000_000u64;
+        let sol_amount = 2_000_000_000u64;
+        let array_index = active_id as i64 / 70;
+        let mut bins: DlmmBinArrays = HashMap::new();
+        bins.insert(
+            array_index,
+            vec![BinData {
+                offset: 0,
+                amount_x: token_amount,
+                amount_y: sol_amount,
+            }],
+        );
+        let token_mint = Pubkey::new_unique();
+        let state = CachedPoolState::Meteora(MeteoraState {
+            token_x_mint: token_mint,
+            token_y_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+            reserve_x: Pubkey::new_unique(),
+            reserve_y: Pubkey::new_unique(),
+            active_id,
+            bin_step,
+            reserve_x_balance: Some(1_000_000_000_000),
+            reserve_y_balance: Some(500_000_000),
+        });
+        let sol_in = DLMM_PROBE_SOL_LAMPORTS;
+        let cp_out = cpmm_amount_out(
+            sol_amount as u128,
+            token_amount as u128,
+            sol_in,
+            cpmm_fee_bps("meteora_dlmm"),
+        )
+        .expect("cp approx");
+        let bin_out = dlmm_token_output_from_bins(active_id, bin_step, sol_in, &bins, false)
+            .expect("bin walker");
+        assert_ne!(
+            cp_out, bin_out,
+            "test requires bin walker and reserve CP to diverge"
+        );
+        let quote = quote_from_cached_pool(
+            &state,
+            "dlmmPool",
+            NATIVE_SOL_MINT,
+            &token_mint.to_string(),
+            sol_in,
+            Some(&bins),
+            1,
+            Instant::now(),
+            6,
+            &QuoteFreshnessConfig::default(),
+        )
+        .expect("dlmm pool quote");
+        assert_eq!(quote.kind, QuoteKind::ExecutableMarginal);
+        assert_eq!(quote.amount_out, bin_out);
+        assert_ne!(quote.amount_out, cp_out);
     }
 
     #[test]

--- a/src/arbitrage/pool_ranker.rs
+++ b/src/arbitrage/pool_ranker.rs
@@ -141,6 +141,7 @@ impl<Q: QuoteProvider> PoolRanker<Q> {
             let mut ranked_pools = Vec::with_capacity(pools.len());
 
             for edge in pools {
+                // I-ARB-9: beam expansion skips pools outside quote-ready set.
                 if !self.quote_provider.is_pool_quote_ready(&edge.pool_address) {
                     continue;
                 }
@@ -192,6 +193,7 @@ impl<Q: QuoteProvider> PoolRanker<Q> {
             output_mint,
             self.config.probe_amount,
         ) else {
+            // Anomaly: pool was quote-ready but probe quote failed at expansion time.
             crate::metrics::multi_hop_hop_missing_quote_inc();
             return None;
         };

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4329,6 +4329,7 @@ pub static MULTI_HOP_SEARCHES_COALESCED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| At
 pub static MULTI_HOP_QUOTE_FROM_CACHE_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static MULTI_HOP_QUOTE_FROM_TRADE_CACHE_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+pub static MULTI_HOP_QUOTE_FROM_POOL_QUOTE_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static MULTI_HOP_CYCLE_REJECTED_SANITY_EDGE_RATIO: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static MULTI_HOP_CYCLE_REJECTED_SANITY_PROFIT_CAP: Lazy<AtomicU64> =
@@ -4386,6 +4387,10 @@ pub fn multi_hop_quote_from_cache_inc() {
 
 pub fn multi_hop_quote_from_trade_cache_inc() {
     MULTI_HOP_QUOTE_FROM_TRADE_CACHE_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn multi_hop_quote_from_pool_quote_inc() {
+    MULTI_HOP_QUOTE_FROM_POOL_QUOTE_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 pub fn multi_hop_cycle_rejected_sanity_inc(reason: MultiHopSanityRejectReason) {
@@ -7268,6 +7273,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "multi_hop_quote_from_trade_cache_total",
         MULTI_HOP_QUOTE_FROM_TRADE_CACHE_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "multi_hop_quote_from_pool_quote_total",
+        MULTI_HOP_QUOTE_FROM_POOL_QUOTE_TOTAL.load(Ordering::Relaxed)
     );
     out.push_str("multi_hop_cycle_rejected_sanity_total{reason=\"edge_ratio\"} ");
     out.push_str(


### PR DESCRIPTION
## Summary
- CachedQuoteProvider delegates to pool_quote (DLMM bin-walker, no quote_calculator CP approx)
- Quote-ready index tightened (ExecutableMarginal or fresh trade cache)
- multi_hop_hop_missing_quote only for ready-set anomalies
- Metric: multi_hop_quote_from_pool_quote_total

Milestone M3 per plan_arb_profit_first_rebuild.md

## Test plan
- [x] cargo fmt/clippy/test
- [ ] Eval Level 5 CI
- [ ] E-ARB-3 eval PR after merge

## Note
Bin-array feed arb_strategy → CachedQuoteProvider::update_dlmm_bin_array may need follow-up for full DLMM coverage in prod.