### PR TITLE
fix(arb): chunk arb.track_requests NATS publishes under 1MB (P0 pre-M4)

### DIFF
--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -68,6 +68,7 @@ use ironcrab::metrics::{
     arb_two_hop_v2_incompatible_kind_inc, arb_two_hop_v2_rejected_inc, arb_two_hop_v2_screen_inc,
     record_arb_heartbeat_phase, record_arb_price_freshness_stale_age_ms,
     record_arb_quote_shadow_round_trip, record_arb_track_requests_messages_total,
+    record_arb_track_requests_publish_chunks_total, record_arb_track_requests_publish_failed_total,
     record_arb_writer_lock_wait, serve_metrics, set_arb_pool_cache_apply_batch_size_gauge,
     set_arb_quote_shadow_legacy_spread_bps, set_arb_tracker_write_coalescer_pending,
     set_arb_tracker_write_queue_depth, set_arb_two_hop_blocked_on_apply_trade,
@@ -85,9 +86,10 @@ use ironcrab::metrics::{
     TOKENS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
-    arb_strategy_pool_cache_live_consumer_config, config_consumer_config, config_subject,
+    arb_strategy_pool_cache_live_consumer_config, arb_track_payload_bytes, config_consumer_config,
+    config_subject, split_arb_track_requests_update, trim_reconcile_update_to_budget,
     ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackRemovedEntry, ArbTrackRemovedReason,
-    ArbTrackRequestsUpdate, CONFIG_STREAM_NAME, STREAM_NAME,
+    ArbTrackRequestsUpdate, ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES, CONFIG_STREAM_NAME, STREAM_NAME,
 };
 use ironcrab::nats::{NatsClient, NatsConfig};
 use ironcrab::nats::{TOPIC_ARB_TRACK_REQUESTS, TOPIC_MARKET_EVENTS, TOPIC_TRADE_INTENTS};
@@ -4653,15 +4655,58 @@ impl ArbContext {
             removed,
             reconcile,
         };
-        record_arb_track_requests_messages_total();
-        self.arb_track_published.fetch_add(1, Ordering::Relaxed);
-        tokio::spawn(async move {
-            if let Err(e) = nats.publish(TOPIC_ARB_TRACK_REQUESTS, &update).await {
+
+        let chunks = if reconcile {
+            if arb_track_payload_bytes(&update) > ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES {
                 warn!(
-                    error = %e,
-                    topic = TOPIC_ARB_TRACK_REQUESTS,
-                    "ArbTrackRequests NATS publish failed"
+                    payload_bytes = arb_track_payload_bytes(&update),
+                    max_bytes = ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES,
+                    active_len = update.active.len(),
+                    "ArbTrackRequests reconcile snapshot exceeds NATS publish budget; trimming active"
                 );
+                match trim_reconcile_update_to_budget(update) {
+                    Some(trimmed) => vec![trimmed],
+                    None => {
+                        warn!(
+                            max_bytes = ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES,
+                            "ArbTrackRequests reconcile snapshot still exceeds budget after trim; skipping publish"
+                        );
+                        return;
+                    }
+                }
+            } else {
+                vec![update]
+            }
+        } else {
+            split_arb_track_requests_update(update)
+        };
+
+        if chunks.is_empty() {
+            return;
+        }
+
+        self.arb_track_published
+            .fetch_add(chunks.len() as u64, Ordering::Relaxed);
+        tokio::spawn(async move {
+            for chunk in chunks {
+                match nats.publish(TOPIC_ARB_TRACK_REQUESTS, &chunk).await {
+                    Ok(_) => {
+                        record_arb_track_requests_messages_total();
+                        record_arb_track_requests_publish_chunks_total();
+                    }
+                    Err(e) => {
+                        record_arb_track_requests_publish_failed_total();
+                        warn!(
+                            error = %e,
+                            topic = TOPIC_ARB_TRACK_REQUESTS,
+                            payload_bytes = arb_track_payload_bytes(&chunk),
+                            active_len = chunk.active.len(),
+                            removed_len = chunk.removed.len(),
+                            reconcile = chunk.reconcile,
+                            "ArbTrackRequests NATS publish failed"
+                        );
+                    }
+                }
             }
         });
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -288,6 +288,12 @@ pub static MARKET_DATA_MOMENTUM_COALESCED_BATCHES_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 /// arb-strategy published `ArbTrackRequestsUpdate` payloads (Phase 3).
 pub static ARB_TRACK_REQUESTS_MESSAGES_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// arb-strategy NATS publish failures for `ArbTrackRequestsUpdate` chunks (Phase 3).
+pub static ARB_TRACK_REQUESTS_PUBLISH_FAILED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// arb-strategy successfully published `ArbTrackRequestsUpdate` NATS chunks (Phase 3).
+pub static ARB_TRACK_REQUESTS_PUBLISH_CHUNKS_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// market-data applied `ArbTrackRequestsUpdate` from core NATS (Phase 3).
 pub static MARKET_DATA_ARB_TRACK_REQUESTS_MESSAGES_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -520,6 +526,16 @@ pub fn inc_market_data_momentum_coalesced_batches_total() {
 #[inline]
 pub fn record_arb_track_requests_messages_total() {
     ARB_TRACK_REQUESTS_MESSAGES_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_arb_track_requests_publish_failed_total() {
+    ARB_TRACK_REQUESTS_PUBLISH_FAILED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_arb_track_requests_publish_chunks_total() {
+    ARB_TRACK_REQUESTS_PUBLISH_CHUNKS_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -5363,6 +5379,14 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "arb_track_requests_messages_total",
         ARB_TRACK_REQUESTS_MESSAGES_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_track_requests_publish_failed_total",
+        ARB_TRACK_REQUESTS_PUBLISH_FAILED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_track_requests_publish_chunks_total",
+        ARB_TRACK_REQUESTS_PUBLISH_CHUNKS_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_arb_track_requests_messages_total",

--- a/src/nats/arb_track_requests.rs
+++ b/src/nats/arb_track_requests.rs
@@ -4,6 +4,9 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Max serialized JSON size per NATS publish (server limit ~1 MiB; leave headroom).
+pub const ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES: usize = 900_000;
+
 /// Wire payload for `ironcrab.v1.arb.track_requests` ([`crate::nats::topics::TOPIC_ARB_TRACK_REQUESTS`]).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ArbTrackRequestsUpdate {
@@ -45,9 +48,143 @@ pub enum ArbTrackRemovedReason {
     Budget,
 }
 
+/// Serialized JSON byte length for a wire payload (used for NATS max-payload budgeting).
+pub fn arb_track_payload_bytes(update: &ArbTrackRequestsUpdate) -> usize {
+    serde_json::to_vec(update)
+        .map(|v| v.len())
+        .unwrap_or(usize::MAX)
+}
+
+/// Split an update into NATS-safe chunks. `reconcile: true` is never split (caller must handle oversize).
+pub fn split_arb_track_requests_update(
+    update: ArbTrackRequestsUpdate,
+) -> Vec<ArbTrackRequestsUpdate> {
+    if update.reconcile {
+        return vec![update];
+    }
+    if arb_track_payload_bytes(&update) <= ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES {
+        return vec![update];
+    }
+
+    let version = update.version;
+    let ts_unix_ms = update.ts_unix_ms;
+    let mut chunks = chunk_removed_entries(version, ts_unix_ms, update.removed);
+    chunks.extend(chunk_active_entries(version, ts_unix_ms, update.active));
+    chunks
+}
+
+/// Trim `active` on a reconcile snapshot until it fits the publish budget (drops tail entries).
+pub fn trim_reconcile_update_to_budget(
+    mut update: ArbTrackRequestsUpdate,
+) -> Option<ArbTrackRequestsUpdate> {
+    debug_assert!(update.reconcile);
+    while arb_track_payload_bytes(&update) > ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES
+        && !update.active.is_empty()
+    {
+        update.active.pop();
+    }
+    if arb_track_payload_bytes(&update) <= ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES {
+        Some(update)
+    } else {
+        None
+    }
+}
+
+fn chunk_removed_entries(
+    version: u32,
+    ts_unix_ms: u64,
+    removed: Vec<ArbTrackRemovedEntry>,
+) -> Vec<ArbTrackRequestsUpdate> {
+    chunk_entries(removed, |removed| ArbTrackRequestsUpdate {
+        version,
+        ts_unix_ms,
+        active: Vec::new(),
+        removed,
+        reconcile: false,
+    })
+}
+
+fn chunk_active_entries(
+    version: u32,
+    ts_unix_ms: u64,
+    active: Vec<ArbTrackActiveEntry>,
+) -> Vec<ArbTrackRequestsUpdate> {
+    chunk_entries(active, |active| ArbTrackRequestsUpdate {
+        version,
+        ts_unix_ms,
+        active,
+        removed: Vec::new(),
+        reconcile: false,
+    })
+}
+
+fn chunk_entries<T: Clone>(
+    entries: Vec<T>,
+    build: impl Fn(Vec<T>) -> ArbTrackRequestsUpdate,
+) -> Vec<ArbTrackRequestsUpdate> {
+    if entries.is_empty() {
+        return Vec::new();
+    }
+
+    let mut chunks = Vec::new();
+    let mut idx = 0;
+    while idx < entries.len() {
+        let remaining = entries.len() - idx;
+        let mut lo = 1usize;
+        let mut hi = remaining;
+        let mut best = 1;
+        while lo <= hi {
+            let mid = lo + (hi - lo) / 2;
+            let trial = build(entries[idx..idx + mid].to_vec());
+            if arb_track_payload_bytes(&trial) <= ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES {
+                best = mid;
+                lo = mid + 1;
+            } else {
+                if mid == 0 {
+                    break;
+                }
+                hi = mid - 1;
+            }
+        }
+        let chunk = build(entries[idx..idx + best].to_vec());
+        if arb_track_payload_bytes(&chunk) > ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES {
+            // Single entry exceeds budget (unexpected for pool pubkeys); publish anyway.
+            chunks.push(chunk);
+            idx += 1;
+        } else {
+            chunks.push(chunk);
+            idx += best;
+        }
+    }
+
+    chunks
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_pool_id(i: usize) -> String {
+        format!("Pool{i:040}")
+    }
+
+    fn large_removed_entries(count: usize) -> Vec<ArbTrackRemovedEntry> {
+        (0..count)
+            .map(|i| ArbTrackRemovedEntry {
+                pool: sample_pool_id(i),
+                reason: ArbTrackRemovedReason::Stale,
+            })
+            .collect()
+    }
+
+    fn large_baseline_active(count: usize) -> Vec<ArbTrackActiveEntry> {
+        (0..count)
+            .map(|i| ArbTrackActiveEntry {
+                pool: sample_pool_id(i),
+                reason: ArbTrackActiveReason::Baseline,
+            })
+            .collect()
+    }
 
     #[test]
     fn arb_track_requests_update_roundtrip_json() {
@@ -78,5 +215,73 @@ mod tests {
         let json = r#"{"version":1,"ts_unix_ms":1,"active":[],"removed":[]}"#;
         let u: ArbTrackRequestsUpdate = serde_json::from_str(json).expect("deserialize");
         assert!(!u.reconcile);
+    }
+
+    #[test]
+    fn split_large_removed_produces_multiple_chunks_under_budget() {
+        let update = ArbTrackRequestsUpdate {
+            version: 1,
+            ts_unix_ms: 1_700_000_000,
+            active: Vec::new(),
+            removed: large_removed_entries(60_000),
+            reconcile: false,
+        };
+        assert!(
+            arb_track_payload_bytes(&update) > ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES,
+            "fixture must exceed budget"
+        );
+
+        let chunks = split_arb_track_requests_update(update);
+        assert!(
+            chunks.len() > 1,
+            "expected multiple chunks, got {}",
+            chunks.len()
+        );
+        for chunk in &chunks {
+            assert!(!chunk.reconcile);
+            assert!(chunk.active.is_empty());
+            assert!(!chunk.removed.is_empty());
+            assert!(
+                arb_track_payload_bytes(chunk) <= ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES,
+                "chunk payload {} exceeds budget",
+                arb_track_payload_bytes(chunk)
+            );
+            let json = serde_json::to_string(chunk).expect("serialize chunk");
+            let back: ArbTrackRequestsUpdate =
+                serde_json::from_str(&json).expect("deserialize chunk");
+            assert_eq!(*chunk, back);
+        }
+    }
+
+    #[test]
+    fn reconcile_baseline_500_stays_single_chunk() {
+        let update = ArbTrackRequestsUpdate {
+            version: 1,
+            ts_unix_ms: 1_700_000_000,
+            active: large_baseline_active(500),
+            removed: Vec::new(),
+            reconcile: true,
+        };
+        let chunks = split_arb_track_requests_update(update.clone());
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], update);
+        assert!(
+            arb_track_payload_bytes(&chunks[0]) <= ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES,
+            "baseline reconcile should fit budget"
+        );
+    }
+
+    #[test]
+    fn reconcile_true_never_split_even_when_incremental_would() {
+        let update = ArbTrackRequestsUpdate {
+            version: 1,
+            ts_unix_ms: 1_700_000_000,
+            active: Vec::new(),
+            removed: large_removed_entries(60_000),
+            reconcile: true,
+        };
+        let chunks = split_arb_track_requests_update(update.clone());
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], update);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Split large `active`/`removed` payloads before NATS publish (budget: 900 KB)
- Preserve single-message `reconcile: true` baseline snapshots (≤500 pools, never split)
- Fix misleading `arb_track_requests_messages_total` — increments only on successful publish
- Add `arb_track_requests_publish_failed_total` and `arb_track_requests_publish_chunks_total` metrics
- Unblocks Geyser Arb pins blocked since ~03.07. on prod

## Prod context

~4.9 MB prune/removal blobs → 237+ NATS `max payload size exceeded` errors/h; `market_data_arb_pinned_pools=0`.

## Implementation

- `split_arb_track_requests_update()` in `src/nats/arb_track_requests.rs` — byte-budget via `serde_json::to_vec`, binary-search chunk sizing
- `spawn_publish_arb_track_requests` refactored: one `tokio::spawn`, one loop, exactly one `nats.publish(TOPIC_ARB_TRACK_REQUESTS, …)` site (I-4e)
- `reconcile: true` oversize guard: warn + trim `active` tail; skip publish if still over budget

## STOP-CHECK

- I-7: No RPC (local split + NATS only, cold path)
- I-4e: Single publish site in `arb_strategy.rs` preserved
- I-9: Not affected
- Level-5: No eval test reads

## Tests

- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` — all green
- Unit: 60k `removed` → multiple chunks, each < 900 KB; 500 baseline `reconcile: true` → single chunk

## Post-deploy verification

```bash
journalctl -u arb-strategy --since '10 min ago' | grep 'max payload size exceeded'
curl -s http://127.0.0.1:9801/metrics | grep market_data_arb_pinned_pools
curl -s http://127.0.0.1:9803/metrics | grep arb_track_requests_publish
```

## Dependency

M4 I-ARB-10 (proactive pinning) should deploy **after** this fix.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4586562e-aa92-40f0-92a0-be9c31724b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4586562e-aa92-40f0-92a0-be9c31724b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

