### PR TITLE
fix(market-data): Phase 1 P1 Universal TX — Creator/DevWallet without hot-set dependency

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -7631,7 +7631,7 @@ async fn handle_geyser_transaction(
             );
         }
 
-        // Phase-R-R4: pool_mint_map + DevWallet off hot path (`md-sidefx`).
+        // Phase-R-R4 / P1: pool_mint_map + DevWallet (creator_override) off hot path (`md-sidefx`).
         match parsed {
             ParsedDexEvent::PoolCreated {
                 pool_address,
@@ -7681,31 +7681,6 @@ async fn handle_geyser_transaction(
             md_sidefx,
             MdSidefxCommand::TradePoolLruTouch {
                 pool: *pool_address,
-            },
-        );
-    }
-
-    // Pump.fun: propagate creator/dev wallet so strategy can build deterministic intents.
-    // The PoolCreated MarketEventKind intentionally does not carry creator today, so emit
-    // a separate DevWalletIdentified event when available.
-    // Also cache the creator for later Trade events.
-    if let Some(ParsedDexEvent::PoolCreated {
-        pool_address,
-        base_mint,
-        dex: DexType::PumpFun,
-        creator: Some(creator),
-        ..
-    }) = parsed_event.as_ref()
-    {
-        md_sidefx_try_enqueue(
-            md_sidefx,
-            MdSidefxCommand::PumpFunDevWalletFromPoolCreated {
-                run_id: run_id.to_string(),
-                pool_address: *pool_address,
-                base_mint: *base_mint,
-                creator: *creator,
-                slot: tx_update.slot,
-                tx_geyser_recv_at,
             },
         );
     }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -89,7 +89,8 @@ use ironcrab::metrics::{
     geyser_metrics_set_subscription_accounts, geyser_metrics_set_tracked_pinned_accounts,
     inc_market_data_account_high_priority_queue_depth,
     inc_market_data_account_low_priority_queue_depth, inc_market_data_account_worker_queue_depth,
-    inc_market_data_balance_updated_from_cache_total, inc_market_data_geyser_sync_partial_total,
+    inc_market_data_balance_updated_from_cache_total, inc_market_data_devwallet_tx_published_total,
+    inc_market_data_geyser_sync_partial_total,
     inc_market_data_geyser_sync_skipped_rate_limit_total,
     inc_market_data_ingest_membership_snapshot_hits_total,
     inc_market_data_jsonl_enqueue_dropped_total,
@@ -6632,8 +6633,41 @@ async fn account_worker_recv_next(
     }
 }
 
-/// After `pool_mint_map` insert on the TX path: emit `DevWalletIdentified` if bonding-curve cache
-/// already holds authoritative creator (no Swap parsing; I-4 / BUG-D).
+/// Resolve PumpFun creator on TX ingest (P1): parse → mint cache → pool cache → LivePoolCache (no RPC).
+fn resolve_pumpfun_creator_tx_path(
+    ctx: &MarketDataContext,
+    pool_address: &str,
+    mint: &str,
+    pool_pubkey: &Pubkey,
+    parsed_creator: Option<&Pubkey>,
+) -> Option<String> {
+    if let Some(c) = parsed_creator {
+        return Some(c.to_string());
+    }
+    {
+        let cache = ctx.creator_cache.read();
+        if let Some(c) = cache.get(mint) {
+            if !c.is_empty() {
+                return Some(c.clone());
+            }
+        }
+    }
+    {
+        let pool_cache = ctx.pool_creator_cache.read();
+        if let Some(c) = pool_cache.get(pool_address) {
+            if !c.is_empty() {
+                return Some(c.clone());
+            }
+        }
+    }
+    ctx.live_pool_cache
+        .get_pumpfun_creator(pool_pubkey)
+        .filter(|pk| *pk != Pubkey::default())
+        .map(|pk| pk.to_string())
+}
+
+/// After `pool_mint_map` insert on the TX path: emit `DevWalletIdentified` when creator is known
+/// from TX parse, pool_creator_cache, or LivePoolCache (no Swap parsing; I-4 / BUG-D).
 ///
 /// NATS: when `publish_tx` is set (same channel as dedicated publish runtime), enqueue only —
 /// avoids blocking the TX ingest task on Core NATS backpressure (PR151 follow-up).
@@ -6649,12 +6683,28 @@ async fn maybe_emit_dev_wallet_after_pool_mint_map(
     tx_grpc_recv_at: Instant,
     publish_tx: Option<&mpsc::Sender<AccountPathNatsJob>>,
     nats: Option<&NatsClient>,
+    creator_override: Option<&str>,
 ) -> bool {
     let pool_str = pool.to_string();
-    let creator_str = match ctx.pool_creator_cache.read().get(&pool_str).cloned() {
-        Some(s) if !s.is_empty() => s,
-        _ => return false,
+    let creator_str = if let Some(c) = creator_override.filter(|s| !s.is_empty()) {
+        c.to_string()
+    } else if let Some(s) = ctx
+        .pool_creator_cache
+        .read()
+        .get(&pool_str)
+        .cloned()
+        .filter(|s| !s.is_empty())
+    {
+        s
+    } else {
+        match ctx.live_pool_cache.get_pumpfun_creator(pool) {
+            Some(pk) if pk != Pubkey::default() => pk.to_string(),
+            _ => return false,
+        }
     };
+    ctx.pool_creator_cache
+        .write()
+        .insert(pool_str.clone(), creator_str.clone());
     let existing = {
         let mut creator_cache = ctx.creator_cache.write();
         let existing = creator_cache.get(mint).cloned();
@@ -6680,12 +6730,14 @@ async fn maybe_emit_dev_wallet_after_pool_mint_map(
     }
     let publish_at = Instant::now();
     record_market_data_pool_mint_map_to_devwallet_ms(tx_grpc_recv_at, publish_at);
+    inc_market_data_devwallet_tx_published_total();
     info!(
         mint = %mint,
         pool = %pool_str,
         creator = %creator_str,
         corrected = existing.is_some(),
-        "DevWalletIdentified from TX path after pool_mint_map (creator from pool_creator_cache)"
+        had_override = creator_override.is_some(),
+        "DevWalletIdentified from TX path after pool_mint_map (P1 creator)"
     );
     let dev_event = MarketEvent::new(
         "market-data",
@@ -7584,6 +7636,7 @@ async fn handle_geyser_transaction(
             ParsedDexEvent::PoolCreated {
                 pool_address,
                 base_mint,
+                creator,
                 dex: DexType::PumpFun,
                 ..
             } => {
@@ -7595,12 +7648,14 @@ async fn handle_geyser_transaction(
                         mint_str: base_mint.to_string(),
                         slot: Some(tx_update.slot),
                         tx_grpc_recv_at: tx_update.grpc_recv_at,
+                        creator_override: *creator,
                     },
                 );
             }
             ParsedDexEvent::Trade {
                 pool_address,
                 mint,
+                creator,
                 dex: DexType::PumpFun,
                 ..
             } => {
@@ -7612,6 +7667,7 @@ async fn handle_geyser_transaction(
                         mint_str: mint.to_string(),
                         slot: Some(tx_update.slot),
                         tx_grpc_recv_at: tx_update.grpc_recv_at,
+                        creator_override: *creator,
                     },
                 );
             }
@@ -7634,6 +7690,7 @@ async fn handle_geyser_transaction(
     // a separate DevWalletIdentified event when available.
     // Also cache the creator for later Trade events.
     if let Some(ParsedDexEvent::PoolCreated {
+        pool_address,
         base_mint,
         dex: DexType::PumpFun,
         creator: Some(creator),
@@ -7644,6 +7701,7 @@ async fn handle_geyser_transaction(
             md_sidefx,
             MdSidefxCommand::PumpFunDevWalletFromPoolCreated {
                 run_id: run_id.to_string(),
+                pool_address: *pool_address,
                 base_mint: *base_mint,
                 creator: *creator,
                 slot: tx_update.slot,
@@ -7819,6 +7877,15 @@ async fn handle_geyser_transaction(
         return;
     };
 
+    let pumpfun_trade_creator = match &parsed {
+        ParsedDexEvent::Trade {
+            dex: DexType::PumpFun,
+            creator,
+            ..
+        } => creator.as_ref(),
+        _ => None,
+    };
+
     info!(
         slot = tx_update.slot,
         sig = %tx_update.signature,
@@ -7826,7 +7893,7 @@ async fn handle_geyser_transaction(
     );
     let mut kind = parsed.to_market_event_kind();
 
-    // Enrich Trade events with creator from cache (P0: PumpFun intent building)
+    // Enrich Trade events with creator (P1 TX path: parse → caches → LivePoolCache; no RPC)
     if let MarketEventKind::Trade {
         ref pool_address,
         ref mint,
@@ -7836,25 +7903,34 @@ async fn handle_geyser_transaction(
     } = kind
     {
         if dex == "pumpfun" || dex == "pump_amm" {
-            let mut found_creator = None;
-            {
-                let cache = ctx.creator_cache.read();
-                if let Some(cached_creator) = cache.get(mint) {
-                    found_creator = Some(cached_creator.clone());
-                }
-            }
-            if found_creator.is_none() {
-                let pool_cache = ctx.pool_creator_cache.read();
-                if let Some(pool_creator) = pool_cache.get(pool_address) {
-                    found_creator = Some(pool_creator.clone());
-                    drop(pool_cache);
+            if let Ok(pool_pk) = Pubkey::from_str(pool_address) {
+                if let Some(cached_creator) = resolve_pumpfun_creator_tx_path(
+                    &ctx,
+                    pool_address,
+                    mint,
+                    &pool_pk,
+                    pumpfun_trade_creator,
+                ) {
+                    ctx.pool_creator_cache
+                        .write()
+                        .insert(pool_address.clone(), cached_creator.clone());
                     ctx.creator_cache
                         .write()
-                        .insert(mint.clone(), found_creator.clone().unwrap());
+                        .insert(mint.clone(), cached_creator.clone());
+                    *creator = Some(cached_creator.clone());
+                    let _ = maybe_emit_dev_wallet_after_pool_mint_map(
+                        &ctx,
+                        run_id,
+                        &pool_pk,
+                        mint,
+                        Some(tx_update.slot),
+                        tx_geyser_recv_at,
+                        account_publish_tx,
+                        ctx.nats.as_ref(),
+                        Some(cached_creator.as_str()),
+                    )
+                    .await;
                 }
-            }
-            if let Some(cached_creator) = found_creator {
-                *creator = Some(cached_creator.clone());
             }
         }
     }
@@ -11320,6 +11396,7 @@ mod pr_b_geyser_tracking_tests {
                     mint_str: "mint".into(),
                     slot: None,
                     tx_grpc_recv_at: Instant::now(),
+                    creator_override: None,
                 },
             );
         }
@@ -12208,6 +12285,7 @@ mod pr_b_geyser_tracking_tests {
                 grpc_at,
                 Some(&publish_tx),
                 None,
+                Some(creator.to_string().as_str()),
             )
             .await
         );
@@ -12234,6 +12312,7 @@ mod pr_b_geyser_tracking_tests {
                 grpc_at,
                 Some(&publish_tx),
                 None,
+                Some(creator.to_string().as_str()),
             )
             .await,
             "second call with same creator must not re-emit"
@@ -13644,6 +13723,7 @@ mod pr_b_geyser_tracking_tests {
                 mint_str: mint.clone(),
                 slot: Some(99),
                 tx_grpc_recv_at: Instant::now(),
+                creator_override: None,
             },
         );
 
@@ -13653,6 +13733,54 @@ mod pr_b_geyser_tracking_tests {
         assert_eq!(
             ctx.pool_mint_map.read().get(&pool.to_string()).cloned(),
             Some(mint)
+        );
+    }
+
+    /// Phase 1 P1: pool_mint_map + creator_override emits DevWallet without pre-filled pool_creator_cache.
+    #[tokio::test(flavor = "current_thread")]
+    async fn phase1_sidefx_pool_mint_map_emits_devwallet_with_creator_override() {
+        use ironcrab::metrics::MARKET_DATA_DEVWALLET_TX_PUBLISHED_TOTAL;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let md_state = test_spawn_md_state(&ctx);
+        let md_sidefx = test_spawn_md_sidefx(&ctx, &md_state, test_noop_track_worker_sender());
+
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique().to_string();
+        let creator = Pubkey::new_unique();
+        let tx0 = MARKET_DATA_DEVWALLET_TX_PUBLISHED_TOTAL.load(Ordering::Relaxed);
+        md_sidefx_try_enqueue(
+            &md_sidefx,
+            MdSidefxCommand::PumpFunPoolMintMapInsert {
+                run_id: "run-p1".into(),
+                pool_address: pool,
+                mint_str: mint.clone(),
+                slot: Some(42),
+                tx_grpc_recv_at: Instant::now(),
+                creator_override: Some(creator),
+            },
+        );
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            MARKET_DATA_DEVWALLET_TX_PUBLISHED_TOTAL.load(Ordering::Relaxed) > tx0,
+            "creator_override must publish DevWallet on TX path"
+        );
+        assert_eq!(
+            ctx.pool_creator_cache
+                .read()
+                .get(&pool.to_string())
+                .cloned(),
+            Some(creator.to_string()),
+            "pool_creator_cache must be filled from creator_override"
+        );
+        assert_eq!(
+            ctx.creator_cache.read().get(&mint).cloned(),
+            Some(creator.to_string()),
+            "creator_cache must be filled from creator_override"
         );
     }
 

--- a/src/market_data/sidefx/handlers.rs
+++ b/src/market_data/sidefx/handlers.rs
@@ -19,6 +19,7 @@ use crate::ipc::{
     POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use crate::metrics::{
+    inc_market_data_devwallet_bonding_path_total, inc_market_data_devwallet_tx_published_total,
     inc_market_data_pool_state_publish_skipped_balance_unchanged_total,
     record_market_data_bonding_curve_grpc_to_devwallet_ms,
     record_market_data_pool_mint_map_to_devwallet_ms, MarketDataLatencySegment,
@@ -161,12 +162,23 @@ pub fn sidefx_maybe_emit_dev_wallet_after_pool_mint_map(
     mint: &str,
     slot: Option<u64>,
     tx_grpc_recv_at: Instant,
+    creator_override: Option<&str>,
 ) -> bool {
     let pool_str = pool.to_string();
-    let creator_str = match host.pool_creator_cache_get(&pool_str) {
-        Some(s) if !s.is_empty() => s,
-        _ => return false,
+    let creator_str = if let Some(c) = creator_override.filter(|s| !s.is_empty()) {
+        c.to_string()
+    } else if let Some(s) = host
+        .pool_creator_cache_get(&pool_str)
+        .filter(|s| !s.is_empty())
+    {
+        s
+    } else {
+        match host.live_pool_cache().get_pumpfun_creator(pool) {
+            Some(pk) if pk != Pubkey::default() => pk.to_string(),
+            _ => return false,
+        }
     };
+    host.pool_creator_cache_insert(pool_str.clone(), creator_str.clone());
     let existing = host.creator_cache_insert_returning_old(mint.to_string(), creator_str.clone());
     let should_emit = match &existing {
         None => true,
@@ -187,12 +199,14 @@ pub fn sidefx_maybe_emit_dev_wallet_after_pool_mint_map(
     }
     let publish_at = Instant::now();
     record_market_data_pool_mint_map_to_devwallet_ms(tx_grpc_recv_at, publish_at);
+    inc_market_data_devwallet_tx_published_total();
     info!(
         mint = %mint,
         pool = %pool_str,
         creator = %creator_str,
         corrected = existing.is_some(),
-        "DevWalletIdentified from TX path after pool_mint_map (creator from pool_creator_cache)"
+        had_override = creator_override.is_some(),
+        "DevWalletIdentified from TX path after pool_mint_map (P1 creator)"
     );
     let dev_event = MarketEvent::new(
         "market-data",
@@ -231,6 +245,7 @@ pub fn md_sidefx_process_pump_fun_pool_mint_map(
         mint_str,
         slot,
         tx_grpc_recv_at,
+        creator_override,
     } = job
     else {
         return;
@@ -239,6 +254,7 @@ pub fn md_sidefx_process_pump_fun_pool_mint_map(
         host.pool_mint_map_insert(pool_address.to_string(), mint_str.clone());
         host.high_priority_bonding_curves_insert(*pool_address);
     }
+    let override_str = creator_override.as_ref().map(|pk| pk.to_string());
     sidefx_maybe_emit_dev_wallet_after_pool_mint_map(
         host,
         run_id,
@@ -246,6 +262,7 @@ pub fn md_sidefx_process_pump_fun_pool_mint_map(
         mint_str,
         *slot,
         *tx_grpc_recv_at,
+        override_str.as_deref(),
     );
 }
 
@@ -255,6 +272,7 @@ pub fn md_sidefx_process_pump_fun_dev_wallet_from_pool_created(
 ) {
     let MdSidefxCommand::PumpFunDevWalletFromPoolCreated {
         run_id,
+        pool_address,
         base_mint,
         creator,
         slot,
@@ -263,12 +281,17 @@ pub fn md_sidefx_process_pump_fun_dev_wallet_from_pool_created(
     else {
         return;
     };
-    host.creator_cache_set(base_mint.to_string(), creator.to_string());
+    let pool_str = pool_address.to_string();
+    let creator_str = creator.to_string();
+    host.pool_creator_cache_insert(pool_str.clone(), creator_str.clone());
+    host.creator_cache_set(base_mint.to_string(), creator_str.clone());
     debug!(
         mint = %base_mint,
+        pool = %pool_str,
         creator = %creator,
-        "Cached PumpFun creator for Trade enrichment"
+        "Cached PumpFun creator for Trade enrichment (PoolCreated TX path)"
     );
+    inc_market_data_devwallet_tx_published_total();
     let dev_event = MarketEvent::new(
         "market-data",
         host.build_version(),
@@ -872,6 +895,7 @@ pub fn md_sidefx_process_bonding_curve(host: &dyn SidefxWorkerHost, job: &MdSide
                     }),
                 );
             }
+            inc_market_data_devwallet_bonding_path_total();
             record_market_data_bonding_curve_grpc_to_devwallet_ms(*grpc_recv_at, Instant::now());
         }
     }

--- a/src/market_data/sidefx/worker.rs
+++ b/src/market_data/sidefx/worker.rs
@@ -27,9 +27,12 @@ pub enum MdSidefxCommand {
         mint_str: String,
         slot: Option<u64>,
         tx_grpc_recv_at: Instant,
+        /// P1: creator from TX parse when known (avoids pool_creator_cache hen-and-egg).
+        creator_override: Option<Pubkey>,
     },
     PumpFunDevWalletFromPoolCreated {
         run_id: String,
+        pool_address: Pubkey,
         base_mint: Pubkey,
         creator: Pubkey,
         slot: u64,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -948,6 +948,12 @@ pub static MARKET_DATA_MD_SIDEFX_ENQUEUE_DROPPED_TOTAL: Lazy<AtomicU64> =
 /// Phase-R-R4: jobs processed by the `md-sidefx` worker.
 pub static MARKET_DATA_MD_SIDEFX_JOBS_PROCESSED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// Phase 1 P1: `DevWalletIdentified` published from TX ingest (PoolCreated / trade fast-path).
+pub static MARKET_DATA_DEVWALLET_TX_PUBLISHED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Phase 1 P2: `DevWalletIdentified` published from bonding-curve account path.
+pub static MARKET_DATA_DEVWALLET_BONDING_PATH_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 #[inline]
 pub fn record_market_data_tx_handler_processed() {
@@ -1679,6 +1685,16 @@ pub fn inc_market_data_account_low_priority_queue_depth() {
 #[inline]
 pub fn dec_market_data_account_low_priority_queue_depth() {
     MARKET_DATA_ACCOUNT_LOW_PRIORITY_QUEUE_DEPTH.fetch_sub(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_devwallet_tx_published_total() {
+    MARKET_DATA_DEVWALLET_TX_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_devwallet_bonding_path_total() {
+    MARKET_DATA_DEVWALLET_BONDING_PATH_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Wall ms from Geyser `grpc_recv_at` on the TX update to `DevWalletIdentified` publish (TX fast-path).
@@ -5688,6 +5704,14 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_md_sidefx_jobs_processed_total",
         MARKET_DATA_MD_SIDEFX_JOBS_PROCESSED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_devwallet_tx_published_total",
+        MARKET_DATA_DEVWALLET_TX_PUBLISHED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_devwallet_bonding_path_total",
+        MARKET_DATA_DEVWALLET_BONDING_PATH_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_unparsed_tx_dropped_total",

--- a/src/solana/dex_parser.rs
+++ b/src/solana/dex_parser.rs
@@ -911,6 +911,7 @@ fn parse_pumpfun_create(update: &GeyserTransactionUpdate) -> Option<ParsedDexEve
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_pumpfun_trade_event(
     update: &GeyserTransactionUpdate,
     bonding_curve: Pubkey,
@@ -919,9 +920,9 @@ fn build_pumpfun_trade_event(
     is_buy: bool,
     sol_amount: u64,
     token_amount: u64,
+    creator: Option<Pubkey>,
 ) -> ParsedDexEvent {
     let token_decimals = get_token_decimals(&update.post_token_balances, &mint);
-    let creator: Option<Pubkey> = None;
 
     let spl_token_str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
     let token_2022_str = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
@@ -1056,6 +1057,7 @@ fn parse_pumpfun_buy_exact_sol_in(update: &GeyserTransactionUpdate) -> Option<Pa
         true,
         swap_sol_used,
         tokens_received,
+        None,
     ))
 }
 
@@ -1206,6 +1208,7 @@ fn parse_pumpfun_swap(update: &GeyserTransactionUpdate, is_buy: bool) -> Option<
         is_buy,
         sol_amount,
         token_amount,
+        None,
     ))
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the P1 Universal TX gap where Momentum enrichment (`missing_creator`) broke after Hot-Set shrink because Creator/DevWallet depended on bonding-curve account updates (P2) instead of TX parse.

- **Fix 1:** `PumpFunDevWalletFromPoolCreated` now carries `pool_address` and fills `pool_creator_cache` before DevWallet publish
- **Fix 2:** `PumpFunPoolMintMapInsert` accepts `creator_override`; `sidefx_maybe_emit_dev_wallet_after_pool_mint_map` resolves creator from override → `pool_creator_cache` → `LivePoolCache` (no RPC)
- **Fix 3:** `build_pumpfun_trade_event` accepts optional `creator` (parser passes `None`; enrichment in MD)
- **Fix 4:** Trade enrichment order: parsed `Trade.creator` → caches → LivePoolCache; sync DevWallet emit with FIX-22 dedupe
- **Fix 5:** Metrics `market_data_devwallet_tx_published_total` vs `market_data_devwallet_bonding_path_total`

## Invariant compliance

| Invariant | Status |
|-----------|--------|
| I-MD-1 | No new `is_hot_pool()` gate on TX publish |
| I-MD-3 | PoolCreated + Trade TX paths fill caches and emit DevWallet when creator parseable |
| I-7 | No RPC added |
| I-9 | No TX sends |

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] New: `phase1_sidefx_pool_mint_map_emits_devwallet_with_creator_override`
- [x] Updated: `tx_fast_path_dev_wallet_after_pool_mint_map_emits_once`

## STOP-CHECK performed

1. Hot Path RPC (I-7): no new RPC calls
2. Existing pattern: `allow_rpc_on_miss` / cache fallback pattern preserved
3. Architecture boundaries: only allowed MD files changed
4. Simulation-Gate: unchanged
5. Repo-Isolation: no eval tests read
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41ed9a01-1a1f-4ed0-b9dd-db910b8f802c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41ed9a01-1a1f-4ed0-b9dd-db910b8f802c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

