### PR TITLE
fix(market-data): narrow unparsed TX DEX detection to Geyser-extracted instructions

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -14530,12 +14530,16 @@ mod pr_b_geyser_tracking_tests {
             "tx_handler must use labeled unparsed TX metric"
         );
         assert!(
-            tx_handler_src.contains("tx_involves_known_dex_program"),
-            "tx_handler must classify DEX vs non-DEX unparsed drops"
+            tx_handler_src.contains("unparsed_tx_drop_reason"),
+            "tx_handler must classify DEX vs non-DEX unparsed drops via Geyser TX"
         );
         assert!(
-            tx_parse_src.contains("pub fn tx_involves_known_dex_program"),
-            "tx_parse must define DEX program detection helper"
+            tx_parse_src.contains("pub fn tx_geyser_had_extracted_dex_instruction"),
+            "tx_parse must define Geyser-extracted DEX instruction detection"
+        );
+        assert!(
+            tx_parse_src.contains("pub fn unparsed_tx_drop_reason"),
+            "tx_parse must define unparsed TX drop reason helper"
         );
     }
 

--- a/src/market_data/ingest/tx_handler.rs
+++ b/src/market_data/ingest/tx_handler.rs
@@ -4,7 +4,7 @@
 use super::tx_host::TxIngestHost;
 use super::tx_parse::{
     maybe_emit_dev_wallet_after_pool_mint_map, process_wallet_balance_snapshots_from_tx_meta,
-    resolve_pumpfun_creator_tx_path, tx_involves_known_dex_program, tx_publish_segment,
+    resolve_pumpfun_creator_tx_path, tx_publish_segment, unparsed_tx_drop_reason,
 };
 use crate::ipc::{IntentTier, MarketEvent, MarketEventKind, PriorityFeePercentiles};
 use crate::market_data::md_state::{md_state_try_enqueue, MdStateCommand, MdStateSender};
