### PR TITLE
feat(market-data): Phase 2 P2 Enrichment Registry — publish without hot-set gate

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -79,8 +79,8 @@ use ironcrab::market_data::sidefx::{
 };
 use ironcrab::market_data::track::{
     arb_coalesce_try_send, explicit_subscription_has_new_keys, momentum_coalesce_try_send,
-    spawn_track_worker, track_worker_try_enqueue, ConsumerId, DesiredExplicitSet, TrackPinReason,
-    TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
+    pool_is_enrichment_member, spawn_track_worker, track_worker_try_enqueue, ConsumerId,
+    DesiredExplicitSet, TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -113,11 +113,12 @@ use ironcrab::metrics::{
     record_market_data_tokio_progress, record_market_data_tx_broadcast_lagged,
     record_market_data_tx_channel_lag_ms, record_market_data_tx_handler_processed, serve_metrics,
     set_market_data_account_broadcast_queue_depth, set_market_data_account_worker_count,
-    set_market_data_arb_pinned_pools_gauge, set_market_data_geyser_merge_pending,
-    set_market_data_geyser_sync_pending, set_market_data_hot_pool_registry_pools_gauge,
-    set_market_data_md_state_evict_pending, set_market_data_momentum_active_pool_pins_gauge,
-    set_market_data_tx_broadcast_queue_depth, set_readiness_control_sub_active, set_readiness_mode,
-    set_readiness_nats_connected, touch_market_data_global_ingest_progress,
+    set_market_data_arb_pinned_pools_gauge, set_market_data_enrichment_registry_pools_gauge,
+    set_market_data_geyser_merge_pending, set_market_data_geyser_sync_pending,
+    set_market_data_hot_pool_registry_pools_gauge, set_market_data_md_state_evict_pending,
+    set_market_data_momentum_active_pool_pins_gauge, set_market_data_tx_broadcast_queue_depth,
+    set_readiness_control_sub_active, set_readiness_mode, set_readiness_nats_connected,
+    touch_market_data_global_ingest_progress,
     touch_market_data_tracked_membership_snapshot_refresh, update_readiness_market_data_current,
     GeyserTrackedEvictKind, MarketDataLatencySegment, MetricsComponent,
     MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS, MARKET_EVENTS_RECEIVED_TOTAL,
@@ -543,6 +544,14 @@ impl SidefxWorkerHost for MarketDataSidefxHost {
 
     fn is_hot_pool(&self, pool: &Pubkey) -> bool {
         self.ctx.hot_pool_registry.is_hot_pool(*pool)
+    }
+
+    fn is_enrichment_member(&self, pool: &Pubkey) -> bool {
+        self.ctx.ingest_is_enrichment_member(pool)
+    }
+
+    fn pool_has_live_vault_geyser_feed(&self, pool: Pubkey) -> bool {
+        self.ctx.pool_has_live_vault_geyser_feed(pool)
     }
 
     fn maybe_refresh_arb_dlmm_bin_window(&self, pool: Pubkey, new_active_id: i32) -> bool {
@@ -1955,6 +1964,14 @@ impl IngestHost for MarketDataContext {
         self.hot_pool_registry.is_hot_pool(*pool)
     }
 
+    fn ingest_is_enrichment_member(&self, pool: &Pubkey) -> bool {
+        pool_is_enrichment_member(
+            self.pool_mint_map.read().contains_key(&pool.to_string()),
+            self.high_priority_bonding_curves.read().contains(pool),
+            self.hot_pool_registry.is_hot_pool(*pool),
+        )
+    }
+
     fn ingest_pool_mint_map_contains(&self, pool: &Pubkey) -> bool {
         self.pool_mint_map.read().contains_key(&pool.to_string())
     }
@@ -1990,6 +2007,10 @@ impl IngestHost for MarketDataContext {
 
     fn ingest_record_vault_high_priority_dispatch(&self) {
         inc_market_data_vault_high_priority_dispatch_total();
+    }
+
+    fn ingest_record_enrichment_relevance_hit(&self) {
+        ironcrab::metrics::inc_market_data_account_relevance_enrichment_hit_total();
     }
 }
 
@@ -2117,6 +2138,27 @@ impl MarketDataContext {
         set_market_data_hot_pool_registry_pools_gauge("both", 0);
         set_market_data_momentum_active_pool_pins_gauge(self.hot_pool_registry.pair_count());
         set_market_data_arb_pinned_pools_gauge(arb);
+        self.refresh_enrichment_registry_gauge();
+    }
+
+    fn refresh_enrichment_registry_gauge(&self) {
+        let mut pools: HashSet<Pubkey> = self
+            .hot_pool_registry
+            .snapshot_arb_pools()
+            .into_iter()
+            .collect();
+        for (_, pool) in self.hot_pool_registry.snapshot_pairs() {
+            pools.insert(pool);
+        }
+        for pool_str in self.pool_mint_map.read().keys() {
+            if let Ok(pk) = Pubkey::from_str(pool_str) {
+                pools.insert(pk);
+            }
+        }
+        for pool in self.high_priority_bonding_curves.read().iter() {
+            pools.insert(*pool);
+        }
+        set_market_data_enrichment_registry_pools_gauge(pools.len() as u64);
     }
 
     /// PR237 + Phase1: rebuild ingest/sidefx snapshot from authoritative md-state maps.
@@ -12379,6 +12421,50 @@ mod pr_b_geyser_tracking_tests {
             grpc_recv_at: Instant::now(),
         };
         assert!(account_geyser_update_might_be_relevant(&ctx, &u));
+        assert!(ctx.ingest_is_enrichment_member(&pool));
+    }
+
+    #[test]
+    fn account_geyser_update_might_be_relevant_arb_pinned_without_pool_mint_map() {
+        use ironcrab::metrics::MARKET_DATA_ACCOUNT_RELEVANCE_ENRICHMENT_HIT_TOTAL;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+        assert!(!ctx.ingest_pool_mint_map_contains(&pool));
+        let before = MARKET_DATA_ACCOUNT_RELEVANCE_ENRICHMENT_HIT_TOTAL.load(Ordering::Relaxed);
+        let u = GeyserAccountUpdate {
+            pubkey: pool,
+            slot: 1,
+            owner: RAYDIUM_CPMM_OWNER,
+            data: vec![],
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        };
+        assert!(account_geyser_update_might_be_relevant(&ctx, &u));
+        assert!(
+            MARKET_DATA_ACCOUNT_RELEVANCE_ENRICHMENT_HIT_TOTAL.load(Ordering::Relaxed) > before
+        );
+    }
+
+    #[test]
+    fn enrichment_sidefx_host_pool_mint_map_is_member_without_hot_pin() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let (md_state, _depth, _md_state_rx) = test_md_state_sender_no_worker();
+        let worker = test_sidefx_host(&ctx, md_state, test_noop_track_worker_sender());
+        let pool = Pubkey::new_unique();
+        ctx.pool_mint_map
+            .write()
+            .insert(pool.to_string(), Pubkey::new_unique().to_string());
+        assert!(worker.is_enrichment_member(&pool));
+        assert!(!worker.is_hot_pool(&pool));
+        assert!(!worker.pool_has_live_vault_geyser_feed(pool));
     }
 
     #[test]

--- a/src/market_data/ingest/account_filter.rs
+++ b/src/market_data/ingest/account_filter.rs
@@ -1,6 +1,7 @@
 //! Geyser account update relevance + dispatch-priority filters.
 
 use super::host::IngestHost;
+use crate::metrics::inc_market_data_account_relevance_enrichment_hit_total;
 use crate::solana::geyser_listener::GeyserAccountUpdate;
 use solana_sdk::pubkey::Pubkey;
 
@@ -55,13 +56,8 @@ pub fn account_geyser_update_might_be_relevant<H: IngestHost>(
     }
 
     let pool_pk = u.pubkey;
-    if host.ingest_is_hot_pool(&pool_pk) {
-        return true;
-    }
-    if host.ingest_pool_mint_map_contains(&pool_pk) {
-        return true;
-    }
-    if host.ingest_high_priority_bonding_curve_contains(&pool_pk) {
+    if host.ingest_is_enrichment_member(&pool_pk) {
+        inc_market_data_account_relevance_enrichment_hit_total();
         return true;
     }
     if u.owner == PUMPFUN_PROGRAM_OWNER && host.ingest_pumpfun_bonding_curve_tracks_wallet(&pool_pk)
@@ -91,7 +87,7 @@ pub fn account_geyser_dispatch_priority_high<H: IngestHost>(
     if host.ingest_pool_mint_map_contains(&pool_pk) {
         return true;
     }
-    if host.ingest_is_hot_pool(&pool_pk) {
+    if host.ingest_is_enrichment_member(&pool_pk) {
         return true;
     }
     if host.ingest_wallet_tracks_mint(&pool_pk) {

--- a/src/market_data/ingest/host.rs
+++ b/src/market_data/ingest/host.rs
@@ -18,6 +18,9 @@ pub trait IngestHost: Send + Sync {
 
     fn ingest_is_hot_pool(&self, pool: &Pubkey) -> bool;
 
+    /// P2 EnrichmentRegistry: pool_mint_map ∪ bonding-curve priority ∪ hot-pool pins.
+    fn ingest_is_enrichment_member(&self, pool: &Pubkey) -> bool;
+
     fn ingest_pool_mint_map_contains(&self, pool: &Pubkey) -> bool;
 
     fn ingest_high_priority_bonding_curve_contains(&self, pool: &Pubkey) -> bool;
@@ -33,4 +36,6 @@ pub trait IngestHost: Send + Sync {
     fn ingest_record_membership_snapshot_hit(&self);
 
     fn ingest_record_vault_high_priority_dispatch(&self);
+
+    fn ingest_record_enrichment_relevance_hit(&self);
 }

--- a/src/market_data/ingest/mod.rs
+++ b/src/market_data/ingest/mod.rs
@@ -41,6 +41,10 @@ impl<T: IngestHost + ?Sized> IngestHost for Arc<T> {
         (**self).ingest_is_hot_pool(pool)
     }
 
+    fn ingest_is_enrichment_member(&self, pool: &solana_sdk::pubkey::Pubkey) -> bool {
+        (**self).ingest_is_enrichment_member(pool)
+    }
+
     fn ingest_pool_mint_map_contains(&self, pool: &solana_sdk::pubkey::Pubkey) -> bool {
         (**self).ingest_pool_mint_map_contains(pool)
     }
@@ -73,5 +77,9 @@ impl<T: IngestHost + ?Sized> IngestHost for Arc<T> {
 
     fn ingest_record_vault_high_priority_dispatch(&self) {
         (**self).ingest_record_vault_high_priority_dispatch()
+    }
+
+    fn ingest_record_enrichment_relevance_hit(&self) {
+        (**self).ingest_record_enrichment_relevance_hit()
     }
 }

--- a/src/market_data/sidefx/handlers.rs
+++ b/src/market_data/sidefx/handlers.rs
@@ -2,6 +2,7 @@
 
 use super::host::{MarketEventCorePublishTrace, SidefxWorkerHost};
 use super::pool_publish::{
+    cache_balance_fields_unchanged, cached_pool_has_fresh_reserve_basis,
     meteora_cpmm_onchain_mints_for_pool_cache_update, meteora_cpmm_vaults_for_pool_cache_update,
     meteora_dlmm_metadata_for_pool_cache_update, orca_metadata_for_pool_cache_update,
     pool_cache_balance_fields_from_state, pump_amm_sell_layout_publish_state,
@@ -20,6 +21,8 @@ use crate::ipc::{
 };
 use crate::metrics::{
     inc_market_data_devwallet_bonding_path_total, inc_market_data_devwallet_tx_published_total,
+    inc_market_data_enrichment_balance_updated_total,
+    inc_market_data_enrichment_pool_state_publish_total,
     inc_market_data_pool_state_publish_skipped_balance_unchanged_total,
     record_market_data_bonding_curve_grpc_to_devwallet_ms,
     record_market_data_pool_mint_map_to_devwallet_ms, MarketDataLatencySegment,
@@ -55,6 +58,133 @@ fn sidefx_host_enqueue_jetstream<T: serde::Serialize>(
         log_fail,
         bump_market_events_published_total,
     );
+}
+
+fn md_sidefx_build_balance_updated_from_cache(
+    host: &dyn SidefxWorkerHost,
+    run_id: &str,
+    pool_pubkey: &Pubkey,
+    slot: u64,
+) -> Option<PoolCacheUpdate> {
+    let state = host.live_pool_cache().get(pool_pubkey)?;
+    if !cached_pool_has_fresh_reserve_basis(&state) {
+        return None;
+    }
+    let (base_mint, quote_mint, base_reserve, quote_reserve, dex) =
+        pool_cache_balance_fields_from_state(&state)?;
+    let mut balance_update = PoolCacheUpdate::new_balance_updated(
+        "market-data",
+        host.build_version(),
+        run_id,
+        pool_pubkey.to_string(),
+        dex.to_string(),
+        base_mint.to_string(),
+        quote_mint.to_string(),
+        base_reserve,
+        quote_reserve,
+        slot,
+    );
+    match &state {
+        CachedPoolState::RaydiumCpmm(s) => {
+            let mut meta = std::collections::HashMap::new();
+            meta.insert(
+                POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY.to_string(),
+                raydium_cpmm_vaults_for_pool_cache_update(s),
+            );
+            balance_update.metadata = Some(meta);
+            let readiness = raydium_cpmm_readiness_for_pool_cache_update(s);
+            balance_update.set_dex_readiness_in_metadata(readiness);
+            host.live_pool_cache()
+                .merge_raydium_cpmm_pool_readiness(*pool_pubkey, readiness);
+        }
+        CachedPoolState::MeteoraCpmm(s) => {
+            let mut meta = std::collections::HashMap::new();
+            meta.insert(
+                POOL_CACHE_UPDATE_METEORA_CPMM_VAULTS_KEY.to_string(),
+                meteora_cpmm_vaults_for_pool_cache_update(s),
+            );
+            meta.insert(
+                POOL_CACHE_UPDATE_METEORA_CPMM_ONCHAIN_MINTS_KEY.to_string(),
+                meteora_cpmm_onchain_mints_for_pool_cache_update(s),
+            );
+            balance_update.metadata = Some(meta);
+            let readiness = meteora_cpmm_readiness_for_pool_cache_update(s);
+            balance_update.set_dex_readiness_in_metadata(readiness);
+            host.live_pool_cache()
+                .merge_meteora_cpmm_pool_readiness(*pool_pubkey, readiness);
+        }
+        CachedPoolState::RaydiumAmm(s) => {
+            let readiness = raydium_amm_readiness_for_pool_cache_update(s);
+            balance_update.set_dex_readiness_in_metadata(readiness);
+            host.live_pool_cache()
+                .merge_raydium_amm_pool_readiness(*pool_pubkey, readiness);
+        }
+        CachedPoolState::Orca(s) => {
+            balance_update.metadata = Some(orca_metadata_for_pool_cache_update(s));
+            let readiness = orca_readiness_for_pool_cache_update(s);
+            balance_update.set_dex_readiness_in_metadata(readiness);
+            host.live_pool_cache()
+                .merge_orca_pool_readiness(*pool_pubkey, readiness);
+        }
+        CachedPoolState::Meteora(s) => {
+            balance_update.metadata = Some(meteora_dlmm_metadata_for_pool_cache_update(s));
+            let readiness = meteora_dlmm_readiness_for_pool_cache_update(s);
+            balance_update.set_dex_readiness_in_metadata(readiness);
+            host.live_pool_cache()
+                .merge_meteora_dlmm_pool_readiness(*pool_pubkey, readiness);
+        }
+        CachedPoolState::PumpAmm(_) | CachedPoolState::PumpFun(_) => {}
+    }
+    Some(balance_update)
+}
+
+/// P2: JetStream BalanceUpdated + Core PoolStateUpdate after MASTER cache upsert (I-MD-4).
+fn md_sidefx_publish_enrichment_from_cache_upsert(
+    host: &dyn SidefxWorkerHost,
+    run_id: &str,
+    pool_pubkey: &Pubkey,
+    cached_state: &CachedPoolState,
+    prev_state: Option<CachedPoolState>,
+    slot: u64,
+    grpc_recv_at: Instant,
+) {
+    if !host.is_enrichment_member(pool_pubkey) {
+        return;
+    }
+    if host.pool_has_live_vault_geyser_feed(*pool_pubkey) {
+        return;
+    }
+    if !cached_pool_has_fresh_reserve_basis(cached_state) {
+        return;
+    }
+    let balance_unchanged = prev_state
+        .as_ref()
+        .is_some_and(|prev| cache_balance_fields_unchanged(prev, cached_state));
+    if balance_unchanged {
+        inc_market_data_pool_state_publish_skipped_balance_unchanged_total();
+        return;
+    }
+
+    if host.nats_enabled() {
+        if let Some(balance_update) =
+            md_sidefx_build_balance_updated_from_cache(host, run_id, pool_pubkey, slot)
+        {
+            let subject = pool_subject(&pool_pubkey.to_string());
+            sidefx_host_enqueue_jetstream(
+                host,
+                subject,
+                &balance_update,
+                "PoolCacheUpdate::BalanceUpdated (enrichment cache upsert)",
+                false,
+            );
+            inc_market_data_enrichment_balance_updated_total();
+        }
+    }
+
+    if md_sidefx_publish_pool_state_update_from_cache(host, run_id, pool_pubkey, slot, grpc_recv_at)
+    {
+        inc_market_data_enrichment_pool_state_publish_total();
+    }
 }
 
 /// Build PoolStateUpdate from MASTER LivePoolCache (Geyser-only; no RPC).
@@ -1010,7 +1140,8 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
         return;
     };
     if let Some(mut cached_state) = parse_pool_account(owner, account_data) {
-        let prev_meteora_meta = host.live_pool_cache().get(pool_pubkey).and_then(|s| {
+        let prev_state = host.live_pool_cache().get(pool_pubkey);
+        let prev_meteora_meta = prev_state.as_ref().and_then(|s| {
             if let CachedPoolState::Meteora(m) = s {
                 Some((m.active_id, m.bin_step))
             } else {
@@ -1403,6 +1534,16 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
                 false,
             );
         }
+
+        md_sidefx_publish_enrichment_from_cache_upsert(
+            host,
+            run_id,
+            pool_pubkey,
+            &cached_state,
+            prev_state,
+            *slot,
+            *grpc_recv_at,
+        );
     }
 }
 

--- a/src/market_data/sidefx/host.rs
+++ b/src/market_data/sidefx/host.rs
@@ -75,6 +75,12 @@ pub trait SidefxWorkerHost: Send + Sync {
     /// True when pool is in momentum/arb hot set (arb-pinned DLMM PoolStateUpdate gate).
     fn is_hot_pool(&self, pool: &Pubkey) -> bool;
 
+    /// P2 EnrichmentRegistry membership (pool_mint_map ∪ pins ∪ bonding-curve priority).
+    fn is_enrichment_member(&self, pool: &Pubkey) -> bool;
+
+    /// True when vault/bin pubkeys for this pool were included in the last Geyser sync flush.
+    fn pool_has_live_vault_geyser_feed(&self, pool: Pubkey) -> bool;
+
     /// Re-register DLMM bin-array window when arb-pinned pool `active_id` drifts (Fix B).
     fn maybe_refresh_arb_dlmm_bin_window(&self, pool: Pubkey, new_active_id: i32) -> bool;
 }

--- a/src/market_data/sidefx/pool_publish.rs
+++ b/src/market_data/sidefx/pool_publish.rs
@@ -297,3 +297,89 @@ pub fn pool_cache_balance_fields_from_state(
         CachedPoolState::PumpFun(_) => None,
     }
 }
+
+/// True when the cached pool row has at least one non-zero reserve / vault balance.
+pub fn cached_pool_has_fresh_reserve_basis(state: &CachedPoolState) -> bool {
+    let fresh = |opt: Option<u64>| opt.is_some_and(|v| v > 0);
+    let fresh_u64 = |v: u64| v > 0;
+    match state {
+        CachedPoolState::RaydiumCpmm(s) => fresh(s.reserve_0) || fresh(s.reserve_1),
+        CachedPoolState::MeteoraCpmm(s) => fresh_u64(s.reserve_0) || fresh_u64(s.reserve_1),
+        CachedPoolState::Meteora(s) => fresh(s.reserve_x_balance) || fresh(s.reserve_y_balance),
+        CachedPoolState::PumpAmm(s) => fresh(s.base_reserve) || fresh(s.quote_reserve),
+        CachedPoolState::Orca(s) => fresh(s.vault_a_balance) || fresh(s.vault_b_balance),
+        CachedPoolState::RaydiumAmm(s) => fresh(s.coin_reserve) || fresh(s.pc_reserve),
+        CachedPoolState::PumpFun(_) => false,
+    }
+}
+
+/// Compare normalized reserve fields between two cache rows.
+pub fn cache_balance_fields_unchanged(prev: &CachedPoolState, new: &CachedPoolState) -> bool {
+    match (
+        pool_cache_balance_fields_from_state(prev),
+        pool_cache_balance_fields_from_state(new),
+    ) {
+        (Some((_, _, pb, pq, _)), Some((_, _, nb, nq, _))) => pb == nb && pq == nq,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution::live_pool_cache::RaydiumCpmmState;
+
+    #[test]
+    fn cached_pool_has_fresh_reserve_basis_requires_nonzero() {
+        let with = CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+            token_0_mint: Pubkey::new_unique(),
+            token_1_mint: Pubkey::new_unique(),
+            token_0_vault: Pubkey::new_unique(),
+            token_1_vault: Pubkey::new_unique(),
+            reserve_0: Some(1),
+            reserve_1: None,
+        });
+        let without = CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+            token_0_mint: Pubkey::new_unique(),
+            token_1_mint: Pubkey::new_unique(),
+            token_0_vault: Pubkey::new_unique(),
+            token_1_vault: Pubkey::new_unique(),
+            reserve_0: None,
+            reserve_1: None,
+        });
+        assert!(cached_pool_has_fresh_reserve_basis(&with));
+        assert!(!cached_pool_has_fresh_reserve_basis(&without));
+    }
+
+    #[test]
+    fn cache_balance_fields_unchanged_detects_equal_reserves() {
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let a = CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+            token_0_mint: mint_a,
+            token_1_mint: mint_b,
+            token_0_vault: Pubkey::new_unique(),
+            token_1_vault: Pubkey::new_unique(),
+            reserve_0: Some(100),
+            reserve_1: Some(200),
+        });
+        let b = CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+            token_0_mint: mint_a,
+            token_1_mint: mint_b,
+            token_0_vault: Pubkey::new_unique(),
+            token_1_vault: Pubkey::new_unique(),
+            reserve_0: Some(100),
+            reserve_1: Some(200),
+        });
+        let c = CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+            token_0_mint: mint_a,
+            token_1_mint: mint_b,
+            token_0_vault: Pubkey::new_unique(),
+            token_1_vault: Pubkey::new_unique(),
+            reserve_0: Some(101),
+            reserve_1: Some(200),
+        });
+        assert!(cache_balance_fields_unchanged(&a, &b));
+        assert!(!cache_balance_fields_unchanged(&a, &c));
+    }
+}

