### PR TITLE
fix(md): P2 hardening — eliminate false-positive unparsed drops + labeled metrics

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -14490,6 +14490,55 @@ mod pr_b_geyser_tracking_tests {
         );
     }
 
+    /// P2 hardening: account handler early-returns after sidefx paths (no false unparsed drops).
+    #[test]
+    fn p2_account_handler_early_return_after_sidefx_paths() {
+        let account_handler_src = include_str!("../market_data/ingest/account_handler.rs");
+        assert!(
+            account_handler_src.contains("MdSidefxCommand::VaultBalanceTick"),
+            "account_handler must enqueue VaultBalanceTick"
+        );
+        let vault_tick_pos = account_handler_src
+            .find("MdSidefxCommand::VaultBalanceTick")
+            .expect("VaultBalanceTick");
+        let after_vault_tick = &account_handler_src[vault_tick_pos..];
+        assert!(
+            after_vault_tick.contains("return;"),
+            "account_handler must return after VaultBalanceTick enqueue"
+        );
+        assert!(
+            account_handler_src.contains("MdSidefxCommand::LivePoolCacheAccountUpdate"),
+            "account_handler must enqueue LivePoolCacheAccountUpdate"
+        );
+        assert!(
+            account_handler_src.contains("account_geyser_update_is_sidefx_only_pool_owner"),
+            "account_handler must gate sidefx-only pool owner early return"
+        );
+        assert!(
+            account_handler_src.contains("record_market_data_unparsed_account_dropped"),
+            "account_handler must use labeled unparsed account metric"
+        );
+    }
+
+    /// P2 hardening: TX handler uses labeled unparsed metric with DEX detection helper.
+    #[test]
+    fn p2_tx_handler_labeled_unparsed_drop_metric() {
+        let tx_handler_src = include_str!("../market_data/ingest/tx_handler.rs");
+        let tx_parse_src = include_str!("../market_data/ingest/tx_parse.rs");
+        assert!(
+            tx_handler_src.contains("record_market_data_unparsed_tx_dropped"),
+            "tx_handler must use labeled unparsed TX metric"
+        );
+        assert!(
+            tx_handler_src.contains("tx_involves_known_dex_program"),
+            "tx_handler must classify DEX vs non-DEX unparsed drops"
+        );
+        assert!(
+            tx_parse_src.contains("pub fn tx_involves_known_dex_program"),
+            "tx_parse must define DEX program detection helper"
+        );
+    }
+
     /// Phase 4b: account ingest module must not read tracked_* maps or arb reconcile paths.
     #[test]
     fn phase4b_account_ingest_no_tracked_reads() {

--- a/src/market_data/ingest/account_filter.rs
+++ b/src/market_data/ingest/account_filter.rs
@@ -35,6 +35,17 @@ pub fn account_geyser_update_is_dex_pool_owner(owner: &Pubkey) -> bool {
         || o == PUMPFUN_AMM_PROGRAM_OWNER
 }
 
+/// DEX pool owners handled exclusively via `md-sidefx` (`LivePoolCacheAccountUpdate`).
+/// Legacy `parse_account_update` remains for Raydium AMM v4, Orca, and PumpFun bonding.
+#[inline]
+pub fn account_geyser_update_is_sidefx_only_pool_owner(owner: &Pubkey) -> bool {
+    let o = *owner;
+    o == RAYDIUM_CPMM_OWNER
+        || o == METEORA_CPMM_OWNER
+        || o == METEORA_DLMM_OWNER
+        || o == PUMPFUN_AMM_PROGRAM_OWNER
+}
+
 /// Result of the cheap account relevance filter (before DEX parse / heavy locks).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccountGeyserRelevance {

--- a/src/market_data/ingest/account_handler.rs
+++ b/src/market_data/ingest/account_handler.rs
@@ -1,7 +1,9 @@
 //! Geyser account ingest handler (dedizierte worker pool, MARKET-DATA-ACCOUNT-THROUGHPUT-P0).
 //! STOP-CHECK: keine neuen RPC-Calls.
 
-use super::account_filter::account_geyser_update_is_dex_pool_owner;
+use super::account_filter::{
+    account_geyser_update_is_dex_pool_owner, account_geyser_update_is_sidefx_only_pool_owner,
+};
 use super::account_host::AccountIngestHost;
 use super::account_parse::{
     account_publish_segment, try_parse_mint_account, try_parse_token_account_balance,
@@ -17,7 +19,8 @@ use crate::market_data::sidefx::{
     md_sidefx_try_enqueue, MarketEventCorePublishTrace, MdSidefxCommand, MdSidefxSender,
 };
 use crate::metrics::{
-    inc_market_data_unparsed_account_dropped_total, record_market_data_tokio_progress,
+    record_market_data_tokio_progress, record_market_data_unparsed_account_dropped,
+    MarketDataUnparsedAccountDropReason,
 };
 use crate::nats::wallet_snapshot_subject;
 use crate::solana::dex::meteora_bin_array_layout::BinArray;
@@ -303,6 +306,7 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
                 )
                 .await;
             }
