### PR TITLE
fix(arb): sell_quote_none forensics + quote-layer fix (P2)

### DIFF
--- a/src/arbitrage/mod.rs
+++ b/src/arbitrage/mod.rs
@@ -47,16 +47,17 @@ pub use multi_hop_integration::{
 };
 pub use pool_graph::{GraphStats, PoolGraph};
 pub use pool_quote::{
-    classify_cross_dex_sell_failure, dlmm_marginal_price_plausible, dlmm_sol_output_from_bins,
-    dlmm_token_output_from_bins, flatten_bin_array_bins, is_quote_fresh, is_usable_quote_kind,
-    quote_exact_in, quote_exact_in_with_freshness, quote_from_cached_pool,
-    quote_sol_per_token_for_screening, quotes_pairable, round_trip_profit_lamports,
-    round_trip_profit_lamports_with_freshness, select_round_trip_pools,
+    classify_cross_dex_sell_failure, diagnose_sell_quote_none, dlmm_marginal_price_plausible,
+    dlmm_sol_output_from_bins, dlmm_token_output_from_bins, flatten_bin_array_bins, is_quote_fresh,
+    is_usable_quote_kind, quote_exact_in, quote_exact_in_with_freshness, quote_from_cached_pool,
+    quote_sell_round_trip, quote_sol_per_token_for_screening, quotes_pairable,
+    round_trip_profit_lamports, round_trip_profit_lamports_with_freshness, select_round_trip_pools,
     sol_quoted_seed_from_cached_state, state_fingerprint, token_decimals_from_cached_state,
-    DlmmBinArrays, NoCrossDexSellDetailReason, PoolQuote, QuoteFreshnessConfig, QuoteKind,
-    QuotePoolInput, QuoteSide, QuoteVaultInput, RoundTripInsufficient,
-    RoundTripInsufficientSubreason, RoundTripLeg, RoundTripPoolCandidate, RoundTripPoolSelection,
-    RoundTripSelectFailure, SolQuotedPoolSeed, DLMM_PROBE_SOL_LAMPORTS, STATE_TTL_MS, TRADE_TTL_MS,
+    CrossDexSellFailure, DlmmBinArrays, NoCrossDexSellDetailReason, PoolQuote,
+    QuoteFreshnessConfig, QuoteKind, QuotePoolInput, QuoteSide, QuoteVaultInput,
+    RoundTripInsufficient, RoundTripInsufficientSubreason, RoundTripLeg, RoundTripPoolCandidate,
+    RoundTripPoolSelection, RoundTripSelectFailure, SellQuoteNoneDetailReason, SolQuotedPoolSeed,
+    DLMM_PROBE_SOL_LAMPORTS, STATE_TTL_MS, TRADE_TTL_MS,
 };
 pub use pool_ranker::{PoolRanker, QuoteProvider, RankerConfig};
 pub use types::{

--- a/src/arbitrage/pool_quote.rs
+++ b/src/arbitrage/pool_quote.rs
@@ -442,9 +442,16 @@ fn executable_marginal_quote(
                 trade_implied_sol_per_token(amount_out, amount_in, pool.token_decimals)
             }
         };
