### PR TITLE
fix(arb): cross-DEX sell quote readiness — pair selection + MD cache seed (P1)

### DIFF
--- a/src/arbitrage/mod.rs
+++ b/src/arbitrage/mod.rs
@@ -47,15 +47,16 @@ pub use multi_hop_integration::{
 };
 pub use pool_graph::{GraphStats, PoolGraph};
 pub use pool_quote::{
-    dlmm_marginal_price_plausible, dlmm_sol_output_from_bins, dlmm_token_output_from_bins,
-    flatten_bin_array_bins, is_quote_fresh, is_usable_quote_kind, quote_exact_in,
-    quote_exact_in_with_freshness, quote_from_cached_pool, quote_sol_per_token_for_screening,
-    quotes_pairable, round_trip_profit_lamports, round_trip_profit_lamports_with_freshness,
-    select_round_trip_pools, sol_quoted_seed_from_cached_state, state_fingerprint,
-    token_decimals_from_cached_state, DlmmBinArrays, PoolQuote, QuoteFreshnessConfig, QuoteKind,
-    QuotePoolInput, QuoteSide, QuoteVaultInput, RoundTripInsufficientSubreason, RoundTripLeg,
-    RoundTripPoolCandidate, RoundTripPoolSelection, RoundTripSelectFailure, SolQuotedPoolSeed,
-    DLMM_PROBE_SOL_LAMPORTS, STATE_TTL_MS, TRADE_TTL_MS,
+    classify_cross_dex_sell_failure, dlmm_marginal_price_plausible, dlmm_sol_output_from_bins,
+    dlmm_token_output_from_bins, flatten_bin_array_bins, is_quote_fresh, is_usable_quote_kind,
+    quote_exact_in, quote_exact_in_with_freshness, quote_from_cached_pool,
+    quote_sol_per_token_for_screening, quotes_pairable, round_trip_profit_lamports,
+    round_trip_profit_lamports_with_freshness, select_round_trip_pools,
+    sol_quoted_seed_from_cached_state, state_fingerprint, token_decimals_from_cached_state,
+    DlmmBinArrays, NoCrossDexSellDetailReason, PoolQuote, QuoteFreshnessConfig, QuoteKind,
+    QuotePoolInput, QuoteSide, QuoteVaultInput, RoundTripInsufficient,
+    RoundTripInsufficientSubreason, RoundTripLeg, RoundTripPoolCandidate, RoundTripPoolSelection,
+    RoundTripSelectFailure, SolQuotedPoolSeed, DLMM_PROBE_SOL_LAMPORTS, STATE_TTL_MS, TRADE_TTL_MS,
 };
 pub use pool_ranker::{PoolRanker, QuoteProvider, RankerConfig};
 pub use types::{

--- a/src/arbitrage/pool_quote.rs
+++ b/src/arbitrage/pool_quote.rs
@@ -1164,10 +1164,48 @@ pub enum RoundTripInsufficientSubreason {
     SingleDexCandidates,
 }
 
+/// Drill-down reason when every cross-DEX sell leg failed after at least one valid buy quote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NoCrossDexSellDetailReason {
+    SellMissingVault,
+    SellMissingDlmmBins,
+    SellQuoteNone,
+    SellNotFresh,
+    SellZeroOut,
+}
+
+impl NoCrossDexSellDetailReason {
+    pub fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::SellMissingVault => "sell_missing_vault",
+            Self::SellMissingDlmmBins => "sell_missing_dlmm_bins",
+            Self::SellQuoteNone => "sell_quote_none",
+            Self::SellNotFresh => "sell_not_fresh",
+            Self::SellZeroOut => "sell_zero_out",
+        }
+    }
+}
+
+/// Insufficient-pool outcome with optional `NoCrossDexSell` drill-down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RoundTripInsufficient {
+    pub subreason: RoundTripInsufficientSubreason,
+    pub no_cross_dex_sell_detail: Option<NoCrossDexSellDetailReason>,
+}
+
+impl RoundTripInsufficient {
+    pub fn new(subreason: RoundTripInsufficientSubreason) -> Self {
+        Self {
+            subreason,
+            no_cross_dex_sell_detail: None,
+        }
+    }
+}
+
 /// Failure reason for `select_round_trip_pools`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RoundTripSelectFailure {
-    InsufficientPools(RoundTripInsufficientSubreason),
+    InsufficientPools(RoundTripInsufficient),
     IncompatibleQuoteKind,
     QuoteStale,
 }
@@ -1180,7 +1218,56 @@ fn sol_per_token_from_sell_quote(quote: &PoolQuote, token_decimals: u8) -> Decim
     trade_implied_sol_per_token(quote.amount_out, quote.amount_in, token_decimals)
 }
 