+            return;
         }
     }
 
@@ -323,6 +327,7 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
                     grpc_recv_at: account_update.grpc_recv_at,
                 },
             );
+            return;
         }
     }
 
@@ -410,6 +415,7 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
                     );
                 }
             }
+            return;
         }
     }
 
@@ -426,6 +432,9 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
                 grpc_recv_at: account_geyser_recv_at,
             },
         );
+        if account_geyser_update_is_sidefx_only_pool_owner(&account_update.owner) {
+            return;
+        }
     }
 
     // Try to parse as DEX pool event (for MarketEvents - existing logic)
@@ -465,7 +474,9 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
     }
 
     let Some(parsed) = parsed else {
-        inc_market_data_unparsed_account_dropped_total();
+        record_market_data_unparsed_account_dropped(
+            MarketDataUnparsedAccountDropReason::LegacyDexParseMiss,
+        );
         return;
     };
 

--- a/src/market_data/ingest/tx_handler.rs
+++ b/src/market_data/ingest/tx_handler.rs
@@ -4,7 +4,7 @@
 use super::tx_host::TxIngestHost;
 use super::tx_parse::{
     maybe_emit_dev_wallet_after_pool_mint_map, process_wallet_balance_snapshots_from_tx_meta,
-    resolve_pumpfun_creator_tx_path, tx_publish_segment,
+    resolve_pumpfun_creator_tx_path, tx_involves_known_dex_program, tx_publish_segment,
 };
 use crate::ipc::{IntentTier, MarketEvent, MarketEventKind, PriorityFeePercentiles};
 use crate::market_data::md_state::{md_state_try_enqueue, MdStateCommand, MdStateSender};