-        if !dlmm_marginal_price_plausible(marginal_price, reserve_mid, trade_mid)
-            || !is_plausible_sol_per_token_price(&pool.token_mint, marginal_price)
-        {
+        // Buy screening uses a small SOL probe where marginal ≈ mid. Sell legs in round-trip
+        // pairing use the full buy token amount; slippage vs reserve mid is expected and must
+        // not reject an otherwise valid bin-walker quote (P2 sell_quote_none fix).
+        let marginal_ok = if side == QuoteSide::Sell {
+            is_plausible_sol_per_token_price(&pool.token_mint, marginal_price)
+        } else {
+            dlmm_marginal_price_plausible(marginal_price, reserve_mid, trade_mid)
+                && is_plausible_sol_per_token_price(&pool.token_mint, marginal_price)
+        };
+        if !marginal_ok {
             return None;
         }
         return Some(PoolQuote {
@@ -1155,6 +1162,286 @@ pub struct RoundTripPoolSelection {
     pub sell_quote: PoolQuote,
 }
 
+/// Drill-down when `quote_exact_in_with_freshness` returns `None` on a sell leg.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SellQuoteNoneDetailReason {
+    StateStale,
+    ReservesImplausible,
+    DlmmActiveBinMissing,
+    DlmmWalkerZero,
+    DlmmMarginalReject,
+    CpmmMathNone,
+    UnsupportedDex,
+    TradeFallbackNone,
+    MintDirectionInvalid,
+}
+
+impl SellQuoteNoneDetailReason {
+    pub fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::StateStale => "state_stale",
+            Self::ReservesImplausible => "reserves_implausible",
+            Self::DlmmActiveBinMissing => "dlmm_active_bin_missing",
+            Self::DlmmWalkerZero => "dlmm_walker_zero",
+            Self::DlmmMarginalReject => "dlmm_marginal_reject",
+            Self::CpmmMathNone => "cpmm_math_none",
+            Self::UnsupportedDex => "unsupported_dex",
+            Self::TradeFallbackNone => "trade_fallback_none",
+            Self::MintDirectionInvalid => "mint_direction_invalid",
+        }
+    }
+}
+
+/// Outcome of classifying a cross-DEX sell leg (metrics / snapshots).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CrossDexSellFailure {
+    MissingDlmmBins,
+    MissingVault,
+    QuoteNone(SellQuoteNoneDetailReason),
+    NotFresh,
+    ZeroOut,
+}
+
+impl CrossDexSellFailure {
+    pub fn as_top_level_detail(self) -> NoCrossDexSellDetailReason {
+        match self {
+            Self::MissingDlmmBins => NoCrossDexSellDetailReason::SellMissingDlmmBins,
+            Self::MissingVault => NoCrossDexSellDetailReason::SellMissingVault,
+            Self::QuoteNone(SellQuoteNoneDetailReason::StateStale) => {
+                NoCrossDexSellDetailReason::SellNotFresh
+            }
+            Self::QuoteNone(_) => NoCrossDexSellDetailReason::SellQuoteNone,
+            Self::NotFresh => NoCrossDexSellDetailReason::SellNotFresh,
+            Self::ZeroOut => NoCrossDexSellDetailReason::SellZeroOut,
+        }
+    }
+
+    pub fn sell_quote_none_subreason(self) -> Option<SellQuoteNoneDetailReason> {
+        match self {
+            Self::QuoteNone(reason) => Some(reason),
+            _ => None,
+        }
+    }
+}
+
+fn diagnose_executable_marginal_none(
+    pool: &QuotePoolInput,
+    vault: &QuoteVaultInput,
+    dlmm_bins: Option<&DlmmBinArrays>,
+    amount_in: u64,
+    now: Instant,
+    freshness: &QuoteFreshnessConfig,
+) -> Option<SellQuoteNoneDetailReason> {
+    if !state_fresh(vault, now, freshness.state_ttl_ms) {
+        return Some(SellQuoteNoneDetailReason::StateStale);
+    }
+
+    if pool.dex == "meteora_dlmm" {
+        let active_id = vault.active_id?;
+        let bin_step = vault.bin_step?;
+        let bins = dlmm_bins?;
+        let sol_is_x = vault_dlmm_sol_is_x(vault);
+        let flat_bins = flatten_bins_for_walker(bins);
+        if !active_bin_present(active_id, &flat_bins) {
+            return Some(SellQuoteNoneDetailReason::DlmmActiveBinMissing);
+        }
+
+        let walker = walker_from_bins(active_id, bin_step, &flat_bins);
+        let fee_bps = dlmm_fee_bps(bin_step);
+        let amount_out = {
+            let (out, _, _) = if sol_is_x {
+                walker.quote_y_to_x(amount_in, fee_bps).ok()?
+            } else {
+                walker.quote_x_to_y(amount_in, fee_bps).ok()?
+            };
+            if out == 0 {
+                return Some(SellQuoteNoneDetailReason::DlmmWalkerZero);
+            }
+            out
+        };
+
+        let marginal_price =
+            trade_implied_sol_per_token(amount_out, amount_in, pool.token_decimals);
+        if !is_plausible_sol_per_token_price(&pool.token_mint, marginal_price) {
+            return Some(SellQuoteNoneDetailReason::DlmmMarginalReject);
+        }
+        return None;
+    }
+
+    if !supports_cpmm(&pool.dex) {
+        return Some(SellQuoteNoneDetailReason::UnsupportedDex);
+    }
+    if !reserves_plausible(
+        vault.reserve_base,
+        vault.reserve_quote,
+        pool.token_decimals,
+        &pool.token_mint,
+    ) {
+        return Some(SellQuoteNoneDetailReason::ReservesImplausible);
+    }
+
+    let (reserve_in, reserve_out) = (vault.reserve_base as u128, vault.reserve_quote as u128);
+    if cpmm_amount_out(reserve_in, reserve_out, amount_in, cpmm_fee_bps(&pool.dex)).is_none() {
+        return Some(SellQuoteNoneDetailReason::CpmmMathNone);
+    }
+    None
+}
+
+/// Diagnose why a token→SOL sell quote returned `None` (no RPC; existing inputs only).
+pub fn diagnose_sell_quote_none(
+    pool: &QuotePoolInput,
+    vault: Option<&QuoteVaultInput>,
+    dlmm_bins: Option<&DlmmBinArrays>,
+    token_amount_in: u64,
+    freshness: &QuoteFreshnessConfig,
+    now: Instant,
+) -> SellQuoteNoneDetailReason {
+    if quote_side_from_mints(&pool.token_mint, &pool.token_mint, NATIVE_SOL_MINT).is_none() {
+        return SellQuoteNoneDetailReason::MintDirectionInvalid;
+    }
+    if token_amount_in == 0 {
+        return SellQuoteNoneDetailReason::CpmmMathNone;
+    }
+
+    if let Some(vault) = vault {
+        if let Some(reason) = diagnose_executable_marginal_none(
+            pool,
+            vault,
+            dlmm_bins,
+            token_amount_in,
+            now,
+            freshness,
+        ) {
+            return reason;
+        }
+    }
+
+    SellQuoteNoneDetailReason::TradeFallbackNone
+}
+
+/// Max token input sellable via DLMM bins (sum of token-side liquidity from active bin).
+fn dlmm_max_sell_token_in(
+    active_id: i32,
+    bin_step: u16,
+    bin_arrays: &DlmmBinArrays,
+    sol_is_x: bool,
+) -> u64 {
+    let flat_bins = flatten_bins_for_walker(bin_arrays);
+    if !active_bin_present(active_id, &flat_bins) {
+        return 0;
+    }
+    let walker = walker_from_bins(active_id, bin_step, &flat_bins);
+    let fee_bps = dlmm_fee_bps(bin_step);
+    let mut lo = 0u64;
+    let mut hi = flat_bins
+        .iter()
+        .map(|(_, x, y)| if sol_is_x { *y } else { *x })
+        .sum::<u64>()
+        .saturating_add(1);
+    if hi == 0 {
+        return 0;
+    }
+    while lo < hi {
+        let mid = lo + (hi - lo).div_ceil(2);
+        let ok = if sol_is_x {
+            walker
+                .quote_y_to_x(mid, fee_bps)
+                .ok()
+                .map(|(out, _, _)| out)
+                .filter(|o| *o > 0)
+                .is_some()
+        } else {
+            walker
+                .quote_x_to_y(mid, fee_bps)
+                .ok()
+                .map(|(out, _, _)| out)
+                .filter(|o| *o > 0)
+                .is_some()
+        };
+        if ok {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    lo
+}
+
+/// Cap sell token input to what the pool can quote (DLMM bin depth / CPMM reserves).
+fn cap_sell_token_in(
+    pool: &QuotePoolInput,
+    vault: &QuoteVaultInput,
+    dlmm_bins: Option<&DlmmBinArrays>,
+    token_amount_in: u64,
+) -> u64 {
+    if pool.dex == "meteora_dlmm" {
+        if let (Some(active_id), Some(bin_step), Some(bins)) =
+            (vault.active_id, vault.bin_step, dlmm_bins)
+        {
+            let max_in =
+                dlmm_max_sell_token_in(active_id, bin_step, bins, vault_dlmm_sol_is_x(vault));
+            if max_in > 0 && token_amount_in > max_in {
+                return max_in;
+            }
+        }
+    } else if supports_cpmm(&pool.dex)
+        && reserves_plausible(
+            vault.reserve_base,
+            vault.reserve_quote,
+            pool.token_decimals,
+            &pool.token_mint,
+        )
+    {
+        let fee_bps = cpmm_fee_bps(&pool.dex);
+        let reserve_in = vault.reserve_base as u128;
+        let reserve_out = vault.reserve_quote as u128;
+        let mut lo = 0u64;
+        let mut hi = token_amount_in;
+        while lo < hi {
+            let mid = lo + (hi - lo).div_ceil(2);
+            if cpmm_amount_out(reserve_in, reserve_out, mid, fee_bps).is_some() {
+                lo = mid;
+            } else {
+                hi = mid - 1;
+            }
+        }
+        if lo > 0 && lo < token_amount_in {
+            return lo;
+        }
+    }
+    token_amount_in
+}
+
+/// Token→SOL sell quote for round-trip pairing (caps input to pool realizable depth).
+pub fn quote_sell_round_trip(
+    pool: &QuotePoolInput,
+    vault: &QuoteVaultInput,
+    dlmm_bins: Option<&DlmmBinArrays>,
+    token_amount_in: u64,
+    freshness: &QuoteFreshnessConfig,
+) -> Option<PoolQuote> {
+    quote_sell_exact_in_with_cap(pool, vault, dlmm_bins, token_amount_in, freshness)
+}
+
+fn quote_sell_exact_in_with_cap(
+    pool: &QuotePoolInput,
+    vault: &QuoteVaultInput,
+    dlmm_bins: Option<&DlmmBinArrays>,
+    token_amount_in: u64,
+    freshness: &QuoteFreshnessConfig,
+) -> Option<PoolQuote> {
+    let capped = cap_sell_token_in(pool, vault, dlmm_bins, token_amount_in);
+    quote_exact_in_with_freshness(
+        pool,
+        Some(vault),
+        dlmm_bins,
+        &pool.token_mint,
+        NATIVE_SOL_MINT,
+        capped,
+        freshness,
+    )
+}
+
 /// Subreason when `select_round_trip_pools` cannot form a cross-DEX round trip.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RoundTripInsufficientSubreason {
@@ -1187,10 +1474,11 @@ impl NoCrossDexSellDetailReason {
 }
 
 /// Insufficient-pool outcome with optional `NoCrossDexSell` drill-down.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RoundTripInsufficient {
     pub subreason: RoundTripInsufficientSubreason,
     pub no_cross_dex_sell_detail: Option<NoCrossDexSellDetailReason>,
+    pub sell_quote_none_detail_counts: Option<HashMap<SellQuoteNoneDetailReason, usize>>,
 }
 
 impl RoundTripInsufficient {
@@ -1198,12 +1486,13 @@ impl RoundTripInsufficient {
         Self {
             subreason,
             no_cross_dex_sell_detail: None,
+            sell_quote_none_detail_counts: None,
         }
     }
 }
 
 /// Failure reason for `select_round_trip_pools`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RoundTripSelectFailure {
     InsufficientPools(RoundTripInsufficient),
     IncompatibleQuoteKind,
@@ -1229,33 +1518,39 @@ pub fn classify_cross_dex_sell_failure(
     freshness: &QuoteFreshnessConfig,
     now: Instant,
     token_decimals: u8,
-) -> NoCrossDexSellDetailReason {
+) -> Option<CrossDexSellFailure> {
     if is_meteora_dlmm_dex(candidate.dex) && candidate.dlmm_bins.is_none() {
-        return NoCrossDexSellDetailReason::SellMissingDlmmBins;
+        return Some(CrossDexSellFailure::MissingDlmmBins);
     }
     if candidate.vault.is_none() {
-        return NoCrossDexSellDetailReason::SellMissingVault;
+        return Some(CrossDexSellFailure::MissingVault);
     }
-    let sell_quote = quote_exact_in_with_freshness(
+    let sell_quote = quote_sell_exact_in_with_cap(
         candidate.pool,
-        candidate.vault,
+        candidate.vault.expect("vault checked"),
         candidate.dlmm_bins,
-        &candidate.pool.token_mint,
-        NATIVE_SOL_MINT,
         token_amount_in,
         freshness,
     );
     let Some(sell_quote) = sell_quote else {
-        return NoCrossDexSellDetailReason::SellQuoteNone;
+        let sub = diagnose_sell_quote_none(
+            candidate.pool,
+            candidate.vault,
+            candidate.dlmm_bins,
+            token_amount_in,
+            freshness,
+            now,
+        );
+        return Some(CrossDexSellFailure::QuoteNone(sub));
     };
     if !is_quote_fresh(&sell_quote, freshness, candidate.vault, now) {
-        return NoCrossDexSellDetailReason::SellNotFresh;
+        return Some(CrossDexSellFailure::NotFresh);
     }
     let sol_per_token = sol_per_token_from_sell_quote(&sell_quote, token_decimals);
     if sol_per_token <= Decimal::ZERO {
-        return NoCrossDexSellDetailReason::SellZeroOut;
+        return Some(CrossDexSellFailure::ZeroOut);
     }
-    NoCrossDexSellDetailReason::SellQuoteNone
+    None
 }
 
 fn dominant_no_cross_dex_sell_detail(
@@ -1343,6 +1638,8 @@ pub fn select_round_trip_pools(
     let mut saw_incompatible_kind = false;
     let mut sell_fail_counts: std::collections::HashMap<NoCrossDexSellDetailReason, usize> =
         std::collections::HashMap::new();
+    let mut sell_quote_none_detail_counts: HashMap<SellQuoteNoneDetailReason, usize> =
+        HashMap::new();
 
     for buy in &valid_buys {
         for sell_candidate in candidates {
@@ -1356,26 +1653,36 @@ pub fn select_round_trip_pools(
                     .or_default() += 1;
                 continue;
             }
-            if sell_candidate.vault.is_none() {
+            let Some(sell_vault) = sell_candidate.vault else {
                 *sell_fail_counts
                     .entry(NoCrossDexSellDetailReason::SellMissingVault)
                     .or_default() += 1;
                 continue;
-            }
+            };
 
-            let sell_quote = quote_exact_in_with_freshness(
+            let sell_quote = quote_sell_exact_in_with_cap(
                 sell_candidate.pool,
-                sell_candidate.vault,
+                sell_vault,
                 sell_candidate.dlmm_bins,
-                &sell_candidate.pool.token_mint,
-                NATIVE_SOL_MINT,
                 buy.quote.amount_out,
                 freshness,
             );
             let Some(sell_quote) = sell_quote else {
-                *sell_fail_counts
-                    .entry(NoCrossDexSellDetailReason::SellQuoteNone)
-                    .or_default() += 1;
+                let sub = diagnose_sell_quote_none(
+                    sell_candidate.pool,
+                    sell_candidate.vault,
+                    sell_candidate.dlmm_bins,
+                    buy.quote.amount_out,
+                    freshness,
+                    now,
+                );
+                *sell_quote_none_detail_counts.entry(sub).or_default() += 1;
+                let top = if sub == SellQuoteNoneDetailReason::StateStale {
+                    NoCrossDexSellDetailReason::SellNotFresh
+                } else {
+                    NoCrossDexSellDetailReason::SellQuoteNone
+                };
+                *sell_fail_counts.entry(top).or_default() += 1;
                 continue;
             };
             if !is_quote_fresh(&sell_quote, freshness, sell_candidate.vault, now) {
@@ -1422,6 +1729,8 @@ pub fn select_round_trip_pools(
             RoundTripInsufficient {
                 subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
                 no_cross_dex_sell_detail: dominant_no_cross_dex_sell_detail(&sell_fail_counts),
+                sell_quote_none_detail_counts: (!sell_quote_none_detail_counts.is_empty())
+                    .then_some(sell_quote_none_detail_counts),
             },
         ));
     };
@@ -1787,13 +2096,23 @@ mod tests {
             &QuoteFreshnessConfig::default(),
         )
         .unwrap_err();
-        assert_eq!(
+        assert!(matches!(
             err,
             RoundTripSelectFailure::InsufficientPools(RoundTripInsufficient {
                 subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
                 no_cross_dex_sell_detail: Some(NoCrossDexSellDetailReason::SellQuoteNone),
+                ..
             })
-        );
+        ));
+        if let RoundTripSelectFailure::InsufficientPools(insufficient) = err {
+            let counts = insufficient
+                .sell_quote_none_detail_counts
+                .expect("sell quote none subcounts");
+            assert_eq!(
+                counts.get(&SellQuoteNoneDetailReason::ReservesImplausible),
+                Some(&1)
+            );
+        }
     }
 
     #[test]
@@ -1910,6 +2229,7 @@ mod tests {
             RoundTripSelectFailure::InsufficientPools(RoundTripInsufficient {
                 subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
                 no_cross_dex_sell_detail: Some(NoCrossDexSellDetailReason::SellMissingVault),
+                sell_quote_none_detail_counts: None,
             })
         );
     }
@@ -1945,6 +2265,7 @@ mod tests {
             RoundTripSelectFailure::InsufficientPools(RoundTripInsufficient {
                 subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
                 no_cross_dex_sell_detail: Some(NoCrossDexSellDetailReason::SellMissingDlmmBins),
+                sell_quote_none_detail_counts: None,
             })
         );
     }
@@ -1965,7 +2286,7 @@ mod tests {
             Instant::now(),
             6,
         );
-        assert_eq!(reason, NoCrossDexSellDetailReason::SellMissingVault);
+        assert_eq!(reason, Some(CrossDexSellFailure::MissingVault));
     }
 
     #[test]
@@ -2001,5 +2322,176 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err, RoundTripSelectFailure::IncompatibleQuoteKind);
+    }
+
+    #[test]
+    fn diagnose_sell_quote_none_state_stale() {
+        let pool = sample_pool("orca", "stale");
+        let mut vault = sample_vault(1_000_000_000_000, 1_000_000_000);
+        vault.updated_at = Instant::now() - Duration::from_secs(300);
+        let reason = diagnose_sell_quote_none(
+            &pool,
+            Some(&vault),
+            None,
+            1_000_000,
+            &QuoteFreshnessConfig::default(),
+            Instant::now(),
+        );
+        assert_eq!(reason, SellQuoteNoneDetailReason::StateStale);
+    }
+
+    #[test]
+    fn diagnose_sell_quote_none_reserves_implausible() {
+        let pool = sample_pool("pump_amm", "bad");
+        let vault = sample_vault(0, 1_000_000_000);
+        let reason = diagnose_sell_quote_none(
+            &pool,
+            Some(&vault),
+            None,
+            1_000,
+            &QuoteFreshnessConfig::default(),
+            Instant::now(),
+        );
+        assert_eq!(reason, SellQuoteNoneDetailReason::ReservesImplausible);
+    }
+
+    #[test]
+    fn diagnose_sell_quote_none_trade_fallback_none() {
+        let pool = sample_pool("orca", "noTrade");
+        let reason = diagnose_sell_quote_none(
+            &pool,
+            None,
+            None,
+            1_000,
+            &QuoteFreshnessConfig::default(),
+            Instant::now(),
+        );
+        assert_eq!(reason, SellQuoteNoneDetailReason::TradeFallbackNone);
+    }
+
+    #[test]
+    fn diagnose_sell_quote_none_dlmm_active_bin_missing() {
+        let pool = sample_pool("meteora_dlmm", "dlmm");
+        let vault = QuoteVaultInput {
+            reserve_base: 1_000_000_000_000,
+            reserve_quote: 1_000_000_000,
+            update_slot: 1,
+            updated_at: Instant::now(),
+            active_id: Some(100),
+            bin_step: Some(100),
+            dlmm_sol_is_x: false,
+            dlmm_token_x_mint: Some(pool.token_mint.clone()),
+        };
+        let bins: DlmmBinArrays = HashMap::new();
+        let reason = diagnose_sell_quote_none(
+            &pool,
+            Some(&vault),
+            Some(&bins),
+            1_000_000,
+            &QuoteFreshnessConfig::default(),
+            Instant::now(),
+        );
+        assert_eq!(reason, SellQuoteNoneDetailReason::DlmmActiveBinMissing);
+    }
+
+    #[test]
+    fn classify_cross_dex_sell_failure_ok_returns_none() {
+        let pool = sample_pool("orca", "poolO");
+        let vault = sample_vault(1_000_000_000_000, 1_000_000_000);
+        let candidate = RoundTripPoolCandidate {
+            pool: &pool,
+            vault: Some(&vault),
+            dlmm_bins: None,
+            dex: "orca",
+        };
+        let failure = classify_cross_dex_sell_failure(
+            &candidate,
+            1_000_000,
+            &QuoteFreshnessConfig::default(),
+            Instant::now(),
+            6,
+        );
+        assert!(failure.is_none());
+    }
+
+    #[test]
+    fn dlmm_sell_large_token_amount_succeeds_without_marginal_probe_gate() {
+        let active_id = 0i32;
+        let bin_step = 100u16;
+        let token_amount = 1_000_000_000_000u64;
+        let sol_amount = 1_000_000_000u64;
+        let array_index = active_id as i64 / 70;
+        let mut bins: DlmmBinArrays = HashMap::new();
+        bins.insert(
+            array_index,
+            vec![BinData {
+                offset: 0,
+                amount_x: token_amount,
+                amount_y: sol_amount,
+            }],
+        );
+        let pool = sample_pool("meteora_dlmm", "dlmm");
+        let vault = QuoteVaultInput {
+            reserve_base: token_amount,
+            reserve_quote: sol_amount,
+            update_slot: 1,
+            updated_at: Instant::now(),
+            active_id: Some(active_id),
+            bin_step: Some(bin_step),
+            dlmm_sol_is_x: false,
+            dlmm_token_x_mint: Some(pool.token_mint.clone()),
+        };
+        let buy_quote = quote_exact_in(
+            &pool,
+            Some(&vault),
+            Some(&bins),
+            NATIVE_SOL_MINT,
+            &pool.token_mint,
+            DLMM_PROBE_SOL_LAMPORTS,
+        )
+        .expect("buy");
+        let sell_quote = quote_exact_in(
+            &pool,
+            Some(&vault),
+            Some(&bins),
+            &pool.token_mint,
+            NATIVE_SOL_MINT,
+            buy_quote.amount_out,
+        );
+        assert!(
+            sell_quote.is_some(),
+            "large DLMM sell must not fail marginal probe gate"
+        );
+    }
+
+    #[test]
+    fn select_round_trip_pools_cross_dex_sell_with_capped_token_amount() {
+        let pool_a = sample_pool("orca", "poolA");
+        let pool_b = sample_pool("pump_amm", "poolB");
+        let vault_a = sample_vault(1_000_000_000_000, 900_000_000);
+        let vault_b = sample_vault(1_000, 1_100_000_000);
+        let candidates = [
+            RoundTripPoolCandidate {
+                pool: &pool_a,
+                vault: Some(&vault_a),
+                dlmm_bins: None,
+                dex: "orca",
+            },
+            RoundTripPoolCandidate {
+                pool: &pool_b,
+                vault: Some(&vault_b),
+                dlmm_bins: None,
+                dex: "pump_amm",
+            },
+        ];
+        let selection = select_round_trip_pools(
+            &candidates,
+            DLMM_PROBE_SOL_LAMPORTS,
+            &QuoteFreshnessConfig::default(),
+        )
+        .expect("capped sell should enable cross-dex pair");
+        assert_eq!(selection.buy_pool_address, "poolA");
+        assert_eq!(selection.sell_pool_address, "poolB");
+        assert!(selection.sell_quote.amount_out > 0);
     }
 }

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -31,12 +31,12 @@ use uuid::Uuid;
 use ironcrab::arbitrage::{
     classify_cross_dex_sell_failure, dlmm_marginal_price_plausible, dlmm_sol_output_from_bins,
     dlmm_token_output_from_bins, is_quote_fresh, populate_arb_slave_from_live_pool_cache,
-    quote_exact_in, quote_exact_in_with_freshness, quotes_pairable, round_trip_profit_lamports,
-    select_round_trip_pools, sync_arb_slave_from_pool_cache_update, MultiHopArbitrage,
-    MultiHopConfig, MultiHopIntentBatch, NoCrossDexSellDetailReason, PoolQuote,
-    QuoteFreshnessConfig, QuotePoolInput, QuoteVaultInput, RoundTripInsufficient,
+    quote_exact_in, quote_exact_in_with_freshness, quote_sell_round_trip, quotes_pairable,
+    round_trip_profit_lamports, select_round_trip_pools, sync_arb_slave_from_pool_cache_update,
+    MultiHopArbitrage, MultiHopConfig, MultiHopIntentBatch, NoCrossDexSellDetailReason, PoolQuote,
+    QuoteFreshnessConfig, QuoteKind, QuotePoolInput, QuoteVaultInput, RoundTripInsufficient,
     RoundTripInsufficientSubreason, RoundTripLeg, RoundTripPoolCandidate, RoundTripSelectFailure,
-    DLMM_PROBE_SOL_LAMPORTS,
+    SellQuoteNoneDetailReason, DLMM_PROBE_SOL_LAMPORTS,
 };
 use ironcrab::config::Config as AppConfig;
 use ironcrab::execution::live_pool_cache::{
@@ -69,7 +69,8 @@ use ironcrab::metrics::{
     arb_two_hop_rejected_inc, arb_two_hop_tracker_seeded_pools_add,
     arb_two_hop_v2_incompatible_kind_inc, arb_two_hop_v2_insufficient_subreason_inc,
     arb_two_hop_v2_no_cross_dex_sell_detail_inc, arb_two_hop_v2_rejected_inc,
-    arb_two_hop_v2_screen_inc, arb_two_hop_v2_screen_multi_dex_inc, record_arb_heartbeat_phase,
+    arb_two_hop_v2_screen_inc, arb_two_hop_v2_screen_multi_dex_inc,
+    arb_two_hop_v2_sell_quote_none_detail_inc, record_arb_heartbeat_phase,
     record_arb_price_freshness_stale_age_ms, record_arb_proactive_pin_first_publish,
     record_arb_proactive_track_publish_total, record_arb_quote_pair_slot_delta,
     record_arb_quote_shadow_round_trip, record_arb_track_requests_messages_total,
@@ -83,14 +84,14 @@ use ironcrab::metrics::{
     ArbStrategyWarmupSkipReason, ArbTrackerWriteJobType, ArbTwoHopInsufficientSubreason,
     ArbTwoHopPoolGate, ArbTwoHopRejectReason, ArbTwoHopRejectSubreason,
     ArbTwoHopV2InsufficientSubreason, ArbTwoHopV2NoCrossDexSellDetail, ArbTwoHopV2RejectReason,
-    ArbWriterLockKind, MetricsComponent, ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH,
-    ARB_REJECTED_MISSING_ACCOUNTS, ARB_SUBSCRIBER_HIGH_PROCESSED_TOTAL,
-    ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH, ARB_TRACKER_WRITE_COALESCER_PENDING,
-    ARB_TRACKER_WRITE_CURRENT_JOB_STARTED_UNIX_MS, ARB_TRACKER_WRITE_CURRENT_JOB_TYPE,
-    ARB_TRACKER_WRITE_QUEUE_DEPTH, ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH,
-    ARB_TRIANGLE_OPPORTUNITIES, INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL,
-    NATS_MESSAGES_PUBLISHED_TOTAL, NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE,
-    TOKENS_TRACKED_GAUGE,
+    ArbTwoHopV2SellQuoteNoneDetail, ArbWriterLockKind, MetricsComponent,
+    ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH, ARB_REJECTED_MISSING_ACCOUNTS,
+    ARB_SUBSCRIBER_HIGH_PROCESSED_TOTAL, ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH,
+    ARB_TRACKER_WRITE_COALESCER_PENDING, ARB_TRACKER_WRITE_CURRENT_JOB_STARTED_UNIX_MS,
+    ARB_TRACKER_WRITE_CURRENT_JOB_TYPE, ARB_TRACKER_WRITE_QUEUE_DEPTH,
+    ARB_TRACKER_WRITE_SECONDS_SINCE_LAST_FINISH, ARB_TRIANGLE_OPPORTUNITIES,
+    INTENTS_GENERATED_TOTAL, MARKET_EVENTS_CONSUMED_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
+    NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     arb_strategy_pool_cache_live_consumer_config, arb_track_payload_bytes, config_consumer_config,
@@ -1601,6 +1602,9 @@ struct PoolV2EligibilityRow {
     sell_quote_ok: bool,
     sell_quote_fresh: bool,
     sell_fail_reason: Option<String>,
+    sell_quote_none_reason: Option<String>,
+    token_amount_in: Option<u64>,
+    sell_quote_kind: Option<String>,
 }
 
 /// Aggregated mint-level v2 eligibility breakdown for rate-limited snapshots.
@@ -1694,6 +1698,9 @@ impl ArbV2EligibilityForensics {
                         "sell_quote_ok": row.sell_quote_ok,
                         "sell_quote_fresh": row.sell_quote_fresh,
                         "sell_fail_reason": row.sell_fail_reason,
+                        "sell_quote_none_reason": row.sell_quote_none_reason,
+                        "token_amount_in": row.token_amount_in,
+                        "sell_quote_kind": row.sell_quote_kind,
                     })
                 })
                 .collect();
