### PR TITLE
fix(arb): bound track requests to quote-ready cross-dex sets

### DIFF
--- a/src/arbitrage/mod.rs
+++ b/src/arbitrage/mod.rs
@@ -33,6 +33,7 @@ pub mod multi_hop_integration;
 pub mod pool_graph;
 pub mod pool_quote;
 pub mod pool_ranker;
+pub mod track_selection;
 pub mod types;
 
 // Re-exports for convenient access
@@ -60,6 +61,10 @@ pub use pool_quote::{
     DLMM_PROBE_SOL_LAMPORTS, STATE_TTL_MS, TRADE_TTL_MS,
 };
 pub use pool_ranker::{PoolRanker, QuoteProvider, RankerConfig};
+pub use track_selection::{
+    arb_track_removal_reason, select_arb_track_pools, SelectedTrackPool, TrackCandidateCounts,
+    TrackMintInput, TrackPoolInput, TrackPoolReadiness, TrackSelectionConfig, TrackSelectionResult,
+};
 pub use types::{
     clamp_edge_ratio, profit_to_return_bps, ArbCycle, DexType, ParseDexTypeError, PoolEdge,
     RankedPool, SearchNode, MAX_CYCLE_PROFIT_MULTIPLIER, MAX_EDGE_RATIO, MAX_RETURN_BPS,

--- a/src/arbitrage/track_selection.rs
+++ b/src/arbitrage/track_selection.rs
@@ -1,0 +1,907 @@
+//! Deterministic, bounded Arb Geyser pin selection (I-ARB-10b).
+//!
+//! Pure selection logic: no locks, NATS, RPC, or logging.
+
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+use std::time::Instant;
+
+use crate::nats::{ArbTrackActiveReason, ArbTrackRemovedReason};
+
+use super::pool_quote::{
+    is_quote_fresh, quote_exact_in_with_freshness, select_round_trip_pools, DlmmBinArrays,
+    QuoteFreshnessConfig, QuotePoolInput, QuoteVaultInput, RoundTripPoolCandidate, NATIVE_SOL_MINT,
+};
+
+/// Readiness tier for a pool candidate (lowest ordinal = highest priority).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TrackPoolReadiness {
+    Rejected = 0,
+    Warmable = 1,
+    QuoteReady = 2,
+    Executable = 3,
+}
+
+impl TrackPoolReadiness {
+    pub fn metric_label(self) -> &'static str {
+        match self {
+            TrackPoolReadiness::Executable => "executable",
+            TrackPoolReadiness::QuoteReady => "quote_ready",
+            TrackPoolReadiness::Warmable => "warmable",
+            TrackPoolReadiness::Rejected => "rejected",
+        }
+    }
+}
+
+/// Per-pool inputs for track selection (built by arb-strategy from tracker/cache state).
+#[derive(Debug, Clone)]
+pub struct TrackPoolInput {
+    pub pool_address: String,
+    pub dex: String,
+    pub known: bool,
+    pub quote_pool: QuotePoolInput,
+    pub vault: Option<QuoteVaultInput>,
+    pub dlmm_bins: Option<DlmmBinArrays>,
+    pub token_decimals: u8,
+}
+
+/// Per-mint bundle of pools considered for pin selection.
+#[derive(Debug, Clone)]
+pub struct TrackMintInput {
+    pub mint: String,
+    pub pools: Vec<TrackPoolInput>,
+    /// Optional trade-signal buy/sell pair for this mint (highest pin priority).
+    pub trade_signal_pools: Option<(String, String)>,
+}
+
+/// Global selection limits and quote parameters.
+#[derive(Debug, Clone, Copy)]
+pub struct TrackSelectionConfig {
+    pub max_pools: usize,
+    pub max_pools_per_mint: usize,
+    pub probe_lamports: u64,
+    pub freshness: QuoteFreshnessConfig,
+}
+
+/// A pool chosen for the authoritative Arb pin set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectedTrackPool {
+    pub mint: String,
+    pub pool: String,
+    pub readiness: TrackPoolReadiness,
+    pub active_reason: ArbTrackActiveReason,
+}
+
+/// Candidate readiness histogram (for metrics).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TrackCandidateCounts {
+    pub executable: u64,
+    pub quote_ready: u64,
+    pub warmable: u64,
+    pub rejected: u64,
+}
+
+impl TrackCandidateCounts {
+    pub fn record(&mut self, readiness: TrackPoolReadiness) {
+        match readiness {
+            TrackPoolReadiness::Executable => self.executable += 1,
+            TrackPoolReadiness::QuoteReady => self.quote_ready += 1,
+            TrackPoolReadiness::Warmable => self.warmable += 1,
+            TrackPoolReadiness::Rejected => self.rejected += 1,
+        }
+    }
+}
+
+/// Full selection output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrackSelectionResult {
+    pub selected: Vec<SelectedTrackPool>,
+    /// Pools that would have been selected for a mint but were dropped by the global budget.
+    pub budget_displaced: Vec<String>,
+    pub selected_mints: usize,
+    pub candidate_counts: TrackCandidateCounts,
+}
+
+/// Select the authoritative bounded Arb pin set across all mints.
+pub fn select_arb_track_pools(
+    mints: &[TrackMintInput],
+    config: &TrackSelectionConfig,
+) -> TrackSelectionResult {
+    let now = Instant::now();
+    let mut candidate_counts = TrackCandidateCounts::default();
+    let mut per_pool_readiness: HashMap<String, TrackPoolReadiness> = HashMap::new();
+
+    for mint in mints {
+        for pool in &mint.pools {
+            let readiness = classify_pool_readiness(pool, config, now);
+            candidate_counts.record(readiness);
+            per_pool_readiness.insert(pool.pool_address.clone(), readiness);
+        }
+    }
+
+    let mut bundles: Vec<MintBundle> = Vec::new();
+    let mut mint_inputs: Vec<&TrackMintInput> = mints.iter().collect();
+    mint_inputs.sort_by(|a, b| a.mint.cmp(&b.mint));
+
+    for mint in mint_inputs {
+        if let Some(bundle) = build_mint_bundle(mint, config, &per_pool_readiness, now) {
+            bundles.push(bundle);
+        }
+    }
+
+    bundles.sort_by(|a, b| {
+        b.priority
+            .cmp(&a.priority)
+            .then_with(|| a.mint.cmp(&b.mint))
+    });
+
+    let mut selected: Vec<SelectedTrackPool> = Vec::new();
+    let mut budget_displaced: Vec<String> = Vec::new();
+    let mut selected_mints = HashSet::new();
+
+    for bundle in bundles {
+        let bundle_len = bundle.pools.len();
+        if bundle_len < 2 {
+            continue;
+        }
+        if selected.len() + bundle_len > config.max_pools {
+            for pool in &bundle.pools {
+                budget_displaced.push(pool.pool.clone());
+            }
+            continue;
+        }
+        selected_mints.insert(bundle.mint.clone());
+        selected.extend(bundle.pools);
+    }
+
+    budget_displaced.sort();
+    budget_displaced.dedup();
+
+    TrackSelectionResult {
+        selected_mints: selected_mints.len(),
+        selected,
+        budget_displaced,
+        candidate_counts,
+    }
+}
+
+/// Map selection removals for pools no longer in the target set.
+pub fn arb_track_removal_reason(
+    pool: &str,
+    still_tracker_valid: bool,
+    budget_displaced: &HashSet<String>,
+) -> ArbTrackRemovedReason {
+    if budget_displaced.contains(pool) || still_tracker_valid {
+        ArbTrackRemovedReason::Budget
+    } else {
+        ArbTrackRemovedReason::Stale
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MintBundle {
+    mint: String,
+    priority: TrackPoolReadiness,
+    pools: Vec<SelectedTrackPool>,
+}
+
+fn build_mint_bundle(
+    mint: &TrackMintInput,
+    config: &TrackSelectionConfig,
+    per_pool_readiness: &HashMap<String, TrackPoolReadiness>,
+    now: Instant,
+) -> Option<MintBundle> {
+    let eligible: Vec<&TrackPoolInput> = mint
+        .pools
+        .iter()
+        .filter(|p| {
+            per_pool_readiness
+                .get(&p.pool_address)
+                .copied()
+                .unwrap_or(TrackPoolReadiness::Rejected)
+                != TrackPoolReadiness::Rejected
+        })
+        .collect();
+
+    let distinct_dexes: HashSet<&str> = eligible.iter().map(|p| p.dex.as_str()).collect();
+    if distinct_dexes.len() < 2 {
+        return None;
+    }
+
+    if let Some((buy, sell)) = &mint.trade_signal_pools {
+        if let Some(bundle) =
+            bundle_from_trade_signal(mint, buy, sell, &eligible, config, per_pool_readiness)
+        {
+            return Some(bundle);
+        }
+    }
+
+    if let Some(bundle) = bundle_from_round_trip(mint, &eligible, config, per_pool_readiness) {
+        return Some(bundle);
+    }
+
+    bundle_from_warmable_pair(mint, &eligible, config, per_pool_readiness, now)
+}
+
+fn bundle_from_trade_signal(
+    mint: &TrackMintInput,
+    buy: &str,
+    sell: &str,
+    eligible: &[&TrackPoolInput],
+    config: &TrackSelectionConfig,
+    per_pool_readiness: &HashMap<String, TrackPoolReadiness>,
+) -> Option<MintBundle> {
+    let buy_pool = eligible.iter().find(|p| p.pool_address == buy)?;
+    let sell_pool = eligible.iter().find(|p| p.pool_address == sell)?;
+    if buy_pool.dex == sell_pool.dex {
+        return None;
+    }
+
+    let mut pools = vec![
+        selected_pool(
+            mint,
+            buy_pool,
+            TrackPoolReadiness::Executable,
+            ArbTrackActiveReason::TradeSignal,
+            per_pool_readiness,
+        ),
+        selected_pool(
+            mint,
+            sell_pool,
+            TrackPoolReadiness::Executable,
+            ArbTrackActiveReason::TradeSignal,
+            per_pool_readiness,
+        ),
+    ];
+    maybe_add_third_pool(mint, &mut pools, eligible, config, per_pool_readiness);
+    pools.sort_by(pool_address_cmp);
+
+    Some(MintBundle {
+        mint: mint.mint.clone(),
+        priority: TrackPoolReadiness::Executable,
+        pools,
+    })
+}
+
+fn bundle_from_round_trip(
+    mint: &TrackMintInput,
+    eligible: &[&TrackPoolInput],
+    config: &TrackSelectionConfig,
+    per_pool_readiness: &HashMap<String, TrackPoolReadiness>,
+) -> Option<MintBundle> {
+    let candidates: Vec<RoundTripPoolCandidate<'_>> = eligible
+        .iter()
+        .map(|p| RoundTripPoolCandidate {
+            pool: &p.quote_pool,
+            vault: p.vault.as_ref(),
+            dlmm_bins: p.dlmm_bins.as_ref(),
+            dex: &p.dex,
+        })
+        .collect();
+
+    let selection =
+        select_round_trip_pools(&candidates, config.probe_lamports, &config.freshness).ok()?;
+    let buy_pool = eligible
+        .iter()
+        .find(|p| p.pool_address == selection.buy_pool_address)?;
+    let sell_pool = eligible
+        .iter()
+        .find(|p| p.pool_address == selection.sell_pool_address)?;
+
+    let mut pools = vec![
+        selected_pool(
+            mint,
+            buy_pool,
+            TrackPoolReadiness::QuoteReady,
+            ArbTrackActiveReason::MultiDex,
+            per_pool_readiness,
+        ),
+        selected_pool(
+            mint,
+            sell_pool,
+            TrackPoolReadiness::QuoteReady,
+            ArbTrackActiveReason::MultiDex,
+            per_pool_readiness,
+        ),
+    ];
+    maybe_add_third_pool(mint, &mut pools, eligible, config, per_pool_readiness);
+    pools.sort_by(pool_address_cmp);
+
+    Some(MintBundle {
+        mint: mint.mint.clone(),
+        priority: TrackPoolReadiness::QuoteReady,
+        pools,
+    })
+}
+
+fn bundle_from_warmable_pair(
+    mint: &TrackMintInput,
+    eligible: &[&TrackPoolInput],
+    config: &TrackSelectionConfig,
+    per_pool_readiness: &HashMap<String, TrackPoolReadiness>,
+    now: Instant,
+) -> Option<MintBundle> {
+    let mut warmable: Vec<&TrackPoolInput> = eligible
+        .iter()
+        .copied()
+        .filter(|p| is_warmable_pool(p, config, now))
+        .collect();
+    warmable.sort_by(|a, b| dex_then_pool_cmp(a, b));
+
+    let mut buy: Option<&TrackPoolInput> = None;
+    let mut sell: Option<&TrackPoolInput> = None;
+    'outer: for (i, a) in warmable.iter().enumerate() {
+        for b in warmable.iter().skip(i + 1) {
+            if a.dex != b.dex {
+                buy = Some(a);
+                sell = Some(b);
+                break 'outer;
+            }
+        }
+    }
+    let (buy_pool, sell_pool) = (buy?, sell?);
+
+    let mut pools = vec![
+        selected_pool(
+            mint,
+            buy_pool,
+            TrackPoolReadiness::Warmable,
+            ArbTrackActiveReason::MultiDex,
+            per_pool_readiness,
+        ),
+        selected_pool(
+            mint,
+            sell_pool,
+            TrackPoolReadiness::Warmable,
+            ArbTrackActiveReason::MultiDex,
+            per_pool_readiness,
+        ),
+    ];
+    maybe_add_third_pool(mint, &mut pools, eligible, config, per_pool_readiness);
+    pools.sort_by(pool_address_cmp);
+
+    Some(MintBundle {
+        mint: mint.mint.clone(),
+        priority: TrackPoolReadiness::Warmable,
+        pools,
+    })
+}
+
+fn maybe_add_third_pool(
+    mint: &TrackMintInput,
+    pools: &mut Vec<SelectedTrackPool>,
+    eligible: &[&TrackPoolInput],
+    config: &TrackSelectionConfig,
+    per_pool_readiness: &HashMap<String, TrackPoolReadiness>,
+) {
+    if pools.len() >= config.max_pools_per_mint {
+        return;
+    }
+    let used: HashSet<&str> = pools.iter().map(|p| p.pool.as_str()).collect();
+    let used_dexes: HashSet<&str> = pools
+        .iter()
+        .filter_map(|sp| {
+            eligible
+                .iter()
+                .find(|p| p.pool_address == sp.pool)
+                .map(|p| p.dex.as_str())
+        })
+        .collect();
+
+    let mut candidates: Vec<&TrackPoolInput> = eligible
+        .iter()
+        .copied()
+        .filter(|p| !used.contains(p.pool_address.as_str()))
+        .filter(|p| !used_dexes.contains(p.dex.as_str()))
+        .filter(|p| {
+            per_pool_readiness
+                .get(&p.pool_address)
+                .copied()
+                .unwrap_or(TrackPoolReadiness::Rejected)
+                >= TrackPoolReadiness::Warmable
+        })
+        .collect();
+    candidates.sort_by(|a, b| dex_then_pool_cmp(a, b));
+
+    if let Some(third) = candidates.first() {
+        let readiness = per_pool_readiness
+            .get(&third.pool_address)
+            .copied()
+            .unwrap_or(TrackPoolReadiness::Warmable);
+        pools.push(selected_pool(
+            mint,
+            third,
+            readiness,
+            ArbTrackActiveReason::MultiDex,
+            per_pool_readiness,
+        ));
+    }
+}
+
+fn selected_pool(
+    mint: &TrackMintInput,
+    pool: &TrackPoolInput,
+    default_readiness: TrackPoolReadiness,
+    reason: ArbTrackActiveReason,
+    per_pool_readiness: &HashMap<String, TrackPoolReadiness>,
+) -> SelectedTrackPool {
+    let readiness = per_pool_readiness
+        .get(&pool.pool_address)
+        .copied()
+        .unwrap_or(default_readiness);
+    SelectedTrackPool {
+        mint: mint.mint.clone(),
+        pool: pool.pool_address.clone(),
+        readiness,
+        active_reason: reason,
+    }
+}
+
+fn classify_pool_readiness(
+    pool: &TrackPoolInput,
+    config: &TrackSelectionConfig,
+    now: Instant,
+) -> TrackPoolReadiness {
+    if !pool.known || !is_arb_track_dex(&pool.dex) {
+        return TrackPoolReadiness::Rejected;
+    }
+    if !is_structurally_quote_capable(pool) {
+        return TrackPoolReadiness::Rejected;
+    }
+    if can_fresh_buy_quote(pool, config, now) {
+        TrackPoolReadiness::QuoteReady
+    } else if is_warmable_pool(pool, config, now) {
+        TrackPoolReadiness::Warmable
+    } else {
+        TrackPoolReadiness::Rejected
+    }
+}
+
+fn is_warmable_pool(pool: &TrackPoolInput, config: &TrackSelectionConfig, now: Instant) -> bool {
+    if !pool.known || !is_structurally_quote_capable(pool) {
+        return false;
+    }
+    if can_fresh_buy_quote(pool, config, now) {
+        return false;
+    }
+    // Structural quote path exists but freshness is missing.
+    quote_exact_in_with_freshness(
+        &pool.quote_pool,
+        pool.vault.as_ref(),
+        pool.dlmm_bins.as_ref(),
+        NATIVE_SOL_MINT,
+        &pool.quote_pool.token_mint,
+        config.probe_lamports,
+        &config.freshness,
+    )
+    .is_some()
+        || pool.quote_pool.has_reserve_data
+}
+
+fn can_fresh_buy_quote(pool: &TrackPoolInput, config: &TrackSelectionConfig, now: Instant) -> bool {
+    let Some(quote) = quote_exact_in_with_freshness(
+        &pool.quote_pool,
+        pool.vault.as_ref(),
+        pool.dlmm_bins.as_ref(),
+        NATIVE_SOL_MINT,
+        &pool.quote_pool.token_mint,
+        config.probe_lamports,
+        &config.freshness,
+    ) else {
+        return false;
+    };
+    is_quote_fresh(&quote, &config.freshness, pool.vault.as_ref(), now)
+}
+
+fn is_structurally_quote_capable(pool: &TrackPoolInput) -> bool {
+    if pool.quote_pool.dex == "meteora_dlmm" {
+        if let Some(vault) = &pool.vault {
+            if vault.reserve_base > 0 && vault.reserve_quote > 0 {
+                let has_dlmm_meta = vault.active_id.is_some() && vault.bin_step.is_some();
+                if has_dlmm_meta || pool.dlmm_bins.is_some() {
+                    return true;
+                }
+            }
+        }
+        return pool.dlmm_bins.is_some();
+    }
+    if let Some(vault) = &pool.vault {
+        if vault.reserve_base > 0 && vault.reserve_quote > 0 {
+            return true;
+        }
+    }
+    pool.quote_pool.has_reserve_data
+}
+
+fn is_arb_track_dex(dex: &str) -> bool {
+    matches!(
+        dex,
+        "raydium" | "raydium_cpmm" | "orca" | "meteora_dlmm" | "pump_amm"
+    )
+}
+
+fn dex_then_pool_cmp(a: &TrackPoolInput, b: &TrackPoolInput) -> Ordering {
+    a.dex
+        .cmp(&b.dex)
+        .then_with(|| a.pool_address.cmp(&b.pool_address))
+}
+
+fn pool_address_cmp(a: &SelectedTrackPool, b: &SelectedTrackPool) -> Ordering {
+    a.pool.cmp(&b.pool)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    fn quote_pool(dex: &str, addr: &str, mint: &str, has_reserve: bool) -> QuotePoolInput {
+        QuotePoolInput {
+            pool_address: addr.to_string(),
+            dex: dex.to_string(),
+            token_mint: mint.to_string(),
+            trade_price_buy: None,
+            trade_price_sell: None,
+            trade_updated_at: Instant::now(),
+            has_reserve_data: has_reserve,
+            token_decimals: 6,
+        }
+    }
+
+    fn vault(reserve_base: u64, reserve_quote: u64) -> QuoteVaultInput {
+        QuoteVaultInput {
+            reserve_base,
+            reserve_quote,
+            update_slot: 1,
+            updated_at: Instant::now(),
+            active_id: None,
+            bin_step: None,
+            dlmm_sol_is_x: false,
+            dlmm_token_x_mint: None,
+        }
+    }
+
+    fn pool_input(
+        dex: &str,
+        addr: &str,
+        mint: &str,
+        known: bool,
+        has_reserve: bool,
+        vault: Option<QuoteVaultInput>,
+    ) -> TrackPoolInput {
+        TrackPoolInput {
+            pool_address: addr.to_string(),
+            dex: dex.to_string(),
+            known,
+            quote_pool: quote_pool(dex, addr, mint, has_reserve),
+            vault,
+            dlmm_bins: None,
+            token_decimals: 6,
+        }
+    }
+
+    fn default_config(max_pools: usize) -> TrackSelectionConfig {
+        TrackSelectionConfig {
+            max_pools,
+            max_pools_per_mint: 3,
+            probe_lamports: 10_000_000,
+            freshness: QuoteFreshnessConfig::default(),
+        }
+    }
+
+    const MINT: &str = "TokenMint11111111111111111111111111111111";
+    const RESERVE_BASE: u64 = 1_000_000_000_000;
+    const RESERVE_QUOTE: u64 = 1_000_000_000;
+
+    #[test]
+    fn single_dex_mint_selects_nothing() {
+        let mint = TrackMintInput {
+            mint: MINT.to_string(),
+            pools: vec![
+                pool_input(
+                    "orca",
+                    "poolA",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                ),
+                pool_input(
+                    "orca",
+                    "poolB",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                ),
+            ],
+            trade_signal_pools: None,
+        };
+        let result = select_arb_track_pools(&[mint], &default_config(500));
+        assert!(result.selected.is_empty());
+    }
+
+    #[test]
+    fn three_pools_one_dex_plus_one_cross_dex_is_bounded() {
+        let mint = TrackMintInput {
+            mint: MINT.to_string(),
+            pools: vec![
+                pool_input(
+                    "orca",
+                    "orca1",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                ),
+                pool_input(
+                    "orca",
+                    "orca2",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                ),
+                pool_input(
+                    "orca",
+                    "orca3",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                ),
+                pool_input(
+                    "pump_amm",
+                    "pump1",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
+                ),
+            ],
+            trade_signal_pools: None,
+        };
+        let result = select_arb_track_pools(&[mint], &default_config(500));
+        let pools: HashSet<_> = result.selected.iter().map(|p| p.pool.as_str()).collect();
+        assert_eq!(result.selected.len(), 2);
+        assert!(pools.contains("orca1") || pools.contains("orca2") || pools.contains("orca3"));
+        assert!(pools.contains("pump1"));
+        assert!(
+            !pools.contains("orca1")
+                || !pools.contains("orca2")
+                || !pools.contains("orca3")
+                || result.selected.len() <= 3
+        );
+    }
+
+    #[test]
+    fn tracker_only_unknown_cache_pools_not_selected() {
+        let mint = TrackMintInput {
+            mint: MINT.to_string(),
+            pools: vec![
+                pool_input(
+                    "orca",
+                    "known",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                ),
+                pool_input(
+                    "pump_amm",
+                    "unknown",
+                    MINT,
+                    false,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                ),
+            ],
+            trade_signal_pools: None,
+        };
+        let result = select_arb_track_pools(&[mint], &default_config(500));
+        assert!(result.selected.is_empty());
+        assert!(result.candidate_counts.rejected >= 1);
+    }
+
+    #[test]
+    fn quote_ready_pair_preferred_over_warmable() {
+        let fresh_vault = vault(RESERVE_BASE, RESERVE_QUOTE);
+        let stale_vault = QuoteVaultInput {
+            updated_at: Instant::now() - std::time::Duration::from_secs(600),
+            ..fresh_vault.clone()
+        };
+        let mint_quote = TrackMintInput {
+            mint: "MintQuoteReady111111111111111111111111".to_string(),
+            pools: vec![
+                pool_input(
+                    "orca",
+                    "freshA",
+                    MINT,
+                    true,
+                    true,
+                    Some(fresh_vault.clone()),
+                ),
+                pool_input("pump_amm", "freshB", MINT, true, true, Some(fresh_vault)),
+            ],
+            trade_signal_pools: None,
+        };
+        let mint_warm = TrackMintInput {
+            mint: "MintWarmable11111111111111111111111111".to_string(),
+            pools: vec![
+                pool_input(
+                    "orca",
+                    "staleA",
+                    MINT,
+                    true,
+                    true,
+                    Some(stale_vault.clone()),
+                ),
+                pool_input("pump_amm", "staleB", MINT, true, true, Some(stale_vault)),
+            ],
+            trade_signal_pools: None,
+        };
+        let result = select_arb_track_pools(&[mint_warm, mint_quote], &default_config(4));
+        let selected_mints: HashSet<_> = result.selected.iter().map(|p| p.mint.as_str()).collect();
+        assert!(selected_mints.contains("MintQuoteReady111111111111111111111111"));
+    }
+
+    #[test]
+    fn rest_budget_of_one_does_not_take_isolated_pool() {
+        let make_mint = |suffix: &str| TrackMintInput {
+            mint: format!("Mint{suffix}"),
+            pools: vec![
+                pool_input(
+                    "orca",
+                    &format!("orca_{suffix}"),
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                ),
+                pool_input(
+                    "pump_amm",
+                    &format!("pump_{suffix}"),
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
+                ),
+            ],
+            trade_signal_pools: None,
+        };
+        let mints: Vec<_> = (0..3).map(|i| make_mint(&i.to_string())).collect();
+        let result = select_arb_track_pools(&mints, &default_config(5));
+        assert!(result.selected.len() <= 5);
+        assert_eq!(result.selected.len() % 2, 0);
+    }
+
+    #[test]
+    fn selection_is_deterministic_across_input_order() {
+        let mint_a = TrackMintInput {
+            mint: "MintA".to_string(),
+            pools: vec![
+                pool_input(
+                    "orca",
+                    "a_orca",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                ),
+                pool_input(
+                    "pump_amm",
+                    "a_pump",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
+                ),
+            ],
+            trade_signal_pools: None,
+        };
+        let mint_b = TrackMintInput {
+            mint: "MintB".to_string(),
+            pools: vec![
+                pool_input(
+                    "raydium",
+                    "b_ray",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                ),
+                pool_input(
+                    "pump_amm",
+                    "b_pump",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
+                ),
+            ],
+            trade_signal_pools: None,
+        };
+        let r1 = select_arb_track_pools(&[mint_a.clone(), mint_b.clone()], &default_config(500));
+        let r2 = select_arb_track_pools(&[mint_b, mint_a], &default_config(500));
+        let pools1: Vec<_> = r1.selected.iter().map(|p| p.pool.clone()).collect();
+        let pools2: Vec<_> = r2.selected.iter().map(|p| p.pool.clone()).collect();
+        assert_eq!(pools1, pools2);
+    }
+
+    #[test]
+    fn result_size_never_exceeds_max_pools() {
+        let mut mints = Vec::new();
+        for i in 0..50 {
+            mints.push(TrackMintInput {
+                mint: format!("Mint{i:04}"),
+                pools: vec![
+                    pool_input(
+                        "orca",
+                        &format!("orca_{i}"),
+                        MINT,
+                        true,
+                        true,
+                        Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                    ),
+                    pool_input(
+                        "pump_amm",
+                        &format!("pump_{i}"),
+                        MINT,
+                        true,
+                        true,
+                        Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
+                    ),
+                ],
+                trade_signal_pools: None,
+            });
+        }
+        let result = select_arb_track_pools(&mints, &default_config(10));
+        assert!(result.selected.len() <= 10);
+    }
+
+    #[test]
+    fn budget_displacement_marks_reason_budget() {
+        let pool = "orphan";
+        let displaced: HashSet<_> = [pool.to_string()].into_iter().collect();
+        assert_eq!(
+            arb_track_removal_reason(pool, true, &displaced),
+            ArbTrackRemovedReason::Budget
+        );
+        assert_eq!(
+            arb_track_removal_reason("gone", false, &displaced),
+            ArbTrackRemovedReason::Stale
+        );
+    }
+
+    #[test]
+    fn trade_signal_pair_selected_as_executable() {
+        let mint = TrackMintInput {
+            mint: MINT.to_string(),
+            pools: vec![
+                pool_input(
+                    "orca",
+                    "sig_buy",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                ),
+                pool_input(
+                    "pump_amm",
+                    "sig_sell",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
+                ),
+            ],
+            trade_signal_pools: Some(("sig_buy".to_string(), "sig_sell".to_string())),
+        };
+        let result = select_arb_track_pools(&[mint], &default_config(500));
+        assert_eq!(result.selected.len(), 2);
+        assert!(result
+            .selected
+            .iter()
+            .all(|p| p.active_reason == ArbTrackActiveReason::TradeSignal));
+    }
+}

--- a/src/arbitrage/track_selection.rs
+++ b/src/arbitrage/track_selection.rs
@@ -43,6 +43,8 @@ pub struct TrackPoolInput {
     pub vault: Option<QuoteVaultInput>,
     pub dlmm_bins: Option<DlmmBinArrays>,
     pub token_decimals: u8,
+    /// Latest activity from tracker/cache state (unix ms).
+    pub last_activity_unix_ms: u64,
 }
 
 /// Per-mint bundle of pools considered for pin selection.
@@ -52,6 +54,8 @@ pub struct TrackMintInput {
     pub pools: Vec<TrackPoolInput>,
     /// Optional trade-signal buy/sell pair for this mint (highest pin priority).
     pub trade_signal_pools: Option<(String, String)>,
+    /// Mint-level recency for global bundle ranking.
+    pub last_activity_unix_ms: u64,
 }
 
 /// Global selection limits and quote parameters.
@@ -120,20 +124,13 @@ pub fn select_arb_track_pools(
     }
 
     let mut bundles: Vec<MintBundle> = Vec::new();
-    let mut mint_inputs: Vec<&TrackMintInput> = mints.iter().collect();
-    mint_inputs.sort_by(|a, b| a.mint.cmp(&b.mint));
-
-    for mint in mint_inputs {
+    for mint in mints {
         if let Some(bundle) = build_mint_bundle(mint, config, &per_pool_readiness, now) {
             bundles.push(bundle);
         }
     }
 
-    bundles.sort_by(|a, b| {
-        b.priority
-            .cmp(&a.priority)
-            .then_with(|| a.mint.cmp(&b.mint))
-    });
+    bundles.sort_by(compare_bundles);
 
     let mut selected: Vec<SelectedTrackPool> = Vec::new();
     let mut budget_displaced: Vec<String> = Vec::new();
@@ -168,10 +165,9 @@ pub fn select_arb_track_pools(
 /// Map selection removals for pools no longer in the target set.
 pub fn arb_track_removal_reason(
     pool: &str,
-    still_tracker_valid: bool,
     budget_displaced: &HashSet<String>,
 ) -> ArbTrackRemovedReason {
-    if budget_displaced.contains(pool) || still_tracker_valid {
+    if budget_displaced.contains(pool) {
         ArbTrackRemovedReason::Budget
     } else {
         ArbTrackRemovedReason::Stale
@@ -182,7 +178,15 @@ pub fn arb_track_removal_reason(
 struct MintBundle {
     mint: String,
     priority: TrackPoolReadiness,
+    last_activity_unix_ms: u64,
     pools: Vec<SelectedTrackPool>,
+}
+
+fn compare_bundles(a: &MintBundle, b: &MintBundle) -> Ordering {
+    b.priority
+        .cmp(&a.priority)
+        .then_with(|| b.last_activity_unix_ms.cmp(&a.last_activity_unix_ms))
+        .then_with(|| a.mint.cmp(&b.mint))
 }
 
 fn build_mint_bundle(
@@ -220,7 +224,7 @@ fn build_mint_bundle(
         return Some(bundle);
     }
 
-    bundle_from_warmable_pair(mint, &eligible, config, per_pool_readiness, now)
+    bundle_from_pinable_pair(mint, &eligible, config, per_pool_readiness, now)
 }
 
 fn bundle_from_trade_signal(
@@ -259,6 +263,7 @@ fn bundle_from_trade_signal(
     Some(MintBundle {
         mint: mint.mint.clone(),
         priority: TrackPoolReadiness::Executable,
+        last_activity_unix_ms: mint.last_activity_unix_ms,
         pools,
     })
 }
@@ -310,49 +315,72 @@ fn bundle_from_round_trip(
     Some(MintBundle {
         mint: mint.mint.clone(),
         priority: TrackPoolReadiness::QuoteReady,
+        last_activity_unix_ms: mint.last_activity_unix_ms,
         pools,
     })
 }
 
-fn bundle_from_warmable_pair(
+fn bundle_from_pinable_pair(
     mint: &TrackMintInput,
     eligible: &[&TrackPoolInput],
     config: &TrackSelectionConfig,
     per_pool_readiness: &HashMap<String, TrackPoolReadiness>,
     now: Instant,
 ) -> Option<MintBundle> {
-    let mut warmable: Vec<&TrackPoolInput> = eligible
+    let mut pinable: Vec<&TrackPoolInput> = eligible
         .iter()
         .copied()
-        .filter(|p| is_warmable_pool(p, config, now))
+        .filter(|p| is_pinable_pool(p, config, now, per_pool_readiness))
         .collect();
-    warmable.sort_by(|a, b| dex_then_pool_cmp(a, b));
+    pinable.sort_by(|a, b| {
+        pool_readiness(a, per_pool_readiness)
+            .cmp(&pool_readiness(b, per_pool_readiness))
+            .reverse()
+            .then_with(|| dex_then_pool_cmp(a, b))
+    });
 
-    let mut buy: Option<&TrackPoolInput> = None;
-    let mut sell: Option<&TrackPoolInput> = None;
-    'outer: for (i, a) in warmable.iter().enumerate() {
-        for b in warmable.iter().skip(i + 1) {
-            if a.dex != b.dex {
-                buy = Some(a);
-                sell = Some(b);
-                break 'outer;
+    let mut best: Option<(&TrackPoolInput, &TrackPoolInput, TrackPoolReadiness)> = None;
+    for (i, a) in pinable.iter().enumerate() {
+        for b in pinable.iter().skip(i + 1) {
+            if a.dex == b.dex {
+                continue;
+            }
+            let ra = pool_readiness(a, per_pool_readiness);
+            let rb = pool_readiness(b, per_pool_readiness);
+            let bundle_priority = ra.min(rb);
+            let replace = match best {
+                None => true,
+                Some((best_a, best_b, current_priority)) => {
+                    if bundle_priority != current_priority {
+                        bundle_priority > current_priority
+                    } else {
+                        let activity = a.last_activity_unix_ms.max(b.last_activity_unix_ms);
+                        let best_activity = best_a
+                            .last_activity_unix_ms
+                            .max(best_b.last_activity_unix_ms);
+                        activity > best_activity
+                    }
+                }
+            };
+            if replace {
+                best = Some((a, b, bundle_priority));
             }
         }
     }
-    let (buy_pool, sell_pool) = (buy?, sell?);
+    let (buy_pool, sell_pool, bundle_priority) = best?;
 
     let mut pools = vec![
         selected_pool(
             mint,
             buy_pool,
-            TrackPoolReadiness::Warmable,
+            bundle_priority,
             ArbTrackActiveReason::MultiDex,
             per_pool_readiness,
         ),
         selected_pool(
             mint,
             sell_pool,
-            TrackPoolReadiness::Warmable,
+            bundle_priority,
             ArbTrackActiveReason::MultiDex,
             per_pool_readiness,
         ),
@@ -362,7 +390,8 @@ fn bundle_from_warmable_pair(
 
     Some(MintBundle {
         mint: mint.mint.clone(),
-        priority: TrackPoolReadiness::Warmable,
+        priority: bundle_priority,
+        last_activity_unix_ms: mint.last_activity_unix_ms,
         pools,
     })
 }
@@ -393,21 +422,17 @@ fn maybe_add_third_pool(
         .copied()
         .filter(|p| !used.contains(p.pool_address.as_str()))
         .filter(|p| !used_dexes.contains(p.dex.as_str()))
-        .filter(|p| {
-            per_pool_readiness
-                .get(&p.pool_address)
-                .copied()
-                .unwrap_or(TrackPoolReadiness::Rejected)
-                >= TrackPoolReadiness::Warmable
-        })
+        .filter(|p| is_pinable_pool(p, config, Instant::now(), per_pool_readiness))
         .collect();
-    candidates.sort_by(|a, b| dex_then_pool_cmp(a, b));
+    candidates.sort_by(|a, b| {
+        pool_readiness(a, per_pool_readiness)
+            .cmp(&pool_readiness(b, per_pool_readiness))
+            .reverse()
+            .then_with(|| dex_then_pool_cmp(a, b))
+    });
 
     if let Some(third) = candidates.first() {
-        let readiness = per_pool_readiness
-            .get(&third.pool_address)
-            .copied()
-            .unwrap_or(TrackPoolReadiness::Warmable);
+        let readiness = pool_readiness(third, per_pool_readiness);
         pools.push(selected_pool(
             mint,
             third,
@@ -437,6 +462,26 @@ fn selected_pool(
     }
 }
 
+fn pool_readiness(
+    pool: &TrackPoolInput,
+    per_pool_readiness: &HashMap<String, TrackPoolReadiness>,
+) -> TrackPoolReadiness {
+    per_pool_readiness
+        .get(&pool.pool_address)
+        .copied()
+        .unwrap_or(TrackPoolReadiness::Rejected)
+}
+
+fn is_pinable_pool(
+    pool: &TrackPoolInput,
+    config: &TrackSelectionConfig,
+    now: Instant,
+    per_pool_readiness: &HashMap<String, TrackPoolReadiness>,
+) -> bool {
+    pool_readiness(pool, per_pool_readiness) >= TrackPoolReadiness::Warmable
+        || is_warmable_pool(pool, config, now)
+}
+
 fn classify_pool_readiness(
     pool: &TrackPoolInput,
     config: &TrackSelectionConfig,
@@ -464,18 +509,8 @@ fn is_warmable_pool(pool: &TrackPoolInput, config: &TrackSelectionConfig, now: I
     if can_fresh_buy_quote(pool, config, now) {
         return false;
     }
-    // Structural quote path exists but freshness is missing.
-    quote_exact_in_with_freshness(
-        &pool.quote_pool,
-        pool.vault.as_ref(),
-        pool.dlmm_bins.as_ref(),
-        NATIVE_SOL_MINT,
-        &pool.quote_pool.token_mint,
-        config.probe_lamports,
-        &config.freshness,
-    )
-    .is_some()
-        || pool.quote_pool.has_reserve_data
+    // Known + structural DEX support; reserve/bin freshness may be missing.
+    true
 }
 
 fn can_fresh_buy_quote(pool: &TrackPoolInput, config: &TrackSelectionConfig, now: Instant) -> bool {
@@ -494,23 +529,21 @@ fn can_fresh_buy_quote(pool: &TrackPoolInput, config: &TrackSelectionConfig, now
 }
 
 fn is_structurally_quote_capable(pool: &TrackPoolInput) -> bool {
-    if pool.quote_pool.dex == "meteora_dlmm" {
-        if let Some(vault) = &pool.vault {
-            if vault.reserve_base > 0 && vault.reserve_quote > 0 {
-                let has_dlmm_meta = vault.active_id.is_some() && vault.bin_step.is_some();
-                if has_dlmm_meta || pool.dlmm_bins.is_some() {
+    if !pool.known || !is_arb_track_dex(&pool.dex) {
+        return false;
+    }
+    match pool.quote_pool.dex.as_str() {
+        "meteora_dlmm" => {
+            if let Some(vault) = &pool.vault {
+                if vault.active_id.is_some() && vault.bin_step.is_some() {
                     return true;
                 }
             }
+            pool.dlmm_bins.is_some() || pool.known
         }
-        return pool.dlmm_bins.is_some();
+        "orca" | "raydium" | "raydium_cpmm" | "pump_amm" => true,
+        _ => false,
     }
-    if let Some(vault) = &pool.vault {
-        if vault.reserve_base > 0 && vault.reserve_quote > 0 {
-            return true;
-        }
-    }
-    pool.quote_pool.has_reserve_data
 }
 
 fn is_arb_track_dex(dex: &str) -> bool {
@@ -568,6 +601,7 @@ mod tests {
         known: bool,
         has_reserve: bool,
         vault: Option<QuoteVaultInput>,
+        activity_ms: u64,
     ) -> TrackPoolInput {
         TrackPoolInput {
             pool_address: addr.to_string(),
@@ -577,6 +611,21 @@ mod tests {
             vault,
             dlmm_bins: None,
             token_decimals: 6,
+            last_activity_unix_ms: activity_ms,
+        }
+    }
+
+    fn mint_input(
+        mint: &str,
+        pools: Vec<TrackPoolInput>,
+        activity_ms: u64,
+        trade_signal: Option<(String, String)>,
+    ) -> TrackMintInput {
+        TrackMintInput {
+            mint: mint.to_string(),
+            pools,
+            trade_signal_pools: trade_signal,
+            last_activity_unix_ms: activity_ms,
         }
     }
 
@@ -595,9 +644,9 @@ mod tests {
 
     #[test]
     fn single_dex_mint_selects_nothing() {
-        let mint = TrackMintInput {
-            mint: MINT.to_string(),
-            pools: vec![
+        let mint = mint_input(
+            MINT,
+            vec![
                 pool_input(
                     "orca",
                     "poolA",
@@ -605,6 +654,7 @@ mod tests {
                     true,
                     true,
                     Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                    1,
                 ),
                 pool_input(
                     "orca",
@@ -613,271 +663,145 @@ mod tests {
                     true,
                     true,
                     Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                    2,
                 ),
             ],
-            trade_signal_pools: None,
-        };
+            2,
+            None,
+        );
         let result = select_arb_track_pools(&[mint], &default_config(500));
         assert!(result.selected.is_empty());
     }
 
     #[test]
-    fn three_pools_one_dex_plus_one_cross_dex_is_bounded() {
-        let mint = TrackMintInput {
-            mint: MINT.to_string(),
-            pools: vec![
-                pool_input(
-                    "orca",
-                    "orca1",
-                    MINT,
-                    true,
-                    true,
-                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
-                ),
-                pool_input(
-                    "orca",
-                    "orca2",
-                    MINT,
-                    true,
-                    true,
-                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
-                ),
-                pool_input(
-                    "orca",
-                    "orca3",
-                    MINT,
-                    true,
-                    true,
-                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
-                ),
+    fn known_cache_pool_without_reserves_is_warmable() {
+        let mint = mint_input(
+            MINT,
+            vec![
+                pool_input("orca", "warm", MINT, true, false, None, 1),
                 pool_input(
                     "pump_amm",
-                    "pump1",
+                    "fresh",
                     MINT,
                     true,
                     true,
                     Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
+                    2,
                 ),
             ],
-            trade_signal_pools: None,
-        };
+            2,
+            None,
+        );
+        let result = select_arb_track_pools(&[mint], &default_config(500));
+        let pools: HashSet<_> = result.selected.iter().map(|p| p.pool.as_str()).collect();
+        assert!(pools.contains("warm"));
+        assert!(pools.contains("fresh"));
+        assert!(result.candidate_counts.warmable >= 1);
+    }
+
+    #[test]
+    fn quote_ready_plus_warmable_pair_selected() {
+        let fresh_vault = vault(RESERVE_BASE, RESERVE_QUOTE);
+        let mint = mint_input(
+            MINT,
+            vec![
+                pool_input(
+                    "orca",
+                    "quote_ready",
+                    MINT,
+                    true,
+                    true,
+                    Some(fresh_vault),
+                    10,
+                ),
+                pool_input("pump_amm", "warm_only", MINT, true, false, None, 5),
+            ],
+            10,
+            None,
+        );
         let result = select_arb_track_pools(&[mint], &default_config(500));
         let pools: HashSet<_> = result.selected.iter().map(|p| p.pool.as_str()).collect();
         assert_eq!(result.selected.len(), 2);
-        assert!(pools.contains("orca1") || pools.contains("orca2") || pools.contains("orca3"));
-        assert!(pools.contains("pump1"));
-        assert!(
-            !pools.contains("orca1")
-                || !pools.contains("orca2")
-                || !pools.contains("orca3")
-                || result.selected.len() <= 3
+        assert!(pools.contains("quote_ready"));
+        assert!(pools.contains("warm_only"));
+    }
+
+    #[test]
+    fn newer_equal_readiness_bundle_wins_over_older_mint_name() {
+        let old_mint = mint_input(
+            "AAAAOldMint111111111111111111111111111",
+            vec![
+                pool_input(
+                    "orca",
+                    "old_orca",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                    1,
+                ),
+                pool_input(
+                    "pump_amm",
+                    "old_pump",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
+                    1,
+                ),
+            ],
+            1,
+            None,
         );
-    }
-
-    #[test]
-    fn tracker_only_unknown_cache_pools_not_selected() {
-        let mint = TrackMintInput {
-            mint: MINT.to_string(),
-            pools: vec![
+        let new_mint = mint_input(
+            "ZZZZNewMint111111111111111111111111111",
+            vec![
                 pool_input(
                     "orca",
-                    "known",
+                    "new_orca",
                     MINT,
                     true,
                     true,
                     Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                    9_999,
                 ),
                 pool_input(
                     "pump_amm",
-                    "unknown",
-                    MINT,
-                    false,
-                    true,
-                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
-                ),
-            ],
-            trade_signal_pools: None,
-        };
-        let result = select_arb_track_pools(&[mint], &default_config(500));
-        assert!(result.selected.is_empty());
-        assert!(result.candidate_counts.rejected >= 1);
-    }
-
-    #[test]
-    fn quote_ready_pair_preferred_over_warmable() {
-        let fresh_vault = vault(RESERVE_BASE, RESERVE_QUOTE);
-        let stale_vault = QuoteVaultInput {
-            updated_at: Instant::now() - std::time::Duration::from_secs(600),
-            ..fresh_vault.clone()
-        };
-        let mint_quote = TrackMintInput {
-            mint: "MintQuoteReady111111111111111111111111".to_string(),
-            pools: vec![
-                pool_input(
-                    "orca",
-                    "freshA",
+                    "new_pump",
                     MINT,
                     true,
                     true,
-                    Some(fresh_vault.clone()),
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
+                    9_999,
                 ),
-                pool_input("pump_amm", "freshB", MINT, true, true, Some(fresh_vault)),
             ],
-            trade_signal_pools: None,
-        };
-        let mint_warm = TrackMintInput {
-            mint: "MintWarmable11111111111111111111111111".to_string(),
-            pools: vec![
-                pool_input(
-                    "orca",
-                    "staleA",
-                    MINT,
-                    true,
-                    true,
-                    Some(stale_vault.clone()),
-                ),
-                pool_input("pump_amm", "staleB", MINT, true, true, Some(stale_vault)),
-            ],
-            trade_signal_pools: None,
-        };
-        let result = select_arb_track_pools(&[mint_warm, mint_quote], &default_config(4));
+            9_999,
+            None,
+        );
+        let result = select_arb_track_pools(&[old_mint, new_mint], &default_config(2));
         let selected_mints: HashSet<_> = result.selected.iter().map(|p| p.mint.as_str()).collect();
-        assert!(selected_mints.contains("MintQuoteReady111111111111111111111111"));
+        assert!(selected_mints.contains("ZZZZNewMint111111111111111111111111111"));
+        assert!(!selected_mints.contains("AAAAOldMint111111111111111111111111111"));
     }
 
     #[test]
-    fn rest_budget_of_one_does_not_take_isolated_pool() {
-        let make_mint = |suffix: &str| TrackMintInput {
-            mint: format!("Mint{suffix}"),
-            pools: vec![
-                pool_input(
-                    "orca",
-                    &format!("orca_{suffix}"),
-                    MINT,
-                    true,
-                    true,
-                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
-                ),
-                pool_input(
-                    "pump_amm",
-                    &format!("pump_{suffix}"),
-                    MINT,
-                    true,
-                    true,
-                    Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
-                ),
-            ],
-            trade_signal_pools: None,
-        };
-        let mints: Vec<_> = (0..3).map(|i| make_mint(&i.to_string())).collect();
-        let result = select_arb_track_pools(&mints, &default_config(5));
-        assert!(result.selected.len() <= 5);
-        assert_eq!(result.selected.len() % 2, 0);
-    }
-
-    #[test]
-    fn selection_is_deterministic_across_input_order() {
-        let mint_a = TrackMintInput {
-            mint: "MintA".to_string(),
-            pools: vec![
-                pool_input(
-                    "orca",
-                    "a_orca",
-                    MINT,
-                    true,
-                    true,
-                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
-                ),
-                pool_input(
-                    "pump_amm",
-                    "a_pump",
-                    MINT,
-                    true,
-                    true,
-                    Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
-                ),
-            ],
-            trade_signal_pools: None,
-        };
-        let mint_b = TrackMintInput {
-            mint: "MintB".to_string(),
-            pools: vec![
-                pool_input(
-                    "raydium",
-                    "b_ray",
-                    MINT,
-                    true,
-                    true,
-                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
-                ),
-                pool_input(
-                    "pump_amm",
-                    "b_pump",
-                    MINT,
-                    true,
-                    true,
-                    Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
-                ),
-            ],
-            trade_signal_pools: None,
-        };
-        let r1 = select_arb_track_pools(&[mint_a.clone(), mint_b.clone()], &default_config(500));
-        let r2 = select_arb_track_pools(&[mint_b, mint_a], &default_config(500));
-        let pools1: Vec<_> = r1.selected.iter().map(|p| p.pool.clone()).collect();
-        let pools2: Vec<_> = r2.selected.iter().map(|p| p.pool.clone()).collect();
-        assert_eq!(pools1, pools2);
-    }
-
-    #[test]
-    fn result_size_never_exceeds_max_pools() {
-        let mut mints = Vec::new();
-        for i in 0..50 {
-            mints.push(TrackMintInput {
-                mint: format!("Mint{i:04}"),
-                pools: vec![
-                    pool_input(
-                        "orca",
-                        &format!("orca_{i}"),
-                        MINT,
-                        true,
-                        true,
-                        Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
-                    ),
-                    pool_input(
-                        "pump_amm",
-                        &format!("pump_{i}"),
-                        MINT,
-                        true,
-                        true,
-                        Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
-                    ),
-                ],
-                trade_signal_pools: None,
-            });
-        }
-        let result = select_arb_track_pools(&mints, &default_config(10));
-        assert!(result.selected.len() <= 10);
-    }
-
-    #[test]
-    fn budget_displacement_marks_reason_budget() {
-        let pool = "orphan";
-        let displaced: HashSet<_> = [pool.to_string()].into_iter().collect();
+    fn budget_displacement_marks_reason_budget_only_when_displaced() {
+        let displaced: HashSet<_> = ["pool_budget".to_string()].into_iter().collect();
         assert_eq!(
-            arb_track_removal_reason(pool, true, &displaced),
+            arb_track_removal_reason("pool_budget", &displaced),
             ArbTrackRemovedReason::Budget
         );
         assert_eq!(
-            arb_track_removal_reason("gone", false, &displaced),
+            arb_track_removal_reason("pool_stale", &displaced),
             ArbTrackRemovedReason::Stale
         );
     }
 
     #[test]
     fn trade_signal_pair_selected_as_executable() {
-        let mint = TrackMintInput {
-            mint: MINT.to_string(),
-            pools: vec![
+        let mint = mint_input(
+            MINT,
+            vec![
                 pool_input(
                     "orca",
                     "sig_buy",
@@ -885,6 +809,7 @@ mod tests {
                     true,
                     true,
                     Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                    1,
                 ),
                 pool_input(
                     "pump_amm",
@@ -893,15 +818,51 @@ mod tests {
                     true,
                     true,
                     Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
+                    2,
                 ),
             ],
-            trade_signal_pools: Some(("sig_buy".to_string(), "sig_sell".to_string())),
-        };
+            2,
+            Some(("sig_buy".to_string(), "sig_sell".to_string())),
+        );
         let result = select_arb_track_pools(&[mint], &default_config(500));
         assert_eq!(result.selected.len(), 2);
         assert!(result
             .selected
             .iter()
             .all(|p| p.active_reason == ArbTrackActiveReason::TradeSignal));
+    }
+
+    #[test]
+    fn result_size_never_exceeds_max_pools() {
+        let mut mints = Vec::new();
+        for i in 0..50 {
+            mints.push(mint_input(
+                &format!("Mint{i:04}"),
+                vec![
+                    pool_input(
+                        "orca",
+                        &format!("orca_{i}"),
+                        MINT,
+                        true,
+                        true,
+                        Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                        i as u64,
+                    ),
+                    pool_input(
+                        "pump_amm",
+                        &format!("pump_{i}"),
+                        MINT,
+                        true,
+                        true,
+                        Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
+                        i as u64,
+                    ),
+                ],
+                i as u64,
+                None,
+            ));
+        }
+        let result = select_arb_track_pools(&mints, &default_config(10));
+        assert!(result.selected.len() <= 10);
     }
 }

--- a/src/arbitrage/track_selection.rs
+++ b/src/arbitrage/track_selection.rs
@@ -116,8 +116,21 @@ pub fn select_arb_track_pools(
     let mut per_pool_readiness: HashMap<String, TrackPoolReadiness> = HashMap::new();
 
     for mint in mints {
+        let signal_pools: HashSet<&str> = mint
+            .trade_signal_pools
+            .as_ref()
+            .map(|(buy, sell)| [buy.as_str(), sell.as_str()])
+            .into_iter()
+            .flatten()
+            .collect();
+
         for pool in &mint.pools {
-            let readiness = classify_pool_readiness(pool, config, now);
+            let mut readiness = classify_pool_readiness(pool, config, now);
+            if signal_pools.contains(pool.pool_address.as_str())
+                && readiness >= TrackPoolReadiness::Warmable
+            {
+                readiness = TrackPoolReadiness::Executable;
+            }
             candidate_counts.record(readiness);
             per_pool_readiness.insert(pool.pool_address.clone(), readiness);
         }
@@ -826,6 +839,7 @@ mod tests {
         );
         let result = select_arb_track_pools(&[mint], &default_config(500));
         assert_eq!(result.selected.len(), 2);
+        assert_eq!(result.candidate_counts.executable, 2);
         assert!(result
             .selected
             .iter()

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -102,8 +102,8 @@ use ironcrab::metrics::{
 use ironcrab::nats::{
     arb_strategy_pool_cache_live_consumer_config, arb_track_payload_bytes, config_consumer_config,
     config_subject, split_arb_track_requests_update, trim_reconcile_update_to_budget,
-    ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackRemovedEntry, ArbTrackRemovedReason,
-    ArbTrackRequestsUpdate, ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES, CONFIG_STREAM_NAME, STREAM_NAME,
+    ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackRemovedEntry, ArbTrackRequestsUpdate,
+    ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES, CONFIG_STREAM_NAME, STREAM_NAME,
 };
 use ironcrab::nats::{NatsClient, NatsConfig};
 use ironcrab::nats::{TOPIC_ARB_TRACK_REQUESTS, TOPIC_MARKET_EVENTS, TOPIC_TRADE_INTENTS};
@@ -564,6 +564,8 @@ impl ArbTrackSelectionHandle {
             return;
         }
         if self.wake_tx.try_send(()).is_err() {
+            // Channel full: a wake token is already queued (capacity 1). Arm full
+            // reconcile so the in-flight worker pass performs authoritative recovery.
             record_arb_track_selection_queue_overflow_total();
             self.pending_full_reconcile.store(true, Ordering::Release);
         }
@@ -6218,33 +6220,10 @@ impl ArbContext {
         self.mark_arb_track_mint_dirty(mint);
     }
 
+    /// Heartbeat hook: schedule authoritative stale-pin cleanup via the selection worker.
+    /// No tracker scan, pinned-set mutation, or direct publish on the async path.
     fn prune_arb_track_stale_pools(self: &Arc<Self>) {
-        if self.nats.is_none() {
-            return;
-        }
-        let trackers = self.trackers.read();
-        let mut still_active: HashSet<String> = HashSet::new();
-        for tracker in trackers.values() {
-            if tracker.pool_count_on_distinct_dexes() >= 2 {
-                still_active.extend(tracker.pools.keys().cloned());
-            }
-        }
-        drop(trackers);
-        let mut removed = Vec::new();
-        let mut pinned = self.arb_pinned_pools.write();
-        for pool in pinned.clone().into_iter() {
-            if !still_active.contains(&pool) {
-                pinned.remove(&pool);
-                removed.push(ArbTrackRemovedEntry {
-                    pool,
-                    reason: ArbTrackRemovedReason::Stale,
-                });
-            }
-        }
-        drop(pinned);
-        if !removed.is_empty() {
-            self.spawn_publish_arb_track_requests(Vec::new(), removed, false);
-        }
+        self.arb_track_selection.request_full_reconcile();
     }
 }
 
@@ -11241,6 +11220,102 @@ mod two_hop_price_tests {
         assert!(admit_a.contains("mint_01"));
         assert!(admit_a.contains("mint_02"));
         assert!(admit_a.contains("mint_03"));
+    }
+
+    #[test]
+    fn prune_arb_track_stale_pools_only_schedules_full_reconcile() {
+        let cache = create_shared_cache();
+        let ctx = Arc::new(test_arb_context(cache));
+        let stale_pool = "stale_pool_addr";
+        ctx.arb_pinned_pools.write().insert(stale_pool.to_string());
+        assert!(!ctx
+            .arb_track_selection
+            .pending_full_reconcile
+            .load(Ordering::Acquire));
+        ctx.prune_arb_track_stale_pools();
+        assert!(
+            ctx.arb_track_selection
+                .pending_full_reconcile
+                .load(Ordering::Acquire),
+            "heartbeat prune must arm authoritative full reconcile only"
+        );
+        assert!(
+            ctx.arb_pinned_pools.read().contains(stale_pool),
+            "heartbeat prune must not mutate pinned set directly"
+        );
+    }
+
+    #[test]
+    fn full_reconcile_clears_stale_pinned_pool_via_authoritative_selection() {
+        let cache = create_shared_cache();
+        let ctx = Arc::new(test_arb_context(cache));
+        let stale_mint = "StalePinnedMint111111111111111111111111";
+        let stale_pool = "stale_pool_addr";
+        {
+            let mut snapshots = ctx.arb_track_mint_snapshots.write();
+            snapshots.insert_bounded(
+                stale_mint.to_string(),
+                TrackMintInput {
+                    mint: stale_mint.to_string(),
+                    pools: vec![
+                        TrackPoolInput {
+                            pool_address: stale_pool.to_string(),
+                            dex: "orca".to_string(),
+                            known: true,
+                            quote_pool: QuotePoolInput {
+                                pool_address: stale_pool.to_string(),
+                                dex: "orca".to_string(),
+                                token_mint: stale_mint.to_string(),
+                                trade_price_buy: None,
+                                trade_price_sell: None,
+                                trade_updated_at: Instant::now(),
+                                has_reserve_data: true,
+                                token_decimals: 6,
+                            },
+                            vault: None,
+                            dlmm_bins: None,
+                            token_decimals: 6,
+                            last_activity_unix_ms: 1,
+                        },
+                        TrackPoolInput {
+                            pool_address: "other_pool".to_string(),
+                            dex: "pump_amm".to_string(),
+                            known: true,
+                            quote_pool: QuotePoolInput {
+                                pool_address: "other_pool".to_string(),
+                                dex: "pump_amm".to_string(),
+                                token_mint: stale_mint.to_string(),
+                                trade_price_buy: None,
+                                trade_price_sell: None,
+                                trade_updated_at: Instant::now(),
+                                has_reserve_data: true,
+                                token_decimals: 6,
+                            },
+                            vault: None,
+                            dlmm_bins: None,
+                            token_decimals: 6,
+                            last_activity_unix_ms: 2,
+                        },
+                    ],
+                    trade_signal_pools: None,
+                    last_activity_unix_ms: 2,
+                },
+                &HashSet::new(),
+            );
+        }
+        ctx.arb_pinned_pools.write().insert(stale_pool.to_string());
+        run_arb_track_selection_batch(&ctx, Vec::new(), true);
+        assert!(
+            !ctx.arb_pinned_pools.read().contains(stale_pool),
+            "authoritative full reconcile must clear stale pins"
+        );
+        assert!(
+            !ctx.arb_track_mint_snapshots
+                .read()
+                .entries
+                .contains_key(stale_mint),
+            "stale snapshot must be rebuilt/removed from tracker truth"
+        );
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -718,6 +718,20 @@ impl ArbTrackMintSnapshotCache {
         self.compact_heap_if_needed(false);
         true
     }
+
+    #[cfg(test)]
+    fn test_access_generations_in_order(&self, mints: &[String]) -> Vec<u64> {
+        mints
+            .iter()
+            .filter_map(|mint| self.entries.get(mint).map(|entry| entry.access_gen))
+            .collect()
+    }
+
+    #[cfg(test)]
+    fn test_eviction_victim(&mut self, protected: &HashSet<String>) -> Option<String> {
+        self.pop_eviction_victim(protected, true)
+            .or_else(|| self.pop_eviction_victim(protected, false))
+    }
 }
 
 /// Coalesces selection jobs for bounded worker scheduling (unit-tested).
@@ -758,12 +772,69 @@ impl ArbTrackSelectionCoalescer {
 }
 
 fn pool_activity_unix_ms(pool: &PoolState, vault: Option<&VaultBalanceCache>) -> u64 {
-    let pool_ms =
-        wall_clock_unix_ms_now().saturating_sub(pool.last_update.elapsed().as_millis() as u64);
+    let pool_ms = pool_last_update_activity_unix_ms(pool);
     vault
         .map(|v| wall_clock_unix_ms_now().saturating_sub(v.updated_at.elapsed().as_millis() as u64))
         .unwrap_or(pool_ms)
         .max(pool_ms)
+}
+
+/// Tracker-only coarse recency for top-K admission ranking (no vault lock).
+fn pool_last_update_activity_unix_ms(pool: &PoolState) -> u64 {
+    wall_clock_unix_ms_now().saturating_sub(pool.last_update.elapsed().as_millis() as u64)
+}
+
+fn tracker_coarse_activity_unix_ms(tracker: &TokenArbTracker) -> u64 {
+    tracker
+        .pools
+        .values()
+        .map(pool_last_update_activity_unix_ms)
+        .max()
+        .unwrap_or_else(wall_clock_unix_ms_now)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MintCoarseRankSnapshot {
+    mint: String,
+    activity_unix_ms: u64,
+}
+
+/// Clone minimal per-mint rank data while `trackers` read guard is held.
+fn build_multi_dex_coarse_rank_snapshot(
+    trackers: &HashMap<String, TokenArbTracker>,
+    mints: &[String],
+) -> Vec<MintCoarseRankSnapshot> {
+    mints
+        .iter()
+        .filter_map(|mint| {
+            let tracker = trackers.get(mint)?;
+            if tracker.pool_count_on_distinct_dexes() < 2 {
+                return None;
+            }
+            Some(MintCoarseRankSnapshot {
+                mint: mint.clone(),
+                activity_unix_ms: tracker_coarse_activity_unix_ms(tracker),
+            })
+        })
+        .collect()
+}
+
+fn rank_coarse_rank_snapshot(snapshot: &mut [MintCoarseRankSnapshot]) -> Vec<String> {
+    snapshot.sort_by(|a, b| {
+        b.activity_unix_ms
+            .cmp(&a.activity_unix_ms)
+            .then_with(|| a.mint.cmp(&b.mint))
+    });
+    snapshot.iter().map(|row| row.mint.clone()).collect()
+}
+
+/// Deterministic full-admit refresh order: ranked traversal, HashSet membership only.
+fn admit_refresh_order(ranked: &[String], admit: &HashSet<String>) -> Vec<String> {
+    ranked
+        .iter()
+        .filter(|mint| admit.contains(*mint))
+        .cloned()
+        .collect()
 }
 
 fn tracker_mint_activity_unix_ms(
@@ -5844,21 +5915,14 @@ impl ArbContext {
     }
 
     fn rank_multi_dex_mints_by_activity(&self, mints: &[String]) -> Vec<String> {
-        let trackers = self.trackers.read();
-        let vault_balances = self.vault_balances.read();
-        let mut ranked: Vec<(u64, String)> = mints
-            .iter()
-            .filter_map(|mint| {
-                let tracker = trackers.get(mint)?;
-                if tracker.pool_count_on_distinct_dexes() < 2 {
-                    return None;
-                }
-                let activity = tracker_mint_activity_unix_ms(tracker, &vault_balances);
-                Some((activity, mint.clone()))
-            })
-            .collect();
-        ranked.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
-        ranked.into_iter().map(|(_, mint)| mint).collect()
+        // Lock contract: `trackers` read guard only for cloning coarse rank rows.
+        // Vault balances are not read here; per-mint snapshot build uses separate
+        // short vault scopes in `build_track_mint_input`.
+        let mut snapshot = {
+            let trackers = self.trackers.read();
+            build_multi_dex_coarse_rank_snapshot(&trackers, mints)
+        };
+        rank_coarse_rank_snapshot(&mut snapshot)
     }
 
     fn commit_mint_snapshot(
@@ -6522,7 +6586,8 @@ fn run_arb_track_selection_batch(
         let all_mints = ctx.collect_multi_dex_mint_ids();
         let ranked = ctx.rank_multi_dex_mints_by_activity(&all_mints);
         let admit = compute_snapshot_admit_set(&ranked, &protected, ARB_TRACK_MINT_SNAPSHOTS_CAP);
-        for mint in &admit {
+        let refresh_order = admit_refresh_order(&ranked, &admit);
+        for mint in &refresh_order {
             ctx.refresh_mint_snapshot(mint, &protected);
         }
         ctx.arb_track_mint_snapshots
@@ -10866,6 +10931,50 @@ mod two_hop_price_tests {
         assert!(admit_a.contains("mint_01"));
         assert!(admit_a.contains("mint_02"));
         assert!(admit_a.contains("mint_03"));
+    }
+
+    #[test]
+    fn admit_refresh_order_preserves_rank_not_hashset_iteration() {
+        let ranked: Vec<String> = (0..8).map(|i| format!("mint_{i}")).collect();
+        let admit: HashSet<String> = ranked.iter().take(5).cloned().collect();
+        let ordered = admit_refresh_order(&ranked, &admit);
+        assert_eq!(ordered, ranked[..5]);
+    }
+
+    #[test]
+    fn full_admit_refresh_produces_identical_generations_and_eviction_victim() {
+        let ranked: Vec<String> = (0..8).map(|i| format!("mint_{i}")).collect();
+        let admit = compute_snapshot_admit_set(&ranked, &HashSet::new(), 5);
+        let refresh = admit_refresh_order(&ranked, &admit);
+
+        let run = || -> (Vec<u64>, Option<String>) {
+            let mut cache = ArbTrackMintSnapshotCache::default();
+            let protected = HashSet::new();
+            for mint in &refresh {
+                let input = TrackMintInput {
+                    mint: mint.clone(),
+                    pools: Vec::new(),
+                    trade_signal_pools: None,
+                    last_activity_unix_ms: 0,
+                };
+                assert!(cache.insert_bounded(mint.clone(), input, &protected));
+            }
+            let gens = cache.test_access_generations_in_order(&refresh);
+            let victim = cache.test_eviction_victim(&protected);
+            (gens, victim)
+        };
+
+        let (gens_a, victim_a) = run();
+        let (gens_b, victim_b) = run();
+        assert_eq!(
+            gens_a, gens_b,
+            "rank-ordered refresh must assign identical generations"
+        );
+        assert_eq!(
+            victim_a, victim_b,
+            "rank-ordered refresh must pick identical eviction victim"
+        );
+        assert_eq!(victim_a.as_deref(), Some("mint_0"));
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -820,7 +820,6 @@ impl ArbTrackMintSnapshotCache {
 #[derive(Debug, Default)]
 struct ArbTrackSelectionCoalescer {
     dirty_mints: HashSet<String>,
-    pending_full: bool,
     dirty_overflow: bool,
 }
 
@@ -842,21 +841,15 @@ impl ArbTrackSelectionCoalescer {
         false
     }
 
-    fn note_full_reconcile(&mut self) {
-        self.pending_full = true;
-    }
-
     fn note_dirty_overflow(&mut self) {
         self.dirty_overflow = true;
     }
 
-    fn take_batch(&mut self) -> (Vec<String>, bool, bool) {
-        let full = self.pending_full;
+    fn take_batch(&mut self) -> (Vec<String>, bool) {
         let overflow = self.dirty_overflow;
-        self.pending_full = false;
         self.dirty_overflow = false;
         let dirty = self.dirty_mints.drain().collect();
-        (dirty, full, overflow)
+        (dirty, overflow)
     }
 }
 
@@ -6691,15 +6684,50 @@ fn maybe_arb_tracker_write_stall_watchdog_warn(queue_cap: usize) {
     arb_tracker_write_stall_watchdog_inc();
 }
 
+/// Authoritative batch-mode decision for the selection worker (unit-tested).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArbTrackBatchPlan {
+    Idle,
+    /// Full reconcile requested but rate-limited; no dirty mints to process incrementally.
+    DeferFullReconcile,
+    /// Process dirty mints only; `keep_pending_full` preserves deferred full reconcile.
+    Incremental {
+        keep_pending_full: bool,
+    },
+    FullReconcile,
+}
+
+fn resolve_arb_track_batch_plan(
+    wants_full_reconcile: bool,
+    has_dirty_mints: bool,
+    elapsed_since_full: Duration,
+    full_reconcile_min: Duration,
+) -> ArbTrackBatchPlan {
+    let full_allowed = wants_full_reconcile && elapsed_since_full >= full_reconcile_min;
+    if full_allowed {
+        return ArbTrackBatchPlan::FullReconcile;
+    }
+    if wants_full_reconcile && has_dirty_mints {
+        return ArbTrackBatchPlan::Incremental {
+            keep_pending_full: true,
+        };
+    }
+    if wants_full_reconcile {
+        return ArbTrackBatchPlan::DeferFullReconcile;
+    }
+    if has_dirty_mints {
+        return ArbTrackBatchPlan::Incremental {
+            keep_pending_full: false,
+        };
+    }
+    ArbTrackBatchPlan::Idle
+}
+
 fn run_arb_track_selection_batch(
     ctx: &Arc<ArbContext>,
     mut dirty_mints: Vec<String>,
-    mut full_reconcile: bool,
+    full_reconcile: bool,
 ) {
-    if ctx.arb_track_selection.take_pending_full() {
-        full_reconcile = true;
-    }
-
     let protected = ctx.mandatory_protected_snapshot_mints();
 
     if full_reconcile {
@@ -6742,9 +6770,6 @@ fn spawn_arb_track_selection_worker(ctx: Arc<ArbContext>, mut wake_rx: mpsc::Rec
             ctx.arb_track_selection.clear_wake_pending();
             ctx.arb_track_selection
                 .drain_ingress_to_coalescer(&mut coalescer);
-            if ctx.arb_track_selection.take_pending_full() {
-                coalescer.note_full_reconcile();
-            }
 
             let coalesce_deadline =
                 Instant::now() + Duration::from_millis(ARB_TRACK_SELECTION_COALESCE_MS);
@@ -6760,64 +6785,77 @@ fn spawn_arb_track_selection_worker(ctx: Arc<ArbContext>, mut wake_rx: mpsc::Rec
                 }
                 ctx.arb_track_selection
                     .drain_ingress_to_coalescer(&mut coalescer);
-                if ctx.arb_track_selection.take_pending_full() {
-                    coalescer.note_full_reconcile();
-                }
             }
 
-            let (dirty_mints, mut full_reconcile, dirty_overflow) = coalescer.take_batch();
+            let (dirty_mints, dirty_overflow) = coalescer.take_batch();
             if dirty_overflow {
                 ctx.arb_track_selection
                     .pending_full_reconcile
                     .store(true, Ordering::Release);
-                full_reconcile = true;
             }
-            if ctx.arb_track_selection.take_pending_full() {
-                full_reconcile = true;
-            }
+            let wants_full_reconcile = ctx
+                .arb_track_selection
+                .pending_full_reconcile
+                .load(Ordering::Acquire);
+            let plan = resolve_arb_track_batch_plan(
+                wants_full_reconcile,
+                !dirty_mints.is_empty(),
+                last_full_reconcile.elapsed(),
+                full_reconcile_min,
+            );
 
-            if full_reconcile && last_full_reconcile.elapsed() < full_reconcile_min {
-                ctx.arb_track_selection
-                    .pending_full_reconcile
-                    .store(true, Ordering::Release);
-                full_reconcile = false;
-            }
-
-            if dirty_mints.is_empty() && !full_reconcile {
-                if ctx
-                    .arb_track_selection
-                    .pending_full_reconcile
-                    .load(Ordering::Acquire)
-                {
+            match plan {
+                ArbTrackBatchPlan::Idle => {}
+                ArbTrackBatchPlan::DeferFullReconcile => {
+                    ctx.arb_track_selection
+                        .pending_full_reconcile
+                        .store(true, Ordering::Release);
                     let sleep = full_reconcile_min.saturating_sub(last_full_reconcile.elapsed());
                     if sleep > Duration::ZERO {
                         tokio::time::sleep(sleep).await;
                     }
                     ctx.arb_track_selection.schedule_worker_wake();
+                    continue;
                 }
-                continue;
-            }
-
-            if !full_reconcile {
-                let min_interval = Duration::from_millis(ARB_TRACK_INCREMENTAL_MIN_INTERVAL_MS);
-                let elapsed = last_incremental.elapsed();
-                if elapsed < min_interval {
-                    tokio::time::sleep(min_interval - elapsed).await;
+                ArbTrackBatchPlan::Incremental { keep_pending_full } => {
+                    if keep_pending_full {
+                        ctx.arb_track_selection
+                            .pending_full_reconcile
+                            .store(true, Ordering::Release);
+                    }
+                    let min_interval = Duration::from_millis(ARB_TRACK_INCREMENTAL_MIN_INTERVAL_MS);
+                    let elapsed = last_incremental.elapsed();
+                    if elapsed < min_interval {
+                        tokio::time::sleep(min_interval - elapsed).await;
+                    }
+                    let ctx_blocking = Arc::clone(&ctx);
+                    let dirty = dirty_mints;
+                    let blocking = tokio::task::spawn_blocking(move || {
+                        run_arb_track_selection_batch(&ctx_blocking, dirty, false);
+                    });
+                    if blocking.await.is_err() {
+                        warn!("arb track selection blocking batch join failed");
+                        ctx.arb_track_selection.record_blocking_join_failed();
+                    }
+                    last_incremental = Instant::now();
+                    if keep_pending_full {
+                        ctx.arb_track_selection.schedule_worker_wake();
+                    }
                 }
-            } else {
-                last_full_reconcile = Instant::now();
+                ArbTrackBatchPlan::FullReconcile => {
+                    let _ = ctx.arb_track_selection.take_pending_full();
+                    last_full_reconcile = Instant::now();
+                    let ctx_blocking = Arc::clone(&ctx);
+                    let blocking = tokio::task::spawn_blocking(move || {
+                        run_arb_track_selection_batch(&ctx_blocking, Vec::new(), true);
+                    });
+                    if blocking.await.is_err() {
+                        warn!("arb track selection blocking batch join failed");
+                        ctx.arb_track_selection.record_blocking_join_failed();
+                    }
+                    last_incremental = Instant::now();
+                }
             }
-
-            let ctx_blocking = Arc::clone(&ctx);
-            let dirty = dirty_mints;
-            let blocking = tokio::task::spawn_blocking(move || {
-                run_arb_track_selection_batch(&ctx_blocking, dirty, full_reconcile);
-            });
-            if blocking.await.is_err() {
-                warn!("arb track selection blocking batch join failed");
-                ctx.arb_track_selection.record_blocking_join_failed();
-            }
-            last_incremental = Instant::now();
 
             if ctx.arb_track_selection.ingress_has_work() {
                 ctx.arb_track_selection.schedule_worker_wake();
@@ -10965,13 +11003,11 @@ mod two_hop_price_tests {
         for i in 0..100 {
             coalescer.ingest_dirty(format!("mint_{i}"));
         }
-        let (dirty, full, overflow) = coalescer.take_batch();
-        assert!(!full);
+        let (dirty, overflow) = coalescer.take_batch();
         assert!(!overflow);
         assert_eq!(dirty.len(), 100);
-        let (dirty2, full2, overflow2) = coalescer.take_batch();
+        let (dirty2, overflow2) = coalescer.take_batch();
         assert!(dirty2.is_empty());
-        assert!(!full2);
         assert!(!overflow2);
     }
 
@@ -10982,8 +11018,7 @@ mod two_hop_price_tests {
             assert!(!coalescer.ingest_dirty(format!("mint_{i}")));
         }
         assert!(coalescer.ingest_dirty("overflow_mint".to_string()));
-        let (dirty, full, overflow) = coalescer.take_batch();
-        assert!(!full);
+        let (dirty, overflow) = coalescer.take_batch();
         assert!(
             overflow,
             "overflow must schedule authoritative full reconcile"
@@ -11006,7 +11041,7 @@ mod two_hop_price_tests {
             }
         }
         assert!(overflow_seen);
-        let (dirty, _, overflow) = coalescer.take_batch();
+        let (dirty, overflow) = coalescer.take_batch();
         assert!(overflow);
         assert_eq!(dirty.len(), cap);
     }
@@ -11019,9 +11054,62 @@ mod two_hop_price_tests {
             assert!(!coalescer.ingest_dirty(format!("mint_{i}")));
         }
         assert!(!coalescer.ingest_dirty("mint_0".to_string()));
-        let (dirty, _, overflow) = coalescer.take_batch();
+        let (dirty, overflow) = coalescer.take_batch();
         assert!(!overflow);
         assert_eq!(dirty.len(), cap);
+    }
+
+    #[test]
+    fn resolve_arb_track_batch_plan_defers_full_with_dirty_as_incremental() {
+        let min = Duration::from_secs(5);
+        let plan = resolve_arb_track_batch_plan(true, true, Duration::from_millis(100), min);
+        assert_eq!(
+            plan,
+            ArbTrackBatchPlan::Incremental {
+                keep_pending_full: true
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_arb_track_batch_plan_keeps_full_pending_until_interval_elapsed() {
+        let min = Duration::from_secs(5);
+        let deferred = resolve_arb_track_batch_plan(true, true, Duration::from_secs(1), min);
+        assert_eq!(
+            deferred,
+            ArbTrackBatchPlan::Incremental {
+                keep_pending_full: true
+            }
+        );
+        let eligible = resolve_arb_track_batch_plan(true, true, Duration::from_secs(5), min);
+        assert_eq!(eligible, ArbTrackBatchPlan::FullReconcile);
+    }
+
+    #[test]
+    fn resolve_arb_track_batch_plan_defers_full_without_dirty() {
+        let plan = resolve_arb_track_batch_plan(
+            true,
+            false,
+            Duration::from_millis(0),
+            Duration::from_secs(5),
+        );
+        assert_eq!(plan, ArbTrackBatchPlan::DeferFullReconcile);
+    }
+
+    #[test]
+    fn resolve_arb_track_batch_plan_incremental_without_pending_full_when_not_deferred() {
+        let plan = resolve_arb_track_batch_plan(
+            false,
+            true,
+            Duration::from_secs(0),
+            Duration::from_secs(5),
+        );
+        assert_eq!(
+            plan,
+            ArbTrackBatchPlan::Incremental {
+                keep_pending_full: false
+            }
+        );
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -18,10 +18,10 @@ use clap::Parser;
 use parking_lot::RwLock;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
@@ -78,12 +78,12 @@ use ironcrab::metrics::{
     record_arb_quote_shadow_round_trip, record_arb_track_publish_skipped_unchanged_total,
     record_arb_track_removed_total, record_arb_track_requests_messages_total,
     record_arb_track_requests_publish_chunks_total, record_arb_track_requests_publish_failed_total,
-    record_arb_track_selection_recompute_total, record_arb_writer_lock_wait, serve_metrics,
-    set_arb_pool_cache_apply_batch_size_gauge, set_arb_quote_shadow_legacy_spread_bps,
-    set_arb_track_selection_metrics, set_arb_tracker_write_coalescer_pending,
-    set_arb_tracker_write_queue_depth, set_arb_two_hop_blocked_on_apply_trade,
-    set_readiness_nats_connected, tick_arb_heartbeat_seconds_since_last_finish,
-    tick_arb_tracker_write_seconds_since_last_finish,
+    record_arb_track_selection_queue_overflow_total, record_arb_track_selection_recompute_total,
+    record_arb_writer_lock_wait, serve_metrics, set_arb_pool_cache_apply_batch_size_gauge,
+    set_arb_quote_shadow_legacy_spread_bps, set_arb_track_selection_metrics,
+    set_arb_tracker_write_coalescer_pending, set_arb_tracker_write_queue_depth,
+    set_arb_two_hop_blocked_on_apply_trade, set_readiness_nats_connected,
+    tick_arb_heartbeat_seconds_since_last_finish, tick_arb_tracker_write_seconds_since_last_finish,
     try_record_arb_track_pin_before_first_screen_ms, wall_clock_unix_ms_now, ArbHeartbeatPhase,
     ArbStrategyWarmupSkipReason, ArbTrackerWriteJobType, ArbTwoHopInsufficientSubreason,
     ArbTwoHopPoolGate, ArbTwoHopRejectReason, ArbTwoHopRejectSubreason,
@@ -131,8 +131,12 @@ const ARB_TRACK_SELECTION_COALESCE_MS: u64 = 50;
 const ARB_TRACK_INCREMENTAL_MIN_INTERVAL_MS: u64 = 1_000;
 /// Max dirty mints queued between incremental selects.
 const ARB_TRACK_SELECTION_DIRTY_MINTS_CAP: usize = 4_096;
-/// Yield between mint snapshot refreshes during full reconcile.
-const ARB_TRACK_FULL_RECONCILE_BATCH_YIELD: usize = 32;
+/// Max mint snapshots retained for selection (bounded publish/readiness state).
+const ARB_TRACK_MINT_SNAPSHOTS_CAP: usize = 2_048;
+/// Max dirty mints processed per incremental batch; overflow schedules full reconcile.
+const ARB_TRACK_INCREMENTAL_MINTS_MAX: usize = 64;
+/// Selection worker job queue depth.
+const ARB_TRACK_SELECTION_QUEUE_CAP: usize = 4_096;
 
 /// Bounded queue for off-hot-loop 2-hop trade detection (Scope D).
 const ARB_TWO_HOP_WORKER_QUEUE_CAP: usize = 4096;
@@ -500,24 +504,114 @@ enum ArbTrackSelectionJob {
 
 struct ArbTrackSelectionHandle {
     tx: mpsc::Sender<ArbTrackSelectionJob>,
+    pending_full_reconcile: Arc<AtomicBool>,
 }
 
 impl ArbTrackSelectionHandle {
     fn mark_dirty(&self, mint: &str) {
-        let _ = self.tx.try_send(ArbTrackSelectionJob::MarkDirty {
-            mint: mint.to_string(),
-        });
+        if self
+            .tx
+            .try_send(ArbTrackSelectionJob::MarkDirty {
+                mint: mint.to_string(),
+            })
+            .is_err()
+        {
+            record_arb_track_selection_queue_overflow_total();
+            self.pending_full_reconcile.store(true, Ordering::Release);
+        }
     }
 
     fn request_full_reconcile(&self) {
-        let _ = self.tx.try_send(ArbTrackSelectionJob::FullReconcile);
+        self.pending_full_reconcile.store(true, Ordering::Release);
+        if self
+            .tx
+            .try_send(ArbTrackSelectionJob::FullReconcile)
+            .is_err()
+        {
+            record_arb_track_selection_queue_overflow_total();
+        }
+    }
+
+    fn take_pending_full(&self) -> bool {
+        self.pending_full_reconcile.swap(false, Ordering::AcqRel)
     }
 }
 
 #[cfg(test)]
 fn dummy_arb_track_selection_handle() -> ArbTrackSelectionHandle {
     let (tx, _rx) = mpsc::channel::<ArbTrackSelectionJob>(1);
-    ArbTrackSelectionHandle { tx }
+    ArbTrackSelectionHandle {
+        tx,
+        pending_full_reconcile: Arc::new(AtomicBool::new(false)),
+    }
+}
+
+/// Bounded LRU cache of per-mint selection snapshots.
+#[derive(Debug, Default)]
+struct ArbTrackMintSnapshotCache {
+    entries: HashMap<String, TrackMintInput>,
+    lru_order: VecDeque<String>,
+}
+
+impl ArbTrackMintSnapshotCache {
+    #[allow(dead_code)] // used by unit tests (clippy does not count cfg(test) callers)
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn values(&self) -> impl Iterator<Item = &TrackMintInput> {
+        self.entries.values()
+    }
+
+    fn remove(&mut self, mint: &str) {
+        self.entries.remove(mint);
+        self.lru_order.retain(|m| m != mint);
+    }
+
+    fn retain(&mut self, mut keep: impl FnMut(&String) -> bool) {
+        self.entries.retain(|mint, _| keep(mint));
+        self.lru_order.retain(|mint| keep(mint));
+    }
+
+    fn touch_lru(&mut self, mint: &str) {
+        self.lru_order.retain(|m| m != mint);
+        self.lru_order.push_back(mint.to_string());
+    }
+
+    fn evict_one_unprotected(&mut self, protected: &HashSet<String>) -> bool {
+        let mut idx = 0;
+        while idx < self.lru_order.len() {
+            if let Some(mint) = self.lru_order.get(idx).cloned() {
+                if !protected.contains(&mint) {
+                    self.lru_order.remove(idx);
+                    self.entries.remove(&mint);
+                    return true;
+                }
+                idx += 1;
+            } else {
+                break;
+            }
+        }
+        false
+    }
+
+    fn insert_bounded(
+        &mut self,
+        mint: String,
+        input: TrackMintInput,
+        protected: &HashSet<String>,
+    ) -> bool {
+        if !self.entries.contains_key(&mint)
+            && self.entries.len() >= ARB_TRACK_MINT_SNAPSHOTS_CAP
+            && !protected.contains(&mint)
+            && !self.evict_one_unprotected(protected)
+        {
+            return false;
+        }
+        self.entries.insert(mint.clone(), input);
+        self.touch_lru(&mint);
+        true
+    }
 }
 
 /// Coalesces selection jobs for bounded worker scheduling (unit-tested).
@@ -525,28 +619,35 @@ fn dummy_arb_track_selection_handle() -> ArbTrackSelectionHandle {
 struct ArbTrackSelectionCoalescer {
     dirty_mints: HashSet<String>,
     pending_full: bool,
+    dirty_overflow: bool,
 }
 
 impl ArbTrackSelectionCoalescer {
-    fn ingest(&mut self, job: ArbTrackSelectionJob) {
+    /// Returns `true` when dirty overflow requires a full reconcile recovery.
+    fn ingest(&mut self, job: ArbTrackSelectionJob) -> bool {
         match job {
             ArbTrackSelectionJob::MarkDirty { mint } => {
                 if self.dirty_mints.len() >= ARB_TRACK_SELECTION_DIRTY_MINTS_CAP {
-                    if let Some(old) = self.dirty_mints.iter().next().cloned() {
-                        self.dirty_mints.remove(&old);
-                    }
+                    self.dirty_overflow = true;
+                    return true;
                 }
                 self.dirty_mints.insert(mint);
+                false
             }
-            ArbTrackSelectionJob::FullReconcile => self.pending_full = true,
+            ArbTrackSelectionJob::FullReconcile => {
+                self.pending_full = true;
+                false
+            }
         }
     }
 
-    fn take_batch(&mut self) -> (Vec<String>, bool) {
+    fn take_batch(&mut self) -> (Vec<String>, bool, bool) {
         let full = self.pending_full;
+        let overflow = self.dirty_overflow;
         self.pending_full = false;
+        self.dirty_overflow = false;
         let dirty = self.dirty_mints.drain().collect();
-        (dirty, full)
+        (dirty, full, overflow)
     }
 }
 
@@ -4104,8 +4205,8 @@ struct ArbContext {
     arb_trade_signal_pairs: RwLock<HashMap<String, ArbTradeSignalPair>>,
     /// LRU order for trade-signal pair eviction (oldest at front).
     arb_trade_signal_pair_order: RwLock<Vec<String>>,
-    /// Cached per-mint selection snapshots (updated incrementally by selection worker).
-    arb_track_mint_snapshots: RwLock<HashMap<String, TrackMintInput>>,
+    /// Cached per-mint selection snapshots (bounded LRU, selection worker only).
+    arb_track_mint_snapshots: RwLock<ArbTrackMintSnapshotCache>,
     arb_track_selection: ArbTrackSelectionHandle,
     /// Phase 3: count of track_requests publishes (heartbeat).
     arb_track_published: AtomicU64,
@@ -5544,29 +5645,62 @@ impl ArbContext {
             return None;
         }
         let token_decimals = tracker.token_decimals?;
+        let pool_addresses: Vec<String> = tracker.pools.keys().cloned().collect();
 
-        let known_pools = self.known_pools.read();
-        let vault_balances = self.vault_balances.read();
-        let bin_arrays = self.bin_arrays.read();
-        let mint_activity = tracker_mint_activity_unix_ms(&tracker, &vault_balances);
-        let trade_signal_pools = self
-            .arb_trade_signal_pairs
-            .read()
-            .get(mint)
-            .map(|pair| (pair.buy_pool.clone(), pair.sell_pool.clone()));
+        let known_for_pools: HashSet<String> = {
+            let known_pools = self.known_pools.read();
+            pool_addresses
+                .iter()
+                .filter(|pool| known_pools.contains(*pool))
+                .cloned()
+                .collect()
+        };
+
+        let vaults_for_pools: HashMap<String, VaultBalanceCache> = {
+            let vault_balances = self.vault_balances.read();
+            pool_addresses
+                .iter()
+                .filter_map(|pool| {
+                    vault_balances
+                        .get(pool)
+                        .map(|vault| (pool.clone(), vault.clone()))
+                })
+                .collect()
+        };
+
+        let bins_for_pools: HashMap<String, HashMap<i64, BinArrayCache>> = {
+            let bin_arrays = self.bin_arrays.read();
+            pool_addresses
+                .iter()
+                .filter_map(|pool| {
+                    bin_arrays
+                        .get(pool)
+                        .map(|bins| (pool.clone(), bins.clone()))
+                })
+                .collect()
+        };
+
+        let trade_signal_pools = {
+            self.arb_trade_signal_pairs
+                .read()
+                .get(mint)
+                .map(|pair| (pair.buy_pool.clone(), pair.sell_pool.clone()))
+        };
+
+        let mint_activity = tracker_mint_activity_unix_ms(&tracker, &vaults_for_pools);
 
         let pools: Vec<TrackPoolInput> = tracker
             .pools
             .values()
             .map(|pool| {
-                let vault = vault_balances.get(&pool.pool_address);
+                let vault = vaults_for_pools.get(&pool.pool_address);
                 TrackPoolInput {
                     pool_address: pool.pool_address.clone(),
                     dex: pool.dex.clone(),
-                    known: known_pools.contains(&pool.pool_address),
+                    known: known_for_pools.contains(&pool.pool_address),
                     quote_pool: pool_state_to_quote_input(pool, mint, token_decimals),
                     vault: vault.map(vault_cache_to_quote_input),
-                    dlmm_bins: bin_arrays
+                    dlmm_bins: bins_for_pools
                         .get(&pool.pool_address)
                         .map(flatten_bin_array_cache),
                     token_decimals,
@@ -5583,23 +5717,46 @@ impl ArbContext {
         })
     }
 
-    fn refresh_mint_snapshot(&self, mint: &str) {
+    fn protected_snapshot_mints(&self, refreshing: &HashSet<String>) -> HashSet<String> {
+        let mut protected = refreshing.clone();
+        for mint in self.arb_trade_signal_pairs.read().keys() {
+            protected.insert(mint.clone());
+        }
+        let pinned = self.arb_pinned_pools.read();
+        let snapshots = self.arb_track_mint_snapshots.read();
+        for (mint, input) in &snapshots.entries {
+            if input
+                .pools
+                .iter()
+                .any(|pool| pinned.contains(&pool.pool_address))
+            {
+                protected.insert(mint.clone());
+            }
+        }
+        protected
+    }
+
+    fn commit_mint_snapshot(
+        &self,
+        mint: &str,
+        input: Option<TrackMintInput>,
+        protected: &HashSet<String>,
+    ) {
         let mut snapshots = self.arb_track_mint_snapshots.write();
-        match self.build_track_mint_input(mint) {
+        match input {
             Some(input) => {
-                snapshots.insert(mint.to_string(), input);
+                let _ = snapshots.insert_bounded(mint.to_string(), input, protected);
             }
-            None => {
-                snapshots.remove(mint);
-            }
+            None => snapshots.remove(mint),
         }
     }
 
-    fn run_arb_track_selection_from_snapshots(self: &Arc<Self>, reconcile: bool) {
-        if self.nats.is_none() {
-            return;
-        }
+    fn refresh_mint_snapshot(&self, mint: &str, protected: &HashSet<String>) {
+        let input = self.build_track_mint_input(mint);
+        self.commit_mint_snapshot(mint, input, protected);
+    }
 
+    fn run_arb_track_selection_from_snapshots(self: &Arc<Self>, reconcile: bool) {
         let mint_inputs: Vec<TrackMintInput> = self
             .arb_track_mint_snapshots
             .read()
@@ -5633,6 +5790,13 @@ impl ArbContext {
             record_arb_track_publish_skipped_unchanged_total();
             return;
         }
+
+        let newly_active_mints: HashSet<String> = result
+            .selected
+            .iter()
+            .filter(|p| !old_pools.contains(&p.pool))
+            .map(|p| p.mint.clone())
+            .collect();
 
         let active = if reconcile {
             result
@@ -5681,22 +5845,21 @@ impl ArbContext {
             *pinned = new_pools;
         }
 
+        let will_publish = reconcile || !active.is_empty() || !removed.is_empty();
+        if !will_publish {
+            record_arb_track_publish_skipped_unchanged_total();
+            return;
+        }
+
+        for mint in &newly_active_mints {
+            record_arb_proactive_pin_first_publish(mint);
+        }
+
         if reconcile {
             self.spawn_publish_arb_track_requests(active, Vec::new(), true);
-        } else if active.is_empty() && removed.is_empty() {
-            record_arb_track_publish_skipped_unchanged_total();
         } else {
             if !active.is_empty() {
                 record_arb_proactive_track_publish_total();
-            }
-            let newly_active_mints: HashSet<String> = result
-                .selected
-                .iter()
-                .filter(|p| !old_pools.contains(&p.pool))
-                .map(|p| p.mint.clone())
-                .collect();
-            for mint in newly_active_mints {
-                record_arb_proactive_pin_first_publish(&mint);
             }
             self.spawn_publish_arb_track_requests(active, removed, false);
         }
@@ -6219,6 +6382,49 @@ fn maybe_arb_tracker_write_stall_watchdog_warn(queue_cap: usize) {
     arb_tracker_write_stall_watchdog_inc();
 }
 
+fn run_arb_track_selection_batch(
+    ctx: &Arc<ArbContext>,
+    mut dirty_mints: Vec<String>,
+    mut full_reconcile: bool,
+) {
+    if ctx.arb_track_selection.take_pending_full() {
+        full_reconcile = true;
+    }
+
+    let refresh_mints: HashSet<String> = if full_reconcile {
+        ctx.collect_multi_dex_mint_ids().into_iter().collect()
+    } else {
+        dirty_mints.sort();
+        dirty_mints.dedup();
+        if dirty_mints.len() > ARB_TRACK_INCREMENTAL_MINTS_MAX {
+            ctx.arb_track_selection
+                .pending_full_reconcile
+                .store(true, Ordering::Release);
+            dirty_mints.truncate(ARB_TRACK_INCREMENTAL_MINTS_MAX);
+        }
+        dirty_mints.into_iter().collect()
+    };
+
+    let protected = ctx.protected_snapshot_mints(&refresh_mints);
+
+    if full_reconcile {
+        for mint in &refresh_mints {
+            ctx.refresh_mint_snapshot(mint, &protected);
+        }
+        let retain: HashSet<String> = refresh_mints.clone();
+        ctx.arb_track_mint_snapshots
+            .write()
+            .retain(|mint| retain.contains(mint));
+    } else {
+        for mint in &refresh_mints {
+            ctx.refresh_mint_snapshot(mint, &protected);
+        }
+    }
+
+    ctx.run_arb_track_selection_from_snapshots(full_reconcile);
+    record_arb_track_selection_recompute_total();
+}
+
 fn spawn_arb_track_selection_worker(
     ctx: Arc<ArbContext>,
     mut rx: mpsc::Receiver<ArbTrackSelectionJob>,
@@ -6228,12 +6434,22 @@ fn spawn_arb_track_selection_worker(
         let mut last_incremental = Instant::now() - Duration::from_secs(3600);
 
         while let Some(first) = rx.recv().await {
-            coalescer.ingest(first);
+            if coalescer.ingest(first) {
+                ctx.arb_track_selection
+                    .pending_full_reconcile
+                    .store(true, Ordering::Release);
+            }
             let coalesce_deadline =
                 Instant::now() + Duration::from_millis(ARB_TRACK_SELECTION_COALESCE_MS);
             while Instant::now() < coalesce_deadline {
                 match rx.try_recv() {
-                    Ok(job) => coalescer.ingest(job),
+                    Ok(job) => {
+                        if coalescer.ingest(job) {
+                            ctx.arb_track_selection
+                                .pending_full_reconcile
+                                .store(true, Ordering::Release);
+                        }
+                    }
                     Err(mpsc::error::TryRecvError::Empty) => {
                         tokio::time::sleep(Duration::from_millis(5)).await;
                     }
@@ -6241,7 +6457,16 @@ fn spawn_arb_track_selection_worker(
                 }
             }
 
-            let (dirty_mints, full_reconcile) = coalescer.take_batch();
+            let (dirty_mints, mut full_reconcile, dirty_overflow) = coalescer.take_batch();
+            if dirty_overflow {
+                ctx.arb_track_selection
+                    .pending_full_reconcile
+                    .store(true, Ordering::Release);
+                full_reconcile = true;
+            }
+            if ctx.arb_track_selection.take_pending_full() {
+                full_reconcile = true;
+            }
             if dirty_mints.is_empty() && !full_reconcile {
                 continue;
             }
@@ -6254,30 +6479,14 @@ fn spawn_arb_track_selection_worker(
                 }
             }
 
-            let refresh_mints: Vec<String> = if full_reconcile {
-                ctx.collect_multi_dex_mint_ids()
-            } else {
-                let mut mints = dirty_mints;
-                mints.sort();
-                mints.dedup();
-                mints
-            };
-
-            for (idx, mint) in refresh_mints.iter().enumerate() {
-                ctx.refresh_mint_snapshot(mint);
-                if full_reconcile && (idx + 1) % ARB_TRACK_FULL_RECONCILE_BATCH_YIELD == 0 {
-                    tokio::task::yield_now().await;
-                }
+            let ctx_blocking = Arc::clone(&ctx);
+            let dirty = dirty_mints;
+            let blocking = tokio::task::spawn_blocking(move || {
+                run_arb_track_selection_batch(&ctx_blocking, dirty, full_reconcile);
+            });
+            if blocking.await.is_err() {
+                warn!("arb track selection blocking batch join failed");
             }
-
-            if full_reconcile {
-                let snapshot_mints: HashSet<String> = refresh_mints.into_iter().collect();
-                let mut snapshots = ctx.arb_track_mint_snapshots.write();
-                snapshots.retain(|mint, _| snapshot_mints.contains(mint));
-            }
-
-            ctx.run_arb_track_selection_from_snapshots(full_reconcile);
-            record_arb_track_selection_recompute_total();
             last_incremental = Instant::now();
         }
         info!("arb-strategy track selection worker stopped");
@@ -6518,9 +6727,10 @@ async fn main() -> Result<()> {
         capacity: ARB_TRACKER_WRITE_QUEUE_CAP,
     };
     let (arb_track_selection_tx, arb_track_selection_rx) =
-        mpsc::channel::<ArbTrackSelectionJob>(ARB_TRACKER_WRITE_QUEUE_CAP);
+        mpsc::channel::<ArbTrackSelectionJob>(ARB_TRACK_SELECTION_QUEUE_CAP);
     let arb_track_selection = ArbTrackSelectionHandle {
         tx: arb_track_selection_tx,
+        pending_full_reconcile: Arc::new(AtomicBool::new(false)),
     };
 
     let ctx = Arc::new(ArbContext {
@@ -6548,7 +6758,7 @@ async fn main() -> Result<()> {
         arb_pinned_pools: RwLock::new(HashSet::new()),
         arb_trade_signal_pairs: RwLock::new(HashMap::new()),
         arb_trade_signal_pair_order: RwLock::new(Vec::new()),
-        arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+        arb_track_mint_snapshots: RwLock::new(ArbTrackMintSnapshotCache::default()),
         arb_track_selection,
         arb_track_published: AtomicU64::new(0),
         two_hop_tx,
@@ -7614,7 +7824,7 @@ mod event_pipeline_tests {
             arb_pinned_pools: RwLock::new(HashSet::new()),
             arb_trade_signal_pairs: RwLock::new(HashMap::new()),
             arb_trade_signal_pair_order: RwLock::new(Vec::new()),
-            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_mint_snapshots: RwLock::new(ArbTrackMintSnapshotCache::default()),
             arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
@@ -7725,7 +7935,7 @@ mod event_pipeline_tests {
             arb_pinned_pools: RwLock::new(HashSet::new()),
             arb_trade_signal_pairs: RwLock::new(HashMap::new()),
             arb_trade_signal_pair_order: RwLock::new(Vec::new()),
-            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_mint_snapshots: RwLock::new(ArbTrackMintSnapshotCache::default()),
             arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
@@ -7834,7 +8044,7 @@ mod event_pipeline_tests {
             arb_pinned_pools: RwLock::new(HashSet::new()),
             arb_trade_signal_pairs: RwLock::new(HashMap::new()),
             arb_trade_signal_pair_order: RwLock::new(Vec::new()),
-            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_mint_snapshots: RwLock::new(ArbTrackMintSnapshotCache::default()),
             arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
@@ -8053,7 +8263,7 @@ mod event_pipeline_tests {
             arb_pinned_pools: RwLock::new(HashSet::new()),
             arb_trade_signal_pairs: RwLock::new(HashMap::new()),
             arb_trade_signal_pair_order: RwLock::new(Vec::new()),
-            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_mint_snapshots: RwLock::new(ArbTrackMintSnapshotCache::default()),
             arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
@@ -8160,7 +8370,7 @@ mod event_pipeline_tests {
             arb_pinned_pools: RwLock::new(HashSet::new()),
             arb_trade_signal_pairs: RwLock::new(HashMap::new()),
             arb_trade_signal_pair_order: RwLock::new(Vec::new()),
-            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_mint_snapshots: RwLock::new(ArbTrackMintSnapshotCache::default()),
             arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
@@ -8271,7 +8481,7 @@ mod event_pipeline_tests {
             arb_pinned_pools: RwLock::new(HashSet::new()),
             arb_trade_signal_pairs: RwLock::new(HashMap::new()),
             arb_trade_signal_pair_order: RwLock::new(Vec::new()),
-            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_mint_snapshots: RwLock::new(ArbTrackMintSnapshotCache::default()),
             arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
@@ -8353,7 +8563,7 @@ mod event_pipeline_tests {
             arb_pinned_pools: RwLock::new(HashSet::new()),
             arb_trade_signal_pairs: RwLock::new(HashMap::new()),
             arb_trade_signal_pair_order: RwLock::new(Vec::new()),
-            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_mint_snapshots: RwLock::new(ArbTrackMintSnapshotCache::default()),
             arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
@@ -8496,7 +8706,7 @@ mod two_hop_price_tests {
             arb_pinned_pools: RwLock::new(HashSet::new()),
             arb_trade_signal_pairs: RwLock::new(HashMap::new()),
             arb_trade_signal_pair_order: RwLock::new(Vec::new()),
-            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_mint_snapshots: RwLock::new(ArbTrackMintSnapshotCache::default()),
             arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx: {
@@ -10422,12 +10632,157 @@ mod two_hop_price_tests {
                 mint: format!("mint_{i}"),
             });
         }
-        let (dirty, full) = coalescer.take_batch();
+        let (dirty, full, overflow) = coalescer.take_batch();
         assert!(!full);
+        assert!(!overflow);
         assert_eq!(dirty.len(), 100);
-        let (dirty2, full2) = coalescer.take_batch();
+        let (dirty2, full2, overflow2) = coalescer.take_batch();
         assert!(dirty2.is_empty());
         assert!(!full2);
+        assert!(!overflow2);
+    }
+
+    #[test]
+    fn arb_track_selection_coalescer_dirty_overflow_requests_full_reconcile() {
+        let mut coalescer = ArbTrackSelectionCoalescer::default();
+        for i in 0..ARB_TRACK_SELECTION_DIRTY_MINTS_CAP {
+            assert!(!coalescer.ingest(ArbTrackSelectionJob::MarkDirty {
+                mint: format!("mint_{i}"),
+            }));
+        }
+        assert!(coalescer.ingest(ArbTrackSelectionJob::MarkDirty {
+            mint: "overflow_mint".to_string(),
+        }));
+        let (dirty, full, overflow) = coalescer.take_batch();
+        assert!(!full);
+        assert!(overflow);
+        assert_eq!(dirty.len(), ARB_TRACK_SELECTION_DIRTY_MINTS_CAP);
+    }
+
+    #[test]
+    fn arb_track_selection_queue_overflow_sets_pending_full_reconcile() {
+        let (tx, _rx) = mpsc::channel::<ArbTrackSelectionJob>(1);
+        tx.try_send(ArbTrackSelectionJob::FullReconcile).unwrap();
+        let pending = Arc::new(AtomicBool::new(false));
+        let handle = ArbTrackSelectionHandle {
+            tx,
+            pending_full_reconcile: Arc::clone(&pending),
+        };
+        handle.mark_dirty("mint_overflow");
+        assert!(pending.load(Ordering::Acquire));
+        pending.store(false, Ordering::Release);
+        handle.request_full_reconcile();
+        assert!(pending.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn arb_track_mint_snapshot_cache_respects_cap() {
+        let mut cache = ArbTrackMintSnapshotCache::default();
+        let protected = HashSet::new();
+        for i in 0..ARB_TRACK_MINT_SNAPSHOTS_CAP + 100 {
+            let mint = format!("mint_{i:05}");
+            let input = TrackMintInput {
+                mint: mint.clone(),
+                pools: Vec::new(),
+                trade_signal_pools: None,
+                last_activity_unix_ms: i as u64,
+            };
+            let _ = cache.insert_bounded(mint, input, &protected);
+        }
+        assert!(cache.len() <= ARB_TRACK_MINT_SNAPSHOTS_CAP);
+    }
+
+    #[test]
+    fn reconcile_first_publish_records_newly_active_mints() {
+        use ironcrab::metrics::{
+            try_record_arb_track_pin_before_first_screen_ms,
+            ARB_TRACK_PIN_BEFORE_FIRST_SCREEN_MS_COUNT,
+        };
+
+        let cache = create_shared_cache();
+        let ctx = Arc::new(test_arb_context(cache));
+        let mint = "MintReconcileFirst111111111111111111111111";
+        let pool_a = "pool_reconcile_a";
+        let pool_b = "pool_reconcile_b";
+        {
+            let mut snapshots = ctx.arb_track_mint_snapshots.write();
+            snapshots.insert_bounded(
+                mint.to_string(),
+                TrackMintInput {
+                    mint: mint.to_string(),
+                    pools: vec![
+                        TrackPoolInput {
+                            pool_address: pool_a.to_string(),
+                            dex: "orca".to_string(),
+                            known: true,
+                            quote_pool: QuotePoolInput {
+                                pool_address: pool_a.to_string(),
+                                dex: "orca".to_string(),
+                                token_mint: mint.to_string(),
+                                trade_price_buy: None,
+                                trade_price_sell: None,
+                                trade_updated_at: Instant::now(),
+                                has_reserve_data: true,
+                                token_decimals: 6,
+                            },
+                            vault: Some(QuoteVaultInput {
+                                reserve_base: 1_000_000_000,
+                                reserve_quote: 2_000_000_000,
+                                update_slot: 1,
+                                updated_at: Instant::now(),
+                                active_id: None,
+                                bin_step: None,
+                                dlmm_sol_is_x: false,
+                                dlmm_token_x_mint: None,
+                            }),
+                            dlmm_bins: None,
+                            token_decimals: 6,
+                            last_activity_unix_ms: 1,
+                        },
+                        TrackPoolInput {
+                            pool_address: pool_b.to_string(),
+                            dex: "pump_amm".to_string(),
+                            known: true,
+                            quote_pool: QuotePoolInput {
+                                pool_address: pool_b.to_string(),
+                                dex: "pump_amm".to_string(),
+                                token_mint: mint.to_string(),
+                                trade_price_buy: None,
+                                trade_price_sell: None,
+                                trade_updated_at: Instant::now(),
+                                has_reserve_data: true,
+                                token_decimals: 6,
+                            },
+                            vault: Some(QuoteVaultInput {
+                                reserve_base: 1_000_000_000,
+                                reserve_quote: 2_000_000_000,
+                                update_slot: 1,
+                                updated_at: Instant::now(),
+                                active_id: None,
+                                bin_step: None,
+                                dlmm_sol_is_x: false,
+                                dlmm_token_x_mint: None,
+                            }),
+                            dlmm_bins: None,
+                            token_decimals: 6,
+                            last_activity_unix_ms: 2,
+                        },
+                    ],
+                    trade_signal_pools: None,
+                    last_activity_unix_ms: 2,
+                },
+                &HashSet::new(),
+            );
+        }
+        let before = ARB_TRACK_PIN_BEFORE_FIRST_SCREEN_MS_COUNT.load(Ordering::Relaxed);
+        ctx.run_arb_track_selection_from_snapshots(true);
+        try_record_arb_track_pin_before_first_screen_ms(mint);
+        let after = ARB_TRACK_PIN_BEFORE_FIRST_SCREEN_MS_COUNT.load(Ordering::Relaxed);
+        assert_eq!(
+            after,
+            before + 1,
+            "reconcile publish must seed first-publish timing for newly active mints"
+        );
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -11119,7 +11119,7 @@ mod two_hop_price_tests {
             handle.mark_dirty("mint_a");
         }
         assert_eq!(handle.ingress_dirty_len(), 1);
-        assert_eq!(wake_rx.try_recv().unwrap(), ());
+        assert!(wake_rx.try_recv().is_ok());
         assert!(wake_rx.try_recv().is_err());
     }
 
@@ -11143,7 +11143,7 @@ mod two_hop_price_tests {
         let (handle, mut wake_rx) = test_arb_track_selection_handle();
         handle.request_full_reconcile();
         assert!(handle.pending_full_reconcile.load(Ordering::Acquire));
-        assert_eq!(wake_rx.try_recv().unwrap(), ());
+        assert!(wake_rx.try_recv().is_ok());
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -21,7 +21,7 @@ use rust_decimal::Decimal;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
@@ -73,11 +73,12 @@ use ironcrab::metrics::{
     arb_two_hop_v2_no_cross_dex_sell_detail_inc, arb_two_hop_v2_rejected_inc,
     arb_two_hop_v2_screen_inc, arb_two_hop_v2_screen_multi_dex_inc,
     arb_two_hop_v2_sell_quote_none_detail_inc, record_arb_heartbeat_phase,
-    record_arb_price_freshness_stale_age_ms, record_arb_proactive_track_publish_total,
-    record_arb_quote_pair_slot_delta, record_arb_quote_shadow_round_trip,
-    record_arb_track_publish_skipped_unchanged_total, record_arb_track_removed_total,
-    record_arb_track_requests_messages_total, record_arb_track_requests_publish_chunks_total,
-    record_arb_track_requests_publish_failed_total, record_arb_writer_lock_wait, serve_metrics,
+    record_arb_price_freshness_stale_age_ms, record_arb_proactive_pin_first_publish,
+    record_arb_proactive_track_publish_total, record_arb_quote_pair_slot_delta,
+    record_arb_quote_shadow_round_trip, record_arb_track_publish_skipped_unchanged_total,
+    record_arb_track_removed_total, record_arb_track_requests_messages_total,
+    record_arb_track_requests_publish_chunks_total, record_arb_track_requests_publish_failed_total,
+    record_arb_track_selection_recompute_total, record_arb_writer_lock_wait, serve_metrics,
     set_arb_pool_cache_apply_batch_size_gauge, set_arb_quote_shadow_legacy_spread_bps,
     set_arb_track_selection_metrics, set_arb_tracker_write_coalescer_pending,
     set_arb_tracker_write_queue_depth, set_arb_two_hop_blocked_on_apply_trade,
@@ -122,10 +123,16 @@ const ARB_TRACK_REQUESTS_WIRE_VERSION: u32 = 1;
 const ARB_TRACK_BASELINE_MAX_POOLS_DEFAULT: usize = 500;
 /// Default baseline reconcile interval (configurable via `arb_track_reconcile_interval_secs`).
 const ARB_TRACK_RECONCILE_INTERVAL_SECS_DEFAULT: u64 = 60;
-/// Max trade-signal pools remembered for pin priority (bounded).
-const ARB_TRADE_SIGNAL_POOLS_CAP: usize = 64;
-/// Coalesce window before recomputing Arb track selection after dirty marks.
-const ARB_TRACK_RECOMPUTE_COALESCE_MS: u64 = 50;
+/// Max trade-signal pairs remembered per mint (bounded LRU by recency).
+const ARB_TRADE_SIGNAL_PAIRS_CAP: usize = 64;
+/// Coalesce dirty-mint marks before an incremental global select.
+const ARB_TRACK_SELECTION_COALESCE_MS: u64 = 50;
+/// Minimum interval between incremental global selects (rate limit).
+const ARB_TRACK_INCREMENTAL_MIN_INTERVAL_MS: u64 = 1_000;
+/// Max dirty mints queued between incremental selects.
+const ARB_TRACK_SELECTION_DIRTY_MINTS_CAP: usize = 4_096;
+/// Yield between mint snapshot refreshes during full reconcile.
+const ARB_TRACK_FULL_RECONCILE_BATCH_YIELD: usize = 32;
 
 /// Bounded queue for off-hot-loop 2-hop trade detection (Scope D).
 const ARB_TWO_HOP_WORKER_QUEUE_CAP: usize = 4096;
@@ -477,27 +484,91 @@ fn arb_tracked_token_mint<'a>(base_mint: &'a str, quote_mint: &'a str) -> Option
     None
 }
 
-fn trade_signal_pair_for_mint(
-    tracker: &TokenArbTracker,
-    trade_signals: &HashSet<String>,
-) -> Option<(String, String)> {
-    let mut signal_pools: Vec<String> = tracker
-        .pools
-        .keys()
-        .filter(|pool| trade_signals.contains(*pool))
-        .cloned()
-        .collect();
-    signal_pools.sort();
-    for (i, buy) in signal_pools.iter().enumerate() {
-        let buy_dex = tracker.pools.get(buy)?.dex.as_str();
-        for sell in signal_pools.iter().skip(i + 1) {
-            let sell_dex = tracker.pools.get(sell)?.dex.as_str();
-            if buy_dex != sell_dex {
-                return Some((buy.clone(), sell.clone()));
+/// Bounded per-mint trade-signal buy/sell pair with recency.
+#[derive(Debug, Clone)]
+struct ArbTradeSignalPair {
+    buy_pool: String,
+    sell_pool: String,
+    #[allow(dead_code)]
+    seen_at_unix_ms: u64,
+}
+
+enum ArbTrackSelectionJob {
+    MarkDirty { mint: String },
+    FullReconcile,
+}
+
+struct ArbTrackSelectionHandle {
+    tx: mpsc::Sender<ArbTrackSelectionJob>,
+}
+
+impl ArbTrackSelectionHandle {
+    fn mark_dirty(&self, mint: &str) {
+        let _ = self.tx.try_send(ArbTrackSelectionJob::MarkDirty {
+            mint: mint.to_string(),
+        });
+    }
+
+    fn request_full_reconcile(&self) {
+        let _ = self.tx.try_send(ArbTrackSelectionJob::FullReconcile);
+    }
+}
+
+#[cfg(test)]
+fn dummy_arb_track_selection_handle() -> ArbTrackSelectionHandle {
+    let (tx, _rx) = mpsc::channel::<ArbTrackSelectionJob>(1);
+    ArbTrackSelectionHandle { tx }
+}
+
+/// Coalesces selection jobs for bounded worker scheduling (unit-tested).
+#[derive(Debug, Default)]
+struct ArbTrackSelectionCoalescer {
+    dirty_mints: HashSet<String>,
+    pending_full: bool,
+}
+
+impl ArbTrackSelectionCoalescer {
+    fn ingest(&mut self, job: ArbTrackSelectionJob) {
+        match job {
+            ArbTrackSelectionJob::MarkDirty { mint } => {
+                if self.dirty_mints.len() >= ARB_TRACK_SELECTION_DIRTY_MINTS_CAP {
+                    if let Some(old) = self.dirty_mints.iter().next().cloned() {
+                        self.dirty_mints.remove(&old);
+                    }
+                }
+                self.dirty_mints.insert(mint);
             }
+            ArbTrackSelectionJob::FullReconcile => self.pending_full = true,
         }
     }
-    None
+
+    fn take_batch(&mut self) -> (Vec<String>, bool) {
+        let full = self.pending_full;
+        self.pending_full = false;
+        let dirty = self.dirty_mints.drain().collect();
+        (dirty, full)
+    }
+}
+
+fn pool_activity_unix_ms(pool: &PoolState, vault: Option<&VaultBalanceCache>) -> u64 {
+    let pool_ms =
+        wall_clock_unix_ms_now().saturating_sub(pool.last_update.elapsed().as_millis() as u64);
+    vault
+        .map(|v| wall_clock_unix_ms_now().saturating_sub(v.updated_at.elapsed().as_millis() as u64))
+        .unwrap_or(pool_ms)
+        .max(pool_ms)
+}
+
+fn tracker_mint_activity_unix_ms(
+    tracker: &TokenArbTracker,
+    vault_balances: &HashMap<String, VaultBalanceCache>,
+) -> u64 {
+    tracker
+        .pools
+        .values()
+        .map(|pool| pool_activity_unix_ms(pool, vault_balances.get(&pool.pool_address)))
+        .max()
+        .unwrap_or_else(wall_clock_unix_ms_now)
 }
 
 /// Reject obviously wrong side/decimal comparable prices (stablecoins only).
@@ -3784,7 +3855,11 @@ fn spawn_arb_two_hop_worker(ctx: Arc<ArbContext>, mut rx: mpsc::Receiver<ArbTwoH
                     profit_lamports = opp.estimated_profit_lamports,
                     "🔥 Arbitrage opportunity detected (two-hop worker)"
                 );
-                ctx.publish_arb_trade_signal_track_pins(&opp.buy_pool, &opp.sell_pool);
+                ctx.publish_arb_trade_signal_track_pins(
+                    &opp.base_mint,
+                    &opp.buy_pool,
+                    &opp.sell_pool,
+                );
                 if let Some(mut intent) = create_arb_intent(&ctx, &opp) {
                     if let Some(slot) = job.slot {
                         intent.metadata.insert("slot".to_string(), slot.to_string());
@@ -4025,10 +4100,13 @@ struct ArbContext {
 
     /// Phase 3: pools published as active via `TOPIC_ARB_TRACK_REQUESTS`.
     arb_pinned_pools: RwLock<HashSet<String>>,
-    /// Trade-signal pools with elevated pin priority (bounded).
-    arb_trade_signal_pools: RwLock<HashSet<String>>,
-    /// Coalesce concurrent Arb track recomputes.
-    arb_track_recompute_scheduled: AtomicBool,
+    /// Bounded per-mint trade-signal pairs (mint -> buy/sell + recency).
+    arb_trade_signal_pairs: RwLock<HashMap<String, ArbTradeSignalPair>>,
+    /// LRU order for trade-signal pair eviction (oldest at front).
+    arb_trade_signal_pair_order: RwLock<Vec<String>>,
+    /// Cached per-mint selection snapshots (updated incrementally by selection worker).
+    arb_track_mint_snapshots: RwLock<HashMap<String, TrackMintInput>>,
+    arb_track_selection: ArbTrackSelectionHandle,
     /// Phase 3: count of track_requests publishes (heartbeat).
     arb_track_published: AtomicU64,
     /// Scope D: enqueue-only sender for off-hot-loop 2-hop detection.
@@ -5444,14 +5522,91 @@ impl ArbContext {
         });
     }
 
-    fn build_track_selection_input(&self) -> (Vec<TrackMintInput>, TrackSelectionConfig) {
+    fn collect_multi_dex_mint_ids(&self) -> Vec<String> {
         let trackers = self.trackers.read();
+        let mut mints: Vec<String> = trackers
+            .iter()
+            .filter(|(_, tracker)| {
+                tracker.pool_count_on_distinct_dexes() >= 2 && tracker.token_decimals.is_some()
+            })
+            .map(|(mint, _)| mint.clone())
+            .collect();
+        mints.sort();
+        mints
+    }
+
+    fn build_track_mint_input(&self, mint: &str) -> Option<TrackMintInput> {
+        let tracker = {
+            let trackers = self.trackers.read();
+            trackers.get(mint)?.clone()
+        };
+        if tracker.pool_count_on_distinct_dexes() < 2 {
+            return None;
+        }
+        let token_decimals = tracker.token_decimals?;
+
         let known_pools = self.known_pools.read();
         let vault_balances = self.vault_balances.read();
         let bin_arrays = self.bin_arrays.read();
-        let config = self.config.read();
-        let trade_signals = self.arb_trade_signal_pools.read();
+        let mint_activity = tracker_mint_activity_unix_ms(&tracker, &vault_balances);
+        let trade_signal_pools = self
+            .arb_trade_signal_pairs
+            .read()
+            .get(mint)
+            .map(|pair| (pair.buy_pool.clone(), pair.sell_pool.clone()));
 
+        let pools: Vec<TrackPoolInput> = tracker
+            .pools
+            .values()
+            .map(|pool| {
+                let vault = vault_balances.get(&pool.pool_address);
+                TrackPoolInput {
+                    pool_address: pool.pool_address.clone(),
+                    dex: pool.dex.clone(),
+                    known: known_pools.contains(&pool.pool_address),
+                    quote_pool: pool_state_to_quote_input(pool, mint, token_decimals),
+                    vault: vault.map(vault_cache_to_quote_input),
+                    dlmm_bins: bin_arrays
+                        .get(&pool.pool_address)
+                        .map(flatten_bin_array_cache),
+                    token_decimals,
+                    last_activity_unix_ms: pool_activity_unix_ms(pool, vault),
+                }
+            })
+            .collect();
+
+        Some(TrackMintInput {
+            mint: mint.to_string(),
+            pools,
+            trade_signal_pools,
+            last_activity_unix_ms: mint_activity,
+        })
+    }
+
+    fn refresh_mint_snapshot(&self, mint: &str) {
+        let mut snapshots = self.arb_track_mint_snapshots.write();
+        match self.build_track_mint_input(mint) {
+            Some(input) => {
+                snapshots.insert(mint.to_string(), input);
+            }
+            None => {
+                snapshots.remove(mint);
+            }
+        }
+    }
+
+    fn run_arb_track_selection_from_snapshots(self: &Arc<Self>, reconcile: bool) {
+        if self.nats.is_none() {
+            return;
+        }
+
+        let mint_inputs: Vec<TrackMintInput> = self
+            .arb_track_mint_snapshots
+            .read()
+            .values()
+            .cloned()
+            .collect();
+        let config = self.config.read();
         let selection_config = TrackSelectionConfig {
             max_pools: config.arb_track_baseline_max_pools,
             max_pools_per_mint: 3,
@@ -5461,57 +5616,9 @@ impl ArbContext {
                 state_ttl_ms: config.arb_quote_state_ttl_ms,
             },
         };
+        drop(config);
 
-        let mut mints = Vec::new();
-        for (mint, tracker) in trackers.iter() {
-            if tracker.pool_count_on_distinct_dexes() < 2 {
-                continue;
-            }
-            let Some(token_decimals) = tracker.token_decimals else {
-                continue;
-            };
-            let pools: Vec<TrackPoolInput> = tracker
-                .pools
-                .values()
-                .map(|pool| TrackPoolInput {
-                    pool_address: pool.pool_address.clone(),
-                    dex: pool.dex.clone(),
-                    known: known_pools.contains(&pool.pool_address),
-                    quote_pool: pool_state_to_quote_input(pool, mint, token_decimals),
-                    vault: vault_balances
-                        .get(&pool.pool_address)
-                        .map(vault_cache_to_quote_input),
-                    dlmm_bins: bin_arrays
-                        .get(&pool.pool_address)
-                        .map(flatten_bin_array_cache),
-                    token_decimals,
-                })
-                .collect();
-            let trade_signal_pools = trade_signal_pair_for_mint(tracker, &trade_signals);
-            mints.push(TrackMintInput {
-                mint: mint.clone(),
-                pools,
-                trade_signal_pools,
-            });
-        }
-
-        (mints, selection_config)
-    }
-
-    fn pool_still_tracker_valid(&self, pool: &str) -> bool {
-        let trackers = self.trackers.read();
-        trackers.values().any(|tracker| {
-            tracker.pool_count_on_distinct_dexes() >= 2 && tracker.pools.contains_key(pool)
-        })
-    }
-
-    fn recompute_arb_track_selection(self: &Arc<Self>, reconcile: bool) {
-        if self.nats.is_none() {
-            return;
-        }
-
-        let (mints, selection_config) = self.build_track_selection_input();
-        let result = select_arb_track_pools(&mints, &selection_config);
+        let result = select_arb_track_pools(&mint_inputs, &selection_config);
         set_arb_track_selection_metrics(
             result.selected.len(),
             result.selected_mints,
@@ -5559,11 +5666,7 @@ impl ArbContext {
                 .iter()
                 .filter(|pool| !new_pools.contains(*pool))
                 .map(|pool| {
-                    let reason = arb_track_removal_reason(
-                        pool,
-                        self.pool_still_tracker_valid(pool),
-                        &budget_displaced,
-                    );
+                    let reason = arb_track_removal_reason(pool, &budget_displaced);
                     record_arb_track_removed_total(reason);
                     ArbTrackRemovedEntry {
                         pool: pool.clone(),
@@ -5586,53 +5689,71 @@ impl ArbContext {
             if !active.is_empty() {
                 record_arb_proactive_track_publish_total();
             }
+            let newly_active_mints: HashSet<String> = result
+                .selected
+                .iter()
+                .filter(|p| !old_pools.contains(&p.pool))
+                .map(|p| p.mint.clone())
+                .collect();
+            for mint in newly_active_mints {
+                record_arb_proactive_pin_first_publish(&mint);
+            }
             self.spawn_publish_arb_track_requests(active, removed, false);
         }
     }
 
-    fn schedule_arb_track_recompute(self: &Arc<Self>) {
-        if self
-            .arb_track_recompute_scheduled
-            .swap(true, Ordering::AcqRel)
-        {
-            return;
-        }
-        let ctx = Arc::clone(self);
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(ARB_TRACK_RECOMPUTE_COALESCE_MS)).await;
-            ctx.arb_track_recompute_scheduled
-                .store(false, Ordering::Release);
-            ctx.recompute_arb_track_selection(false);
-        });
+    fn mark_arb_track_mint_dirty(self: &Arc<Self>, mint: &str) {
+        self.arb_track_selection.mark_dirty(mint);
     }
 
     fn reconcile_arb_track_baseline_publish(self: &Arc<Self>) {
-        self.recompute_arb_track_selection(true);
+        self.arb_track_selection.request_full_reconcile();
     }
 
-    fn publish_proactive_arb_track_for_mint(self: &Arc<Self>, _mint: &str) {
-        self.schedule_arb_track_recompute();
+    fn publish_proactive_arb_track_for_mint(self: &Arc<Self>, mint: &str) {
+        self.mark_arb_track_mint_dirty(mint);
     }
 
-    fn publish_arb_trade_signal_track_pins(self: &Arc<Self>, buy_pool: &str, sell_pool: &str) {
-        {
-            let mut signals = self.arb_trade_signal_pools.write();
-            signals.insert(buy_pool.to_string());
-            signals.insert(sell_pool.to_string());
-            if signals.len() > ARB_TRADE_SIGNAL_POOLS_CAP {
-                let mut keys: Vec<_> = signals.iter().cloned().collect();
-                keys.sort();
-                let drain = signals.len() - ARB_TRADE_SIGNAL_POOLS_CAP;
-                for key in keys.into_iter().take(drain) {
-                    signals.remove(&key);
-                }
-            }
+    fn record_arb_trade_signal_pair(self: &Arc<Self>, mint: &str, buy_pool: &str, sell_pool: &str) {
+        let seen_at = wall_clock_unix_ms_now();
+        let mut pairs = self.arb_trade_signal_pairs.write();
+        let mut order = self.arb_trade_signal_pair_order.write();
+        if !pairs.contains_key(mint) {
+            order.push(mint.to_string());
         }
-        self.schedule_arb_track_recompute();
+        pairs.insert(
+            mint.to_string(),
+            ArbTradeSignalPair {
+                buy_pool: buy_pool.to_string(),
+                sell_pool: sell_pool.to_string(),
+                seen_at_unix_ms: seen_at,
+            },
+        );
+        if let Some(pos) = order.iter().position(|m| m == mint) {
+            order.remove(pos);
+        }
+        order.push(mint.to_string());
+        while pairs.len() > ARB_TRADE_SIGNAL_PAIRS_CAP {
+            let Some(evict_mint) = order.first().cloned() else {
+                break;
+            };
+            order.remove(0);
+            pairs.remove(&evict_mint);
+        }
+    }
+
+    fn publish_arb_trade_signal_track_pins(
+        self: &Arc<Self>,
+        mint: &str,
+        buy_pool: &str,
+        sell_pool: &str,
+    ) {
+        self.record_arb_trade_signal_pair(mint, buy_pool, sell_pool);
+        self.mark_arb_track_mint_dirty(mint);
     }
 
     fn prune_arb_track_stale_pools(self: &Arc<Self>) {
-        self.schedule_arb_track_recompute();
+        self.arb_track_selection.request_full_reconcile();
     }
 }
 
@@ -6098,6 +6219,71 @@ fn maybe_arb_tracker_write_stall_watchdog_warn(queue_cap: usize) {
     arb_tracker_write_stall_watchdog_inc();
 }
 
+fn spawn_arb_track_selection_worker(
+    ctx: Arc<ArbContext>,
+    mut rx: mpsc::Receiver<ArbTrackSelectionJob>,
+) {
+    tokio::spawn(async move {
+        let mut coalescer = ArbTrackSelectionCoalescer::default();
+        let mut last_incremental = Instant::now() - Duration::from_secs(3600);
+
+        while let Some(first) = rx.recv().await {
+            coalescer.ingest(first);
+            let coalesce_deadline =
+                Instant::now() + Duration::from_millis(ARB_TRACK_SELECTION_COALESCE_MS);
+            while Instant::now() < coalesce_deadline {
+                match rx.try_recv() {
+                    Ok(job) => coalescer.ingest(job),
+                    Err(mpsc::error::TryRecvError::Empty) => {
+                        tokio::time::sleep(Duration::from_millis(5)).await;
+                    }
+                    Err(mpsc::error::TryRecvError::Disconnected) => break,
+                }
+            }
+
+            let (dirty_mints, full_reconcile) = coalescer.take_batch();
+            if dirty_mints.is_empty() && !full_reconcile {
+                continue;
+            }
+
+            if !full_reconcile {
+                let min_interval = Duration::from_millis(ARB_TRACK_INCREMENTAL_MIN_INTERVAL_MS);
+                let elapsed = last_incremental.elapsed();
+                if elapsed < min_interval {
+                    tokio::time::sleep(min_interval - elapsed).await;
+                }
+            }
+
+            let refresh_mints: Vec<String> = if full_reconcile {
+                ctx.collect_multi_dex_mint_ids()
+            } else {
+                let mut mints = dirty_mints;
+                mints.sort();
+                mints.dedup();
+                mints
+            };
+
+            for (idx, mint) in refresh_mints.iter().enumerate() {
+                ctx.refresh_mint_snapshot(mint);
+                if full_reconcile && (idx + 1) % ARB_TRACK_FULL_RECONCILE_BATCH_YIELD == 0 {
+                    tokio::task::yield_now().await;
+                }
+            }
+
+            if full_reconcile {
+                let snapshot_mints: HashSet<String> = refresh_mints.into_iter().collect();
+                let mut snapshots = ctx.arb_track_mint_snapshots.write();
+                snapshots.retain(|mint, _| snapshot_mints.contains(mint));
+            }
+
+            ctx.run_arb_track_selection_from_snapshots(full_reconcile);
+            record_arb_track_selection_recompute_total();
+            last_incremental = Instant::now();
+        }
+        info!("arb-strategy track selection worker stopped");
+    });
+}
+
 fn spawn_arb_tracker_write_worker(
     ctx: Arc<ArbContext>,
     mut rx: mpsc::Receiver<ArbTrackerWriteJob>,
@@ -6331,6 +6517,11 @@ async fn main() -> Result<()> {
         tx: tracker_write_tx,
         capacity: ARB_TRACKER_WRITE_QUEUE_CAP,
     };
+    let (arb_track_selection_tx, arb_track_selection_rx) =
+        mpsc::channel::<ArbTrackSelectionJob>(ARB_TRACKER_WRITE_QUEUE_CAP);
+    let arb_track_selection = ArbTrackSelectionHandle {
+        tx: arb_track_selection_tx,
+    };
 
     let ctx = Arc::new(ArbContext {
         run_id: run_id.clone(),
@@ -6355,8 +6546,10 @@ async fn main() -> Result<()> {
         eligibility_forensics: ArbEligibilityForensics::new(),
         v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
         arb_pinned_pools: RwLock::new(HashSet::new()),
-        arb_trade_signal_pools: RwLock::new(HashSet::new()),
-        arb_track_recompute_scheduled: AtomicBool::new(false),
+        arb_trade_signal_pairs: RwLock::new(HashMap::new()),
+        arb_trade_signal_pair_order: RwLock::new(Vec::new()),
+        arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+        arb_track_selection,
         arb_track_published: AtomicU64::new(0),
         two_hop_tx,
         tracker_write,
@@ -6364,6 +6557,7 @@ async fn main() -> Result<()> {
     });
 
     spawn_arb_tracker_write_worker(Arc::clone(&ctx), tracker_write_rx);
+    spawn_arb_track_selection_worker(Arc::clone(&ctx), arb_track_selection_rx);
     spawn_arb_two_hop_worker(Arc::clone(&ctx), two_hop_rx);
 
     // Bootstrap SLAVE LivePoolCache from JetStream (same path as execution-engine).
@@ -7418,8 +7612,10 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
-            arb_trade_signal_pools: RwLock::new(HashSet::new()),
-            arb_track_recompute_scheduled: AtomicBool::new(false),
+            arb_trade_signal_pairs: RwLock::new(HashMap::new()),
+            arb_trade_signal_pair_order: RwLock::new(Vec::new()),
+            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -7527,8 +7723,10 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
-            arb_trade_signal_pools: RwLock::new(HashSet::new()),
-            arb_track_recompute_scheduled: AtomicBool::new(false),
+            arb_trade_signal_pairs: RwLock::new(HashMap::new()),
+            arb_trade_signal_pair_order: RwLock::new(Vec::new()),
+            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -7634,8 +7832,10 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
-            arb_trade_signal_pools: RwLock::new(HashSet::new()),
-            arb_track_recompute_scheduled: AtomicBool::new(false),
+            arb_trade_signal_pairs: RwLock::new(HashMap::new()),
+            arb_trade_signal_pair_order: RwLock::new(Vec::new()),
+            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -7851,8 +8051,10 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
-            arb_trade_signal_pools: RwLock::new(HashSet::new()),
-            arb_track_recompute_scheduled: AtomicBool::new(false),
+            arb_trade_signal_pairs: RwLock::new(HashMap::new()),
+            arb_trade_signal_pair_order: RwLock::new(Vec::new()),
+            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -7956,8 +8158,10 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
-            arb_trade_signal_pools: RwLock::new(HashSet::new()),
-            arb_track_recompute_scheduled: AtomicBool::new(false),
+            arb_trade_signal_pairs: RwLock::new(HashMap::new()),
+            arb_trade_signal_pair_order: RwLock::new(Vec::new()),
+            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -8065,8 +8269,10 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
-            arb_trade_signal_pools: RwLock::new(HashSet::new()),
-            arb_track_recompute_scheduled: AtomicBool::new(false),
+            arb_trade_signal_pairs: RwLock::new(HashMap::new()),
+            arb_trade_signal_pair_order: RwLock::new(Vec::new()),
+            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -8145,8 +8351,10 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
-            arb_trade_signal_pools: RwLock::new(HashSet::new()),
-            arb_track_recompute_scheduled: AtomicBool::new(false),
+            arb_trade_signal_pairs: RwLock::new(HashMap::new()),
+            arb_trade_signal_pair_order: RwLock::new(Vec::new()),
+            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -8286,8 +8494,10 @@ mod two_hop_price_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
-            arb_trade_signal_pools: RwLock::new(HashSet::new()),
-            arb_track_recompute_scheduled: AtomicBool::new(false),
+            arb_trade_signal_pairs: RwLock::new(HashMap::new()),
+            arb_trade_signal_pair_order: RwLock::new(Vec::new()),
+            arb_track_mint_snapshots: RwLock::new(HashMap::new()),
+            arb_track_selection: dummy_arb_track_selection_handle(),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx: {
                 let (tx, _rx) = mpsc::channel(1);
@@ -10155,6 +10365,7 @@ mod two_hop_price_tests {
                     }),
                     dlmm_bins: None,
                     token_decimals: 6,
+                    last_activity_unix_ms: 1,
                 },
                 TrackPoolInput {
                     pool_address: "pump_pool".to_string(),
@@ -10182,9 +10393,11 @@ mod two_hop_price_tests {
                     }),
                     dlmm_bins: None,
                     token_decimals: 6,
+                    last_activity_unix_ms: 2,
                 },
             ],
             trade_signal_pools: None,
+            last_activity_unix_ms: 2,
         };
         let config = TrackSelectionConfig {
             max_pools: 500,
@@ -10199,6 +10412,54 @@ mod two_hop_price_tests {
         let reconcile_pools: HashSet<_> =
             reconcile.selected.iter().map(|p| p.pool.clone()).collect();
         assert_eq!(proactive_pools, reconcile_pools);
+    }
+
+    #[test]
+    fn arb_track_selection_coalescer_bounds_burst_to_one_batch() {
+        let mut coalescer = ArbTrackSelectionCoalescer::default();
+        for i in 0..100 {
+            coalescer.ingest(ArbTrackSelectionJob::MarkDirty {
+                mint: format!("mint_{i}"),
+            });
+        }
+        let (dirty, full) = coalescer.take_batch();
+        assert!(!full);
+        assert_eq!(dirty.len(), 100);
+        let (dirty2, full2) = coalescer.take_batch();
+        assert!(dirty2.is_empty());
+        assert!(!full2);
+    }
+
+    #[test]
+    fn arb_trade_signal_pair_preserves_actual_buy_sell_mapping() {
+        let cache = create_shared_cache();
+        let ctx = Arc::new(test_arb_context(cache));
+        ctx.publish_arb_trade_signal_track_pins("mintA", "buy_pool", "sell_pool");
+        let pair = ctx
+            .arb_trade_signal_pairs
+            .read()
+            .get("mintA")
+            .cloned()
+            .unwrap();
+        assert_eq!(pair.buy_pool, "buy_pool");
+        assert_eq!(pair.sell_pool, "sell_pool");
+    }
+
+    #[test]
+    fn arb_trade_signal_pairs_evict_oldest_not_lexicographic() {
+        let cache = create_shared_cache();
+        let ctx = Arc::new(test_arb_context(cache));
+        for i in 0..=ARB_TRADE_SIGNAL_PAIRS_CAP {
+            ctx.publish_arb_trade_signal_track_pins(
+                &format!("mint_{i:03}"),
+                &format!("buy_{i}"),
+                &format!("sell_{i}"),
+            );
+        }
+        let pairs = ctx.arb_trade_signal_pairs.read();
+        assert_eq!(pairs.len(), ARB_TRADE_SIGNAL_PAIRS_CAP);
+        assert!(!pairs.contains_key("mint_000"));
+        assert!(pairs.contains_key(&format!("mint_{:03}", ARB_TRADE_SIGNAL_PAIRS_CAP)));
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -747,11 +747,11 @@ impl ArbTrackSelectionCoalescer {
     fn ingest(&mut self, job: ArbTrackSelectionJob) -> bool {
         match job {
             ArbTrackSelectionJob::MarkDirty { mint } => {
-                if self.dirty_mints.len() >= ARB_TRACK_SELECTION_DIRTY_MINTS_CAP {
+                self.dirty_mints.insert(mint);
+                if self.dirty_mints.len() > ARB_TRACK_SELECTION_DIRTY_MINTS_CAP {
                     self.dirty_overflow = true;
                     return true;
                 }
-                self.dirty_mints.insert(mint);
                 false
             }
             ArbTrackSelectionJob::FullReconcile => {
@@ -5930,19 +5930,32 @@ impl ArbContext {
         mint: &str,
         input: Option<TrackMintInput>,
         protected: &HashSet<String>,
-    ) {
+    ) -> bool {
         let mut snapshots = self.arb_track_mint_snapshots.write();
         match input {
             Some(input) => {
-                let _ = snapshots.insert_bounded(mint.to_string(), input, protected);
+                if snapshots.insert_bounded(mint.to_string(), input, protected) {
+                    true
+                } else {
+                    drop(snapshots);
+                    self.arb_track_selection
+                        .pending_full_reconcile
+                        .store(true, Ordering::Release);
+                    false
+                }
             }
-            None => snapshots.remove(mint),
+            None => {
+                snapshots.remove(mint);
+                true
+            }
         }
     }
 
     fn refresh_mint_snapshot(&self, mint: &str, protected: &HashSet<String>) {
         let input = self.build_track_mint_input(mint);
-        self.commit_mint_snapshot(mint, input, protected);
+        if !self.commit_mint_snapshot(mint, input, protected) {
+            self.arb_track_selection.mark_dirty(mint);
+        }
     }
 
     fn run_arb_track_selection_from_snapshots(self: &Arc<Self>, reconcile: bool) {
@@ -10843,7 +10856,8 @@ mod two_hop_price_tests {
         let (dirty, full, overflow) = coalescer.take_batch();
         assert!(!full);
         assert!(overflow);
-        assert_eq!(dirty.len(), ARB_TRACK_SELECTION_DIRTY_MINTS_CAP);
+        assert_eq!(dirty.len(), ARB_TRACK_SELECTION_DIRTY_MINTS_CAP + 1);
+        assert!(dirty.iter().any(|m| m == "overflow_mint"));
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -18,7 +18,8 @@ use clap::Parser;
 use parking_lot::RwLock;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -78,6 +79,7 @@ use ironcrab::metrics::{
     record_arb_quote_shadow_round_trip, record_arb_track_publish_skipped_unchanged_total,
     record_arb_track_removed_total, record_arb_track_requests_messages_total,
     record_arb_track_requests_publish_chunks_total, record_arb_track_requests_publish_failed_total,
+    record_arb_track_selection_blocking_join_failed_total,
     record_arb_track_selection_queue_overflow_total, record_arb_track_selection_recompute_total,
     record_arb_writer_lock_wait, serve_metrics, set_arb_pool_cache_apply_batch_size_gauge,
     set_arb_quote_shadow_legacy_spread_bps, set_arb_track_selection_metrics,
@@ -532,6 +534,11 @@ impl ArbTrackSelectionHandle {
         }
     }
 
+    fn record_blocking_join_failed(&self) {
+        record_arb_track_selection_blocking_join_failed_total();
+        self.pending_full_reconcile.store(true, Ordering::Release);
+    }
+
     fn take_pending_full(&self) -> bool {
         self.pending_full_reconcile.swap(false, Ordering::AcqRel)
     }
@@ -546,70 +553,169 @@ fn dummy_arb_track_selection_handle() -> ArbTrackSelectionHandle {
     }
 }
 
-/// Bounded LRU cache of per-mint selection snapshots.
+/// Deterministic top-K mint admission for bounded snapshot cache (unit-tested).
+fn compute_snapshot_admit_set(
+    ranked_mints: &[String],
+    protected: &HashSet<String>,
+    cap: usize,
+) -> HashSet<String> {
+    let mut admit = HashSet::new();
+    if cap == 0 {
+        return admit;
+    }
+    for mint in ranked_mints {
+        if protected.contains(mint) {
+            admit.insert(mint.clone());
+            if admit.len() >= cap {
+                return admit;
+            }
+        }
+    }
+    for mint in ranked_mints {
+        if admit.len() >= cap {
+            break;
+        }
+        admit.insert(mint.clone());
+    }
+    admit
+}
+
+#[derive(Debug, Clone)]
+struct MintSnapshotEntry {
+    input: TrackMintInput,
+    access_gen: u64,
+}
+
+/// Bounded mint snapshot cache with lazy min-heap eviction (O(log cap) touch).
 #[derive(Debug, Default)]
 struct ArbTrackMintSnapshotCache {
-    entries: HashMap<String, TrackMintInput>,
-    lru_order: VecDeque<String>,
+    entries: HashMap<String, MintSnapshotEntry>,
+    next_gen: u64,
+    eviction_heap: BinaryHeap<Reverse<(u64, String)>>,
 }
 
 impl ArbTrackMintSnapshotCache {
+    const HEAP_COMPACT_FACTOR: usize = 4;
+    const HEAP_COMPACT_MIN_EXTRA: usize = 64;
+
     #[allow(dead_code)] // used by unit tests (clippy does not count cfg(test) callers)
     fn len(&self) -> usize {
         self.entries.len()
     }
 
+    #[cfg(test)]
+    fn heap_len(&self) -> usize {
+        self.eviction_heap.len()
+    }
+
     fn values(&self) -> impl Iterator<Item = &TrackMintInput> {
-        self.entries.values()
+        self.entries.values().map(|entry| &entry.input)
     }
 
     fn remove(&mut self, mint: &str) {
         self.entries.remove(mint);
-        self.lru_order.retain(|m| m != mint);
     }
 
     fn retain(&mut self, mut keep: impl FnMut(&String) -> bool) {
         self.entries.retain(|mint, _| keep(mint));
-        self.lru_order.retain(|mint| keep(mint));
+        self.compact_heap_if_needed(true);
     }
 
-    fn touch_lru(&mut self, mint: &str) {
-        self.lru_order.retain(|m| m != mint);
-        self.lru_order.push_back(mint.to_string());
+    fn compact_heap_if_needed(&mut self, force: bool) {
+        let threshold = self
+            .entries
+            .len()
+            .saturating_mul(Self::HEAP_COMPACT_FACTOR)
+            .max(Self::HEAP_COMPACT_MIN_EXTRA);
+        if force || self.eviction_heap.len() > threshold {
+            self.eviction_heap = self
+                .entries
+                .iter()
+                .map(|(mint, entry)| Reverse((entry.access_gen, mint.clone())))
+                .collect();
+        }
     }
 
-    fn evict_one_unprotected(&mut self, protected: &HashSet<String>) -> bool {
-        let mut idx = 0;
-        while idx < self.lru_order.len() {
-            if let Some(mint) = self.lru_order.get(idx).cloned() {
-                if !protected.contains(&mint) {
-                    self.lru_order.remove(idx);
-                    self.entries.remove(&mint);
-                    return true;
-                }
-                idx += 1;
-            } else {
-                break;
+    fn touch_entry(&mut self, mint: &str) {
+        self.next_gen = self.next_gen.saturating_add(1);
+        let gen = self.next_gen;
+        if let Some(entry) = self.entries.get_mut(mint) {
+            entry.access_gen = gen;
+            self.eviction_heap.push(Reverse((gen, mint.to_string())));
+        }
+    }
+
+    fn pop_eviction_victim(
+        &mut self,
+        protected: &HashSet<String>,
+        unprotected_only: bool,
+    ) -> Option<String> {
+        let mut deferred = Vec::new();
+        let victim = loop {
+            let Some(Reverse((heap_gen, mint))) = self.eviction_heap.pop() else {
+                break None;
+            };
+            let Some(entry) = self.entries.get(&mint) else {
+                continue;
+            };
+            if entry.access_gen != heap_gen {
+                continue;
             }
+            if unprotected_only && protected.contains(&mint) {
+                deferred.push(Reverse((heap_gen, mint)));
+                continue;
+            }
+            break Some(mint);
+        };
+        for item in deferred {
+            self.eviction_heap.push(item);
+        }
+        victim
+    }
+
+    fn evict_one(&mut self, protected: &HashSet<String>) -> bool {
+        if let Some(victim) = self.pop_eviction_victim(protected, true) {
+            self.entries.remove(&victim);
+            return true;
+        }
+        if let Some(victim) = self.pop_eviction_victim(protected, false) {
+            self.entries.remove(&victim);
+            return true;
         }
         false
     }
 
+    /// Hard cap: protection only affects eviction preference, never bypasses capacity.
     fn insert_bounded(
         &mut self,
         mint: String,
         input: TrackMintInput,
         protected: &HashSet<String>,
     ) -> bool {
-        if !self.entries.contains_key(&mint)
-            && self.entries.len() >= ARB_TRACK_MINT_SNAPSHOTS_CAP
-            && !protected.contains(&mint)
-            && !self.evict_one_unprotected(protected)
-        {
-            return false;
+        if self.entries.contains_key(&mint) {
+            self.entries.get_mut(&mint).unwrap().input = input;
+            self.touch_entry(&mint);
+            self.compact_heap_if_needed(false);
+            return true;
         }
-        self.entries.insert(mint.clone(), input);
-        self.touch_lru(&mint);
+
+        while self.entries.len() >= ARB_TRACK_MINT_SNAPSHOTS_CAP {
+            if !self.evict_one(protected) {
+                return false;
+            }
+        }
+
+        self.next_gen = self.next_gen.saturating_add(1);
+        let gen = self.next_gen;
+        self.entries.insert(
+            mint.clone(),
+            MintSnapshotEntry {
+                input,
+                access_gen: gen,
+            },
+        );
+        self.eviction_heap.push(Reverse((gen, mint)));
+        self.compact_heap_if_needed(false);
         true
     }
 }
@@ -5717,15 +5823,16 @@ impl ArbContext {
         })
     }
 
-    fn protected_snapshot_mints(&self, refreshing: &HashSet<String>) -> HashSet<String> {
-        let mut protected = refreshing.clone();
+    fn mandatory_protected_snapshot_mints(&self) -> HashSet<String> {
+        let mut protected = HashSet::new();
         for mint in self.arb_trade_signal_pairs.read().keys() {
             protected.insert(mint.clone());
         }
         let pinned = self.arb_pinned_pools.read();
         let snapshots = self.arb_track_mint_snapshots.read();
-        for (mint, input) in &snapshots.entries {
-            if input
+        for (mint, entry) in &snapshots.entries {
+            if entry
+                .input
                 .pools
                 .iter()
                 .any(|pool| pinned.contains(&pool.pool_address))
@@ -5734,6 +5841,24 @@ impl ArbContext {
             }
         }
         protected
+    }
+
+    fn rank_multi_dex_mints_by_activity(&self, mints: &[String]) -> Vec<String> {
+        let trackers = self.trackers.read();
+        let vault_balances = self.vault_balances.read();
+        let mut ranked: Vec<(u64, String)> = mints
+            .iter()
+            .filter_map(|mint| {
+                let tracker = trackers.get(mint)?;
+                if tracker.pool_count_on_distinct_dexes() < 2 {
+                    return None;
+                }
+                let activity = tracker_mint_activity_unix_ms(tracker, &vault_balances);
+                Some((activity, mint.clone()))
+            })
+            .collect();
+        ranked.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+        ranked.into_iter().map(|(_, mint)| mint).collect()
     }
 
     fn commit_mint_snapshot(
@@ -6391,8 +6516,18 @@ fn run_arb_track_selection_batch(
         full_reconcile = true;
     }
 
-    let refresh_mints: HashSet<String> = if full_reconcile {
-        ctx.collect_multi_dex_mint_ids().into_iter().collect()
+    let protected = ctx.mandatory_protected_snapshot_mints();
+
+    if full_reconcile {
+        let all_mints = ctx.collect_multi_dex_mint_ids();
+        let ranked = ctx.rank_multi_dex_mints_by_activity(&all_mints);
+        let admit = compute_snapshot_admit_set(&ranked, &protected, ARB_TRACK_MINT_SNAPSHOTS_CAP);
+        for mint in &admit {
+            ctx.refresh_mint_snapshot(mint, &protected);
+        }
+        ctx.arb_track_mint_snapshots
+            .write()
+            .retain(|mint| admit.contains(mint));
     } else {
         dirty_mints.sort();
         dirty_mints.dedup();
@@ -6402,21 +6537,7 @@ fn run_arb_track_selection_batch(
                 .store(true, Ordering::Release);
             dirty_mints.truncate(ARB_TRACK_INCREMENTAL_MINTS_MAX);
         }
-        dirty_mints.into_iter().collect()
-    };
-
-    let protected = ctx.protected_snapshot_mints(&refresh_mints);
-
-    if full_reconcile {
-        for mint in &refresh_mints {
-            ctx.refresh_mint_snapshot(mint, &protected);
-        }
-        let retain: HashSet<String> = refresh_mints.clone();
-        ctx.arb_track_mint_snapshots
-            .write()
-            .retain(|mint| retain.contains(mint));
-    } else {
-        for mint in &refresh_mints {
+        for mint in &dirty_mints {
             ctx.refresh_mint_snapshot(mint, &protected);
         }
     }
@@ -6486,6 +6607,7 @@ fn spawn_arb_track_selection_worker(
             });
             if blocking.await.is_err() {
                 warn!("arb track selection blocking batch join failed");
+                ctx.arb_track_selection.record_blocking_join_failed();
             }
             last_incremental = Instant::now();
         }
@@ -10688,8 +10810,119 @@ mod two_hop_price_tests {
                 last_activity_unix_ms: i as u64,
             };
             let _ = cache.insert_bounded(mint, input, &protected);
+            assert!(cache.len() <= ARB_TRACK_MINT_SNAPSHOTS_CAP);
         }
-        assert!(cache.len() <= ARB_TRACK_MINT_SNAPSHOTS_CAP);
+    }
+
+    #[test]
+    fn arb_track_mint_snapshot_cache_never_exceeds_cap_when_incoming_protected() {
+        let mut cache = ArbTrackMintSnapshotCache::default();
+        let empty = HashSet::new();
+        for i in 0..ARB_TRACK_MINT_SNAPSHOTS_CAP {
+            let mint = format!("seed_{i:05}");
+            let input = TrackMintInput {
+                mint: mint.clone(),
+                pools: Vec::new(),
+                trade_signal_pools: None,
+                last_activity_unix_ms: i as u64,
+            };
+            assert!(cache.insert_bounded(mint, input, &empty));
+        }
+        assert_eq!(cache.len(), ARB_TRACK_MINT_SNAPSHOTS_CAP);
+
+        let mut all_incoming_protected: HashSet<String> = HashSet::new();
+        for i in 0..512 {
+            all_incoming_protected.insert(format!("incoming_{i:05}"));
+        }
+        for i in 0..512 {
+            let mint = format!("incoming_{i:05}");
+            let input = TrackMintInput {
+                mint: mint.clone(),
+                pools: Vec::new(),
+                trade_signal_pools: None,
+                last_activity_unix_ms: 10_000 + i as u64,
+            };
+            let _ = cache.insert_bounded(mint, input, &all_incoming_protected);
+            assert!(
+                cache.len() <= ARB_TRACK_MINT_SNAPSHOTS_CAP,
+                "protected incoming must not bypass hard cap"
+            );
+        }
+    }
+
+    #[test]
+    fn compute_snapshot_admit_set_is_deterministic_top_k() {
+        let ranked: Vec<String> = (0..20).map(|i| format!("mint_{i:02}")).collect();
+        let mut protected = HashSet::new();
+        protected.insert("mint_19".to_string());
+        protected.insert("mint_00".to_string());
+
+        let admit_a = compute_snapshot_admit_set(&ranked, &protected, 5);
+        let admit_b = compute_snapshot_admit_set(&ranked, &protected, 5);
+        assert_eq!(admit_a, admit_b);
+        assert_eq!(admit_a.len(), 5);
+        assert!(admit_a.contains("mint_00"));
+        assert!(admit_a.contains("mint_19"));
+        assert!(admit_a.contains("mint_01"));
+        assert!(admit_a.contains("mint_02"));
+        assert!(admit_a.contains("mint_03"));
+    }
+
+    #[test]
+    fn snapshot_cache_hot_touch_keeps_heap_bounded() {
+        let mut cache = ArbTrackMintSnapshotCache::default();
+        let protected = HashSet::new();
+        for i in 0..ARB_TRACK_MINT_SNAPSHOTS_CAP {
+            let mint = format!("mint_{i:05}");
+            let input = TrackMintInput {
+                mint: mint.clone(),
+                pools: Vec::new(),
+                trade_signal_pools: None,
+                last_activity_unix_ms: i as u64,
+            };
+            cache.insert_bounded(mint, input, &protected);
+        }
+        let hot_mint = "mint_00000".to_string();
+        let hot_input = TrackMintInput {
+            mint: hot_mint.clone(),
+            pools: Vec::new(),
+            trade_signal_pools: None,
+            last_activity_unix_ms: u64::MAX,
+        };
+        for gen in 0..10_000 {
+            let input = TrackMintInput {
+                last_activity_unix_ms: gen,
+                ..hot_input.clone()
+            };
+            cache.insert_bounded(hot_mint.clone(), input, &protected);
+        }
+        let heap_bound = ARB_TRACK_MINT_SNAPSHOTS_CAP
+            .saturating_mul(ArbTrackMintSnapshotCache::HEAP_COMPACT_FACTOR)
+            .max(ArbTrackMintSnapshotCache::HEAP_COMPACT_MIN_EXTRA);
+        assert!(
+            cache.heap_len() <= heap_bound,
+            "heap must compact and stay bounded after hot touches"
+        );
+        assert_eq!(cache.len(), ARB_TRACK_MINT_SNAPSHOTS_CAP);
+    }
+
+    #[test]
+    fn arb_track_selection_blocking_join_failed_sets_pending_full() {
+        use ironcrab::metrics::ARB_TRACK_SELECTION_BLOCKING_JOIN_FAILED_TOTAL;
+
+        let (tx, _rx) = mpsc::channel::<ArbTrackSelectionJob>(1);
+        let pending = Arc::new(AtomicBool::new(false));
+        let handle = ArbTrackSelectionHandle {
+            tx,
+            pending_full_reconcile: Arc::clone(&pending),
+        };
+        let before = ARB_TRACK_SELECTION_BLOCKING_JOIN_FAILED_TOTAL.load(Ordering::Relaxed);
+        handle.record_blocking_join_failed();
+        assert!(pending.load(Ordering::Acquire));
+        assert_eq!(
+            ARB_TRACK_SELECTION_BLOCKING_JOIN_FAILED_TOTAL.load(Ordering::Relaxed),
+            before + 1
+        );
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -744,14 +744,21 @@ struct ArbTrackSelectionCoalescer {
 
 impl ArbTrackSelectionCoalescer {
     /// Returns `true` when dirty overflow requires a full reconcile recovery.
+    ///
+    /// Lock-free bounded state: `dirty_mints` never exceeds
+    /// `ARB_TRACK_SELECTION_DIRTY_MINTS_CAP`. Overflow mints are not retained; full
+    /// reconcile scans current tracker truth and will include eligible mints.
     fn ingest(&mut self, job: ArbTrackSelectionJob) -> bool {
         match job {
             ArbTrackSelectionJob::MarkDirty { mint } => {
-                self.dirty_mints.insert(mint);
-                if self.dirty_mints.len() > ARB_TRACK_SELECTION_DIRTY_MINTS_CAP {
+                if self.dirty_mints.contains(&mint) {
+                    return false;
+                }
+                if self.dirty_mints.len() >= ARB_TRACK_SELECTION_DIRTY_MINTS_CAP {
                     self.dirty_overflow = true;
                     return true;
                 }
+                self.dirty_mints.insert(mint);
                 false
             }
             ArbTrackSelectionJob::FullReconcile => {
@@ -10855,9 +10862,50 @@ mod two_hop_price_tests {
         }));
         let (dirty, full, overflow) = coalescer.take_batch();
         assert!(!full);
+        assert!(
+            overflow,
+            "overflow must schedule authoritative full reconcile"
+        );
+        assert_eq!(dirty.len(), ARB_TRACK_SELECTION_DIRTY_MINTS_CAP);
+        assert!(
+            !dirty.iter().any(|m| m == "overflow_mint"),
+            "overflow mint is not retained; full reconcile recovers from tracker truth"
+        );
+    }
+
+    #[test]
+    fn arb_track_selection_coalescer_burst_never_exceeds_dirty_cap() {
+        let mut coalescer = ArbTrackSelectionCoalescer::default();
+        let cap = ARB_TRACK_SELECTION_DIRTY_MINTS_CAP;
+        let mut overflow_seen = false;
+        for i in 0..cap + 5_000 {
+            if coalescer.ingest(ArbTrackSelectionJob::MarkDirty {
+                mint: format!("burst_{i}"),
+            }) {
+                overflow_seen = true;
+            }
+        }
+        assert!(overflow_seen);
+        let (dirty, _, overflow) = coalescer.take_batch();
         assert!(overflow);
-        assert_eq!(dirty.len(), ARB_TRACK_SELECTION_DIRTY_MINTS_CAP + 1);
-        assert!(dirty.iter().any(|m| m == "overflow_mint"));
+        assert_eq!(dirty.len(), cap);
+    }
+
+    #[test]
+    fn arb_track_selection_coalescer_duplicate_dirty_at_cap_is_idempotent() {
+        let mut coalescer = ArbTrackSelectionCoalescer::default();
+        let cap = ARB_TRACK_SELECTION_DIRTY_MINTS_CAP;
+        for i in 0..cap {
+            assert!(!coalescer.ingest(ArbTrackSelectionJob::MarkDirty {
+                mint: format!("mint_{i}"),
+            }));
+        }
+        assert!(!coalescer.ingest(ArbTrackSelectionJob::MarkDirty {
+            mint: "mint_0".to_string(),
+        }));
+        let (dirty, _, overflow) = coalescer.take_batch();
+        assert!(!overflow);
+        assert_eq!(dirty.len(), cap);
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -21,7 +21,7 @@ use rust_decimal::Decimal;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
@@ -29,14 +29,16 @@ use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 use ironcrab::arbitrage::{
-    classify_cross_dex_sell_failure, dlmm_marginal_price_plausible, dlmm_sol_output_from_bins,
-    dlmm_token_output_from_bins, is_quote_fresh, populate_arb_slave_from_live_pool_cache,
-    quote_exact_in, quote_exact_in_with_freshness, quote_sell_round_trip, quotes_pairable,
-    round_trip_profit_lamports, select_round_trip_pools, sync_arb_slave_from_pool_cache_update,
-    MultiHopArbitrage, MultiHopConfig, MultiHopIntentBatch, NoCrossDexSellDetailReason, PoolQuote,
+    arb_track_removal_reason, classify_cross_dex_sell_failure, dlmm_marginal_price_plausible,
+    dlmm_sol_output_from_bins, dlmm_token_output_from_bins, is_quote_fresh,
+    populate_arb_slave_from_live_pool_cache, quote_exact_in, quote_exact_in_with_freshness,
+    quote_sell_round_trip, quotes_pairable, round_trip_profit_lamports, select_arb_track_pools,
+    select_round_trip_pools, sync_arb_slave_from_pool_cache_update, MultiHopArbitrage,
+    MultiHopConfig, MultiHopIntentBatch, NoCrossDexSellDetailReason, PoolQuote,
     QuoteFreshnessConfig, QuoteKind, QuotePoolInput, QuoteVaultInput, RoundTripInsufficient,
     RoundTripInsufficientSubreason, RoundTripLeg, RoundTripPoolCandidate, RoundTripSelectFailure,
-    SellQuoteNoneDetailReason, DLMM_PROBE_SOL_LAMPORTS,
+    SellQuoteNoneDetailReason, TrackMintInput, TrackPoolInput, TrackSelectionConfig,
+    DLMM_PROBE_SOL_LAMPORTS,
 };
 use ironcrab::config::Config as AppConfig;
 use ironcrab::execution::live_pool_cache::{
@@ -71,12 +73,13 @@ use ironcrab::metrics::{
     arb_two_hop_v2_no_cross_dex_sell_detail_inc, arb_two_hop_v2_rejected_inc,
     arb_two_hop_v2_screen_inc, arb_two_hop_v2_screen_multi_dex_inc,
     arb_two_hop_v2_sell_quote_none_detail_inc, record_arb_heartbeat_phase,
-    record_arb_price_freshness_stale_age_ms, record_arb_proactive_pin_first_publish,
-    record_arb_proactive_track_publish_total, record_arb_quote_pair_slot_delta,
-    record_arb_quote_shadow_round_trip, record_arb_track_requests_messages_total,
-    record_arb_track_requests_publish_chunks_total, record_arb_track_requests_publish_failed_total,
-    record_arb_writer_lock_wait, serve_metrics, set_arb_pool_cache_apply_batch_size_gauge,
-    set_arb_quote_shadow_legacy_spread_bps, set_arb_tracker_write_coalescer_pending,
+    record_arb_price_freshness_stale_age_ms, record_arb_proactive_track_publish_total,
+    record_arb_quote_pair_slot_delta, record_arb_quote_shadow_round_trip,
+    record_arb_track_publish_skipped_unchanged_total, record_arb_track_removed_total,
+    record_arb_track_requests_messages_total, record_arb_track_requests_publish_chunks_total,
+    record_arb_track_requests_publish_failed_total, record_arb_writer_lock_wait, serve_metrics,
+    set_arb_pool_cache_apply_batch_size_gauge, set_arb_quote_shadow_legacy_spread_bps,
+    set_arb_track_selection_metrics, set_arb_tracker_write_coalescer_pending,
     set_arb_tracker_write_queue_depth, set_arb_two_hop_blocked_on_apply_trade,
     set_readiness_nats_connected, tick_arb_heartbeat_seconds_since_last_finish,
     tick_arb_tracker_write_seconds_since_last_finish,
@@ -96,8 +99,8 @@ use ironcrab::metrics::{
 use ironcrab::nats::{
     arb_strategy_pool_cache_live_consumer_config, arb_track_payload_bytes, config_consumer_config,
     config_subject, split_arb_track_requests_update, trim_reconcile_update_to_budget,
-    ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackRemovedEntry, ArbTrackRemovedReason,
-    ArbTrackRequestsUpdate, ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES, CONFIG_STREAM_NAME, STREAM_NAME,
+    ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackRemovedEntry, ArbTrackRequestsUpdate,
+    ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES, CONFIG_STREAM_NAME, STREAM_NAME,
 };
 use ironcrab::nats::{NatsClient, NatsConfig};
 use ironcrab::nats::{TOPIC_ARB_TRACK_REQUESTS, TOPIC_MARKET_EVENTS, TOPIC_TRADE_INTENTS};
@@ -119,6 +122,10 @@ const ARB_TRACK_REQUESTS_WIRE_VERSION: u32 = 1;
 const ARB_TRACK_BASELINE_MAX_POOLS_DEFAULT: usize = 500;
 /// Default baseline reconcile interval (configurable via `arb_track_reconcile_interval_secs`).
 const ARB_TRACK_RECONCILE_INTERVAL_SECS_DEFAULT: u64 = 60;
+/// Max trade-signal pools remembered for pin priority (bounded).
+const ARB_TRADE_SIGNAL_POOLS_CAP: usize = 64;
+/// Coalesce window before recomputing Arb track selection after dirty marks.
+const ARB_TRACK_RECOMPUTE_COALESCE_MS: u64 = 50;
 
 /// Bounded queue for off-hot-loop 2-hop trade detection (Scope D).
 const ARB_TWO_HOP_WORKER_QUEUE_CAP: usize = 4096;
@@ -466,6 +473,29 @@ fn arb_tracked_token_mint<'a>(base_mint: &'a str, quote_mint: &'a str) -> Option
     }
     if is_stablecoin_mint(base_mint) {
         return Some(quote_mint);
+    }
+    None
+}
+
+fn trade_signal_pair_for_mint(
+    tracker: &TokenArbTracker,
+    trade_signals: &HashSet<String>,
+) -> Option<(String, String)> {
+    let mut signal_pools: Vec<String> = tracker
+        .pools
+        .keys()
+        .filter(|pool| trade_signals.contains(*pool))
+        .cloned()
+        .collect();
+    signal_pools.sort();
+    for (i, buy) in signal_pools.iter().enumerate() {
+        let buy_dex = tracker.pools.get(buy)?.dex.as_str();
+        for sell in signal_pools.iter().skip(i + 1) {
+            let sell_dex = tracker.pools.get(sell)?.dex.as_str();
+            if buy_dex != sell_dex {
+                return Some((buy.clone(), sell.clone()));
+            }
+        }
     }
     None
 }
@@ -3995,6 +4025,10 @@ struct ArbContext {
 
     /// Phase 3: pools published as active via `TOPIC_ARB_TRACK_REQUESTS`.
     arb_pinned_pools: RwLock<HashSet<String>>,
+    /// Trade-signal pools with elevated pin priority (bounded).
+    arb_trade_signal_pools: RwLock<HashSet<String>>,
+    /// Coalesce concurrent Arb track recomputes.
+    arb_track_recompute_scheduled: AtomicBool,
     /// Phase 3: count of track_requests publishes (heartbeat).
     arb_track_published: AtomicU64,
     /// Scope D: enqueue-only sender for off-hot-loop 2-hop detection.
@@ -5410,127 +5444,195 @@ impl ArbContext {
         });
     }
 
-    fn collect_arb_track_baseline_active(&self) -> Vec<ArbTrackActiveEntry> {
+    fn build_track_selection_input(&self) -> (Vec<TrackMintInput>, TrackSelectionConfig) {
         let trackers = self.trackers.read();
-        let max_pools = self.config.read().arb_track_baseline_max_pools;
-        let mut seen = HashSet::new();
-        let mut out = Vec::new();
-        for tracker in trackers.values() {
+        let known_pools = self.known_pools.read();
+        let vault_balances = self.vault_balances.read();
+        let bin_arrays = self.bin_arrays.read();
+        let config = self.config.read();
+        let trade_signals = self.arb_trade_signal_pools.read();
+
+        let selection_config = TrackSelectionConfig {
+            max_pools: config.arb_track_baseline_max_pools,
+            max_pools_per_mint: 3,
+            probe_lamports: config.arb_probe_lamports,
+            freshness: QuoteFreshnessConfig {
+                trade_ttl_ms: config.arb_quote_trade_ttl_ms,
+                state_ttl_ms: config.arb_quote_state_ttl_ms,
+            },
+        };
+
+        let mut mints = Vec::new();
+        for (mint, tracker) in trackers.iter() {
             if tracker.pool_count_on_distinct_dexes() < 2 {
                 continue;
             }
-            for pool in tracker.pools.keys() {
-                if seen.len() >= max_pools {
-                    return out;
-                }
-                if seen.insert(pool.clone()) {
-                    out.push(ArbTrackActiveEntry {
-                        pool: pool.clone(),
-                        reason: ArbTrackActiveReason::Baseline,
-                    });
-                }
-            }
+            let Some(token_decimals) = tracker.token_decimals else {
+                continue;
+            };
+            let pools: Vec<TrackPoolInput> = tracker
+                .pools
+                .values()
+                .map(|pool| TrackPoolInput {
+                    pool_address: pool.pool_address.clone(),
+                    dex: pool.dex.clone(),
+                    known: known_pools.contains(&pool.pool_address),
+                    quote_pool: pool_state_to_quote_input(pool, mint, token_decimals),
+                    vault: vault_balances
+                        .get(&pool.pool_address)
+                        .map(vault_cache_to_quote_input),
+                    dlmm_bins: bin_arrays
+                        .get(&pool.pool_address)
+                        .map(flatten_bin_array_cache),
+                    token_decimals,
+                })
+                .collect();
+            let trade_signal_pools = trade_signal_pair_for_mint(tracker, &trade_signals);
+            mints.push(TrackMintInput {
+                mint: mint.clone(),
+                pools,
+                trade_signal_pools,
+            });
         }
-        out
+
+        (mints, selection_config)
+    }
+
+    fn pool_still_tracker_valid(&self, pool: &str) -> bool {
+        let trackers = self.trackers.read();
+        trackers.values().any(|tracker| {
+            tracker.pool_count_on_distinct_dexes() >= 2 && tracker.pools.contains_key(pool)
+        })
+    }
+
+    fn recompute_arb_track_selection(self: &Arc<Self>, reconcile: bool) {
+        if self.nats.is_none() {
+            return;
+        }
+
+        let (mints, selection_config) = self.build_track_selection_input();
+        let result = select_arb_track_pools(&mints, &selection_config);
+        set_arb_track_selection_metrics(
+            result.selected.len(),
+            result.selected_mints,
+            &result.candidate_counts,
+        );
+
+        let budget_displaced: HashSet<String> = result.budget_displaced.into_iter().collect();
+        let new_pools: HashSet<String> = result.selected.iter().map(|p| p.pool.clone()).collect();
+        let old_pools = self.arb_pinned_pools.read().clone();
+
+        if !reconcile && old_pools == new_pools {
+            record_arb_track_publish_skipped_unchanged_total();
+            return;
+        }
+
+        let active = if reconcile {
+            result
+                .selected
+                .iter()
+                .map(|p| ArbTrackActiveEntry {
+                    pool: p.pool.clone(),
+                    reason: if p.active_reason == ArbTrackActiveReason::TradeSignal {
+                        ArbTrackActiveReason::TradeSignal
+                    } else {
+                        ArbTrackActiveReason::Baseline
+                    },
+                })
+                .collect()
+        } else {
+            result
+                .selected
+                .iter()
+                .filter(|p| !old_pools.contains(&p.pool))
+                .map(|p| ArbTrackActiveEntry {
+                    pool: p.pool.clone(),
+                    reason: p.active_reason,
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let removed = if reconcile {
+            Vec::new()
+        } else {
+            old_pools
+                .iter()
+                .filter(|pool| !new_pools.contains(*pool))
+                .map(|pool| {
+                    let reason = arb_track_removal_reason(
+                        pool,
+                        self.pool_still_tracker_valid(pool),
+                        &budget_displaced,
+                    );
+                    record_arb_track_removed_total(reason);
+                    ArbTrackRemovedEntry {
+                        pool: pool.clone(),
+                        reason,
+                    }
+                })
+                .collect()
+        };
+
+        {
+            let mut pinned = self.arb_pinned_pools.write();
+            *pinned = new_pools;
+        }
+
+        if reconcile {
+            self.spawn_publish_arb_track_requests(active, Vec::new(), true);
+        } else if active.is_empty() && removed.is_empty() {
+            record_arb_track_publish_skipped_unchanged_total();
+        } else {
+            if !active.is_empty() {
+                record_arb_proactive_track_publish_total();
+            }
+            self.spawn_publish_arb_track_requests(active, removed, false);
+        }
+    }
+
+    fn schedule_arb_track_recompute(self: &Arc<Self>) {
+        if self
+            .arb_track_recompute_scheduled
+            .swap(true, Ordering::AcqRel)
+        {
+            return;
+        }
+        let ctx = Arc::clone(self);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(ARB_TRACK_RECOMPUTE_COALESCE_MS)).await;
+            ctx.arb_track_recompute_scheduled
+                .store(false, Ordering::Release);
+            ctx.recompute_arb_track_selection(false);
+        });
     }
 
     fn reconcile_arb_track_baseline_publish(self: &Arc<Self>) {
-        if self.nats.is_none() {
-            return;
-        }
-        let active = self.collect_arb_track_baseline_active();
-        {
-            let mut pinned = self.arb_pinned_pools.write();
-            pinned.clear();
-            for a in &active {
-                pinned.insert(a.pool.clone());
-            }
-        }
-        self.spawn_publish_arb_track_requests(active, Vec::new(), true);
+        self.recompute_arb_track_selection(true);
     }
 
-    /// I-ARB-10: publish all tracker pools when mint is multi-DEX (proactive coverage).
-    fn publish_proactive_arb_track_for_mint(self: &Arc<Self>, mint: &str) {
-        if self.nats.is_none() {
-            return;
-        }
-        let trackers = self.trackers.read();
-        let Some(tracker) = trackers.get(mint) else {
-            return;
-        };
-        if tracker.pool_count_on_distinct_dexes() < 2 {
-            return;
-        }
-        let active: Vec<ArbTrackActiveEntry> = tracker
-            .pools
-            .keys()
-            .map(|pool| ArbTrackActiveEntry {
-                pool: pool.clone(),
-                reason: ArbTrackActiveReason::MultiDex,
-            })
-            .collect();
-        drop(trackers);
-        if active.is_empty() {
-            return;
-        }
-        {
-            let mut pinned = self.arb_pinned_pools.write();
-            for entry in &active {
-                pinned.insert(entry.pool.clone());
-            }
-        }
-        record_arb_proactive_track_publish_total();
-        record_arb_proactive_pin_first_publish(mint);
-        self.spawn_publish_arb_track_requests(active, Vec::new(), false);
+    fn publish_proactive_arb_track_for_mint(self: &Arc<Self>, _mint: &str) {
+        self.schedule_arb_track_recompute();
     }
 
     fn publish_arb_trade_signal_track_pins(self: &Arc<Self>, buy_pool: &str, sell_pool: &str) {
-        if self.nats.is_none() {
-            return;
-        }
-        let mut active = Vec::new();
-        let mut pinned = self.arb_pinned_pools.write();
-        for pool in [buy_pool, sell_pool] {
-            if pinned.insert(pool.to_string()) {
-                active.push(ArbTrackActiveEntry {
-                    pool: pool.to_string(),
-                    reason: ArbTrackActiveReason::TradeSignal,
-                });
+        {
+            let mut signals = self.arb_trade_signal_pools.write();
+            signals.insert(buy_pool.to_string());
+            signals.insert(sell_pool.to_string());
+            if signals.len() > ARB_TRADE_SIGNAL_POOLS_CAP {
+                let mut keys: Vec<_> = signals.iter().cloned().collect();
+                keys.sort();
+                let drain = signals.len() - ARB_TRADE_SIGNAL_POOLS_CAP;
+                for key in keys.into_iter().take(drain) {
+                    signals.remove(&key);
+                }
             }
         }
-        drop(pinned);
-        if !active.is_empty() {
-            self.spawn_publish_arb_track_requests(active, Vec::new(), false);
-        }
+        self.schedule_arb_track_recompute();
     }
 
     fn prune_arb_track_stale_pools(self: &Arc<Self>) {
-        if self.nats.is_none() {
-            return;
-        }
-        let trackers = self.trackers.read();
-        let mut still_active: HashSet<String> = HashSet::new();
-        for tracker in trackers.values() {
-            if tracker.pool_count_on_distinct_dexes() >= 2 {
-                still_active.extend(tracker.pools.keys().cloned());
-            }
-        }
-        drop(trackers);
-        let mut removed = Vec::new();
-        let mut pinned = self.arb_pinned_pools.write();
-        for pool in pinned.clone().into_iter() {
-            if !still_active.contains(&pool) {
-                pinned.remove(&pool);
-                removed.push(ArbTrackRemovedEntry {
-                    pool,
-                    reason: ArbTrackRemovedReason::Stale,
-                });
-            }
-        }
-        drop(pinned);
-        if !removed.is_empty() {
-            self.spawn_publish_arb_track_requests(Vec::new(), removed, false);
-        }
+        self.schedule_arb_track_recompute();
     }
 }
 
@@ -6253,6 +6355,8 @@ async fn main() -> Result<()> {
         eligibility_forensics: ArbEligibilityForensics::new(),
         v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
         arb_pinned_pools: RwLock::new(HashSet::new()),
+        arb_trade_signal_pools: RwLock::new(HashSet::new()),
+        arb_track_recompute_scheduled: AtomicBool::new(false),
         arb_track_published: AtomicU64::new(0),
         two_hop_tx,
         tracker_write,
@@ -7314,6 +7418,8 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
+            arb_trade_signal_pools: RwLock::new(HashSet::new()),
+            arb_track_recompute_scheduled: AtomicBool::new(false),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -7421,6 +7527,8 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
+            arb_trade_signal_pools: RwLock::new(HashSet::new()),
+            arb_track_recompute_scheduled: AtomicBool::new(false),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -7526,6 +7634,8 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
+            arb_trade_signal_pools: RwLock::new(HashSet::new()),
+            arb_track_recompute_scheduled: AtomicBool::new(false),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -7741,6 +7851,8 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
+            arb_trade_signal_pools: RwLock::new(HashSet::new()),
+            arb_track_recompute_scheduled: AtomicBool::new(false),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -7844,6 +7956,8 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
+            arb_trade_signal_pools: RwLock::new(HashSet::new()),
+            arb_track_recompute_scheduled: AtomicBool::new(false),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -7951,6 +8065,8 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
+            arb_trade_signal_pools: RwLock::new(HashSet::new()),
+            arb_track_recompute_scheduled: AtomicBool::new(false),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -8029,6 +8145,8 @@ mod event_pipeline_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
+            arb_trade_signal_pools: RwLock::new(HashSet::new()),
+            arb_track_recompute_scheduled: AtomicBool::new(false),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx,
             tracker_write,
@@ -8168,6 +8286,8 @@ mod two_hop_price_tests {
             eligibility_forensics: ArbEligibilityForensics::new(),
             v2_eligibility_forensics: ArbV2EligibilityForensics::new(),
             arb_pinned_pools: RwLock::new(HashSet::new()),
+            arb_trade_signal_pools: RwLock::new(HashSet::new()),
+            arb_track_recompute_scheduled: AtomicBool::new(false),
             arb_track_published: AtomicU64::new(0),
             two_hop_tx: {
                 let (tx, _rx) = mpsc::channel(1);
@@ -10002,6 +10122,83 @@ mod two_hop_price_tests {
             ironcrab::metrics::ARB_TWO_HOP_V2_SCREEN_MULTI_DEX_TOTAL.load(Ordering::Relaxed)
                 > before_multi
         );
+    }
+
+    #[test]
+    fn arb_track_reconcile_and_proactive_use_same_selection() {
+        let mint = TrackMintInput {
+            mint: "MintShared111111111111111111111111111".to_string(),
+            pools: vec![
+                TrackPoolInput {
+                    pool_address: "orca_pool".to_string(),
+                    dex: "orca".to_string(),
+                    known: true,
+                    quote_pool: QuotePoolInput {
+                        pool_address: "orca_pool".to_string(),
+                        dex: "orca".to_string(),
+                        token_mint: "MintShared111111111111111111111111111".to_string(),
+                        trade_price_buy: None,
+                        trade_price_sell: None,
+                        trade_updated_at: Instant::now(),
+                        has_reserve_data: true,
+                        token_decimals: 6,
+                    },
+                    vault: Some(QuoteVaultInput {
+                        reserve_base: 1_000_000_000_000,
+                        reserve_quote: 1_000_000_000,
+                        update_slot: 1,
+                        updated_at: Instant::now(),
+                        active_id: None,
+                        bin_step: None,
+                        dlmm_sol_is_x: false,
+                        dlmm_token_x_mint: None,
+                    }),
+                    dlmm_bins: None,
+                    token_decimals: 6,
+                },
+                TrackPoolInput {
+                    pool_address: "pump_pool".to_string(),
+                    dex: "pump_amm".to_string(),
+                    known: true,
+                    quote_pool: QuotePoolInput {
+                        pool_address: "pump_pool".to_string(),
+                        dex: "pump_amm".to_string(),
+                        token_mint: "MintShared111111111111111111111111111".to_string(),
+                        trade_price_buy: None,
+                        trade_price_sell: None,
+                        trade_updated_at: Instant::now(),
+                        has_reserve_data: true,
+                        token_decimals: 6,
+                    },
+                    vault: Some(QuoteVaultInput {
+                        reserve_base: 1_000_000_000_000,
+                        reserve_quote: 2_000_000_000,
+                        update_slot: 1,
+                        updated_at: Instant::now(),
+                        active_id: None,
+                        bin_step: None,
+                        dlmm_sol_is_x: false,
+                        dlmm_token_x_mint: None,
+                    }),
+                    dlmm_bins: None,
+                    token_decimals: 6,
+                },
+            ],
+            trade_signal_pools: None,
+        };
+        let config = TrackSelectionConfig {
+            max_pools: 500,
+            max_pools_per_mint: 3,
+            probe_lamports: 10_000_000,
+            freshness: QuoteFreshnessConfig::default(),
+        };
+        let proactive = select_arb_track_pools(std::slice::from_ref(&mint), &config);
+        let reconcile = select_arb_track_pools(std::slice::from_ref(&mint), &config);
+        let proactive_pools: HashSet<_> =
+            proactive.selected.iter().map(|p| p.pool.clone()).collect();
+        let reconcile_pools: HashSet<_> =
+            reconcile.selected.iter().map(|p| p.pool.clone()).collect();
+        assert_eq!(proactive_pools, reconcile_pools);
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -571,6 +571,19 @@ fn compute_snapshot_admit_set(
             }
         }
     }
+    let ranked_set: HashSet<&str> = ranked_mints.iter().map(String::as_str).collect();
+    let mut extra_protected: Vec<String> = protected
+        .iter()
+        .filter(|mint| !ranked_set.contains(mint.as_str()))
+        .cloned()
+        .collect();
+    extra_protected.sort();
+    for mint in extra_protected {
+        admit.insert(mint);
+        if admit.len() >= cap {
+            return admit;
+        }
+    }
     for mint in ranked_mints {
         if admit.len() >= cap {
             break;
@@ -5188,8 +5201,8 @@ impl ArbContext {
         let write_wait = Instant::now();
         let mut trackers = self.trackers.write();
         record_arb_writer_lock_wait(ArbWriterLockKind::TrackersWrite, write_wait.elapsed());
-        for mint in mints_with_pool {
-            let Some(tracker) = trackers.get_mut(&mint) else {
+        for mint in &mints_with_pool {
+            let Some(tracker) = trackers.get_mut(mint) else {
                 continue;
             };
             let Some(pool) = tracker.pools.get_mut(pool_address) else {
@@ -5212,6 +5225,10 @@ impl ArbContext {
                     }
                 }
             }
+        }
+        drop(trackers);
+        for mint in &mints_with_pool {
+            self.arb_track_selection.mark_dirty(mint);
         }
     }
 
@@ -5265,8 +5282,8 @@ impl ArbContext {
             let write_wait = Instant::now();
             let mut trackers = self.trackers.write();
             record_arb_writer_lock_wait(ArbWriterLockKind::TrackersWrite, write_wait.elapsed());
-            for mint in mints_with_pool {
-                let Some(tracker) = trackers.get_mut(&mint) else {
+            for mint in &mints_with_pool {
+                let Some(tracker) = trackers.get_mut(mint) else {
                     continue;
                 };
                 let Some(pool) = tracker.pools.get_mut(pool_address) else {
@@ -5275,6 +5292,10 @@ impl ArbContext {
                 if pool.dex == "meteora_dlmm" {
                     pool.last_update = now;
                 }
+            }
+            drop(trackers);
+            for mint in &mints_with_pool {
+                self.arb_track_selection.mark_dirty(mint);
             }
         }
 

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -102,8 +102,8 @@ use ironcrab::metrics::{
 use ironcrab::nats::{
     arb_strategy_pool_cache_live_consumer_config, arb_track_payload_bytes, config_consumer_config,
     config_subject, split_arb_track_requests_update, trim_reconcile_update_to_budget,
-    ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackRemovedEntry, ArbTrackRequestsUpdate,
-    ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES, CONFIG_STREAM_NAME, STREAM_NAME,
+    ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackRemovedEntry, ArbTrackRemovedReason,
+    ArbTrackRequestsUpdate, ARB_TRACK_PUBLISH_MAX_PAYLOAD_BYTES, CONFIG_STREAM_NAME, STREAM_NAME,
 };
 use ironcrab::nats::{NatsClient, NatsConfig};
 use ironcrab::nats::{TOPIC_ARB_TRACK_REQUESTS, TOPIC_MARKET_EVENTS, TOPIC_TRADE_INTENTS};
@@ -565,6 +565,7 @@ impl ArbTrackSelectionHandle {
         }
         if self.wake_tx.try_send(()).is_err() {
             record_arb_track_selection_queue_overflow_total();
+            self.pending_full_reconcile.store(true, Ordering::Release);
         }
     }
 
@@ -6218,7 +6219,32 @@ impl ArbContext {
     }
 
     fn prune_arb_track_stale_pools(self: &Arc<Self>) {
-        self.arb_track_selection.request_full_reconcile();
+        if self.nats.is_none() {
+            return;
+        }
+        let trackers = self.trackers.read();
+        let mut still_active: HashSet<String> = HashSet::new();
+        for tracker in trackers.values() {
+            if tracker.pool_count_on_distinct_dexes() >= 2 {
+                still_active.extend(tracker.pools.keys().cloned());
+            }
+        }
+        drop(trackers);
+        let mut removed = Vec::new();
+        let mut pinned = self.arb_pinned_pools.write();
+        for pool in pinned.clone().into_iter() {
+            if !still_active.contains(&pool) {
+                pinned.remove(&pool);
+                removed.push(ArbTrackRemovedEntry {
+                    pool,
+                    reason: ArbTrackRemovedReason::Stale,
+                });
+            }
+        }
+        drop(pinned);
+        if !removed.is_empty() {
+            self.spawn_publish_arb_track_requests(Vec::new(), removed, false);
+        }
     }
 }
 

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -133,12 +133,16 @@ const ARB_TRACK_SELECTION_COALESCE_MS: u64 = 50;
 const ARB_TRACK_INCREMENTAL_MIN_INTERVAL_MS: u64 = 1_000;
 /// Max dirty mints queued between incremental selects.
 const ARB_TRACK_SELECTION_DIRTY_MINTS_CAP: usize = 4_096;
+/// Hot-path ingress dedup set cap (one slot per unique mint, not per Geyser update).
+const ARB_TRACK_SELECTION_INGRESS_DIRTY_CAP: usize = ARB_TRACK_SELECTION_DIRTY_MINTS_CAP;
+/// Single wake token queue: coalesces unlimited hot-path marks into one worker wakeup.
+const ARB_TRACK_SELECTION_WAKE_QUEUE_CAP: usize = 1;
+/// Minimum interval between global full-reconcile scans (prevents 50ms scan storms).
+const ARB_TRACK_FULL_RECONCILE_MIN_INTERVAL_MS: u64 = 5_000;
 /// Max mint snapshots retained for selection (bounded publish/readiness state).
 const ARB_TRACK_MINT_SNAPSHOTS_CAP: usize = 2_048;
 /// Max dirty mints processed per incremental batch; overflow schedules full reconcile.
 const ARB_TRACK_INCREMENTAL_MINTS_MAX: usize = 64;
-/// Selection worker job queue depth.
-const ARB_TRACK_SELECTION_QUEUE_CAP: usize = 4_096;
 
 /// Bounded queue for off-hot-loop 2-hop trade detection (Scope D).
 const ARB_TWO_HOP_WORKER_QUEUE_CAP: usize = 4096;
@@ -499,58 +503,123 @@ struct ArbTradeSignalPair {
     seen_at_unix_ms: u64,
 }
 
-enum ArbTrackSelectionJob {
-    MarkDirty { mint: String },
-    FullReconcile,
+#[derive(Debug, Default)]
+struct ArbTrackSelectionIngress {
+    dirty_mints: parking_lot::Mutex<HashSet<String>>,
+    dirty_overflow: AtomicBool,
+    wake_pending: AtomicBool,
 }
 
 struct ArbTrackSelectionHandle {
-    tx: mpsc::Sender<ArbTrackSelectionJob>,
+    ingress: ArbTrackSelectionIngress,
+    wake_tx: mpsc::Sender<()>,
     pending_full_reconcile: Arc<AtomicBool>,
 }
 
 impl ArbTrackSelectionHandle {
+    /// Hot path: bounded dedup ingress. Never allocates a queue slot per Geyser update.
     fn mark_dirty(&self, mint: &str) {
-        if self
-            .tx
-            .try_send(ArbTrackSelectionJob::MarkDirty {
-                mint: mint.to_string(),
-            })
-            .is_err()
-        {
-            record_arb_track_selection_queue_overflow_total();
-            self.pending_full_reconcile.store(true, Ordering::Release);
+        let schedule_wake = {
+            let mut dirty = self.ingress.dirty_mints.lock();
+            if dirty.contains(mint) {
+                return;
+            }
+            if dirty.len() >= ARB_TRACK_SELECTION_INGRESS_DIRTY_CAP {
+                self.ingress.dirty_overflow.store(true, Ordering::Release);
+                self.pending_full_reconcile.store(true, Ordering::Release);
+                true
+            } else {
+                dirty.insert(mint.to_string());
+                true
+            }
+        };
+        if schedule_wake {
+            self.schedule_worker_wake();
         }
     }
 
     fn request_full_reconcile(&self) {
         self.pending_full_reconcile.store(true, Ordering::Release);
-        if self
-            .tx
-            .try_send(ArbTrackSelectionJob::FullReconcile)
-            .is_err()
-        {
-            record_arb_track_selection_queue_overflow_total();
-        }
+        self.schedule_worker_wake();
     }
 
     fn record_blocking_join_failed(&self) {
         record_arb_track_selection_blocking_join_failed_total();
         self.pending_full_reconcile.store(true, Ordering::Release);
+        self.schedule_worker_wake();
     }
 
     fn take_pending_full(&self) -> bool {
         self.pending_full_reconcile.swap(false, Ordering::AcqRel)
     }
+
+    /// At most one wake token in flight; additional marks coalesce in the ingress set.
+    fn schedule_worker_wake(&self) {
+        if self
+            .ingress
+            .wake_pending
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        if self.wake_tx.try_send(()).is_err() {
+            record_arb_track_selection_queue_overflow_total();
+        }
+    }
+
+    fn clear_wake_pending(&self) {
+        self.ingress.wake_pending.store(false, Ordering::Release);
+    }
+
+    fn drain_ingress_dirty(&self) -> (Vec<String>, bool) {
+        let mut dirty = self.ingress.dirty_mints.lock();
+        let overflow = self.ingress.dirty_overflow.swap(false, Ordering::AcqRel);
+        let mints: Vec<String> = dirty.drain().collect();
+        (mints, overflow)
+    }
+
+    fn drain_ingress_to_coalescer(&self, coalescer: &mut ArbTrackSelectionCoalescer) {
+        let (mints, overflow) = self.drain_ingress_dirty();
+        for mint in mints {
+            coalescer.ingest_dirty(mint);
+        }
+        if overflow {
+            coalescer.note_dirty_overflow();
+        }
+    }
+
+    fn ingress_has_work(&self) -> bool {
+        !self.ingress.dirty_mints.lock().is_empty()
+            || self.ingress.dirty_overflow.load(Ordering::Acquire)
+            || self.pending_full_reconcile.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    fn ingress_dirty_len(&self) -> usize {
+        self.ingress.dirty_mints.lock().len()
+    }
 }
 
 #[cfg(test)]
 fn dummy_arb_track_selection_handle() -> ArbTrackSelectionHandle {
-    let (tx, _rx) = mpsc::channel::<ArbTrackSelectionJob>(1);
+    let (wake_tx, _wake_rx) = mpsc::channel::<()>(ARB_TRACK_SELECTION_WAKE_QUEUE_CAP);
     ArbTrackSelectionHandle {
-        tx,
+        ingress: ArbTrackSelectionIngress::default(),
+        wake_tx,
         pending_full_reconcile: Arc::new(AtomicBool::new(false)),
     }
+}
+
+#[cfg(test)]
+fn test_arb_track_selection_handle() -> (ArbTrackSelectionHandle, mpsc::Receiver<()>) {
+    let (wake_tx, wake_rx) = mpsc::channel::<()>(ARB_TRACK_SELECTION_WAKE_QUEUE_CAP);
+    let handle = ArbTrackSelectionHandle {
+        ingress: ArbTrackSelectionIngress::default(),
+        wake_tx,
+        pending_full_reconcile: Arc::new(AtomicBool::new(false)),
+    };
+    (handle, wake_rx)
 }
 
 /// Deterministic top-K mint admission for bounded snapshot cache (unit-tested).
@@ -761,24 +830,24 @@ impl ArbTrackSelectionCoalescer {
     /// Lock-free bounded state: `dirty_mints` never exceeds
     /// `ARB_TRACK_SELECTION_DIRTY_MINTS_CAP`. Overflow mints are not retained; full
     /// reconcile scans current tracker truth and will include eligible mints.
-    fn ingest(&mut self, job: ArbTrackSelectionJob) -> bool {
-        match job {
-            ArbTrackSelectionJob::MarkDirty { mint } => {
-                if self.dirty_mints.contains(&mint) {
-                    return false;
-                }
-                if self.dirty_mints.len() >= ARB_TRACK_SELECTION_DIRTY_MINTS_CAP {
-                    self.dirty_overflow = true;
-                    return true;
-                }
-                self.dirty_mints.insert(mint);
-                false
-            }
-            ArbTrackSelectionJob::FullReconcile => {
-                self.pending_full = true;
-                false
-            }
+    fn ingest_dirty(&mut self, mint: String) -> bool {
+        if self.dirty_mints.contains(&mint) {
+            return false;
         }
+        if self.dirty_mints.len() >= ARB_TRACK_SELECTION_DIRTY_MINTS_CAP {
+            self.dirty_overflow = true;
+            return true;
+        }
+        self.dirty_mints.insert(mint);
+        false
+    }
+
+    fn note_full_reconcile(&mut self) {
+        self.pending_full = true;
+    }
+
+    fn note_dirty_overflow(&mut self) {
+        self.dirty_overflow = true;
     }
 
     fn take_batch(&mut self) -> (Vec<String>, bool, bool) {
@@ -848,13 +917,23 @@ fn rank_coarse_rank_snapshot(snapshot: &mut [MintCoarseRankSnapshot]) -> Vec<Str
     snapshot.iter().map(|row| row.mint.clone()).collect()
 }
 
-/// Deterministic full-admit refresh order: ranked traversal, HashSet membership only.
+/// Deterministic full-admit refresh order: ranked admitted mints first, then
+/// admitted-but-unranked mints in stable sorted order (HashSet membership only).
 fn admit_refresh_order(ranked: &[String], admit: &HashSet<String>) -> Vec<String> {
-    ranked
+    let ranked_set: HashSet<&str> = ranked.iter().map(String::as_str).collect();
+    let mut order: Vec<String> = ranked
         .iter()
         .filter(|mint| admit.contains(*mint))
         .cloned()
-        .collect()
+        .collect();
+    let mut unranked_admitted: Vec<String> = admit
+        .iter()
+        .filter(|mint| !ranked_set.contains(mint.as_str()))
+        .cloned()
+        .collect();
+    unranked_admitted.sort();
+    order.extend(unranked_admitted);
+    order
 }
 
 fn tracker_mint_activity_unix_ms(
@@ -6652,35 +6731,37 @@ fn run_arb_track_selection_batch(
     record_arb_track_selection_recompute_total();
 }
 
-fn spawn_arb_track_selection_worker(
-    ctx: Arc<ArbContext>,
-    mut rx: mpsc::Receiver<ArbTrackSelectionJob>,
-) {
+fn spawn_arb_track_selection_worker(ctx: Arc<ArbContext>, mut wake_rx: mpsc::Receiver<()>) {
     tokio::spawn(async move {
         let mut coalescer = ArbTrackSelectionCoalescer::default();
         let mut last_incremental = Instant::now() - Duration::from_secs(3600);
+        let mut last_full_reconcile = Instant::now() - Duration::from_secs(3600);
+        let full_reconcile_min = Duration::from_millis(ARB_TRACK_FULL_RECONCILE_MIN_INTERVAL_MS);
 
-        while let Some(first) = rx.recv().await {
-            if coalescer.ingest(first) {
-                ctx.arb_track_selection
-                    .pending_full_reconcile
-                    .store(true, Ordering::Release);
+        while wake_rx.recv().await.is_some() {
+            ctx.arb_track_selection.clear_wake_pending();
+            ctx.arb_track_selection
+                .drain_ingress_to_coalescer(&mut coalescer);
+            if ctx.arb_track_selection.take_pending_full() {
+                coalescer.note_full_reconcile();
             }
+
             let coalesce_deadline =
                 Instant::now() + Duration::from_millis(ARB_TRACK_SELECTION_COALESCE_MS);
             while Instant::now() < coalesce_deadline {
-                match rx.try_recv() {
-                    Ok(job) => {
-                        if coalescer.ingest(job) {
-                            ctx.arb_track_selection
-                                .pending_full_reconcile
-                                .store(true, Ordering::Release);
-                        }
+                match wake_rx.try_recv() {
+                    Ok(()) => {
+                        ctx.arb_track_selection.clear_wake_pending();
                     }
                     Err(mpsc::error::TryRecvError::Empty) => {
                         tokio::time::sleep(Duration::from_millis(5)).await;
                     }
-                    Err(mpsc::error::TryRecvError::Disconnected) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => return,
+                }
+                ctx.arb_track_selection
+                    .drain_ingress_to_coalescer(&mut coalescer);
+                if ctx.arb_track_selection.take_pending_full() {
+                    coalescer.note_full_reconcile();
                 }
             }
 
@@ -6694,7 +6775,26 @@ fn spawn_arb_track_selection_worker(
             if ctx.arb_track_selection.take_pending_full() {
                 full_reconcile = true;
             }
+
+            if full_reconcile && last_full_reconcile.elapsed() < full_reconcile_min {
+                ctx.arb_track_selection
+                    .pending_full_reconcile
+                    .store(true, Ordering::Release);
+                full_reconcile = false;
+            }
+
             if dirty_mints.is_empty() && !full_reconcile {
+                if ctx
+                    .arb_track_selection
+                    .pending_full_reconcile
+                    .load(Ordering::Acquire)
+                {
+                    let sleep = full_reconcile_min.saturating_sub(last_full_reconcile.elapsed());
+                    if sleep > Duration::ZERO {
+                        tokio::time::sleep(sleep).await;
+                    }
+                    ctx.arb_track_selection.schedule_worker_wake();
+                }
                 continue;
             }
 
@@ -6704,6 +6804,8 @@ fn spawn_arb_track_selection_worker(
                 if elapsed < min_interval {
                     tokio::time::sleep(min_interval - elapsed).await;
                 }
+            } else {
+                last_full_reconcile = Instant::now();
             }
 
             let ctx_blocking = Arc::clone(&ctx);
@@ -6716,6 +6818,10 @@ fn spawn_arb_track_selection_worker(
                 ctx.arb_track_selection.record_blocking_join_failed();
             }
             last_incremental = Instant::now();
+
+            if ctx.arb_track_selection.ingress_has_work() {
+                ctx.arb_track_selection.schedule_worker_wake();
+            }
         }
         info!("arb-strategy track selection worker stopped");
     });
@@ -6954,10 +7060,11 @@ async fn main() -> Result<()> {
         tx: tracker_write_tx,
         capacity: ARB_TRACKER_WRITE_QUEUE_CAP,
     };
-    let (arb_track_selection_tx, arb_track_selection_rx) =
-        mpsc::channel::<ArbTrackSelectionJob>(ARB_TRACK_SELECTION_QUEUE_CAP);
+    let (arb_track_selection_wake_tx, arb_track_selection_wake_rx) =
+        mpsc::channel::<()>(ARB_TRACK_SELECTION_WAKE_QUEUE_CAP);
     let arb_track_selection = ArbTrackSelectionHandle {
-        tx: arb_track_selection_tx,
+        ingress: ArbTrackSelectionIngress::default(),
+        wake_tx: arb_track_selection_wake_tx,
         pending_full_reconcile: Arc::new(AtomicBool::new(false)),
     };
 
@@ -6995,7 +7102,7 @@ async fn main() -> Result<()> {
     });
 
     spawn_arb_tracker_write_worker(Arc::clone(&ctx), tracker_write_rx);
-    spawn_arb_track_selection_worker(Arc::clone(&ctx), arb_track_selection_rx);
+    spawn_arb_track_selection_worker(Arc::clone(&ctx), arb_track_selection_wake_rx);
     spawn_arb_two_hop_worker(Arc::clone(&ctx), two_hop_rx);
 
     // Bootstrap SLAVE LivePoolCache from JetStream (same path as execution-engine).
@@ -10856,9 +10963,7 @@ mod two_hop_price_tests {
     fn arb_track_selection_coalescer_bounds_burst_to_one_batch() {
         let mut coalescer = ArbTrackSelectionCoalescer::default();
         for i in 0..100 {
-            coalescer.ingest(ArbTrackSelectionJob::MarkDirty {
-                mint: format!("mint_{i}"),
-            });
+            coalescer.ingest_dirty(format!("mint_{i}"));
         }
         let (dirty, full, overflow) = coalescer.take_batch();
         assert!(!full);
@@ -10874,13 +10979,9 @@ mod two_hop_price_tests {
     fn arb_track_selection_coalescer_dirty_overflow_requests_full_reconcile() {
         let mut coalescer = ArbTrackSelectionCoalescer::default();
         for i in 0..ARB_TRACK_SELECTION_DIRTY_MINTS_CAP {
-            assert!(!coalescer.ingest(ArbTrackSelectionJob::MarkDirty {
-                mint: format!("mint_{i}"),
-            }));
+            assert!(!coalescer.ingest_dirty(format!("mint_{i}")));
         }
-        assert!(coalescer.ingest(ArbTrackSelectionJob::MarkDirty {
-            mint: "overflow_mint".to_string(),
-        }));
+        assert!(coalescer.ingest_dirty("overflow_mint".to_string()));
         let (dirty, full, overflow) = coalescer.take_batch();
         assert!(!full);
         assert!(
@@ -10900,9 +11001,7 @@ mod two_hop_price_tests {
         let cap = ARB_TRACK_SELECTION_DIRTY_MINTS_CAP;
         let mut overflow_seen = false;
         for i in 0..cap + 5_000 {
-            if coalescer.ingest(ArbTrackSelectionJob::MarkDirty {
-                mint: format!("burst_{i}"),
-            }) {
+            if coalescer.ingest_dirty(format!("burst_{i}")) {
                 overflow_seen = true;
             }
         }
@@ -10917,32 +11016,46 @@ mod two_hop_price_tests {
         let mut coalescer = ArbTrackSelectionCoalescer::default();
         let cap = ARB_TRACK_SELECTION_DIRTY_MINTS_CAP;
         for i in 0..cap {
-            assert!(!coalescer.ingest(ArbTrackSelectionJob::MarkDirty {
-                mint: format!("mint_{i}"),
-            }));
+            assert!(!coalescer.ingest_dirty(format!("mint_{i}")));
         }
-        assert!(!coalescer.ingest(ArbTrackSelectionJob::MarkDirty {
-            mint: "mint_0".to_string(),
-        }));
+        assert!(!coalescer.ingest_dirty("mint_0".to_string()));
         let (dirty, _, overflow) = coalescer.take_batch();
         assert!(!overflow);
         assert_eq!(dirty.len(), cap);
     }
 
     #[test]
-    fn arb_track_selection_queue_overflow_sets_pending_full_reconcile() {
-        let (tx, _rx) = mpsc::channel::<ArbTrackSelectionJob>(1);
-        tx.try_send(ArbTrackSelectionJob::FullReconcile).unwrap();
-        let pending = Arc::new(AtomicBool::new(false));
-        let handle = ArbTrackSelectionHandle {
-            tx,
-            pending_full_reconcile: Arc::clone(&pending),
-        };
-        handle.mark_dirty("mint_overflow");
-        assert!(pending.load(Ordering::Acquire));
-        pending.store(false, Ordering::Release);
+    fn arb_track_selection_ingress_deduplicates_burst() {
+        let (handle, mut wake_rx) = test_arb_track_selection_handle();
+        for _ in 0..1_000 {
+            handle.mark_dirty("mint_a");
+        }
+        assert_eq!(handle.ingress_dirty_len(), 1);
+        assert_eq!(wake_rx.try_recv().unwrap(), ());
+        assert!(wake_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn arb_track_selection_ingress_hard_cap_sets_overflow() {
+        let (handle, _wake_rx) = test_arb_track_selection_handle();
+        let cap = ARB_TRACK_SELECTION_INGRESS_DIRTY_CAP;
+        for i in 0..cap {
+            handle.mark_dirty(&format!("mint_{i}"));
+        }
+        assert_eq!(handle.ingress_dirty_len(), cap);
+        handle.mark_dirty("overflow_mint");
+        assert_eq!(handle.ingress_dirty_len(), cap);
+        assert!(handle.pending_full_reconcile.load(Ordering::Acquire));
+        let (_, overflow) = handle.drain_ingress_dirty();
+        assert!(overflow);
+    }
+
+    #[test]
+    fn arb_track_selection_request_full_reconcile_sets_pending() {
+        let (handle, mut wake_rx) = test_arb_track_selection_handle();
         handle.request_full_reconcile();
-        assert!(pending.load(Ordering::Acquire));
+        assert!(handle.pending_full_reconcile.load(Ordering::Acquire));
+        assert_eq!(wake_rx.try_recv().unwrap(), ());
     }
 
     #[test]
@@ -11014,6 +11127,75 @@ mod two_hop_price_tests {
         assert!(admit_a.contains("mint_01"));
         assert!(admit_a.contains("mint_02"));
         assert!(admit_a.contains("mint_03"));
+    }
+
+    #[test]
+    fn admit_refresh_order_includes_unranked_protected_mints() {
+        let ranked = vec!["mint_a".to_string(), "mint_b".to_string()];
+        let mut admit = HashSet::new();
+        admit.insert("mint_a".to_string());
+        admit.insert("stale_pinned".to_string());
+        let order = admit_refresh_order(&ranked, &admit);
+        assert_eq!(order, vec!["mint_a", "stale_pinned"]);
+    }
+
+    #[test]
+    fn full_reconcile_refresh_removes_stale_unranked_protected_snapshot() {
+        let cache = create_shared_cache();
+        let ctx = Arc::new(test_arb_context(cache));
+        let stale_mint = "StalePinnedMint111111111111111111111111";
+        let stale_pool = "stale_pool_addr";
+        {
+            let mut snapshots = ctx.arb_track_mint_snapshots.write();
+            snapshots.insert_bounded(
+                stale_mint.to_string(),
+                TrackMintInput {
+                    mint: stale_mint.to_string(),
+                    pools: vec![TrackPoolInput {
+                        pool_address: stale_pool.to_string(),
+                        dex: "orca".to_string(),
+                        known: true,
+                        quote_pool: QuotePoolInput {
+                            pool_address: stale_pool.to_string(),
+                            dex: "orca".to_string(),
+                            token_mint: stale_mint.to_string(),
+                            trade_price_buy: None,
+                            trade_price_sell: None,
+                            trade_updated_at: Instant::now(),
+                            has_reserve_data: true,
+                            token_decimals: 6,
+                        },
+                        vault: None,
+                        dlmm_bins: None,
+                        token_decimals: 6,
+                        last_activity_unix_ms: 1,
+                    }],
+                    trade_signal_pools: None,
+                    last_activity_unix_ms: 1,
+                },
+                &HashSet::new(),
+            );
+        }
+        ctx.arb_pinned_pools.write().insert(stale_pool.to_string());
+        let ranked = vec!["active_mint".to_string()];
+        let protected = ctx.mandatory_protected_snapshot_mints();
+        assert!(protected.contains(stale_mint));
+        let admit = compute_snapshot_admit_set(&ranked, &protected, ARB_TRACK_MINT_SNAPSHOTS_CAP);
+        let refresh_order = admit_refresh_order(&ranked, &admit);
+        assert!(
+            refresh_order.iter().any(|m| m == stale_mint),
+            "unranked protected mint must be refreshed during full reconcile"
+        );
+        for mint in &refresh_order {
+            ctx.refresh_mint_snapshot(mint, &protected);
+        }
+        assert!(
+            !ctx.arb_track_mint_snapshots
+                .read()
+                .entries
+                .contains_key(stale_mint),
+            "stale protected snapshot must be removed when tracker truth is absent"
+        );
     }
 
     #[test]
@@ -11102,15 +11284,10 @@ mod two_hop_price_tests {
     fn arb_track_selection_blocking_join_failed_sets_pending_full() {
         use ironcrab::metrics::ARB_TRACK_SELECTION_BLOCKING_JOIN_FAILED_TOTAL;
 
-        let (tx, _rx) = mpsc::channel::<ArbTrackSelectionJob>(1);
-        let pending = Arc::new(AtomicBool::new(false));
-        let handle = ArbTrackSelectionHandle {
-            tx,
-            pending_full_reconcile: Arc::clone(&pending),
-        };
+        let (handle, _wake_rx) = test_arb_track_selection_handle();
         let before = ARB_TRACK_SELECTION_BLOCKING_JOIN_FAILED_TOTAL.load(Ordering::Relaxed);
         handle.record_blocking_join_failed();
-        assert!(pending.load(Ordering::Acquire));
+        assert!(handle.pending_full_reconcile.load(Ordering::Acquire));
         assert_eq!(
             ARB_TRACK_SELECTION_BLOCKING_JOIN_FAILED_TOTAL.load(Ordering::Relaxed),
             before + 1

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3263,6 +3263,17 @@ pub static ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_TRADE_FALLBACK_NONE: Lazy<Atomi
 pub static ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_MINT_DIRECTION_INVALID: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_PROACTIVE_TRACK_PUBLISH_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_SELECTED_POOLS_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_SELECTED_MINTS_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_CANDIDATE_POOLS_EXECUTABLE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_CANDIDATE_POOLS_QUOTE_READY: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_CANDIDATE_POOLS_WARMABLE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_CANDIDATE_POOLS_REJECTED: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_REMOVED_BUDGET_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_REMOVED_STALE_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_REMOVED_COOLDOWN_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_PUBLISH_SKIPPED_UNCHANGED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 const ARB_QUOTE_PAIR_SLOT_DELTA_BUCKETS: &[u64] = &[0, 1, 2, 3, 4, 5, 8, 16, 32];
 static ARB_QUOTE_PAIR_SLOT_DELTA_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
@@ -3913,6 +3924,41 @@ pub fn try_record_arb_track_pin_before_first_screen_ms(mint: &str) {
 /// Increment `arb_proactive_track_publish_total`.
 pub fn record_arb_proactive_track_publish_total() {
     ARB_PROACTIVE_TRACK_PUBLISH_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Update bounded Arb track selection gauges and candidate counters.
+pub fn set_arb_track_selection_metrics(
+    selected_pools: usize,
+    selected_mints: usize,
+    candidate_counts: &crate::arbitrage::TrackCandidateCounts,
+) {
+    ARB_TRACK_SELECTED_POOLS_GAUGE.store(selected_pools as u64, Ordering::Relaxed);
+    ARB_TRACK_SELECTED_MINTS_GAUGE.store(selected_mints as u64, Ordering::Relaxed);
+    ARB_TRACK_CANDIDATE_POOLS_EXECUTABLE.store(candidate_counts.executable, Ordering::Relaxed);
+    ARB_TRACK_CANDIDATE_POOLS_QUOTE_READY.store(candidate_counts.quote_ready, Ordering::Relaxed);
+    ARB_TRACK_CANDIDATE_POOLS_WARMABLE.store(candidate_counts.warmable, Ordering::Relaxed);
+    ARB_TRACK_CANDIDATE_POOLS_REJECTED.store(candidate_counts.rejected, Ordering::Relaxed);
+}
+
+/// Increment `arb_track_removed_total{reason=...}`.
+pub fn record_arb_track_removed_total(reason: crate::nats::ArbTrackRemovedReason) {
+    use crate::nats::ArbTrackRemovedReason;
+    match reason {
+        ArbTrackRemovedReason::Budget => {
+            ARB_TRACK_REMOVED_BUDGET_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+        ArbTrackRemovedReason::Stale => {
+            ARB_TRACK_REMOVED_STALE_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+        ArbTrackRemovedReason::Cooldown => {
+            ARB_TRACK_REMOVED_COOLDOWN_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Increment `arb_track_publish_skipped_unchanged_total`.
+pub fn record_arb_track_publish_skipped_unchanged_total() {
+    ARB_TRACK_PUBLISH_SKIPPED_UNCHANGED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Add to `arb_two_hop_tracker_seeded_pools_total` after SLAVE cache tracker seed.
@@ -7446,6 +7492,67 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "arb_proactive_track_publish_total",
         ARB_PROACTIVE_TRACK_PUBLISH_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_track_selected_pools",
+        ARB_TRACK_SELECTED_POOLS_GAUGE.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_track_selected_mints",
+        ARB_TRACK_SELECTED_MINTS_GAUGE.load(Ordering::Relaxed)
+    );
+    out.push_str("arb_track_candidate_pools_total{readiness=\"executable\"} ");
+    out.push_str(
+        &ARB_TRACK_CANDIDATE_POOLS_EXECUTABLE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_track_candidate_pools_total{readiness=\"quote_ready\"} ");
+    out.push_str(
+        &ARB_TRACK_CANDIDATE_POOLS_QUOTE_READY
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_track_candidate_pools_total{readiness=\"warmable\"} ");
+    out.push_str(
+        &ARB_TRACK_CANDIDATE_POOLS_WARMABLE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_track_candidate_pools_total{readiness=\"rejected\"} ");
+    out.push_str(
+        &ARB_TRACK_CANDIDATE_POOLS_REJECTED
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_track_removed_total{reason=\"budget\"} ");
+    out.push_str(
+        &ARB_TRACK_REMOVED_BUDGET_TOTAL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_track_removed_total{reason=\"stale\"} ");
+    out.push_str(
+        &ARB_TRACK_REMOVED_STALE_TOTAL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_track_removed_total{reason=\"cooldown\"} ");
+    out.push_str(
+        &ARB_TRACK_REMOVED_COOLDOWN_TOTAL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    line!(
+        "arb_track_publish_skipped_unchanged_total",
+        ARB_TRACK_PUBLISH_SKIPPED_UNCHANGED_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "arb_strategy_bootstrap_live_pool_cache_rows",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3274,6 +3274,7 @@ pub static ARB_TRACK_REMOVED_STALE_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU
 pub static ARB_TRACK_REMOVED_COOLDOWN_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TRACK_PUBLISH_SKIPPED_UNCHANGED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_SELECTION_RECOMPUTES_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
 const ARB_QUOTE_PAIR_SLOT_DELTA_BUCKETS: &[u64] = &[0, 1, 2, 3, 4, 5, 8, 16, 32];
 static ARB_QUOTE_PAIR_SLOT_DELTA_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
@@ -3959,6 +3960,11 @@ pub fn record_arb_track_removed_total(reason: crate::nats::ArbTrackRemovedReason
 /// Increment `arb_track_publish_skipped_unchanged_total`.
 pub fn record_arb_track_publish_skipped_unchanged_total() {
     ARB_TRACK_PUBLISH_SKIPPED_UNCHANGED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Increment `arb_track_selection_recomputes_total`.
+pub fn record_arb_track_selection_recompute_total() {
+    ARB_TRACK_SELECTION_RECOMPUTES_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Add to `arb_two_hop_tracker_seeded_pools_total` after SLAVE cache tracker seed.
@@ -7553,6 +7559,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "arb_track_publish_skipped_unchanged_total",
         ARB_TRACK_PUBLISH_SKIPPED_UNCHANGED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_track_selection_recomputes_total",
+        ARB_TRACK_SELECTION_RECOMPUTES_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "arb_strategy_bootstrap_live_pool_cache_rows",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3275,6 +3275,8 @@ pub static ARB_TRACK_REMOVED_COOLDOWN_TOTAL: Lazy<AtomicU64> = Lazy::new(|| Atom
 pub static ARB_TRACK_PUBLISH_SKIPPED_UNCHANGED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TRACK_SELECTION_RECOMPUTES_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_SELECTION_QUEUE_OVERFLOW_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 const ARB_QUOTE_PAIR_SLOT_DELTA_BUCKETS: &[u64] = &[0, 1, 2, 3, 4, 5, 8, 16, 32];
 static ARB_QUOTE_PAIR_SLOT_DELTA_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
@@ -3965,6 +3967,11 @@ pub fn record_arb_track_publish_skipped_unchanged_total() {
 /// Increment `arb_track_selection_recomputes_total`.
 pub fn record_arb_track_selection_recompute_total() {
     ARB_TRACK_SELECTION_RECOMPUTES_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Increment `arb_track_selection_queue_overflow_total`.
+pub fn record_arb_track_selection_queue_overflow_total() {
+    ARB_TRACK_SELECTION_QUEUE_OVERFLOW_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Add to `arb_two_hop_tracker_seeded_pools_total` after SLAVE cache tracker seed.
@@ -7563,6 +7570,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "arb_track_selection_recomputes_total",
         ARB_TRACK_SELECTION_RECOMPUTES_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_track_selection_queue_overflow_total",
+        ARB_TRACK_SELECTION_QUEUE_OVERFLOW_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "arb_strategy_bootstrap_live_pool_cache_rows",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3277,6 +3277,8 @@ pub static ARB_TRACK_PUBLISH_SKIPPED_UNCHANGED_TOTAL: Lazy<AtomicU64> =
 pub static ARB_TRACK_SELECTION_RECOMPUTES_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TRACK_SELECTION_QUEUE_OVERFLOW_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_SELECTION_BLOCKING_JOIN_FAILED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 const ARB_QUOTE_PAIR_SLOT_DELTA_BUCKETS: &[u64] = &[0, 1, 2, 3, 4, 5, 8, 16, 32];
 static ARB_QUOTE_PAIR_SLOT_DELTA_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
@@ -3972,6 +3974,11 @@ pub fn record_arb_track_selection_recompute_total() {
 /// Increment `arb_track_selection_queue_overflow_total`.
 pub fn record_arb_track_selection_queue_overflow_total() {
     ARB_TRACK_SELECTION_QUEUE_OVERFLOW_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Increment `arb_track_selection_blocking_join_failed_total`.
+pub fn record_arb_track_selection_blocking_join_failed_total() {
+    ARB_TRACK_SELECTION_BLOCKING_JOIN_FAILED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Add to `arb_two_hop_tracker_seeded_pools_total` after SLAVE cache tracker seed.
@@ -7574,6 +7581,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "arb_track_selection_queue_overflow_total",
         ARB_TRACK_SELECTION_QUEUE_OVERFLOW_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_track_selection_blocking_join_failed_total",
+        ARB_TRACK_SELECTION_BLOCKING_JOIN_FAILED_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "arb_strategy_bootstrap_live_pool_cache_rows",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zweiter Supervisor-Review — Merge-Blocker behoben

### Execution-Isolation
- **Async (`tokio::spawn`)**: Nur Orchestrierung — Job-Coalescing (50ms), Rate-Limit (1s incremental), `pending_full_reconcile`-Polling, `spawn_blocking` + `await`.
- **Blocking (`tokio::task::spawn_blocking`)**: Gesamte CPU-Arbeit in `run_arb_track_selection_batch()` — Mint-Snapshot-Refresh (separate Lock-Scopes), bounded LRU-Cache, `select_arb_track_pools()`, Pin-State-Update, Publish-Vorbereitung.

### Hard Caps
| Cap | Wert | Semantik |
|-----|------|----------|
| Selected pools | `arb_track_baseline_max_pools` (500) | Globales Pin-Budget |
| Mint snapshots | 2048 | LRU-Eviction; geschützt: trade-signal, pinned, refreshing |
| Selection queue | 4096 | `try_send`-Overflow → `pending_full_reconcile` |
| Dirty mints/coalescer | 4096 | Overflow → full reconcile (kein arbitrary HashSet-Drop) |
| Incremental batch | 64 mints | Rest → `pending_full_reconcile` |
| Trade-signal pairs | 64 | LRU-Eviction |

### Overflow-Recovery
- `mark_dirty` / `request_full_reconcile` bei voller Queue: Metrik `arb_track_selection_queue_overflow_total` + `pending_full_reconcile=true`.
- Coalescer dirty-overflow: setzt ebenfalls pending full; Worker erzwingt full reconcile.
- `take_pending_full()` am Batch-Start konsumiert das Signal — **kein stillschweigendes Verlieren von Full-Reconcile-Jobs**.

### Weitere Fixes
- `build_track_mint_input()`: tracker/known/vault/bins in **separaten** kurzen Read-Scopes; `commit_mint_snapshot()` baut erst, dann Write-Lock.
- I-ARB-12: `newly_active_mints` vor Branch; `record_arb_proactive_pin_first_publish` für reconcile **und** incremental nach `will_publish`.
- `TrackCandidateCounts.executable`: Trade-Signal-Pool-Members als Executable gezählt.

### Tests
- Snapshot-cap, dirty-overflow→full, queue-overflow→pending-full, reconcile-first-publish, executable candidate count.

### CI
- `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` lokal grün.
- Eval Level 5 via CI-Workflow nach Push.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36df113b-de79-46d4-bead-0559518f3251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36df113b-de79-46d4-bead-0559518f3251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

