### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
- Bump `crossbeam-epoch` 0.9.18 → **0.9.20** in `Cargo.lock` via `cargo update -p crossbeam-epoch --precise 0.9.20`
- Fixes CI `Security audit (cargo-audit)` failure **RUSTSEC-2026-0204** (transitive via Solana/rayon)

## Timeline
- PR #272 CI (2026-07-06 ~21:45 UTC): cargo-audit **green** — advisory not yet in RustSec DB
- PR #273 CI (2026-07-07 ~13:37 UTC): cargo-audit **red** — new advisory published/fetched
- **Not caused by PR #273 code** — advisory DB drift

## Test plan
- [x] `cargo audit --deny warnings`
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