-/// I-ARB-5: per-DEX best buy + cross-DEX best sell with matching QuoteKind.
+fn is_meteora_dlmm_dex(dex: &str) -> bool {
+    dex == "meteora_dlmm"
+}
+
+/// Classify why a cross-DEX sell leg failed for drill-down metrics / snapshots.
+pub fn classify_cross_dex_sell_failure(
+    candidate: &RoundTripPoolCandidate<'_>,
+    token_amount_in: u64,
+    freshness: &QuoteFreshnessConfig,
+    now: Instant,
+    token_decimals: u8,
+) -> NoCrossDexSellDetailReason {
+    if is_meteora_dlmm_dex(candidate.dex) && candidate.dlmm_bins.is_none() {
+        return NoCrossDexSellDetailReason::SellMissingDlmmBins;
+    }
+    if candidate.vault.is_none() {
+        return NoCrossDexSellDetailReason::SellMissingVault;
+    }
+    let sell_quote = quote_exact_in_with_freshness(
+        candidate.pool,
+        candidate.vault,
+        candidate.dlmm_bins,
+        &candidate.pool.token_mint,
+        NATIVE_SOL_MINT,
+        token_amount_in,
+        freshness,
+    );
+    let Some(sell_quote) = sell_quote else {
+        return NoCrossDexSellDetailReason::SellQuoteNone;
+    };
+    if !is_quote_fresh(&sell_quote, freshness, candidate.vault, now) {
+        return NoCrossDexSellDetailReason::SellNotFresh;
+    }
+    let sol_per_token = sol_per_token_from_sell_quote(&sell_quote, token_decimals);
+    if sol_per_token <= Decimal::ZERO {
+        return NoCrossDexSellDetailReason::SellZeroOut;
+    }
+    NoCrossDexSellDetailReason::SellQuoteNone
+}
+
+fn dominant_no_cross_dex_sell_detail(
+    counts: &std::collections::HashMap<NoCrossDexSellDetailReason, usize>,
+) -> Option<NoCrossDexSellDetailReason> {
+    counts
+        .iter()
+        .max_by_key(|(_, count)| *count)
+        .map(|(reason, _)| *reason)
+}
+
+/// I-ARB-5 evolution: enumerate valid cross-DEX (buy, sell) pairs and pick best round-trip.
 pub fn select_round_trip_pools(
     candidates: &[RoundTripPoolCandidate<'_>],
     probe_lamports: u64,
@@ -1188,7 +1275,7 @@ pub fn select_round_trip_pools(
 ) -> Result<RoundTripPoolSelection, RoundTripSelectFailure> {
     if candidates.len() < 2 {
         return Err(RoundTripSelectFailure::InsufficientPools(
-            RoundTripInsufficientSubreason::CandidatesLt2,
+            RoundTripInsufficient::new(RoundTripInsufficientSubreason::CandidatesLt2),
         ));
     }
 
@@ -1204,7 +1291,12 @@ pub fn select_round_trip_pools(
         sol_per_token: Decimal,
     }
 
-    let mut best_buy: Option<BuyCandidate<'_>> = None;
+    struct SellCandidate<'a> {
+        candidate: &'a RoundTripPoolCandidate<'a>,
+        quote: PoolQuote,
+    }
+
+    let mut valid_buys: Vec<BuyCandidate<'_>> = Vec::new();
     for candidate in candidates {
         let buy_quote = quote_exact_in_with_freshness(
             candidate.pool,
@@ -1225,82 +1317,112 @@ pub fn select_round_trip_pools(
         if sol_per_token <= Decimal::ZERO {
             continue;
         }
-        let replace = match &best_buy {
-            None => true,
-            Some(current) => sol_per_token < current.sol_per_token,
-        };
-        if replace {
-            best_buy = Some(BuyCandidate {
-                candidate,
-                quote: buy_quote,
-                sol_per_token,
-            });
-        }
+        valid_buys.push(BuyCandidate {
+            candidate,
+            quote: buy_quote,
+            sol_per_token,
+        });
     }
 
-    let Some(best_buy) = best_buy else {
+    if valid_buys.is_empty() {
         return Err(RoundTripSelectFailure::InsufficientPools(
-            RoundTripInsufficientSubreason::NoFreshBuyQuote,
+            RoundTripInsufficient::new(RoundTripInsufficientSubreason::NoFreshBuyQuote),
         ));
-    };
+    }
 
     let distinct_dexes: std::collections::HashSet<&str> =
         candidates.iter().map(|c| c.dex).collect();
     if distinct_dexes.len() < 2 {
         return Err(RoundTripSelectFailure::InsufficientPools(
-            RoundTripInsufficientSubreason::SingleDexCandidates,
+            RoundTripInsufficient::new(RoundTripInsufficientSubreason::SingleDexCandidates),
         ));
     }
 
-    let mut best_sell: Option<BuyCandidate<'_>> = None;
+    let mut best_pair: Option<(BuyCandidate<'_>, SellCandidate<'_>)> = None;
+    let mut best_round_trip_profit: i64 = i64::MIN;
     let mut saw_incompatible_kind = false;
+    let mut sell_fail_counts: std::collections::HashMap<NoCrossDexSellDetailReason, usize> =
+        std::collections::HashMap::new();
 
-    for candidate in candidates {
-        if candidate.dex == best_buy.candidate.dex {
-            continue;
-        }
-        let sell_quote = quote_exact_in_with_freshness(
-            candidate.pool,
-            candidate.vault,
-            candidate.dlmm_bins,
-            &candidate.pool.token_mint,
-            NATIVE_SOL_MINT,
-            best_buy.quote.amount_out,
-            freshness,
-        );
-        let Some(sell_quote) = sell_quote else {
-            continue;
-        };
-        if !is_quote_fresh(&sell_quote, freshness, candidate.vault, now) {
-            continue;
-        }
-        if !quotes_pairable(&best_buy.quote, &sell_quote) {
-            saw_incompatible_kind = true;
-            continue;
-        }
-        let sol_per_token = sol_per_token_from_sell_quote(&sell_quote, token_decimals);
-        if sol_per_token <= Decimal::ZERO {
-            continue;
-        }
-        let replace = match &best_sell {
-            None => true,
-            Some(current) => sol_per_token > current.sol_per_token,
-        };
-        if replace {
-            best_sell = Some(BuyCandidate {
-                candidate,
-                quote: sell_quote,
-                sol_per_token,
-            });
+    for buy in &valid_buys {
+        for sell_candidate in candidates {
+            if sell_candidate.dex == buy.candidate.dex {
+                continue;
+            }
+
+            if is_meteora_dlmm_dex(sell_candidate.dex) && sell_candidate.dlmm_bins.is_none() {
+                *sell_fail_counts
+                    .entry(NoCrossDexSellDetailReason::SellMissingDlmmBins)
+                    .or_default() += 1;
+                continue;
+            }
+            if sell_candidate.vault.is_none() {
+                *sell_fail_counts
+                    .entry(NoCrossDexSellDetailReason::SellMissingVault)
+                    .or_default() += 1;
+                continue;
+            }
+
+            let sell_quote = quote_exact_in_with_freshness(
+                sell_candidate.pool,
+                sell_candidate.vault,
+                sell_candidate.dlmm_bins,
+                &sell_candidate.pool.token_mint,
+                NATIVE_SOL_MINT,
+                buy.quote.amount_out,
+                freshness,
+            );
+            let Some(sell_quote) = sell_quote else {
+                *sell_fail_counts
+                    .entry(NoCrossDexSellDetailReason::SellQuoteNone)
+                    .or_default() += 1;
+                continue;
+            };
+            if !is_quote_fresh(&sell_quote, freshness, sell_candidate.vault, now) {
+                *sell_fail_counts
+                    .entry(NoCrossDexSellDetailReason::SellNotFresh)
+                    .or_default() += 1;
+                continue;
+            }
+            if !quotes_pairable(&buy.quote, &sell_quote) {
+                saw_incompatible_kind = true;
+                continue;
+            }
+            let sol_per_token = sol_per_token_from_sell_quote(&sell_quote, token_decimals);
+            if sol_per_token <= Decimal::ZERO {
+                *sell_fail_counts
+                    .entry(NoCrossDexSellDetailReason::SellZeroOut)
+                    .or_default() += 1;
+                continue;
+            }
+
+            let round_trip_profit = sell_quote.amount_out as i64 - probe_lamports as i64;
+            if round_trip_profit > best_round_trip_profit {
+                best_round_trip_profit = round_trip_profit;
+                best_pair = Some((
+                    BuyCandidate {
+                        candidate: buy.candidate,
+                        quote: buy.quote.clone(),
+                        sol_per_token: buy.sol_per_token,
+                    },
+                    SellCandidate {
+                        candidate: sell_candidate,
+                        quote: sell_quote,
+                    },
+                ));
+            }
         }
     }
 
-    let Some(best_sell) = best_sell else {
+    let Some((best_buy, best_sell)) = best_pair else {
         if saw_incompatible_kind {
             return Err(RoundTripSelectFailure::IncompatibleQuoteKind);
         }
         return Err(RoundTripSelectFailure::InsufficientPools(
-            RoundTripInsufficientSubreason::NoCrossDexSell,
+            RoundTripInsufficient {
+                subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
+                no_cross_dex_sell_detail: dominant_no_cross_dex_sell_detail(&sell_fail_counts),
+            },
         ));
     };
 
@@ -1599,9 +1721,9 @@ mod tests {
         .unwrap_err();
         assert_eq!(
             err,
-            RoundTripSelectFailure::InsufficientPools(
+            RoundTripSelectFailure::InsufficientPools(RoundTripInsufficient::new(
                 RoundTripInsufficientSubreason::CandidatesLt2
-            )
+            ))
         );
     }
 
@@ -1633,9 +1755,9 @@ mod tests {
         .unwrap_err();
         assert_eq!(
             err,
-            RoundTripSelectFailure::InsufficientPools(
+            RoundTripSelectFailure::InsufficientPools(RoundTripInsufficient::new(
                 RoundTripInsufficientSubreason::SingleDexCandidates
-            )
+            ))
         );
     }
 
@@ -1667,10 +1789,183 @@ mod tests {
         .unwrap_err();
         assert_eq!(
             err,
-            RoundTripSelectFailure::InsufficientPools(
-                RoundTripInsufficientSubreason::NoCrossDexSell
-            )
+            RoundTripSelectFailure::InsufficientPools(RoundTripInsufficient {
+                subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
+                no_cross_dex_sell_detail: Some(NoCrossDexSellDetailReason::SellQuoteNone),
+            })
         );
+    }
+
+    #[test]
+    fn select_round_trip_pools_pair_aware_matches_brute_force_best_round_trip() {
+        let pool_a = sample_pool("orca", "poolA");
+        let pool_b = sample_pool("pump_amm", "poolB");
+        let vault_a = sample_vault(1_000_000_000_000, 900_000_000);
+        let vault_b = sample_vault(1_000, 1_100_000_000);
+        let candidates = [
+            RoundTripPoolCandidate {
+                pool: &pool_a,
+                vault: Some(&vault_a),
+                dlmm_bins: None,
+                dex: "orca",
+            },
+            RoundTripPoolCandidate {
+                pool: &pool_b,
+                vault: Some(&vault_b),
+                dlmm_bins: None,
+                dex: "pump_amm",
+            },
+        ];
+        let freshness = QuoteFreshnessConfig::default();
+        let probe = DLMM_PROBE_SOL_LAMPORTS;
+        let now = Instant::now();
+
+        let mut brute_best_profit = i64::MIN;
+        let mut brute_best: Option<(String, String)> = None;
+        for buy in &candidates {
+            let buy_quote = quote_exact_in_with_freshness(
+                buy.pool,
+                buy.vault,
+                buy.dlmm_bins,
+                NATIVE_SOL_MINT,
+                &buy.pool.token_mint,
+                probe,
+                &freshness,
+            );
+            let Some(buy_quote) = buy_quote else { continue };
+            if !is_quote_fresh(&buy_quote, &freshness, buy.vault, now) {
+                continue;
+            }
+            for sell in &candidates {
+                if sell.dex == buy.dex {
+                    continue;
+                }
+                let sell_quote = quote_exact_in_with_freshness(
+                    sell.pool,
+                    sell.vault,
+                    sell.dlmm_bins,
+                    &sell.pool.token_mint,
+                    NATIVE_SOL_MINT,
+                    buy_quote.amount_out,
+                    &freshness,
+                );
+                let Some(sell_quote) = sell_quote else {
+                    continue;
+                };
+                if !is_quote_fresh(&sell_quote, &freshness, sell.vault, now) {
+                    continue;
+                }
+                if !quotes_pairable(&buy_quote, &sell_quote) {
+                    continue;
+                }
+                let profit = sell_quote.amount_out as i64 - probe as i64;
+                if profit > brute_best_profit {
+                    brute_best_profit = profit;
+                    brute_best = Some((
+                        buy.pool.pool_address.clone(),
+                        sell.pool.pool_address.clone(),
+                    ));
+                }
+            }
+        }
+
+        let selection =
+            select_round_trip_pools(&candidates, probe, &freshness).expect("pair-aware selection");
+        let expected = brute_best.expect("brute-force must find a pair");
+        assert_eq!(selection.buy_pool_address, expected.0);
+        assert_eq!(selection.sell_pool_address, expected.1);
+        assert!(
+            selection.sell_quote.amount_out as i64 - probe as i64 == brute_best_profit,
+            "selection must maximize round-trip profit"
+        );
+    }
+
+    #[test]
+    fn select_round_trip_pools_cross_dex_missing_vault_records_detail() {
+        let pool_a = sample_pool("orca", "poolA");
+        let pool_b = sample_pool("pump_amm", "poolB");
+        let vault_a = sample_vault(1_000_000_000_000, 900_000_000);
+        let candidates = [
+            RoundTripPoolCandidate {
+                pool: &pool_a,
+                vault: Some(&vault_a),
+                dlmm_bins: None,
+                dex: "orca",
+            },
+            RoundTripPoolCandidate {
+                pool: &pool_b,
+                vault: None,
+                dlmm_bins: None,
+                dex: "pump_amm",
+            },
+        ];
+        let err = select_round_trip_pools(
+            &candidates,
+            DLMM_PROBE_SOL_LAMPORTS,
+            &QuoteFreshnessConfig::default(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            RoundTripSelectFailure::InsufficientPools(RoundTripInsufficient {
+                subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
+                no_cross_dex_sell_detail: Some(NoCrossDexSellDetailReason::SellMissingVault),
+            })
+        );
+    }
+
+    #[test]
+    fn select_round_trip_pools_dlmm_missing_bins_records_detail() {
+        let pool_a = sample_pool("pump_amm", "poolA");
+        let pool_b = sample_pool("meteora_dlmm", "poolB");
+        let vault_a = sample_vault(1_000_000_000_000, 900_000_000);
+        let vault_b = sample_vault(1_000_000_000_000, 1_100_000_000);
+        let candidates = [
+            RoundTripPoolCandidate {
+                pool: &pool_a,
+                vault: Some(&vault_a),
+                dlmm_bins: None,
+                dex: "pump_amm",
+            },
+            RoundTripPoolCandidate {
+                pool: &pool_b,
+                vault: Some(&vault_b),
+                dlmm_bins: None,
+                dex: "meteora_dlmm",
+            },
+        ];
+        let err = select_round_trip_pools(
+            &candidates,
+            DLMM_PROBE_SOL_LAMPORTS,
+            &QuoteFreshnessConfig::default(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            RoundTripSelectFailure::InsufficientPools(RoundTripInsufficient {
+                subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
+                no_cross_dex_sell_detail: Some(NoCrossDexSellDetailReason::SellMissingDlmmBins),
+            })
+        );
+    }
+
+    #[test]
+    fn classify_cross_dex_sell_failure_missing_vault() {
+        let pool = sample_pool("orca", "poolO");
+        let candidate = RoundTripPoolCandidate {
+            pool: &pool,
+            vault: None,
+            dlmm_bins: None,
+            dex: "orca",
+        };
+        let reason = classify_cross_dex_sell_failure(
+            &candidate,
+            1_000,
+            &QuoteFreshnessConfig::default(),
+            Instant::now(),
+            6,
+        );
+        assert_eq!(reason, NoCrossDexSellDetailReason::SellMissingVault);
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -29,13 +29,14 @@ use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 use ironcrab::arbitrage::{
-    dlmm_marginal_price_plausible, dlmm_sol_output_from_bins, dlmm_token_output_from_bins,
-    is_quote_fresh, populate_arb_slave_from_live_pool_cache, quote_exact_in,
-    quote_exact_in_with_freshness, quotes_pairable, round_trip_profit_lamports,
+    classify_cross_dex_sell_failure, dlmm_marginal_price_plausible, dlmm_sol_output_from_bins,
+    dlmm_token_output_from_bins, is_quote_fresh, populate_arb_slave_from_live_pool_cache,
+    quote_exact_in, quote_exact_in_with_freshness, quotes_pairable, round_trip_profit_lamports,
     select_round_trip_pools, sync_arb_slave_from_pool_cache_update, MultiHopArbitrage,
-    MultiHopConfig, MultiHopIntentBatch, PoolQuote, QuoteFreshnessConfig, QuotePoolInput,
-    QuoteVaultInput, RoundTripInsufficientSubreason, RoundTripLeg, RoundTripPoolCandidate,
-    RoundTripSelectFailure, DLMM_PROBE_SOL_LAMPORTS,
+    MultiHopConfig, MultiHopIntentBatch, NoCrossDexSellDetailReason, PoolQuote,
+    QuoteFreshnessConfig, QuotePoolInput, QuoteVaultInput, RoundTripInsufficient,
+    RoundTripInsufficientSubreason, RoundTripLeg, RoundTripPoolCandidate, RoundTripSelectFailure,
+    DLMM_PROBE_SOL_LAMPORTS,
 };
 use ironcrab::config::Config as AppConfig;
 use ironcrab::execution::live_pool_cache::{
@@ -67,27 +68,29 @@ use ironcrab::metrics::{
     arb_two_hop_opportunity_inc, arb_two_hop_pool_gate_add, arb_two_hop_reject_subreason_inc,
     arb_two_hop_rejected_inc, arb_two_hop_tracker_seeded_pools_add,
     arb_two_hop_v2_incompatible_kind_inc, arb_two_hop_v2_insufficient_subreason_inc,
-    arb_two_hop_v2_rejected_inc, arb_two_hop_v2_screen_inc, arb_two_hop_v2_screen_multi_dex_inc,
-    record_arb_heartbeat_phase, record_arb_price_freshness_stale_age_ms,
-    record_arb_proactive_pin_first_publish, record_arb_proactive_track_publish_total,
-    record_arb_quote_pair_slot_delta, record_arb_quote_shadow_round_trip,
-    record_arb_track_requests_messages_total, record_arb_track_requests_publish_chunks_total,
-    record_arb_track_requests_publish_failed_total, record_arb_writer_lock_wait, serve_metrics,
-    set_arb_pool_cache_apply_batch_size_gauge, set_arb_quote_shadow_legacy_spread_bps,
-    set_arb_tracker_write_coalescer_pending, set_arb_tracker_write_queue_depth,
-    set_arb_two_hop_blocked_on_apply_trade, set_readiness_nats_connected,
-    tick_arb_heartbeat_seconds_since_last_finish, tick_arb_tracker_write_seconds_since_last_finish,
+    arb_two_hop_v2_no_cross_dex_sell_detail_inc, arb_two_hop_v2_rejected_inc,
+    arb_two_hop_v2_screen_inc, arb_two_hop_v2_screen_multi_dex_inc, record_arb_heartbeat_phase,
+    record_arb_price_freshness_stale_age_ms, record_arb_proactive_pin_first_publish,
+    record_arb_proactive_track_publish_total, record_arb_quote_pair_slot_delta,
+    record_arb_quote_shadow_round_trip, record_arb_track_requests_messages_total,
+    record_arb_track_requests_publish_chunks_total, record_arb_track_requests_publish_failed_total,
+    record_arb_writer_lock_wait, serve_metrics, set_arb_pool_cache_apply_batch_size_gauge,
+    set_arb_quote_shadow_legacy_spread_bps, set_arb_tracker_write_coalescer_pending,
+    set_arb_tracker_write_queue_depth, set_arb_two_hop_blocked_on_apply_trade,
+    set_readiness_nats_connected, tick_arb_heartbeat_seconds_since_last_finish,
+    tick_arb_tracker_write_seconds_since_last_finish,
     try_record_arb_track_pin_before_first_screen_ms, wall_clock_unix_ms_now, ArbHeartbeatPhase,
     ArbStrategyWarmupSkipReason, ArbTrackerWriteJobType, ArbTwoHopInsufficientSubreason,
     ArbTwoHopPoolGate, ArbTwoHopRejectReason, ArbTwoHopRejectSubreason,
-    ArbTwoHopV2InsufficientSubreason, ArbTwoHopV2RejectReason, ArbWriterLockKind, MetricsComponent,
-    ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH, ARB_REJECTED_MISSING_ACCOUNTS,
-    ARB_SUBSCRIBER_HIGH_PROCESSED_TOTAL, ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH,
-    ARB_TRACKER_WRITE_COALESCER_PENDING, ARB_TRACKER_WRITE_CURRENT_JOB_STARTED_UNIX_MS,
-    ARB_TRACKER_WRITE_CURRENT_JOB_TYPE, ARB_TRACKER_WRITE_QUEUE_DEPTH,
-    ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH, ARB_TRIANGLE_OPPORTUNITIES,
-    INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
-    NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
+    ArbTwoHopV2InsufficientSubreason, ArbTwoHopV2NoCrossDexSellDetail, ArbTwoHopV2RejectReason,
+    ArbWriterLockKind, MetricsComponent, ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH,
+    ARB_REJECTED_MISSING_ACCOUNTS, ARB_SUBSCRIBER_HIGH_PROCESSED_TOTAL,
+    ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH, ARB_TRACKER_WRITE_COALESCER_PENDING,
+    ARB_TRACKER_WRITE_CURRENT_JOB_STARTED_UNIX_MS, ARB_TRACKER_WRITE_CURRENT_JOB_TYPE,
+    ARB_TRACKER_WRITE_QUEUE_DEPTH, ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH,
+    ARB_TRIANGLE_OPPORTUNITIES, INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL,
+    NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE,
+    TOKENS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     arb_strategy_pool_cache_live_consumer_config, arb_track_payload_bytes, config_consumer_config,
@@ -1597,6 +1600,7 @@ struct PoolV2EligibilityRow {
     buy_quote_fresh: bool,
     sell_quote_ok: bool,
     sell_quote_fresh: bool,
+    sell_fail_reason: Option<String>,
 }
 
 /// Aggregated mint-level v2 eligibility breakdown for rate-limited snapshots.
@@ -1689,6 +1693,7 @@ impl ArbV2EligibilityForensics {
                         "buy_quote_fresh": row.buy_quote_fresh,
                         "sell_quote_ok": row.sell_quote_ok,
                         "sell_quote_fresh": row.sell_quote_fresh,
+                        "sell_fail_reason": row.sell_fail_reason,
                     })
                 })
                 .collect();
@@ -1750,8 +1755,29 @@ fn v2_insufficient_subreason_to_metric(
     }
 }
 
-fn record_v2_insufficient_subreason(subreason: RoundTripInsufficientSubreason) {
-    arb_two_hop_v2_insufficient_subreason_inc(v2_insufficient_subreason_to_metric(subreason));
+fn v2_no_cross_dex_sell_detail_to_metric(
+    detail: NoCrossDexSellDetailReason,
+) -> ArbTwoHopV2NoCrossDexSellDetail {
+    match detail {
+        NoCrossDexSellDetailReason::SellMissingVault => {
+            ArbTwoHopV2NoCrossDexSellDetail::SellMissingVault
+        }
+        NoCrossDexSellDetailReason::SellMissingDlmmBins => {
+            ArbTwoHopV2NoCrossDexSellDetail::SellMissingDlmmBins
+        }
+        NoCrossDexSellDetailReason::SellQuoteNone => ArbTwoHopV2NoCrossDexSellDetail::SellQuoteNone,
+        NoCrossDexSellDetailReason::SellNotFresh => ArbTwoHopV2NoCrossDexSellDetail::SellNotFresh,
+        NoCrossDexSellDetailReason::SellZeroOut => ArbTwoHopV2NoCrossDexSellDetail::SellZeroOut,
+    }
+}
+
+fn record_v2_insufficient_subreason(insufficient: RoundTripInsufficient) {
+    arb_two_hop_v2_insufficient_subreason_inc(v2_insufficient_subreason_to_metric(
+        insufficient.subreason,
+    ));
+    if let Some(detail) = insufficient.no_cross_dex_sell_detail {
+        arb_two_hop_v2_no_cross_dex_sell_detail_inc(v2_no_cross_dex_sell_detail_to_metric(detail));
+    }
 }
 
 fn record_eligibility_metrics(breakdown: &MintEligibilityBreakdown) {
@@ -2321,6 +2347,18 @@ impl TokenArbTracker {
                 (false, false)
             };
 
+            let sell_fail_reason = best_buy_amount_out.map(|token_amount| {
+                classify_cross_dex_sell_failure(
+                    candidate,
+                    token_amount,
+                    freshness,
+                    now,
+                    token_decimals,
+                )
+                .as_metric_label()
+                .to_string()
+            });
+
             pool_rows.push(PoolV2EligibilityRow {
                 pool_address: candidate.pool.pool_address.clone(),
                 dex: candidate.dex.to_string(),
@@ -2331,6 +2369,7 @@ impl TokenArbTracker {
                 buy_quote_fresh,
                 sell_quote_ok,
                 sell_quote_fresh,
+                sell_fail_reason,
             });
         }
 
@@ -2390,8 +2429,8 @@ impl TokenArbTracker {
 
         let selection = match select_round_trip_pools(&candidates, probe, &freshness) {
             Ok(selection) => selection,
-            Err(RoundTripSelectFailure::InsufficientPools(subreason)) => {
-                record_v2_insufficient_subreason(subreason);
+            Err(RoundTripSelectFailure::InsufficientPools(insufficient)) => {
+                record_v2_insufficient_subreason(insufficient);
                 arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::InsufficientPools);
                 if let Some(collector) = v2_forensics {
                     let breakdown = self.build_v2_eligibility_breakdown(
@@ -2401,7 +2440,7 @@ impl TokenArbTracker {
                         token_decimals,
                         probe,
                         &freshness,
-                        subreason,
+                        insufficient.subreason,
                     );
                     collector.record(breakdown);
                 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1101,6 +1101,14 @@ struct MarketDataContext {
     last_arb_snapshot_target: parking_lot::RwLock<Option<HashSet<Pubkey>>>,
     /// Last `active_id` used when registering DLMM bin-array window per pool (Fix B).
     dlmm_registered_active_id: parking_lot::RwLock<HashMap<Pubkey, i32>>,
+    /// Cold-path RPC for arb-pin pool seed (set at Geyser loop start).
+    cold_path_rpc: parking_lot::RwLock<Option<Arc<SolanaRpc>>>,
+    /// Debounced arb-pin ensure enqueue (pool → last spawn time).
+    arb_pin_ensure_debounce: parking_lot::Mutex<HashMap<Pubkey, Instant>>,
+    /// Self `Arc` for cold-path spawns from `&self` md-state handlers.
+    self_arc: parking_lot::RwLock<Option<Arc<MarketDataContext>>>,
+    /// md-state sender for post-ensure Geyser sync scheduling.
+    md_state_sender: parking_lot::RwLock<Option<MdStateSender>>,
 }
 
 #[derive(Debug, Default)]
@@ -1149,6 +1157,11 @@ const WALLET_BOOTSTRAP_DEX_VERIFY_GRACE_MS: u64 = 400;
 
 /// Max wallet-held mints to run PumpSwap/PumpFun bootstrap verification for per startup (deduped).
 const WALLET_BOOTSTRAP_DEX_VERIFY_MAX_MINTS: usize = 8;
+
+/// Debounce arb-pin cold-path pool ensure per pool (seconds).
+const ARB_PIN_ENSURE_DEBOUNCE_SECS: u64 = 60;
+/// Cap debounce map for arb-pin ensure enqueue (LRU via oldest eviction).
+const ARB_PIN_ENSURE_DEBOUNCE_MAP_CAP: usize = 2048;
 
 /// Wallet bootstrap PumpFun step: must use `force_refresh` so `handle_ensure_pumpfun_bonding_curve`
 /// does not early-return on `CachedPoolState::PumpFun` without explicit Ready (merge + JetStream).
@@ -2014,6 +2027,18 @@ impl MdStateContext for MarketDataContext {
 }
 
 impl MarketDataContext {
+    fn set_self_arc(&self, arc: Arc<MarketDataContext>) {
+        *self.self_arc.write() = Some(arc);
+    }
+
+    fn set_cold_path_rpc(&self, rpc: Arc<SolanaRpc>) {
+        *self.cold_path_rpc.write() = Some(rpc);
+    }
+
+    fn set_md_state_sender(&self, sender: MdStateSender) {
+        *self.md_state_sender.write() = Some(sender);
+    }
+
     /// Non-blocking JSONL enqueue (dedicated `jsonl-writer` thread). Skips `AccountUpdate` / `TransactionDetected`.
     fn write_market_event_jsonl(&self, event: &MarketEvent) {
         write_market_event_jsonl(self, event);
@@ -3482,6 +3507,72 @@ impl MarketDataContext {
         batch_dirty
     }
 
+    fn non_sol_mint_for_arb_pool_seed(state: &CachedPoolState) -> Option<Pubkey> {
+        let sol = Pubkey::from_str(NATIVE_SOL_MINT).ok()?;
+        match state {
+            CachedPoolState::Orca(s) => {
+                if s.token_mint_a == sol {
+                    Some(s.token_mint_b)
+                } else if s.token_mint_b == sol {
+                    Some(s.token_mint_a)
+                } else {
+                    None
+                }
+            }
+            CachedPoolState::Meteora(s) => {
+                if s.token_x_mint == sol {
+                    Some(s.token_y_mint)
+                } else if s.token_y_mint == sol {
+                    Some(s.token_x_mint)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn arb_pin_ensure_debounce_should_enqueue(&self, pool: Pubkey) -> bool {
+        let now = Instant::now();
+        let mut debounce = self.arb_pin_ensure_debounce.lock();
+        if let Some(last) = debounce.get(&pool) {
+            if last.elapsed() < Duration::from_secs(ARB_PIN_ENSURE_DEBOUNCE_SECS) {
+                return false;
+            }
+        }
+        if debounce.len() >= ARB_PIN_ENSURE_DEBOUNCE_MAP_CAP {
+            if let Some(oldest_pool) = debounce
+                .iter()
+                .min_by_key(|(_, ts)| *ts)
+                .map(|(pool, _)| *pool)
+            {
+                debounce.remove(&oldest_pool);
+            }
+        }
+        debounce.insert(pool, now);
+        true
+    }
+
+    fn maybe_enqueue_arb_pin_cold_path_ensure(&self, pool: Pubkey) {
+        if !self.arb_pin_ensure_debounce_should_enqueue(pool) {
+            return;
+        }
+        let Some(ctx) = self.self_arc.read().clone() else {
+            return;
+        };
+        let Some(rpc) = self.cold_path_rpc.read().clone() else {
+            return;
+        };
+        let Some(handle) = self.ingest_tokio_handle.read().clone() else {
+            return;
+        };
+        let md_state = self.md_state_sender.read().clone();
+
+        handle.spawn(async move {
+            arb_pin_cold_path_seed_pool_state(ctx, rpc, md_state, pool).await;
+        });
+    }
+
     fn apply_arb_active_entries(&self, active: &[ArbTrackActiveEntry]) -> bool {
         let mut batch_dirty = false;
         for a in active {
@@ -3492,6 +3583,13 @@ impl MarketDataContext {
             self.hot_pool_registry.pin_arb_pool(pool_pk);
             if self.register_geyser_reserves_for_arb_active_pool(pool_pk) {
                 batch_dirty = true;
+            } else if self.live_pool_cache.get(&pool_pk).is_none()
+                || matches!(
+                    self.live_pool_cache.get(&pool_pk),
+                    Some(CachedPoolState::Orca(_)) | Some(CachedPoolState::Meteora(_))
+                )
+            {
+                self.maybe_enqueue_arb_pin_cold_path_ensure(pool_pk);
             }
             let _ = &a.reason;
         }
@@ -4660,6 +4758,101 @@ async fn handle_wallet_bootstrap_meteora_dlmm_verify_for_mint(
             ctx, rpc, run_id, request_id, base_mint, pool_addr, state,
         )
         .await;
+    }
+}
+
+/// Cold-path only: debounced pool seed when arb pin hits LivePoolCache miss or Orca/DLMM rows
+/// need RPC refresh before vault/bin Geyser registration.
+async fn arb_pin_cold_path_seed_pool_state(
+    ctx: Arc<MarketDataContext>,
+    rpc: Arc<SolanaRpc>,
+    md_state: Option<MdStateSender>,
+    pool: Pubkey,
+) {
+    let run_id = ctx.run_id.clone();
+    let request_id = format!("arb-pin-ensure-{}", pool);
+
+    if let Some(state) = ctx.live_pool_cache.get(&pool) {
+        let Some(base_mint) = MarketDataContext::non_sol_mint_for_arb_pool_seed(&state) else {
+            return;
+        };
+        let base_mint_str = base_mint.to_string();
+        let pool_hint = pool.to_string();
+        match state {
+            CachedPoolState::Orca(_) => {
+                handle_ensure_orca_whirlpool_pool_state(
+                    ctx.as_ref(),
+                    &rpc,
+                    run_id.as_str(),
+                    &request_id,
+                    &base_mint_str,
+                    Some(pool_hint.as_str()),
+                    false,
+                )
+                .await;
+            }
+            CachedPoolState::Meteora(_) if ctx.config.read().enable_meteora_dlmm => {
+                handle_ensure_meteora_dlmm_pool_state(
+                    ctx.as_ref(),
+                    &rpc,
+                    run_id.as_str(),
+                    &request_id,
+                    &base_mint_str,
+                    Some(pool_hint.as_str()),
+                    false,
+                )
+                .await;
+            }
+            _ => return,
+        }
+    } else {
+        let pool_acc = match rpc.get_account_opt_retry(&pool).await {
+            Ok(Some(acc)) => acc,
+            Ok(None) | Err(_) => {
+                debug!(pool = %pool, "Arb pin cold seed: pool account fetch miss");
+                return;
+            }
+        };
+        let Some(parsed) = parse_pool_account(&pool_acc.owner, &pool_acc.data) else {
+            debug!(pool = %pool, "Arb pin cold seed: unsupported pool owner/layout");
+            return;
+        };
+        let Some(base_mint) = MarketDataContext::non_sol_mint_for_arb_pool_seed(&parsed) else {
+            return;
+        };
+        match parsed {
+            CachedPoolState::Orca(s) => {
+                cold_path_rpc_refresh_orca_whirlpool_pool_row(
+                    ctx.as_ref(),
+                    &rpc,
+                    run_id.as_str(),
+                    &request_id,
+                    &base_mint,
+                    pool,
+                    s,
+                )
+                .await;
+            }
+            CachedPoolState::Meteora(s) if ctx.config.read().enable_meteora_dlmm => {
+                cold_path_rpc_refresh_meteora_dlmm_pool_row(
+                    ctx.as_ref(),
+                    &rpc,
+                    run_id.as_str(),
+                    &request_id,
+                    &base_mint,
+                    pool,
+                    s,
+                )
+                .await;
+            }
+            _ => return,
+        }
+    }
+
+    if ctx.register_geyser_reserves_for_arb_active_pool(pool) {
+        if let Some(md_state) = md_state {
+            ctx.schedule_geyser_sync_batch_debounced(&md_state);
+        }
     }
 }
 
@@ -5975,6 +6168,10 @@ async fn main() -> Result<()> {
         last_momentum_snapshot_target: parking_lot::RwLock::new(None),
         last_arb_snapshot_target: parking_lot::RwLock::new(None),
         dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+        cold_path_rpc: parking_lot::RwLock::new(None),
+        arb_pin_ensure_debounce: parking_lot::Mutex::new(HashMap::new()),
+        self_arc: parking_lot::RwLock::new(None),
+        md_state_sender: parking_lot::RwLock::new(None),
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -7737,6 +7934,9 @@ async fn run_geyser_loop(
         tokio::runtime::Handle::current(),
         track_worker.clone(),
     );
+    ctx.set_self_arc(Arc::clone(&ctx));
+    ctx.set_cold_path_rpc(Arc::clone(&rpc));
+    ctx.set_md_state_sender(md_state.clone());
 
     // === P0: Wallet Balance Snapshot (Position Reconciliation) ===
     // Bootstrap wallet state at startup (max 1 RPC roundtrip) using known mints from JetStream.
@@ -9055,6 +9255,9 @@ async fn run_simulation_loop(
         tokio::runtime::Handle::current(),
         track_worker.clone(),
     );
+    ctx.set_self_arc(Arc::clone(&ctx));
+    ctx.set_cold_path_rpc(Arc::clone(&rpc));
+    ctx.set_md_state_sender(md_state.clone());
 
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
     let mut slot: u64 = 0;
@@ -10512,6 +10715,10 @@ mod wallet_snapshot_stale_cleanup_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            cold_path_rpc: parking_lot::RwLock::new(None),
+            arb_pin_ensure_debounce: parking_lot::Mutex::new(HashMap::new()),
+            self_arc: parking_lot::RwLock::new(None),
+            md_state_sender: parking_lot::RwLock::new(None),
         }
     }
 
@@ -10728,6 +10935,10 @@ mod wallet_tx_meta_balance_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            cold_path_rpc: parking_lot::RwLock::new(None),
+            arb_pin_ensure_debounce: parking_lot::Mutex::new(HashMap::new()),
+            self_arc: parking_lot::RwLock::new(None),
+            md_state_sender: parking_lot::RwLock::new(None),
         })
     }
 
@@ -11599,6 +11810,10 @@ mod pr_b_geyser_tracking_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            cold_path_rpc: parking_lot::RwLock::new(None),
+            arb_pin_ensure_debounce: parking_lot::Mutex::new(HashMap::new()),
+            self_arc: parking_lot::RwLock::new(None),
+            md_state_sender: parking_lot::RwLock::new(None),
         })
     }
 
@@ -11671,6 +11886,10 @@ mod pr_b_geyser_tracking_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            cold_path_rpc: parking_lot::RwLock::new(None),
+            arb_pin_ensure_debounce: parking_lot::Mutex::new(HashMap::new()),
+            self_arc: parking_lot::RwLock::new(None),
+            md_state_sender: parking_lot::RwLock::new(None),
         });
         (
             ctx,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3043,6 +3043,16 @@ pub static ARB_TWO_HOP_V2_INSUFFICIENT_NO_CROSS_DEX_SELL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TWO_HOP_V2_INSUFFICIENT_SINGLE_DEX_CANDIDATES: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_MISSING_VAULT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_MISSING_DLMM_BINS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_QUOTE_NONE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_NOT_FRESH: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_ZERO_OUT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 pub static ARB_PROACTIVE_TRACK_PUBLISH_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
 const ARB_QUOTE_PAIR_SLOT_DELTA_BUCKETS: &[u64] = &[0, 1, 2, 3, 4, 5, 8, 16, 32];
@@ -3529,6 +3539,38 @@ pub fn arb_two_hop_v2_insufficient_subreason_inc(reason: ArbTwoHopV2Insufficient
         }
         ArbTwoHopV2InsufficientSubreason::SingleDexCandidates => {
             &*ARB_TWO_HOP_V2_INSUFFICIENT_SINGLE_DEX_CANDIDATES
+        }
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Drill-down reason for `arb_two_hop_v2_no_cross_dex_sell_detail_total{reason=...}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArbTwoHopV2NoCrossDexSellDetail {
+    SellMissingVault,
+    SellMissingDlmmBins,
+    SellQuoteNone,
+    SellNotFresh,
+    SellZeroOut,
+}
+
+/// Increment `arb_two_hop_v2_no_cross_dex_sell_detail_total{reason=...}`.
+pub fn arb_two_hop_v2_no_cross_dex_sell_detail_inc(reason: ArbTwoHopV2NoCrossDexSellDetail) {
+    let counter = match reason {
+        ArbTwoHopV2NoCrossDexSellDetail::SellMissingVault => {
+            &*ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_MISSING_VAULT
+        }
+        ArbTwoHopV2NoCrossDexSellDetail::SellMissingDlmmBins => {
+            &*ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_MISSING_DLMM_BINS
+        }
+        ArbTwoHopV2NoCrossDexSellDetail::SellQuoteNone => {
+            &*ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_QUOTE_NONE
+        }
+        ArbTwoHopV2NoCrossDexSellDetail::SellNotFresh => {
+            &*ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_NOT_FRESH
+        }
+        ArbTwoHopV2NoCrossDexSellDetail::SellZeroOut => {
+            &*ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_ZERO_OUT
         }
     };
     counter.fetch_add(1, Ordering::Relaxed);
@@ -4273,6 +4315,46 @@ fn append_arb_two_hop_v2_insufficient_subreason_total(out: &mut String) {
     out.push_str("arb_two_hop_v2_insufficient_subreason_total{reason=\"single_dex_candidates\"} ");
     out.push_str(
         &ARB_TWO_HOP_V2_INSUFFICIENT_SINGLE_DEX_CANDIDATES
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+}
+
+fn append_arb_two_hop_v2_no_cross_dex_sell_detail_total(out: &mut String) {
+    out.push_str("arb_two_hop_v2_no_cross_dex_sell_detail_total{reason=\"sell_missing_vault\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_MISSING_VAULT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str(
+        "arb_two_hop_v2_no_cross_dex_sell_detail_total{reason=\"sell_missing_dlmm_bins\"} ",
+    );
+    out.push_str(
+        &ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_MISSING_DLMM_BINS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_no_cross_dex_sell_detail_total{reason=\"sell_quote_none\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_QUOTE_NONE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_no_cross_dex_sell_detail_total{reason=\"sell_not_fresh\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_NOT_FRESH
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_no_cross_dex_sell_detail_total{reason=\"sell_zero_out\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_ZERO_OUT
             .load(Ordering::Relaxed)
             .to_string(),
     );
@@ -6929,6 +7011,7 @@ async fn metrics_response() -> Response<Body> {
         ARB_TWO_HOP_V2_SCREEN_MULTI_DEX_TOTAL.load(Ordering::Relaxed)
     );
     append_arb_two_hop_v2_insufficient_subreason_total(&mut out);
+    append_arb_two_hop_v2_no_cross_dex_sell_detail_total(&mut out);
     append_momentum_latency_histogram_prometheus(
         &mut out,
         "arb_quote_pair_slot_delta",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Pair-aware `select_round_trip_pools`**: enumerate all valid cross-DEX `(buy, sell)` pairs with fresh quotes and `quotes_pairable`; pick best round-trip profit (`sell.amount_out - probe`) instead of greedy min-buy-first + sell search (I-ARB-5 evolution).
- **NoCrossDexSell drill-down metrics**: `arb_two_hop_v2_no_cross_dex_sell_detail_total{reason=...}` for `sell_missing_vault`, `sell_missing_dlmm_bins`, `sell_quote_none`, `sell_not_fresh`, `sell_zero_out` (dominant reason on aggregate fail).
- **v2 eligibility snapshots**: optional `sell_fail_reason` per `top_pools` row (low cardinality).
- **MD arb pin cache miss**: debounced (60s/pool, capped map) cold-path `handle_ensure_orca_whirlpool_pool_state` / `handle_ensure_meteora_dlmm_pool_state` or RPC seed when `LivePoolCache` miss on arb pin; re-register Geyser vault/bins after ensure.

## Prod context

Deploy #264 sample: ~58% of multi-DEX insufficient screens = `no_cross_dex_sell`; snapshots show missing Orca vault + Meteora DLMM bins on sell leg.

## Invariants

- No Hot Path RPC in arb_strategy (I-7)
- Cold-path ensure only in market-data (I-4)
- No second NATS `track_requests` publish (I-4e)
- Existing insufficient subreasons preserved

## Tests

- `select_round_trip_pools` pair-aware vs brute-force best round-trip
- `NoCrossDexSell` + detail counters (vault / DLMM bins)
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` green locally

## Post-merge

Impl CI **Eval (Level 5)** required before prod deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5825d4c-a4a9-4a90-81da-3fdfca2af5bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5825d4c-a4a9-4a90-81da-3fdfca2af5bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

