### PR TITLE
fix(md): P2 enrichment metrics on vault-tick path + labeled early-drop

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -105,7 +105,7 @@ use ironcrab::metrics::{
     market_data_geyser_tracking_jobs_processed_value, market_data_md_state_bursts_completed_value,
     market_data_request_account_session_reconnect, market_data_request_tx_session_reconnect,
     market_data_tx_handler_processed_value, record_market_data_account_broadcast_lagged,
-    record_market_data_account_channel_lag_ms, record_market_data_account_early_drop_total,
+    record_market_data_account_channel_lag_ms, record_market_data_account_early_drop,
     record_market_data_account_handler_duration_us,
     record_market_data_arb_track_requests_messages_total,
     record_market_data_geyser_merge_coalesced_total, record_market_data_geyser_sync_batch_total,
@@ -286,12 +286,21 @@ fn spawn_arb_tracking_coalescer(
 }
 
 /// Eval grep: account relevance filter in `ingest/account_filter.rs` (tracked_membership snapshot).
+#[cfg_attr(not(test), allow(dead_code))]
 fn account_geyser_update_might_be_relevant(
     ctx: &MarketDataContext,
     u: &GeyserAccountUpdate,
 ) -> bool {
     // I-4b eval grep: tracked_membership_contains_pubkey / tracked_membership snapshot (ingest/account_filter.rs).
     ironcrab::market_data::ingest::account_geyser_update_might_be_relevant(ctx, u)
+}
+
+/// Eval grep: account relevance filter with early-drop reason in `ingest/account_filter.rs`.
+fn account_geyser_update_relevance(
+    ctx: &MarketDataContext,
+    u: &GeyserAccountUpdate,
+) -> ironcrab::market_data::ingest::AccountGeyserRelevance {
+    ironcrab::market_data::ingest::account_geyser_update_relevance(ctx, u)
 }
 
 /// Eval grep: account dispatch priority in `ingest/account_filter.rs` (tracked_membership snapshot).
@@ -7692,9 +7701,14 @@ async fn run_geyser_loop(
                     set_market_data_account_broadcast_queue_depth(account_rx_geyser.len());
                     market_data_bump_geyser_head_slot(account_update.slot);
 
-                    if !account_geyser_update_might_be_relevant(&ctx_geyser_acc, &account_update) {
-                        record_market_data_account_early_drop_total();
-                        continue;
+                    match account_geyser_update_relevance(&ctx_geyser_acc, &account_update) {
+                        ironcrab::market_data::ingest::AccountGeyserRelevance::Relevant => {}
+                        ironcrab::market_data::ingest::AccountGeyserRelevance::EarlyDrop(
+                            reason,
+                        ) => {
+                            record_market_data_account_early_drop(reason);
+                            continue;
+                        }
                     }
 
                     let shard = market_data_account_worker_shard(&account_update.pubkey);
@@ -11672,6 +11686,98 @@ mod pr_b_geyser_tracking_tests {
     }
 
     #[test]
+    fn account_geyser_update_relevance_non_enrichment_dex_pool_early_drop_reason() {
+        use ironcrab::market_data::ingest::AccountGeyserRelevance;
+        use ironcrab::metrics::MarketDataAccountEarlyDropReason;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let u = GeyserAccountUpdate {
+            pubkey: pool,
+            slot: 1,
+            owner: RAYDIUM_CPMM_OWNER,
+            data: vec![],
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        };
+        assert_eq!(
+            account_geyser_update_relevance(&ctx, &u),
+            AccountGeyserRelevance::EarlyDrop(
+                MarketDataAccountEarlyDropReason::DexPoolNotEnrichment
+            )
+        );
+    }
+
+    #[test]
+    fn account_geyser_update_relevance_random_non_dex_early_drop_reason() {
+        use ironcrab::market_data::ingest::AccountGeyserRelevance;
+        use ironcrab::metrics::MarketDataAccountEarlyDropReason;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let u = GeyserAccountUpdate {
+            pubkey: Pubkey::new_unique(),
+            slot: 1,
+            owner: Pubkey::new_unique(),
+            data: vec![],
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        };
+        assert_eq!(
+            account_geyser_update_relevance(&ctx, &u),
+            AccountGeyserRelevance::EarlyDrop(
+                MarketDataAccountEarlyDropReason::NonDexNonMembership
+            )
+        );
+    }
+
+    #[test]
+    fn account_geyser_update_relevance_membership_explicit_vault_no_early_drop() {
+        use ironcrab::market_data::ingest::AccountGeyserRelevance;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let vault = Pubkey::new_unique();
+        ctx.tracked_vaults.write().insert(
+            vault,
+            VaultInfo {
+                pool_address: Pubkey::new_unique(),
+                dex: "raydium_cpmm".to_string(),
+                base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                is_base_vault: true,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: Instant::now(),
+                pinned: false,
+                pin: None,
+                active_id: None,
+                bin_step: None,
+                sibling_vault: None,
+            },
+        );
+        ctx.refresh_tracked_membership_snapshot();
+        let u = GeyserAccountUpdate {
+            pubkey: vault,
+            slot: 1,
+            owner: Pubkey::new_unique(),
+            data: vec![],
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        };
+        assert_eq!(
+            account_geyser_update_relevance(&ctx, &u),
+            AccountGeyserRelevance::Relevant
+        );
+    }
+
+    #[test]
     fn enrichment_sidefx_host_pool_mint_map_is_member_without_hot_pin() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
@@ -14327,6 +14433,14 @@ mod pr_b_geyser_tracking_tests {
             "account_filter.rs must contain account_geyser_update_might_be_relevant"
         );
         assert!(
+            account_src.contains("pub fn account_geyser_update_relevance"),
+            "account_filter.rs must contain account_geyser_update_relevance"
+        );
+        assert!(
+            bin_src.contains("record_market_data_account_early_drop"),
+            "bin must record labeled account early-drop metrics"
+        );
+        assert!(
             account_src.contains("pub fn account_geyser_dispatch_priority_high"),
             "account_filter.rs must contain account_geyser_dispatch_priority_high"
         );
@@ -14518,6 +14632,22 @@ mod pr_b_geyser_tracking_tests {
         assert!(
             bin_src.contains("fn md_sidefx_process_vault_balance_tick"),
             "bin must retain eval-grep wrapper for md_sidefx_process_vault_balance_tick"
+        );
+        assert!(
+            handlers_src.contains("fn md_sidefx_inc_enrichment_publish_metrics_if_member"),
+            "handlers.rs must count enrichment metrics on vault-tick publish path"
+        );
+        assert!(
+            handlers_src.contains("md_sidefx_inc_enrichment_publish_metrics_if_member"),
+            "md_sidefx_process_vault_balance_tick must call enrichment metric helper"
+        );
+        assert!(
+            handlers_src.contains("inc_market_data_enrichment_balance_updated_total"),
+            "vault-tick path must increment enrichment BalanceUpdated counter"
+        );
+        assert!(
+            handlers_src.contains("inc_market_data_enrichment_pool_state_publish_total"),
+            "vault-tick path must increment enrichment PoolState counter"
         );
     }
 

--- a/src/market_data/ingest/account_filter.rs
+++ b/src/market_data/ingest/account_filter.rs
@@ -1,7 +1,9 @@
 //! Geyser account update relevance + dispatch-priority filters.
 
 use super::host::IngestHost;
-use crate::metrics::inc_market_data_account_relevance_enrichment_hit_total;
+use crate::metrics::{
+    inc_market_data_account_relevance_enrichment_hit_total, MarketDataAccountEarlyDropReason,
+};
 use crate::solana::geyser_listener::GeyserAccountUpdate;
 use solana_sdk::pubkey::Pubkey;
 
@@ -33,38 +35,59 @@ pub fn account_geyser_update_is_dex_pool_owner(owner: &Pubkey) -> bool {
         || o == PUMPFUN_AMM_PROGRAM_OWNER
 }
 
+/// Result of the cheap account relevance filter (before DEX parse / heavy locks).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccountGeyserRelevance {
+    Relevant,
+    EarlyDrop(MarketDataAccountEarlyDropReason),
+}
+
+/// Cheap filter before DEX parse / heavy locks: drop clearly irrelevant account updates.
+/// Conservative: any DEX program owner we parse in `parse_pool_account` / `parse_account_update` stays in.
+pub fn account_geyser_update_relevance<H: IngestHost>(
+    host: &H,
+    u: &GeyserAccountUpdate,
+) -> AccountGeyserRelevance {
+    if let Some((wallet, wsol_ata)) = host.ingest_tracked_wallet_pubkeys() {
+        if u.pubkey == wallet || u.pubkey == wsol_ata {
+            return AccountGeyserRelevance::Relevant;
+        }
+        if host.ingest_tracked_wallet_token_account_contains(&u.pubkey) {
+            return AccountGeyserRelevance::Relevant;
+        }
+    }
+    if host.ingest_membership_contains(&u.pubkey) {
+        return AccountGeyserRelevance::Relevant;
+    }
+
+    if !account_geyser_update_is_dex_pool_owner(&u.owner) {
+        return AccountGeyserRelevance::EarlyDrop(
+            MarketDataAccountEarlyDropReason::NonDexNonMembership,
+        );
+    }
+
+    let pool_pk = u.pubkey;
+    if host.ingest_is_enrichment_member(&pool_pk) {
+        inc_market_data_account_relevance_enrichment_hit_total();
+        return AccountGeyserRelevance::Relevant;
+    }
+    if u.owner == PUMPFUN_PROGRAM_OWNER && host.ingest_pumpfun_bonding_curve_tracks_wallet(&pool_pk)
+    {
+        return AccountGeyserRelevance::Relevant;
+    }
+    AccountGeyserRelevance::EarlyDrop(MarketDataAccountEarlyDropReason::DexPoolNotEnrichment)
+}
+
 /// Cheap filter before DEX parse / heavy locks: drop clearly irrelevant account updates.
 /// Conservative: any DEX program owner we parse in `parse_pool_account` / `parse_account_update` stays in.
 pub fn account_geyser_update_might_be_relevant<H: IngestHost>(
     host: &H,
     u: &GeyserAccountUpdate,
 ) -> bool {
-    if let Some((wallet, wsol_ata)) = host.ingest_tracked_wallet_pubkeys() {
-        if u.pubkey == wallet || u.pubkey == wsol_ata {
-            return true;
-        }
-        if host.ingest_tracked_wallet_token_account_contains(&u.pubkey) {
-            return true;
-        }
-    }
-    if host.ingest_membership_contains(&u.pubkey) {
-        return true;
-    }
-
-    if !account_geyser_update_is_dex_pool_owner(&u.owner) {
-        return false;
-    }
-
-    let pool_pk = u.pubkey;
-    if host.ingest_is_enrichment_member(&pool_pk) {
-        inc_market_data_account_relevance_enrichment_hit_total();
-        return true;
-    }
-    if u.owner == PUMPFUN_PROGRAM_OWNER && host.ingest_pumpfun_bonding_curve_tracks_wallet(&pool_pk)
-    {
-        return true;
-    }
-    false
+    matches!(
+        account_geyser_update_relevance(host, u),
+        AccountGeyserRelevance::Relevant
+    )
 }
 
 /// Strategic HIGH admission for account worker sharding (ACCOUNT-PATH-TX-PARITY-CREATOR).
@@ -97,4 +120,137 @@ pub fn account_geyser_dispatch_priority_high<H: IngestHost>(
         return true;
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::MarketDataAccountEarlyDropReason;
+    use std::collections::HashSet;
+    use std::time::Instant;
+
+    struct MockIngestHost {
+        membership: HashSet<Pubkey>,
+        enrichment_members: HashSet<Pubkey>,
+        pumpfun_wallet_track: HashSet<Pubkey>,
+    }
+
+    impl IngestHost for MockIngestHost {
+        fn ingest_tracked_wallet_pubkeys(&self) -> Option<(Pubkey, Pubkey)> {
+            None
+        }
+
+        fn ingest_tracked_wallet_token_account_contains(&self, _pubkey: &Pubkey) -> bool {
+            false
+        }
+
+        fn ingest_membership_contains(&self, pubkey: &Pubkey) -> bool {
+            self.membership.contains(pubkey)
+        }
+
+        fn ingest_membership_vault_contains(&self, _pubkey: &Pubkey) -> bool {
+            false
+        }
+
+        fn ingest_membership_bin_array_contains(&self, _pubkey: &Pubkey) -> bool {
+            false
+        }
+
+        fn ingest_is_hot_pool(&self, _pool: &Pubkey) -> bool {
+            false
+        }
+
+        fn ingest_is_enrichment_member(&self, pool: &Pubkey) -> bool {
+            self.enrichment_members.contains(pool)
+        }
+
+        fn ingest_pool_mint_map_contains(&self, pool: &Pubkey) -> bool {
+            self.enrichment_members.contains(pool)
+        }
+
+        fn ingest_high_priority_bonding_curve_contains(&self, _pool: &Pubkey) -> bool {
+            false
+        }
+
+        fn ingest_wallet_tracks_mint(&self, _mint: &Pubkey) -> bool {
+            false
+        }
+
+        fn ingest_pumpfun_bonding_curve_tracks_wallet(&self, pool: &Pubkey) -> bool {
+            self.pumpfun_wallet_track.contains(pool)
+        }
+
+        fn ingest_pumpfun_wallet_tracks_pool_mint(&self, _pool: &Pubkey) -> bool {
+            false
+        }
+
+        fn ingest_record_membership_snapshot_hit(&self) {}
+
+        fn ingest_record_vault_high_priority_dispatch(&self) {}
+
+        fn ingest_record_enrichment_relevance_hit(&self) {}
+    }
+
+    fn sample_update(pubkey: Pubkey, owner: Pubkey) -> GeyserAccountUpdate {
+        GeyserAccountUpdate {
+            pubkey,
+            slot: 1,
+            owner,
+            data: vec![],
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn account_geyser_update_relevance_non_enrichment_dex_pool() {
+        let host = MockIngestHost {
+            membership: HashSet::new(),
+            enrichment_members: HashSet::new(),
+            pumpfun_wallet_track: HashSet::new(),
+        };
+        let pool = Pubkey::new_unique();
+        let u = sample_update(pool, RAYDIUM_CPMM_OWNER);
+        assert_eq!(
+            account_geyser_update_relevance(&host, &u),
+            AccountGeyserRelevance::EarlyDrop(
+                MarketDataAccountEarlyDropReason::DexPoolNotEnrichment
+            )
+        );
+        assert!(!account_geyser_update_might_be_relevant(&host, &u));
+    }
+
+    #[test]
+    fn account_geyser_update_relevance_random_non_dex_pubkey() {
+        let host = MockIngestHost {
+            membership: HashSet::new(),
+            enrichment_members: HashSet::new(),
+            pumpfun_wallet_track: HashSet::new(),
+        };
+        let pubkey = Pubkey::new_unique();
+        let u = sample_update(pubkey, Pubkey::new_unique());
+        assert_eq!(
+            account_geyser_update_relevance(&host, &u),
+            AccountGeyserRelevance::EarlyDrop(
+                MarketDataAccountEarlyDropReason::NonDexNonMembership
+            )
+        );
+        assert!(!account_geyser_update_might_be_relevant(&host, &u));
+    }
+
+    #[test]
+    fn account_geyser_update_relevance_membership_explicit_vault_no_early_drop() {
+        let vault = Pubkey::new_unique();
+        let host = MockIngestHost {
+            membership: HashSet::from([vault]),
+            enrichment_members: HashSet::new(),
+            pumpfun_wallet_track: HashSet::new(),
+        };
+        let u = sample_update(vault, Pubkey::new_unique());
+        assert_eq!(
+            account_geyser_update_relevance(&host, &u),
+            AccountGeyserRelevance::Relevant
+        );
+        assert!(account_geyser_update_might_be_relevant(&host, &u));
+    }
 }

--- a/src/market_data/ingest/mod.rs
+++ b/src/market_data/ingest/mod.rs
@@ -10,7 +10,8 @@ pub mod tx_parse;
 
 pub use account_filter::{
     account_geyser_dispatch_priority_high, account_geyser_update_is_dex_pool_owner,
-    account_geyser_update_might_be_relevant,
+    account_geyser_update_might_be_relevant, account_geyser_update_relevance,
+    AccountGeyserRelevance,
 };
 pub use account_handler::handle_geyser_account_update;
 pub use account_host::{AccountBinArrayView, AccountIngestHost, AccountTrackedWalletView};

--- a/src/market_data/sidefx/handlers.rs
+++ b/src/market_data/sidefx/handlers.rs
@@ -187,6 +187,24 @@ fn md_sidefx_publish_enrichment_from_cache_upsert(
     }
 }
 
+/// P2 SLO: count enrichment publishes only for EnrichmentRegistry members.
+fn md_sidefx_inc_enrichment_publish_metrics_if_member(
+    host: &dyn SidefxWorkerHost,
+    pool: &Pubkey,
+    balance_js: bool,
+    pool_state: bool,
+) {
+    if !host.is_enrichment_member(pool) {
+        return;
+    }
+    if balance_js {
+        inc_market_data_enrichment_balance_updated_total();
+    }
+    if pool_state {
+        inc_market_data_enrichment_pool_state_publish_total();
+    }
+}
+
 /// Build PoolStateUpdate from MASTER LivePoolCache (Geyser-only; no RPC).
 fn md_sidefx_build_pool_state_update_from_cache(
     host: &dyn SidefxWorkerHost,
@@ -1696,6 +1714,12 @@ pub fn md_sidefx_process_vault_balance_tick(
             "PoolCacheUpdate::BalanceUpdated",
             false,
         );
+        md_sidefx_inc_enrichment_publish_metrics_if_member(
+            host,
+            &vault_view.pool_address,
+            true,
+            false,
+        );
         info!(
             pool = %vault_view.pool_address,
             slot = slot,
@@ -1726,13 +1750,19 @@ pub fn md_sidefx_process_vault_balance_tick(
     host.write_market_event_jsonl(&state_event);
 
     if host.nats_enabled() {
-        host.enqueue_core_market_event(
+        let pool_state_enqueued = host.enqueue_core_market_event(
             state_event,
             Some(MarketEventCorePublishTrace {
                 recv_at: *grpc_recv_at,
                 cold_path: false,
                 segment: MarketDataLatencySegment::Other,
             }),
+        );
+        md_sidefx_inc_enrichment_publish_metrics_if_member(
+            host,
+            &vault_view.pool_address,
+            false,
+            pool_state_enqueued,
         );
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1546,8 +1546,28 @@ static MARKET_DATA_ACCOUNT_PUBLISH_WORKER_JOB_DURATION_US_SUM: Lazy<AtomicU64> =
 static MARKET_DATA_ACCOUNT_PUBLISH_WORKER_JOB_DURATION_US_COUNT: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
+/// Early-drop reason for `market_data_account_early_drop_total{reason=...}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarketDataAccountEarlyDropReason {
+    NonDexNonMembership,
+    DexPoolNotEnrichment,
+}
+
+impl MarketDataAccountEarlyDropReason {
+    #[inline]
+    pub fn as_prometheus_label(self) -> &'static str {
+        match self {
+            Self::NonDexNonMembership => "non_dex_non_membership",
+            Self::DexPoolNotEnrichment => "dex_pool_not_enrichment",
+        }
+    }
+}
+
 /// Account ingest: cheap relevance filter discarded the update before `handle_geyser_account` body.
-pub static MARKET_DATA_ACCOUNT_EARLY_DROP_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_ACCOUNT_EARLY_DROP_NON_DEX_NON_MEMBERSHIP: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_ACCOUNT_EARLY_DROP_DEX_POOL_NOT_ENRICHMENT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 /// Wall microseconds for `handle_geyser_account` body per worker (excludes queue wait).
 const MARKET_DATA_ACCOUNT_HANDLER_DURATION_US_BUCKETS: &[u64] = &[
@@ -1842,8 +1862,16 @@ pub fn set_market_data_account_publish_worker_last_success_unix_ms(worker_id: us
 }
 
 #[inline]
-pub fn record_market_data_account_early_drop_total() {
-    MARKET_DATA_ACCOUNT_EARLY_DROP_TOTAL.fetch_add(1, Ordering::Relaxed);
+pub fn record_market_data_account_early_drop(reason: MarketDataAccountEarlyDropReason) {
+    let counter = match reason {
+        MarketDataAccountEarlyDropReason::NonDexNonMembership => {
+            &*MARKET_DATA_ACCOUNT_EARLY_DROP_NON_DEX_NON_MEMBERSHIP
+        }
+        MarketDataAccountEarlyDropReason::DexPoolNotEnrichment => {
+            &*MARKET_DATA_ACCOUNT_EARLY_DROP_DEX_POOL_NOT_ENRICHMENT
+        }
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Per-account-update handler wall time (worker), microseconds.
@@ -6390,10 +6418,20 @@ async fn metrics_response() -> Response<Body> {
         &MARKET_DATA_ACCOUNT_PUBLISH_WORKER_JOB_DURATION_US_SUM,
         &MARKET_DATA_ACCOUNT_PUBLISH_WORKER_JOB_DURATION_US_COUNT,
     );
-    line!(
-        "market_data_account_early_drop_total",
-        MARKET_DATA_ACCOUNT_EARLY_DROP_TOTAL.load(Ordering::Relaxed)
+    out.push_str("market_data_account_early_drop_total{reason=\"non_dex_non_membership\"} ");
+    out.push_str(
+        &MARKET_DATA_ACCOUNT_EARLY_DROP_NON_DEX_NON_MEMBERSHIP
+            .load(Ordering::Relaxed)
+            .to_string(),
     );
+    out.push('\n');
+    out.push_str("market_data_account_early_drop_total{reason=\"dex_pool_not_enrichment\"} ");
+    out.push_str(
+        &MARKET_DATA_ACCOUNT_EARLY_DROP_DEX_POOL_NOT_ENRICHMENT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
     append_momentum_latency_histogram_prometheus(
         &mut out,
         "market_data_account_handler_duration_us",


### PR DESCRIPTION
## Summary
- Hook `inc_market_data_enrichment_*` on the real vault-tick publish path when pool is enrichment member (cache-upsert skip for vault-feed pools unchanged).
- Replace unlabeled `market_data_account_early_drop_total` with `{reason=non_dex_non_membership|dex_pool_not_enrichment}` via `account_geyser_update_relevance()` — **no relevance semantics change**.
- Unit + grep tests for drop reasons and vault-tick enrichment counters.

Forensik: `Iron_crab-eval/docs/supervisor/findings_p2_event_rate_20260706.md`

**Observability only — no publish gating or relevance filter behavior change.**

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [ ] Post-deploy: `rate(market_data_enrichment_pool_state_publish_total[5m])` > 0
- [ ] Post-deploy: early_drop reasons visible in Prometheus

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics and test wiring only; PR explicitly states no relevance semantics or publish gating changes.
> 
> **Overview**
> **Observability-only** changes for market-data P2 SLOs: no relevance-filter or publish-gating behavior changes.
> 
> Account Geyser ingest now uses `account_geyser_update_relevance()` (with `AccountGeyserRelevance::EarlyDrop(reason)`) instead of a boolean check; the bin records **`market_data_account_early_drop_total{reason=...}`** via `record_market_data_account_early_drop` for `non_dex_non_membership` vs `dex_pool_not_enrichment`. `account_geyser_update_might_be_relevant` remains as a thin wrapper over the same logic.
> 
> On **`md_sidefx_process_vault_balance_tick`**, `inc_market_data_enrichment_balance_updated_total` and `inc_market_data_enrichment_pool_state_publish_total` are incremented through **`md_sidefx_inc_enrichment_publish_metrics_if_member`** so enrichment counters track real JetStream/core publishes for registry members (pool-state metric respects whether core enqueue succeeded).
> 
> Unit and grep tests cover drop reasons and the vault-tick metric wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dce949cf15c1c2227eb086b35d5b355fe158452a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->