### PR TITLE
fix(market-data): remove arb-pin cold RPC — Geyser-only pins + quote fail logging

### DIFF
--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -1822,6 +1822,96 @@ fn record_v2_insufficient_subreason(insufficient: &RoundTripInsufficient) {
 }
 
 const CROSS_DEX_PAIR_DEBUG_SAMPLE_MAX: usize = 3;
+const HOT_PATH_LOG_THROTTLE_SECS: u64 = 60;
+const HOT_PATH_LOG_THROTTLE_MAP_CAP: usize = 2048;
+
+mod bounded_log_throttle {
+    use std::collections::HashMap;
+    use std::hash::Hash;
+    use std::time::{Duration, Instant};
+
+    #[derive(Debug)]
+    pub(super) struct BoundedLogThrottle<K> {
+        entries: HashMap<K, Instant>,
+        cap: usize,
+        interval: Duration,
+    }
+
+    impl<K: Eq + Hash + Clone> BoundedLogThrottle<K> {
+        pub(super) fn new(cap: usize, interval: Duration) -> Self {
+            Self {
+                entries: HashMap::new(),
+                cap: cap.max(1),
+                interval,
+            }
+        }
+
+        /// Returns true when a diagnostic log may be emitted for `key` at `now`.
+        pub(super) fn should_emit(&mut self, key: K, now: Instant) -> bool {
+            if let Some(last) = self.entries.get(&key) {
+                if now.duration_since(*last) < self.interval {
+                    return false;
+                }
+            }
+            if self.entries.len() >= self.cap {
+                if let Some(oldest_key) = self
+                    .entries
+                    .iter()
+                    .min_by_key(|(_, ts)| *ts)
+                    .map(|(k, _)| k.clone())
+                {
+                    self.entries.remove(&oldest_key);
+                }
+            }
+            self.entries.insert(key, now);
+            true
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn repeated_key_suppressed_until_interval_elapses() {
+            let mut throttle = BoundedLogThrottle::new(8, Duration::from_secs(60));
+            let key = "mint-a:no_cross_dex_sell";
+            let t0 = Instant::now();
+            assert!(throttle.should_emit(key, t0));
+            assert!(!throttle.should_emit(key, t0 + Duration::from_secs(1)));
+            assert!(!throttle.should_emit(key, t0 + Duration::from_secs(59)));
+            assert!(throttle.should_emit(key, t0 + Duration::from_secs(60)));
+        }
+
+        #[test]
+        fn distinct_keys_emit_independently() {
+            let mut throttle = BoundedLogThrottle::new(8, Duration::from_secs(60));
+            let t0 = Instant::now();
+            assert!(throttle.should_emit("mint-a", t0));
+            assert!(throttle.should_emit("mint-b", t0));
+            assert!(!throttle.should_emit("mint-a", t0 + Duration::from_secs(1)));
+        }
+
+        #[test]
+        fn map_capacity_is_bounded() {
+            let mut throttle = BoundedLogThrottle::new(2, Duration::from_secs(60));
+            let t0 = Instant::now();
+            assert!(throttle.should_emit("k1", t0));
+            assert!(throttle.should_emit("k2", t0 + Duration::from_secs(1)));
+            assert!(throttle.should_emit("k3", t0 + Duration::from_secs(2)));
+            assert_eq!(throttle.entries.len(), 2);
+        }
+    }
+}
+
+static ARB_V2_INSUFFICIENT_LOG_THROTTLE: std::sync::LazyLock<
+    parking_lot::Mutex<bounded_log_throttle::BoundedLogThrottle<String>>,
+> = std::sync::LazyLock::new(|| {
+    parking_lot::Mutex::new(bounded_log_throttle::BoundedLogThrottle::new(
+        HOT_PATH_LOG_THROTTLE_MAP_CAP,
+        Duration::from_secs(HOT_PATH_LOG_THROTTLE_SECS),
+    ))
+});
 
 fn insufficient_subreason_metric_label(subreason: RoundTripInsufficientSubreason) -> &'static str {
     match subreason {
@@ -1842,11 +1932,23 @@ fn log_v2_round_trip_insufficient_pools(
 ) {
     let subreason = insufficient.subreason;
     let subreason_label = insufficient_subreason_metric_label(subreason);
+    let dominant = insufficient
+        .no_cross_dex_sell_detail
+        .map(|d| d.as_metric_label())
+        .unwrap_or("unknown");
+    let throttle_key = if subreason == RoundTripInsufficientSubreason::NoCrossDexSell {
+        format!("no_cross_dex:{mint}:{dominant}")
+    } else {
+        format!("insufficient:{mint}:{subreason_label}")
+    };
+    let now = Instant::now();
+    if !ARB_V2_INSUFFICIENT_LOG_THROTTLE
+        .lock()
+        .should_emit(throttle_key, now)
+    {
+        return;
+    }
     if subreason == RoundTripInsufficientSubreason::NoCrossDexSell {
-        let dominant = insufficient
-            .no_cross_dex_sell_detail
-            .map(|d| d.as_metric_label())
-            .unwrap_or("unknown");
         warn!(
             mint = %mint,
             subreason = subreason_label,

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -1821,6 +1821,106 @@ fn record_v2_insufficient_subreason(insufficient: &RoundTripInsufficient) {
     }
 }
 
+const CROSS_DEX_PAIR_DEBUG_SAMPLE_MAX: usize = 3;
+
+fn insufficient_subreason_metric_label(subreason: RoundTripInsufficientSubreason) -> &'static str {
+    match subreason {
+        RoundTripInsufficientSubreason::CandidatesLt2 => "candidates_lt2",
+        RoundTripInsufficientSubreason::NoFreshBuyQuote => "no_fresh_buy_quote",
+        RoundTripInsufficientSubreason::NoCrossDexSell => "no_cross_dex_sell",
+        RoundTripInsufficientSubreason::SingleDexCandidates => "single_dex_candidates",
+    }
+}
+
+fn log_v2_round_trip_insufficient_pools(
+    mint: &str,
+    insufficient: &RoundTripInsufficient,
+    candidates: &[RoundTripPoolCandidate<'_>],
+    probe: u64,
+    freshness: &QuoteFreshnessConfig,
+    token_decimals: u8,
+) {
+    let subreason = insufficient.subreason;
+    let subreason_label = insufficient_subreason_metric_label(subreason);
+    if subreason == RoundTripInsufficientSubreason::NoCrossDexSell {
+        let dominant = insufficient
+            .no_cross_dex_sell_detail
+            .map(|d| d.as_metric_label())
+            .unwrap_or("unknown");
+        warn!(
+            mint = %mint,
+            subreason = subreason_label,
+            dominant_sell_fail_reason = dominant,
+            "arb v2 screen: insufficient pools (no cross-dex sell)"
+        );
+        log_v2_cross_dex_pair_failures_debug_sample(
+            mint,
+            candidates,
+            probe,
+            freshness,
+            token_decimals,
+        );
+    } else {
+        info!(
+            mint = %mint,
+            subreason = subreason_label,
+            "arb v2 screen: insufficient pools"
+        );
+    }
+}
+
+fn log_v2_cross_dex_pair_failures_debug_sample(
+    mint: &str,
+    candidates: &[RoundTripPoolCandidate<'_>],
+    probe: u64,
+    freshness: &QuoteFreshnessConfig,
+    token_decimals: u8,
+) {
+    let now = Instant::now();
+    let mut logged = 0usize;
+    'outer: for buy in candidates {
+        let Some(buy_quote) = quote_exact_in_with_freshness(
+            buy.pool,
+            buy.vault,
+            buy.dlmm_bins,
+            NATIVE_SOL_MINT,
+            &buy.pool.token_mint,
+            probe,
+            freshness,
+        ) else {
+            continue;
+        };
+        if !is_quote_fresh(&buy_quote, freshness, buy.vault, now) {
+            continue;
+        }
+        for sell in candidates {
+            if sell.dex == buy.dex {
+                continue;
+            }
+            let Some(failure) = classify_cross_dex_sell_failure(
+                sell,
+                buy_quote.amount_out,
+                freshness,
+                now,
+                token_decimals,
+            ) else {
+                continue;
+            };
+            debug!(
+                mint = %mint,
+                buy_dex = buy.dex,
+                sell_dex = sell.dex,
+                sell_fail_reason = failure.as_top_level_detail().as_metric_label(),
+                "arb v2 screen: cross-dex pair sell failure sample"
+            );
+            logged += 1;
+            if logged >= CROSS_DEX_PAIR_DEBUG_SAMPLE_MAX {
+                break 'outer;
+            }
+        }
+    }
+}
+
 fn record_eligibility_metrics(breakdown: &MintEligibilityBreakdown) {
     arb_two_hop_pool_gate_add(
         ArbTwoHopPoolGate::CandidatePools,
@@ -2496,6 +2596,14 @@ impl TokenArbTracker {
             Ok(selection) => selection,
             Err(RoundTripSelectFailure::InsufficientPools(insufficient)) => {
                 record_v2_insufficient_subreason(&insufficient);
+                log_v2_round_trip_insufficient_pools(
+                    &self.base_mint,
+                    &insufficient,
+                    &candidates,
+                    probe,
+                    &freshness,
+                    token_decimals,
+                );
                 arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::InsufficientPools);
                 if let Some(collector) = v2_forensics {
                     let breakdown = self.build_v2_eligibility_breakdown(

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -1949,45 +1949,6 @@ static ARB_V2_INSUFFICIENT_LOG_THROTTLE: std::sync::LazyLock<
     ))
 });
 
-#[cfg(test)]
-mod v2_insufficient_log_throttle_tests {
-    use super::*;
-
-    #[test]
-    fn category_is_fixed_per_subreason_and_detail() {
-        let no_fresh = RoundTripInsufficient::new(RoundTripInsufficientSubreason::NoFreshBuyQuote);
-        assert_eq!(
-            v2_insufficient_log_category(&no_fresh),
-            V2InsufficientLogCategory::NoFreshBuyQuote
-        );
-        let cross_dex = RoundTripInsufficient {
-            subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
-            no_cross_dex_sell_detail: Some(NoCrossDexSellDetailReason::SellMissingVault),
-            sell_quote_none_detail_counts: None,
-        };
-        assert_eq!(
-            v2_insufficient_log_category(&cross_dex),
-            V2InsufficientLogCategory::NoCrossDexSellMissingVault
-        );
-    }
-
-    #[test]
-    fn production_log_path_has_no_dynamic_string_keys() {
-        let src = include_str!("arb_strategy.rs");
-        let start = src
-            .find("fn log_v2_round_trip_insufficient_pools(")
-            .expect("log_v2_round_trip_insufficient_pools");
-        let end = src[start..]
-            .find("fn log_v2_cross_dex_pair_failures_debug_sample")
-            .expect("after log_v2_round_trip_insufficient_pools");
-        let fn_body = &src[start..start + end];
-        assert!(
-            !fn_body.contains("format!("),
-            "throttle decision must not allocate dynamic string keys"
-        );
-    }
-}
-
 fn insufficient_subreason_metric_label(subreason: RoundTripInsufficientSubreason) -> &'static str {
     match subreason {
         RoundTripInsufficientSubreason::CandidatesLt2 => "candidates_lt2",
@@ -10060,6 +10021,40 @@ mod two_hop_price_tests {
         let back: ArbTrackRequestsUpdate = serde_json::from_str(&json).expect("deserialize");
         assert!(back.reconcile);
         assert_eq!(back.active.len(), 1);
+    }
+
+    #[test]
+    fn v2_insufficient_log_category_is_fixed_per_subreason_and_detail() {
+        let no_fresh = RoundTripInsufficient::new(RoundTripInsufficientSubreason::NoFreshBuyQuote);
+        assert_eq!(
+            v2_insufficient_log_category(&no_fresh),
+            V2InsufficientLogCategory::NoFreshBuyQuote
+        );
+        let cross_dex = RoundTripInsufficient {
+            subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
+            no_cross_dex_sell_detail: Some(NoCrossDexSellDetailReason::SellMissingVault),
+            sell_quote_none_detail_counts: None,
+        };
+        assert_eq!(
+            v2_insufficient_log_category(&cross_dex),
+            V2InsufficientLogCategory::NoCrossDexSellMissingVault
+        );
+    }
+
+    #[test]
+    fn v2_insufficient_log_path_has_no_dynamic_string_keys() {
+        let src = include_str!("arb_strategy.rs");
+        let start = src
+            .find("fn log_v2_round_trip_insufficient_pools(")
+            .expect("log_v2_round_trip_insufficient_pools");
+        let end = src[start..]
+            .find("fn log_v2_cross_dex_pair_failures_debug_sample")
+            .expect("after log_v2_round_trip_insufficient_pools");
+        let fn_body = &src[start..start + end];
+        assert!(
+            !fn_body.contains("format!("),
+            "throttle decision must not allocate dynamic string keys"
+        );
     }
 }
 

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -1823,47 +1823,33 @@ fn record_v2_insufficient_subreason(insufficient: &RoundTripInsufficient) {
 
 const CROSS_DEX_PAIR_DEBUG_SAMPLE_MAX: usize = 3;
 const HOT_PATH_LOG_THROTTLE_SECS: u64 = 60;
-const HOT_PATH_LOG_THROTTLE_MAP_CAP: usize = 2048;
+const V2_INSUFFICIENT_LOG_CATEGORY_COUNT: usize = 9;
 
-mod bounded_log_throttle {
-    use std::collections::HashMap;
-    use std::hash::Hash;
+mod fixed_category_log_throttle {
     use std::time::{Duration, Instant};
 
     #[derive(Debug)]
-    pub(super) struct BoundedLogThrottle<K> {
-        entries: HashMap<K, Instant>,
-        cap: usize,
+    pub(super) struct FixedCategoryLogThrottle<const N: usize> {
+        last_emit: [Option<Instant>; N],
         interval: Duration,
     }
 
-    impl<K: Eq + Hash + Clone> BoundedLogThrottle<K> {
-        pub(super) fn new(cap: usize, interval: Duration) -> Self {
+    impl<const N: usize> FixedCategoryLogThrottle<N> {
+        pub(super) fn new(interval: Duration) -> Self {
             Self {
-                entries: HashMap::new(),
-                cap: cap.max(1),
+                last_emit: [None; N],
                 interval,
             }
         }
 
-        /// Returns true when a diagnostic log may be emitted for `key` at `now`.
-        pub(super) fn should_emit(&mut self, key: K, now: Instant) -> bool {
-            if let Some(last) = self.entries.get(&key) {
-                if now.duration_since(*last) < self.interval {
+        pub(super) fn should_emit(&mut self, category: usize, now: Instant) -> bool {
+            debug_assert!(category < N);
+            if let Some(last) = self.last_emit[category] {
+                if now.duration_since(last) < self.interval {
                     return false;
                 }
             }
-            if self.entries.len() >= self.cap {
-                if let Some(oldest_key) = self
-                    .entries
-                    .iter()
-                    .min_by_key(|(_, ts)| *ts)
-                    .map(|(k, _)| k.clone())
-                {
-                    self.entries.remove(&oldest_key);
-                }
-            }
-            self.entries.insert(key, now);
+            self.last_emit[category] = Some(now);
             true
         }
     }
@@ -1873,45 +1859,134 @@ mod bounded_log_throttle {
         use super::*;
 
         #[test]
-        fn repeated_key_suppressed_until_interval_elapses() {
-            let mut throttle = BoundedLogThrottle::new(8, Duration::from_secs(60));
-            let key = "mint-a:no_cross_dex_sell";
+        fn many_distinct_mint_values_share_one_category_slot() {
+            let mut throttle = FixedCategoryLogThrottle::<2>::new(Duration::from_secs(60));
+            let category = 0usize;
             let t0 = Instant::now();
-            assert!(throttle.should_emit(key, t0));
-            assert!(!throttle.should_emit(key, t0 + Duration::from_secs(1)));
-            assert!(!throttle.should_emit(key, t0 + Duration::from_secs(59)));
-            assert!(throttle.should_emit(key, t0 + Duration::from_secs(60)));
+            assert!(throttle.should_emit(category, t0));
+            for offset in 1..=1000u64 {
+                assert!(
+                    !throttle.should_emit(category, t0 + Duration::from_millis(offset)),
+                    "category must stay suppressed regardless of mint cardinality"
+                );
+            }
+            assert!(throttle.should_emit(category, t0 + Duration::from_secs(60)));
         }
 
         #[test]
-        fn distinct_keys_emit_independently() {
-            let mut throttle = BoundedLogThrottle::new(8, Duration::from_secs(60));
+        fn distinct_categories_emit_independently() {
+            let mut throttle = FixedCategoryLogThrottle::<3>::new(Duration::from_secs(60));
             let t0 = Instant::now();
-            assert!(throttle.should_emit("mint-a", t0));
-            assert!(throttle.should_emit("mint-b", t0));
-            assert!(!throttle.should_emit("mint-a", t0 + Duration::from_secs(1)));
+            assert!(throttle.should_emit(0, t0));
+            assert!(throttle.should_emit(1, t0));
+            assert!(!throttle.should_emit(0, t0 + Duration::from_secs(1)));
         }
 
         #[test]
-        fn map_capacity_is_bounded() {
-            let mut throttle = BoundedLogThrottle::new(2, Duration::from_secs(60));
+        fn category_reopens_after_interval() {
+            let mut throttle = FixedCategoryLogThrottle::<1>::new(Duration::from_secs(60));
             let t0 = Instant::now();
-            assert!(throttle.should_emit("k1", t0));
-            assert!(throttle.should_emit("k2", t0 + Duration::from_secs(1)));
-            assert!(throttle.should_emit("k3", t0 + Duration::from_secs(2)));
-            assert_eq!(throttle.entries.len(), 2);
+            assert!(throttle.should_emit(0, t0));
+            assert!(!throttle.should_emit(0, t0 + Duration::from_secs(59)));
+            assert!(throttle.should_emit(0, t0 + Duration::from_secs(60)));
+        }
+    }
+}
+
+#[repr(usize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum V2InsufficientLogCategory {
+    CandidatesLt2 = 0,
+    NoFreshBuyQuote = 1,
+    SingleDexCandidates = 2,
+    NoCrossDexSellUnknown = 3,
+    NoCrossDexSellMissingVault = 4,
+    NoCrossDexSellMissingDlmmBins = 5,
+    NoCrossDexSellQuoteNone = 6,
+    NoCrossDexSellNotFresh = 7,
+    NoCrossDexSellZeroOut = 8,
+}
+
+fn v2_insufficient_log_category(insufficient: &RoundTripInsufficient) -> V2InsufficientLogCategory {
+    match insufficient.subreason {
+        RoundTripInsufficientSubreason::CandidatesLt2 => V2InsufficientLogCategory::CandidatesLt2,
+        RoundTripInsufficientSubreason::NoFreshBuyQuote => {
+            V2InsufficientLogCategory::NoFreshBuyQuote
+        }
+        RoundTripInsufficientSubreason::SingleDexCandidates => {
+            V2InsufficientLogCategory::SingleDexCandidates
+        }
+        RoundTripInsufficientSubreason::NoCrossDexSell => {
+            match insufficient.no_cross_dex_sell_detail {
+                Some(NoCrossDexSellDetailReason::SellMissingVault) => {
+                    V2InsufficientLogCategory::NoCrossDexSellMissingVault
+                }
+                Some(NoCrossDexSellDetailReason::SellMissingDlmmBins) => {
+                    V2InsufficientLogCategory::NoCrossDexSellMissingDlmmBins
+                }
+                Some(NoCrossDexSellDetailReason::SellQuoteNone) => {
+                    V2InsufficientLogCategory::NoCrossDexSellQuoteNone
+                }
+                Some(NoCrossDexSellDetailReason::SellNotFresh) => {
+                    V2InsufficientLogCategory::NoCrossDexSellNotFresh
+                }
+                Some(NoCrossDexSellDetailReason::SellZeroOut) => {
+                    V2InsufficientLogCategory::NoCrossDexSellZeroOut
+                }
+                None => V2InsufficientLogCategory::NoCrossDexSellUnknown,
+            }
         }
     }
 }
 
 static ARB_V2_INSUFFICIENT_LOG_THROTTLE: std::sync::LazyLock<
-    parking_lot::Mutex<bounded_log_throttle::BoundedLogThrottle<String>>,
+    parking_lot::Mutex<
+        fixed_category_log_throttle::FixedCategoryLogThrottle<V2_INSUFFICIENT_LOG_CATEGORY_COUNT>,
+    >,
 > = std::sync::LazyLock::new(|| {
-    parking_lot::Mutex::new(bounded_log_throttle::BoundedLogThrottle::new(
-        HOT_PATH_LOG_THROTTLE_MAP_CAP,
+    parking_lot::Mutex::new(fixed_category_log_throttle::FixedCategoryLogThrottle::new(
         Duration::from_secs(HOT_PATH_LOG_THROTTLE_SECS),
     ))
 });
+
+#[cfg(test)]
+mod v2_insufficient_log_throttle_tests {
+    use super::*;
+
+    #[test]
+    fn category_is_fixed_per_subreason_and_detail() {
+        let no_fresh = RoundTripInsufficient::new(RoundTripInsufficientSubreason::NoFreshBuyQuote);
+        assert_eq!(
+            v2_insufficient_log_category(&no_fresh),
+            V2InsufficientLogCategory::NoFreshBuyQuote
+        );
+        let cross_dex = RoundTripInsufficient {
+            subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
+            no_cross_dex_sell_detail: Some(NoCrossDexSellDetailReason::SellMissingVault),
+            sell_quote_none_detail_counts: None,
+        };
+        assert_eq!(
+            v2_insufficient_log_category(&cross_dex),
+            V2InsufficientLogCategory::NoCrossDexSellMissingVault
+        );
+    }
+
+    #[test]
+    fn production_log_path_has_no_dynamic_string_keys() {
+        let src = include_str!("arb_strategy.rs");
+        let start = src
+            .find("fn log_v2_round_trip_insufficient_pools(")
+            .expect("log_v2_round_trip_insufficient_pools");
+        let end = src[start..]
+            .find("fn log_v2_cross_dex_pair_failures_debug_sample")
+            .expect("after log_v2_round_trip_insufficient_pools");
+        let fn_body = &src[start..start + end];
+        assert!(
+            !fn_body.contains("format!("),
+            "throttle decision must not allocate dynamic string keys"
+        );
+    }
+}
 
 fn insufficient_subreason_metric_label(subreason: RoundTripInsufficientSubreason) -> &'static str {
     match subreason {
@@ -1930,25 +2005,21 @@ fn log_v2_round_trip_insufficient_pools(
     freshness: &QuoteFreshnessConfig,
     token_decimals: u8,
 ) {
-    let subreason = insufficient.subreason;
-    let subreason_label = insufficient_subreason_metric_label(subreason);
-    let dominant = insufficient
-        .no_cross_dex_sell_detail
-        .map(|d| d.as_metric_label())
-        .unwrap_or("unknown");
-    let throttle_key = if subreason == RoundTripInsufficientSubreason::NoCrossDexSell {
-        format!("no_cross_dex:{mint}:{dominant}")
-    } else {
-        format!("insufficient:{mint}:{subreason_label}")
-    };
+    let category = v2_insufficient_log_category(insufficient);
     let now = Instant::now();
     if !ARB_V2_INSUFFICIENT_LOG_THROTTLE
         .lock()
-        .should_emit(throttle_key, now)
+        .should_emit(category as usize, now)
     {
         return;
     }
+    let subreason = insufficient.subreason;
+    let subreason_label = insufficient_subreason_metric_label(subreason);
     if subreason == RoundTripInsufficientSubreason::NoCrossDexSell {
+        let dominant = insufficient
+            .no_cross_dex_sell_detail
+            .map(|d| d.as_metric_label())
+            .unwrap_or("unknown");
         warn!(
             mint = %mint,
             subreason = subreason_label,

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -94,6 +94,7 @@ use ironcrab::metrics::{
     geyser_metrics_set_subscription_accounts, geyser_metrics_set_tracked_pinned_accounts,
     inc_market_data_account_high_priority_queue_depth,
     inc_market_data_account_low_priority_queue_depth, inc_market_data_account_worker_queue_depth,
+    inc_market_data_arb_pin_geyser_register_deferred_total,
     inc_market_data_balance_updated_from_cache_total, inc_market_data_geyser_sync_partial_total,
     inc_market_data_geyser_sync_skipped_rate_limit_total,
     inc_market_data_ingest_membership_snapshot_hits_total,
@@ -1119,14 +1120,6 @@ struct MarketDataContext {
     last_arb_snapshot_target: parking_lot::RwLock<Option<HashSet<Pubkey>>>,
     /// Last `active_id` used when registering DLMM bin-array window per pool (Fix B).
     dlmm_registered_active_id: parking_lot::RwLock<HashMap<Pubkey, i32>>,
-    /// Cold-path RPC for arb-pin pool seed (set at Geyser loop start).
-    cold_path_rpc: parking_lot::RwLock<Option<Arc<SolanaRpc>>>,
-    /// Debounced arb-pin ensure enqueue (pool → last spawn time).
-    arb_pin_ensure_debounce: parking_lot::Mutex<HashMap<Pubkey, Instant>>,
-    /// Self `Arc` for cold-path spawns from `&self` md-state handlers.
-    self_arc: parking_lot::RwLock<Option<Arc<MarketDataContext>>>,
-    /// md-state sender for post-ensure Geyser sync scheduling.
-    md_state_sender: parking_lot::RwLock<Option<MdStateSender>>,
 }
 
 #[derive(Debug, Default)]
@@ -1175,11 +1168,6 @@ const WALLET_BOOTSTRAP_DEX_VERIFY_GRACE_MS: u64 = 400;
 
 /// Max wallet-held mints to run PumpSwap/PumpFun bootstrap verification for per startup (deduped).
 const WALLET_BOOTSTRAP_DEX_VERIFY_MAX_MINTS: usize = 8;
-
-/// Debounce arb-pin cold-path pool ensure per pool (seconds).
-const ARB_PIN_ENSURE_DEBOUNCE_SECS: u64 = 60;
-/// Cap debounce map for arb-pin ensure enqueue (LRU via oldest eviction).
-const ARB_PIN_ENSURE_DEBOUNCE_MAP_CAP: usize = 2048;
 
 /// Wallet bootstrap PumpFun step: must use `force_refresh` so `handle_ensure_pumpfun_bonding_curve`
 /// does not early-return on `CachedPoolState::PumpFun` without explicit Ready (merge + JetStream).
@@ -2362,18 +2350,6 @@ impl MdStateContext for MarketDataContext {
 }
 
 impl MarketDataContext {
-    fn set_self_arc(&self, arc: Arc<MarketDataContext>) {
-        *self.self_arc.write() = Some(arc);
-    }
-
-    fn set_cold_path_rpc(&self, rpc: Arc<SolanaRpc>) {
-        *self.cold_path_rpc.write() = Some(rpc);
-    }
-
-    fn set_md_state_sender(&self, sender: MdStateSender) {
-        *self.md_state_sender.write() = Some(sender);
-    }
-
     /// Non-blocking JSONL enqueue (dedicated `jsonl-writer` thread). Skips `AccountUpdate` / `TransactionDetected`.
     fn write_market_event_jsonl(&self, event: &MarketEvent) {
         write_market_event_jsonl(self, event);
@@ -4054,72 +4030,6 @@ impl MarketDataContext {
         batch_dirty
     }
 
-    fn non_sol_mint_for_arb_pool_seed(state: &CachedPoolState) -> Option<Pubkey> {
-        let sol = Pubkey::from_str(NATIVE_SOL_MINT).ok()?;
-        match state {
-            CachedPoolState::Orca(s) => {
-                if s.token_mint_a == sol {
-                    Some(s.token_mint_b)
-                } else if s.token_mint_b == sol {
-                    Some(s.token_mint_a)
-                } else {
-                    None
-                }
-            }
-            CachedPoolState::Meteora(s) => {
-                if s.token_x_mint == sol {
-                    Some(s.token_y_mint)
-                } else if s.token_y_mint == sol {
-                    Some(s.token_x_mint)
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        }
-    }
-
-    fn arb_pin_ensure_debounce_should_enqueue(&self, pool: Pubkey) -> bool {
-        let now = Instant::now();
-        let mut debounce = self.arb_pin_ensure_debounce.lock();
-        if let Some(last) = debounce.get(&pool) {
-            if last.elapsed() < Duration::from_secs(ARB_PIN_ENSURE_DEBOUNCE_SECS) {
-                return false;
-            }
-        }
-        if debounce.len() >= ARB_PIN_ENSURE_DEBOUNCE_MAP_CAP {
-            if let Some(oldest_pool) = debounce
-                .iter()
-                .min_by_key(|(_, ts)| *ts)
-                .map(|(pool, _)| *pool)
-            {
-                debounce.remove(&oldest_pool);
-            }
-        }
-        debounce.insert(pool, now);
-        true
-    }
-
-    fn maybe_enqueue_arb_pin_cold_path_ensure(&self, pool: Pubkey) {
-        if !self.arb_pin_ensure_debounce_should_enqueue(pool) {
-            return;
-        }
-        let Some(ctx) = self.self_arc.read().clone() else {
-            return;
-        };
-        let Some(rpc) = self.cold_path_rpc.read().clone() else {
-            return;
-        };
-        let Some(handle) = self.ingest_tokio_handle.read().clone() else {
-            return;
-        };
-        let md_state = self.md_state_sender.read().clone();
-
-        handle.spawn(async move {
-            arb_pin_cold_path_seed_pool_state(ctx, rpc, md_state, pool).await;
-        });
-    }
-
     fn apply_arb_active_entries(&self, active: &[ArbTrackActiveEntry]) -> bool {
         let mut batch_dirty = false;
         for a in active {
@@ -4130,13 +4040,20 @@ impl MarketDataContext {
             self.hot_pool_registry.pin_arb_pool(pool_pk);
             if self.register_geyser_reserves_for_arb_active_pool(pool_pk) {
                 batch_dirty = true;
-            } else if self.live_pool_cache.get(&pool_pk).is_none()
-                || matches!(
-                    self.live_pool_cache.get(&pool_pk),
-                    Some(CachedPoolState::Orca(_)) | Some(CachedPoolState::Meteora(_))
-                )
-            {
-                self.maybe_enqueue_arb_pin_cold_path_ensure(pool_pk);
+            } else {
+                let reason = if self.live_pool_cache.get(&pool_pk).is_none() {
+                    "live_pool_cache_miss"
+                } else {
+                    "vault_register_no_change"
+                };
+                warn!(
+                    run_id = %self.run_id,
+                    pool = %pool_pk,
+                    pin = "ArbMultiDex",
+                    reason = reason,
+                    "Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)"
+                );
+                inc_market_data_arb_pin_geyser_register_deferred_total(reason);
             }
             let _ = &a.reason;
         }
@@ -5013,101 +4930,6 @@ async fn handle_wallet_bootstrap_meteora_dlmm_verify_for_mint(
             ctx, rpc, run_id, request_id, base_mint, pool_addr, state,
         )
         .await;
-    }
-}
-
-/// Cold-path only: debounced pool seed when arb pin hits LivePoolCache miss or Orca/DLMM rows
-/// need RPC refresh before vault/bin Geyser registration.
-async fn arb_pin_cold_path_seed_pool_state(
-    ctx: Arc<MarketDataContext>,
-    rpc: Arc<SolanaRpc>,
-    md_state: Option<MdStateSender>,
-    pool: Pubkey,
-) {
-    let run_id = ctx.run_id.clone();
-    let request_id = format!("arb-pin-ensure-{}", pool);
-
-    if let Some(state) = ctx.live_pool_cache.get(&pool) {
-        let Some(base_mint) = MarketDataContext::non_sol_mint_for_arb_pool_seed(&state) else {
-            return;
-        };
-        let base_mint_str = base_mint.to_string();
-        let pool_hint = pool.to_string();
-        match state {
-            CachedPoolState::Orca(_) => {
-                handle_ensure_orca_whirlpool_pool_state(
-                    ctx.as_ref(),
-                    &rpc,
-                    run_id.as_str(),
-                    &request_id,
-                    &base_mint_str,
-                    Some(pool_hint.as_str()),
-                    false,
-                )
-                .await;
-            }
-            CachedPoolState::Meteora(_) if ctx.config.read().enable_meteora_dlmm => {
-                handle_ensure_meteora_dlmm_pool_state(
-                    ctx.as_ref(),
-                    &rpc,
-                    run_id.as_str(),
-                    &request_id,
-                    &base_mint_str,
-                    Some(pool_hint.as_str()),
-                    false,
-                )
-                .await;
-            }
-            _ => return,
-        }
-    } else {
-        let pool_acc = match rpc.get_account_opt_retry(&pool).await {
-            Ok(Some(acc)) => acc,
-            Ok(None) | Err(_) => {
-                debug!(pool = %pool, "Arb pin cold seed: pool account fetch miss");
-                return;
-            }
-        };
-        let Some(parsed) = parse_pool_account(&pool_acc.owner, &pool_acc.data) else {
-            debug!(pool = %pool, "Arb pin cold seed: unsupported pool owner/layout");
-            return;
-        };
-        let Some(base_mint) = MarketDataContext::non_sol_mint_for_arb_pool_seed(&parsed) else {
-            return;
-        };
-        match parsed {
-            CachedPoolState::Orca(s) => {
-                cold_path_rpc_refresh_orca_whirlpool_pool_row(
-                    ctx.as_ref(),
-                    &rpc,
-                    run_id.as_str(),
-                    &request_id,
-                    &base_mint,
-                    pool,
-                    s,
-                )
-                .await;
-            }
-            CachedPoolState::Meteora(s) if ctx.config.read().enable_meteora_dlmm => {
-                cold_path_rpc_refresh_meteora_dlmm_pool_row(
-                    ctx.as_ref(),
-                    &rpc,
-                    run_id.as_str(),
-                    &request_id,
-                    &base_mint,
-                    pool,
-                    s,
-                )
-                .await;
-            }
-            _ => return,
-        }
-    }
-
-    if ctx.register_geyser_reserves_for_arb_active_pool(pool) {
-        if let Some(md_state) = md_state {
-            ctx.schedule_geyser_sync_batch_debounced(&md_state);
-        }
     }
 }
 
@@ -6423,10 +6245,6 @@ async fn main() -> Result<()> {
         last_momentum_snapshot_target: parking_lot::RwLock::new(None),
         last_arb_snapshot_target: parking_lot::RwLock::new(None),
         dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
-        cold_path_rpc: parking_lot::RwLock::new(None),
-        arb_pin_ensure_debounce: parking_lot::Mutex::new(HashMap::new()),
-        self_arc: parking_lot::RwLock::new(None),
-        md_state_sender: parking_lot::RwLock::new(None),
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -7225,9 +7043,6 @@ async fn run_geyser_loop(
         tokio::runtime::Handle::current(),
         track_worker.clone(),
     );
-    ctx.set_self_arc(Arc::clone(&ctx));
-    ctx.set_cold_path_rpc(Arc::clone(&rpc));
-    ctx.set_md_state_sender(md_state.clone());
 
     // === P0: Wallet Balance Snapshot (Position Reconciliation) ===
     // Bootstrap wallet state at startup (max 1 RPC roundtrip) using known mints from JetStream.
@@ -8578,9 +8393,6 @@ async fn run_simulation_loop(
         tokio::runtime::Handle::current(),
         track_worker.clone(),
     );
-    ctx.set_self_arc(Arc::clone(&ctx));
-    ctx.set_cold_path_rpc(Arc::clone(&rpc));
-    ctx.set_md_state_sender(md_state.clone());
 
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
     let mut slot: u64 = 0;
@@ -10038,10 +9850,6 @@ mod wallet_snapshot_stale_cleanup_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
-            cold_path_rpc: parking_lot::RwLock::new(None),
-            arb_pin_ensure_debounce: parking_lot::Mutex::new(HashMap::new()),
-            self_arc: parking_lot::RwLock::new(None),
-            md_state_sender: parking_lot::RwLock::new(None),
         }
     }
 
@@ -10262,10 +10070,6 @@ mod wallet_tx_meta_balance_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
-            cold_path_rpc: parking_lot::RwLock::new(None),
-            arb_pin_ensure_debounce: parking_lot::Mutex::new(HashMap::new()),
-            self_arc: parking_lot::RwLock::new(None),
-            md_state_sender: parking_lot::RwLock::new(None),
         })
     }
 
@@ -11139,10 +10943,6 @@ mod pr_b_geyser_tracking_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
-            cold_path_rpc: parking_lot::RwLock::new(None),
-            arb_pin_ensure_debounce: parking_lot::Mutex::new(HashMap::new()),
-            self_arc: parking_lot::RwLock::new(None),
-            md_state_sender: parking_lot::RwLock::new(None),
         })
     }
 
@@ -11215,10 +11015,6 @@ mod pr_b_geyser_tracking_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
-            cold_path_rpc: parking_lot::RwLock::new(None),
-            arb_pin_ensure_debounce: parking_lot::Mutex::new(HashMap::new()),
-            self_arc: parking_lot::RwLock::new(None),
-            md_state_sender: parking_lot::RwLock::new(None),
         });
         (
             ctx,
@@ -14353,6 +14149,41 @@ mod pr_b_geyser_tracking_tests {
         assert!(
             bin_src.contains("fn spawn_market_data_account_publish_runtime"),
             "bin must retain thin spawn wrapper for md-publish runtime"
+        );
+    }
+
+    /// Arb pin track path must remain Geyser-only (no cold-path RPC seed on pin).
+    #[test]
+    fn apply_arb_active_entries_geyser_only_no_cold_rpc() {
+        let bin_src = include_str!("market_data.rs");
+        let code_src = bin_src
+            .split("mod discovery_tests")
+            .next()
+            .expect("production + inline helpers before test modules");
+        assert!(
+            !code_src.contains("cold_path_rpc: parking_lot::RwLock"),
+            "MarketDataContext must not carry arb-pin cold_path_rpc"
+        );
+        assert!(
+            !code_src.contains("arb_pin_ensure_debounce"),
+            "arb-pin ensure debounce map must be removed"
+        );
+        assert!(
+            code_src.contains("Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)"),
+            "apply_arb_active_entries must log deferred Geyser register without RPC"
+        );
+        let impl_marker = "Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)";
+        let impl_start = code_src
+            .find(impl_marker)
+            .expect("apply_arb_active_entries geyser-only path");
+        let impl_window = &code_src[impl_start.saturating_sub(800)..impl_start + 200];
+        assert!(
+            !impl_window.contains("handle_ensure_"),
+            "apply_arb_active_entries must not call handle_ensure_*"
+        );
+        assert!(
+            !impl_window.contains("cold_path_rpc_refresh"),
+            "apply_arb_active_entries must not call cold_path_rpc_refresh"
         );
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1173,6 +1173,87 @@ const WALLET_BOOTSTRAP_DEX_VERIFY_MAX_MINTS: usize = 8;
 /// does not early-return on `CachedPoolState::PumpFun` without explicit Ready (merge + JetStream).
 const WALLET_BOOTSTRAP_ENSURE_PUMPFUN_FORCE_REFRESH: bool = true;
 
+const HOT_PATH_LOG_THROTTLE_SECS: u64 = 60;
+const HOT_PATH_LOG_THROTTLE_MAP_CAP: usize = 2048;
+
+mod bounded_log_throttle {
+    use std::collections::HashMap;
+    use std::hash::Hash;
+    use std::time::{Duration, Instant};
+
+    #[derive(Debug)]
+    pub(super) struct BoundedLogThrottle<K> {
+        entries: HashMap<K, Instant>,
+        cap: usize,
+        interval: Duration,
+    }
+
+    impl<K: Eq + Hash + Clone> BoundedLogThrottle<K> {
+        pub(super) fn new(cap: usize, interval: Duration) -> Self {
+            Self {
+                entries: HashMap::new(),
+                cap: cap.max(1),
+                interval,
+            }
+        }
+
+        pub(super) fn should_emit(&mut self, key: K, now: Instant) -> bool {
+            if let Some(last) = self.entries.get(&key) {
+                if now.duration_since(*last) < self.interval {
+                    return false;
+                }
+            }
+            if self.entries.len() >= self.cap {
+                if let Some(oldest_key) = self
+                    .entries
+                    .iter()
+                    .min_by_key(|(_, ts)| *ts)
+                    .map(|(k, _)| k.clone())
+                {
+                    self.entries.remove(&oldest_key);
+                }
+            }
+            self.entries.insert(key, now);
+            true
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn repeated_pool_reason_suppressed_until_interval_elapses() {
+            let mut throttle = BoundedLogThrottle::new(8, Duration::from_secs(60));
+            let key = "pool-a:live_pool_cache_miss";
+            let t0 = Instant::now();
+            assert!(throttle.should_emit(key, t0));
+            assert!(!throttle.should_emit(key, t0 + Duration::from_secs(5)));
+            assert!(throttle.should_emit(key, t0 + Duration::from_secs(60)));
+        }
+
+        #[test]
+        fn distinct_pool_reason_keys_emit_independently() {
+            let mut throttle = BoundedLogThrottle::new(8, Duration::from_secs(60));
+            let t0 = Instant::now();
+            assert!(throttle.should_emit("pool-a:live_pool_cache_miss", t0));
+            assert!(throttle.should_emit("pool-a:vault_register_no_change", t0));
+            assert!(
+                !throttle.should_emit("pool-a:live_pool_cache_miss", t0 + Duration::from_secs(1))
+            );
+        }
+    }
+}
+
+static ARB_PIN_DEFERRED_LOG_THROTTLE: std::sync::LazyLock<
+    parking_lot::Mutex<bounded_log_throttle::BoundedLogThrottle<String>>,
+> = std::sync::LazyLock::new(|| {
+    parking_lot::Mutex::new(bounded_log_throttle::BoundedLogThrottle::new(
+        HOT_PATH_LOG_THROTTLE_MAP_CAP,
+        Duration::from_secs(HOT_PATH_LOG_THROTTLE_SECS),
+    ))
+});
+
 /// Associated Token Program ID
 const ASSOCIATED_TOKEN_PROGRAM_ID: &str = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL";
 
@@ -4046,14 +4127,21 @@ impl MarketDataContext {
                 } else {
                     "vault_register_no_change"
                 };
-                warn!(
-                    run_id = %self.run_id,
-                    pool = %pool_pk,
-                    pin = "ArbMultiDex",
-                    reason = reason,
-                    "Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)"
-                );
                 inc_market_data_arb_pin_geyser_register_deferred_total(reason);
+                let throttle_key = format!("{pool_pk}:{reason}");
+                let now = Instant::now();
+                if ARB_PIN_DEFERRED_LOG_THROTTLE
+                    .lock()
+                    .should_emit(throttle_key, now)
+                {
+                    warn!(
+                        run_id = %self.run_id,
+                        pool = %pool_pk,
+                        pin = "ArbMultiDex",
+                        reason = reason,
+                        "Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)"
+                    );
+                }
             }
             let _ = &a.reason;
         }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1174,46 +1174,32 @@ const WALLET_BOOTSTRAP_DEX_VERIFY_MAX_MINTS: usize = 8;
 const WALLET_BOOTSTRAP_ENSURE_PUMPFUN_FORCE_REFRESH: bool = true;
 
 const HOT_PATH_LOG_THROTTLE_SECS: u64 = 60;
-const HOT_PATH_LOG_THROTTLE_MAP_CAP: usize = 2048;
 
-mod bounded_log_throttle {
-    use std::collections::HashMap;
-    use std::hash::Hash;
+mod fixed_category_log_throttle {
     use std::time::{Duration, Instant};
 
     #[derive(Debug)]
-    pub(super) struct BoundedLogThrottle<K> {
-        entries: HashMap<K, Instant>,
-        cap: usize,
+    pub(super) struct FixedCategoryLogThrottle<const N: usize> {
+        last_emit: [Option<Instant>; N],
         interval: Duration,
     }
 
-    impl<K: Eq + Hash + Clone> BoundedLogThrottle<K> {
-        pub(super) fn new(cap: usize, interval: Duration) -> Self {
+    impl<const N: usize> FixedCategoryLogThrottle<N> {
+        pub(super) fn new(interval: Duration) -> Self {
             Self {
-                entries: HashMap::new(),
-                cap: cap.max(1),
+                last_emit: [None; N],
                 interval,
             }
         }
 
-        pub(super) fn should_emit(&mut self, key: K, now: Instant) -> bool {
-            if let Some(last) = self.entries.get(&key) {
-                if now.duration_since(*last) < self.interval {
+        pub(super) fn should_emit(&mut self, category: usize, now: Instant) -> bool {
+            debug_assert!(category < N);
+            if let Some(last) = self.last_emit[category] {
+                if now.duration_since(last) < self.interval {
                     return false;
                 }
             }
-            if self.entries.len() >= self.cap {
-                if let Some(oldest_key) = self
-                    .entries
-                    .iter()
-                    .min_by_key(|(_, ts)| *ts)
-                    .map(|(k, _)| k.clone())
-                {
-                    self.entries.remove(&oldest_key);
-                }
-            }
-            self.entries.insert(key, now);
+            self.last_emit[category] = Some(now);
             true
         }
     }
@@ -1223,33 +1209,42 @@ mod bounded_log_throttle {
         use super::*;
 
         #[test]
-        fn repeated_pool_reason_suppressed_until_interval_elapses() {
-            let mut throttle = BoundedLogThrottle::new(8, Duration::from_secs(60));
-            let key = "pool-a:live_pool_cache_miss";
+        fn many_distinct_pool_values_share_one_reason_category() {
+            let mut throttle = FixedCategoryLogThrottle::<2>::new(Duration::from_secs(60));
+            let category = 0usize;
             let t0 = Instant::now();
-            assert!(throttle.should_emit(key, t0));
-            assert!(!throttle.should_emit(key, t0 + Duration::from_secs(5)));
-            assert!(throttle.should_emit(key, t0 + Duration::from_secs(60)));
+            assert!(throttle.should_emit(category, t0));
+            for offset in 1..=1000u64 {
+                assert!(
+                    !throttle.should_emit(category, t0 + Duration::from_millis(offset)),
+                    "reason category must stay suppressed regardless of pool cardinality"
+                );
+            }
+            assert!(throttle.should_emit(category, t0 + Duration::from_secs(60)));
         }
 
         #[test]
-        fn distinct_pool_reason_keys_emit_independently() {
-            let mut throttle = BoundedLogThrottle::new(8, Duration::from_secs(60));
+        fn distinct_reason_categories_emit_independently() {
+            let mut throttle = FixedCategoryLogThrottle::<2>::new(Duration::from_secs(60));
             let t0 = Instant::now();
-            assert!(throttle.should_emit("pool-a:live_pool_cache_miss", t0));
-            assert!(throttle.should_emit("pool-a:vault_register_no_change", t0));
-            assert!(
-                !throttle.should_emit("pool-a:live_pool_cache_miss", t0 + Duration::from_secs(1))
-            );
+            assert!(throttle.should_emit(0, t0));
+            assert!(throttle.should_emit(1, t0));
+            assert!(!throttle.should_emit(0, t0 + Duration::from_secs(1)));
         }
     }
 }
 
+#[repr(usize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArbPinDeferredLogCategory {
+    LivePoolCacheMiss = 0,
+    VaultRegisterNoChange = 1,
+}
+
 static ARB_PIN_DEFERRED_LOG_THROTTLE: std::sync::LazyLock<
-    parking_lot::Mutex<bounded_log_throttle::BoundedLogThrottle<String>>,
+    parking_lot::Mutex<fixed_category_log_throttle::FixedCategoryLogThrottle<2>>,
 > = std::sync::LazyLock::new(|| {
-    parking_lot::Mutex::new(bounded_log_throttle::BoundedLogThrottle::new(
-        HOT_PATH_LOG_THROTTLE_MAP_CAP,
+    parking_lot::Mutex::new(fixed_category_log_throttle::FixedCategoryLogThrottle::new(
         Duration::from_secs(HOT_PATH_LOG_THROTTLE_SECS),
     ))
 });
@@ -4122,17 +4117,20 @@ impl MarketDataContext {
             if self.register_geyser_reserves_for_arb_active_pool(pool_pk) {
                 batch_dirty = true;
             } else {
-                let reason = if self.live_pool_cache.get(&pool_pk).is_none() {
-                    "live_pool_cache_miss"
+                let category = if self.live_pool_cache.get(&pool_pk).is_none() {
+                    ArbPinDeferredLogCategory::LivePoolCacheMiss
                 } else {
-                    "vault_register_no_change"
+                    ArbPinDeferredLogCategory::VaultRegisterNoChange
+                };
+                let reason: &'static str = match category {
+                    ArbPinDeferredLogCategory::LivePoolCacheMiss => "live_pool_cache_miss",
+                    ArbPinDeferredLogCategory::VaultRegisterNoChange => "vault_register_no_change",
                 };
                 inc_market_data_arb_pin_geyser_register_deferred_total(reason);
-                let throttle_key = format!("{pool_pk}:{reason}");
                 let now = Instant::now();
                 if ARB_PIN_DEFERRED_LOG_THROTTLE
                     .lock()
-                    .should_emit(throttle_key, now)
+                    .should_emit(category as usize, now)
                 {
                     warn!(
                         run_id = %self.run_id,
@@ -14273,6 +14271,26 @@ mod pr_b_geyser_tracking_tests {
         assert!(
             !impl_window.contains("cold_path_rpc_refresh"),
             "apply_arb_active_entries must not call cold_path_rpc_refresh"
+        );
+    }
+
+    /// Arb-pin deferred warn throttle must not build dynamic string keys.
+    #[test]
+    fn apply_arb_active_entries_throttle_has_no_dynamic_string_keys() {
+        let bin_src = include_str!("market_data.rs");
+        let anchor = bin_src
+            .find("ArbPinDeferredLogCategory::LivePoolCacheMiss")
+            .expect("apply_arb_active_entries deferred category");
+        let start = bin_src[..anchor]
+            .rfind("fn apply_arb_active_entries(")
+            .expect("apply_arb_active_entries");
+        let end = bin_src[anchor..]
+            .find("fn arb_pool_leg_mint_still_required")
+            .expect("after apply_arb_active_entries");
+        let fn_body = &bin_src[start..anchor + end];
+        assert!(
+            !fn_body.contains("format!("),
+            "throttle decision must not allocate dynamic string keys"
         );
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -14169,7 +14169,8 @@ mod pr_b_geyser_tracking_tests {
             "arb-pin ensure debounce map must be removed"
         );
         assert!(
-            code_src.contains("Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)"),
+            code_src
+                .contains("Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)"),
             "apply_arb_active_entries must log deferred Geyser register without RPC"
         );
         let impl_marker = "Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)";

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -360,6 +360,12 @@ pub static MARKET_DATA_ARB_PIN_EVICTION_REASON_STALE_BUDGET: Lazy<AtomicU64> =
 /// Arb pin add skipped because only activity-protected pools would need eviction.
 pub static MARKET_DATA_ARB_PIN_EVICTION_REASON_ACTIVE_PROTECTED: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// Arb pin: Geyser reserve registration deferred because LivePoolCache has no row yet.
+pub static MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_LIVE_POOL_CACHE_MISS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Arb pin: Geyser reserve registration deferred because vault/bin register was a no-op.
+pub static MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_VAULT_NO_CHANGE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 /// Geyser explicit-tracked subscription list syncs coalesced from the TX trade path (debounced flush).
 pub static MARKET_DATA_GEYSER_SYNC_BATCH_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -697,6 +703,21 @@ pub fn inc_market_data_arb_pin_eviction_reason_stale_budget() {
 #[inline]
 pub fn inc_market_data_arb_pin_eviction_reason_active_protected() {
     MARKET_DATA_ARB_PIN_EVICTION_REASON_ACTIVE_PROTECTED.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_arb_pin_geyser_register_deferred_total(reason: &str) {
+    match reason {
+        "live_pool_cache_miss" => {
+            MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_LIVE_POOL_CACHE_MISS
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        "vault_register_no_change" => {
+            MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_VAULT_NO_CHANGE
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        _ => {}
+    }
 }
 
 #[inline]
@@ -6025,6 +6046,24 @@ async fn metrics_response() -> Response<Body> {
     out.push_str("market_data_arb_pin_eviction_reason{reason=\"active_protected\"} ");
     out.push_str(
         &MARKET_DATA_ARB_PIN_EVICTION_REASON_ACTIVE_PROTECTED
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str(
+        "market_data_arb_pin_geyser_register_deferred_total{reason=\"live_pool_cache_miss\"} ",
+    );
+    out.push_str(
+        &MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_LIVE_POOL_CACHE_MISS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str(
+        "market_data_arb_pin_geyser_register_deferred_total{reason=\"vault_register_no_change\"} ",
+    );
+    out.push_str(
+        &MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_VAULT_NO_CHANGE
             .load(Ordering::Relaxed)
             .to_string(),
     );


### PR DESCRIPTION
## Summary
- Revert 843dc40 arb_pin cold-path RPC seed (prod validator RAM forensics)
- Arb track_requests: Geyser register only; defer on cache miss with structured log
- Cross-DEX quote failures: structured WARN for later Cold-RPC decision (no RPC in this PR)

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -D warnings
- [x] cargo test
- [x] rg arb_pin_cold_path|maybe_enqueue_arb_pin|arb-pin-ensure src/ → 0 matches
- [ ] Impl CI Eval (Level 5) green
- [ ] Bugbot review