@@ -1771,12 +1778,46 @@ fn v2_no_cross_dex_sell_detail_to_metric(
     }
 }
 
-fn record_v2_insufficient_subreason(insufficient: RoundTripInsufficient) {
+fn v2_sell_quote_none_detail_to_metric(
+    detail: SellQuoteNoneDetailReason,
+) -> ArbTwoHopV2SellQuoteNoneDetail {
+    match detail {
+        SellQuoteNoneDetailReason::StateStale => ArbTwoHopV2SellQuoteNoneDetail::StateStale,
+        SellQuoteNoneDetailReason::ReservesImplausible => {
+            ArbTwoHopV2SellQuoteNoneDetail::ReservesImplausible
+        }
+        SellQuoteNoneDetailReason::DlmmActiveBinMissing => {
+            ArbTwoHopV2SellQuoteNoneDetail::DlmmActiveBinMissing
+        }
+        SellQuoteNoneDetailReason::DlmmWalkerZero => ArbTwoHopV2SellQuoteNoneDetail::DlmmWalkerZero,
+        SellQuoteNoneDetailReason::DlmmMarginalReject => {
+            ArbTwoHopV2SellQuoteNoneDetail::DlmmMarginalReject
+        }
+        SellQuoteNoneDetailReason::CpmmMathNone => ArbTwoHopV2SellQuoteNoneDetail::CpmmMathNone,
+        SellQuoteNoneDetailReason::UnsupportedDex => ArbTwoHopV2SellQuoteNoneDetail::UnsupportedDex,
+        SellQuoteNoneDetailReason::TradeFallbackNone => {
+            ArbTwoHopV2SellQuoteNoneDetail::TradeFallbackNone
+        }
+        SellQuoteNoneDetailReason::MintDirectionInvalid => {
+            ArbTwoHopV2SellQuoteNoneDetail::MintDirectionInvalid
+        }
+    }
+}
+
+fn record_v2_insufficient_subreason(insufficient: &RoundTripInsufficient) {
     arb_two_hop_v2_insufficient_subreason_inc(v2_insufficient_subreason_to_metric(
         insufficient.subreason,
     ));
     if let Some(detail) = insufficient.no_cross_dex_sell_detail {
         arb_two_hop_v2_no_cross_dex_sell_detail_inc(v2_no_cross_dex_sell_detail_to_metric(detail));
+    }
+    if let Some(counts) = &insufficient.sell_quote_none_detail_counts {
+        for (reason, count) in counts {
+            let metric = v2_sell_quote_none_detail_to_metric(*reason);
+            for _ in 0..*count {
+                arb_two_hop_v2_sell_quote_none_detail_inc(metric);
+            }
+        }
     }
 }
 
@@ -2281,8 +2322,8 @@ impl TokenArbTracker {
         let distinct_dexes: HashSet<&str> = candidates.iter().map(|c| c.dex).collect();
         let now = Instant::now();
 
-        let mut best_buy_amount_out: Option<u64> = None;
-        let mut best_buy_quote: Option<PoolQuote> = None;
+        let mut pairing_token_amount: Option<u64> = None;
+        let mut pairing_buy_quote: Option<PoolQuote> = None;
         for candidate in &candidates {
             let buy_quote = quote_exact_in_with_freshness(
                 candidate.pool,
@@ -2299,13 +2340,13 @@ impl TokenArbTracker {
             if !is_quote_fresh(&buy_quote, freshness, candidate.vault, now) {
                 continue;
             }
-            let replace = match best_buy_amount_out {
+            let replace = match pairing_token_amount {
                 None => true,
                 Some(current) => buy_quote.amount_out > current,
             };
             if replace {
-                best_buy_amount_out = Some(buy_quote.amount_out);
-                best_buy_quote = Some(buy_quote);
+                pairing_token_amount = Some(buy_quote.amount_out);
+                pairing_buy_quote = Some(buy_quote);
             }
         }
 
@@ -2326,36 +2367,57 @@ impl TokenArbTracker {
                 .as_ref()
                 .is_some_and(|q| is_quote_fresh(q, freshness, candidate.vault, now));
 
-            let (sell_quote_ok, sell_quote_fresh) = if let (Some(token_amount), Some(buy_q)) =
-                (best_buy_amount_out, best_buy_quote.as_ref())
+            let token_amount_in = pairing_token_amount;
+            let (
+                sell_quote_ok,
+                sell_quote_fresh,
+                sell_quote,
+                sell_fail_reason,
+                sell_quote_none_reason,
+            ) = if let (Some(token_amount), Some(buy_q)) =
+                (token_amount_in, pairing_buy_quote.as_ref())
             {
-                let sell_quote = quote_exact_in_with_freshness(
-                    candidate.pool,
-                    candidate.vault,
-                    candidate.dlmm_bins,
-                    &candidate.pool.token_mint,
-                    NATIVE_SOL_MINT,
-                    token_amount,
-                    freshness,
-                );
+                let sell_quote = if let Some(vault) = candidate.vault {
+                    quote_sell_round_trip(
+                        candidate.pool,
+                        vault,
+                        candidate.dlmm_bins,
+                        token_amount,
+                        freshness,
+                    )
+                } else {
+                    None
+                };
                 let ok = sell_quote.is_some();
                 let fresh = sell_quote.as_ref().is_some_and(|q| {
                     is_quote_fresh(q, freshness, candidate.vault, now) && quotes_pairable(buy_q, q)
                 });
-                (ok, fresh)
+                let failure = if ok {
+                    None
+                } else {
+                    classify_cross_dex_sell_failure(
+                        candidate,
+                        token_amount,
+                        freshness,
+                        now,
+                        token_decimals,
+                    )
+                };
+                let fail = failure
+                    .as_ref()
+                    .map(|f| f.as_top_level_detail().as_metric_label().to_string());
+                let none_reason = failure
+                    .and_then(|f| f.sell_quote_none_subreason())
+                    .map(|sub| sub.as_metric_label().to_string());
+                (ok, fresh, sell_quote, fail, none_reason)
             } else {
-                (false, false)
+                (false, false, None, None, None)
             };
-
-            let sell_fail_reason = best_buy_amount_out.map(|token_amount| {
-                classify_cross_dex_sell_failure(
-                    candidate,
-                    token_amount,
-                    freshness,
-                    now,
-                    token_decimals,
-                )
-                .as_metric_label()
+            let sell_quote_kind = sell_quote.as_ref().map(|q| {
+                match q.kind {
+                    QuoteKind::ExecutableMarginal => "executable_marginal",
+                    QuoteKind::LastTradeMid => "last_trade_mid",
+                }
                 .to_string()
             });
 
@@ -2370,6 +2432,9 @@ impl TokenArbTracker {
                 sell_quote_ok,
                 sell_quote_fresh,
                 sell_fail_reason,
+                sell_quote_none_reason,
+                token_amount_in,
+                sell_quote_kind,
             });
         }
 
@@ -2430,7 +2495,7 @@ impl TokenArbTracker {
         let selection = match select_round_trip_pools(&candidates, probe, &freshness) {
             Ok(selection) => selection,
             Err(RoundTripSelectFailure::InsufficientPools(insufficient)) => {
-                record_v2_insufficient_subreason(insufficient);
+                record_v2_insufficient_subreason(&insufficient);
                 arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::InsufficientPools);
                 if let Some(collector) = v2_forensics {
                     let breakdown = self.build_v2_eligibility_breakdown(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3053,6 +3053,24 @@ pub static ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_NOT_FRESH: Lazy<AtomicU6
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_ZERO_OUT: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_STATE_STALE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_RESERVES_IMPLAUSIBLE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_DLMM_ACTIVE_BIN_MISSING: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_DLMM_WALKER_ZERO: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_DLMM_MARGINAL_REJECT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_CPMM_MATH_NONE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_UNSUPPORTED_DEX: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_TRADE_FALLBACK_NONE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_MINT_DIRECTION_INVALID: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 pub static ARB_PROACTIVE_TRACK_PUBLISH_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
 const ARB_QUOTE_PAIR_SLOT_DELTA_BUCKETS: &[u64] = &[0, 1, 2, 3, 4, 5, 8, 16, 32];
@@ -3571,6 +3589,54 @@ pub fn arb_two_hop_v2_no_cross_dex_sell_detail_inc(reason: ArbTwoHopV2NoCrossDex
         }
         ArbTwoHopV2NoCrossDexSellDetail::SellZeroOut => {
             &*ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_ZERO_OUT
+        }
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Drill-down reason for `arb_two_hop_v2_sell_quote_none_detail_total{reason=...}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArbTwoHopV2SellQuoteNoneDetail {
+    StateStale,
+    ReservesImplausible,
+    DlmmActiveBinMissing,
+    DlmmWalkerZero,
+    DlmmMarginalReject,
+    CpmmMathNone,
+    UnsupportedDex,
+    TradeFallbackNone,
+    MintDirectionInvalid,
+}
+
+/// Increment `arb_two_hop_v2_sell_quote_none_detail_total{reason=...}`.
+pub fn arb_two_hop_v2_sell_quote_none_detail_inc(reason: ArbTwoHopV2SellQuoteNoneDetail) {
+    let counter = match reason {
+        ArbTwoHopV2SellQuoteNoneDetail::StateStale => {
+            &*ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_STATE_STALE
+        }
+        ArbTwoHopV2SellQuoteNoneDetail::ReservesImplausible => {
+            &*ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_RESERVES_IMPLAUSIBLE
+        }
+        ArbTwoHopV2SellQuoteNoneDetail::DlmmActiveBinMissing => {
+            &*ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_DLMM_ACTIVE_BIN_MISSING
+        }
+        ArbTwoHopV2SellQuoteNoneDetail::DlmmWalkerZero => {
+            &*ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_DLMM_WALKER_ZERO
+        }
+        ArbTwoHopV2SellQuoteNoneDetail::DlmmMarginalReject => {
+            &*ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_DLMM_MARGINAL_REJECT
+        }
+        ArbTwoHopV2SellQuoteNoneDetail::CpmmMathNone => {
+            &*ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_CPMM_MATH_NONE
+        }
+        ArbTwoHopV2SellQuoteNoneDetail::UnsupportedDex => {
+            &*ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_UNSUPPORTED_DEX
+        }
+        ArbTwoHopV2SellQuoteNoneDetail::TradeFallbackNone => {
+            &*ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_TRADE_FALLBACK_NONE
+        }
+        ArbTwoHopV2SellQuoteNoneDetail::MintDirectionInvalid => {
+            &*ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_MINT_DIRECTION_INVALID
         }
     };
     counter.fetch_add(1, Ordering::Relaxed);
@@ -4355,6 +4421,74 @@ fn append_arb_two_hop_v2_no_cross_dex_sell_detail_total(out: &mut String) {
     out.push_str("arb_two_hop_v2_no_cross_dex_sell_detail_total{reason=\"sell_zero_out\"} ");
     out.push_str(
         &ARB_TWO_HOP_V2_NO_CROSS_DEX_SELL_DETAIL_SELL_ZERO_OUT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+}
+
+fn append_arb_two_hop_v2_sell_quote_none_detail_total(out: &mut String) {
+    out.push_str("arb_two_hop_v2_sell_quote_none_detail_total{reason=\"state_stale\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_STATE_STALE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_sell_quote_none_detail_total{reason=\"reserves_implausible\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_RESERVES_IMPLAUSIBLE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str(
+        "arb_two_hop_v2_sell_quote_none_detail_total{reason=\"dlmm_active_bin_missing\"} ",
+    );
+    out.push_str(
+        &ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_DLMM_ACTIVE_BIN_MISSING
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_sell_quote_none_detail_total{reason=\"dlmm_walker_zero\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_DLMM_WALKER_ZERO
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_sell_quote_none_detail_total{reason=\"dlmm_marginal_reject\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_DLMM_MARGINAL_REJECT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_sell_quote_none_detail_total{reason=\"cpmm_math_none\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_CPMM_MATH_NONE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_sell_quote_none_detail_total{reason=\"unsupported_dex\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_UNSUPPORTED_DEX
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_sell_quote_none_detail_total{reason=\"trade_fallback_none\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_TRADE_FALLBACK_NONE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_sell_quote_none_detail_total{reason=\"mint_direction_invalid\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_MINT_DIRECTION_INVALID
             .load(Ordering::Relaxed)
             .to_string(),
     );
@@ -7012,6 +7146,7 @@ async fn metrics_response() -> Response<Body> {
     );
     append_arb_two_hop_v2_insufficient_subreason_total(&mut out);
     append_arb_two_hop_v2_no_cross_dex_sell_detail_total(&mut out);
+    append_arb_two_hop_v2_sell_quote_none_detail_total(&mut out);
     append_momentum_latency_histogram_prometheus(
         &mut out,
         "arb_quote_pair_slot_delta",
@@ -8508,6 +8643,38 @@ mod arb_two_hop_subreason_metrics_tests {
             assert!(
                 out.contains(&format!("reason=\"{label}\"")),
                 "missing reject label {label}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod arb_two_hop_v2_sell_quote_none_detail_metrics_tests {
+    use super::*;
+
+    #[test]
+    fn sell_quote_none_detail_inc_and_prometheus_labels() {
+        let before = ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_STATE_STALE.load(Ordering::Relaxed);
+        arb_two_hop_v2_sell_quote_none_detail_inc(ArbTwoHopV2SellQuoteNoneDetail::StateStale);
+        let after = ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_STATE_STALE.load(Ordering::Relaxed);
+        assert_eq!(after, before + 1);
+
+        let mut out = String::new();
+        append_arb_two_hop_v2_sell_quote_none_detail_total(&mut out);
+        for label in [
+            "state_stale",
+            "reserves_implausible",
+            "dlmm_active_bin_missing",
+            "dlmm_walker_zero",
+            "dlmm_marginal_reject",
+            "cpmm_math_none",
+            "unsupported_dex",
+            "trade_fallback_none",
+            "mint_direction_invalid",
+        ] {
+            assert!(
+                out.contains(&format!("reason=\"{label}\"")),
+                "missing sell_quote_none detail label {label}"
             );
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Sub-metrics for `sell_quote_none` (`arb_two_hop_v2_sell_quote_none_detail_total{reason=...}`) via `diagnose_sell_quote_none` — no RPC, existing inputs only
- Fix dominant root causes in quote / round-trip pairing layer
- v2 snapshot: accurate `sell_fail_reason`, optional `sell_quote_none_reason`, `token_amount_in`, `sell_quote_kind`

## Prod context

After P1 (#265), `sell_quote_none` is ~39% of remaining `no_cross_dex_sell`; vault/bins often present but sell leg returns `None`.

## Changes

### Forensics (`pool_quote.rs`, `metrics.rs`)
- `SellQuoteNoneDetailReason` enum with 9 fixed labels (state_stale, reserves_implausible, dlmm_*, cpmm_math_none, trade_fallback_none, …)
- `diagnose_sell_quote_none()` mirrors executable + fallback failure paths
- `select_round_trip_pools` counts sub-reasons per sell-None; `RoundTripInsufficient.sell_quote_none_detail_counts`
- `state_stale` reclassified to top-level `sell_not_fresh`

### Root-cause fixes (`pool_quote.rs`)
- **DLMM sell:** skip `dlmm_marginal_price_plausible` probe gate on `QuoteSide::Sell` (large buy token amounts have expected slippage vs reserve mid)
- **Pairing cap:** `quote_sell_round_trip` caps token input to DLMM bin depth / CPMM realizable reserves before quoting
- `classify_cross_dex_sell_failure` returns `Option` (`None` = success) — fixes misleading snapshot lines

### Snapshot fix (`arb_strategy.rs`)
- `sell_fail_reason` only set when sell quote actually fails
- Sell probe uses best **valid buy** from pairing context (not blind max over all pools)
- New fields: `sell_quote_none_reason`, `token_amount_in`, `sell_quote_kind`

## STOP-CHECK (performed)
1. I-7 Hot Path RPC: no new RPC calls
2. Pattern consistency: cap + diagnose follow existing freshness / vault patterns
3. Scope: only allowed files touched
4. I-9 Simulation-Gate: unchanged
5. Level-5: no eval test reads

## Verification
- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test` ✓ (incl. `pool_quote`, `select_round_trip`, `sell_quote_none`)

## Expected prod impact (post-deploy)
- `sell_quote_none` share of `no_cross_dex_sell` details should drop
- `no_cross_dex_sell` vs insufficient should continue falling
- Journal snapshots: `sell_fail_reason` consistent with `sell_quote_ok`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13366366-888b-4681-9409-a3491c8c3d5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13366366-888b-4681-9409-a3491c8c3d5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