@@ -17,8 +17,9 @@ use crate::market_data::sidefx::{
     MdSidefxCommand, MdSidefxSender,
 };
 use crate::metrics::{
-    inc_market_data_unparsed_tx_dropped_total, market_data_bump_geyser_head_slot,
-    record_market_data_tx_channel_lag_ms, record_market_data_tx_handler_processed,
+    market_data_bump_geyser_head_slot, record_market_data_tx_channel_lag_ms,
+    record_market_data_tx_handler_processed, record_market_data_unparsed_tx_dropped,
+    MarketDataUnparsedTxDropReason,
 };
 use crate::nats::TOPIC_PRIORITY_FEE_SAMPLES;
 use crate::solana::dex_parser::{
@@ -320,7 +321,12 @@ pub async fn handle_geyser_transaction_update<H: TxIngestHost>(
     }
 
     let Some(parsed) = parsed_event else {
-        inc_market_data_unparsed_tx_dropped_total();
+        let reason = if tx_involves_known_dex_program(&tx_update.account_keys) {
+            MarketDataUnparsedTxDropReason::DexParseMiss
+        } else {
+            MarketDataUnparsedTxDropReason::NonDexTransaction
+        };
+        record_market_data_unparsed_tx_dropped(reason);
         return;
     };
 

--- a/src/market_data/ingest/tx_parse.rs
+++ b/src/market_data/ingest/tx_parse.rs
@@ -12,6 +12,10 @@ use crate::metrics::{
     MarketDataLatencySegment,
 };
 use crate::nats::{wallet_snapshot_subject, NatsClient};
+use crate::solana::dex_parser::{
+    METEORA_DLMM, ORCA_WHIRLPOOL, PUMPFUN_AMM_PROGRAM, PUMPFUN_PROGRAM, RAYDIUM_AMM_V4,
+    RAYDIUM_CPMM,
+};
 use crate::solana::geyser_listener::{
     geyser_token_balance_account_pubkey, geyser_tx_involves_wallet,
     geyser_wallet_post_token_balances, GeyserTransactionUpdate, TokenBalance,
@@ -313,5 +317,57 @@ pub(crate) fn tx_publish_segment(kind: &MarketEventKind) -> MarketDataLatencySeg
         MarketEventKind::BondingCurveProgress { .. } => MarketDataLatencySegment::BondingCurve,
         MarketEventKind::PoolCreated { .. } => MarketDataLatencySegment::PoolCreated,
         _ => MarketDataLatencySegment::Other,
+    }
+}
+
+/// Whether any known DEX program id appears in the transaction account keys (no RPC).
+#[inline]
+pub fn tx_involves_known_dex_program(account_keys: &[Pubkey]) -> bool {
+    static PROGRAMS: &[&str] = &[
+        RAYDIUM_AMM_V4,
+        RAYDIUM_CPMM,
+        ORCA_WHIRLPOOL,
+        METEORA_DLMM,
+        PUMPFUN_PROGRAM,
+        PUMPFUN_AMM_PROGRAM,
+    ];
+    PROGRAMS.iter().any(|program_id| {
+        Pubkey::from_str(program_id)
+            .ok()
+            .is_some_and(|pk| account_keys.contains(&pk))
+    })
+}
+
+#[cfg(test)]
+mod tx_dex_detection_tests {
+    use super::*;
+    use crate::metrics::MarketDataUnparsedTxDropReason;
+
+    fn unparsed_tx_drop_reason(account_keys: &[Pubkey]) -> MarketDataUnparsedTxDropReason {
+        if tx_involves_known_dex_program(account_keys) {
+            MarketDataUnparsedTxDropReason::DexParseMiss
+        } else {
+            MarketDataUnparsedTxDropReason::NonDexTransaction
+        }
+    }
+
+    #[test]
+    fn tx_unparsed_drop_reason_non_dex_without_known_program() {
+        let keys = vec![Pubkey::new_unique(), Pubkey::new_unique()];
+        assert_eq!(
+            unparsed_tx_drop_reason(&keys),
+            MarketDataUnparsedTxDropReason::NonDexTransaction
+        );
+    }
+
+    #[test]
+    fn tx_unparsed_drop_reason_dex_parse_miss_when_raydium_present() {
+        let raydium = Pubkey::from_str(RAYDIUM_AMM_V4).unwrap();
+        let keys = vec![Pubkey::new_unique(), raydium];
+        assert!(tx_involves_known_dex_program(&keys));
+        assert_eq!(
+            unparsed_tx_drop_reason(&keys),
+            MarketDataUnparsedTxDropReason::DexParseMiss
+        );
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -889,6 +889,15 @@ pub static MARKET_DATA_TX_HANDLER_STALLS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| A
 pub static MARKET_DATA_UNPARSED_TX_DROPPED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static MARKET_DATA_UNPARSED_ACCOUNT_DROPPED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// Labeled: `market_data_unparsed_account_dropped_total{reason="legacy_dex_parse_miss"}`.
+pub static MARKET_DATA_UNPARSED_ACCOUNT_DROPPED_LEGACY_DEX_PARSE_MISS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Labeled: `market_data_unparsed_tx_dropped_total{reason="non_dex_transaction"}`.
+pub static MARKET_DATA_UNPARSED_TX_DROPPED_NON_DEX_TRANSACTION: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Labeled: `market_data_unparsed_tx_dropped_total{reason="dex_parse_miss"}`.
+pub static MARKET_DATA_UNPARSED_TX_DROPPED_DEX_PARSE_MISS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 static MARKET_DATA_TX_HANDLER_RECONNECT_REQUESTED: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 static MARKET_DATA_ACCOUNT_SESSION_RECONNECT_REQUESTED: Lazy<AtomicU64> =
@@ -1033,13 +1042,70 @@ pub fn record_market_data_tx_handler_stall() {
 }
 
 #[inline]
+#[allow(dead_code)]
 pub fn inc_market_data_unparsed_tx_dropped_total() {
     MARKET_DATA_UNPARSED_TX_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
+#[allow(dead_code)]
 pub fn inc_market_data_unparsed_account_dropped_total() {
     MARKET_DATA_UNPARSED_ACCOUNT_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Unparsed account drop reason for `market_data_unparsed_account_dropped_total{reason=...}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarketDataUnparsedAccountDropReason {
+    LegacyDexParseMiss,
+}
+
+impl MarketDataUnparsedAccountDropReason {
+    #[inline]
+    pub fn as_prometheus_label(self) -> &'static str {
+        match self {
+            Self::LegacyDexParseMiss => "legacy_dex_parse_miss",
+        }
+    }
+}
+
+/// Unparsed TX drop reason for `market_data_unparsed_tx_dropped_total{reason=...}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarketDataUnparsedTxDropReason {
+    NonDexTransaction,
+    DexParseMiss,
+}
+
+impl MarketDataUnparsedTxDropReason {
+    #[inline]
+    pub fn as_prometheus_label(self) -> &'static str {
+        match self {
+            Self::NonDexTransaction => "non_dex_transaction",
+            Self::DexParseMiss => "dex_parse_miss",
+        }
+    }
+}
+
+#[inline]
+pub fn record_market_data_unparsed_account_dropped(reason: MarketDataUnparsedAccountDropReason) {
+    let counter = match reason {
+        MarketDataUnparsedAccountDropReason::LegacyDexParseMiss => {
+            &*MARKET_DATA_UNPARSED_ACCOUNT_DROPPED_LEGACY_DEX_PARSE_MISS
+        }
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_market_data_unparsed_tx_dropped(reason: MarketDataUnparsedTxDropReason) {
+    let counter = match reason {
+        MarketDataUnparsedTxDropReason::NonDexTransaction => {
+            &*MARKET_DATA_UNPARSED_TX_DROPPED_NON_DEX_TRANSACTION
+        }
+        MarketDataUnparsedTxDropReason::DexParseMiss => {
+            &*MARKET_DATA_UNPARSED_TX_DROPPED_DEX_PARSE_MISS
+        }
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -5805,10 +5871,31 @@ async fn metrics_response() -> Response<Body> {
         "market_data_unparsed_tx_dropped_total",
         MARKET_DATA_UNPARSED_TX_DROPPED_TOTAL.load(Ordering::Relaxed)
     );
+    out.push_str("market_data_unparsed_tx_dropped_total{reason=\"non_dex_transaction\"} ");
+    out.push_str(
+        &MARKET_DATA_UNPARSED_TX_DROPPED_NON_DEX_TRANSACTION
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("market_data_unparsed_tx_dropped_total{reason=\"dex_parse_miss\"} ");
+    out.push_str(
+        &MARKET_DATA_UNPARSED_TX_DROPPED_DEX_PARSE_MISS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
     line!(
         "market_data_unparsed_account_dropped_total",
         MARKET_DATA_UNPARSED_ACCOUNT_DROPPED_TOTAL.load(Ordering::Relaxed)
     );
+    out.push_str("market_data_unparsed_account_dropped_total{reason=\"legacy_dex_parse_miss\"} ");
+    out.push_str(
+        &MARKET_DATA_UNPARSED_ACCOUNT_DROPPED_LEGACY_DEX_PARSE_MISS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
     line!(
         "geyser_account_listener_account_updates_total",
         GEYSER_ACCOUNT_LISTENER_ACCOUNT_UPDATES_TOTAL.load(Ordering::Relaxed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Kontext

Prod-Forensik auf `b9a6230` (~19 min Uptime, 120s Messung) zeigte irreführende Unparsed-Metriken:

| Metrik | Rate/s | Problem |
|--------|--------|---------|
| `market_data_unparsed_account_dropped` | ~54 | ≈60% Account-Worker-Arbeit — **False Positives** |
| `market_data_unparsed_tx_dropped` | ~30 | ≈85% TX — erwartetes Nicht-DEX-Rauschen |

- Forensik: [findings_p2_event_rate_20260706.md](https://github.com/Exploratorsclub/Iron_crab-eval/blob/main/docs/supervisor/findings_p2_event_rate_20260706.md)
- Abnahme-Baseline: [abnahme_md_p2_metrics_b9a6230_prod_20260707.md](https://github.com/Exploratorsclub/Iron_crab-eval/blob/main/docs/supervisor/abnahme_md_p2_metrics_b9a6230_prod_20260707.md)
- Plan: P2 Throughput / Observability in `plan_market_data_dual_consumer_architecture_20260705.md`

## Root Cause

**Account:** Nach erfolgreicher Verarbeitung auf Mint-/Vault-/Bin-Array-/Sidefx-Pfaden fiel der Handler ohne `return` in Legacy-`parse_account_update()` — liefert `None` für Meteora DLMM, Raydium CPMM, Vaults etc.

**TX:** Jede nicht parsebare TX zählte als `unparsed_tx_dropped`, auch normale Nicht-DEX-Transaktionen.

## Änderungen

### Scope A — Account early returns
- `return` nach Mint (`TokenMintInfo` + sidefx decimals)
- `return` nach `VaultBalanceTick` enqueue
- `return` nach DLMM bin-array membership (Touch-only inkl.)
- `return` nach `LivePoolCacheAccountUpdate` nur für **sidefx-only** Owner (CPMM, Meteora CPMM/DLMM, Pump AMM)
- Raydium AMM v4 / Orca / PumpFun bonding → Legacy-Parse bleibt erhalten

### Scope B — Labeled metrics
- `market_data_unparsed_account_dropped_total{reason="legacy_dex_parse_miss"}`
- `market_data_unparsed_tx_dropped_total{reason="non_dex_transaction"|"dex_parse_miss"}`
- Legacy unlabeled Counter bleibt im Export (immer 0)

### Scope C — Tests
- Grep/Source-Contract tests in `market_data.rs`
- Unit tests für `tx_involves_known_dex_program` in `tx_parse.rs`

## Erwarteter Prod-Effekt

- `rate(market_data_unparsed_account_dropped_total{reason="legacy_dex_parse_miss"}[5m])` ≪ 54/s (Ziel: nahe 0)
- `non_dex_transaction` dominiert TX-Bucket
- Weniger wasted parse work → `market_events_published` potenziell leicht höher (kein Garantie-Claim)

## STOP-CHECK

- ✅ Kein neuer RPC (I-7)
- ✅ Keine Sidefx-Semantik-Änderung
- ✅ Keine neuen Parser
- ✅ Keine Relevance-Filter-Änderung

## Prüf-Befehle

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅
```

**Kein Deploy** durch diesen PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93404313-b4a7-4a97-8182-443d3ce15000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93404313-b4a7-4a97-8182-443d3ce15000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