@@ -19,7 +19,6 @@ use crate::market_data::sidefx::{
 use crate::metrics::{
     market_data_bump_geyser_head_slot, record_market_data_tx_channel_lag_ms,
     record_market_data_tx_handler_processed, record_market_data_unparsed_tx_dropped,
-    MarketDataUnparsedTxDropReason,
 };
 use crate::nats::TOPIC_PRIORITY_FEE_SAMPLES;
 use crate::solana::dex_parser::{
@@ -321,12 +320,7 @@ pub async fn handle_geyser_transaction_update<H: TxIngestHost>(
     }
 
     let Some(parsed) = parsed_event else {
-        let reason = if tx_involves_known_dex_program(&tx_update.account_keys) {
-            MarketDataUnparsedTxDropReason::DexParseMiss
-        } else {
-            MarketDataUnparsedTxDropReason::NonDexTransaction
-        };
-        record_market_data_unparsed_tx_dropped(reason);
+        record_market_data_unparsed_tx_dropped(unparsed_tx_drop_reason(&tx_update));
         return;
     };
 

--- a/src/market_data/ingest/tx_parse.rs
+++ b/src/market_data/ingest/tx_parse.rs
@@ -9,7 +9,7 @@ use crate::market_data::publish::{
 use crate::market_data::sidefx::MarketEventCorePublishTrace;
 use crate::metrics::{
     inc_market_data_devwallet_tx_published_total, record_market_data_pool_mint_map_to_devwallet_ms,
-    MarketDataLatencySegment,
+    MarketDataLatencySegment, MarketDataUnparsedTxDropReason,
 };
 use crate::nats::{wallet_snapshot_subject, NatsClient};
 use crate::solana::dex_parser::{
@@ -320,54 +320,131 @@ pub(crate) fn tx_publish_segment(kind: &MarketEventKind) -> MarketDataLatencySeg
     }
 }
 
-/// Whether any known DEX program id appears in the transaction account keys (no RPC).
+const KNOWN_DEX_PROGRAM_IDS: &[&str] = &[
+    RAYDIUM_AMM_V4,
+    RAYDIUM_CPMM,
+    ORCA_WHIRLPOOL,
+    METEORA_DLMM,
+    PUMPFUN_PROGRAM,
+    PUMPFUN_AMM_PROGRAM,
+];
+
 #[inline]
-pub fn tx_involves_known_dex_program(account_keys: &[Pubkey]) -> bool {
-    static PROGRAMS: &[&str] = &[
-        RAYDIUM_AMM_V4,
-        RAYDIUM_CPMM,
-        ORCA_WHIRLPOOL,
-        METEORA_DLMM,
-        PUMPFUN_PROGRAM,
-        PUMPFUN_AMM_PROGRAM,
-    ];
-    PROGRAMS.iter().any(|program_id| {
+fn is_known_dex_program(pk: &Pubkey) -> bool {
+    KNOWN_DEX_PROGRAM_IDS.iter().any(|program_id| {
         Pubkey::from_str(program_id)
             .ok()
-            .is_some_and(|pk| account_keys.contains(&pk))
+            .is_some_and(|known| known == *pk)
     })
+}
+
+/// Whether the Geyser listener extracted a DEX instruction for parsing (no RPC).
+///
+/// SSOT: `geyser_listener.rs` sets `instruction_accounts` when a top-level or inner
+/// instruction invokes a subscribed DEX `program_id`. Fallback inspects `inner_instructions`
+/// when `instruction_accounts` is empty (safety parity with listener CPI extraction).
+#[inline]
+pub fn tx_geyser_had_extracted_dex_instruction(tx: &GeyserTransactionUpdate) -> bool {
+    if !tx.instruction_accounts.is_empty() {
+        return true;
+    }
+    tx.inner_instructions.iter().any(|inner| {
+        tx.account_keys
+            .get(inner.program_id_index as usize)
+            .is_some_and(is_known_dex_program)
+    })
+}
+
+/// Classify unparsed TX drops: actionable parse miss vs expected account_include noise.
+#[inline]
+pub fn unparsed_tx_drop_reason(tx: &GeyserTransactionUpdate) -> MarketDataUnparsedTxDropReason {
+    if tx_geyser_had_extracted_dex_instruction(tx) {
+        MarketDataUnparsedTxDropReason::DexParseMiss
+    } else {
+        MarketDataUnparsedTxDropReason::NonDexTransaction
+    }
 }
 
 #[cfg(test)]
 mod tx_dex_detection_tests {
     use super::*;
-    use crate::metrics::MarketDataUnparsedTxDropReason;
+    use crate::solana::geyser_listener::InnerInstruction;
+    use std::time::Instant;
 
-    fn unparsed_tx_drop_reason(account_keys: &[Pubkey]) -> MarketDataUnparsedTxDropReason {
-        if tx_involves_known_dex_program(account_keys) {
-            MarketDataUnparsedTxDropReason::DexParseMiss
-        } else {
-            MarketDataUnparsedTxDropReason::NonDexTransaction
+    fn minimal_tx(
+        account_keys: Vec<Pubkey>,
+        instruction_accounts: Vec<Pubkey>,
+        inner_instructions: Vec<InnerInstruction>,
+    ) -> GeyserTransactionUpdate {
+        GeyserTransactionUpdate {
+            signature: "test".into(),
+            slot: 1,
+            account_keys,
+            instruction_accounts,
+            instruction_data: vec![],
+            inner_instructions,
+            pre_token_balances: vec![],
+            post_token_balances: vec![],
+            pre_balances: vec![],
+            post_balances: vec![],
+            fee_lamports: 0,
+            compute_units_consumed: None,
+            grpc_recv_at: Instant::now(),
         }
     }
 
     #[test]
-    fn tx_unparsed_drop_reason_non_dex_without_known_program() {
-        let keys = vec![Pubkey::new_unique(), Pubkey::new_unique()];
+    fn tx_unparsed_drop_reason_non_dex_when_raydium_only_in_account_keys() {
+        let raydium = Pubkey::from_str(RAYDIUM_AMM_V4).unwrap();
+        let tx = minimal_tx(vec![Pubkey::new_unique(), raydium], vec![], vec![]);
+        assert!(!tx_geyser_had_extracted_dex_instruction(&tx));
         assert_eq!(
-            unparsed_tx_drop_reason(&keys),
+            unparsed_tx_drop_reason(&tx),
             MarketDataUnparsedTxDropReason::NonDexTransaction
         );
     }
 
     #[test]
-    fn tx_unparsed_drop_reason_dex_parse_miss_when_raydium_present() {
-        let raydium = Pubkey::from_str(RAYDIUM_AMM_V4).unwrap();
-        let keys = vec![Pubkey::new_unique(), raydium];
-        assert!(tx_involves_known_dex_program(&keys));
+    fn tx_unparsed_drop_reason_dex_parse_miss_when_instruction_accounts_populated() {
+        let pool = Pubkey::new_unique();
+        let tx = minimal_tx(vec![Pubkey::new_unique()], vec![pool], vec![]);
+        assert!(tx_geyser_had_extracted_dex_instruction(&tx));
         assert_eq!(
-            unparsed_tx_drop_reason(&keys),
+            unparsed_tx_drop_reason(&tx),
             MarketDataUnparsedTxDropReason::DexParseMiss
+        );
+    }
+
+    #[test]
+    fn tx_unparsed_drop_reason_dex_parse_miss_when_inner_raydium_cpi() {
+        let raydium = Pubkey::from_str(RAYDIUM_AMM_V4).unwrap();
+        let tx = minimal_tx(
+            vec![Pubkey::new_unique(), raydium],
+            vec![],
+            vec![InnerInstruction {
+                program_id_index: 1,
+                accounts: vec![0],
+                data: vec![1, 2, 3, 4, 5, 6, 7, 8],
+            }],
+        );
+        assert!(tx_geyser_had_extracted_dex_instruction(&tx));
+        assert_eq!(
+            unparsed_tx_drop_reason(&tx),
+            MarketDataUnparsedTxDropReason::DexParseMiss
+        );
+    }
+
+    #[test]
+    fn tx_unparsed_drop_reason_non_dex_without_extracted_ix_or_inner_dex() {
+        let tx = minimal_tx(
+            vec![Pubkey::new_unique(), Pubkey::new_unique()],
+            vec![],
+            vec![],
+        );
+        assert!(!tx_geyser_had_extracted_dex_instruction(&tx));
+        assert_eq!(
+            unparsed_tx_drop_reason(&tx),
+            MarketDataUnparsedTxDropReason::NonDexTransaction
         );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Prod auf `e98733c` (120s Messung): `unparsed_tx{reason="dex_parse_miss"}` ~12/s (84,8% aller Geyser-TXs), während `non_dex_transaction` 0/s war.

**Root Cause:** `tx_involves_known_dex_program(account_keys)` prüfte nur, ob eine DEX-Program-ID irgendwo in `account_keys` steht. Da die Geyser-TX-Subscription `account_include` pro DEX-Program nutzt, enthält jede empfangene TX das Program in `account_keys` — auch ohne DEX-Swap/CPI (Pool-Account, readonly ALT, Router-Nebenpfad).

## Fix (Metrik-Semantik only)

Ersetzt die breite `account_keys`-Detection durch `tx_geyser_had_extracted_dex_instruction`, aligned mit Geyser-Listener SSOT (`geyser_listener.rs` ~534–593):

| Reason | Neue Bedeutung |
|--------|----------------|
| `dex_parse_miss` | Geyser hat eine DEX-Instruction extrahiert (`instruction_accounts` non-empty oder inner CPI mit known DEX `program_id`), aber Parser liefert `None` — **actionable** |
| `non_dex_transaction` | TX kam durch `account_include`-Filter, aber **keine** extrahierte DEX-Instruction — erwartetes Rauschen |

### Detection-Logik

1. **Primär:** `!tx.instruction_accounts.is_empty()` (Listener hat DEX-Ix extrahiert)
2. **Fallback:** `inner_instructions` mit `account_keys[program_id_index]` ∈ known DEX programs

### Unverändert

- `parse_transaction_update_with_pool_lookup` — kein Parser-Change
- Geyser-Subscription / `build_tx_subscribe_request`
- P1/P2 TX-Publish-Pfad

## STOP-CHECK

- I-7: Kein RPC, nur Metrik-Klassifikation
- I-4b: Non-blocking ingest unverändert
- I-9: Kein Simulation-Gate-Change
- I-MD-1: Publish unverändert

## Tests

- 4 Unit-Tests in `tx_parse.rs` (Raydium nur in account_keys → NonDex; instruction_accounts → DexParseMiss; inner CPI → DexParseMiss; weder noch → NonDex)
- Grep-Test in `market_data.rs` aktualisiert

## Post-Deploy Abnahme (Supervisor)

- `non_dex_transaction` > 0/s bei ähnlichem Traffic
- `dex_parse_miss` ≪ bisherige Gesamtrate (~12/s)
- Keine Regression P1/P2 Publish

## Prüf-Befehle

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅ (487+ tests)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b52b1220-3b6c-4776-9500-7ad2e46d1044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b52b1220-3b6c-4776-9500-7ad2e46d1044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