--- a/src/market_data/track/enrichment.rs
+++ b/src/market_data/track/enrichment.rs
@@ -1,0 +1,75 @@
+//! P2 EnrichmentRegistry — membership superset for account relevance + cache publish.
+//!
+//! Enrichment = `pool_mint_map` ∪ high-priority bonding curves ∪ hot-pool pins (momentum ∪ arb).
+//! Broader than execution hot-set for publish; does not add explicit Geyser subs (I-MD-5).
+
+use solana_sdk::pubkey::Pubkey;
+
+/// Pure membership predicate shared by ingest and sidefx hosts.
+#[inline]
+pub fn pool_is_enrichment_member(
+    pool_mint_map: bool,
+    high_priority_bonding_curve: bool,
+    is_hot_pool: bool,
+) -> bool {
+    pool_mint_map || high_priority_bonding_curve || is_hot_pool
+}
+
+/// Inputs for enrichment membership checks on [`crate::market_data::ingest::IngestHost`].
+pub trait EnrichmentMembershipInputs {
+    fn enrichment_pool_mint_map_contains(&self, pool: &Pubkey) -> bool;
+    fn enrichment_high_priority_bonding_curve_contains(&self, pool: &Pubkey) -> bool;
+    fn enrichment_is_hot_pool(&self, pool: &Pubkey) -> bool;
+}
+
+#[inline]
+pub fn is_enrichment_member_from_inputs(
+    inputs: &dyn EnrichmentMembershipInputs,
+    pool: &Pubkey,
+) -> bool {
+    pool_is_enrichment_member(
+        inputs.enrichment_pool_mint_map_contains(pool),
+        inputs.enrichment_high_priority_bonding_curve_contains(pool),
+        inputs.enrichment_is_hot_pool(pool),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestInputs {
+        mint_map: bool,
+        bonding: bool,
+        hot: bool,
+    }
+
+    impl EnrichmentMembershipInputs for TestInputs {
+        fn enrichment_pool_mint_map_contains(&self, _pool: &Pubkey) -> bool {
+            self.mint_map
+        }
+
+        fn enrichment_high_priority_bonding_curve_contains(&self, _pool: &Pubkey) -> bool {
+            self.bonding
+        }
+
+        fn enrichment_is_hot_pool(&self, _pool: &Pubkey) -> bool {
+            self.hot
+        }
+    }
+
+    #[test]
+    fn pool_is_enrichment_member_union() {
+        let pool = Pubkey::new_unique();
+        assert!(!pool_is_enrichment_member(false, false, false));
+        assert!(pool_is_enrichment_member(true, false, false));
+        assert!(pool_is_enrichment_member(false, true, false));
+        assert!(pool_is_enrichment_member(false, false, true));
+        let inputs = TestInputs {
+            mint_map: false,
+            bonding: false,
+            hot: true,
+        };
+        assert!(is_enrichment_member_from_inputs(&inputs, &pool));
+    }
+}

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -1,5 +1,6 @@
 pub mod coalesce;
 pub mod desired_set;
+pub mod enrichment;
 pub mod geyser_sync;
 pub mod worker;
 
@@ -11,6 +12,9 @@ pub use coalesce::{
 pub use desired_set::{
     pin_priority_from_consumer, symmetric_diff, ConsumerId, DesiredExplicitSet, ExplicitEntry,
     PinPriority,
+};
+pub use enrichment::{
+    is_enrichment_member_from_inputs, pool_is_enrichment_member, EnrichmentMembershipInputs,
 };
 pub use geyser_sync::{
     consumer_id_for_track_pin, explicit_subscription_has_new_keys,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -394,6 +394,18 @@ pub static MARKET_DATA_HOT_POOL_REGISTRY_POOLS_BOTH: Lazy<AtomicU64> =
 /// BalanceUpdated published from MASTER cache without vault Geyser subscription.
 pub static MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// P2: JetStream BalanceUpdated from enrichment cache upsert path.
+pub static MARKET_DATA_ENRICHMENT_BALANCE_UPDATED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// P2: Core NATS PoolStateUpdate from enrichment cache upsert path.
+pub static MARKET_DATA_ENRICHMENT_POOL_STATE_PUBLISH_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// P2: account relevance filter hit via EnrichmentRegistry membership.
+pub static MARKET_DATA_ACCOUNT_RELEVANCE_ENRICHMENT_HIT_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// P2: EnrichmentRegistry pool count gauge (deduplicated union).
+pub static MARKET_DATA_ENRICHMENT_REGISTRY_POOLS_GAUGE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// PoolStateUpdate published to Core NATS (bounded `dex` label).
 pub static MARKET_DATA_POOL_STATE_PUBLISH_ORCA: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static MARKET_DATA_POOL_STATE_PUBLISH_METEORA_DLMM: Lazy<AtomicU64> =
@@ -734,6 +746,22 @@ pub fn set_market_data_hot_pool_registry_pools_gauge(reason: &str, n: usize) {
 #[inline]
 pub fn inc_market_data_balance_updated_from_cache_total() {
     MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn inc_market_data_enrichment_balance_updated_total() {
+    MARKET_DATA_ENRICHMENT_BALANCE_UPDATED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn inc_market_data_enrichment_pool_state_publish_total() {
+    MARKET_DATA_ENRICHMENT_POOL_STATE_PUBLISH_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn inc_market_data_account_relevance_enrichment_hit_total() {
+    MARKET_DATA_ACCOUNT_RELEVANCE_ENRICHMENT_HIT_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn set_market_data_enrichment_registry_pools_gauge(n: u64) {
+    MARKET_DATA_ENRICHMENT_REGISTRY_POOLS_GAUGE.store(n, Ordering::Relaxed);
 }
 
 /// Increment bounded `market_data_pool_state_publish_total{dex}`.
@@ -5990,6 +6018,22 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_balance_updated_from_cache_total",
         MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_enrichment_balance_updated_total",
+        MARKET_DATA_ENRICHMENT_BALANCE_UPDATED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_enrichment_pool_state_publish_total",
+        MARKET_DATA_ENRICHMENT_POOL_STATE_PUBLISH_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_account_relevance_enrichment_hit_total",
+        MARKET_DATA_ACCOUNT_RELEVANCE_ENRICHMENT_HIT_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_enrichment_registry_pools_gauge",
+        MARKET_DATA_ENRICHMENT_REGISTRY_POOLS_GAUGE.load(Ordering::Relaxed)
     );
     line!(
         "market_data_pool_state_publish_skipped_total{reason=\"balance_unchanged\"}",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 2 (P2) decouples **account relevance + publish/JetStream** from the execution hot-set by introducing an explicit **EnrichmentRegistry** membership view:

- `pool_mint_map` ∪ high-priority bonding curves ∪ hot-pool pins (momentum ∪ arb)
- Broader than execution hot-set for publish; **does not** add explicit Geyser subs (I-MD-5)

### Changes

- **`EnrichmentRegistry`** (`market_data/track/enrichment.rs`) with `ingest_is_enrichment_member` / `is_enrichment_member` on ingest + sidefx hosts
- **Account filter** uses enrichment membership (reduces `account_early_drop` for discovered pools)
- **Sidefx cache upsert** (after successful MASTER upsert): for enrichment members without live vault Geyser feed:
  - JetStream `PoolCacheUpdate::BalanceUpdated` (I-MD-4)
  - Core NATS `PoolStateUpdate` from cache reserves (deduped when balance unchanged)
- **Metrics**: `market_data_enrichment_balance_updated_total`, `market_data_enrichment_pool_state_publish_total`, `market_data_account_relevance_enrichment_hit_total`, `market_data_enrichment_registry_pools_gauge`

### Invariants preserved

| Invariant | Status |
|-----------|--------|
| I-MD-1/3 Phase 1 TX paths | No regression |
| I-MD-4 BalanceUpdated on cache upsert with reserve basis | Implemented (sidefx path) |
| I-MD-5 No new explicit subs for enrichment-only | Vault/bin registration unchanged |
| I-7 No Hot Path RPC | Cache-first publish only |
| I-4b Single-Writer | EnrichmentRegistry is read-only membership view |

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] Enrichment membership tests (pool_mint_map without hot pin, arb pin without pool_mint_map)
- [x] Sidefx host enrichment membership wiring test
- [ ] Eval Level 5 (post-merge / CI)

## Prod abnahme (separate deploy)

- `rate(market_events_published_total[5m])` > 100/s sustained
- `account_early_drop` rate drops relative to account ingest for enrichment-covered pools
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-560c7027-4567-4dba-b946-3888d42d5b91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-560c7027-4567-4dba-b946-3888d42d5b91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

