### PR TITLE
fix(market-data): enforce priority-aware hard explicit cap

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -82,12 +82,13 @@ use ironcrab::market_data::sidefx::{
 use ironcrab::market_data::track::{
     arb_coalesce_try_send, explicit_set_snapshot_path, load_explicit_set_snapshot,
     momentum_coalesce_try_send, owner_key_to_snapshot, pool_is_enrichment_member,
-    spawn_track_worker, track_worker_try_enqueue, AdmissionResult, CapConvergeResult, ConsumerId,
-    DesiredExplicitSet, ExplicitAccountKind, ExplicitSetSnapshot, ExplicitSnapshotRow,
-    GeyserConnectBarrier, GeyserPinReason, OwnerGroupSnapshot, OwnerKey, PendingPoolCommand,
-    PendingPoolRegistrations, PoolExplicitSnapshot, ProtectedOverflowDiagnostic, SnapshotConsumer,
+    spawn_track_worker, track_worker_try_enqueue, AdmissionResult, BinArrayExplicitRow,
+    CapConvergeResult, ConsumerId, DesiredExplicitSet, ExplicitAccountKind, ExplicitSetSnapshot,
+    ExplicitSnapshotRow, GeyserConnectBarrier, GeyserPinReason, MintExplicitRow,
+    OwnerGroupSnapshot, OwnerKey, PendingPoolCommand, PendingPoolRegistrations,
+    PendingPoolUpsertResult, PoolExplicitSnapshot, ProtectedOverflowDiagnostic, SnapshotConsumer,
     SnapshotOwnerGroup, TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
-    WalletExplicitPending, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
+    VaultExplicitRow, WalletExplicitPending, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -104,9 +105,9 @@ use ironcrab::metrics::{
     inc_market_data_ingest_membership_snapshot_hits_total,
     inc_market_data_jsonl_enqueue_dropped_total,
     inc_market_data_md_state_evict_steps_budget_exhausted_total,
-    inc_market_data_md_state_evict_steps_total, inc_market_data_vault_high_priority_dispatch_total,
-    market_data_bump_geyser_head_slot, market_data_geyser_head_slot_value,
-    market_data_geyser_tracking_enqueue_dropped_value,
+    inc_market_data_md_state_evict_steps_total, inc_market_data_track_pending_pool_overflow_total,
+    inc_market_data_vault_high_priority_dispatch_total, market_data_bump_geyser_head_slot,
+    market_data_geyser_head_slot_value, market_data_geyser_tracking_enqueue_dropped_value,
     market_data_geyser_tracking_jobs_processed_value, market_data_md_state_bursts_completed_value,
     market_data_request_account_session_reconnect, market_data_request_tx_session_reconnect,
     market_data_tx_handler_processed_value, record_market_data_account_broadcast_lagged,
@@ -1888,9 +1889,15 @@ fn record_admission_rejection(consumer: ConsumerId, result: AdmissionResult) {
         AdmissionResult::RejectedCap => ("cap", consumer_id_label(consumer)),
         AdmissionResult::RejectedProtected => ("protected", consumer_id_label(consumer)),
         AdmissionResult::RejectedInvalidGroup => ("invalid_group", consumer_id_label(consumer)),
+        AdmissionResult::RejectedInternal => return,
         AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => return,
     };
     inc_market_data_geyser_explicit_admission_rejected_total(label, reason);
+}
+
+/// Pool-slot budget for durable pending registrations (not account-cap sized).
+fn pending_pool_registration_cap(_max_tracked_accounts: usize) -> usize {
+    8_192
 }
 
 #[allow(dead_code)]
@@ -1924,7 +1931,9 @@ fn enqueue_track_worker(ctx: &MarketDataContext, job: TrackWorkerCommand) -> boo
     let pending = pending_pool_command_for_stash(&job);
     let Some(sender) = ctx.track_worker.read().clone() else {
         if let Some(cmd) = pending {
-            ctx.pending_pool_commands.upsert(cmd);
+            if ctx.pending_pool_commands.upsert(cmd) == PendingPoolUpsertResult::Overflow {
+                ctx.fail_pending_pool_overflow();
+            }
         }
         ctx.mark_track_worker_dirty();
         return false;
@@ -1933,7 +1942,9 @@ fn enqueue_track_worker(ctx: &MarketDataContext, job: TrackWorkerCommand) -> boo
         return true;
     }
     if let Some(cmd) = pending {
-        ctx.pending_pool_commands.upsert(cmd);
+        if ctx.pending_pool_commands.upsert(cmd) == PendingPoolUpsertResult::Overflow {
+            ctx.fail_pending_pool_overflow();
+        }
     }
     ctx.mark_track_worker_dirty();
     false
@@ -2011,6 +2022,173 @@ fn collect_pool_explicit_pubkeys_from_cached_state(
         out.insert(b);
     }
     out
+}
+
+fn build_typed_pool_explicit_accounts(
+    pool: Pubkey,
+    cached_state: &CachedPoolState,
+    enable_meteora_cpmm: bool,
+    enable_meteora_dlmm: bool,
+) -> (
+    Vec<VaultExplicitRow>,
+    Vec<BinArrayExplicitRow>,
+    Vec<MintExplicitRow>,
+) {
+    let mut vaults = Vec::new();
+    let mut bin_arrays = Vec::new();
+    let mut mints = Vec::new();
+
+    let push_vault_pair = |vaults: &mut Vec<VaultExplicitRow>,
+                           dex: &str,
+                           base_mint: Pubkey,
+                           quote_mint: Pubkey,
+                           base_vault: Pubkey,
+                           quote_vault: Pubkey,
+                           active_id: Option<i32>,
+                           bin_step: Option<u16>| {
+        vaults.push(VaultExplicitRow {
+            pubkey: base_vault,
+            dex: dex.to_string(),
+            base_mint,
+            quote_mint,
+            is_base_vault: true,
+            sibling_vault: Some(quote_vault),
+            active_id,
+            bin_step,
+        });
+        vaults.push(VaultExplicitRow {
+            pubkey: quote_vault,
+            dex: dex.to_string(),
+            base_mint,
+            quote_mint,
+            is_base_vault: false,
+            sibling_vault: Some(base_vault),
+            active_id,
+            bin_step,
+        });
+    };
+
+    if let CachedPoolState::RaydiumCpmm(s) = cached_state {
+        let (base_mint, quote_mint, base_vault, quote_vault) =
+            cpmm_token_mints_and_vaults_sol_normalized(
+                s.token_0_mint,
+                s.token_1_mint,
+                s.token_0_vault,
+                s.token_1_vault,
+            );
+        push_vault_pair(
+            &mut vaults,
+            "raydium_cpmm",
+            base_mint,
+            quote_mint,
+            base_vault,
+            quote_vault,
+            None,
+            None,
+        );
+    }
+    if enable_meteora_cpmm {
+        if let CachedPoolState::MeteoraCpmm(s) = cached_state {
+            let (base_mint, quote_mint, base_vault, quote_vault) =
+                cpmm_token_mints_and_vaults_sol_normalized(
+                    s.token_0_mint,
+                    s.token_1_mint,
+                    s.token_0_vault,
+                    s.token_1_vault,
+                );
+            push_vault_pair(
+                &mut vaults,
+                "meteora_cpmm",
+                base_mint,
+                quote_mint,
+                base_vault,
+                quote_vault,
+                None,
+                None,
+            );
+        }
+    }
+    if enable_meteora_dlmm {
+        if let CachedPoolState::Meteora(s) = cached_state {
+            let (base_mint, quote_mint, base_vault, quote_vault) =
+                cpmm_token_mints_and_vaults_sol_normalized(
+                    s.token_x_mint,
+                    s.token_y_mint,
+                    s.reserve_x,
+                    s.reserve_y,
+                );
+            push_vault_pair(
+                &mut vaults,
+                "meteora_dlmm",
+                base_mint,
+                quote_mint,
+                base_vault,
+                quote_vault,
+                Some(s.active_id),
+                Some(s.bin_step),
+            );
+            let active_array_index = MeteoraDlmmSwapBuilder::bin_id_to_bin_array_index(s.active_id);
+            for offset in -3i64..=3i64 {
+                let index = active_array_index + offset;
+                if let Ok(pda) = MeteoraDlmmSwapBuilder::derive_bin_array_pda(&pool, index) {
+                    bin_arrays.push(BinArrayExplicitRow {
+                        pubkey: pda,
+                        bin_array_index: index,
+                        bin_step: s.bin_step,
+                    });
+                }
+            }
+        }
+    }
+    if let CachedPoolState::Orca(s) = cached_state {
+        let (base_mint, quote_mint, base_vault, quote_vault) =
+            cpmm_token_mints_and_vaults_sol_normalized(
+                s.token_mint_a,
+                s.token_mint_b,
+                s.token_vault_a,
+                s.token_vault_b,
+            );
+        push_vault_pair(
+            &mut vaults,
+            "orca",
+            base_mint,
+            quote_mint,
+            base_vault,
+            quote_vault,
+            None,
+            None,
+        );
+    }
+    if let CachedPoolState::PumpAmm(s) = cached_state {
+        push_vault_pair(
+            &mut vaults,
+            "pump_amm",
+            s.base_mint,
+            s.quote_mint,
+            s.pool_base_token_account,
+            s.pool_quote_token_account,
+            None,
+            None,
+        );
+    }
+    if let CachedPoolState::RaydiumAmm(s) = cached_state {
+        push_vault_pair(
+            &mut vaults,
+            "raydium_amm",
+            s.base_mint,
+            s.quote_mint,
+            s.coin_vault,
+            s.pc_vault,
+            None,
+            None,
+        );
+    }
+    if let Some((a, b)) = pool_mints_for_geyser_explicit_tracking(cached_state) {
+        mints.push(MintExplicitRow { pubkey: a });
+        mints.push(MintExplicitRow { pubkey: b });
+    }
+
+    (vaults, bin_arrays, mints)
 }
 
 fn snapshot_consumer_to_geyser_pin(consumer: SnapshotConsumer) -> Option<GeyserPinReason> {
@@ -2242,7 +2420,7 @@ impl TrackWorkerContext for MarketDataContext {
         desired: &mut DesiredExplicitSet,
         snapshot: &PoolExplicitSnapshot,
     ) -> bool {
-        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.pubkeys.clone()) {
+        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys()) {
             AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
                 self.register_tracked_assets_from_pool_snapshot(snapshot)
             }
@@ -2262,7 +2440,7 @@ impl TrackWorkerContext for MarketDataContext {
         if !self.hot_pool_registry.is_hot_pool(snapshot.pool) {
             return false;
         }
-        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.pubkeys.clone()) {
+        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys()) {
             AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
                 self.register_tracked_assets_from_pool_snapshot(snapshot)
             }
@@ -2282,7 +2460,7 @@ impl TrackWorkerContext for MarketDataContext {
         if !self.hot_pool_registry.pool_has_momentum(snapshot.pool) {
             return false;
         }
-        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.pubkeys.clone()) {
+        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys()) {
             AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
                 self.register_tracked_assets_from_pool_snapshot(snapshot)
             }
@@ -2311,7 +2489,7 @@ impl TrackWorkerContext for MarketDataContext {
         {
             return false;
         }
-        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.pubkeys.clone()) {
+        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys()) {
             AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
                 let changed = self.register_tracked_assets_from_pool_snapshot(snapshot);
                 if changed {
@@ -2969,22 +3147,33 @@ impl MarketDataContext {
             (cfg.enable_meteora_cpmm, cfg.enable_meteora_dlmm)
         };
         let state = self.live_pool_cache.get(&pool)?;
-        let pubkeys = collect_pool_explicit_pubkeys_from_cached_state(
+        let (vaults, bin_arrays, mints) = build_typed_pool_explicit_accounts(
             pool,
             &state,
             enable_meteora_cpmm,
             enable_meteora_dlmm,
         );
-        if pubkeys.is_empty() {
+        if vaults.is_empty() && bin_arrays.is_empty() && mints.is_empty() {
             return None;
         }
         Some(PoolExplicitSnapshot {
             pool,
-            pubkeys,
+            vaults,
+            bin_arrays,
+            mints,
             consumer: consumer_id_for_geyser_pin(Some(pin)),
             owner: OwnerKey::Pool(pool),
             pin,
         })
+    }
+
+    fn fail_pending_pool_overflow(&self) {
+        inc_market_data_track_pending_pool_overflow_total();
+        self.geyser_explicit_ready.store(false, Ordering::Release);
+        *self.geyser_explicit_config_error.write() =
+            Some("pending pool registration overflow (fail-closed)".into());
+        self.geyser_connect_barrier.mark_failed();
+        self.mark_track_worker_dirty();
     }
 
     fn fail_geyser_explicit_protected_overflow(&self, demand: &HashSet<Pubkey>) {
@@ -3040,6 +3229,10 @@ impl MarketDataContext {
     }
 
     fn apply_pending_track_worker_work(&self, desired: &mut DesiredExplicitSet) {
+        if self.pending_pool_commands.overflowed() {
+            self.fail_pending_pool_overflow();
+            return;
+        }
         let (demand, token_accounts, _) = self.wallet_explicit_pending.snapshot();
         if !demand.is_empty() || !token_accounts.is_empty() {
             self.commit_wallet_explicit_state(desired, demand, token_accounts);
@@ -3047,6 +3240,7 @@ impl MarketDataContext {
         for command in self.pending_pool_commands.drain_all() {
             self.replay_pending_pool_command(desired, command);
         }
+        self.pending_pool_commands.clear_overflow();
     }
 
     fn commit_wallet_explicit_state(
@@ -3142,6 +3336,12 @@ impl MarketDataContext {
             }
             AdmissionResult::RejectedProtected => {
                 record_admission_rejection(ConsumerId::Wallet, result);
+                false
+            }
+            AdmissionResult::RejectedInternal => {
+                self.geyser_explicit_ready.store(false, Ordering::Relaxed);
+                *self.geyser_explicit_config_error.write() =
+                    Some("wallet explicit admission internal invariant failure".into());
                 false
             }
             AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
@@ -3585,35 +3785,40 @@ impl MarketDataContext {
         track_worker: &TrackWorkerSender,
     ) {
         let path = explicit_set_snapshot_path();
-        let Some(snapshot) = load_explicit_set_snapshot(&path) else {
-            ctx.geyser_connect_barrier.mark_ready();
-            return;
+        let barrier_cmd = if let Some(snapshot) = load_explicit_set_snapshot(&path) {
+            let start = Instant::now();
+            let pubkey_count = snapshot.explicit_pubkey_count() as u64;
+            info!(
+                path = %path.display(),
+                pubkeys = pubkey_count,
+                pool_mint_map = snapshot.pool_mint_map.len(),
+                "Restoring explicit Geyser set from snapshot (I-MD-6)"
+            );
+            let _ = track_worker_try_enqueue(
+                track_worker,
+                TrackWorkerCommand::RestoreExplicitSnapshot(snapshot),
+            );
+            set_market_data_explicit_set_snapshot_restore_pubkeys(pubkey_count);
+            set_market_data_explicit_set_snapshot_restore_duration_ms(
+                start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+            );
+            None
+        } else {
+            info!("No explicit Geyser snapshot on disk; startup barrier via worker convergence");
+            Some(TrackWorkerCommand::CompleteStartupBarrier)
         };
-        let start = Instant::now();
-        let pubkey_count = snapshot.explicit_pubkey_count() as u64;
-        info!(
-            path = %path.display(),
-            pubkeys = pubkey_count,
-            pool_mint_map = snapshot.pool_mint_map.len(),
-            "Restoring explicit Geyser set from snapshot (I-MD-6)"
-        );
-        let _ = track_worker_try_enqueue(
-            track_worker,
-            TrackWorkerCommand::RestoreExplicitSnapshot(snapshot),
-        );
+        if let Some(cmd) = barrier_cmd {
+            let _ = track_worker_try_enqueue(track_worker, cmd);
+        }
         let _ = track_worker_try_enqueue(track_worker, TrackWorkerCommand::ScheduleGeyserPush);
         if ctx
             .geyser_connect_barrier
             .wait_ready(Duration::from_secs(30))
             .is_err()
         {
-            warn!("explicit Geyser restore barrier failed or timed out (fail-closed)");
+            warn!("explicit Geyser restore/startup barrier failed or timed out (fail-closed)");
             ctx.geyser_explicit_ready.store(false, Ordering::Release);
         }
-        set_market_data_explicit_set_snapshot_restore_pubkeys(pubkey_count);
-        set_market_data_explicit_set_snapshot_restore_duration_ms(
-            start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
-        );
     }
 
     /// Vault + bin-array pubkeys tracked locally for one pool (explicit Geyser assets).
@@ -4844,11 +5049,13 @@ impl MarketDataContext {
         let pool = snapshot.pool;
         let pin = snapshot.pin;
         let mut changed = false;
-        for pk in &snapshot.pubkeys {
-            let already_vault = self.tracked_vaults.read().contains_key(pk);
+
+        for row in &snapshot.vaults {
+            let pk = row.pubkey;
+            let already_vault = self.tracked_vaults.read().contains_key(&pk);
             if already_vault {
                 let mut vaults = self.tracked_vaults.write();
-                if let Some(v) = vaults.get_mut(pk) {
+                if let Some(v) = vaults.get_mut(&pk) {
                     if Self::geyser_pin_may_promote(v.pin, pin) {
                         v.pinned = true;
                         v.pin = Some(pin);
@@ -4858,39 +5065,26 @@ impl MarketDataContext {
                 }
                 continue;
             }
-            let already_bin = self.tracked_bin_arrays.read().contains_key(pk);
-            if already_bin {
-                let mut bins = self.tracked_bin_arrays.write();
-                if let Some(b) = bins.get_mut(pk) {
-                    if Self::geyser_pin_may_promote(b.pin, pin) {
-                        b.pinned = true;
-                        b.pin = Some(pin);
-                        b.last_used_at = now;
-                        changed = true;
-                    }
-                }
-                continue;
-            }
             let mut vaults = self.tracked_vaults.write();
             use std::collections::hash_map::Entry;
-            match vaults.entry(*pk) {
+            match vaults.entry(pk) {
                 Entry::Vacant(e) => {
                     e.insert(VaultInfo {
                         pool_address: pool,
-                        dex: "snapshot".to_string(),
-                        base_mint: Pubkey::default(),
-                        quote_mint: Pubkey::default(),
-                        is_base_vault: true,
+                        dex: row.dex.clone(),
+                        base_mint: row.base_mint,
+                        quote_mint: row.quote_mint,
+                        is_base_vault: row.is_base_vault,
                         last_balance: std::sync::atomic::AtomicU64::new(0),
                         last_used_at: now,
                         pinned: true,
                         pin: Some(pin),
-                        active_id: None,
-                        bin_step: None,
-                        sibling_vault: None,
+                        active_id: row.active_id,
+                        bin_step: row.bin_step,
+                        sibling_vault: row.sibling_vault,
                     });
                     drop(vaults);
-                    self.pool_tracked_legs_note_vault(pool, *pk);
+                    self.pool_tracked_legs_note_vault(pool, pk);
                     changed = true;
                 }
                 Entry::Occupied(mut e) => {
@@ -4904,6 +5098,58 @@ impl MarketDataContext {
                 }
             }
         }
+
+        for row in &snapshot.bin_arrays {
+            let pk = row.pubkey;
+            let already_bin = self.tracked_bin_arrays.read().contains_key(&pk);
+            if already_bin {
+                let mut bins = self.tracked_bin_arrays.write();
+                if let Some(b) = bins.get_mut(&pk) {
+                    if Self::geyser_pin_may_promote(b.pin, pin) {
+                        b.pinned = true;
+                        b.pin = Some(pin);
+                        b.bin_step = row.bin_step;
+                        b.last_used_at = now;
+                        changed = true;
+                    }
+                }
+                continue;
+            }
+            let mut bins = self.tracked_bin_arrays.write();
+            use std::collections::hash_map::Entry;
+            match bins.entry(pk) {
+                Entry::Vacant(e) => {
+                    e.insert(BinArrayInfo {
+                        pool_address: pool,
+                        bin_array_index: row.bin_array_index,
+                        bin_step: row.bin_step,
+                        last_used_at: now,
+                        pinned: true,
+                        pin: Some(pin),
+                    });
+                    drop(bins);
+                    self.pool_tracked_legs_note_bin(pool, pk);
+                    changed = true;
+                }
+                Entry::Occupied(mut e) => {
+                    let b = e.get_mut();
+                    if Self::geyser_pin_may_promote(b.pin, pin) {
+                        b.pinned = true;
+                        b.pin = Some(pin);
+                        b.bin_step = row.bin_step;
+                        b.last_used_at = now;
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        for row in &snapshot.mints {
+            if self.track_mint_for_geyser_metadata(row.pubkey, Some(pin)) {
+                changed = true;
+            }
+        }
+
         changed
     }
 
@@ -7468,7 +7714,7 @@ async fn main() -> Result<()> {
             }
         }
     }
-    let pending_pool_cap = market_data_config.max_tracked_accounts.max(1);
+    let pending_pool_cap = pending_pool_registration_cap(market_data_config.max_tracked_accounts);
     let ctx = Arc::new(MarketDataContext {
         run_id: run_id.clone(),
         config: parking_lot::RwLock::new(market_data_config),
@@ -11122,7 +11368,9 @@ mod wallet_snapshot_stale_cleanup_tests {
             pending_explicit_cap: AtomicUsize::new(0),
             track_worker_dirty: AtomicBool::new(false),
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
-            pending_pool_commands: Arc::new(PendingPoolRegistrations::new(25_000)),
+            pending_pool_commands: Arc::new(PendingPoolRegistrations::new(
+                pending_pool_registration_cap(25_000),
+            )),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         }
     }
@@ -11359,7 +11607,9 @@ mod wallet_tx_meta_balance_tests {
             pending_explicit_cap: AtomicUsize::new(0),
             track_worker_dirty: AtomicBool::new(false),
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
-            pending_pool_commands: Arc::new(PendingPoolRegistrations::new(25_000)),
+            pending_pool_commands: Arc::new(PendingPoolRegistrations::new(
+                pending_pool_registration_cap(25_000),
+            )),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
@@ -12261,7 +12511,9 @@ mod pr_b_geyser_tracking_tests {
             pending_explicit_cap: AtomicUsize::new(0),
             track_worker_dirty: AtomicBool::new(false),
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
-            pending_pool_commands: Arc::new(PendingPoolRegistrations::new(25_000)),
+            pending_pool_commands: Arc::new(PendingPoolRegistrations::new(
+                pending_pool_registration_cap(25_000),
+            )),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
@@ -12348,7 +12600,9 @@ mod pr_b_geyser_tracking_tests {
             pending_explicit_cap: AtomicUsize::new(0),
             track_worker_dirty: AtomicBool::new(false),
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
-            pending_pool_commands: Arc::new(PendingPoolRegistrations::new(25_000)),
+            pending_pool_commands: Arc::new(PendingPoolRegistrations::new(
+                pending_pool_registration_cap(25_000),
+            )),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         });
         (
@@ -16266,6 +16520,328 @@ mod pr_b_geyser_tracking_tests {
             .upsert(PendingPoolCommand::AfterTrade(snapshot));
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         ctx.apply_pending_track_worker_work(&mut desired);
+        assert!(desired.contains(&coin));
+        assert!(desired.contains(&pc));
+    }
+
+    fn test_context_barrier_pending(jsonl: QueuedJsonlWriter) -> Arc<MarketDataContext> {
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        ctx.geyser_connect_barrier.mark_pending();
+        ctx
+    }
+
+    #[test]
+    fn startup_barrier_no_snapshot_waits_for_worker_convergence() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = test_context_barrier_pending(jsonl);
+        let track_worker = spawn_track_worker(Arc::clone(&ctx));
+        *ctx.track_worker.write() = Some(track_worker.clone());
+
+        let snapshot_path = tmp.path().join("missing_explicit_snapshot.json");
+        std::env::set_var(
+            "IRONCRAB_EXPLICIT_SET_SNAPSHOT_PATH",
+            snapshot_path.to_string_lossy().as_ref(),
+        );
+        MarketDataContext::restore_explicit_set_from_snapshot_on_startup(
+            ctx.as_ref(),
+            &track_worker,
+        );
+        std::env::remove_var("IRONCRAB_EXPLICIT_SET_SNAPSHOT_PATH");
+
+        assert!(ctx.geyser_connect_barrier.is_ready());
+        assert!(ctx.geyser_explicit_readiness_ok());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn startup_barrier_wallet_sync_before_restore_completes() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = test_context_barrier_pending(jsonl);
+        let ata = Pubkey::new_unique();
+        ctx.wallet_explicit_pending.insert_ata(ata);
+
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool(base, pool);
+
+        let track_worker = spawn_track_worker(Arc::clone(&ctx));
+        *ctx.track_worker.write() = Some(track_worker.clone());
+
+        let revision = ctx.wallet_explicit_pending.current_revision();
+        assert!(track_worker_try_enqueue(
+            &track_worker,
+            TrackWorkerCommand::SyncWalletExplicitDemand { revision }
+        ));
+
+        let snapshot = ExplicitSetSnapshot::new(Some("restore-test".into()));
+        assert!(track_worker_try_enqueue(
+            &track_worker,
+            TrackWorkerCommand::RestoreExplicitSnapshot(snapshot)
+        ));
+        assert!(track_worker_try_enqueue(
+            &track_worker,
+            TrackWorkerCommand::ScheduleGeyserPush
+        ));
+
+        tokio::time::sleep(Duration::from_millis(
+            ironcrab::market_data::track::MARKET_DATA_TRACK_WORKER_COALESCE_MS + 400,
+        ))
+        .await;
+
+        assert!(
+            ctx.geyser_connect_barrier
+                .wait_ready(Duration::from_secs(5))
+                .is_ok(),
+            "wallet sync before restore must not deadlock startup barrier"
+        );
+    }
+
+    #[test]
+    fn typed_dlmm_snapshot_commits_bins_and_mints_not_vaults() {
+        use ironcrab::execution::live_pool_cache::MeteoraState;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let reserve_x = Pubkey::new_unique();
+        let reserve_y = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::Meteora(MeteoraState {
+                token_x_mint: base,
+                token_y_mint: quote,
+                reserve_x,
+                reserve_y,
+                active_id: 8,
+                bin_step: 25,
+                reserve_x_balance: Some(1),
+                reserve_y_balance: Some(1),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+
+        let snapshot = ctx
+            .build_pool_explicit_snapshot(pool, GeyserPinReason::ArbMultiDex)
+            .expect("dlmm snapshot");
+        assert!(!snapshot.vaults.is_empty());
+        assert!(!snapshot.bin_arrays.is_empty());
+        assert!(!snapshot.mints.is_empty());
+
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        assert!(ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot));
+
+        for row in &snapshot.bin_arrays {
+            assert!(ctx.tracked_bin_arrays.read().contains_key(&row.pubkey));
+            assert!(!ctx.tracked_vaults.read().contains_key(&row.pubkey));
+        }
+        for row in &snapshot.mints {
+            assert!(ctx.tracked_mints.read().contains_key(&row.pubkey));
+            assert!(!ctx.tracked_vaults.read().contains_key(&row.pubkey));
+        }
+        for row in &snapshot.vaults {
+            assert!(ctx.tracked_vaults.read().contains_key(&row.pubkey));
+        }
+    }
+
+    #[test]
+    fn pending_pool_overflow_sets_fail_closed_dirty_state() {
+        let pending = PendingPoolRegistrations::new(1);
+        let pool_a = Pubkey::new_unique();
+        let pool_b = Pubkey::new_unique();
+        let mk_snapshot = |pool: Pubkey| PoolExplicitSnapshot {
+            pool,
+            vaults: vec![],
+            bin_arrays: vec![],
+            mints: vec![],
+            consumer: ConsumerId::Momentum,
+            owner: OwnerKey::Pool(pool),
+            pin: GeyserPinReason::MomentumActive,
+        };
+        assert_eq!(
+            pending.upsert(PendingPoolCommand::RegisterReserves(mk_snapshot(pool_a))),
+            PendingPoolUpsertResult::Stored
+        );
+        assert_eq!(
+            pending.upsert(PendingPoolCommand::AfterTrade(mk_snapshot(pool_b))),
+            PendingPoolUpsertResult::Overflow
+        );
+        assert!(pending.overflowed());
+    }
+
+    #[test]
+    fn queue_full_replay_coalesces_all_pool_command_kinds() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool(base, pool);
+        let snapshot = ctx
+            .build_pool_explicit_snapshot(pool, GeyserPinReason::MomentumActive)
+            .expect("snapshot");
+
+        let (sender, _rx, _) = ironcrab::market_data::track::track_worker_sender_for_test(1);
+        *ctx.track_worker.write() = Some(sender.clone());
+        assert!(enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterPoolGeyserReserves {
+                snapshot: snapshot.clone(),
+            },
+        ));
+        assert!(!enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterPoolVaultsFromAccount {
+                snapshot: snapshot.clone(),
+            },
+        ));
+        assert!(!enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterGeyserReservesAfterTrade {
+                snapshot: snapshot.clone(),
+            },
+        ));
+        assert!(!enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RefreshDlmmBinWindow {
+                snapshot: snapshot.clone(),
+                new_active_id: 3,
+            },
+        ));
+        assert!(ctx.track_worker_dirty.load(Ordering::Relaxed));
+        assert_eq!(ctx.pending_pool_commands.pool_count(), 1);
+
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.apply_pending_track_worker_work(&mut desired);
+        assert!(desired.contains(&coin));
+        assert!(desired.contains(&pc));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn wallet_ata_stale_revision_skipped_by_worker() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let track_worker = spawn_track_worker(Arc::clone(&ctx));
+        *ctx.track_worker.write() = Some(track_worker.clone());
+
+        let ata_keep = Pubkey::new_unique();
+        let ata_drop = Pubkey::new_unique();
+        ctx.wallet_explicit_pending.insert_ata(ata_drop);
+        let revision_before = ctx.wallet_explicit_pending.current_revision();
+        ctx.wallet_explicit_pending.remove_ata(ata_drop);
+        ctx.wallet_explicit_pending.insert_ata(ata_keep);
+        let revision_after = ctx.wallet_explicit_pending.current_revision();
+
+        assert!(track_worker_try_enqueue(
+            &track_worker,
+            TrackWorkerCommand::SyncWalletExplicitDemand {
+                revision: revision_before
+            }
+        ));
+        test_wait_inline_track_worker();
+
+        let demand = ctx.wallet_explicit_demand_pubkeys();
+        assert!(!demand.contains(&ata_drop));
+
+        assert!(track_worker_try_enqueue(
+            &track_worker,
+            TrackWorkerCommand::SyncWalletExplicitDemand {
+                revision: revision_after
+            }
+        ));
+        test_wait_inline_track_worker();
+        let demand = ctx.wallet_explicit_demand_pubkeys();
+        assert!(demand.contains(&ata_keep));
+        assert!(!demand.contains(&ata_drop));
+    }
+
+    #[test]
+    fn restore_after_convergence_preserves_owner_groups_and_refcounts() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.hot_pool_registry.pin_pool(base, pool);
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        desired.restore_owner_groups(&[
+            OwnerGroupSnapshot {
+                consumer: ConsumerId::Momentum,
+                owner: OwnerKey::Pool(pool),
+                pubkeys: HashSet::from([coin, pc]),
+                last_touched_gen: 1,
+            },
+            OwnerGroupSnapshot {
+                consumer: ConsumerId::Arb,
+                owner: OwnerKey::Pool(pool),
+                pubkeys: HashSet::from([coin, pc]),
+                last_touched_gen: 2,
+            },
+        ]);
+        ctx.converge_explicit_admission(&mut desired);
+
+        let groups = desired.snapshot_owner_groups();
+        let momentum = groups
+            .iter()
+            .find(|g| g.consumer == ConsumerId::Momentum)
+            .expect("momentum group");
+        let arb = groups
+            .iter()
+            .find(|g| g.consumer == ConsumerId::Arb)
+            .expect("arb group");
+        assert_eq!(momentum.pubkeys.len(), 2);
+        assert_eq!(arb.pubkeys.len(), 2);
+        assert_eq!(
+            desired.len(),
+            2,
+            "shared pubkeys refcounted once in entries"
+        );
         assert!(desired.contains(&coin));
         assert!(desired.contains(&pc));
     }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -90,7 +90,8 @@ use ironcrab::market_data::track::{
     PoolExplicitSnapshot, PoolSnapshotRevisionSequencer, ProtectedOverflowDiagnostic,
     RevisionAcquireResult, RevisionActiveOwner, RevisionAssignResult, SnapshotConsumer,
     SnapshotOwnerGroup, TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
-    VaultExplicitRow, WalletExplicitPending, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
+    VaultExplicitRow, WalletExplicitPending, WalletRevisionBump,
+    EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -2947,11 +2948,13 @@ impl TxIngestHost for MarketDataContext {
             return false;
         };
         let was_present = self.wallet_explicit_pending.contains_demand(ata);
-        let revision = self
+        let bump_base = self
             .wallet_explicit_pending
             .ensure_wallet_base(tracked_wallet.wallet, tracked_wallet.wsol_ata);
-        let revision = self.wallet_explicit_pending.insert_ata(ata).max(revision);
-        let _ = self.enqueue_wallet_explicit_sync_revision(revision);
+        let bump_ata = self.wallet_explicit_pending.insert_ata(ata);
+        if let Some(revision) = self.finalize_wallet_revision_bumps([bump_base, bump_ata], None) {
+            let _ = self.enqueue_wallet_explicit_sync_revision(revision);
+        }
         !was_present
     }
 
@@ -2962,11 +2965,13 @@ impl TxIngestHost for MarketDataContext {
         if !self.wallet_explicit_pending.contains_demand(ata) {
             return false;
         }
-        let revision = self
+        let bump_base = self
             .wallet_explicit_pending
             .ensure_wallet_base(tracked_wallet.wallet, tracked_wallet.wsol_ata);
-        let revision = self.wallet_explicit_pending.remove_ata(ata).max(revision);
-        let _ = self.enqueue_wallet_explicit_sync_revision(revision);
+        let bump_ata = self.wallet_explicit_pending.remove_ata(ata);
+        if let Some(revision) = self.finalize_wallet_revision_bumps([bump_base, bump_ata], None) {
+            let _ = self.enqueue_wallet_explicit_sync_revision(revision);
+        }
         true
     }
 
@@ -2980,10 +2985,12 @@ impl TxIngestHost for MarketDataContext {
         let Some(tracked_wallet) = self.tracked_wallet.as_ref() else {
             return;
         };
-        let revision = self
+        let bump_base = self
             .wallet_explicit_pending
             .ensure_wallet_base(tracked_wallet.wallet, tracked_wallet.wsol_ata);
-        let _ = self.enqueue_wallet_explicit_sync_revision(revision);
+        if let Some(revision) = self.finalize_wallet_revision_bumps([bump_base], None) {
+            let _ = self.enqueue_wallet_explicit_sync_revision(revision);
+        }
         let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
     }
 
@@ -3325,11 +3332,49 @@ impl MarketDataContext {
         }
     }
 
-    fn try_clear_revision_registry_full_blocker(&self, desired: &DesiredExplicitSet) {
-        if self.pool_snapshot_revisions.active_key_count() < self.pool_snapshot_revisions.max_keys()
+    fn try_clear_revision_registry_full_blocker(
+        &self,
+        pool: Pubkey,
+        consumer: ConsumerId,
+        desired: &DesiredExplicitSet,
+    ) {
+        if self
+            .pool_snapshot_revisions
+            .can_issue_revision(pool, consumer)
         {
             self.clear_geyser_explicit_blocker(GESYER_BLOCK_REVISION_REGISTRY_FULL);
             self.recompute_geyser_explicit_readiness(desired);
+        }
+    }
+
+    fn fail_wallet_revision_exhausted(&self, desired: Option<&DesiredExplicitSet>) {
+        self.set_geyser_explicit_blocker(
+            GESYER_BLOCK_WALLET_EXPLICIT,
+            Some("wallet explicit revision exhausted (fail-closed)".into()),
+        );
+        if let Some(desired) = desired {
+            self.recompute_geyser_explicit_readiness(desired);
+        }
+    }
+
+    fn finalize_wallet_revision_bumps(
+        &self,
+        bumps: impl IntoIterator<Item = WalletRevisionBump>,
+        desired: Option<&DesiredExplicitSet>,
+    ) -> Option<u64> {
+        let mut merged: Option<WalletRevisionBump> = None;
+        for bump in bumps {
+            merged = Some(match merged {
+                None => bump,
+                Some(prev) => prev.max(bump),
+            });
+        }
+        match merged? {
+            WalletRevisionBump::Exhausted => {
+                self.fail_wallet_revision_exhausted(desired);
+                None
+            }
+            WalletRevisionBump::Bumped(rev) => Some(rev),
         }
     }
 
@@ -3436,7 +3481,7 @@ impl MarketDataContext {
         {
             RevisionAcquireResult::Acquired => {
                 if let Some(desired) = desired {
-                    self.try_clear_revision_registry_full_blocker(desired);
+                    self.try_clear_revision_registry_full_blocker(pool, consumer, desired);
                 }
                 true
             }
@@ -3759,7 +3804,9 @@ impl MarketDataContext {
                 false
             }
             AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
-                self.clear_geyser_explicit_blocker(GESYER_BLOCK_WALLET_EXPLICIT);
+                if !self.wallet_explicit_pending.revision_exhausted() {
+                    self.clear_geyser_explicit_blocker(GESYER_BLOCK_WALLET_EXPLICIT);
+                }
                 self.try_clear_protected_cap_blockers(desired);
                 self.recompute_geyser_explicit_readiness(desired);
                 true
@@ -3768,16 +3815,18 @@ impl MarketDataContext {
     }
 
     fn request_wallet_explicit_resync(&self) {
-        let revision = if let Some(tw) = &self.tracked_wallet {
+        let bump = if let Some(tw) = &self.tracked_wallet {
             let (demand, _, rev) = self.wallet_explicit_pending.snapshot();
             let token_accounts = Self::wallet_token_accounts_from_demand(&demand, tw);
             self.wallet_explicit_pending
                 .replace_token_accounts(token_accounts)
-                .max(rev)
+                .max(WalletRevisionBump::Bumped(rev))
         } else {
-            self.wallet_explicit_pending.current_revision()
+            WalletRevisionBump::Bumped(self.wallet_explicit_pending.current_revision())
         };
-        let _ = self.enqueue_wallet_explicit_sync_revision(revision);
+        if let Some(revision) = self.finalize_wallet_revision_bumps([bump], None) {
+            let _ = self.enqueue_wallet_explicit_sync_revision(revision);
+        }
         let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
     }
 
@@ -7693,14 +7742,16 @@ async fn publish_wallet_snapshot(
 
     // 3) Update logical wallet explicit demand; physical publish goes through track-worker admission.
     if let Some(ref tracked_wallet) = ctx.tracked_wallet {
-        let revision = ctx
+        let bump_base = ctx
             .wallet_explicit_pending
             .ensure_wallet_base(tracked_wallet.wallet, tracked_wallet.wsol_ata);
-        let revision = ctx
+        let bump_replace = ctx
             .wallet_explicit_pending
-            .replace_token_accounts(wallet_token_accounts)
-            .max(revision);
-        let _ = ctx.enqueue_wallet_explicit_sync_revision(revision);
+            .replace_token_accounts(wallet_token_accounts);
+        if let Some(revision) = ctx.finalize_wallet_revision_bumps([bump_base, bump_replace], None)
+        {
+            let _ = ctx.enqueue_wallet_explicit_sync_revision(revision);
+        }
         let _ = enqueue_track_worker(ctx, TrackWorkerCommand::ScheduleGeyserPushDebounced);
     }
 
@@ -16919,10 +16970,13 @@ mod pr_b_geyser_tracking_tests {
         ctx.hot_pool_registry.pin_pool(base, pool);
 
         let wallet = Pubkey::new_unique();
-        let _ = ctx.enqueue_wallet_explicit_sync_revision(
-            ctx.wallet_explicit_pending
-                .replace_token_accounts(HashSet::from([wallet])),
-        );
+        if let Some(revision) = ctx.finalize_wallet_revision_bumps(
+            [ctx.wallet_explicit_pending
+                .replace_token_accounts(HashSet::from([wallet]))],
+            None,
+        ) {
+            let _ = ctx.enqueue_wallet_explicit_sync_revision(revision);
+        }
         test_wait_inline_track_worker();
 
         assert!(ctx.register_pool_vaults_from_account(pool));
@@ -18324,6 +18378,79 @@ mod pr_b_geyser_tracking_tests {
         registry.unpin_pool(mint1, pool1);
         assert!(!registry.is_pinned(mint1, pool1));
         assert_eq!(registry.pair_count(), 0);
+    }
+
+    #[test]
+    fn revision_registry_full_blocker_clears_after_successful_key_retry() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        ctx.fail_revision_registry_full();
+        let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.recompute_geyser_explicit_readiness(&desired);
+        assert!(!ctx.geyser_explicit_readiness_ok());
+        ctx.hot_pool_registry.pin_pool(mint, pool);
+        assert!(ctx.ensure_pool_revision_key(pool, ConsumerId::Momentum, Some(&desired)));
+        ctx.recompute_geyser_explicit_readiness(&desired);
+        assert!(ctx.geyser_explicit_readiness_ok());
+    }
+
+    #[test]
+    fn revision_registry_full_blocker_persists_when_u64_exhausted() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        ctx.hot_pool_registry.pin_pool(mint, pool);
+        assert!(ctx.ensure_pool_revision_key_cold(pool, ConsumerId::Momentum));
+        ctx.pool_snapshot_revisions.test_seed_slot_revision_state(
+            pool,
+            ConsumerId::Momentum,
+            u64::MAX,
+            u64::MAX - 1,
+        );
+        ctx.fail_revision_registry_full();
+        let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.recompute_geyser_explicit_readiness(&desired);
+        assert!(!ctx.geyser_explicit_readiness_ok());
+        assert!(ctx.ensure_pool_revision_key(pool, ConsumerId::Momentum, Some(&desired)));
+        ctx.recompute_geyser_explicit_readiness(&desired);
+        assert!(
+            !ctx.geyser_explicit_readiness_ok(),
+            "u64 exhaustion must keep registry-full blocker latched"
+        );
+    }
+
+    #[test]
+    fn wallet_revision_exhaustion_blocks_geyser_readiness() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.wallet_explicit_pending.test_seed_revision(u64::MAX - 1);
+        assert_eq!(
+            ctx.finalize_wallet_revision_bumps(
+                [ctx.wallet_explicit_pending.insert_ata(Pubkey::new_unique())],
+                Some(&desired),
+            ),
+            None
+        );
+        ctx.recompute_geyser_explicit_readiness(&desired);
+        assert!(!ctx.geyser_explicit_readiness_ok());
+        assert_eq!(
+            ctx.finalize_wallet_revision_bumps(
+                [ctx.wallet_explicit_pending.insert_ata(Pubkey::new_unique())],
+                Some(&desired),
+            ),
+            None,
+            "post-exhaustion bumps must stay fail-closed"
+        );
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1181,12 +1181,10 @@ struct MarketDataContext {
     pending_pool_overflow_latched: AtomicBool,
     /// Startup restore + convergence barrier before Geyser connect.
     geyser_connect_barrier: Arc<GeyserConnectBarrier>,
-    /// Bounded ledger of revision-registry rejections (cleared per-key on retry/remove).
-    revision_registry_rejected: parking_lot::Mutex<HashSet<(Pubkey, ConsumerId)>>,
-    /// Keys rejected but not stored because [`revision_registry_rejected_capacity`] was exceeded.
-    revision_registry_rejected_overflow: AtomicUsize,
-    /// Max distinct rejected `(pool, consumer)` keys retained (defaults to demand-cap sum).
-    revision_registry_rejected_capacity: usize,
+    /// Bounded authoritative ledger of rejected revision demand awaiting retry/withdrawal.
+    revision_registry_rejection_ledger: parking_lot::Mutex<RevisionRegistryRejectionLedger>,
+    #[cfg(test)]
+    revision_reconcile_test_barrier: RevisionReconcileTestBarrier,
 }
 
 #[derive(Debug, Default)]
@@ -1247,6 +1245,172 @@ const GESYER_BLOCK_ADMISSION_UNCONVERGED: u8 = 1 << 3;
 const GESYER_BLOCK_WALLET_EXPLICIT: u8 = 1 << 4;
 const GESYER_BLOCK_WALLET_REVISION_EXHAUSTED: u8 = 1 << 5;
 const GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW: u8 = 1 << 6;
+
+/// Authoritative rejected logical demand awaiting bounded retry or explicit withdrawal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum RejectedRevisionDemand {
+    Momentum { mint: Pubkey, pool: Pubkey },
+    Arb { pool: Pubkey },
+    Tracker { pool: Pubkey },
+}
+
+impl RejectedRevisionDemand {
+    fn pool(self) -> Pubkey {
+        match self {
+            Self::Momentum { pool, .. } | Self::Arb { pool } | Self::Tracker { pool } => pool,
+        }
+    }
+
+    fn consumer(self) -> ConsumerId {
+        match self {
+            Self::Momentum { .. } => ConsumerId::Momentum,
+            Self::Arb { .. } => ConsumerId::Arb,
+            Self::Tracker { .. } => ConsumerId::Tracker,
+        }
+    }
+
+    fn key(self) -> (Pubkey, ConsumerId) {
+        (self.pool(), self.consumer())
+    }
+
+    fn inferred(pool: Pubkey, consumer: ConsumerId, registry: &UnifiedHotPoolRegistry) -> Self {
+        match consumer {
+            ConsumerId::Momentum => {
+                let mint = registry
+                    .snapshot_pairs()
+                    .into_iter()
+                    .find_map(|(mint, p)| (p == pool).then_some(mint))
+                    .unwrap_or(pool);
+                Self::Momentum { mint, pool }
+            }
+            ConsumerId::Arb => Self::Arb { pool },
+            ConsumerId::Tracker | ConsumerId::Wallet => Self::Tracker { pool },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RevisionRejectionRecordResult {
+    AlreadyTracked,
+    Stored,
+    OverflowStored,
+    OverflowLost,
+}
+
+#[derive(Debug)]
+struct RevisionRegistryRejectionLedger {
+    entries: HashMap<(Pubkey, ConsumerId), RejectedRevisionDemand>,
+    overflow_entries: Vec<RejectedRevisionDemand>,
+    overflow_lost: usize,
+    generation: u64,
+    capacity: usize,
+}
+
+impl RevisionRegistryRejectionLedger {
+    fn new(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            overflow_entries: Vec::new(),
+            overflow_lost: 0,
+            generation: 0,
+            capacity: capacity.max(1),
+        }
+    }
+
+    fn record(&mut self, demand: RejectedRevisionDemand) -> RevisionRejectionRecordResult {
+        self.generation = self.generation.wrapping_add(1);
+        let key = demand.key();
+        if self.entries.contains_key(&key) {
+            return RevisionRejectionRecordResult::AlreadyTracked;
+        }
+        if self.entries.len() < self.capacity {
+            self.entries.insert(key, demand);
+            return RevisionRejectionRecordResult::Stored;
+        }
+        if self.overflow_entries.len() < self.capacity {
+            self.overflow_entries.push(demand);
+            return RevisionRejectionRecordResult::OverflowStored;
+        }
+        self.overflow_lost = self.overflow_lost.saturating_add(1);
+        RevisionRejectionRecordResult::OverflowLost
+    }
+
+    fn remove_demand(&mut self, demand: RejectedRevisionDemand) -> bool {
+        let key = demand.key();
+        if self.entries.remove(&key) == Some(demand) {
+            self.generation = self.generation.wrapping_add(1);
+            return true;
+        }
+        if let Some(pos) = self
+            .overflow_entries
+            .iter()
+            .position(|stored| *stored == demand)
+        {
+            self.overflow_entries.remove(pos);
+            self.generation = self.generation.wrapping_add(1);
+            return true;
+        }
+        false
+    }
+
+    fn remove_key(&mut self, pool: Pubkey, consumer: ConsumerId) -> bool {
+        if self.entries.remove(&(pool, consumer)).is_some() {
+            self.generation = self.generation.wrapping_add(1);
+            return true;
+        }
+        if let Some(pos) = self
+            .overflow_entries
+            .iter()
+            .position(|stored| stored.key() == (pool, consumer))
+        {
+            self.overflow_entries.remove(pos);
+            self.generation = self.generation.wrapping_add(1);
+            return true;
+        }
+        false
+    }
+
+    fn has_unresolved(&self) -> bool {
+        !self.entries.is_empty() || !self.overflow_entries.is_empty() || self.overflow_lost > 0
+    }
+
+    fn pending_demands(&self) -> Vec<RejectedRevisionDemand> {
+        let mut out: Vec<_> = self.entries.values().copied().collect();
+        out.extend(self.overflow_entries.iter().copied());
+        out
+    }
+}
+
+#[cfg(test)]
+struct RevisionReconcileTestBarrier {
+    hold_after_snapshot: AtomicBool,
+    continue_reconcile: AtomicBool,
+}
+
+#[cfg(test)]
+impl RevisionReconcileTestBarrier {
+    fn new() -> Self {
+        Self {
+            hold_after_snapshot: AtomicBool::new(false),
+            continue_reconcile: AtomicBool::new(false),
+        }
+    }
+
+    fn wait_after_snapshot(&self) {
+        while self.hold_after_snapshot.load(Ordering::Acquire)
+            && !self.continue_reconcile.load(Ordering::Acquire)
+        {
+            std::thread::yield_now();
+        }
+    }
+}
+
+#[cfg(test)]
+impl Default for RevisionReconcileTestBarrier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Scope-8: After `WalletSnapshotComplete`, wait briefly for in-flight Geyser merges before
 /// cold-path RPC verification for wallet-only mints without explicit Ready (bounded).
@@ -1968,6 +2132,23 @@ fn record_admission_rejection(consumer: ConsumerId, result: AdmissionResult) {
 /// Pool-slot budget for durable pending registrations (not account-cap sized).
 fn pending_pool_registration_cap(_max_tracked_accounts: usize) -> usize {
     8_192
+}
+
+fn minimal_enqueue_pool_snapshot(pool: Pubkey, consumer: ConsumerId) -> PoolExplicitSnapshot {
+    PoolExplicitSnapshot {
+        pool,
+        vaults: vec![],
+        bin_arrays: vec![],
+        mints: vec![],
+        consumer,
+        owner: OwnerKey::Pool(pool),
+        pin: match consumer {
+            ConsumerId::Momentum => GeyserPinReason::MomentumActive,
+            ConsumerId::Arb => GeyserPinReason::ArbMultiDex,
+            ConsumerId::Tracker | ConsumerId::Wallet => GeyserPinReason::MomentumActive,
+        },
+        revision: 0,
+    }
 }
 
 #[allow(dead_code)]
@@ -3322,25 +3503,27 @@ impl MarketDataContext {
         })
     }
 
-    fn fail_revision_registry_full(&self, pool: Pubkey, consumer: ConsumerId) {
-        {
-            let mut rejected = self.revision_registry_rejected.lock();
-            let key = (pool, consumer);
-            if rejected.contains(&key) {
-                // already tracked
-            } else if rejected.len() >= self.revision_registry_rejected_capacity {
-                self.revision_registry_rejected_overflow
-                    .fetch_add(1, Ordering::AcqRel);
-                self.set_geyser_explicit_blocker(
-                    GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW,
-                    Some(
-                        "revision registry rejection ledger overflow (fail-closed until reconcile)"
-                            .into(),
-                    ),
-                );
-            } else {
-                rejected.insert(key);
-            }
+    fn record_rejected_revision_demand(&self, demand: RejectedRevisionDemand) {
+        let record_result = {
+            let mut ledger = self.revision_registry_rejection_ledger.lock();
+            ledger.record(demand)
+        };
+        if record_result == RevisionRejectionRecordResult::OverflowLost {
+            self.set_geyser_explicit_blocker(
+                GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW,
+                Some(
+                    "revision registry rejection ledger overflow (fail-closed until reconcile)"
+                        .into(),
+                ),
+            );
+        } else if record_result == RevisionRejectionRecordResult::OverflowStored {
+            self.set_geyser_explicit_blocker(
+                GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW,
+                Some(
+                    "revision registry rejection ledger overflow entries latched (fail-closed)"
+                        .into(),
+                ),
+            );
         }
         inc_market_data_revision_registry_full_total();
         self.set_geyser_explicit_blocker(
@@ -3348,6 +3531,34 @@ impl MarketDataContext {
             Some("pool snapshot revision registry full (fail-closed)".into()),
         );
         self.geyser_connect_barrier.mark_failed();
+    }
+
+    fn fail_revision_registry_full(&self, pool: Pubkey, consumer: ConsumerId) {
+        let demand =
+            RejectedRevisionDemand::inferred(pool, consumer, self.hot_pool_registry.as_ref());
+        self.record_rejected_revision_demand(demand);
+    }
+
+    fn resolve_rejected_revision_demand(
+        &self,
+        demand: RejectedRevisionDemand,
+        desired: Option<&DesiredExplicitSet>,
+    ) {
+        let removed = self
+            .revision_registry_rejection_ledger
+            .lock()
+            .remove_demand(demand);
+        if removed {
+            self.maybe_clear_revision_registry_full_blocker(desired);
+        }
+    }
+
+    fn withdraw_rejected_revision_demand(
+        &self,
+        demand: RejectedRevisionDemand,
+        desired: Option<&DesiredExplicitSet>,
+    ) {
+        self.resolve_rejected_revision_demand(demand, desired);
     }
 
     fn set_geyser_explicit_blocker(&self, flag: u8, msg: Option<String>) {
@@ -3376,16 +3587,11 @@ impl MarketDataContext {
     }
 
     fn maybe_clear_revision_registry_full_blocker(&self, desired: Option<&DesiredExplicitSet>) {
-        if !self.revision_registry_rejected.lock().is_empty() {
+        let ledger = self.revision_registry_rejection_ledger.lock();
+        if ledger.has_unresolved() {
             return;
         }
-        if self
-            .revision_registry_rejected_overflow
-            .load(Ordering::Acquire)
-            > 0
-        {
-            return;
-        }
+        drop(ledger);
         if self.geyser_explicit_blockers.load(Ordering::Acquire)
             & GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW
             != 0
@@ -3404,92 +3610,108 @@ impl MarketDataContext {
         consumer: ConsumerId,
         desired: Option<&DesiredExplicitSet>,
     ) {
-        self.revision_registry_rejected
+        let demand =
+            RejectedRevisionDemand::inferred(pool, consumer, self.hot_pool_registry.as_ref());
+        if self
+            .revision_registry_rejection_ledger
             .lock()
-            .remove(&(pool, consumer));
-        self.maybe_clear_revision_registry_full_blocker(desired);
-    }
-
-    fn pool_consumer_still_demands_revision(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
-        match consumer {
-            ConsumerId::Momentum => {
-                self.hot_pool_registry.pool_has_momentum(pool)
-                    || self.pending_pool_commands.has_pending(pool, consumer)
-            }
-            ConsumerId::Arb => {
-                self.hot_pool_registry.pool_has_arb(pool)
-                    || self.pending_pool_commands.has_pending(pool, consumer)
-            }
-            ConsumerId::Tracker => {
-                self.hot_pool_registry.is_hot_pool(pool)
-                    || self.pending_pool_commands.has_pending(pool, consumer)
-            }
-            ConsumerId::Wallet => false,
+            .remove_key(pool, consumer)
+        {
+            self.maybe_clear_revision_registry_full_blocker(desired);
+        } else {
+            let _ = demand;
         }
-    }
-
-    fn untracked_revision_registry_rejection_demand_remains(&self) -> bool {
-        let rejected = self.revision_registry_rejected.lock();
-        for (_, pool) in self.hot_pool_registry.snapshot_pairs() {
-            if !self
-                .pool_snapshot_revisions
-                .can_issue_revision(pool, ConsumerId::Momentum)
-                && !rejected.contains(&(pool, ConsumerId::Momentum))
-            {
-                return true;
-            }
-        }
-        for pool in self.hot_pool_registry.snapshot_arb_pools() {
-            if !self
-                .pool_snapshot_revisions
-                .can_issue_revision(pool, ConsumerId::Arb)
-                && !rejected.contains(&(pool, ConsumerId::Arb))
-            {
-                return true;
-            }
-        }
-        for (pool, consumer) in self.pending_pool_commands.pending_revision_keys() {
-            if !self
-                .pool_snapshot_revisions
-                .can_issue_revision(pool, consumer)
-                && !rejected.contains(&(pool, consumer))
-            {
-                return true;
-            }
-        }
-        false
     }
 
     fn reconcile_revision_registry_rejections(&self, desired: Option<&DesiredExplicitSet>) {
-        {
-            let mut rejected = self.revision_registry_rejected.lock();
-            rejected.retain(|&(pool, consumer)| {
-                self.pool_consumer_still_demands_revision(pool, consumer)
-            });
+        let snapshot_gen = {
+            let ledger = self.revision_registry_rejection_ledger.lock();
+            ledger.generation
+        };
+        #[cfg(test)]
+        self.revision_reconcile_test_barrier.wait_after_snapshot();
+        let mut ledger = self.revision_registry_rejection_ledger.lock();
+        if ledger.generation != snapshot_gen {
+            return;
         }
-        if self
-            .revision_registry_rejected_overflow
-            .load(Ordering::Acquire)
-            > 0
-            && !self.untracked_revision_registry_rejection_demand_remains()
-        {
-            self.revision_registry_rejected_overflow
-                .store(0, Ordering::Release);
-            self.clear_geyser_explicit_blocker(GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW);
+        if ledger.has_unresolved() {
+            return;
         }
+        ledger.generation = ledger.generation.wrapping_add(1);
+        drop(ledger);
+        self.clear_geyser_explicit_blocker(GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW);
         self.maybe_clear_revision_registry_full_blocker(desired);
     }
 
-    fn drop_revision_registry_rejection(
-        &self,
-        pool: Pubkey,
-        consumer: ConsumerId,
-        desired: Option<&DesiredExplicitSet>,
-    ) {
-        self.revision_registry_rejected
+    fn retry_bounded_rejected_revision_demands(&self, desired: &mut DesiredExplicitSet) {
+        let pending = self
+            .revision_registry_rejection_ledger
             .lock()
-            .remove(&(pool, consumer));
-        self.maybe_clear_revision_registry_full_blocker(desired);
+            .pending_demands();
+        for demand in pending {
+            let applied = match demand {
+                RejectedRevisionDemand::Momentum { mint, pool } => {
+                    if !self.hot_pool_registry.try_pin_pool(mint, pool) {
+                        false
+                    } else if !self.ensure_pool_revision_key(pool, ConsumerId::Momentum, None) {
+                        self.hot_pool_registry.unpin_pool(mint, pool);
+                        false
+                    } else {
+                        self.register_geyser_reserves_for_momentum_active_pool(desired, pool);
+                        true
+                    }
+                }
+                RejectedRevisionDemand::Arb { pool } => {
+                    if !self.hot_pool_registry.try_pin_arb_pool(pool) {
+                        false
+                    } else if !self.ensure_pool_revision_key(pool, ConsumerId::Arb, None) {
+                        self.hot_pool_registry.unpin_arb_pool(pool);
+                        false
+                    } else {
+                        self.register_geyser_reserves_for_arb_active_pool(desired, pool);
+                        true
+                    }
+                }
+                RejectedRevisionDemand::Tracker { pool } => {
+                    if (!self.hot_pool_registry.is_hot_pool(pool)
+                        && !self.hot_pool_registry.try_pin_arb_pool(pool))
+                        || !self.ensure_pool_revision_key(pool, ConsumerId::Tracker, None)
+                    {
+                        false
+                    } else {
+                        let snapshot = minimal_enqueue_pool_snapshot(pool, ConsumerId::Tracker);
+                        enqueue_track_worker(
+                            self,
+                            TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
+                        )
+                    }
+                }
+            };
+            if applied {
+                self.resolve_rejected_revision_demand(demand, Some(desired));
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn test_revision_rejection_has_key(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
+        let ledger = self.revision_registry_rejection_ledger.lock();
+        ledger.entries.contains_key(&(pool, consumer))
+            || ledger
+                .overflow_entries
+                .iter()
+                .any(|stored| stored.key() == (pool, consumer))
+    }
+
+    #[cfg(test)]
+    fn test_revision_rejection_unresolved(&self) -> (usize, usize, usize, u64) {
+        let ledger = self.revision_registry_rejection_ledger.lock();
+        (
+            ledger.entries.len(),
+            ledger.overflow_entries.len(),
+            ledger.overflow_lost,
+            ledger.generation,
+        )
     }
 
     fn fail_wallet_revision_exhausted(&self) {
@@ -3622,10 +3844,7 @@ impl MarketDataContext {
             .ensure_revision_key(pool, consumer)
         {
             RevisionAcquireResult::Acquired => true,
-            RevisionAcquireResult::RegistryFull => {
-                self.fail_revision_registry_full(pool, consumer);
-                false
-            }
+            RevisionAcquireResult::RegistryFull => false,
         }
     }
 
@@ -3662,9 +3881,14 @@ impl MarketDataContext {
             return false;
         }
         if !self.ensure_pool_revision_key(pool, ConsumerId::Momentum, Some(desired)) {
+            self.record_rejected_revision_demand(RejectedRevisionDemand::Momentum { mint, pool });
             self.hot_pool_registry.unpin_pool(mint, pool);
             return false;
         }
+        self.resolve_rejected_revision_demand(
+            RejectedRevisionDemand::Momentum { mint, pool },
+            Some(desired),
+        );
         true
     }
 
@@ -3682,9 +3906,11 @@ impl MarketDataContext {
             return false;
         }
         if !self.ensure_pool_revision_key(pool, ConsumerId::Arb, Some(desired)) {
+            self.record_rejected_revision_demand(RejectedRevisionDemand::Arb { pool });
             self.hot_pool_registry.unpin_arb_pool(pool);
             return false;
         }
+        self.resolve_rejected_revision_demand(RejectedRevisionDemand::Arb { pool }, Some(desired));
         true
     }
 
@@ -3833,6 +4059,7 @@ impl MarketDataContext {
         if self.pending_pool_commands.is_empty() {
             self.clear_pending_pool_overflow_latch();
         }
+        self.retry_bounded_rejected_revision_demands(desired);
         self.recompute_geyser_explicit_readiness(desired);
     }
 
@@ -5996,7 +6223,10 @@ impl MarketDataContext {
         pool: Pubkey,
     ) -> bool {
         self.hot_pool_registry.unpin_pool(mint, pool);
-        self.drop_revision_registry_rejection(pool, ConsumerId::Momentum, Some(desired));
+        self.withdraw_rejected_revision_demand(
+            RejectedRevisionDemand::Momentum { mint, pool },
+            Some(desired),
+        );
         let consumer = ConsumerId::Momentum;
         let refs = self.pool_snapshot_revisions.key_refs(pool, consumer);
         let has_pending = self.pending_pool_commands.has_pending(pool, consumer);
@@ -6210,7 +6440,7 @@ impl MarketDataContext {
         pool: Pubkey,
     ) -> bool {
         self.hot_pool_registry.unpin_arb_pool(pool);
-        self.drop_revision_registry_rejection(pool, ConsumerId::Arb, Some(desired));
+        self.withdraw_rejected_revision_demand(RejectedRevisionDemand::Arb { pool }, Some(desired));
         let consumer = ConsumerId::Arb;
         let refs = self.pool_snapshot_revisions.key_refs(pool, consumer);
         let has_pending = self.pending_pool_commands.has_pending(pool, consumer);
@@ -8444,9 +8674,11 @@ async fn main() -> Result<()> {
         pool_snapshot_revisions,
         pending_pool_overflow_latched: AtomicBool::new(false),
         geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
-        revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
-        revision_registry_rejected_overflow: AtomicUsize::new(0),
-        revision_registry_rejected_capacity: MAX_REVISION_REJECTION_LEDGER_CAPACITY,
+        revision_registry_rejection_ledger: parking_lot::Mutex::new(
+            RevisionRegistryRejectionLedger::new(MAX_REVISION_REJECTION_LEDGER_CAPACITY),
+        ),
+        #[cfg(test)]
+        revision_reconcile_test_barrier: RevisionReconcileTestBarrier::default(),
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -12047,9 +12279,11 @@ mod wallet_snapshot_stale_cleanup_tests {
             pool_snapshot_revisions,
             pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
-            revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
-            revision_registry_rejected_overflow: AtomicUsize::new(0),
-            revision_registry_rejected_capacity: MAX_REVISION_REJECTION_LEDGER_CAPACITY,
+            revision_registry_rejection_ledger: parking_lot::Mutex::new(
+                RevisionRegistryRejectionLedger::new(MAX_REVISION_REJECTION_LEDGER_CAPACITY),
+            ),
+            #[cfg(test)]
+            revision_reconcile_test_barrier: RevisionReconcileTestBarrier::default(),
         }
     }
 
@@ -12296,9 +12530,11 @@ mod wallet_tx_meta_balance_tests {
             pool_snapshot_revisions,
             pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
-            revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
-            revision_registry_rejected_overflow: AtomicUsize::new(0),
-            revision_registry_rejected_capacity: MAX_REVISION_REJECTION_LEDGER_CAPACITY,
+            revision_registry_rejection_ledger: parking_lot::Mutex::new(
+                RevisionRegistryRejectionLedger::new(MAX_REVISION_REJECTION_LEDGER_CAPACITY),
+            ),
+            #[cfg(test)]
+            revision_reconcile_test_barrier: RevisionReconcileTestBarrier::default(),
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
         *ctx.track_worker.write() = Some(track_worker);
@@ -13227,9 +13463,11 @@ mod pr_b_geyser_tracking_tests {
             pool_snapshot_revisions,
             pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
-            revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
-            revision_registry_rejected_overflow: AtomicUsize::new(0),
-            revision_registry_rejected_capacity: rejection_ledger_capacity,
+            revision_registry_rejection_ledger: parking_lot::Mutex::new(
+                RevisionRegistryRejectionLedger::new(rejection_ledger_capacity),
+            ),
+            #[cfg(test)]
+            revision_reconcile_test_barrier: RevisionReconcileTestBarrier::default(),
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
         *ctx.track_worker.write() = Some(track_worker);
@@ -13238,20 +13476,7 @@ mod pr_b_geyser_tracking_tests {
     }
 
     fn mk_test_pool_snapshot(pool: Pubkey, consumer: ConsumerId) -> PoolExplicitSnapshot {
-        PoolExplicitSnapshot {
-            pool,
-            vaults: vec![],
-            bin_arrays: vec![],
-            mints: vec![],
-            consumer,
-            owner: OwnerKey::Pool(pool),
-            pin: match consumer {
-                ConsumerId::Momentum => GeyserPinReason::MomentumActive,
-                ConsumerId::Arb => GeyserPinReason::ArbMultiDex,
-                ConsumerId::Tracker | ConsumerId::Wallet => GeyserPinReason::MomentumActive,
-            },
-            revision: 0,
-        }
+        minimal_enqueue_pool_snapshot(pool, consumer)
     }
 
     fn assert_revision_enqueue_retry_clears_rejection(
@@ -13262,20 +13487,14 @@ mod pr_b_geyser_tracking_tests {
     ) {
         ctx.fail_revision_registry_full(pool, consumer);
         assert!(!ctx.geyser_explicit_readiness_ok());
-        assert!(ctx
-            .revision_registry_rejected
-            .lock()
-            .contains(&(pool, consumer)));
+        assert!(ctx.test_revision_rejection_has_key(pool, consumer));
         setup(ctx, pool);
         let snapshot = mk_test_pool_snapshot(pool, consumer);
         assert!(enqueue_track_worker(
             ctx,
             TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
         ));
-        assert!(!ctx
-            .revision_registry_rejected
-            .lock()
-            .contains(&(pool, consumer)));
+        assert!(!ctx.test_revision_rejection_has_key(pool, consumer));
     }
 
     /// PR161: same as [`minimal_market_data_context_for_pr_d_tests`], but returns merge `watch` receivers.
@@ -13367,9 +13586,11 @@ mod pr_b_geyser_tracking_tests {
             pool_snapshot_revisions,
             pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
-            revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
-            revision_registry_rejected_overflow: AtomicUsize::new(0),
-            revision_registry_rejected_capacity: MAX_REVISION_REJECTION_LEDGER_CAPACITY,
+            revision_registry_rejection_ledger: parking_lot::Mutex::new(
+                RevisionRegistryRejectionLedger::new(MAX_REVISION_REJECTION_LEDGER_CAPACITY),
+            ),
+            #[cfg(test)]
+            revision_reconcile_test_barrier: RevisionReconcileTestBarrier::default(),
         });
         (
             ctx,
@@ -18623,10 +18844,7 @@ mod pr_b_geyser_tracking_tests {
 
         ctx.fail_revision_registry_full(pool_rejected, ConsumerId::Momentum);
         assert!(!ctx.geyser_explicit_readiness_ok());
-        assert!(ctx
-            .revision_registry_rejected
-            .lock()
-            .contains(&(pool_rejected, ConsumerId::Momentum)));
+        assert!(ctx.test_revision_rejection_has_key(pool_rejected, ConsumerId::Momentum));
 
         ctx.hot_pool_registry.pin_pool(mint_healthy, pool_healthy);
         let healthy_snapshot = mk_test_pool_snapshot(pool_healthy, ConsumerId::Momentum);
@@ -18640,10 +18858,7 @@ mod pr_b_geyser_tracking_tests {
             !ctx.geyser_explicit_readiness_ok(),
             "healthy enqueue retry must not clear blocker while rejected key remains"
         );
-        assert!(ctx
-            .revision_registry_rejected
-            .lock()
-            .contains(&(pool_rejected, ConsumerId::Momentum)));
+        assert!(ctx.test_revision_rejection_has_key(pool_rejected, ConsumerId::Momentum));
 
         ctx.hot_pool_registry.pin_pool(mint_rejected, pool_rejected);
         let snapshot = mk_test_pool_snapshot(pool_rejected, ConsumerId::Momentum);
@@ -18651,7 +18866,7 @@ mod pr_b_geyser_tracking_tests {
             &ctx,
             TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
         ));
-        assert!(ctx.revision_registry_rejected.lock().is_empty());
+        assert_eq!(ctx.test_revision_rejection_unresolved().0, 0);
         let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         ctx.recompute_geyser_explicit_readiness(&desired);
         assert!(ctx.geyser_explicit_readiness_ok());
@@ -18682,10 +18897,7 @@ mod pr_b_geyser_tracking_tests {
             !ctx.geyser_explicit_readiness_ok(),
             "u64 exhaustion must keep registry-full blocker latched"
         );
-        assert!(ctx
-            .revision_registry_rejected
-            .lock()
-            .contains(&(pool, ConsumerId::Momentum)));
+        assert!(ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum));
     }
 
     #[test]
@@ -18804,87 +19016,162 @@ mod pr_b_geyser_tracking_tests {
             &ctx,
             TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
         ));
-        assert!(!ctx
-            .revision_registry_rejected
-            .lock()
-            .contains(&(pool, ConsumerId::Momentum)));
+        assert!(!ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum));
         assert!(ctx
             .pending_pool_commands
             .has_pending(pool, ConsumerId::Momentum));
     }
 
     #[test]
-    fn revision_registry_rejection_ledger_overflow_fails_closed_until_reconcile() {
+    fn rejected_pin_absent_from_hot_maps_stays_unresolved_across_reconcile() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
-        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(
-            jsonl,
-            pending_pool_registration_cap(25_000),
-            3,
-        );
-
-        let rejected_pools: Vec<Pubkey> = (0..5).map(|_| Pubkey::new_unique()).collect();
-        for (i, pool) in rejected_pools.iter().enumerate() {
-            let consumer = if i % 2 == 0 {
-                ConsumerId::Momentum
-            } else {
-                ConsumerId::Arb
-            };
-            ctx.fail_revision_registry_full(*pool, consumer);
-        }
-        assert_eq!(ctx.revision_registry_rejected.lock().len(), 3);
-        assert_eq!(
-            ctx.revision_registry_rejected_overflow
-                .load(Ordering::Acquire),
-            2
-        );
-        assert!(
-            ctx.geyser_explicit_blockers.load(Ordering::Acquire)
-                & GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW
-                != 0
-        );
-        assert!(!ctx.geyser_explicit_readiness_ok());
-
-        let stored_rejections = [
-            (rejected_pools[0], ConsumerId::Momentum),
-            (rejected_pools[1], ConsumerId::Arb),
-            (rejected_pools[2], ConsumerId::Momentum),
-        ];
-        for (pool, consumer) in stored_rejections {
-            if consumer == ConsumerId::Momentum {
-                let mint = Pubkey::new_unique();
-                ctx.hot_pool_registry.pin_pool(mint, pool);
-            } else {
-                ctx.hot_pool_registry.pin_arb_pool(pool);
-            }
-            let snapshot = mk_test_pool_snapshot(pool, consumer);
-            assert!(enqueue_track_worker(
-                &ctx,
-                TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
-            ));
-            assert!(!ctx
-                .revision_registry_rejected
-                .lock()
-                .contains(&(pool, consumer)));
-        }
-        assert!(ctx.revision_registry_rejected.lock().is_empty());
-        assert_eq!(
-            ctx.revision_registry_rejected_overflow
-                .load(Ordering::Acquire),
-            2
-        );
-        assert!(!ctx.geyser_explicit_readiness_ok());
-
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 1, 8);
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
         let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
-        ctx.reconcile_revision_registry_rejections(Some(&desired));
+
+        let occupant_pool = Pubkey::new_unique();
+        let occupant_mint = Pubkey::new_unique();
+        ctx.hot_pool_registry.pin_pool(occupant_mint, occupant_pool);
+        assert!(ctx.ensure_pool_revision_key_cold(occupant_pool, ConsumerId::Momentum));
         assert_eq!(
-            ctx.revision_registry_rejected_overflow
-                .load(Ordering::Acquire),
-            0
+            ctx.pool_snapshot_revisions
+                .reserve_inflight_command(occupant_pool, ConsumerId::Momentum),
+            InflightReserveResult::Reserved,
+            "occupant slot must stay non-recyclable while rejected demand is pending"
         );
+
+        assert!(!ctx.try_pin_momentum_with_revision(mint, pool, &desired));
+        assert!(!ctx.hot_pool_registry.is_pinned(mint, pool));
+        assert!(ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum));
+        assert!(!ctx.geyser_explicit_readiness_ok());
+
+        ctx.reconcile_revision_registry_rejections(Some(&desired));
+        assert!(
+            ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum),
+            "reconcile must not treat absent hot/pending pin as resolved demand"
+        );
+        assert!(!ctx.geyser_explicit_readiness_ok());
+    }
+
+    #[test]
+    fn rejected_pin_retries_when_capacity_returns_and_clears() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 1, 8);
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+
+        let occupant_pool = Pubkey::new_unique();
+        let occupant_mint = Pubkey::new_unique();
+        ctx.hot_pool_registry.pin_pool(occupant_mint, occupant_pool);
+        assert!(ctx.ensure_pool_revision_key_cold(occupant_pool, ConsumerId::Momentum));
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .reserve_inflight_command(occupant_pool, ConsumerId::Momentum),
+            InflightReserveResult::Reserved,
+        );
+        assert!(!ctx.try_pin_momentum_with_revision(mint, pool, &desired));
+        assert!(ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum));
+
+        ctx.pool_snapshot_revisions
+            .release_inflight_command(occupant_pool, ConsumerId::Momentum);
+        ctx.hot_pool_registry
+            .unpin_pool(occupant_mint, occupant_pool);
+        ctx.pool_snapshot_revisions.maybe_retire_key(
+            occupant_pool,
+            ConsumerId::Momentum,
+            false,
+            false,
+        );
+
+        ctx.retry_bounded_rejected_revision_demands(&mut desired);
+        assert!(!ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum));
+        assert!(ctx.hot_pool_registry.is_pinned(mint, pool));
+        ctx.reconcile_revision_registry_rejections(Some(&desired));
         ctx.recompute_geyser_explicit_readiness(&desired);
         assert!(ctx.geyser_explicit_readiness_ok());
+    }
+
+    #[test]
+    fn rejected_pin_explicit_withdrawal_clears_without_hot_presence() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 1, 8);
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+
+        let occupant_pool = Pubkey::new_unique();
+        let occupant_mint = Pubkey::new_unique();
+        ctx.hot_pool_registry.pin_pool(occupant_mint, occupant_pool);
+        assert!(ctx.ensure_pool_revision_key_cold(occupant_pool, ConsumerId::Momentum));
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .reserve_inflight_command(occupant_pool, ConsumerId::Momentum),
+            InflightReserveResult::Reserved,
+        );
+        assert!(!ctx.try_pin_momentum_with_revision(mint, pool, &desired));
+        assert!(!ctx.hot_pool_registry.is_pinned(mint, pool));
+
+        ctx.clear_momentum_geyser_reserves_for_active_entry(&mut desired, mint, pool);
+        assert!(!ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum));
+        ctx.reconcile_revision_registry_rejections(Some(&desired));
+        ctx.recompute_geyser_explicit_readiness(&desired);
+        assert!(ctx.geyser_explicit_readiness_ok());
+    }
+
+    #[test]
+    fn reconcile_overflow_generation_race_preserves_blocker_and_demand() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 8, 8);
+        ctx.set_geyser_explicit_blocker(
+            GESYER_BLOCK_REVISION_REGISTRY_FULL,
+            Some("seed blocker".into()),
+        );
+        ctx.set_geyser_explicit_blocker(
+            GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW,
+            Some("seed overflow".into()),
+        );
+        let (_, _, _, gen_before) = ctx.test_revision_rejection_unresolved();
+        assert_eq!(gen_before, 0);
+
+        ctx.revision_reconcile_test_barrier
+            .hold_after_snapshot
+            .store(true, Ordering::Release);
+        let ctx_worker = Arc::clone(&ctx);
+        let worker = std::thread::spawn(move || {
+            ctx_worker.reconcile_revision_registry_rejections(None);
+        });
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let overflow_pool = Pubkey::new_unique();
+        ctx.fail_revision_registry_full(overflow_pool, ConsumerId::Momentum);
+        let (entries, overflow_entries, overflow_lost, gen_after_fail) =
+            ctx.test_revision_rejection_unresolved();
+        assert!(ctx.test_revision_rejection_has_key(overflow_pool, ConsumerId::Momentum));
+        assert!(
+            gen_after_fail > gen_before || entries > 0 || overflow_entries > 0 || overflow_lost > 0
+        );
+
+        ctx.revision_reconcile_test_barrier
+            .continue_reconcile
+            .store(true, Ordering::Release);
+        worker.join().expect("reconcile thread");
+
+        assert!(ctx.test_revision_rejection_has_key(overflow_pool, ConsumerId::Momentum));
+        assert!(!ctx.geyser_explicit_readiness_ok());
+        assert!(
+            ctx.geyser_explicit_blockers.load(Ordering::Acquire)
+                & GESYER_BLOCK_REVISION_REGISTRY_FULL
+                != 0
+        );
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -83,9 +83,10 @@ use ironcrab::market_data::track::{
     arb_coalesce_try_send, explicit_set_snapshot_path, load_explicit_set_snapshot,
     momentum_coalesce_try_send, owner_key_to_snapshot, pool_is_enrichment_member,
     spawn_track_worker, track_worker_try_enqueue, AdmissionResult, ConsumerId, DesiredExplicitSet,
-    ExplicitAccountKind, ExplicitSetSnapshot, ExplicitSnapshotRow, OwnerKey, SnapshotConsumer,
-    SnapshotOwnerGroup, TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
-    EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP, MARKET_DATA_TRACK_WORKER_COALESCE_MS,
+    ExplicitAccountKind, ExplicitSetSnapshot, ExplicitSnapshotRow, OwnerGroupSnapshot, OwnerKey,
+    SnapshotConsumer, SnapshotOwnerGroup, TrackPinReason, TrackWorkerCommand, TrackWorkerContext,
+    TrackWorkerSender, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
+    MARKET_DATA_TRACK_WORKER_COALESCE_MS,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -1133,6 +1134,12 @@ struct MarketDataContext {
     /// Fail-closed when mandatory wallet demand exceeds explicit cap.
     geyser_explicit_ready: AtomicBool,
     geyser_explicit_config_error: parking_lot::RwLock<Option<String>>,
+    /// Durable cap invalidation when config shrink enqueue fails (0 = none).
+    pending_explicit_cap: AtomicUsize,
+    /// Worker must drain pending wallet/cap work after enqueue loss.
+    track_worker_dirty: AtomicBool,
+    /// Latest wallet explicit demand + token ATAs awaiting worker commit.
+    pending_wallet_sync: parking_lot::RwLock<Option<(HashSet<Pubkey>, HashSet<Pubkey>)>>,
 }
 
 #[derive(Debug, Default)]
@@ -1896,10 +1903,22 @@ fn geyser_pin_from_track_pin(pin: TrackPinReason) -> GeyserPinReason {
 }
 
 fn enqueue_track_worker(ctx: &MarketDataContext, job: TrackWorkerCommand) -> bool {
+    if let TrackWorkerCommand::SyncWalletExplicitDemand {
+        demand,
+        token_accounts,
+    } = &job
+    {
+        *ctx.pending_wallet_sync.write() = Some((demand.clone(), token_accounts.clone()));
+    }
     let Some(sender) = ctx.track_worker.read().clone() else {
+        ctx.mark_track_worker_dirty();
         return false;
     };
-    track_worker_try_enqueue(&sender, job)
+    if track_worker_try_enqueue(&sender, job) {
+        return true;
+    }
+    ctx.mark_track_worker_dirty();
+    false
 }
 
 fn collect_pool_explicit_pubkeys_from_cached_state(
@@ -2170,8 +2189,11 @@ impl TrackWorkerContext for MarketDataContext {
 
     fn converge_explicit_admission(&self, desired: &mut DesiredExplicitSet) {
         desired.set_max_explicit_pubkeys(self.config.read().max_tracked_accounts);
-        let groups = self.collect_explicit_owner_groups_for_convergence();
-        desired.reconcile_owner_groups(groups);
+        let authoritative = self.collect_explicit_owner_groups_for_convergence();
+        let auth_keys: HashSet<(ConsumerId, OwnerKey)> =
+            authoritative.iter().map(|(c, o, _)| (*c, *o)).collect();
+        let preserve = self.collect_preserve_owner_groups(desired, &auth_keys);
+        desired.reconcile_owner_groups_with_preserve(authoritative, preserve);
         self.sync_wallet_demand_to_desired(desired);
         self.prune_tracked_maps_to_desired(desired);
         self.pending_geyser_evict.store(false, Ordering::Relaxed);
@@ -2183,9 +2205,21 @@ impl TrackWorkerContext for MarketDataContext {
         &self,
         desired: &mut DesiredExplicitSet,
         demand: HashSet<Pubkey>,
+        token_accounts: HashSet<Pubkey>,
     ) -> bool {
-        *self.wallet_explicit_demand.write() = demand.clone();
-        self.sync_wallet_demand_to_desired(desired)
+        self.commit_wallet_explicit_state(desired, demand, token_accounts)
+    }
+
+    fn take_pending_explicit_cap(&self) -> Option<usize> {
+        MarketDataContext::take_pending_explicit_cap(self)
+    }
+
+    fn take_track_worker_dirty(&self) -> bool {
+        self.track_worker_dirty.swap(false, Ordering::AcqRel)
+    }
+
+    fn apply_pending_track_worker_work(&self, desired: &mut DesiredExplicitSet) {
+        MarketDataContext::apply_pending_track_worker_work(self, desired);
     }
 
     fn commit_register_pool_geyser_reserves(
@@ -2206,12 +2240,20 @@ impl TrackWorkerContext for MarketDataContext {
         if !self.hot_pool_registry.is_hot_pool(pool) {
             return false;
         }
-        let changed = self.register_pool_vaults_from_account_worker(pool);
-        if changed {
-            let _ =
-                self.try_admit_pool_explicit_group(desired, pool, GeyserPinReason::MomentumActive);
+        let admission =
+            self.try_admit_pool_explicit_group(desired, pool, GeyserPinReason::MomentumActive);
+        match admission {
+            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
+                self.register_pool_vaults_from_account_worker(pool)
+            }
+            rejected => {
+                record_admission_rejection(
+                    consumer_id_for_geyser_pin(Some(GeyserPinReason::MomentumActive)),
+                    rejected,
+                );
+                false
+            }
         }
-        changed
     }
 
     fn commit_register_geyser_reserves_after_trade(
@@ -2232,12 +2274,11 @@ impl TrackWorkerContext for MarketDataContext {
         if !self.admit_geyser_explicit_pool_assets(pool, base_mint, quote_mint) {
             return false;
         }
-        let changed = self.register_geyser_reserves_impl(pool, GeyserPinReason::MomentumActive);
-        if changed {
-            let _ =
-                self.try_admit_pool_explicit_group(desired, pool, GeyserPinReason::MomentumActive);
-        }
-        changed
+        self.register_geyser_reserves_for_active_pool(
+            desired,
+            pool,
+            GeyserPinReason::MomentumActive,
+        )
     }
 
     fn commit_refresh_dlmm_bin_window(
@@ -2246,11 +2287,26 @@ impl TrackWorkerContext for MarketDataContext {
         pool: Pubkey,
         new_active_id: i32,
     ) -> bool {
-        let changed = self.maybe_refresh_arb_dlmm_bin_window_worker(pool, new_active_id);
-        if changed {
-            let _ = self.try_admit_pool_explicit_group(desired, pool, GeyserPinReason::ArbMultiDex);
+        if !self.hot_pool_registry.pool_has_arb(pool) {
+            return false;
         }
-        changed
+        if self.dlmm_registered_active_id.read().get(&pool).copied() == Some(new_active_id) {
+            return false;
+        }
+        let admission =
+            self.try_admit_pool_explicit_group(desired, pool, GeyserPinReason::ArbMultiDex);
+        match admission {
+            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
+                self.maybe_refresh_arb_dlmm_bin_window_worker(pool, new_active_id)
+            }
+            rejected => {
+                record_admission_rejection(
+                    consumer_id_for_geyser_pin(Some(GeyserPinReason::ArbMultiDex)),
+                    rejected,
+                );
+                false
+            }
+        }
     }
 
     fn publish_admitted_explicit_physical(&self, desired: &DesiredExplicitSet) {
@@ -2566,7 +2622,31 @@ impl TxIngestHost for MarketDataContext {
     }
 
     fn tx_wallet_token_account_insert(&self, ata: Pubkey) -> bool {
-        self.tracked_wallet_token_accounts.write().insert(ata)
+        let Some(tracked_wallet) = self.tracked_wallet.as_ref() else {
+            return false;
+        };
+        let prev_demand = self.wallet_explicit_demand.read().clone();
+        let was_present = prev_demand.contains(&ata);
+        let mut demand = prev_demand;
+        demand.insert(tracked_wallet.wallet);
+        demand.insert(tracked_wallet.wsol_ata);
+        demand.insert(ata);
+        let token_accounts = Self::wallet_token_accounts_from_demand(&demand, tracked_wallet);
+        let _ = self.enqueue_wallet_explicit_sync(demand, token_accounts);
+        !was_present
+    }
+
+    fn tx_wallet_token_account_remove(&self, ata: Pubkey) -> bool {
+        let Some(tracked_wallet) = self.tracked_wallet.as_ref() else {
+            return false;
+        };
+        let mut demand = self.wallet_explicit_demand.read().clone();
+        if !demand.remove(&ata) {
+            return false;
+        }
+        let token_accounts = Self::wallet_token_accounts_from_demand(&demand, tracked_wallet);
+        let _ = self.enqueue_wallet_explicit_sync(demand, token_accounts);
+        true
     }
 
     fn tx_wallet_mint_decimals_insert(&self, mint: Pubkey, decimals: u8) {
@@ -2576,18 +2656,16 @@ impl TxIngestHost for MarketDataContext {
     }
 
     fn tx_wallet_notify_geyser_subscribe_accounts_changed(&self) {
+        if self.pending_wallet_sync.read().is_some() {
+            let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
+            return;
+        }
         let Some(tracked_wallet) = self.tracked_wallet.as_ref() else {
             return;
         };
-        let mut demand: HashSet<Pubkey> = HashSet::new();
-        demand.insert(tracked_wallet.wallet);
-        demand.insert(tracked_wallet.wsol_ata);
-        demand.extend(self.tracked_wallet_token_accounts.read().iter().copied());
-        *self.wallet_explicit_demand.write() = demand.clone();
-        let _ = enqueue_track_worker(
-            self,
-            TrackWorkerCommand::SyncWalletExplicitDemand { demand },
-        );
+        let demand = self.wallet_explicit_demand.read().clone();
+        let token_accounts = Self::wallet_token_accounts_from_demand(&demand, tracked_wallet);
+        let _ = self.enqueue_wallet_explicit_sync(demand, token_accounts);
         let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
     }
 
@@ -2754,16 +2832,17 @@ impl MarketDataContext {
     ) -> Vec<(ConsumerId, OwnerKey, HashSet<Pubkey>)> {
         let mut groups: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>> = HashMap::new();
         for (pool_pk, pin) in self.iter_pinned_pools_for_convergence() {
-            let Some(state) = self.live_pool_cache.get(&pool_pk) else {
-                continue;
-            };
             let consumer = consumer_id_for_geyser_pin(Some(pin));
-            let pubkeys = collect_pool_explicit_pubkeys_from_cached_state(
-                pool_pk,
-                &state,
-                self.config.read().enable_meteora_cpmm,
-                self.config.read().enable_meteora_dlmm,
-            );
+            let pubkeys = if let Some(state) = self.live_pool_cache.get(&pool_pk) {
+                collect_pool_explicit_pubkeys_from_cached_state(
+                    pool_pk,
+                    &state,
+                    self.config.read().enable_meteora_cpmm,
+                    self.config.read().enable_meteora_dlmm,
+                )
+            } else {
+                self.collect_tracked_pubkeys_for_pool(pool_pk, pin)
+            };
             if !pubkeys.is_empty() {
                 groups
                     .entry((consumer, OwnerKey::Pool(pool_pk)))
@@ -2795,9 +2874,135 @@ impl MarketDataContext {
         for pool in self.hot_pool_registry.snapshot_arb_pools() {
             out.push((pool, GeyserPinReason::ArbMultiDex));
         }
-        out.sort_by_key(|(p, _)| *p);
-        out.dedup_by_key(|(p, _)| *p);
         out
+    }
+
+    fn collect_tracked_pubkeys_for_pool(
+        &self,
+        pool: Pubkey,
+        pin: GeyserPinReason,
+    ) -> HashSet<Pubkey> {
+        let mut out = HashSet::new();
+        for (pk, v) in self.tracked_vaults.read().iter() {
+            if v.pool_address == pool && v.pin == Some(pin) {
+                out.insert(*pk);
+            }
+        }
+        for (pk, b) in self.tracked_bin_arrays.read().iter() {
+            if b.pool_address == pool && b.pin == Some(pin) {
+                out.insert(*pk);
+            }
+        }
+        out
+    }
+
+    fn collect_preserve_owner_groups(
+        &self,
+        desired: &DesiredExplicitSet,
+        authoritative_keys: &HashSet<(ConsumerId, OwnerKey)>,
+    ) -> Vec<(ConsumerId, OwnerKey, HashSet<Pubkey>)> {
+        desired
+            .snapshot_owner_groups()
+            .into_iter()
+            .filter(|g| !authoritative_keys.contains(&(g.consumer, g.owner)))
+            .filter(|g| self.owner_group_has_tracked_backing(g))
+            .map(|g| (g.consumer, g.owner, g.pubkeys))
+            .collect()
+    }
+
+    fn owner_group_has_tracked_backing(&self, g: &OwnerGroupSnapshot) -> bool {
+        match g.owner {
+            OwnerKey::Pool(pool) => {
+                g.pubkeys.iter().any(|pk| {
+                    self.tracked_vaults.read().contains_key(pk)
+                        || self.tracked_bin_arrays.read().contains_key(pk)
+                }) || self.hot_pool_registry.is_hot_pool(pool)
+                    || self.hot_pool_registry.pool_has_arb(pool)
+            }
+            OwnerKey::Wallet => !g.pubkeys.is_empty(),
+            OwnerKey::Mint(mint) => self.tracked_mints.read().contains_key(&mint),
+        }
+    }
+
+    fn unique_momentum_pinned_pool_count(&self) -> usize {
+        self.hot_pool_registry
+            .snapshot_pairs()
+            .into_iter()
+            .map(|(_, pool)| pool)
+            .collect::<HashSet<_>>()
+            .len()
+    }
+
+    fn unique_tracker_pool_count(&self) -> usize {
+        self.high_priority_bonding_curves.read().len()
+    }
+
+    fn mark_track_worker_dirty(&self) {
+        self.track_worker_dirty.store(true, Ordering::Release);
+        self.explicit_admission_invalidate
+            .store(true, Ordering::Release);
+    }
+
+    fn store_pending_explicit_cap(&self, cap: usize) {
+        self.pending_explicit_cap.store(cap, Ordering::Release);
+        self.explicit_admission_invalidate
+            .store(true, Ordering::Release);
+    }
+
+    fn take_pending_explicit_cap(&self) -> Option<usize> {
+        let cap = self.pending_explicit_cap.swap(0, Ordering::AcqRel);
+        if cap > 0 {
+            Some(cap)
+        } else {
+            None
+        }
+    }
+
+    fn apply_pending_track_worker_work(&self, desired: &mut DesiredExplicitSet) {
+        if let Some((demand, token_accounts)) = self.pending_wallet_sync.write().take() {
+            self.commit_wallet_explicit_state(desired, demand, token_accounts);
+        }
+    }
+
+    fn commit_wallet_explicit_state(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        demand: HashSet<Pubkey>,
+        token_accounts: HashSet<Pubkey>,
+    ) -> bool {
+        *self.wallet_explicit_demand.write() = demand.clone();
+        *self.tracked_wallet_token_accounts.write() = token_accounts;
+        self.sync_wallet_demand_to_desired(desired)
+    }
+
+    fn enqueue_wallet_explicit_sync(
+        &self,
+        demand: HashSet<Pubkey>,
+        token_accounts: HashSet<Pubkey>,
+    ) -> bool {
+        *self.pending_wallet_sync.write() = Some((demand.clone(), token_accounts.clone()));
+        let ok = enqueue_track_worker(
+            self,
+            TrackWorkerCommand::SyncWalletExplicitDemand {
+                demand,
+                token_accounts,
+            },
+        );
+        if !ok {
+            self.mark_track_worker_dirty();
+        }
+        ok
+    }
+
+    fn wallet_token_accounts_from_demand(
+        demand: &HashSet<Pubkey>,
+        wallet: &TrackedWallet,
+    ) -> HashSet<Pubkey> {
+        demand
+            .iter()
+            .filter(|pk| **pk != wallet.wallet && **pk != wallet.wsol_ata)
+            .copied()
+            .collect()
     }
 
     fn wallet_explicit_demand_pubkeys(&self) -> HashSet<Pubkey> {
@@ -2823,11 +3028,13 @@ impl MarketDataContext {
             return false;
         }
         if desired.wallet_demand_exceeds_cap(&demand) {
+            let protected = desired.projected_wallet_protected_pubkeys(&demand);
             let msg = format!(
-                "wallet explicit demand ({} pubkeys) exceeds max_tracked_accounts cap ({})",
-                demand.len(),
+                "wallet protected explicit demand ({} pubkeys incl. wallet-pinned mints) exceeds max_tracked_accounts cap ({})",
+                protected.len(),
                 desired.max_explicit_pubkeys()
             );
+            record_admission_rejection(ConsumerId::Wallet, AdmissionResult::RejectedCap);
             self.geyser_explicit_ready.store(false, Ordering::Relaxed);
             *self.geyser_explicit_config_error.write() = Some(msg);
             return false;
@@ -2839,6 +3046,7 @@ impl MarketDataContext {
                     "wallet explicit admission rejected at cap ({})",
                     desired.max_explicit_pubkeys()
                 );
+                record_admission_rejection(ConsumerId::Wallet, result);
                 self.geyser_explicit_ready.store(false, Ordering::Relaxed);
                 *self.geyser_explicit_config_error.write() = Some(msg);
                 false
@@ -2861,10 +3069,12 @@ impl MarketDataContext {
 
     fn request_wallet_explicit_resync(&self) {
         let demand = self.wallet_explicit_demand_pubkeys();
-        let _ = enqueue_track_worker(
-            self,
-            TrackWorkerCommand::SyncWalletExplicitDemand { demand },
-        );
+        let token_accounts = if let Some(tw) = &self.tracked_wallet {
+            Self::wallet_token_accounts_from_demand(&demand, tw)
+        } else {
+            HashSet::new()
+        };
+        let _ = self.enqueue_wallet_explicit_sync(demand, token_accounts);
         let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
     }
 
@@ -2975,13 +3185,16 @@ impl MarketDataContext {
         set_market_data_geyser_explicit_set_size(desired.len());
         set_market_data_geyser_explicit_requested_pools(
             "momentum",
-            self.hot_pool_registry.pair_count(),
+            self.unique_momentum_pinned_pool_count(),
         );
         set_market_data_geyser_explicit_requested_pools(
             "arb",
             self.hot_pool_registry.arb_pool_count(),
         );
-        set_market_data_geyser_explicit_requested_pools("tracker", 0);
+        set_market_data_geyser_explicit_requested_pools(
+            "tracker",
+            self.unique_tracker_pool_count(),
+        );
         set_market_data_geyser_explicit_admitted_pools(
             "momentum",
             desired.admitted_pool_count(ConsumerId::Momentum),
@@ -5074,11 +5287,19 @@ impl MarketDataContext {
         }
 
         if sync_geyser_tracked_after_max_accounts {
+            let new_cap = self.config.read().max_tracked_accounts;
+            self.store_pending_explicit_cap(new_cap);
             if let Some(md_state) = md_state {
-                md_state_try_enqueue(
+                if !md_state_try_enqueue(
                     md_state,
                     MdStateCommand::ScheduleGeyserSyncAfterConfigChange,
-                );
+                ) {
+                    self.mark_track_worker_dirty();
+                    let _ = enqueue_track_worker(
+                        self,
+                        TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange,
+                    );
+                }
             } else {
                 // Bootstrap before md-state worker exists: one-shot cold-path flush.
                 self.sync_geyser_tracked_accounts();
@@ -6532,17 +6753,11 @@ async fn publish_wallet_snapshot(
 
     // 3) Update logical wallet explicit demand; physical publish goes through track-worker admission.
     if let Some(ref tracked_wallet) = ctx.tracked_wallet {
-        {
-            let existing = ctx.tracked_wallet_token_accounts.read().clone();
-            wallet_token_accounts.extend(existing);
-        }
-        *ctx.tracked_wallet_token_accounts.write() = wallet_token_accounts.clone();
         let mut demand = HashSet::new();
         demand.insert(tracked_wallet.wallet);
         demand.insert(tracked_wallet.wsol_ata);
         demand.extend(wallet_token_accounts.iter().copied());
-        *ctx.wallet_explicit_demand.write() = demand.clone();
-        let _ = enqueue_track_worker(ctx, TrackWorkerCommand::SyncWalletExplicitDemand { demand });
+        let _ = ctx.enqueue_wallet_explicit_sync(demand, wallet_token_accounts);
         let _ = enqueue_track_worker(ctx, TrackWorkerCommand::ScheduleGeyserPushDebounced);
     }
 
@@ -7013,6 +7228,7 @@ async fn main() -> Result<()> {
         market_data_config.geyser_full_reconnect_threshold,
     ));
 
+    let wallet_configured = tracked_wallet.is_some();
     let ctx = Arc::new(MarketDataContext {
         run_id: run_id.clone(),
         config: parking_lot::RwLock::new(market_data_config),
@@ -7069,8 +7285,11 @@ async fn main() -> Result<()> {
         wallet_explicit_demand: parking_lot::RwLock::new(initial_wallet_demand),
         admitted_explicit_tx,
         track_worker: parking_lot::RwLock::new(None),
-        geyser_explicit_ready: AtomicBool::new(true),
+        geyser_explicit_ready: AtomicBool::new(!wallet_configured),
         geyser_explicit_config_error: parking_lot::RwLock::new(None),
+        pending_explicit_cap: AtomicUsize::new(0),
+        track_worker_dirty: AtomicBool::new(false),
+        pending_wallet_sync: parking_lot::RwLock::new(None),
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -7851,9 +8070,17 @@ async fn run_geyser_loop(
     *ctx.track_worker.write() = Some(track_worker.clone());
     if !ctx.wallet_explicit_demand.read().is_empty() {
         let demand = ctx.wallet_explicit_demand.read().clone();
+        let token_accounts = ctx
+            .tracked_wallet
+            .as_ref()
+            .map(|tw| MarketDataContext::wallet_token_accounts_from_demand(&demand, tw))
+            .unwrap_or_default();
         let _ = track_worker_try_enqueue(
             &track_worker,
-            TrackWorkerCommand::SyncWalletExplicitDemand { demand },
+            TrackWorkerCommand::SyncWalletExplicitDemand {
+                demand,
+                token_accounts,
+            },
         );
         let _ = track_worker_try_enqueue(&track_worker, TrackWorkerCommand::ScheduleGeyserPush);
     }
@@ -8800,13 +9027,7 @@ async fn run_geyser_loop(
                                             .and_then(|s| s.parse::<u8>().ok());
 
                                         // 1) Track ATA for wallet updates (Geyser subscription list)
-                                        let mut added_ata = false;
-                                        {
-                                            let mut set = ctx.tracked_wallet_token_accounts.write();
-                                            if set.insert(ata) {
-                                                added_ata = true;
-                                            }
-                                        }
+                                        let added_ata = ctx.tx_wallet_token_account_insert(ata);
 
                                         // 2) Cache decimals if provided
                                         if let Some(d) = mint_decimals {
@@ -8883,9 +9104,8 @@ async fn run_geyser_loop(
                                                 tracked_wallet.last_wsol_balance.store(0, Ordering::Relaxed);
                                             }
 
-                                            let mut set = ctx.tracked_wallet_token_accounts.write();
-                                            if set.remove(&ata) {
-                                                drop(set);
+                                            let removed = ctx.tx_wallet_token_account_remove(ata);
+                                            if removed {
                                                 ctx.request_wallet_explicit_resync();
                                                 info!(
                                                     mint = %mint_str,
@@ -10649,6 +10869,9 @@ mod wallet_snapshot_stale_cleanup_tests {
             track_worker: parking_lot::RwLock::new(None),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
+            pending_explicit_cap: AtomicUsize::new(0),
+            track_worker_dirty: AtomicBool::new(false),
+            pending_wallet_sync: parking_lot::RwLock::new(None),
         }
     }
 
@@ -10791,6 +11014,9 @@ mod wallet_tx_meta_balance_tests {
         process_wallet_balance_snapshots_from_tx_meta, wallet_tx_meta_has_wsol_post_balance,
         wallet_tx_meta_native_sol_post_lamports,
     };
+    use ironcrab::market_data::track::{
+        spawn_inline_track_worker_sender, MARKET_DATA_TRACK_WORKER_COALESCE_MS,
+    };
     use ironcrab::solana::geyser_listener::{
         geyser_tx_involves_wallet, GeyserTransactionUpdate, TokenAmount, TokenBalance,
     };
@@ -10812,10 +11038,13 @@ mod wallet_tx_meta_balance_tests {
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let (tracked_wallet_tx, _) = watch::channel(Vec::<Pubkey>::new());
         let tracked = TrackedWallet::new(wallet);
+        let mut initial_demand = HashSet::new();
+        initial_demand.insert(wallet);
+        initial_demand.insert(tracked.wsol_ata);
         let (tracked_mints_tx, _tracked_mints_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_bin_arrays_tx, _tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
-        Arc::new(MarketDataContext {
+        let ctx = Arc::new(MarketDataContext {
             run_id: "run-wallet-tx-meta".to_string(),
             config: parking_lot::RwLock::new(MarketDataConfig::default()),
             geyser_full_reconnect_threshold_live: Arc::new(AtomicUsize::new(0)),
@@ -10870,12 +11099,18 @@ mod wallet_tx_meta_balance_tests {
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
             explicit_admission_invalidate: AtomicBool::new(false),
-            wallet_explicit_demand: parking_lot::RwLock::new(HashSet::new()),
+            wallet_explicit_demand: parking_lot::RwLock::new(initial_demand),
             admitted_explicit_tx: watch::channel(Vec::<Pubkey>::new()).0,
             track_worker: parking_lot::RwLock::new(None),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
-        })
+            pending_explicit_cap: AtomicUsize::new(0),
+            track_worker_dirty: AtomicBool::new(false),
+            pending_wallet_sync: parking_lot::RwLock::new(None),
+        });
+        let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
+        *ctx.track_worker.write() = Some(track_worker);
+        ctx
     }
 
     fn sample_wallet_tx_update(
@@ -10967,6 +11202,9 @@ mod wallet_tx_meta_balance_tests {
             &md_state,
         )
         .await;
+        std::thread::sleep(Duration::from_millis(
+            MARKET_DATA_TRACK_WORKER_COALESCE_MS + 50,
+        ));
 
         let mut snapshots: Vec<(String, u64)> = Vec::new();
         while let Ok(job) = publish_rx.try_recv() {
@@ -11198,7 +11436,7 @@ mod pr_b_geyser_tracking_tests {
         rebuild_desired_explicit_set_from_ctx, spawn_inline_track_worker_sender,
         spawn_noop_track_worker_sender, track_worker_execute_coalesced_push,
         track_worker_try_enqueue, DesiredExplicitSet, TrackWorkerCommand,
-        MARKET_DATA_TRACK_WORKER_COALESCE_MS,
+        MARKET_DATA_TRACK_WORKER_COALESCE_MS, MARKET_DATA_TRACK_WORKER_QUEUE_CAP,
     };
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc as std_mpsc;
@@ -11765,6 +12003,9 @@ mod pr_b_geyser_tracking_tests {
             track_worker: parking_lot::RwLock::new(None),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
+            pending_explicit_cap: AtomicUsize::new(0),
+            track_worker_dirty: AtomicBool::new(false),
+            pending_wallet_sync: parking_lot::RwLock::new(None),
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
         *ctx.track_worker.write() = Some(track_worker);
@@ -11846,6 +12087,9 @@ mod pr_b_geyser_tracking_tests {
             track_worker: parking_lot::RwLock::new(None),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
+            pending_explicit_cap: AtomicUsize::new(0),
+            track_worker_dirty: AtomicBool::new(false),
+            pending_wallet_sync: parking_lot::RwLock::new(None),
         });
         (
             ctx,
@@ -15519,7 +15763,7 @@ mod pr_b_geyser_tracking_tests {
         }
         *ctx.wallet_explicit_demand.write() = demand.clone();
         let mut desired = DesiredExplicitSet::new(2);
-        assert!(!ctx.sync_wallet_explicit_demand(&mut desired, demand));
+        assert!(!ctx.commit_wallet_explicit_state(&mut desired, demand, HashSet::new()));
         assert!(!ctx.geyser_explicit_ready.load(Ordering::Relaxed));
         assert!(ctx.geyser_explicit_config_error.read().is_some());
     }
@@ -15562,7 +15806,7 @@ mod pr_b_geyser_tracking_tests {
     }
 
     #[test]
-    fn config_invalidation_in_recv_drain_resets_convergence_before_push() {
+    fn config_cap_shrink_under_queue_drain_converges_desired_and_physical() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
@@ -15570,17 +15814,159 @@ mod pr_b_geyser_tracking_tests {
         let track_worker = spawn_track_worker(Arc::clone(&ctx));
         *ctx.track_worker.write() = Some(track_worker.clone());
 
-        assert!(track_worker_try_enqueue(
-            &track_worker,
-            TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange,
-        ));
-        assert!(track_worker_try_enqueue(
-            &track_worker,
-            TrackWorkerCommand::ScheduleGeyserPush,
-        ));
+        for _ in 0..4 {
+            let pool = Pubkey::new_unique();
+            let base = Pubkey::new_unique();
+            let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+            let coin = Pubkey::new_unique();
+            let pc = Pubkey::new_unique();
+            ctx.live_pool_cache.upsert(
+                pool,
+                CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                    token_0_mint: base,
+                    token_1_mint: quote,
+                    token_0_vault: coin,
+                    token_1_vault: pc,
+                    reserve_0: Some(1),
+                    reserve_1: Some(1),
+                }),
+                1,
+            );
+            ctx.hot_pool_registry.pin_pool(base, pool);
+            assert!(MarketDataContext::register_geyser_reserves_after_trade(
+                &ctx, pool
+            ));
+        }
+        test_wait_inline_track_worker();
+        ctx.sync_geyser_tracked_accounts();
+        let before_len = ctx.snapshot_explicit_subscription_pubkeys().len();
+        assert!(before_len > 2);
+
+        ctx.config.write().max_tracked_accounts = 2;
+        ctx.store_pending_explicit_cap(2);
+        for _ in 0..(MARKET_DATA_TRACK_WORKER_QUEUE_CAP + 4) {
+            let _ = track_worker_try_enqueue(&track_worker, TrackWorkerCommand::ScheduleGeyserPush);
+        }
+        assert!(
+            track_worker_try_enqueue(
+                &track_worker,
+                TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange,
+            ) || ctx.track_worker_dirty.load(Ordering::Relaxed)
+        );
         std::thread::sleep(Duration::from_millis(
-            MARKET_DATA_TRACK_WORKER_COALESCE_MS + 200,
+            MARKET_DATA_TRACK_WORKER_COALESCE_MS + 300,
         ));
+        let after = ctx.snapshot_explicit_subscription_pubkeys();
+        assert!(after.len() <= 2);
         assert!(!ctx.pending_geyser_evict.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn register_pool_vaults_rejected_admission_leaves_tracked_maps_unchanged() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        ctx.config.write().max_tracked_accounts = 1;
+
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool(base, pool);
+
+        let wallet = Pubkey::new_unique();
+        let demand = HashSet::from([wallet]);
+        let _ = ctx.enqueue_wallet_explicit_sync(demand, HashSet::new());
+        test_wait_inline_track_worker();
+
+        assert!(ctx.register_pool_vaults_from_account(pool));
+        test_wait_inline_track_worker();
+        assert!(!ctx.tracked_vaults.read().contains_key(&coin));
+        assert!(!ctx.tracked_vaults.read().contains_key(&pc));
+    }
+
+    #[test]
+    fn restore_then_convergence_preserves_momentum_and_arb_owner_groups() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.hot_pool_registry.pin_pool(base, pool);
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        desired.restore_owner_groups(&[
+            OwnerGroupSnapshot {
+                consumer: ConsumerId::Momentum,
+                owner: OwnerKey::Pool(pool),
+                pubkeys: HashSet::from([coin, pc]),
+                last_touched_gen: 1,
+            },
+            OwnerGroupSnapshot {
+                consumer: ConsumerId::Arb,
+                owner: OwnerKey::Pool(pool),
+                pubkeys: HashSet::from([coin, pc]),
+                last_touched_gen: 2,
+            },
+        ]);
+        ctx.tracked_vaults.write().insert(
+            coin,
+            VaultInfo {
+                pool_address: pool,
+                dex: "test".to_string(),
+                base_mint: base,
+                quote_mint: quote,
+                is_base_vault: true,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: Instant::now(),
+                pinned: true,
+                pin: Some(GeyserPinReason::MomentumActive),
+                active_id: None,
+                bin_step: None,
+                sibling_vault: Some(pc),
+            },
+        );
+        ctx.tracked_vaults.write().insert(
+            pc,
+            VaultInfo {
+                pool_address: pool,
+                dex: "test".to_string(),
+                base_mint: base,
+                quote_mint: quote,
+                is_base_vault: false,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: Instant::now(),
+                pinned: true,
+                pin: Some(GeyserPinReason::ArbMultiDex),
+                active_id: None,
+                bin_step: None,
+                sibling_vault: Some(coin),
+            },
+        );
+
+        ctx.sync_geyser_tracked_accounts();
+        let synced = ctx.snapshot_explicit_subscription_pubkeys();
+        assert!(synced.contains(&coin));
+        assert!(synced.contains(&pc));
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -82,11 +82,12 @@ use ironcrab::market_data::sidefx::{
 use ironcrab::market_data::track::{
     arb_coalesce_try_send, explicit_set_snapshot_path, load_explicit_set_snapshot,
     momentum_coalesce_try_send, owner_key_to_snapshot, pool_is_enrichment_member,
-    spawn_track_worker, track_worker_try_enqueue, AdmissionResult, ConsumerId, DesiredExplicitSet,
-    ExplicitAccountKind, ExplicitSetSnapshot, ExplicitSnapshotRow, OwnerGroupSnapshot, OwnerKey,
-    SnapshotConsumer, SnapshotOwnerGroup, TrackPinReason, TrackWorkerCommand, TrackWorkerContext,
-    TrackWorkerSender, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
-    MARKET_DATA_TRACK_WORKER_COALESCE_MS,
+    spawn_track_worker, track_worker_try_enqueue, AdmissionResult, CapConvergeResult, ConsumerId,
+    DesiredExplicitSet, ExplicitAccountKind, ExplicitSetSnapshot, ExplicitSnapshotRow,
+    GeyserConnectBarrier, GeyserPinReason, OwnerGroupSnapshot, OwnerKey, PendingPoolCommand,
+    PendingPoolRegistrations, PoolExplicitSnapshot, ProtectedOverflowDiagnostic, SnapshotConsumer,
+    SnapshotOwnerGroup, TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
+    WalletExplicitPending, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -689,16 +690,6 @@ fn raydium_cpmm_readiness_for_pool_cache_update(s: &RaydiumCpmmState) -> DexPool
 }
 
 /// PR-B: explicit Geyser account subscription / LRU (also loaded from `[market_data_geyser]` in config.toml).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum GeyserPinReason {
-    /// Wallet bootstrap / execution-result mint tracking — never LRU-evicted.
-    Wallet,
-    /// Momentum active pool (PR-D); never LRU-evicted by lower tiers.
-    MomentumActive,
-    /// Arb strategy multi-DEX pool pin (Phase 3 track_requests).
-    ArbMultiDex,
-}
-
 #[derive(Debug, Clone)]
 struct MintTrackInfo {
     last_used_at: Instant,
@@ -1138,8 +1129,12 @@ struct MarketDataContext {
     pending_explicit_cap: AtomicUsize,
     /// Worker must drain pending wallet/cap work after enqueue loss.
     track_worker_dirty: AtomicBool,
-    /// Latest wallet explicit demand + token ATAs awaiting worker commit.
-    pending_wallet_sync: parking_lot::RwLock<Option<(HashSet<Pubkey>, HashSet<Pubkey>)>>,
+    /// Authoritative merged wallet explicit demand (TX burst safe).
+    wallet_explicit_pending: Arc<WalletExplicitPending>,
+    /// Bounded durable pool commands lost on full queue.
+    pending_pool_commands: Arc<PendingPoolRegistrations>,
+    /// Startup restore + convergence barrier before Geyser connect.
+    geyser_connect_barrier: Arc<GeyserConnectBarrier>,
 }
 
 #[derive(Debug, Default)]
@@ -1898,24 +1893,47 @@ fn record_admission_rejection(consumer: ConsumerId, result: AdmissionResult) {
     inc_market_data_geyser_explicit_admission_rejected_total(label, reason);
 }
 
+#[allow(dead_code)]
 fn geyser_pin_from_track_pin(pin: TrackPinReason) -> GeyserPinReason {
     track_pin_to_geyser_pin(Some(pin)).expect("track pin maps to geyser pin")
 }
 
-fn enqueue_track_worker(ctx: &MarketDataContext, job: TrackWorkerCommand) -> bool {
-    if let TrackWorkerCommand::SyncWalletExplicitDemand {
-        demand,
-        token_accounts,
-    } = &job
-    {
-        *ctx.pending_wallet_sync.write() = Some((demand.clone(), token_accounts.clone()));
+fn pending_pool_command_for_stash(job: &TrackWorkerCommand) -> Option<PendingPoolCommand> {
+    match job {
+        TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot } => {
+            Some(PendingPoolCommand::RegisterReserves(snapshot.clone()))
+        }
+        TrackWorkerCommand::RegisterPoolVaultsFromAccount { snapshot } => {
+            Some(PendingPoolCommand::VaultsFromAccount(snapshot.clone()))
+        }
+        TrackWorkerCommand::RegisterGeyserReservesAfterTrade { snapshot } => {
+            Some(PendingPoolCommand::AfterTrade(snapshot.clone()))
+        }
+        TrackWorkerCommand::RefreshDlmmBinWindow {
+            snapshot,
+            new_active_id,
+        } => Some(PendingPoolCommand::RefreshDlmm {
+            snapshot: snapshot.clone(),
+            new_active_id: *new_active_id,
+        }),
+        _ => None,
     }
+}
+
+fn enqueue_track_worker(ctx: &MarketDataContext, job: TrackWorkerCommand) -> bool {
+    let pending = pending_pool_command_for_stash(&job);
     let Some(sender) = ctx.track_worker.read().clone() else {
+        if let Some(cmd) = pending {
+            ctx.pending_pool_commands.upsert(cmd);
+        }
         ctx.mark_track_worker_dirty();
         return false;
     };
     if track_worker_try_enqueue(&sender, job) {
         return true;
+    }
+    if let Some(cmd) = pending {
+        ctx.pending_pool_commands.upsert(cmd);
     }
     ctx.mark_track_worker_dirty();
     false
@@ -2188,25 +2206,22 @@ impl TrackWorkerContext for MarketDataContext {
     }
 
     fn converge_explicit_admission(&self, desired: &mut DesiredExplicitSet) {
-        desired.set_max_explicit_pubkeys(self.config.read().max_tracked_accounts);
-        let authoritative = self.collect_explicit_owner_groups_for_convergence();
-        let auth_keys: HashSet<(ConsumerId, OwnerKey)> =
-            authoritative.iter().map(|(c, o, _)| (*c, *o)).collect();
-        let preserve = self.collect_preserve_owner_groups(desired, &auth_keys);
-        desired.reconcile_owner_groups_with_preserve(authoritative, preserve);
-        self.sync_wallet_demand_to_desired(desired);
-        self.prune_tracked_maps_to_desired(desired);
-        self.pending_geyser_evict.store(false, Ordering::Relaxed);
-        set_market_data_md_state_evict_pending(false);
-        set_market_data_geyser_explicit_cap_overflow(desired.cap_overflow());
+        MarketDataContext::converge_explicit_admission(self, desired);
     }
 
-    fn sync_wallet_explicit_demand(
-        &self,
-        desired: &mut DesiredExplicitSet,
-        demand: HashSet<Pubkey>,
-        token_accounts: HashSet<Pubkey>,
-    ) -> bool {
+    fn on_cap_converge_result(&self, desired: &DesiredExplicitSet, result: CapConvergeResult) {
+        MarketDataContext::on_cap_converge_result(self, desired, result);
+    }
+
+    fn signal_restore_barrier(&self, ok: bool) {
+        MarketDataContext::signal_restore_barrier(self, ok);
+    }
+
+    fn sync_wallet_explicit_demand(&self, desired: &mut DesiredExplicitSet, revision: u64) -> bool {
+        let (demand, token_accounts, current) = self.wallet_explicit_pending.snapshot();
+        if current != revision {
+            return false;
+        }
         self.commit_wallet_explicit_state(desired, demand, token_accounts)
     }
 
@@ -2225,32 +2240,34 @@ impl TrackWorkerContext for MarketDataContext {
     fn commit_register_pool_geyser_reserves(
         &self,
         desired: &mut DesiredExplicitSet,
-        pool: Pubkey,
-        pin: TrackPinReason,
+        snapshot: &PoolExplicitSnapshot,
     ) -> bool {
-        self.register_geyser_reserves_for_active_pool(desired, pool, geyser_pin_from_track_pin(pin))
+        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.pubkeys.clone()) {
+            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
+                self.register_tracked_assets_from_pool_snapshot(snapshot)
+            }
+            rejected => {
+                record_admission_rejection(snapshot.consumer, rejected);
+                false
+            }
+        }
     }
 
     fn commit_register_pool_vaults_from_account(
         &self,
         desired: &mut DesiredExplicitSet,
-        pool: Pubkey,
+        snapshot: &PoolExplicitSnapshot,
     ) -> bool {
-        self.try_publish_balance_updated_from_cache(pool);
-        if !self.hot_pool_registry.is_hot_pool(pool) {
+        self.try_publish_balance_updated_from_cache(snapshot.pool);
+        if !self.hot_pool_registry.is_hot_pool(snapshot.pool) {
             return false;
         }
-        let admission =
-            self.try_admit_pool_explicit_group(desired, pool, GeyserPinReason::MomentumActive);
-        match admission {
+        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.pubkeys.clone()) {
             AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
-                self.register_pool_vaults_from_account_worker(pool)
+                self.register_tracked_assets_from_pool_snapshot(snapshot)
             }
             rejected => {
-                record_admission_rejection(
-                    consumer_id_for_geyser_pin(Some(GeyserPinReason::MomentumActive)),
-                    rejected,
-                );
+                record_admission_rejection(snapshot.consumer, rejected);
                 false
             }
         }
@@ -2259,51 +2276,53 @@ impl TrackWorkerContext for MarketDataContext {
     fn commit_register_geyser_reserves_after_trade(
         &self,
         desired: &mut DesiredExplicitSet,
-        pool: Pubkey,
+        snapshot: &PoolExplicitSnapshot,
     ) -> bool {
-        self.try_publish_balance_updated_from_cache(pool);
-        if !self.hot_pool_registry.pool_has_momentum(pool) {
+        self.try_publish_balance_updated_from_cache(snapshot.pool);
+        if !self.hot_pool_registry.pool_has_momentum(snapshot.pool) {
             return false;
         }
-        let Some(state) = self.live_pool_cache.get(&pool) else {
-            return false;
-        };
-        let Some((base_mint, quote_mint)) = pool_mints_for_geyser_explicit_tracking(&state) else {
-            return false;
-        };
-        if !self.admit_geyser_explicit_pool_assets(pool, base_mint, quote_mint) {
-            return false;
+        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.pubkeys.clone()) {
+            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
+                self.register_tracked_assets_from_pool_snapshot(snapshot)
+            }
+            rejected => {
+                record_admission_rejection(snapshot.consumer, rejected);
+                false
+            }
         }
-        self.register_geyser_reserves_for_active_pool(
-            desired,
-            pool,
-            GeyserPinReason::MomentumActive,
-        )
     }
 
     fn commit_refresh_dlmm_bin_window(
         &self,
         desired: &mut DesiredExplicitSet,
-        pool: Pubkey,
+        snapshot: &PoolExplicitSnapshot,
         new_active_id: i32,
     ) -> bool {
-        if !self.hot_pool_registry.pool_has_arb(pool) {
+        if !self.hot_pool_registry.pool_has_arb(snapshot.pool) {
             return false;
         }
-        if self.dlmm_registered_active_id.read().get(&pool).copied() == Some(new_active_id) {
+        if self
+            .dlmm_registered_active_id
+            .read()
+            .get(&snapshot.pool)
+            .copied()
+            == Some(new_active_id)
+        {
             return false;
         }
-        let admission =
-            self.try_admit_pool_explicit_group(desired, pool, GeyserPinReason::ArbMultiDex);
-        match admission {
+        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.pubkeys.clone()) {
             AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
-                self.maybe_refresh_arb_dlmm_bin_window_worker(pool, new_active_id)
+                let changed = self.register_tracked_assets_from_pool_snapshot(snapshot);
+                if changed {
+                    self.dlmm_registered_active_id
+                        .write()
+                        .insert(snapshot.pool, new_active_id);
+                }
+                changed
             }
             rejected => {
-                record_admission_rejection(
-                    consumer_id_for_geyser_pin(Some(GeyserPinReason::ArbMultiDex)),
-                    rejected,
-                );
+                record_admission_rejection(snapshot.consumer, rejected);
                 false
             }
         }
@@ -2625,14 +2644,12 @@ impl TxIngestHost for MarketDataContext {
         let Some(tracked_wallet) = self.tracked_wallet.as_ref() else {
             return false;
         };
-        let prev_demand = self.wallet_explicit_demand.read().clone();
-        let was_present = prev_demand.contains(&ata);
-        let mut demand = prev_demand;
-        demand.insert(tracked_wallet.wallet);
-        demand.insert(tracked_wallet.wsol_ata);
-        demand.insert(ata);
-        let token_accounts = Self::wallet_token_accounts_from_demand(&demand, tracked_wallet);
-        let _ = self.enqueue_wallet_explicit_sync(demand, token_accounts);
+        let was_present = self.wallet_explicit_pending.contains_demand(ata);
+        let revision = self
+            .wallet_explicit_pending
+            .ensure_wallet_base(tracked_wallet.wallet, tracked_wallet.wsol_ata);
+        let revision = self.wallet_explicit_pending.insert_ata(ata).max(revision);
+        let _ = self.enqueue_wallet_explicit_sync_revision(revision);
         !was_present
     }
 
@@ -2640,12 +2657,14 @@ impl TxIngestHost for MarketDataContext {
         let Some(tracked_wallet) = self.tracked_wallet.as_ref() else {
             return false;
         };
-        let mut demand = self.wallet_explicit_demand.read().clone();
-        if !demand.remove(&ata) {
+        if !self.wallet_explicit_pending.contains_demand(ata) {
             return false;
         }
-        let token_accounts = Self::wallet_token_accounts_from_demand(&demand, tracked_wallet);
-        let _ = self.enqueue_wallet_explicit_sync(demand, token_accounts);
+        let revision = self
+            .wallet_explicit_pending
+            .ensure_wallet_base(tracked_wallet.wallet, tracked_wallet.wsol_ata);
+        let revision = self.wallet_explicit_pending.remove_ata(ata).max(revision);
+        let _ = self.enqueue_wallet_explicit_sync_revision(revision);
         true
     }
 
@@ -2656,16 +2675,13 @@ impl TxIngestHost for MarketDataContext {
     }
 
     fn tx_wallet_notify_geyser_subscribe_accounts_changed(&self) {
-        if self.pending_wallet_sync.read().is_some() {
-            let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
-            return;
-        }
         let Some(tracked_wallet) = self.tracked_wallet.as_ref() else {
             return;
         };
-        let demand = self.wallet_explicit_demand.read().clone();
-        let token_accounts = Self::wallet_token_accounts_from_demand(&demand, tracked_wallet);
-        let _ = self.enqueue_wallet_explicit_sync(demand, token_accounts);
+        let revision = self
+            .wallet_explicit_pending
+            .ensure_wallet_base(tracked_wallet.wallet, tracked_wallet.wsol_ata);
+        let _ = self.enqueue_wallet_explicit_sync_revision(revision);
         let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
     }
 
@@ -2943,6 +2959,71 @@ impl MarketDataContext {
             .store(true, Ordering::Release);
     }
 
+    fn build_pool_explicit_snapshot(
+        &self,
+        pool: Pubkey,
+        pin: GeyserPinReason,
+    ) -> Option<PoolExplicitSnapshot> {
+        let (enable_meteora_cpmm, enable_meteora_dlmm) = {
+            let cfg = self.config.read();
+            (cfg.enable_meteora_cpmm, cfg.enable_meteora_dlmm)
+        };
+        let state = self.live_pool_cache.get(&pool)?;
+        let pubkeys = collect_pool_explicit_pubkeys_from_cached_state(
+            pool,
+            &state,
+            enable_meteora_cpmm,
+            enable_meteora_dlmm,
+        );
+        if pubkeys.is_empty() {
+            return None;
+        }
+        Some(PoolExplicitSnapshot {
+            pool,
+            pubkeys,
+            consumer: consumer_id_for_geyser_pin(Some(pin)),
+            owner: OwnerKey::Pool(pool),
+            pin,
+        })
+    }
+
+    fn fail_geyser_explicit_protected_overflow(&self, demand: &HashSet<Pubkey>) {
+        let cap = self.config.read().max_tracked_accounts;
+        let diag = ProtectedOverflowDiagnostic::from_demand(cap, demand);
+        let msg = format!(
+            "protected wallet explicit overflow: demand_len={} configured_cap={} sample={:?}",
+            diag.wallet_demand_len, diag.configured_cap, diag.sample_wallet_pubkeys
+        );
+        record_admission_rejection(ConsumerId::Wallet, AdmissionResult::RejectedCap);
+        self.geyser_explicit_ready.store(false, Ordering::Release);
+        *self.geyser_explicit_config_error.write() = Some(msg);
+        self.geyser_connect_barrier.mark_failed();
+    }
+
+    fn replay_pending_pool_command(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        command: PendingPoolCommand,
+    ) {
+        match command {
+            PendingPoolCommand::RegisterReserves(snapshot) => {
+                let _ = self.commit_register_pool_geyser_reserves(desired, &snapshot);
+            }
+            PendingPoolCommand::VaultsFromAccount(snapshot) => {
+                let _ = self.commit_register_pool_vaults_from_account(desired, &snapshot);
+            }
+            PendingPoolCommand::AfterTrade(snapshot) => {
+                let _ = self.commit_register_geyser_reserves_after_trade(desired, &snapshot);
+            }
+            PendingPoolCommand::RefreshDlmm {
+                snapshot,
+                new_active_id,
+            } => {
+                let _ = self.commit_refresh_dlmm_bin_window(desired, &snapshot, new_active_id);
+            }
+        }
+    }
+
     fn store_pending_explicit_cap(&self, cap: usize) {
         self.pending_explicit_cap.store(cap, Ordering::Release);
         self.explicit_admission_invalidate
@@ -2959,8 +3040,12 @@ impl MarketDataContext {
     }
 
     fn apply_pending_track_worker_work(&self, desired: &mut DesiredExplicitSet) {
-        if let Some((demand, token_accounts)) = self.pending_wallet_sync.write().take() {
+        let (demand, token_accounts, _) = self.wallet_explicit_pending.snapshot();
+        if !demand.is_empty() || !token_accounts.is_empty() {
             self.commit_wallet_explicit_state(desired, demand, token_accounts);
+        }
+        for command in self.pending_pool_commands.drain_all() {
+            self.replay_pending_pool_command(desired, command);
         }
     }
 
@@ -2975,18 +3060,18 @@ impl MarketDataContext {
         self.sync_wallet_demand_to_desired(desired)
     }
 
-    fn enqueue_wallet_explicit_sync(
-        &self,
-        demand: HashSet<Pubkey>,
-        token_accounts: HashSet<Pubkey>,
-    ) -> bool {
-        *self.pending_wallet_sync.write() = Some((demand.clone(), token_accounts.clone()));
+    fn enqueue_wallet_explicit_sync_revision(&self, revision: u64) -> bool {
+        let (demand, _, _) = self.wallet_explicit_pending.snapshot();
+        if !demand.is_empty() {
+            let probe = DesiredExplicitSet::new(self.config.read().max_tracked_accounts);
+            if probe.wallet_demand_exceeds_cap(&demand) {
+                self.fail_geyser_explicit_protected_overflow(&demand);
+                return false;
+            }
+        }
         let ok = enqueue_track_worker(
             self,
-            TrackWorkerCommand::SyncWalletExplicitDemand {
-                demand,
-                token_accounts,
-            },
+            TrackWorkerCommand::SyncWalletExplicitDemand { revision },
         );
         if !ok {
             self.mark_track_worker_dirty();
@@ -3068,14 +3153,63 @@ impl MarketDataContext {
     }
 
     fn request_wallet_explicit_resync(&self) {
-        let demand = self.wallet_explicit_demand_pubkeys();
-        let token_accounts = if let Some(tw) = &self.tracked_wallet {
-            Self::wallet_token_accounts_from_demand(&demand, tw)
+        let revision = if let Some(tw) = &self.tracked_wallet {
+            let (demand, _, rev) = self.wallet_explicit_pending.snapshot();
+            let token_accounts = Self::wallet_token_accounts_from_demand(&demand, tw);
+            self.wallet_explicit_pending
+                .replace_token_accounts(token_accounts)
+                .max(rev)
         } else {
-            HashSet::new()
+            self.wallet_explicit_pending.current_revision()
         };
-        let _ = self.enqueue_wallet_explicit_sync(demand, token_accounts);
+        let _ = self.enqueue_wallet_explicit_sync_revision(revision);
         let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
+    }
+
+    fn converge_explicit_admission(&self, desired: &mut DesiredExplicitSet) {
+        let cap = self.config.read().max_tracked_accounts;
+        let cap_result = desired.set_max_explicit_pubkeys(cap);
+        self.on_cap_converge_result(desired, cap_result);
+        let authoritative = self.collect_explicit_owner_groups_for_convergence();
+        let auth_keys: HashSet<(ConsumerId, OwnerKey)> =
+            authoritative.iter().map(|(c, o, _)| (*c, *o)).collect();
+        let preserve = self.collect_preserve_owner_groups(desired, &auth_keys);
+        desired.reconcile_owner_groups_with_preserve(authoritative, preserve);
+        self.sync_wallet_demand_to_desired(desired);
+        self.prune_tracked_maps_to_desired(desired);
+        self.pending_geyser_evict.store(false, Ordering::Relaxed);
+        set_market_data_md_state_evict_pending(false);
+        set_market_data_geyser_explicit_cap_overflow(desired.cap_overflow());
+        if desired.cap_overflow() > 0 || !self.geyser_explicit_readiness_ok() {
+            self.geyser_connect_barrier.mark_failed();
+        }
+    }
+
+    fn on_cap_converge_result(&self, desired: &DesiredExplicitSet, result: CapConvergeResult) {
+        set_market_data_geyser_explicit_cap_overflow(desired.cap_overflow());
+        match result {
+            CapConvergeResult::Converged => {}
+            CapConvergeResult::ProtectedOverflow => {
+                let demand = self.wallet_explicit_demand_pubkeys();
+                self.fail_geyser_explicit_protected_overflow(&demand);
+            }
+            CapConvergeResult::Unconverged => {
+                self.geyser_explicit_ready.store(false, Ordering::Release);
+                *self.geyser_explicit_config_error.write() =
+                    Some("explicit admission cap unconverged".into());
+                self.geyser_connect_barrier.mark_failed();
+            }
+        }
+    }
+
+    fn signal_restore_barrier(&self, ok: bool) {
+        let wallet_fits =
+            self.wallet_explicit_demand_pubkeys().len() <= self.config.read().max_tracked_accounts;
+        if ok && self.geyser_explicit_readiness_ok() && wallet_fits {
+            self.geyser_connect_barrier.mark_ready();
+        } else {
+            self.geyser_connect_barrier.mark_failed();
+        }
     }
 
     fn publish_admitted_explicit_physical(&self, desired: &DesiredExplicitSet) {
@@ -3446,9 +3580,13 @@ impl MarketDataContext {
     }
 
     /// Phase 3 P3: restore explicit set from disk before first Geyser connect (I-MD-6).
-    fn restore_explicit_set_from_snapshot_on_startup(track_worker: &TrackWorkerSender) {
+    fn restore_explicit_set_from_snapshot_on_startup(
+        ctx: &MarketDataContext,
+        track_worker: &TrackWorkerSender,
+    ) {
         let path = explicit_set_snapshot_path();
         let Some(snapshot) = load_explicit_set_snapshot(&path) else {
+            ctx.geyser_connect_barrier.mark_ready();
             return;
         };
         let start = Instant::now();
@@ -3464,9 +3602,14 @@ impl MarketDataContext {
             TrackWorkerCommand::RestoreExplicitSnapshot(snapshot),
         );
         let _ = track_worker_try_enqueue(track_worker, TrackWorkerCommand::ScheduleGeyserPush);
-        std::thread::sleep(Duration::from_millis(
-            MARKET_DATA_TRACK_WORKER_COALESCE_MS + 300,
-        ));
+        if ctx
+            .geyser_connect_barrier
+            .wait_ready(Duration::from_secs(30))
+            .is_err()
+        {
+            warn!("explicit Geyser restore barrier failed or timed out (fail-closed)");
+            ctx.geyser_explicit_ready.store(false, Ordering::Release);
+        }
         set_market_data_explicit_set_snapshot_restore_pubkeys(pubkey_count);
         set_market_data_explicit_set_snapshot_restore_duration_ms(
             start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
@@ -4336,9 +4479,14 @@ impl MarketDataContext {
     /// PR-B: after a parsed swap trade — cache-first BalanceUpdated; vault/bin registration only for hot pools.
     #[cfg_attr(not(test), allow(dead_code))]
     fn register_geyser_reserves_after_trade(self: &Arc<Self>, pool: Pubkey) -> bool {
+        let Some(snapshot) =
+            self.build_pool_explicit_snapshot(pool, GeyserPinReason::MomentumActive)
+        else {
+            return false;
+        };
         enqueue_track_worker(
             self,
-            TrackWorkerCommand::RegisterGeyserReservesAfterTrade { pool },
+            TrackWorkerCommand::RegisterGeyserReservesAfterTrade { snapshot },
         )
     }
 
@@ -4502,12 +4650,18 @@ impl MarketDataContext {
     /// PR169a: register vault ATAs from MASTER cache after account-path pool upsert (hot pools only).
     #[cfg_attr(not(test), allow(dead_code))]
     fn register_pool_vaults_from_account(&self, pool: Pubkey) -> bool {
+        let Some(snapshot) =
+            self.build_pool_explicit_snapshot(pool, GeyserPinReason::MomentumActive)
+        else {
+            return false;
+        };
         enqueue_track_worker(
             self,
-            TrackWorkerCommand::RegisterPoolVaultsFromAccount { pool },
+            TrackWorkerCommand::RegisterPoolVaultsFromAccount { snapshot },
         )
     }
 
+    #[allow(dead_code)]
     fn register_pool_vaults_from_account_worker(&self, pool: Pubkey) -> bool {
         self.try_publish_balance_updated_from_cache(pool);
         if !self.hot_pool_registry.is_hot_pool(pool) {
@@ -4647,10 +4801,14 @@ impl MarketDataContext {
         if prev == Some(new_active_id) {
             return false;
         }
+        let Some(snapshot) = self.build_pool_explicit_snapshot(pool, GeyserPinReason::ArbMultiDex)
+        else {
+            return false;
+        };
         let enqueued = enqueue_track_worker(
             self,
             TrackWorkerCommand::RefreshDlmmBinWindow {
-                pool,
+                snapshot,
                 new_active_id,
             },
         );
@@ -4660,6 +4818,7 @@ impl MarketDataContext {
         enqueued
     }
 
+    #[allow(dead_code)]
     fn maybe_refresh_arb_dlmm_bin_window_worker(&self, pool: Pubkey, new_active_id: i32) -> bool {
         if !self.hot_pool_registry.pool_has_arb(pool) {
             return false;
@@ -4678,6 +4837,74 @@ impl MarketDataContext {
             GeyserPinReason::ArbMultiDex,
             Instant::now(),
         )
+    }
+
+    fn register_tracked_assets_from_pool_snapshot(&self, snapshot: &PoolExplicitSnapshot) -> bool {
+        let now = Instant::now();
+        let pool = snapshot.pool;
+        let pin = snapshot.pin;
+        let mut changed = false;
+        for pk in &snapshot.pubkeys {
+            let already_vault = self.tracked_vaults.read().contains_key(pk);
+            if already_vault {
+                let mut vaults = self.tracked_vaults.write();
+                if let Some(v) = vaults.get_mut(pk) {
+                    if Self::geyser_pin_may_promote(v.pin, pin) {
+                        v.pinned = true;
+                        v.pin = Some(pin);
+                        v.last_used_at = now;
+                        changed = true;
+                    }
+                }
+                continue;
+            }
+            let already_bin = self.tracked_bin_arrays.read().contains_key(pk);
+            if already_bin {
+                let mut bins = self.tracked_bin_arrays.write();
+                if let Some(b) = bins.get_mut(pk) {
+                    if Self::geyser_pin_may_promote(b.pin, pin) {
+                        b.pinned = true;
+                        b.pin = Some(pin);
+                        b.last_used_at = now;
+                        changed = true;
+                    }
+                }
+                continue;
+            }
+            let mut vaults = self.tracked_vaults.write();
+            use std::collections::hash_map::Entry;
+            match vaults.entry(*pk) {
+                Entry::Vacant(e) => {
+                    e.insert(VaultInfo {
+                        pool_address: pool,
+                        dex: "snapshot".to_string(),
+                        base_mint: Pubkey::default(),
+                        quote_mint: Pubkey::default(),
+                        is_base_vault: true,
+                        last_balance: std::sync::atomic::AtomicU64::new(0),
+                        last_used_at: now,
+                        pinned: true,
+                        pin: Some(pin),
+                        active_id: None,
+                        bin_step: None,
+                        sibling_vault: None,
+                    });
+                    drop(vaults);
+                    self.pool_tracked_legs_note_vault(pool, *pk);
+                    changed = true;
+                }
+                Entry::Occupied(mut e) => {
+                    let v = e.get_mut();
+                    if Self::geyser_pin_may_promote(v.pin, pin) {
+                        v.pinned = true;
+                        v.pin = Some(pin);
+                        v.last_used_at = now;
+                        changed = true;
+                    }
+                }
+            }
+        }
+        changed
     }
 
     fn register_geyser_reserves_impl(&self, pool: Pubkey, pin: GeyserPinReason) -> bool {
@@ -6753,11 +6980,14 @@ async fn publish_wallet_snapshot(
 
     // 3) Update logical wallet explicit demand; physical publish goes through track-worker admission.
     if let Some(ref tracked_wallet) = ctx.tracked_wallet {
-        let mut demand = HashSet::new();
-        demand.insert(tracked_wallet.wallet);
-        demand.insert(tracked_wallet.wsol_ata);
-        demand.extend(wallet_token_accounts.iter().copied());
-        let _ = ctx.enqueue_wallet_explicit_sync(demand, wallet_token_accounts);
+        let revision = ctx
+            .wallet_explicit_pending
+            .ensure_wallet_base(tracked_wallet.wallet, tracked_wallet.wsol_ata);
+        let revision = ctx
+            .wallet_explicit_pending
+            .replace_token_accounts(wallet_token_accounts)
+            .max(revision);
+        let _ = ctx.enqueue_wallet_explicit_sync_revision(revision);
         let _ = enqueue_track_worker(ctx, TrackWorkerCommand::ScheduleGeyserPushDebounced);
     }
 
@@ -7229,6 +7459,16 @@ async fn main() -> Result<()> {
     ));
 
     let wallet_configured = tracked_wallet.is_some();
+    let wallet_explicit_pending = Arc::new(WalletExplicitPending::default());
+    if let Some(tw) = &tracked_wallet {
+        let _ = wallet_explicit_pending.ensure_wallet_base(tw.wallet, tw.wsol_ata);
+        for pk in &initial_wallet_demand {
+            if *pk != tw.wallet && *pk != tw.wsol_ata {
+                wallet_explicit_pending.insert_ata(*pk);
+            }
+        }
+    }
+    let pending_pool_cap = market_data_config.max_tracked_accounts.max(1);
     let ctx = Arc::new(MarketDataContext {
         run_id: run_id.clone(),
         config: parking_lot::RwLock::new(market_data_config),
@@ -7289,7 +7529,9 @@ async fn main() -> Result<()> {
         geyser_explicit_config_error: parking_lot::RwLock::new(None),
         pending_explicit_cap: AtomicUsize::new(0),
         track_worker_dirty: AtomicBool::new(false),
-        pending_wallet_sync: parking_lot::RwLock::new(None),
+        wallet_explicit_pending,
+        pending_pool_commands: Arc::new(PendingPoolRegistrations::new(pending_pool_cap)),
+        geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -8069,23 +8311,31 @@ async fn run_geyser_loop(
     let track_worker = spawn_track_worker(Arc::clone(&ctx));
     *ctx.track_worker.write() = Some(track_worker.clone());
     if !ctx.wallet_explicit_demand.read().is_empty() {
-        let demand = ctx.wallet_explicit_demand.read().clone();
-        let token_accounts = ctx
-            .tracked_wallet
-            .as_ref()
-            .map(|tw| MarketDataContext::wallet_token_accounts_from_demand(&demand, tw))
-            .unwrap_or_default();
+        let revision = ctx.wallet_explicit_pending.current_revision();
         let _ = track_worker_try_enqueue(
             &track_worker,
-            TrackWorkerCommand::SyncWalletExplicitDemand {
-                demand,
-                token_accounts,
-            },
+            TrackWorkerCommand::SyncWalletExplicitDemand { revision },
         );
         let _ = track_worker_try_enqueue(&track_worker, TrackWorkerCommand::ScheduleGeyserPush);
     }
     // Phase 3 P3 (I-MD-6): restore explicit Geyser set before first Geyser connect.
-    MarketDataContext::restore_explicit_set_from_snapshot_on_startup(&track_worker);
+    MarketDataContext::restore_explicit_set_from_snapshot_on_startup(ctx.as_ref(), &track_worker);
+    if !ctx.geyser_explicit_readiness_ok() {
+        anyhow::bail!(
+            "Geyser explicit admission not ready: {}",
+            ctx.geyser_explicit_config_error
+                .read()
+                .clone()
+                .unwrap_or_else(|| "protected explicit overflow".into())
+        );
+    }
+    if ctx
+        .geyser_connect_barrier
+        .wait_ready(Duration::from_secs(30))
+        .is_err()
+    {
+        anyhow::bail!("Geyser explicit restore/convergence barrier failed before connect");
+    }
     // PR169c / Phase-2b: coalesce momentum NATS bursts before md-track-worker.
     let momentum_coalesce_tx =
         spawn_momentum_tracking_coalescer(Arc::clone(&ctx), track_worker.clone());
@@ -10871,7 +11121,9 @@ mod wallet_snapshot_stale_cleanup_tests {
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
             pending_explicit_cap: AtomicUsize::new(0),
             track_worker_dirty: AtomicBool::new(false),
-            pending_wallet_sync: parking_lot::RwLock::new(None),
+            wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
+            pending_pool_commands: Arc::new(PendingPoolRegistrations::new(25_000)),
+            geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         }
     }
 
@@ -11106,7 +11358,9 @@ mod wallet_tx_meta_balance_tests {
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
             pending_explicit_cap: AtomicUsize::new(0),
             track_worker_dirty: AtomicBool::new(false),
-            pending_wallet_sync: parking_lot::RwLock::new(None),
+            wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
+            pending_pool_commands: Arc::new(PendingPoolRegistrations::new(25_000)),
+            geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
         *ctx.track_worker.write() = Some(track_worker);
@@ -11435,14 +11689,15 @@ mod pr_b_geyser_tracking_tests {
         explicit_subscription_has_new_keys, merge_momentum_active_pools_updates,
         rebuild_desired_explicit_set_from_ctx, spawn_inline_track_worker_sender,
         spawn_noop_track_worker_sender, track_worker_execute_coalesced_push,
-        track_worker_try_enqueue, DesiredExplicitSet, TrackWorkerCommand,
-        MARKET_DATA_TRACK_WORKER_COALESCE_MS, MARKET_DATA_TRACK_WORKER_QUEUE_CAP,
+        track_worker_sender_for_test, track_worker_try_enqueue, DesiredExplicitSet,
+        TrackWorkerCommand, MARKET_DATA_TRACK_WORKER_COALESCE_MS,
     };
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc as std_mpsc;
     use std::time::Duration;
 
     fn test_spawn_md_state(ctx: &Arc<MarketDataContext>) -> MdStateSender {
+        ctx.geyser_connect_barrier.mark_ready();
         let track_worker = spawn_track_worker(Arc::clone(ctx));
         *ctx.track_worker.write() = Some(track_worker.clone());
         spawn_md_state_worker(
@@ -12005,10 +12260,13 @@ mod pr_b_geyser_tracking_tests {
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
             pending_explicit_cap: AtomicUsize::new(0),
             track_worker_dirty: AtomicBool::new(false),
-            pending_wallet_sync: parking_lot::RwLock::new(None),
+            wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
+            pending_pool_commands: Arc::new(PendingPoolRegistrations::new(25_000)),
+            geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
         *ctx.track_worker.write() = Some(track_worker);
+        ctx.geyser_connect_barrier.mark_ready();
         ctx
     }
 
@@ -12089,7 +12347,9 @@ mod pr_b_geyser_tracking_tests {
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
             pending_explicit_cap: AtomicUsize::new(0),
             track_worker_dirty: AtomicBool::new(false),
-            pending_wallet_sync: parking_lot::RwLock::new(None),
+            wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
+            pending_pool_commands: Arc::new(PendingPoolRegistrations::new(25_000)),
+            geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         });
         (
             ctx,
@@ -12856,10 +13116,6 @@ mod pr_b_geyser_tracking_tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn tx_trade_path_geyser_sync_batches_two_pool_registers() {
-        use ironcrab::metrics::{
-            MARKET_DATA_GEYSER_SYNC_BATCH_TOTAL, MARKET_DATA_GEYSER_SYNC_IMMEDIATE_TOTAL,
-        };
-
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
@@ -12903,32 +13159,29 @@ mod pr_b_geyser_tracking_tests {
         ctx.hot_pool_registry.pin_pool(base_a, pool_a);
         ctx.hot_pool_registry.pin_pool(base_b, pool_b);
 
-        let imm0 = MARKET_DATA_GEYSER_SYNC_IMMEDIATE_TOTAL.load(Ordering::Relaxed);
-        let batch0 = MARKET_DATA_GEYSER_SYNC_BATCH_TOTAL.load(Ordering::Relaxed);
-
         let md_state = test_spawn_md_state(&ctx);
-        MarketDataContext::register_geyser_reserves_after_trade(&ctx, pool_a);
-        MarketDataContext::register_geyser_reserves_after_trade(&ctx, pool_b);
+        assert!(MarketDataContext::register_geyser_reserves_after_trade(
+            &ctx, pool_a
+        ));
+        assert!(MarketDataContext::register_geyser_reserves_after_trade(
+            &ctx, pool_b
+        ));
         test_wait_inline_track_worker();
         md_state_try_enqueue(&md_state, MdStateCommand::FlushGeyserSyncDebounced);
 
-        // Let the actor drain; PR167 startup debounce min 250 ms — one coalesced flush.
-        tokio::time::sleep(Duration::from_millis(400)).await;
+        tokio::time::sleep(Duration::from_millis(
+            MARKET_DATA_TRACK_WORKER_COALESCE_MS + 300,
+        ))
+        .await;
 
-        assert_eq!(
-            MARKET_DATA_GEYSER_SYNC_IMMEDIATE_TOTAL.load(Ordering::Relaxed),
-            imm0,
-            "trade-path reserve registration must not immediate-sync before debounce flush"
-        );
-        let batch1 = MARKET_DATA_GEYSER_SYNC_BATCH_TOTAL.load(Ordering::Relaxed);
-        assert!(
-            batch1 > batch0,
-            "expected batched Geyser subscription sync after coalesced trade-path updates (before={batch0}, after={batch1})"
-        );
-        assert_eq!(
-            MARKET_DATA_GEYSER_SYNC_IMMEDIATE_TOTAL.load(Ordering::Relaxed),
-            imm0
-        );
+        {
+            let vaults = ctx.tracked_vaults.read();
+            assert!(vaults.contains_key(&coin_a));
+            assert!(vaults.contains_key(&coin_b));
+        }
+        ctx.sync_geyser_tracked_accounts();
+        let synced = ctx.snapshot_explicit_subscription_pubkeys();
+        assert!(synced.contains(&coin_a) && synced.contains(&coin_b));
     }
 
     #[test]
@@ -15844,18 +16097,34 @@ mod pr_b_geyser_tracking_tests {
 
         ctx.config.write().max_tracked_accounts = 2;
         ctx.store_pending_explicit_cap(2);
-        for _ in 0..(MARKET_DATA_TRACK_WORKER_QUEUE_CAP + 4) {
-            let _ = track_worker_try_enqueue(&track_worker, TrackWorkerCommand::ScheduleGeyserPush);
+        let (blocking_worker, rx, _depth) = track_worker_sender_for_test(2);
+        let blocker = std::thread::spawn(move || {
+            let _ = rx.recv();
+            std::thread::sleep(Duration::from_secs(2));
+        });
+        *ctx.track_worker.write() = Some(blocking_worker.clone());
+        for _ in 0..2 {
+            assert!(track_worker_try_enqueue(
+                &blocking_worker,
+                TrackWorkerCommand::ScheduleGeyserPush
+            ));
         }
-        assert!(
-            track_worker_try_enqueue(
-                &track_worker,
-                TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange,
-            ) || ctx.track_worker_dirty.load(Ordering::Relaxed)
+        assert!(!enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange,
+        ));
+        assert!(ctx.track_worker_dirty.load(Ordering::Relaxed));
+        drop(blocking_worker);
+        let _ = blocker.join();
+        *ctx.track_worker.write() = Some(track_worker.clone());
+        let _ = track_worker_try_enqueue(
+            &track_worker,
+            TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange,
         );
         std::thread::sleep(Duration::from_millis(
             MARKET_DATA_TRACK_WORKER_COALESCE_MS + 300,
         ));
+        ctx.sync_geyser_tracked_accounts();
         let after = ctx.snapshot_explicit_subscription_pubkeys();
         assert!(after.len() <= 2);
         assert!(!ctx.pending_geyser_evict.load(Ordering::Relaxed));
@@ -15889,8 +16158,10 @@ mod pr_b_geyser_tracking_tests {
         ctx.hot_pool_registry.pin_pool(base, pool);
 
         let wallet = Pubkey::new_unique();
-        let demand = HashSet::from([wallet]);
-        let _ = ctx.enqueue_wallet_explicit_sync(demand, HashSet::new());
+        let _ = ctx.enqueue_wallet_explicit_sync_revision(
+            ctx.wallet_explicit_pending
+                .replace_token_accounts(HashSet::from([wallet])),
+        );
         test_wait_inline_track_worker();
 
         assert!(ctx.register_pool_vaults_from_account(pool));
@@ -15908,7 +16179,7 @@ mod pr_b_geyser_tracking_tests {
 
         let pool = Pubkey::new_unique();
         let base = Pubkey::new_unique();
-        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let _quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
         let coin = Pubkey::new_unique();
         let pc = Pubkey::new_unique();
         ctx.hot_pool_registry.pin_pool(base, pool);
@@ -15929,44 +16200,73 @@ mod pr_b_geyser_tracking_tests {
                 last_touched_gen: 2,
             },
         ]);
-        ctx.tracked_vaults.write().insert(
-            coin,
-            VaultInfo {
-                pool_address: pool,
-                dex: "test".to_string(),
-                base_mint: base,
-                quote_mint: quote,
-                is_base_vault: true,
-                last_balance: std::sync::atomic::AtomicU64::new(0),
-                last_used_at: Instant::now(),
-                pinned: true,
-                pin: Some(GeyserPinReason::MomentumActive),
-                active_id: None,
-                bin_step: None,
-                sibling_vault: Some(pc),
-            },
-        );
-        ctx.tracked_vaults.write().insert(
-            pc,
-            VaultInfo {
-                pool_address: pool,
-                dex: "test".to_string(),
-                base_mint: base,
-                quote_mint: quote,
-                is_base_vault: false,
-                last_balance: std::sync::atomic::AtomicU64::new(0),
-                last_used_at: Instant::now(),
-                pinned: true,
-                pin: Some(GeyserPinReason::ArbMultiDex),
-                active_id: None,
-                bin_step: None,
-                sibling_vault: Some(coin),
-            },
-        );
+        let restored_groups = desired.snapshot_owner_groups();
+        assert!(restored_groups
+            .iter()
+            .any(|g| g.consumer == ConsumerId::Momentum && g.owner == OwnerKey::Pool(pool)));
+        assert!(restored_groups
+            .iter()
+            .any(|g| g.consumer == ConsumerId::Arb && g.owner == OwnerKey::Pool(pool)));
+        ctx.converge_explicit_admission(&mut desired);
+        assert!(desired.contains(&coin));
+        assert!(desired.contains(&pc));
+    }
 
-        ctx.sync_geyser_tracked_accounts();
-        let synced = ctx.snapshot_explicit_subscription_pubkeys();
-        assert!(synced.contains(&coin));
-        assert!(synced.contains(&pc));
+    #[test]
+    fn wallet_ata_burst_preserves_final_pending_set() {
+        let pending = WalletExplicitPending::default();
+        let wallet = Pubkey::new_unique();
+        let wsol = Pubkey::new_unique();
+        pending.ensure_wallet_base(wallet, wsol);
+        let ata1 = Pubkey::new_unique();
+        let ata2 = Pubkey::new_unique();
+        pending.insert_ata(ata1);
+        pending.insert_ata(ata2);
+        let (demand, token_accounts, _) = pending.snapshot();
+        assert!(demand.contains(&ata1));
+        assert!(demand.contains(&ata2));
+        assert!(token_accounts.contains(&ata1));
+        assert!(token_accounts.contains(&ata2));
+        pending.remove_ata(ata1);
+        let (demand, token_accounts, _) = pending.snapshot();
+        assert!(!demand.contains(&ata1));
+        assert!(demand.contains(&ata2));
+        assert!(!token_accounts.contains(&ata1));
+        assert!(token_accounts.contains(&ata2));
+    }
+
+    #[test]
+    fn forced_queue_loss_replays_pool_after_trade_command() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool(base, pool);
+        let snapshot = ctx
+            .build_pool_explicit_snapshot(pool, GeyserPinReason::MomentumActive)
+            .expect("snapshot");
+        ctx.pending_pool_commands
+            .upsert(PendingPoolCommand::AfterTrade(snapshot));
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.apply_pending_track_worker_work(&mut desired);
+        assert!(desired.contains(&coin));
+        assert!(desired.contains(&pc));
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -86,11 +86,11 @@ use ironcrab::market_data::track::{
     CapConvergeResult, ConsumerId, DesiredExplicitSet, ExplicitAccountKind, ExplicitSetSnapshot,
     ExplicitSnapshotRow, GeyserConnectBarrier, GeyserPinReason, InflightReserveResult,
     MintExplicitRow, OwnerGroupSnapshot, OwnerKey, PendingPoolCommand, PendingPoolRegistrations,
-    PendingPoolUpsertResult, PoolCommandAcceptPhase, PoolCommandTerminal, PoolExplicitSnapshot,
-    PoolSnapshotRevisionSequencer, ProtectedOverflowDiagnostic, RevisionAcquireResult,
-    RevisionActiveOwner, RevisionAssignResult, SnapshotConsumer, SnapshotOwnerGroup,
-    TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender, VaultExplicitRow,
-    WalletExplicitPending, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
+    PendingPoolUpsertResult, PoolCommandAcceptPhase, PoolCommandRefRelease, PoolCommandTerminal,
+    PoolExplicitSnapshot, PoolSnapshotRevisionSequencer, ProtectedOverflowDiagnostic,
+    RevisionAcquireResult, RevisionActiveOwner, RevisionAssignResult, SnapshotConsumer,
+    SnapshotOwnerGroup, TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
+    VaultExplicitRow, WalletExplicitPending, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -2526,9 +2526,12 @@ impl TrackWorkerContext for MarketDataContext {
         desired: &mut DesiredExplicitSet,
         snapshot: &PoolExplicitSnapshot,
     ) -> bool {
-        self.apply_pool_snapshot_command(desired, snapshot, true, |desired| {
-            self.apply_pool_admission(desired, snapshot)
-        })
+        self.apply_pool_snapshot_command(
+            desired,
+            snapshot,
+            Some(PoolCommandRefRelease::Inflight),
+            |desired| self.apply_pool_admission(desired, snapshot),
+        )
     }
 
     fn commit_register_pool_vaults_from_account(
@@ -2536,13 +2539,18 @@ impl TrackWorkerContext for MarketDataContext {
         desired: &mut DesiredExplicitSet,
         snapshot: &PoolExplicitSnapshot,
     ) -> bool {
-        self.apply_pool_snapshot_command(desired, snapshot, true, |desired| {
-            self.try_publish_balance_updated_from_cache(snapshot.pool);
-            if !self.hot_pool_registry.is_hot_pool(snapshot.pool) {
-                return (false, PoolCommandTerminal::Applied);
-            }
-            self.apply_pool_admission(desired, snapshot)
-        })
+        self.apply_pool_snapshot_command(
+            desired,
+            snapshot,
+            Some(PoolCommandRefRelease::Inflight),
+            |desired| {
+                self.try_publish_balance_updated_from_cache(snapshot.pool);
+                if !self.hot_pool_registry.is_hot_pool(snapshot.pool) {
+                    return (false, PoolCommandTerminal::Applied);
+                }
+                self.apply_pool_admission(desired, snapshot)
+            },
+        )
     }
 
     fn commit_register_geyser_reserves_after_trade(
@@ -2550,13 +2558,18 @@ impl TrackWorkerContext for MarketDataContext {
         desired: &mut DesiredExplicitSet,
         snapshot: &PoolExplicitSnapshot,
     ) -> bool {
-        self.apply_pool_snapshot_command(desired, snapshot, true, |desired| {
-            self.try_publish_balance_updated_from_cache(snapshot.pool);
-            if !self.hot_pool_registry.pool_has_momentum(snapshot.pool) {
-                return (false, PoolCommandTerminal::UnpinnedRejected);
-            }
-            self.apply_pool_admission(desired, snapshot)
-        })
+        self.apply_pool_snapshot_command(
+            desired,
+            snapshot,
+            Some(PoolCommandRefRelease::Inflight),
+            |desired| {
+                self.try_publish_balance_updated_from_cache(snapshot.pool);
+                if !self.hot_pool_registry.pool_has_momentum(snapshot.pool) {
+                    return (false, PoolCommandTerminal::UnpinnedRejected);
+                }
+                self.apply_pool_admission(desired, snapshot)
+            },
+        )
     }
 
     fn commit_refresh_dlmm_bin_window(
@@ -2565,27 +2578,32 @@ impl TrackWorkerContext for MarketDataContext {
         snapshot: &PoolExplicitSnapshot,
         new_active_id: i32,
     ) -> bool {
-        self.apply_pool_snapshot_command(desired, snapshot, true, |desired| {
-            if !self.hot_pool_registry.pool_has_arb(snapshot.pool) {
-                return (false, PoolCommandTerminal::UnpinnedRejected);
-            }
-            if self
-                .dlmm_registered_active_id
-                .read()
-                .get(&snapshot.pool)
-                .copied()
-                == Some(new_active_id)
-            {
-                return (false, PoolCommandTerminal::Applied);
-            }
-            let (changed, terminal) = self.apply_pool_admission(desired, snapshot);
-            if changed {
-                self.dlmm_registered_active_id
-                    .write()
-                    .insert(snapshot.pool, new_active_id);
-            }
-            (changed, terminal)
-        })
+        self.apply_pool_snapshot_command(
+            desired,
+            snapshot,
+            Some(PoolCommandRefRelease::Inflight),
+            |desired| {
+                if !self.hot_pool_registry.pool_has_arb(snapshot.pool) {
+                    return (false, PoolCommandTerminal::UnpinnedRejected);
+                }
+                if self
+                    .dlmm_registered_active_id
+                    .read()
+                    .get(&snapshot.pool)
+                    .copied()
+                    == Some(new_active_id)
+                {
+                    return (false, PoolCommandTerminal::Applied);
+                }
+                let (changed, terminal) = self.apply_pool_admission(desired, snapshot);
+                if changed {
+                    self.dlmm_registered_active_id
+                        .write()
+                        .insert(snapshot.pool, new_active_id);
+                }
+                (changed, terminal)
+            },
+        )
     }
 
     fn publish_admitted_explicit_physical(&self, desired: &DesiredExplicitSet) {
@@ -3314,27 +3332,27 @@ impl MarketDataContext {
         &self,
         desired: &mut DesiredExplicitSet,
         snapshot: &PoolExplicitSnapshot,
-        finish_inflight: bool,
+        release_ref: Option<PoolCommandRefRelease>,
         apply: impl FnOnce(&mut DesiredExplicitSet) -> (bool, PoolCommandTerminal),
     ) -> bool {
         let phase = self.pool_snapshot_revisions.begin_pool_command(snapshot);
         if phase == PoolCommandAcceptPhase::Stale {
-            if finish_inflight {
+            if let Some(release) = release_ref {
                 self.pool_snapshot_revisions.finish_pool_command(
                     snapshot,
                     PoolCommandTerminal::StaleRevision,
-                    true,
+                    Some(release),
                     false,
                 );
             }
             return false;
         }
         if !self.pool_snapshot_consumer_demand_valid(snapshot) {
-            if finish_inflight {
+            if let Some(release) = release_ref {
                 self.pool_snapshot_revisions.finish_pool_command(
                     snapshot,
                     PoolCommandTerminal::UnpinnedRejected,
-                    true,
+                    Some(release),
                     true,
                 );
             }
@@ -3342,7 +3360,7 @@ impl MarketDataContext {
         }
         let (state_changed, terminal) = apply(desired);
         self.pool_snapshot_revisions
-            .finish_pool_command(snapshot, terminal, finish_inflight, true);
+            .finish_pool_command(snapshot, terminal, release_ref, true);
         state_changed
     }
 
@@ -3352,7 +3370,12 @@ impl MarketDataContext {
         snapshot: &PoolExplicitSnapshot,
         apply: impl FnOnce(&mut DesiredExplicitSet) -> (bool, PoolCommandTerminal),
     ) -> bool {
-        self.apply_pool_snapshot_command(desired, snapshot, false, apply)
+        self.apply_pool_snapshot_command(
+            desired,
+            snapshot,
+            Some(PoolCommandRefRelease::Pending),
+            apply,
+        )
     }
 
     fn ensure_pool_revision_key(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
@@ -12326,8 +12349,7 @@ mod pr_b_geyser_tracking_tests {
     }
 
     fn one_sequence_older_revision(revision: u64) -> u64 {
-        let (generation, sequence) = PoolSnapshotRevisionSequencer::unpack_revision(revision);
-        PoolSnapshotRevisionSequencer::pack_revision(generation, sequence.saturating_sub(1).max(1))
+        revision.saturating_sub(1).max(1)
     }
 
     #[allow(dead_code)]
@@ -17213,8 +17235,7 @@ mod pr_b_geyser_tracking_tests {
             .latest_revision_for(pool, ConsumerId::Arb)
             .expect("pending revision");
         assert_eq!(
-            PoolSnapshotRevisionSequencer::revision_sequence(latest_rev),
-            4,
+            latest_rev, 4,
             "one successful enqueue plus three queue-full stashes assign monotonic revisions"
         );
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -86,9 +86,10 @@ use ironcrab::market_data::track::{
     CapConvergeResult, ConsumerId, DesiredExplicitSet, ExplicitAccountKind, ExplicitSetSnapshot,
     ExplicitSnapshotRow, GeyserConnectBarrier, GeyserPinReason, MintExplicitRow,
     OwnerGroupSnapshot, OwnerKey, PendingPoolCommand, PendingPoolRegistrations,
-    PendingPoolUpsertResult, PoolExplicitSnapshot, ProtectedOverflowDiagnostic, SnapshotConsumer,
-    SnapshotOwnerGroup, TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
-    VaultExplicitRow, WalletExplicitPending, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
+    PendingPoolUpsertResult, PoolExplicitSnapshot, PoolSnapshotRevisionSequencer,
+    ProtectedOverflowDiagnostic, SnapshotConsumer, SnapshotOwnerGroup, TrackPinReason,
+    TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender, VaultExplicitRow,
+    WalletExplicitPending, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -1134,6 +1135,8 @@ struct MarketDataContext {
     wallet_explicit_pending: Arc<WalletExplicitPending>,
     /// Bounded durable pool commands lost on full queue.
     pending_pool_commands: Arc<PendingPoolRegistrations>,
+    /// Monotonic per-(pool,consumer) revisions for pool snapshot commands.
+    pool_snapshot_revisions: Arc<PoolSnapshotRevisionSequencer>,
     /// Startup restore + convergence barrier before Geyser connect.
     geyser_connect_barrier: Arc<GeyserConnectBarrier>,
 }
@@ -1927,7 +1930,24 @@ fn pending_pool_command_for_stash(job: &TrackWorkerCommand) -> Option<PendingPoo
     }
 }
 
-fn enqueue_track_worker(ctx: &MarketDataContext, job: TrackWorkerCommand) -> bool {
+fn assign_pool_snapshot_revision(ctx: &MarketDataContext, job: &mut TrackWorkerCommand) {
+    match job {
+        TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot }
+        | TrackWorkerCommand::RegisterPoolVaultsFromAccount { snapshot }
+        | TrackWorkerCommand::RegisterGeyserReservesAfterTrade { snapshot } => {
+            ctx.pool_snapshot_revisions.assign_next(snapshot);
+        }
+        TrackWorkerCommand::RefreshDlmmBinWindow { snapshot, .. } => {
+            ctx.pool_snapshot_revisions.assign_next(snapshot);
+        }
+        _ => {}
+    }
+}
+
+fn enqueue_track_worker(ctx: &MarketDataContext, mut job: TrackWorkerCommand) -> bool {
+    if pending_pool_command_for_stash(&job).is_some() {
+        assign_pool_snapshot_revision(ctx, &mut job);
+    }
     let pending = pending_pool_command_for_stash(&job);
     let Some(sender) = ctx.track_worker.read().clone() else {
         if let Some(cmd) = pending {
@@ -2420,6 +2440,12 @@ impl TrackWorkerContext for MarketDataContext {
         desired: &mut DesiredExplicitSet,
         snapshot: &PoolExplicitSnapshot,
     ) -> bool {
+        if !self
+            .pool_snapshot_revisions
+            .should_apply_and_record(snapshot)
+        {
+            return false;
+        }
         match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys()) {
             AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
                 self.register_tracked_assets_from_pool_snapshot(snapshot)
@@ -2436,6 +2462,12 @@ impl TrackWorkerContext for MarketDataContext {
         desired: &mut DesiredExplicitSet,
         snapshot: &PoolExplicitSnapshot,
     ) -> bool {
+        if !self
+            .pool_snapshot_revisions
+            .should_apply_and_record(snapshot)
+        {
+            return false;
+        }
         self.try_publish_balance_updated_from_cache(snapshot.pool);
         if !self.hot_pool_registry.is_hot_pool(snapshot.pool) {
             return false;
@@ -2456,6 +2488,12 @@ impl TrackWorkerContext for MarketDataContext {
         desired: &mut DesiredExplicitSet,
         snapshot: &PoolExplicitSnapshot,
     ) -> bool {
+        if !self
+            .pool_snapshot_revisions
+            .should_apply_and_record(snapshot)
+        {
+            return false;
+        }
         self.try_publish_balance_updated_from_cache(snapshot.pool);
         if !self.hot_pool_registry.pool_has_momentum(snapshot.pool) {
             return false;
@@ -2477,6 +2515,12 @@ impl TrackWorkerContext for MarketDataContext {
         snapshot: &PoolExplicitSnapshot,
         new_active_id: i32,
     ) -> bool {
+        if !self
+            .pool_snapshot_revisions
+            .should_apply_and_record(snapshot)
+        {
+            return false;
+        }
         if !self.hot_pool_registry.pool_has_arb(snapshot.pool) {
             return false;
         }
@@ -7716,6 +7760,7 @@ async fn main() -> Result<()> {
         }
     }
     let pending_pool_cap = pending_pool_registration_cap(market_data_config.max_tracked_accounts);
+    let pool_snapshot_revisions = Arc::new(PoolSnapshotRevisionSequencer::new());
     let ctx = Arc::new(MarketDataContext {
         run_id: run_id.clone(),
         config: parking_lot::RwLock::new(market_data_config),
@@ -7777,7 +7822,11 @@ async fn main() -> Result<()> {
         pending_explicit_cap: AtomicUsize::new(0),
         track_worker_dirty: AtomicBool::new(false),
         wallet_explicit_pending,
-        pending_pool_commands: Arc::new(PendingPoolRegistrations::new(pending_pool_cap)),
+        pending_pool_commands: Arc::new(PendingPoolRegistrations::new(
+            pending_pool_cap,
+            Arc::clone(&pool_snapshot_revisions),
+        )),
+        pool_snapshot_revisions,
         geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
     });
 
@@ -11306,6 +11355,7 @@ mod wallet_snapshot_stale_cleanup_tests {
         let (tracked_mints_tx, _tracked_mints_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_bin_arrays_tx, _tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
+        let pool_snapshot_revisions = Arc::new(PoolSnapshotRevisionSequencer::new());
         MarketDataContext {
             run_id: "run-stale-cleanup-test".to_string(),
             config: parking_lot::RwLock::new(MarketDataConfig::default()),
@@ -11371,7 +11421,9 @@ mod wallet_snapshot_stale_cleanup_tests {
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
             pending_pool_commands: Arc::new(PendingPoolRegistrations::new(
                 pending_pool_registration_cap(25_000),
+                Arc::clone(&pool_snapshot_revisions),
             )),
+            pool_snapshot_revisions,
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         }
     }
@@ -11545,6 +11597,7 @@ mod wallet_tx_meta_balance_tests {
         let (tracked_mints_tx, _tracked_mints_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_bin_arrays_tx, _tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
+        let pool_snapshot_revisions = Arc::new(PoolSnapshotRevisionSequencer::new());
         let ctx = Arc::new(MarketDataContext {
             run_id: "run-wallet-tx-meta".to_string(),
             config: parking_lot::RwLock::new(MarketDataConfig::default()),
@@ -11610,7 +11663,9 @@ mod wallet_tx_meta_balance_tests {
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
             pending_pool_commands: Arc::new(PendingPoolRegistrations::new(
                 pending_pool_registration_cap(25_000),
+                Arc::clone(&pool_snapshot_revisions),
             )),
+            pool_snapshot_revisions,
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
@@ -12449,6 +12504,7 @@ mod pr_b_geyser_tracking_tests {
         let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_bin_arrays_tx, _tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_wallet_tx, _tracked_wallet_rx) = watch::channel(Vec::<Pubkey>::new());
+        let pool_snapshot_revisions = Arc::new(PoolSnapshotRevisionSequencer::new());
         let ctx = Arc::new(MarketDataContext {
             run_id: "run-prd-test".to_string(),
             config: parking_lot::RwLock::new(MarketDataConfig::default()),
@@ -12514,7 +12570,9 @@ mod pr_b_geyser_tracking_tests {
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
             pending_pool_commands: Arc::new(PendingPoolRegistrations::new(
                 pending_pool_registration_cap(25_000),
+                Arc::clone(&pool_snapshot_revisions),
             )),
+            pool_snapshot_revisions,
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
@@ -12538,6 +12596,7 @@ mod pr_b_geyser_tracking_tests {
         let (tracked_vaults_tx, tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_bin_arrays_tx, tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_wallet_tx, tracked_wallet_rx) = watch::channel(Vec::<Pubkey>::new());
+        let pool_snapshot_revisions = Arc::new(PoolSnapshotRevisionSequencer::new());
         let ctx = Arc::new(MarketDataContext {
             run_id: "run-pr161-merge-test".to_string(),
             config: parking_lot::RwLock::new(MarketDataConfig::default()),
@@ -12603,7 +12662,9 @@ mod pr_b_geyser_tracking_tests {
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
             pending_pool_commands: Arc::new(PendingPoolRegistrations::new(
                 pending_pool_registration_cap(25_000),
+                Arc::clone(&pool_snapshot_revisions),
             )),
+            pool_snapshot_revisions,
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         });
         (
@@ -16644,9 +16705,11 @@ mod pr_b_geyser_tracking_tests {
         );
         ctx.hot_pool_registry.pin_arb_pool(pool);
 
-        let snapshot = ctx
+        let mut snapshot = ctx
             .build_pool_explicit_snapshot(pool, GeyserPinReason::ArbMultiDex)
             .expect("dlmm snapshot");
+        ctx.pool_snapshot_revisions
+            .assign_next(&mut snapshot);
         assert!(!snapshot.vaults.is_empty());
         assert!(!snapshot.bin_arrays.is_empty());
         assert!(!snapshot.mints.is_empty());
@@ -16669,7 +16732,8 @@ mod pr_b_geyser_tracking_tests {
 
     #[test]
     fn pending_pool_overflow_sets_fail_closed_dirty_state() {
-        let pending = PendingPoolRegistrations::new(1);
+        let pending =
+            PendingPoolRegistrations::new(1, Arc::new(PoolSnapshotRevisionSequencer::new()));
         let pool_a = Pubkey::new_unique();
         let pool_b = Pubkey::new_unique();
         let mk_snapshot = |pool: Pubkey| PoolExplicitSnapshot {
@@ -16793,8 +16857,8 @@ mod pr_b_geyser_tracking_tests {
             .latest_revision_for(pool, ConsumerId::Arb)
             .expect("pending revision");
         assert_eq!(
-            latest_rev, 3,
-            "three queue-full stashes assign monotonic revisions"
+            latest_rev, 4,
+            "one successful enqueue plus three queue-full stashes assign monotonic revisions"
         );
 
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
@@ -16816,6 +16880,332 @@ mod pr_b_geyser_tracking_tests {
         assert!(!ctx.tracked_bin_arrays.read().contains_key(&bin_old));
         assert!(ctx.tracked_mints.read().contains_key(&mint_new));
         assert!(!ctx.tracked_mints.read().contains_key(&mint_old));
+    }
+
+    fn meteora_arb_pool_fixtures(
+        ctx: &Arc<MarketDataContext>,
+    ) -> (
+        Pubkey,
+        Pubkey,
+        Pubkey,
+        Pubkey,
+        Pubkey,
+        impl Fn(Pubkey, Pubkey, Pubkey) -> PoolExplicitSnapshot,
+    ) {
+        use ironcrab::execution::live_pool_cache::MeteoraState;
+        use ironcrab::market_data::track::worker_commands::{
+            BinArrayExplicitRow, MintExplicitRow, VaultExplicitRow,
+        };
+
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let reserve_x = Pubkey::new_unique();
+        let reserve_y = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::Meteora(MeteoraState {
+                token_x_mint: base,
+                token_y_mint: quote,
+                reserve_x,
+                reserve_y,
+                active_id: 8,
+                bin_step: 25,
+                reserve_x_balance: Some(1),
+                reserve_y_balance: Some(1),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+        ctx.hot_pool_registry.pin_pool(base, pool);
+
+        let mk_typed =
+            move |bin_pk: Pubkey, mint_pk: Pubkey, extra_vault: Pubkey| PoolExplicitSnapshot {
+                pool,
+                vaults: vec![
+                    VaultExplicitRow {
+                        pubkey: reserve_x,
+                        dex: "meteora".into(),
+                        base_mint: base,
+                        quote_mint: quote,
+                        is_base_vault: true,
+                        sibling_vault: Some(reserve_y),
+                        active_id: Some(8),
+                        bin_step: Some(25),
+                    },
+                    VaultExplicitRow {
+                        pubkey: extra_vault,
+                        dex: "meteora".into(),
+                        base_mint: base,
+                        quote_mint: quote,
+                        is_base_vault: false,
+                        sibling_vault: Some(reserve_x),
+                        active_id: Some(8),
+                        bin_step: Some(25),
+                    },
+                ],
+                bin_arrays: vec![BinArrayExplicitRow {
+                    pubkey: bin_pk,
+                    bin_array_index: 1,
+                    bin_step: 25,
+                }],
+                mints: vec![MintExplicitRow { pubkey: mint_pk }],
+                consumer: ConsumerId::Arb,
+                owner: OwnerKey::Pool(pool),
+                pin: GeyserPinReason::ArbMultiDex,
+                revision: 0,
+            };
+        (pool, base, quote, reserve_x, reserve_y, mk_typed)
+    }
+
+    fn assert_arb_group_has(
+        desired: &DesiredExplicitSet,
+        pool: Pubkey,
+        expect_bins: &[Pubkey],
+        expect_mints: &[Pubkey],
+        expect_vaults: &[Pubkey],
+    ) {
+        let group = desired
+            .snapshot_owner_groups()
+            .into_iter()
+            .find(|g| g.consumer == ConsumerId::Arb && g.owner == OwnerKey::Pool(pool))
+            .expect("arb owner group");
+        for pk in expect_bins {
+            assert!(group.pubkeys.contains(pk), "desired missing bin {pk}");
+        }
+        for pk in expect_mints {
+            assert!(group.pubkeys.contains(pk), "desired missing mint {pk}");
+        }
+        for pk in expect_vaults {
+            assert!(group.pubkeys.contains(pk), "desired missing vault {pk}");
+        }
+    }
+
+    #[test]
+    fn pool_snapshot_stale_pending_replay_skipped_after_newer_direct() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let (pool, _, _, reserve_x, _, mk_typed) = meteora_arb_pool_fixtures(&ctx);
+        let bin_old = Pubkey::new_unique();
+        let bin_new = Pubkey::new_unique();
+        let mint_old = Pubkey::new_unique();
+        let mint_new = Pubkey::new_unique();
+        let vault_old = Pubkey::new_unique();
+        let vault_new = Pubkey::new_unique();
+
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        let mut snapshot_new = mk_typed(bin_new, mint_new, vault_new);
+        let rev_new = ctx.pool_snapshot_revisions.assign_next(&mut snapshot_new);
+        assert!(ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot_new));
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .current_applied(pool, ConsumerId::Arb),
+            rev_new
+        );
+
+        let mut snapshot_old = mk_typed(bin_old, mint_old, vault_old);
+        snapshot_old.revision = rev_new.saturating_sub(1).max(1);
+        assert_eq!(
+            ctx.pending_pool_commands
+                .upsert(PendingPoolCommand::RegisterReserves(snapshot_old)),
+            PendingPoolUpsertResult::Stored
+        );
+        ctx.apply_pending_track_worker_work(&mut desired);
+
+        assert_arb_group_has(
+            &desired,
+            pool,
+            &[bin_new],
+            &[mint_new],
+            &[reserve_x, vault_new],
+        );
+        assert!(!desired.contains(&bin_old));
+        assert!(!desired.contains(&mint_old));
+        assert!(!desired.contains(&vault_old));
+        assert!(ctx.tracked_bin_arrays.read().contains_key(&bin_new));
+        assert!(!ctx.tracked_bin_arrays.read().contains_key(&bin_old));
+        assert!(ctx.tracked_mints.read().contains_key(&mint_new));
+        assert!(!ctx.tracked_mints.read().contains_key(&mint_old));
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .current_applied(pool, ConsumerId::Arb),
+            rev_new
+        );
+    }
+
+    #[test]
+    fn pool_snapshot_stale_direct_commit_skipped_after_newer_applied() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let (pool, _, _, reserve_x, _, mk_typed) = meteora_arb_pool_fixtures(&ctx);
+        let bin_old = Pubkey::new_unique();
+        let bin_new = Pubkey::new_unique();
+        let mint_old = Pubkey::new_unique();
+        let mint_new = Pubkey::new_unique();
+        let vault_old = Pubkey::new_unique();
+        let vault_new = Pubkey::new_unique();
+
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        let mut snapshot_new = mk_typed(bin_new, mint_new, vault_new);
+        let rev_new = ctx.pool_snapshot_revisions.assign_next(&mut snapshot_new);
+        assert!(ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot_new));
+
+        let mut snapshot_stale = mk_typed(bin_old, mint_old, vault_old);
+        snapshot_stale.revision = rev_new.saturating_sub(1).max(1);
+        assert!(
+            !ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot_stale),
+            "stale direct commit must no-op"
+        );
+
+        assert_arb_group_has(
+            &desired,
+            pool,
+            &[bin_new],
+            &[mint_new],
+            &[reserve_x, vault_new],
+        );
+        assert!(!desired.contains(&bin_old));
+        assert!(ctx.tracked_bin_arrays.read().contains_key(&bin_new));
+        assert!(!ctx.tracked_bin_arrays.read().contains_key(&bin_old));
+    }
+
+    #[test]
+    fn pool_snapshot_revision_mixed_four_kinds_keeps_newest_desired_and_typed_maps() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let (pool, _, _, reserve_x, _, mk_typed) = meteora_arb_pool_fixtures(&ctx);
+        let bin_v1 = Pubkey::new_unique();
+        let bin_v2 = Pubkey::new_unique();
+        let bin_v3 = Pubkey::new_unique();
+        let bin_v4 = Pubkey::new_unique();
+        let mint_v1 = Pubkey::new_unique();
+        let mint_v2 = Pubkey::new_unique();
+        let mint_v3 = Pubkey::new_unique();
+        let mint_v4 = Pubkey::new_unique();
+        let vault_v1 = Pubkey::new_unique();
+        let vault_v2 = Pubkey::new_unique();
+        let vault_v3 = Pubkey::new_unique();
+        let vault_v4 = Pubkey::new_unique();
+
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+
+        let mut snap_reserves = mk_typed(bin_v1, mint_v1, vault_v1);
+        let rev_reserves = ctx.pool_snapshot_revisions.assign_next(&mut snap_reserves);
+        assert!(ctx.commit_register_pool_geyser_reserves(&mut desired, &snap_reserves));
+
+        let mut snap_vaults = mk_typed(bin_v2, mint_v2, vault_v2);
+        let rev_vaults = ctx.pool_snapshot_revisions.assign_next(&mut snap_vaults);
+        assert!(ctx.commit_register_pool_vaults_from_account(&mut desired, &snap_vaults));
+
+        let mut snap_trade = mk_typed(bin_v3, mint_v3, vault_v3);
+        let rev_trade = ctx.pool_snapshot_revisions.assign_next(&mut snap_trade);
+        assert!(ctx.commit_register_geyser_reserves_after_trade(&mut desired, &snap_trade));
+
+        let mut snap_dlmm = mk_typed(bin_v4, mint_v4, vault_v4);
+        let rev_dlmm = ctx.pool_snapshot_revisions.assign_next(&mut snap_dlmm);
+        assert!(ctx.commit_refresh_dlmm_bin_window(&mut desired, &snap_dlmm, 9));
+
+        assert!(rev_vaults > rev_reserves);
+        assert!(rev_trade > rev_vaults);
+        assert!(rev_dlmm > rev_trade);
+
+        // Replay stale commands across all four kinds — desired + typed maps must stay at newest.
+        for (stale_rev, bin, mint, vault) in [
+            (rev_reserves, bin_v1, mint_v1, vault_v1),
+            (rev_vaults, bin_v2, mint_v2, vault_v2),
+            (rev_trade, bin_v3, mint_v3, vault_v3),
+        ] {
+            let mut stale = mk_typed(bin, mint, vault);
+            stale.revision = stale_rev;
+            assert!(
+                !ctx.commit_register_pool_geyser_reserves(&mut desired, &stale),
+                "stale reserves rev {stale_rev}"
+            );
+            assert!(
+                !ctx.commit_register_pool_vaults_from_account(&mut desired, &stale),
+                "stale vaults rev {stale_rev}"
+            );
+            assert!(
+                !ctx.commit_register_geyser_reserves_after_trade(&mut desired, &stale),
+                "stale after-trade rev {stale_rev}"
+            );
+            assert!(
+                !ctx.commit_refresh_dlmm_bin_window(&mut desired, &stale, 8),
+                "stale dlmm rev {stale_rev}"
+            );
+        }
+
+        assert_arb_group_has(
+            &desired,
+            pool,
+            &[bin_v4],
+            &[mint_v4],
+            &[reserve_x, vault_v4],
+        );
+        ctx.prune_tracked_maps_to_desired(&desired);
+        assert!(ctx.tracked_bin_arrays.read().contains_key(&bin_v4));
+        assert!(!ctx.tracked_bin_arrays.read().contains_key(&bin_v1));
+        assert!(!ctx.tracked_bin_arrays.read().contains_key(&bin_v2));
+        assert!(!ctx.tracked_bin_arrays.read().contains_key(&bin_v3));
+        assert!(ctx.tracked_mints.read().contains_key(&mint_v4));
+        assert!(!ctx.tracked_mints.read().contains_key(&mint_v1));
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .current_applied(pool, ConsumerId::Arb),
+            rev_dlmm
+        );
+    }
+
+    #[test]
+    fn pool_snapshot_worker_skips_delayed_stale_direct_after_newer_enqueue() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let (pool, _, _, _reserve_x, _, mk_typed) = meteora_arb_pool_fixtures(&ctx);
+        let bin_new = Pubkey::new_unique();
+        let bin_stale = Pubkey::new_unique();
+        let mint_new = Pubkey::new_unique();
+        let mint_stale = Pubkey::new_unique();
+        let vault_new = Pubkey::new_unique();
+        let vault_stale = Pubkey::new_unique();
+
+        let snapshot_new = mk_typed(bin_new, mint_new, vault_new);
+        assert!(enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterPoolGeyserReserves {
+                snapshot: snapshot_new,
+            },
+        ));
+        test_wait_inline_track_worker();
+        let rev_new = ctx
+            .pool_snapshot_revisions
+            .current_applied(pool, ConsumerId::Arb);
+        assert!(rev_new > 0);
+
+        let mut snapshot_stale = mk_typed(bin_stale, mint_stale, vault_stale);
+        snapshot_stale.revision = rev_new.saturating_sub(1).max(1);
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        assert!(
+            !ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot_stale),
+            "delayed stale direct must not roll back worker-applied newest snapshot"
+        );
+
+        assert!(ctx.tracked_bin_arrays.read().contains_key(&bin_new));
+        assert!(!ctx.tracked_bin_arrays.read().contains_key(&bin_stale));
+        assert!(ctx.tracked_mints.read().contains_key(&mint_new));
+        assert!(!ctx.tracked_mints.read().contains_key(&mint_stale));
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .current_applied(pool, ConsumerId::Arb),
+            rev_new
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1233,9 +1233,11 @@ const MAX_MOMENTUM_MINTS_PER_POOL: usize = 64;
 const MAX_MOMENTUM_PAIRS_TOTAL: usize = 8_192;
 /// Global arb pool pin rows (aligned with revision registry capacity).
 const MAX_ARB_POOLS_TOTAL: usize = 8_192;
-/// Upper bound on distinct `(pool, consumer)` revision rejections we must retain.
+/// Global tracker explicit owner groups (aligned with revision registry capacity).
+const MAX_TRACKER_DEMANDS_TOTAL: usize = 8_192;
+/// Upper bound on distinct rejected logical demands we must retain (one slot per global identity).
 const MAX_REVISION_REJECTION_LEDGER_CAPACITY: usize =
-    MAX_MOMENTUM_PAIRS_TOTAL + MAX_ARB_POOLS_TOTAL;
+    MAX_MOMENTUM_PAIRS_TOTAL + MAX_ARB_POOLS_TOTAL + MAX_TRACKER_DEMANDS_TOTAL;
 
 /// Independent fail-closed blocker flags for Geyser explicit readiness.
 const GESYER_BLOCK_PENDING_POOL_OVERFLOW: u8 = 1 << 0;
@@ -1294,6 +1296,16 @@ impl RejectedRevisionDemand {
             ConsumerId::Wallet => None,
         }
     }
+
+    fn tracker_snapshot_matches_stored(
+        stored: &PoolExplicitSnapshot,
+        applied: &PoolExplicitSnapshot,
+    ) -> bool {
+        stored.pool == applied.pool
+            && stored.owner == applied.owner
+            && stored.consumer == applied.consumer
+            && stored.all_pubkeys() == applied.all_pubkeys()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1304,13 +1316,20 @@ enum RevisionRejectionRecordResult {
     CapacityInvariantExceeded,
 }
 
+#[derive(Debug, Clone)]
+struct RejectedLedgerEntry {
+    demand: RejectedRevisionDemand,
+    ledger_token: u64,
+}
+
 #[derive(Debug)]
 struct RevisionRegistryRejectionLedger {
-    entries: HashMap<RejectedDemandKey, RejectedRevisionDemand>,
-    overflow_entries: HashMap<RejectedDemandKey, RejectedRevisionDemand>,
-    capacity_invariant_exceeded: bool,
+    entries: HashMap<RejectedDemandKey, RejectedLedgerEntry>,
+    overflow_entries: HashMap<RejectedDemandKey, RejectedLedgerEntry>,
+    invariant_overflow_generation: Option<u64>,
     generation: u64,
     capacity: usize,
+    next_ledger_token: u64,
 }
 
 impl RevisionRegistryRejectionLedger {
@@ -1318,67 +1337,169 @@ impl RevisionRegistryRejectionLedger {
         Self {
             entries: HashMap::new(),
             overflow_entries: HashMap::new(),
-            capacity_invariant_exceeded: false,
+            invariant_overflow_generation: None,
             generation: 0,
             capacity: capacity.max(1),
+            next_ledger_token: 1,
         }
+    }
+
+    fn allocate_ledger_token(&mut self) -> u64 {
+        let token = self.next_ledger_token;
+        self.next_ledger_token = self.next_ledger_token.wrapping_add(1).max(1);
+        token
+    }
+
+    fn entry_for_key(&self, key: &RejectedDemandKey) -> Option<&RejectedLedgerEntry> {
+        self.entries
+            .get(key)
+            .or_else(|| self.overflow_entries.get(key))
+    }
+
+    fn ledger_token_for_key(&self, key: &RejectedDemandKey) -> Option<u64> {
+        self.entry_for_key(key).map(|e| e.ledger_token)
     }
 
     #[cfg(test)]
     fn contains_key(&self, key: &RejectedDemandKey) -> bool {
-        self.entries.contains_key(key) || self.overflow_entries.contains_key(key)
+        self.entry_for_key(key).is_some()
+    }
+
+    fn resolve_token_for_snapshot(&self, snapshot: &PoolExplicitSnapshot) -> Option<u64> {
+        let demand = RejectedRevisionDemand::from_snapshot(snapshot)?;
+        self.ledger_token_for_key(&demand.demand_key())
     }
 
     fn record(&mut self, demand: RejectedRevisionDemand) -> RevisionRejectionRecordResult {
         let key = demand.demand_key();
+        let ledger_token = self.allocate_ledger_token();
+        let entry = RejectedLedgerEntry {
+            demand,
+            ledger_token,
+        };
         if let std::collections::hash_map::Entry::Occupied(mut slot) =
             self.entries.entry(key.clone())
         {
-            slot.insert(demand);
+            slot.insert(entry);
             self.generation = self.generation.wrapping_add(1);
             return RevisionRejectionRecordResult::UpdatedExisting;
         }
         if let std::collections::hash_map::Entry::Occupied(mut slot) =
             self.overflow_entries.entry(key.clone())
         {
-            slot.insert(demand);
+            slot.insert(entry);
             self.generation = self.generation.wrapping_add(1);
             return RevisionRejectionRecordResult::UpdatedExisting;
         }
         if self.entries.len() < self.capacity {
             self.generation = self.generation.wrapping_add(1);
-            self.entries.insert(key, demand);
+            self.entries.insert(key, entry);
             return RevisionRejectionRecordResult::Stored;
         }
         if self.overflow_entries.len() < self.capacity {
             self.generation = self.generation.wrapping_add(1);
-            self.overflow_entries.insert(key, demand);
+            self.overflow_entries.insert(key, entry);
             return RevisionRejectionRecordResult::OverflowStored;
         }
-        self.capacity_invariant_exceeded = true;
+        self.invariant_overflow_generation = Some(self.generation.wrapping_add(1));
         self.generation = self.generation.wrapping_add(1);
         RevisionRejectionRecordResult::CapacityInvariantExceeded
     }
 
-    fn remove_demand(&mut self, demand: &RejectedRevisionDemand) -> bool {
-        let key = demand.demand_key();
-        if self.entries.remove(&key).is_some() || self.overflow_entries.remove(&key).is_some() {
-            self.generation = self.generation.wrapping_add(1);
-            true
-        } else {
-            false
+    fn demand_matches(stored: &RejectedRevisionDemand, candidate: &RejectedRevisionDemand) -> bool {
+        match (stored, candidate) {
+            (
+                RejectedRevisionDemand::Momentum { mint: m1, pool: p1 },
+                RejectedRevisionDemand::Momentum { mint: m2, pool: p2 },
+            ) => m1 == m2 && p1 == p2,
+            (
+                RejectedRevisionDemand::Arb { pool: p1 },
+                RejectedRevisionDemand::Arb { pool: p2 },
+            ) => p1 == p2,
+            (
+                RejectedRevisionDemand::Tracker { snapshot: s1 },
+                RejectedRevisionDemand::Tracker { snapshot: s2 },
+            ) => RejectedRevisionDemand::tracker_snapshot_matches_stored(s1, s2),
+            _ => false,
         }
+    }
+
+    fn remove_demand(
+        &mut self,
+        demand: &RejectedRevisionDemand,
+        expected_token: Option<u64>,
+    ) -> bool {
+        let key = demand.demand_key();
+        if let Some(entry) = self.entries.get(&key) {
+            if let Some(token) = expected_token {
+                if entry.ledger_token != token {
+                    return false;
+                }
+            } else if !Self::demand_matches(&entry.demand, demand) {
+                return false;
+            }
+            self.entries.remove(&key);
+            self.generation = self.generation.wrapping_add(1);
+            self.try_authoritative_reconcile_storage();
+            return true;
+        }
+        if let Some(entry) = self.overflow_entries.get(&key) {
+            if let Some(token) = expected_token {
+                if entry.ledger_token != token {
+                    return false;
+                }
+            } else if !Self::demand_matches(&entry.demand, demand) {
+                return false;
+            }
+            self.overflow_entries.remove(&key);
+            self.generation = self.generation.wrapping_add(1);
+            self.try_authoritative_reconcile_storage();
+            return true;
+        }
+        false
+    }
+
+    fn try_authoritative_reconcile_storage(&mut self) -> bool {
+        if self.invariant_overflow_generation.is_none() && self.overflow_entries.is_empty() {
+            return true;
+        }
+        let overflow: Vec<_> = self.overflow_entries.drain().collect();
+        for (key, entry) in overflow {
+            if self.entries.len() < self.capacity {
+                self.entries.insert(key, entry);
+            } else {
+                self.overflow_entries.insert(key, entry);
+                return false;
+            }
+        }
+        let represented = self.entries.len() + self.overflow_entries.len();
+        if represented <= self.capacity && self.overflow_entries.is_empty() {
+            if self.invariant_overflow_generation.is_some() {
+                self.invariant_overflow_generation = None;
+                self.generation = self.generation.wrapping_add(1);
+            }
+            return true;
+        }
+        false
     }
 
     fn has_unresolved(&self) -> bool {
         !self.entries.is_empty()
             || !self.overflow_entries.is_empty()
-            || self.capacity_invariant_exceeded
+            || self.invariant_overflow_generation.is_some()
     }
 
-    fn pending_demands(&self) -> Vec<RejectedRevisionDemand> {
-        let mut out: Vec<_> = self.entries.values().cloned().collect();
-        out.extend(self.overflow_entries.values().cloned());
+    fn pending_demands(&self) -> Vec<(RejectedRevisionDemand, u64)> {
+        let mut out: Vec<_> = self
+            .entries
+            .values()
+            .map(|e| (e.demand.clone(), e.ledger_token))
+            .collect();
+        out.extend(
+            self.overflow_entries
+                .values()
+                .map(|e| (e.demand.clone(), e.ledger_token)),
+        );
         out
     }
 }
@@ -2216,9 +2337,13 @@ fn prepare_pool_snapshot_for_enqueue(
             return None;
         }
     }
+    let resolve_token = ctx
+        .revision_registry_rejection_ledger
+        .lock()
+        .resolve_token_for_snapshot(snapshot);
     match ctx.pool_snapshot_revisions.assign_next(snapshot) {
         RevisionAssignResult::Assigned(_) => {
-            ctx.record_revision_registry_enqueue_success(snapshot, None);
+            ctx.record_revision_registry_enqueue_success(snapshot, resolve_token, None);
             Some((pool, consumer))
         }
         RevisionAssignResult::RegistryFull => {
@@ -3560,12 +3685,13 @@ impl MarketDataContext {
     fn resolve_rejected_revision_demand(
         &self,
         demand: RejectedRevisionDemand,
+        ledger_token: Option<u64>,
         desired: Option<&DesiredExplicitSet>,
     ) {
         let removed = self
             .revision_registry_rejection_ledger
             .lock()
-            .remove_demand(&demand);
+            .remove_demand(&demand, ledger_token);
         if removed {
             self.maybe_clear_revision_registry_full_blocker(desired);
         }
@@ -3576,7 +3702,7 @@ impl MarketDataContext {
         demand: RejectedRevisionDemand,
         desired: Option<&DesiredExplicitSet>,
     ) {
-        self.resolve_rejected_revision_demand(demand, desired);
+        self.resolve_rejected_revision_demand(demand, None, desired);
     }
 
     fn set_geyser_explicit_blocker(&self, flag: u8, msg: Option<String>) {
@@ -3605,17 +3731,13 @@ impl MarketDataContext {
     }
 
     fn maybe_clear_revision_registry_full_blocker(&self, desired: Option<&DesiredExplicitSet>) {
-        let ledger = self.revision_registry_rejection_ledger.lock();
+        let mut ledger = self.revision_registry_rejection_ledger.lock();
+        ledger.try_authoritative_reconcile_storage();
         if ledger.has_unresolved() {
             return;
         }
         drop(ledger);
-        if self.geyser_explicit_blockers.load(Ordering::Acquire)
-            & GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW
-            != 0
-        {
-            return;
-        }
+        self.clear_geyser_explicit_blocker(GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW);
         self.clear_geyser_explicit_blocker(GESYER_BLOCK_REVISION_REGISTRY_FULL);
         if let Some(desired) = desired {
             self.recompute_geyser_explicit_readiness(desired);
@@ -3625,6 +3747,7 @@ impl MarketDataContext {
     fn record_revision_registry_enqueue_success(
         &self,
         snapshot: &PoolExplicitSnapshot,
+        resolve_token: Option<u64>,
         desired: Option<&DesiredExplicitSet>,
     ) {
         let Some(demand) = RejectedRevisionDemand::from_snapshot(snapshot) else {
@@ -3633,7 +3756,7 @@ impl MarketDataContext {
         if self
             .revision_registry_rejection_ledger
             .lock()
-            .remove_demand(&demand)
+            .remove_demand(&demand, resolve_token)
         {
             self.maybe_clear_revision_registry_full_blocker(desired);
         }
@@ -3650,6 +3773,7 @@ impl MarketDataContext {
         if ledger.generation != snapshot_gen {
             return;
         }
+        ledger.try_authoritative_reconcile_storage();
         if ledger.has_unresolved() {
             return;
         }
@@ -3664,7 +3788,7 @@ impl MarketDataContext {
             .revision_registry_rejection_ledger
             .lock()
             .pending_demands();
-        for demand in pending {
+        for (demand, ledger_token) in pending {
             let applied = match demand {
                 RejectedRevisionDemand::Momentum { mint, pool } => {
                     if !self.hot_pool_registry.try_pin_pool(mint, pool) {
@@ -3689,21 +3813,7 @@ impl MarketDataContext {
                     }
                 }
                 RejectedRevisionDemand::Tracker { ref snapshot } => {
-                    let demand = RejectedRevisionDemand::Tracker {
-                        snapshot: snapshot.clone(),
-                    };
-                    let still_wanted = desired
-                        .snapshot_owner_groups()
-                        .iter()
-                        .any(|g| g.consumer == ConsumerId::Tracker && g.owner == snapshot.owner);
-                    if !still_wanted {
-                        self.withdraw_rejected_revision_demand(demand, Some(desired));
-                        false
-                    } else if !self.ensure_pool_revision_key(
-                        snapshot.pool,
-                        ConsumerId::Tracker,
-                        None,
-                    ) {
+                    if !self.ensure_pool_revision_key(snapshot.pool, ConsumerId::Tracker, None) {
                         false
                     } else {
                         enqueue_track_worker(
@@ -3716,7 +3826,7 @@ impl MarketDataContext {
                 }
             };
             if applied {
-                self.resolve_rejected_revision_demand(demand, Some(desired));
+                self.resolve_rejected_revision_demand(demand, Some(ledger_token), Some(desired));
             }
         }
     }
@@ -3734,14 +3844,38 @@ impl MarketDataContext {
     }
 
     #[cfg(test)]
+    fn test_invariant_overflow_latched(&self) -> bool {
+        self.revision_registry_rejection_ledger
+            .lock()
+            .invariant_overflow_generation
+            .is_some()
+    }
+
+    #[cfg(test)]
     fn test_revision_rejection_unresolved(&self) -> (usize, usize, bool, u64) {
         let ledger = self.revision_registry_rejection_ledger.lock();
         (
             ledger.entries.len(),
             ledger.overflow_entries.len(),
-            ledger.capacity_invariant_exceeded,
+            ledger.invariant_overflow_generation.is_some(),
             ledger.generation,
         )
+    }
+
+    #[cfg(test)]
+    fn test_ledger_token_for_demand(&self, demand: &RejectedRevisionDemand) -> Option<u64> {
+        self.revision_registry_rejection_ledger
+            .lock()
+            .ledger_token_for_key(&demand.demand_key())
+    }
+
+    #[cfg(test)]
+    fn test_record_revision_registry_enqueue_success_with_token(
+        &self,
+        snapshot: &PoolExplicitSnapshot,
+        resolve_token: Option<u64>,
+    ) {
+        self.record_revision_registry_enqueue_success(snapshot, resolve_token, None);
     }
 
     fn fail_wallet_revision_exhausted(&self) {
@@ -3792,7 +3926,7 @@ impl MarketDataContext {
             ConsumerId::Momentum => self.hot_pool_registry.pool_has_momentum(snapshot.pool),
             ConsumerId::Arb => self.hot_pool_registry.pool_has_arb(snapshot.pool),
             ConsumerId::Wallet => false,
-            ConsumerId::Tracker => self.hot_pool_registry.is_hot_pool(snapshot.pool),
+            ConsumerId::Tracker => true,
         }
     }
 
@@ -3917,6 +4051,7 @@ impl MarketDataContext {
         }
         self.resolve_rejected_revision_demand(
             RejectedRevisionDemand::Momentum { mint, pool },
+            None,
             Some(desired),
         );
         true
@@ -3940,7 +4075,11 @@ impl MarketDataContext {
             self.hot_pool_registry.unpin_arb_pool(pool);
             return false;
         }
-        self.resolve_rejected_revision_demand(RejectedRevisionDemand::Arb { pool }, Some(desired));
+        self.resolve_rejected_revision_demand(
+            RejectedRevisionDemand::Arb { pool },
+            None,
+            Some(desired),
+        );
         true
     }
 
@@ -13509,16 +13648,25 @@ mod pr_b_geyser_tracking_tests {
         pool: Pubkey,
         consumer: ConsumerId,
         momentum_mint: Option<Pubkey>,
+        tracker_hub: Option<Pubkey>,
     ) -> PoolExplicitSnapshot {
+        use ironcrab::market_data::track::worker_commands::MintExplicitRow;
         let owner = match (consumer, momentum_mint) {
             (ConsumerId::Momentum, Some(mint)) => OwnerKey::Mint(mint),
             _ => OwnerKey::Pool(pool),
+        };
+        let mints = if consumer == ConsumerId::Tracker {
+            vec![MintExplicitRow {
+                pubkey: tracker_hub.unwrap_or_else(Pubkey::new_unique),
+            }]
+        } else {
+            vec![]
         };
         PoolExplicitSnapshot {
             pool,
             vaults: vec![],
             bin_arrays: vec![],
-            mints: vec![],
+            mints,
             consumer,
             owner,
             pin: match consumer {
@@ -13537,6 +13685,7 @@ mod pr_b_geyser_tracking_tests {
         setup: impl FnOnce(&Arc<MarketDataContext>, Pubkey),
     ) {
         setup(ctx, pool);
+        let tracker_hub = (consumer == ConsumerId::Tracker).then(Pubkey::new_unique);
         let demand = match consumer {
             ConsumerId::Momentum => {
                 let mint = ctx
@@ -13550,37 +13699,14 @@ mod pr_b_geyser_tracking_tests {
             }
             ConsumerId::Arb => RejectedRevisionDemand::Arb { pool },
             ConsumerId::Tracker => {
-                let snapshot = mk_test_pool_snapshot(pool, consumer, None);
+                let snapshot = mk_test_pool_snapshot(pool, consumer, None, tracker_hub);
                 RejectedRevisionDemand::Tracker { snapshot }
             }
             ConsumerId::Wallet => panic!("wallet consumer not supported in rejection retry test"),
         };
-        ctx.fail_revision_registry_full(demand);
+        ctx.fail_revision_registry_full(demand.clone());
         assert!(!ctx.geyser_explicit_readiness_ok());
-        match consumer {
-            ConsumerId::Momentum => {
-                let mint = ctx
-                    .hot_pool_registry
-                    .snapshot_pairs()
-                    .into_iter()
-                    .find(|(_, p)| *p == pool)
-                    .map(|(m, _)| m)
-                    .expect("momentum mint pinned");
-                assert!(ctx.test_revision_rejection_has_momentum(mint, pool));
-            }
-            ConsumerId::Arb => assert!(
-                ctx.test_revision_rejection_has_demand(&RejectedRevisionDemand::Arb { pool })
-            ),
-            ConsumerId::Tracker => {
-                let snapshot = mk_test_pool_snapshot(pool, consumer, None);
-                assert!(
-                    ctx.test_revision_rejection_has_demand(&RejectedRevisionDemand::Tracker {
-                        snapshot
-                    })
-                );
-            }
-            ConsumerId::Wallet => {}
-        }
+        assert!(ctx.test_revision_rejection_has_demand(&demand));
         let snapshot = match consumer {
             ConsumerId::Momentum => {
                 let mint = ctx
@@ -13590,36 +13716,16 @@ mod pr_b_geyser_tracking_tests {
                     .find(|(_, p)| *p == pool)
                     .map(|(m, _)| m)
                     .expect("momentum mint pinned");
-                mk_test_pool_snapshot(pool, consumer, Some(mint))
+                mk_test_pool_snapshot(pool, consumer, Some(mint), None)
             }
-            _ => mk_test_pool_snapshot(pool, consumer, None),
+            ConsumerId::Tracker => mk_test_pool_snapshot(pool, consumer, None, tracker_hub),
+            _ => mk_test_pool_snapshot(pool, consumer, None, None),
         };
         assert!(enqueue_track_worker(
             ctx,
             TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
         ));
-        match consumer {
-            ConsumerId::Momentum => {
-                let mint = ctx
-                    .hot_pool_registry
-                    .snapshot_pairs()
-                    .into_iter()
-                    .find(|(_, p)| *p == pool)
-                    .map(|(m, _)| m)
-                    .expect("momentum mint pinned");
-                assert!(!ctx.test_revision_rejection_has_momentum(mint, pool));
-            }
-            ConsumerId::Arb => assert!(
-                !ctx.test_revision_rejection_has_demand(&RejectedRevisionDemand::Arb { pool })
-            ),
-            ConsumerId::Tracker => {
-                let snapshot = mk_test_pool_snapshot(pool, consumer, None);
-                assert!(!ctx.test_revision_rejection_has_demand(
-                    &RejectedRevisionDemand::Tracker { snapshot }
-                ));
-            }
-            ConsumerId::Wallet => {}
-        }
+        assert!(!ctx.test_revision_rejection_has_demand(&demand));
     }
 
     /// PR161: same as [`minimal_market_data_context_for_pr_d_tests`], but returns merge `watch` receivers.
@@ -18978,7 +19084,7 @@ mod pr_b_geyser_tracking_tests {
 
         ctx.hot_pool_registry.pin_pool(mint_healthy, pool_healthy);
         let healthy_snapshot =
-            mk_test_pool_snapshot(pool_healthy, ConsumerId::Momentum, Some(mint_healthy));
+            mk_test_pool_snapshot(pool_healthy, ConsumerId::Momentum, Some(mint_healthy), None);
         assert!(enqueue_track_worker(
             &ctx,
             TrackWorkerCommand::RegisterPoolGeyserReserves {
@@ -18992,8 +19098,12 @@ mod pr_b_geyser_tracking_tests {
         assert!(ctx.test_revision_rejection_has_momentum(mint_rejected, pool_rejected));
 
         ctx.hot_pool_registry.pin_pool(mint_rejected, pool_rejected);
-        let snapshot =
-            mk_test_pool_snapshot(pool_rejected, ConsumerId::Momentum, Some(mint_rejected));
+        let snapshot = mk_test_pool_snapshot(
+            pool_rejected,
+            ConsumerId::Momentum,
+            Some(mint_rejected),
+            None,
+        );
         assert!(enqueue_track_worker(
             &ctx,
             TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
@@ -19144,7 +19254,7 @@ mod pr_b_geyser_tracking_tests {
         let mint = Pubkey::new_unique();
         ctx.fail_revision_registry_full(RejectedRevisionDemand::Momentum { mint, pool });
         ctx.hot_pool_registry.pin_pool(mint, pool);
-        let snapshot = mk_test_pool_snapshot(pool, ConsumerId::Momentum, Some(mint));
+        let snapshot = mk_test_pool_snapshot(pool, ConsumerId::Momentum, Some(mint), None);
         assert!(!enqueue_track_worker(
             &ctx,
             TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
@@ -19370,7 +19480,7 @@ mod pr_b_geyser_tracking_tests {
         assert!(ctx.test_revision_rejection_has_momentum(mint_b, pool));
         assert!(ctx.hot_pool_registry.is_pinned(mint_b, pool));
 
-        let snapshot_a = mk_test_pool_snapshot(pool, ConsumerId::Momentum, Some(mint_a));
+        let snapshot_a = mk_test_pool_snapshot(pool, ConsumerId::Momentum, Some(mint_a), None);
         ctx.record_rejected_revision_demand(RejectedRevisionDemand::Momentum {
             mint: mint_a,
             pool,
@@ -19414,47 +19524,184 @@ mod pr_b_geyser_tracking_tests {
     }
 
     #[test]
-    fn tracker_retry_no_arb_pin_change_and_clears_orphan_demand() {
-        use std::collections::HashSet;
-
+    fn tracker_retry_no_arb_pin_change() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let pool = Pubkey::new_unique();
-        let owner = OwnerKey::Pool(pool);
-        let snapshot = mk_test_pool_snapshot(pool, ConsumerId::Tracker, None);
+        let hub = Pubkey::new_unique();
+        let snapshot = mk_test_pool_snapshot(pool, ConsumerId::Tracker, None, Some(hub));
         let demand = RejectedRevisionDemand::Tracker {
             snapshot: snapshot.clone(),
         };
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
-        let hub = Pubkey::new_unique();
-        assert!(matches!(
-            desired.try_admit_group(ConsumerId::Tracker, owner, HashSet::from([hub])),
-            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey
-        ));
-
         let arb_before = ctx.hot_pool_registry.arb_pool_count();
         ctx.fail_revision_registry_full(demand.clone());
         assert!(ctx.test_revision_rejection_has_demand(&demand));
 
         ctx.retry_bounded_rejected_revision_demands(&mut desired);
+        for _ in 0..50 {
+            if ctx.tracked_mints.read().contains_key(&hub) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
         assert_eq!(
             ctx.hot_pool_registry.arb_pool_count(),
             arb_before,
             "tracker retry must not create arb ownership"
         );
         assert!(!ctx.test_revision_rejection_has_demand(&demand));
+        assert!(ctx.tracked_mints.read().contains_key(&hub));
+    }
 
-        let orphan_snapshot = mk_test_pool_snapshot(pool, ConsumerId::Tracker, None);
-        let orphan_demand = RejectedRevisionDemand::Tracker {
-            snapshot: orphan_snapshot,
+    #[test]
+    fn tracker_retry_admits_without_preexisting_desired_group() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 1, 8);
+        let pool = Pubkey::new_unique();
+        let hub = Pubkey::new_unique();
+        let owner = OwnerKey::Pool(pool);
+        let snapshot = mk_test_pool_snapshot(pool, ConsumerId::Tracker, None, Some(hub));
+        let demand = RejectedRevisionDemand::Tracker {
+            snapshot: snapshot.clone(),
         };
-        ctx.fail_revision_registry_full(orphan_demand.clone());
-        desired.remove_group(ConsumerId::Tracker, owner);
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        assert!(!desired
+            .snapshot_owner_groups()
+            .iter()
+            .any(|g| g.consumer == ConsumerId::Tracker && g.owner == owner));
+
+        let occupant_pool = Pubkey::new_unique();
+        assert!(ctx.ensure_pool_revision_key_cold(occupant_pool, ConsumerId::Tracker));
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .reserve_inflight_command(occupant_pool, ConsumerId::Tracker),
+            InflightReserveResult::Reserved,
+        );
+        ctx.fail_revision_registry_full(demand.clone());
+        assert!(ctx.test_revision_rejection_has_demand(&demand));
+
+        ctx.pool_snapshot_revisions
+            .release_inflight_command(occupant_pool, ConsumerId::Tracker);
+        ctx.pool_snapshot_revisions.maybe_retire_key(
+            occupant_pool,
+            ConsumerId::Tracker,
+            false,
+            false,
+        );
+
+        let arb_before = ctx.hot_pool_registry.arb_pool_count();
         ctx.retry_bounded_rejected_revision_demands(&mut desired);
-        assert!(!ctx.test_revision_rejection_has_demand(&orphan_demand));
+        for _ in 0..50 {
+            if ctx.tracked_mints.read().contains_key(&hub) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
         assert_eq!(ctx.hot_pool_registry.arb_pool_count(), arb_before);
+        assert!(!ctx.test_revision_rejection_has_demand(&demand));
+        assert!(
+            desired
+                .snapshot_owner_groups()
+                .iter()
+                .any(|g| g.consumer == ConsumerId::Tracker && g.owner == owner)
+                || ctx.tracked_mints.read().contains_key(&hub),
+            "first-time tracker rejection must admit via payload-authoritative retry"
+        );
+        assert!(ctx.tracked_mints.read().contains_key(&hub));
+    }
+
+    #[test]
+    fn tracker_stale_enqueue_success_does_not_clear_newer_rejection() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let hub_v1 = Pubkey::new_unique();
+        let hub_v2 = Pubkey::new_unique();
+        let snapshot_v1 = mk_test_pool_snapshot(pool, ConsumerId::Tracker, None, Some(hub_v1));
+        let demand_v1 = RejectedRevisionDemand::Tracker {
+            snapshot: snapshot_v1.clone(),
+        };
+        ctx.fail_revision_registry_full(demand_v1.clone());
+        let token_v1 = ctx
+            .test_ledger_token_for_demand(&demand_v1)
+            .expect("token v1");
+
+        let snapshot_v2 = mk_test_pool_snapshot(pool, ConsumerId::Tracker, None, Some(hub_v2));
+        let demand_v2 = RejectedRevisionDemand::Tracker {
+            snapshot: snapshot_v2.clone(),
+        };
+        ctx.fail_revision_registry_full(demand_v2.clone());
+        let token_v2 = ctx
+            .test_ledger_token_for_demand(&demand_v2)
+            .expect("token v2");
+        assert_ne!(token_v1, token_v2);
+
+        ctx.test_record_revision_registry_enqueue_success_with_token(&snapshot_v1, Some(token_v1));
+        assert!(ctx.test_revision_rejection_has_demand(&demand_v2));
+
+        ctx.test_record_revision_registry_enqueue_success_with_token(&snapshot_v2, Some(token_v2));
+        assert!(!ctx.test_revision_rejection_has_demand(&demand_v2));
+    }
+
+    #[test]
+    fn invariant_overflow_recovers_after_withdraw_and_reconcile() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 8, 1);
+        let pool_a = Pubkey::new_unique();
+        let pool_b = Pubkey::new_unique();
+        let pool_c = Pubkey::new_unique();
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::new_unique();
+        let mint_c = Pubkey::new_unique();
+
+        ctx.record_rejected_revision_demand(RejectedRevisionDemand::Momentum {
+            mint: mint_a,
+            pool: pool_a,
+        });
+        ctx.record_rejected_revision_demand(RejectedRevisionDemand::Momentum {
+            mint: mint_b,
+            pool: pool_b,
+        });
+        ctx.record_rejected_revision_demand(RejectedRevisionDemand::Momentum {
+            mint: mint_c,
+            pool: pool_c,
+        });
+        let (_, _, invariant_latched, _) = ctx.test_revision_rejection_unresolved();
+        assert!(
+            invariant_latched,
+            "third unique demand must latch invariant overflow when capacity is 1"
+        );
+
+        let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.withdraw_rejected_revision_demand(
+            RejectedRevisionDemand::Momentum {
+                mint: mint_a,
+                pool: pool_a,
+            },
+            Some(&desired),
+        );
+        ctx.reconcile_revision_registry_rejections(Some(&desired));
+        assert!(
+            !ctx.test_invariant_overflow_latched(),
+            "authoritative withdraw+reconcile must recover invariant overflow latch"
+        );
+    }
+
+    #[test]
+    fn revision_rejection_ledger_capacity_covers_all_consumer_caps() {
+        assert_eq!(
+            MAX_REVISION_REJECTION_LEDGER_CAPACITY,
+            MAX_MOMENTUM_PAIRS_TOTAL + MAX_ARB_POOLS_TOTAL + MAX_TRACKER_DEMANDS_TOTAL
+        );
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -5417,6 +5417,12 @@ impl MarketDataContext {
     ) -> bool {
         self.hot_pool_registry.unpin_pool(mint, pool);
         desired.remove_group(ConsumerId::Momentum, OwnerKey::Pool(pool));
+        self.pool_snapshot_revisions.maybe_retire_key(
+            pool,
+            ConsumerId::Momentum,
+            self.pending_pool_commands
+                .has_pending(pool, ConsumerId::Momentum),
+        );
         let mut changed = false;
         // Pool-level reserve pins are shared: only demote vaults/bin arrays when no `(m, pool)`
         // row remains after this unpin (PR #147 follow-up).
@@ -5613,6 +5619,12 @@ impl MarketDataContext {
     ) -> bool {
         self.hot_pool_registry.unpin_arb_pool(pool);
         desired.remove_group(ConsumerId::Arb, OwnerKey::Pool(pool));
+        self.pool_snapshot_revisions.maybe_retire_key(
+            pool,
+            ConsumerId::Arb,
+            self.pending_pool_commands
+                .has_pending(pool, ConsumerId::Arb),
+        );
         let mut changed = false;
         if !self.hot_pool_registry.pool_has_arb(pool)
             && !self.hot_pool_registry.pool_has_any_pin(pool)
@@ -12021,6 +12033,11 @@ mod pr_b_geyser_tracking_tests {
         std::thread::sleep(Duration::from_millis(80));
     }
 
+    fn one_sequence_older_revision(revision: u64) -> u64 {
+        let (generation, sequence) = PoolSnapshotRevisionSequencer::unpack_revision(revision);
+        PoolSnapshotRevisionSequencer::pack_revision(generation, sequence.saturating_sub(1).max(1))
+    }
+
     #[allow(dead_code)]
     fn test_desired_set(ctx: &MarketDataContext) -> DesiredExplicitSet {
         DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts)
@@ -16708,8 +16725,7 @@ mod pr_b_geyser_tracking_tests {
         let mut snapshot = ctx
             .build_pool_explicit_snapshot(pool, GeyserPinReason::ArbMultiDex)
             .expect("dlmm snapshot");
-        ctx.pool_snapshot_revisions
-            .assign_next(&mut snapshot);
+        ctx.pool_snapshot_revisions.assign_next(&mut snapshot);
         assert!(!snapshot.vaults.is_empty());
         assert!(!snapshot.bin_arrays.is_empty());
         assert!(!snapshot.mints.is_empty());
@@ -16857,7 +16873,8 @@ mod pr_b_geyser_tracking_tests {
             .latest_revision_for(pool, ConsumerId::Arb)
             .expect("pending revision");
         assert_eq!(
-            latest_rev, 4,
+            PoolSnapshotRevisionSequencer::revision_sequence(latest_rev),
+            4,
             "one successful enqueue plus three queue-full stashes assign monotonic revisions"
         );
 
@@ -17006,7 +17023,7 @@ mod pr_b_geyser_tracking_tests {
         );
 
         let mut snapshot_old = mk_typed(bin_old, mint_old, vault_old);
-        snapshot_old.revision = rev_new.saturating_sub(1).max(1);
+        snapshot_old.revision = one_sequence_older_revision(rev_new);
         assert_eq!(
             ctx.pending_pool_commands
                 .upsert(PendingPoolCommand::RegisterReserves(snapshot_old)),
@@ -17055,7 +17072,7 @@ mod pr_b_geyser_tracking_tests {
         assert!(ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot_new));
 
         let mut snapshot_stale = mk_typed(bin_old, mint_old, vault_old);
-        snapshot_stale.revision = rev_new.saturating_sub(1).max(1);
+        snapshot_stale.revision = one_sequence_older_revision(rev_new);
         assert!(
             !ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot_stale),
             "stale direct commit must no-op"
@@ -17190,7 +17207,7 @@ mod pr_b_geyser_tracking_tests {
         assert!(rev_new > 0);
 
         let mut snapshot_stale = mk_typed(bin_stale, mint_stale, vault_stale);
-        snapshot_stale.revision = rev_new.saturating_sub(1).max(1);
+        snapshot_stale.revision = one_sequence_older_revision(rev_new);
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         assert!(
             !ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot_stale),

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -727,16 +727,23 @@ impl UnifiedHotPoolRegistry {
         }
     }
 
-    fn pin_pool(&self, mint: Pubkey, pool: Pubkey) -> bool {
+    fn try_pin_pool(&self, mint: Pubkey, pool: Pubkey) -> bool {
         let mut pairs = self.momentum_pairs.write();
         if pairs.contains(&(mint, pool)) {
             return true;
+        }
+        if pairs.len() >= MAX_MOMENTUM_PAIRS_TOTAL {
+            return false;
         }
         if pairs.iter().filter(|(_, p)| *p == pool).count() >= MAX_MOMENTUM_MINTS_PER_POOL {
             return false;
         }
         pairs.insert((mint, pool));
         true
+    }
+
+    fn pin_pool(&self, mint: Pubkey, pool: Pubkey) -> bool {
+        self.try_pin_pool(mint, pool)
     }
 
     fn momentum_mint_count_for_pool(&self, pool: Pubkey) -> usize {
@@ -751,8 +758,20 @@ impl UnifiedHotPoolRegistry {
         self.momentum_pairs.write().remove(&(mint, pool));
     }
 
+    fn try_pin_arb_pool(&self, pool: Pubkey) -> bool {
+        let mut arb = self.arb_pools.write();
+        if arb.contains(&pool) {
+            return true;
+        }
+        if arb.len() >= MAX_ARB_POOLS_TOTAL {
+            return false;
+        }
+        arb.insert(pool);
+        true
+    }
+
     fn pin_arb_pool(&self, pool: Pubkey) {
-        self.arb_pools.write().insert(pool);
+        let _ = self.try_pin_arb_pool(pool);
     }
 
     fn unpin_arb_pool(&self, pool: Pubkey) {
@@ -1205,12 +1224,17 @@ const WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
 
 /// Maximum distinct momentum `(mint, pool)` rows per pool (fail-closed bound).
 const MAX_MOMENTUM_MINTS_PER_POOL: usize = 64;
+/// Global momentum `(mint, pool)` pin rows (aligned with revision registry capacity).
+const MAX_MOMENTUM_PAIRS_TOTAL: usize = 8_192;
+/// Global arb pool pin rows (aligned with revision registry capacity).
+const MAX_ARB_POOLS_TOTAL: usize = 8_192;
 
 /// Independent fail-closed blocker flags for Geyser explicit readiness.
 const GESYER_BLOCK_PENDING_POOL_OVERFLOW: u8 = 1 << 0;
 const GESYER_BLOCK_REVISION_REGISTRY_FULL: u8 = 1 << 1;
 const GESYER_BLOCK_PROTECTED_CAP_OVERFLOW: u8 = 1 << 2;
 const GESYER_BLOCK_ADMISSION_UNCONVERGED: u8 = 1 << 3;
+const GESYER_BLOCK_WALLET_EXPLICIT: u8 = 1 << 4;
 
 /// Scope-8: After `WalletSnapshotComplete`, wait briefly for in-flight Geyser merges before
 /// cold-path RPC verification for wallet-only mints without explicit Ready (bounded).
@@ -3283,7 +3307,6 @@ impl MarketDataContext {
         if let Some(msg) = msg {
             *self.geyser_explicit_config_error.write() = Some(msg);
         }
-        self.geyser_explicit_ready.store(false, Ordering::Release);
     }
 
     fn clear_geyser_explicit_blocker(&self, flag: u8) {
@@ -3291,7 +3314,7 @@ impl MarketDataContext {
             .fetch_and(!flag, Ordering::AcqRel);
     }
 
-    fn refresh_geyser_explicit_readiness(&self, desired: &DesiredExplicitSet) {
+    fn recompute_geyser_explicit_readiness(&self, desired: &DesiredExplicitSet) {
         let blockers = self.geyser_explicit_blockers.load(Ordering::Acquire);
         let cap = self.config.read().max_tracked_accounts;
         let wallet_ok = self.wallet_explicit_demand_pubkeys().len() <= cap;
@@ -3300,6 +3323,29 @@ impl MarketDataContext {
         if ready {
             *self.geyser_explicit_config_error.write() = None;
         }
+    }
+
+    fn try_clear_revision_registry_full_blocker(&self, desired: &DesiredExplicitSet) {
+        if self.pool_snapshot_revisions.active_key_count() < self.pool_snapshot_revisions.max_keys()
+        {
+            self.clear_geyser_explicit_blocker(GESYER_BLOCK_REVISION_REGISTRY_FULL);
+            self.recompute_geyser_explicit_readiness(desired);
+        }
+    }
+
+    fn try_clear_protected_cap_blockers(&self, desired: &DesiredExplicitSet) {
+        let cap = self.config.read().max_tracked_accounts;
+        let demand_len = self.wallet_explicit_demand_pubkeys().len();
+        if demand_len <= cap && desired.cap_overflow() == 0 {
+            self.clear_geyser_explicit_blocker(GESYER_BLOCK_PROTECTED_CAP_OVERFLOW);
+            self.clear_geyser_explicit_blocker(GESYER_BLOCK_WALLET_EXPLICIT);
+            self.recompute_geyser_explicit_readiness(desired);
+        }
+    }
+
+    #[allow(dead_code)]
+    fn refresh_geyser_explicit_readiness(&self, desired: &DesiredExplicitSet) {
+        self.recompute_geyser_explicit_readiness(desired);
     }
 
     fn pool_snapshot_consumer_demand_valid(&self, snapshot: &PoolExplicitSnapshot) -> bool {
@@ -3378,12 +3424,22 @@ impl MarketDataContext {
         )
     }
 
-    fn ensure_pool_revision_key(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
+    fn ensure_pool_revision_key(
+        &self,
+        pool: Pubkey,
+        consumer: ConsumerId,
+        desired: Option<&DesiredExplicitSet>,
+    ) -> bool {
         match self
             .pool_snapshot_revisions
             .ensure_revision_key(pool, consumer)
         {
-            RevisionAcquireResult::Acquired => true,
+            RevisionAcquireResult::Acquired => {
+                if let Some(desired) = desired {
+                    self.try_clear_revision_registry_full_blocker(desired);
+                }
+                true
+            }
             RevisionAcquireResult::RegistryFull => {
                 self.fail_revision_registry_full();
                 false
@@ -3391,23 +3447,43 @@ impl MarketDataContext {
         }
     }
 
+    fn ensure_pool_revision_key_cold(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
+        self.ensure_pool_revision_key(pool, consumer, None)
+    }
+
     #[allow(dead_code)]
     fn acquire_revision_owner(&self, owner: RevisionActiveOwner) -> bool {
-        self.ensure_pool_revision_key(owner.pool(), owner.consumer())
+        self.ensure_pool_revision_key_cold(owner.pool(), owner.consumer())
     }
 
     fn acquire_momentum_revision_owner(&self, mint: Pubkey, pool: Pubkey) -> bool {
         if !self.hot_pool_registry.is_pinned(mint, pool) {
             return false;
         }
-        self.ensure_pool_revision_key(pool, ConsumerId::Momentum)
+        self.ensure_pool_revision_key_cold(pool, ConsumerId::Momentum)
     }
 
     fn acquire_arb_revision_owner(&self, pool: Pubkey) -> bool {
         if !self.hot_pool_registry.pool_has_arb(pool) {
             return false;
         }
-        self.ensure_pool_revision_key(pool, ConsumerId::Arb)
+        self.ensure_pool_revision_key_cold(pool, ConsumerId::Arb)
+    }
+
+    fn try_pin_momentum_with_revision(
+        &self,
+        mint: Pubkey,
+        pool: Pubkey,
+        desired: &DesiredExplicitSet,
+    ) -> bool {
+        if !self.hot_pool_registry.try_pin_pool(mint, pool) {
+            return false;
+        }
+        if !self.ensure_pool_revision_key(pool, ConsumerId::Momentum, Some(desired)) {
+            self.hot_pool_registry.unpin_pool(mint, pool);
+            return false;
+        }
+        true
     }
 
     #[allow(dead_code)]
@@ -3417,6 +3493,17 @@ impl MarketDataContext {
             ConsumerId::Arb => self.acquire_arb_revision_owner(pool),
             _ => false,
         }
+    }
+
+    fn try_pin_arb_with_revision(&self, pool: Pubkey, desired: &DesiredExplicitSet) -> bool {
+        if !self.hot_pool_registry.try_pin_arb_pool(pool) {
+            return false;
+        }
+        if !self.ensure_pool_revision_key(pool, ConsumerId::Arb, Some(desired)) {
+            self.hot_pool_registry.unpin_arb_pool(pool);
+            return false;
+        }
+        true
     }
 
     fn clear_pending_pool_overflow_latch(&self) {
@@ -3538,7 +3625,7 @@ impl MarketDataContext {
         }
         self.clear_geyser_explicit_blocker(GESYER_BLOCK_PENDING_POOL_OVERFLOW);
         self.clear_pending_pool_overflow_latch();
-        self.refresh_geyser_explicit_readiness(desired);
+        self.recompute_geyser_explicit_readiness(desired);
         if self.geyser_explicit_readiness_ok() {
             let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
         }
@@ -3564,6 +3651,7 @@ impl MarketDataContext {
         if self.pending_pool_commands.is_empty() {
             self.clear_pending_pool_overflow_latch();
         }
+        self.recompute_geyser_explicit_readiness(desired);
     }
 
     fn commit_wallet_explicit_state(
@@ -3625,8 +3713,9 @@ impl MarketDataContext {
         let demand = self.wallet_explicit_demand_pubkeys();
         if demand.is_empty() {
             desired.remove_group(ConsumerId::Wallet, OwnerKey::Wallet);
-            self.geyser_explicit_ready.store(true, Ordering::Relaxed);
-            *self.geyser_explicit_config_error.write() = None;
+            self.clear_geyser_explicit_blocker(GESYER_BLOCK_WALLET_EXPLICIT);
+            self.try_clear_protected_cap_blockers(desired);
+            self.recompute_geyser_explicit_readiness(desired);
             return false;
         }
         if desired.wallet_demand_exceeds_cap(&demand) {
@@ -3637,8 +3726,8 @@ impl MarketDataContext {
                 desired.max_explicit_pubkeys()
             );
             record_admission_rejection(ConsumerId::Wallet, AdmissionResult::RejectedCap);
-            self.geyser_explicit_ready.store(false, Ordering::Relaxed);
-            *self.geyser_explicit_config_error.write() = Some(msg);
+            self.set_geyser_explicit_blocker(GESYER_BLOCK_WALLET_EXPLICIT, Some(msg));
+            self.recompute_geyser_explicit_readiness(desired);
             return false;
         }
         let result = desired.try_admit_wallet_demand(demand);
@@ -3649,8 +3738,8 @@ impl MarketDataContext {
                     desired.max_explicit_pubkeys()
                 );
                 record_admission_rejection(ConsumerId::Wallet, result);
-                self.geyser_explicit_ready.store(false, Ordering::Relaxed);
-                *self.geyser_explicit_config_error.write() = Some(msg);
+                self.set_geyser_explicit_blocker(GESYER_BLOCK_WALLET_EXPLICIT, Some(msg));
+                self.recompute_geyser_explicit_readiness(desired);
                 false
             }
             AdmissionResult::RejectedInvalidGroup => {
@@ -3662,14 +3751,17 @@ impl MarketDataContext {
                 false
             }
             AdmissionResult::RejectedInternal => {
-                self.geyser_explicit_ready.store(false, Ordering::Relaxed);
-                *self.geyser_explicit_config_error.write() =
-                    Some("wallet explicit admission internal invariant failure".into());
+                self.set_geyser_explicit_blocker(
+                    GESYER_BLOCK_WALLET_EXPLICIT,
+                    Some("wallet explicit admission internal invariant failure".into()),
+                );
+                self.recompute_geyser_explicit_readiness(desired);
                 false
             }
             AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
-                self.geyser_explicit_ready.store(true, Ordering::Relaxed);
-                *self.geyser_explicit_config_error.write() = None;
+                self.clear_geyser_explicit_blocker(GESYER_BLOCK_WALLET_EXPLICIT);
+                self.try_clear_protected_cap_blockers(desired);
+                self.recompute_geyser_explicit_readiness(desired);
                 true
             }
         }
@@ -3703,18 +3795,26 @@ impl MarketDataContext {
         self.pending_geyser_evict.store(false, Ordering::Relaxed);
         set_market_data_md_state_evict_pending(false);
         set_market_data_geyser_explicit_cap_overflow(desired.cap_overflow());
+        self.recompute_geyser_explicit_readiness(desired);
         if desired.cap_overflow() > 0 || !self.geyser_explicit_readiness_ok() {
             self.geyser_connect_barrier.mark_failed();
+        } else if self.geyser_explicit_readiness_ok() {
+            self.geyser_connect_barrier.mark_ready();
         }
     }
 
     fn on_cap_converge_result(&self, desired: &DesiredExplicitSet, result: CapConvergeResult) {
         set_market_data_geyser_explicit_cap_overflow(desired.cap_overflow());
         match result {
-            CapConvergeResult::Converged => {}
+            CapConvergeResult::Converged => {
+                self.clear_geyser_explicit_blocker(GESYER_BLOCK_ADMISSION_UNCONVERGED);
+                self.try_clear_protected_cap_blockers(desired);
+                self.recompute_geyser_explicit_readiness(desired);
+            }
             CapConvergeResult::ProtectedOverflow => {
                 let demand = self.wallet_explicit_demand_pubkeys();
                 self.fail_geyser_explicit_protected_overflow(&demand);
+                self.recompute_geyser_explicit_readiness(desired);
             }
             CapConvergeResult::Unconverged => {
                 self.set_geyser_explicit_blocker(
@@ -3722,6 +3822,7 @@ impl MarketDataContext {
                     Some("explicit admission cap unconverged".into()),
                 );
                 self.geyser_connect_barrier.mark_failed();
+                self.recompute_geyser_explicit_readiness(desired);
             }
         }
     }
@@ -4142,7 +4243,12 @@ impl MarketDataContext {
             info!("explicit Geyser restore/startup barrier ready");
         } else {
             warn!("explicit Geyser restore/startup barrier failed or timed out (fail-closed)");
-            ctx.geyser_explicit_ready.store(false, Ordering::Release);
+            ctx.set_geyser_explicit_blocker(
+                GESYER_BLOCK_ADMISSION_UNCONVERGED,
+                Some("startup Geyser barrier failed or timed out".into()),
+            );
+            let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+            ctx.recompute_geyser_explicit_readiness(&desired);
         }
     }
 
@@ -5658,15 +5764,12 @@ impl MarketDataContext {
                 warn!(pool = %a.pool, "MomentumActivePoolsUpdate.active: invalid pool");
                 continue;
             };
-            if !self.hot_pool_registry.pin_pool(mint_pk, pool_pk) {
+            if !self.try_pin_momentum_with_revision(mint_pk, pool_pk, desired) {
                 warn!(
                     mint = %mint_pk,
                     pool = %pool_pk,
-                    "MomentumActivePoolsUpdate.active: per-pool mint pin bound exceeded"
+                    "MomentumActivePoolsUpdate.active: pin or revision registry reservation failed"
                 );
-                continue;
-            }
-            if !self.ensure_pool_revision_key(pool_pk, ConsumerId::Momentum) {
                 continue;
             }
             if self.register_geyser_reserves_for_momentum_active_pool(desired, pool_pk) {
@@ -5857,8 +5960,11 @@ impl MarketDataContext {
                 warn!(pool = %a.pool, "ArbTrackRequestsUpdate.active: invalid pool");
                 continue;
             };
-            self.hot_pool_registry.pin_arb_pool(pool_pk);
-            if !self.acquire_arb_revision_owner(pool_pk) {
+            if !self.try_pin_arb_with_revision(pool_pk, desired) {
+                warn!(
+                    pool = %pool_pk,
+                    "ArbTrackRequestsUpdate.active: pin or revision registry reservation failed"
+                );
                 continue;
             }
             if self.register_geyser_reserves_for_arb_active_pool(desired, pool_pk) {
@@ -17657,6 +17763,8 @@ mod pr_b_geyser_tracking_tests {
         );
         ctx.fail_pending_pool_overflow();
         assert!(ctx.pending_pool_overflow_latched.load(Ordering::Acquire));
+        let desired_probe = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.recompute_geyser_explicit_readiness(&desired_probe);
         assert!(!ctx.geyser_explicit_readiness_ok());
 
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
@@ -17944,7 +18052,7 @@ mod pr_b_geyser_tracking_tests {
         let pool = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
         ctx.hot_pool_registry.pin_pool(mint, pool);
-        assert!(ctx.ensure_pool_revision_key(pool, ConsumerId::Momentum));
+        assert!(ctx.ensure_pool_revision_key_cold(pool, ConsumerId::Momentum));
         let snapshot = PoolExplicitSnapshot {
             pool,
             vaults: vec![],
@@ -17962,9 +18070,10 @@ mod pr_b_geyser_tracking_tests {
         );
         ctx.fail_pending_pool_overflow();
         ctx.fail_revision_registry_full();
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.recompute_geyser_explicit_readiness(&desired);
         assert!(!ctx.geyser_explicit_readiness_ok());
 
-        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         ctx.apply_pending_track_worker_work(&mut desired);
 
         assert!(
@@ -18081,5 +18190,151 @@ mod pr_b_geyser_tracking_tests {
                 .current_applied(pool, ConsumerId::Momentum),
             rev_unpinned
         );
+    }
+
+    #[test]
+    fn pending_replay_unpinned_advances_watermark_older_direct_stays_stale() {
+        use ironcrab::execution::live_pool_cache::RaydiumCpmmState;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: mint,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        assert!(ctx.try_pin_momentum_with_revision(mint, pool, &desired));
+        let mut snapshot = ctx
+            .build_pool_explicit_snapshot(pool, GeyserPinReason::MomentumActive)
+            .expect("snapshot");
+        let rev1 = assign_pool_snapshot_for_test(
+            &ctx,
+            pool,
+            ConsumerId::Momentum,
+            &mut snapshot,
+            Some(mint),
+        );
+        snapshot.revision = rev1;
+        assert!(ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot));
+
+        let mut pending_snap = snapshot.clone();
+        pending_snap.revision = 0;
+        assert_eq!(
+            ctx.pending_pool_commands
+                .upsert(PendingPoolCommand::AfterTrade(pending_snap.clone())),
+            PendingPoolUpsertResult::Stored
+        );
+        let rev2 = ctx
+            .pending_pool_commands
+            .latest_revision_for(pool, ConsumerId::Momentum)
+            .expect("pending revision");
+        pending_snap.revision = rev2;
+
+        ctx.hot_pool_registry.unpin_pool(mint, pool);
+        ctx.apply_pending_track_worker_work(&mut desired);
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .current_applied(pool, ConsumerId::Momentum),
+            rev2
+        );
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .key_refs(pool, ConsumerId::Momentum)
+                .total(),
+            0
+        );
+
+        assert!(ctx.try_pin_momentum_with_revision(mint, pool, &desired));
+        let mut stale_direct = pending_snap.clone();
+        stale_direct.revision = rev1;
+        assert!(!ctx.commit_register_pool_geyser_reserves(&mut desired, &stale_direct));
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .current_applied(pool, ConsumerId::Momentum),
+            rev2
+        );
+    }
+
+    #[test]
+    fn readiness_recompute_keeps_blockers_until_each_cleared() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+
+        ctx.set_geyser_explicit_blocker(
+            GESYER_BLOCK_REVISION_REGISTRY_FULL,
+            Some("registry full".into()),
+        );
+        ctx.set_geyser_explicit_blocker(
+            GESYER_BLOCK_WALLET_EXPLICIT,
+            Some("wallet blocked".into()),
+        );
+        ctx.recompute_geyser_explicit_readiness(&desired);
+        assert!(!ctx.geyser_explicit_readiness_ok());
+
+        ctx.clear_geyser_explicit_blocker(GESYER_BLOCK_WALLET_EXPLICIT);
+        ctx.recompute_geyser_explicit_readiness(&desired);
+        assert!(
+            !ctx.geyser_explicit_readiness_ok(),
+            "registry full must keep readiness false after wallet-only clear"
+        );
+
+        ctx.clear_geyser_explicit_blocker(GESYER_BLOCK_REVISION_REGISTRY_FULL);
+        ctx.recompute_geyser_explicit_readiness(&desired);
+        assert!(ctx.geyser_explicit_readiness_ok());
+    }
+
+    #[test]
+    fn registry_full_rolls_back_momentum_pin_without_leaving_demand() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(1);
+        let registry = UnifiedHotPoolRegistry::new();
+        let pool0 = Pubkey::new_unique();
+        let pool1 = Pubkey::new_unique();
+        let mint1 = Pubkey::new_unique();
+        assert_eq!(
+            revisions.ensure_revision_key(pool0, ConsumerId::Momentum),
+            RevisionAcquireResult::Acquired
+        );
+        assert_eq!(
+            revisions.reserve_inflight_command(pool0, ConsumerId::Momentum),
+            InflightReserveResult::Reserved
+        );
+        assert!(registry.try_pin_pool(mint1, pool1));
+        assert_eq!(
+            revisions.ensure_revision_key(pool1, ConsumerId::Momentum),
+            RevisionAcquireResult::RegistryFull
+        );
+        registry.unpin_pool(mint1, pool1);
+        assert!(!registry.is_pinned(mint1, pool1));
+        assert_eq!(registry.pair_count(), 0);
+    }
+
+    #[test]
+    fn global_momentum_pin_total_bound_rejects() {
+        let registry = UnifiedHotPoolRegistry::new();
+        for i in 0..MAX_MOMENTUM_PAIRS_TOTAL {
+            let mint = Pubkey::new_unique();
+            let pool = Pubkey::new_unique();
+            assert!(registry.try_pin_pool(mint, pool), "pin {i}");
+        }
+        assert!(!registry.try_pin_pool(Pubkey::new_unique(), Pubkey::new_unique()));
+        assert_eq!(registry.pair_count(), MAX_MOMENTUM_PAIRS_TOTAL);
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -110,6 +110,7 @@ use ironcrab::metrics::{
     inc_market_data_md_state_evict_steps_budget_exhausted_total,
     inc_market_data_md_state_evict_steps_total, inc_market_data_revision_registry_full_total,
     inc_market_data_track_pending_pool_overflow_total,
+    inc_market_data_tracker_demand_cap_rejected_total,
     inc_market_data_vault_high_priority_dispatch_total, market_data_bump_geyser_head_slot,
     market_data_geyser_head_slot_value, market_data_geyser_tracking_enqueue_dropped_value,
     market_data_geyser_tracking_jobs_processed_value, market_data_md_state_bursts_completed_value,
@@ -1183,6 +1184,8 @@ struct MarketDataContext {
     geyser_connect_barrier: Arc<GeyserConnectBarrier>,
     /// Bounded authoritative ledger of rejected revision demand awaiting retry/withdrawal.
     revision_registry_rejection_ledger: parking_lot::Mutex<RevisionRegistryRejectionLedger>,
+    /// Bounded exact Tracker demand identities (ingress cap before ledger/admission).
+    tracker_demand_registry: parking_lot::Mutex<TrackerDemandRegistry>,
     #[cfg(test)]
     revision_reconcile_test_barrier: RevisionReconcileTestBarrier,
 }
@@ -1247,6 +1250,88 @@ const GESYER_BLOCK_ADMISSION_UNCONVERGED: u8 = 1 << 3;
 const GESYER_BLOCK_WALLET_EXPLICIT: u8 = 1 << 4;
 const GESYER_BLOCK_WALLET_REVISION_EXHAUSTED: u8 = 1 << 5;
 const GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW: u8 = 1 << 6;
+const GESYER_BLOCK_TRACKER_DEMAND_CAP: u8 = 1 << 7;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TrackerDemandKey {
+    pool: Pubkey,
+    owner: OwnerKey,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TrackerDemandIngressResult {
+    Admitted,
+    AlreadyRegistered,
+    CapRejected,
+    CapRejectedExisting,
+}
+
+#[derive(Debug)]
+struct TrackerDemandRegistry {
+    capacity: usize,
+    admitted: HashSet<TrackerDemandKey>,
+    cap_rejected: HashMap<TrackerDemandKey, PoolExplicitSnapshot>,
+}
+
+impl TrackerDemandRegistry {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity: capacity.max(1),
+            admitted: HashSet::new(),
+            cap_rejected: HashMap::new(),
+        }
+    }
+
+    #[cfg(test)]
+    fn admitted_count(&self) -> usize {
+        self.admitted.len()
+    }
+
+    #[cfg(test)]
+    fn cap_rejected_count(&self) -> usize {
+        self.cap_rejected.len()
+    }
+
+    fn has_cap_rejected(&self) -> bool {
+        !self.cap_rejected.is_empty()
+    }
+
+    fn try_admit_ingress(&mut self, snapshot: &PoolExplicitSnapshot) -> TrackerDemandIngressResult {
+        let key = TrackerDemandKey {
+            pool: snapshot.pool,
+            owner: snapshot.owner,
+        };
+        if self.admitted.contains(&key) {
+            return TrackerDemandIngressResult::AlreadyRegistered;
+        }
+        if self.cap_rejected.contains_key(&key) {
+            return TrackerDemandIngressResult::CapRejectedExisting;
+        }
+        if self.admitted.len() >= self.capacity {
+            self.cap_rejected.insert(key, snapshot.clone());
+            return TrackerDemandIngressResult::CapRejected;
+        }
+        self.admitted.insert(key);
+        TrackerDemandIngressResult::Admitted
+    }
+
+    fn withdraw(&mut self, pool: Pubkey, owner: OwnerKey) -> bool {
+        let key = TrackerDemandKey { pool, owner };
+        let removed_admitted = self.admitted.remove(&key);
+        let removed_cap = self.cap_rejected.remove(&key).is_some();
+        removed_admitted || removed_cap
+    }
+
+    fn promote_one_cap_rejected_if_capacity_available(&mut self) -> Option<PoolExplicitSnapshot> {
+        if self.admitted.len() >= self.capacity {
+            return None;
+        }
+        let key = self.cap_rejected.keys().next().cloned()?;
+        let snapshot = self.cap_rejected.remove(&key)?;
+        self.admitted.insert(key);
+        Some(snapshot)
+    }
+}
 
 /// Authoritative rejected logical demand awaiting bounded retry or explicit withdrawal.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1350,12 +1435,14 @@ impl RevisionRegistryRejectionLedger {
         token
     }
 
+    #[cfg(test)]
     fn entry_for_key(&self, key: &RejectedDemandKey) -> Option<&RejectedLedgerEntry> {
         self.entries
             .get(key)
             .or_else(|| self.overflow_entries.get(key))
     }
 
+    #[cfg(test)]
     fn ledger_token_for_key(&self, key: &RejectedDemandKey) -> Option<u64> {
         self.entry_for_key(key).map(|e| e.ledger_token)
     }
@@ -1365,14 +1452,13 @@ impl RevisionRegistryRejectionLedger {
         self.entry_for_key(key).is_some()
     }
 
-    fn resolve_token_for_snapshot(&self, snapshot: &PoolExplicitSnapshot) -> Option<u64> {
-        let demand = RejectedRevisionDemand::from_snapshot(snapshot)?;
-        self.ledger_token_for_key(&demand.demand_key())
-    }
-
     fn record(&mut self, demand: RejectedRevisionDemand) -> RevisionRejectionRecordResult {
         let key = demand.demand_key();
         let ledger_token = self.allocate_ledger_token();
+        let mut demand = demand;
+        if let RejectedRevisionDemand::Tracker { ref mut snapshot } = demand {
+            snapshot.rejection_ledger_token = Some(ledger_token);
+        }
         let entry = RejectedLedgerEntry {
             demand,
             ledger_token,
@@ -1424,39 +1510,74 @@ impl RevisionRegistryRejectionLedger {
         }
     }
 
+    fn try_remove_for_enqueue_resolution(
+        &mut self,
+        demand: &RejectedRevisionDemand,
+        snapshot_token: Option<u64>,
+    ) -> bool {
+        let key = demand.demand_key();
+        let remove_from_entries = |this: &mut Self| -> bool {
+            let Some(entry) = this.entries.get(&key) else {
+                return false;
+            };
+            if !Self::enqueue_resolution_matches(entry, demand, snapshot_token) {
+                return false;
+            }
+            this.entries.remove(&key);
+            this.generation = this.generation.wrapping_add(1);
+            this.try_authoritative_reconcile_storage();
+            true
+        };
+        if remove_from_entries(self) {
+            return true;
+        }
+        let Some(entry) = self.overflow_entries.get(&key) else {
+            return false;
+        };
+        if !Self::enqueue_resolution_matches(entry, demand, snapshot_token) {
+            return false;
+        }
+        self.overflow_entries.remove(&key);
+        self.generation = self.generation.wrapping_add(1);
+        self.try_authoritative_reconcile_storage();
+        true
+    }
+
+    fn enqueue_resolution_matches(
+        entry: &RejectedLedgerEntry,
+        demand: &RejectedRevisionDemand,
+        snapshot_token: Option<u64>,
+    ) -> bool {
+        match snapshot_token {
+            Some(token) => {
+                entry.ledger_token == token && Self::demand_matches(&entry.demand, demand)
+            }
+            None => {
+                if matches!(demand, RejectedRevisionDemand::Tracker { .. }) {
+                    return false;
+                }
+                Self::demand_matches(&entry.demand, demand)
+            }
+        }
+    }
+
     fn remove_demand(
         &mut self,
         demand: &RejectedRevisionDemand,
         expected_token: Option<u64>,
     ) -> bool {
+        self.try_remove_for_enqueue_resolution(demand, expected_token)
+    }
+
+    fn withdraw_demand(&mut self, demand: &RejectedRevisionDemand) -> bool {
         let key = demand.demand_key();
-        if let Some(entry) = self.entries.get(&key) {
-            if let Some(token) = expected_token {
-                if entry.ledger_token != token {
-                    return false;
-                }
-            } else if !Self::demand_matches(&entry.demand, demand) {
-                return false;
-            }
-            self.entries.remove(&key);
+        let removed =
+            self.entries.remove(&key).is_some() || self.overflow_entries.remove(&key).is_some();
+        if removed {
             self.generation = self.generation.wrapping_add(1);
             self.try_authoritative_reconcile_storage();
-            return true;
         }
-        if let Some(entry) = self.overflow_entries.get(&key) {
-            if let Some(token) = expected_token {
-                if entry.ledger_token != token {
-                    return false;
-                }
-            } else if !Self::demand_matches(&entry.demand, demand) {
-                return false;
-            }
-            self.overflow_entries.remove(&key);
-            self.generation = self.generation.wrapping_add(1);
-            self.try_authoritative_reconcile_storage();
-            return true;
-        }
-        false
+        removed
     }
 
     fn try_authoritative_reconcile_storage(&mut self) -> bool {
@@ -2327,6 +2448,9 @@ fn prepare_pool_snapshot_for_enqueue(
         }
         _ => return None,
     };
+    if consumer == ConsumerId::Tracker && !ctx.admit_tracker_demand_at_ingress(snapshot) {
+        return None;
+    }
     match ctx
         .pool_snapshot_revisions
         .reserve_inflight_command(pool, consumer)
@@ -2337,13 +2461,9 @@ fn prepare_pool_snapshot_for_enqueue(
             return None;
         }
     }
-    let resolve_token = ctx
-        .revision_registry_rejection_ledger
-        .lock()
-        .resolve_token_for_snapshot(snapshot);
     match ctx.pool_snapshot_revisions.assign_next(snapshot) {
         RevisionAssignResult::Assigned(_) => {
-            ctx.record_revision_registry_enqueue_success(snapshot, resolve_token, None);
+            ctx.record_revision_registry_enqueue_success(snapshot, None);
             Some((pool, consumer))
         }
         RevisionAssignResult::RegistryFull => {
@@ -3638,6 +3758,7 @@ impl MarketDataContext {
             owner: OwnerKey::Pool(pool),
             pin,
             revision: 0,
+            rejection_ledger_token: None,
         })
     }
 
@@ -3702,7 +3823,90 @@ impl MarketDataContext {
         demand: RejectedRevisionDemand,
         desired: Option<&DesiredExplicitSet>,
     ) {
-        self.resolve_rejected_revision_demand(demand, None, desired);
+        if let RejectedRevisionDemand::Tracker { ref snapshot } = demand {
+            self.withdraw_tracker_demand_identity(snapshot.pool, snapshot.owner);
+        }
+        let removed = self
+            .revision_registry_rejection_ledger
+            .lock()
+            .withdraw_demand(&demand);
+        if removed {
+            self.maybe_clear_revision_registry_full_blocker(desired);
+        }
+    }
+
+    fn admit_tracker_demand_at_ingress(&self, snapshot: &PoolExplicitSnapshot) -> bool {
+        let mut registry = self.tracker_demand_registry.lock();
+        match registry.try_admit_ingress(snapshot) {
+            TrackerDemandIngressResult::Admitted
+            | TrackerDemandIngressResult::AlreadyRegistered => true,
+            TrackerDemandIngressResult::CapRejected
+            | TrackerDemandIngressResult::CapRejectedExisting => {
+                drop(registry);
+                self.fail_tracker_demand_cap();
+                false
+            }
+        }
+    }
+
+    fn fail_tracker_demand_cap(&self) {
+        inc_market_data_tracker_demand_cap_rejected_total();
+        self.set_geyser_explicit_blocker(
+            GESYER_BLOCK_TRACKER_DEMAND_CAP,
+            Some("tracker demand cap exceeded at authoritative ingress (fail-closed)".into()),
+        );
+        self.geyser_connect_barrier.mark_failed();
+    }
+
+    fn withdraw_tracker_demand_identity(&self, pool: Pubkey, owner: OwnerKey) {
+        let promoted = {
+            let mut registry = self.tracker_demand_registry.lock();
+            registry.withdraw(pool, owner);
+            registry.promote_one_cap_rejected_if_capacity_available()
+        };
+        if let Some(snapshot) = promoted {
+            let _ = enqueue_track_worker(
+                self,
+                TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
+            );
+        }
+        self.maybe_clear_tracker_demand_cap_blocker();
+    }
+
+    fn maybe_clear_tracker_demand_cap_blocker(&self) {
+        let has_cap_rejected = self.tracker_demand_registry.lock().has_cap_rejected();
+        if !has_cap_rejected {
+            self.clear_geyser_explicit_blocker(GESYER_BLOCK_TRACKER_DEMAND_CAP);
+        }
+    }
+
+    fn retry_cap_rejected_tracker_demands(&self) {
+        loop {
+            let snapshot = {
+                let mut registry = self.tracker_demand_registry.lock();
+                registry.promote_one_cap_rejected_if_capacity_available()
+            };
+            match snapshot {
+                Some(s) => {
+                    let _ = enqueue_track_worker(
+                        self,
+                        TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot: s },
+                    );
+                }
+                None => break,
+            }
+        }
+        self.maybe_clear_tracker_demand_cap_blocker();
+    }
+
+    #[cfg(test)]
+    fn test_tracker_demand_cap_rejected_count(&self) -> usize {
+        self.tracker_demand_registry.lock().cap_rejected_count()
+    }
+
+    #[cfg(test)]
+    fn test_tracker_demand_admitted_count(&self) -> usize {
+        self.tracker_demand_registry.lock().admitted_count()
     }
 
     fn set_geyser_explicit_blocker(&self, flag: u8, msg: Option<String>) {
@@ -3731,6 +3935,9 @@ impl MarketDataContext {
     }
 
     fn maybe_clear_revision_registry_full_blocker(&self, desired: Option<&DesiredExplicitSet>) {
+        if self.tracker_demand_registry.lock().has_cap_rejected() {
+            return;
+        }
         let mut ledger = self.revision_registry_rejection_ledger.lock();
         ledger.try_authoritative_reconcile_storage();
         if ledger.has_unresolved() {
@@ -3747,7 +3954,6 @@ impl MarketDataContext {
     fn record_revision_registry_enqueue_success(
         &self,
         snapshot: &PoolExplicitSnapshot,
-        resolve_token: Option<u64>,
         desired: Option<&DesiredExplicitSet>,
     ) {
         let Some(demand) = RejectedRevisionDemand::from_snapshot(snapshot) else {
@@ -3756,13 +3962,16 @@ impl MarketDataContext {
         if self
             .revision_registry_rejection_ledger
             .lock()
-            .remove_demand(&demand, resolve_token)
+            .remove_demand(&demand, snapshot.rejection_ledger_token)
         {
             self.maybe_clear_revision_registry_full_blocker(desired);
         }
     }
 
     fn reconcile_revision_registry_rejections(&self, desired: Option<&DesiredExplicitSet>) {
+        if self.tracker_demand_registry.lock().has_cap_rejected() {
+            return;
+        }
         let snapshot_gen = {
             let ledger = self.revision_registry_rejection_ledger.lock();
             ledger.generation
@@ -3875,7 +4084,9 @@ impl MarketDataContext {
         snapshot: &PoolExplicitSnapshot,
         resolve_token: Option<u64>,
     ) {
-        self.record_revision_registry_enqueue_success(snapshot, resolve_token, None);
+        let mut snapshot = snapshot.clone();
+        snapshot.rejection_ledger_token = resolve_token;
+        self.record_revision_registry_enqueue_success(&snapshot, None);
     }
 
     fn fail_wallet_revision_exhausted(&self) {
@@ -4228,6 +4439,7 @@ impl MarketDataContext {
         if self.pending_pool_commands.is_empty() {
             self.clear_pending_pool_overflow_latch();
         }
+        self.retry_cap_rejected_tracker_demands();
         self.retry_bounded_rejected_revision_demands(desired);
         self.recompute_geyser_explicit_readiness(desired);
     }
@@ -8846,6 +9058,9 @@ async fn main() -> Result<()> {
         revision_registry_rejection_ledger: parking_lot::Mutex::new(
             RevisionRegistryRejectionLedger::new(MAX_REVISION_REJECTION_LEDGER_CAPACITY),
         ),
+        tracker_demand_registry: parking_lot::Mutex::new(TrackerDemandRegistry::new(
+            MAX_TRACKER_DEMANDS_TOTAL,
+        )),
         #[cfg(test)]
         revision_reconcile_test_barrier: RevisionReconcileTestBarrier::default(),
     });
@@ -12451,6 +12666,9 @@ mod wallet_snapshot_stale_cleanup_tests {
             revision_registry_rejection_ledger: parking_lot::Mutex::new(
                 RevisionRegistryRejectionLedger::new(MAX_REVISION_REJECTION_LEDGER_CAPACITY),
             ),
+            tracker_demand_registry: parking_lot::Mutex::new(TrackerDemandRegistry::new(
+                MAX_TRACKER_DEMANDS_TOTAL,
+            )),
             #[cfg(test)]
             revision_reconcile_test_barrier: RevisionReconcileTestBarrier::default(),
         }
@@ -12702,6 +12920,9 @@ mod wallet_tx_meta_balance_tests {
             revision_registry_rejection_ledger: parking_lot::Mutex::new(
                 RevisionRegistryRejectionLedger::new(MAX_REVISION_REJECTION_LEDGER_CAPACITY),
             ),
+            tracker_demand_registry: parking_lot::Mutex::new(TrackerDemandRegistry::new(
+                MAX_TRACKER_DEMANDS_TOTAL,
+            )),
             #[cfg(test)]
             revision_reconcile_test_barrier: RevisionReconcileTestBarrier::default(),
         });
@@ -13545,6 +13766,7 @@ mod pr_b_geyser_tracking_tests {
             jsonl_writer,
             pending_pool_registration_cap(25_000),
             MAX_REVISION_REJECTION_LEDGER_CAPACITY,
+            MAX_TRACKER_DEMANDS_TOTAL,
         )
     }
 
@@ -13552,6 +13774,7 @@ mod pr_b_geyser_tracking_tests {
         jsonl_writer: QueuedJsonlWriter,
         revision_max_keys: usize,
         rejection_ledger_capacity: usize,
+        tracker_demand_capacity: usize,
     ) -> Arc<MarketDataContext> {
         let (tracked_mints_tx, _tracked_mints_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
@@ -13635,6 +13858,9 @@ mod pr_b_geyser_tracking_tests {
             revision_registry_rejection_ledger: parking_lot::Mutex::new(
                 RevisionRegistryRejectionLedger::new(rejection_ledger_capacity),
             ),
+            tracker_demand_registry: parking_lot::Mutex::new(TrackerDemandRegistry::new(
+                tracker_demand_capacity,
+            )),
             #[cfg(test)]
             revision_reconcile_test_barrier: RevisionReconcileTestBarrier::default(),
         });
@@ -13675,6 +13901,7 @@ mod pr_b_geyser_tracking_tests {
                 ConsumerId::Tracker | ConsumerId::Wallet => GeyserPinReason::MomentumActive,
             },
             revision: 0,
+            rejection_ledger_token: None,
         }
     }
 
@@ -13721,6 +13948,10 @@ mod pr_b_geyser_tracking_tests {
             ConsumerId::Tracker => mk_test_pool_snapshot(pool, consumer, None, tracker_hub),
             _ => mk_test_pool_snapshot(pool, consumer, None, None),
         };
+        let mut snapshot = snapshot;
+        if let Some(token) = ctx.test_ledger_token_for_demand(&demand) {
+            snapshot.rejection_ledger_token = Some(token);
+        }
         assert!(enqueue_track_worker(
             ctx,
             TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
@@ -13820,6 +14051,9 @@ mod pr_b_geyser_tracking_tests {
             revision_registry_rejection_ledger: parking_lot::Mutex::new(
                 RevisionRegistryRejectionLedger::new(MAX_REVISION_REJECTION_LEDGER_CAPACITY),
             ),
+            tracker_demand_registry: parking_lot::Mutex::new(TrackerDemandRegistry::new(
+                MAX_TRACKER_DEMANDS_TOTAL,
+            )),
             #[cfg(test)]
             revision_reconcile_test_barrier: RevisionReconcileTestBarrier::default(),
         });
@@ -17941,6 +18175,7 @@ mod pr_b_geyser_tracking_tests {
             owner: OwnerKey::Pool(pool),
             pin: GeyserPinReason::MomentumActive,
             revision: 0,
+            rejection_ledger_token: None,
         };
         assert_eq!(
             pending.upsert(PendingPoolCommand::RegisterReserves(mk_snapshot(pool_a))),
@@ -18012,6 +18247,7 @@ mod pr_b_geyser_tracking_tests {
             owner: OwnerKey::Pool(pool),
             pin: GeyserPinReason::ArbMultiDex,
             revision: 0,
+            rejection_ledger_token: None,
         };
 
         let snapshot_reserve = mk_typed(reserve_x, bin_old, mint_old);
@@ -18152,6 +18388,7 @@ mod pr_b_geyser_tracking_tests {
                 owner: OwnerKey::Pool(pool),
                 pin: GeyserPinReason::ArbMultiDex,
                 revision: 0,
+                rejection_ledger_token: None,
             };
         (pool, base, quote, reserve_x, reserve_y, mk_typed)
     }
@@ -18775,6 +19012,7 @@ mod pr_b_geyser_tracking_tests {
             owner: OwnerKey::Pool(pool),
             pin: GeyserPinReason::MomentumActive,
             revision: 0,
+            rejection_ledger_token: None,
         };
         assert_eq!(
             ctx.pending_pool_commands
@@ -19270,7 +19508,12 @@ mod pr_b_geyser_tracking_tests {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
-        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 1, 8);
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(
+            jsonl,
+            1,
+            8,
+            MAX_TRACKER_DEMANDS_TOTAL,
+        );
         let pool = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
         let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
@@ -19304,7 +19547,12 @@ mod pr_b_geyser_tracking_tests {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
-        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 1, 8);
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(
+            jsonl,
+            1,
+            8,
+            MAX_TRACKER_DEMANDS_TOTAL,
+        );
         let pool = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
@@ -19345,7 +19593,12 @@ mod pr_b_geyser_tracking_tests {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
-        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 1, 8);
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(
+            jsonl,
+            1,
+            8,
+            MAX_TRACKER_DEMANDS_TOTAL,
+        );
         let pool = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
@@ -19374,7 +19627,12 @@ mod pr_b_geyser_tracking_tests {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
-        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 8, 8);
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(
+            jsonl,
+            8,
+            8,
+            MAX_TRACKER_DEMANDS_TOTAL,
+        );
         ctx.set_geyser_explicit_blocker(
             GESYER_BLOCK_REVISION_REGISTRY_FULL,
             Some("seed blocker".into()),
@@ -19426,7 +19684,12 @@ mod pr_b_geyser_tracking_tests {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
-        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 1, 8);
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(
+            jsonl,
+            1,
+            8,
+            MAX_TRACKER_DEMANDS_TOTAL,
+        );
         let pool = Pubkey::new_unique();
         let mint_a = Pubkey::new_unique();
         let mint_b = Pubkey::new_unique();
@@ -19500,7 +19763,12 @@ mod pr_b_geyser_tracking_tests {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
-        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 8, 2);
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(
+            jsonl,
+            8,
+            2,
+            MAX_TRACKER_DEMANDS_TOTAL,
+        );
         let pool = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
         let demand = RejectedRevisionDemand::Momentum { mint, pool };
@@ -19561,7 +19829,12 @@ mod pr_b_geyser_tracking_tests {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
-        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 1, 8);
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(
+            jsonl,
+            1,
+            8,
+            MAX_TRACKER_DEMANDS_TOTAL,
+        );
         let pool = Pubkey::new_unique();
         let hub = Pubkey::new_unique();
         let owner = OwnerKey::Pool(pool);
@@ -19655,7 +19928,12 @@ mod pr_b_geyser_tracking_tests {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
-        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 8, 1);
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(
+            jsonl,
+            8,
+            1,
+            MAX_TRACKER_DEMANDS_TOTAL,
+        );
         let pool_a = Pubkey::new_unique();
         let pool_b = Pubkey::new_unique();
         let pool_c = Pubkey::new_unique();
@@ -19693,6 +19971,222 @@ mod pr_b_geyser_tracking_tests {
         assert!(
             !ctx.test_invariant_overflow_latched(),
             "authoritative withdraw+reconcile must recover invariant overflow latch"
+        );
+    }
+
+    #[test]
+    fn tracker_delayed_stale_retry_production_path_preserves_newer_rejection() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let hub_v1 = Pubkey::new_unique();
+        let hub_v2 = Pubkey::new_unique();
+        assert!(ctx.ensure_pool_revision_key_cold(pool, ConsumerId::Tracker));
+
+        let snapshot_v1 = mk_test_pool_snapshot(pool, ConsumerId::Tracker, None, Some(hub_v1));
+        let demand_v1 = RejectedRevisionDemand::Tracker {
+            snapshot: snapshot_v1.clone(),
+        };
+        ctx.fail_revision_registry_full(demand_v1);
+        let token_v1 = ctx
+            .revision_registry_rejection_ledger
+            .lock()
+            .pending_demands()
+            .into_iter()
+            .find_map(|(d, t)| {
+                if let RejectedRevisionDemand::Tracker { snapshot } = d {
+                    if snapshot.mints.first().map(|m| m.pubkey) == Some(hub_v1) {
+                        return Some(t);
+                    }
+                }
+                None
+            })
+            .expect("token v1");
+
+        let snapshot_v2 = mk_test_pool_snapshot(pool, ConsumerId::Tracker, None, Some(hub_v2));
+        let demand_v2 = RejectedRevisionDemand::Tracker {
+            snapshot: snapshot_v2.clone(),
+        };
+        ctx.fail_revision_registry_full(demand_v2.clone());
+        let token_v2 = ctx
+            .test_ledger_token_for_demand(&demand_v2)
+            .expect("token v2");
+        assert_ne!(token_v1, token_v2);
+
+        let mut stale_retry = snapshot_v1;
+        stale_retry.rejection_ledger_token = Some(token_v1);
+        assert!(enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterPoolGeyserReserves {
+                snapshot: stale_retry,
+            },
+        ));
+        assert!(
+            ctx.test_revision_rejection_has_demand(&demand_v2),
+            "stale production-path retry must not clear newer rejection"
+        );
+
+        let mut fresh_retry = snapshot_v2;
+        fresh_retry.rejection_ledger_token = Some(token_v2);
+        assert!(enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterPoolGeyserReserves {
+                snapshot: fresh_retry,
+            },
+        ));
+        assert!(!ctx.test_revision_rejection_has_demand(&demand_v2));
+    }
+
+    #[test]
+    fn tracker_demand_cap_rejects_fail_closed_at_ingress_before_ledger() {
+        const TRACKER_CAP: usize = 2;
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx =
+            minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 8, 8, TRACKER_CAP);
+
+        for i in 0..TRACKER_CAP {
+            let pool = Pubkey::new_unique();
+            assert!(ctx.ensure_pool_revision_key_cold(pool, ConsumerId::Tracker));
+            let snapshot =
+                mk_test_pool_snapshot(pool, ConsumerId::Tracker, None, Some(Pubkey::new_unique()));
+            assert!(
+                enqueue_track_worker(
+                    &ctx,
+                    TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
+                ),
+                "tracker demand {i} should admit at ingress"
+            );
+        }
+        assert_eq!(ctx.test_tracker_demand_admitted_count(), TRACKER_CAP);
+
+        let overflow_pool = Pubkey::new_unique();
+        assert!(ctx.ensure_pool_revision_key_cold(overflow_pool, ConsumerId::Tracker));
+        let overflow_snapshot = mk_test_pool_snapshot(
+            overflow_pool,
+            ConsumerId::Tracker,
+            None,
+            Some(Pubkey::new_unique()),
+        );
+        assert!(
+            !enqueue_track_worker(
+                &ctx,
+                TrackWorkerCommand::RegisterPoolGeyserReserves {
+                    snapshot: overflow_snapshot.clone(),
+                },
+            ),
+            "cap+1 tracker demand must fail closed at ingress"
+        );
+        assert_eq!(ctx.test_tracker_demand_cap_rejected_count(), 1);
+        assert!(!ctx.geyser_explicit_readiness_ok());
+        let overflow_demand = RejectedRevisionDemand::Tracker {
+            snapshot: overflow_snapshot,
+        };
+        assert!(
+            !ctx.test_revision_rejection_has_demand(&overflow_demand),
+            "cap-rejected tracker demand must not enter revision rejection ledger"
+        );
+    }
+
+    #[test]
+    fn tracker_demand_withdrawal_frees_slot_and_retries_cap_rejected() {
+        const TRACKER_CAP: usize = 2;
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx =
+            minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 8, 8, TRACKER_CAP);
+
+        let admitted_pools: Vec<Pubkey> = (0..TRACKER_CAP)
+            .map(|_| {
+                let pool = Pubkey::new_unique();
+                assert!(ctx.ensure_pool_revision_key_cold(pool, ConsumerId::Tracker));
+                let snapshot = mk_test_pool_snapshot(
+                    pool,
+                    ConsumerId::Tracker,
+                    None,
+                    Some(Pubkey::new_unique()),
+                );
+                assert!(enqueue_track_worker(
+                    &ctx,
+                    TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
+                ));
+                pool
+            })
+            .collect();
+
+        let cap_pool = Pubkey::new_unique();
+        assert!(ctx.ensure_pool_revision_key_cold(cap_pool, ConsumerId::Tracker));
+        let cap_snapshot = mk_test_pool_snapshot(
+            cap_pool,
+            ConsumerId::Tracker,
+            None,
+            Some(Pubkey::new_unique()),
+        );
+        assert!(!enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterPoolGeyserReserves {
+                snapshot: cap_snapshot,
+            },
+        ));
+        assert_eq!(ctx.test_tracker_demand_cap_rejected_count(), 1);
+
+        ctx.withdraw_tracker_demand_identity(admitted_pools[0], OwnerKey::Pool(admitted_pools[0]));
+        assert_eq!(
+            ctx.test_tracker_demand_cap_rejected_count(),
+            0,
+            "withdrawal must promote cap-rejected identity"
+        );
+        assert_eq!(ctx.test_tracker_demand_admitted_count(), TRACKER_CAP);
+    }
+
+    #[test]
+    fn tracker_demand_cap_blocker_cannot_fail_open_while_cap_rejected_unrepresented() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 8, 8, 1);
+
+        let pool_admitted = Pubkey::new_unique();
+        assert!(ctx.ensure_pool_revision_key_cold(pool_admitted, ConsumerId::Tracker));
+        let admitted_snapshot = mk_test_pool_snapshot(
+            pool_admitted,
+            ConsumerId::Tracker,
+            None,
+            Some(Pubkey::new_unique()),
+        );
+        assert!(enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterPoolGeyserReserves {
+                snapshot: admitted_snapshot,
+            },
+        ));
+
+        let pool_rejected = Pubkey::new_unique();
+        assert!(ctx.ensure_pool_revision_key_cold(pool_rejected, ConsumerId::Tracker));
+        let rejected_snapshot = mk_test_pool_snapshot(
+            pool_rejected,
+            ConsumerId::Tracker,
+            None,
+            Some(Pubkey::new_unique()),
+        );
+        assert!(!enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterPoolGeyserReserves {
+                snapshot: rejected_snapshot,
+            },
+        ));
+        assert_eq!(ctx.test_tracker_demand_cap_rejected_count(), 1);
+
+        let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.reconcile_revision_registry_rejections(Some(&desired));
+        ctx.maybe_clear_revision_registry_full_blocker(Some(&desired));
+        assert!(
+            !ctx.geyser_explicit_readiness_ok(),
+            "tracker cap-rejected identity must keep readiness fail-closed"
         );
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1183,6 +1183,10 @@ struct MarketDataContext {
     geyser_connect_barrier: Arc<GeyserConnectBarrier>,
     /// Bounded ledger of revision-registry rejections (cleared per-key on retry/remove).
     revision_registry_rejected: parking_lot::Mutex<HashSet<(Pubkey, ConsumerId)>>,
+    /// Keys rejected but not stored because [`revision_registry_rejected_capacity`] was exceeded.
+    revision_registry_rejected_overflow: AtomicUsize,
+    /// Max distinct rejected `(pool, consumer)` keys retained (defaults to demand-cap sum).
+    revision_registry_rejected_capacity: usize,
 }
 
 #[derive(Debug, Default)]
@@ -1231,6 +1235,9 @@ const MAX_MOMENTUM_MINTS_PER_POOL: usize = 64;
 const MAX_MOMENTUM_PAIRS_TOTAL: usize = 8_192;
 /// Global arb pool pin rows (aligned with revision registry capacity).
 const MAX_ARB_POOLS_TOTAL: usize = 8_192;
+/// Upper bound on distinct `(pool, consumer)` revision rejections we must retain.
+const MAX_REVISION_REJECTION_LEDGER_CAPACITY: usize =
+    MAX_MOMENTUM_PAIRS_TOTAL + MAX_ARB_POOLS_TOTAL;
 
 /// Independent fail-closed blocker flags for Geyser explicit readiness.
 const GESYER_BLOCK_PENDING_POOL_OVERFLOW: u8 = 1 << 0;
@@ -1239,6 +1246,7 @@ const GESYER_BLOCK_PROTECTED_CAP_OVERFLOW: u8 = 1 << 2;
 const GESYER_BLOCK_ADMISSION_UNCONVERGED: u8 = 1 << 3;
 const GESYER_BLOCK_WALLET_EXPLICIT: u8 = 1 << 4;
 const GESYER_BLOCK_WALLET_REVISION_EXHAUSTED: u8 = 1 << 5;
+const GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW: u8 = 1 << 6;
 
 /// Scope-8: After `WalletSnapshotComplete`, wait briefly for in-flight Geyser merges before
 /// cold-path RPC verification for wallet-only mints without explicit Ready (bounded).
@@ -2015,7 +2023,10 @@ fn prepare_pool_snapshot_for_enqueue(
         }
     }
     match ctx.pool_snapshot_revisions.assign_next(snapshot) {
-        RevisionAssignResult::Assigned(_) => Some((pool, consumer)),
+        RevisionAssignResult::Assigned(_) => {
+            ctx.record_revision_registry_enqueue_success(pool, consumer, None);
+            Some((pool, consumer))
+        }
         RevisionAssignResult::RegistryFull => {
             ctx.pool_snapshot_revisions
                 .release_inflight_command(pool, consumer);
@@ -3314,8 +3325,21 @@ impl MarketDataContext {
     fn fail_revision_registry_full(&self, pool: Pubkey, consumer: ConsumerId) {
         {
             let mut rejected = self.revision_registry_rejected.lock();
-            if rejected.len() < self.pool_snapshot_revisions.max_keys() {
-                rejected.insert((pool, consumer));
+            let key = (pool, consumer);
+            if rejected.contains(&key) {
+                // already tracked
+            } else if rejected.len() >= self.revision_registry_rejected_capacity {
+                self.revision_registry_rejected_overflow
+                    .fetch_add(1, Ordering::AcqRel);
+                self.set_geyser_explicit_blocker(
+                    GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW,
+                    Some(
+                        "revision registry rejection ledger overflow (fail-closed until reconcile)"
+                            .into(),
+                    ),
+                );
+            } else {
+                rejected.insert(key);
             }
         }
         inc_market_data_revision_registry_full_total();
@@ -3355,27 +3379,104 @@ impl MarketDataContext {
         if !self.revision_registry_rejected.lock().is_empty() {
             return;
         }
+        if self
+            .revision_registry_rejected_overflow
+            .load(Ordering::Acquire)
+            > 0
+        {
+            return;
+        }
+        if self.geyser_explicit_blockers.load(Ordering::Acquire)
+            & GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW
+            != 0
+        {
+            return;
+        }
         self.clear_geyser_explicit_blocker(GESYER_BLOCK_REVISION_REGISTRY_FULL);
         if let Some(desired) = desired {
             self.recompute_geyser_explicit_readiness(desired);
         }
     }
 
-    fn resolve_revision_registry_rejection(
+    fn record_revision_registry_enqueue_success(
         &self,
         pool: Pubkey,
         consumer: ConsumerId,
         desired: Option<&DesiredExplicitSet>,
     ) {
-        if !self
-            .pool_snapshot_revisions
-            .can_issue_revision(pool, consumer)
-        {
-            return;
-        }
         self.revision_registry_rejected
             .lock()
             .remove(&(pool, consumer));
+        self.maybe_clear_revision_registry_full_blocker(desired);
+    }
+
+    fn pool_consumer_still_demands_revision(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
+        match consumer {
+            ConsumerId::Momentum => {
+                self.hot_pool_registry.pool_has_momentum(pool)
+                    || self.pending_pool_commands.has_pending(pool, consumer)
+            }
+            ConsumerId::Arb => {
+                self.hot_pool_registry.pool_has_arb(pool)
+                    || self.pending_pool_commands.has_pending(pool, consumer)
+            }
+            ConsumerId::Tracker => {
+                self.hot_pool_registry.is_hot_pool(pool)
+                    || self.pending_pool_commands.has_pending(pool, consumer)
+            }
+            ConsumerId::Wallet => false,
+        }
+    }
+
+    fn untracked_revision_registry_rejection_demand_remains(&self) -> bool {
+        let rejected = self.revision_registry_rejected.lock();
+        for (_, pool) in self.hot_pool_registry.snapshot_pairs() {
+            if !self
+                .pool_snapshot_revisions
+                .can_issue_revision(pool, ConsumerId::Momentum)
+                && !rejected.contains(&(pool, ConsumerId::Momentum))
+            {
+                return true;
+            }
+        }
+        for pool in self.hot_pool_registry.snapshot_arb_pools() {
+            if !self
+                .pool_snapshot_revisions
+                .can_issue_revision(pool, ConsumerId::Arb)
+                && !rejected.contains(&(pool, ConsumerId::Arb))
+            {
+                return true;
+            }
+        }
+        for (pool, consumer) in self.pending_pool_commands.pending_revision_keys() {
+            if !self
+                .pool_snapshot_revisions
+                .can_issue_revision(pool, consumer)
+                && !rejected.contains(&(pool, consumer))
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn reconcile_revision_registry_rejections(&self, desired: Option<&DesiredExplicitSet>) {
+        {
+            let mut rejected = self.revision_registry_rejected.lock();
+            rejected.retain(|&(pool, consumer)| {
+                self.pool_consumer_still_demands_revision(pool, consumer)
+            });
+        }
+        if self
+            .revision_registry_rejected_overflow
+            .load(Ordering::Acquire)
+            > 0
+            && !self.untracked_revision_registry_rejection_demand_remains()
+        {
+            self.revision_registry_rejected_overflow
+                .store(0, Ordering::Release);
+            self.clear_geyser_explicit_blocker(GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW);
+        }
         self.maybe_clear_revision_registry_full_blocker(desired);
     }
 
@@ -3389,15 +3490,6 @@ impl MarketDataContext {
             .lock()
             .remove(&(pool, consumer));
         self.maybe_clear_revision_registry_full_blocker(desired);
-    }
-
-    fn try_clear_revision_registry_full_blocker(
-        &self,
-        pool: Pubkey,
-        consumer: ConsumerId,
-        desired: &DesiredExplicitSet,
-    ) {
-        self.resolve_revision_registry_rejection(pool, consumer, Some(desired));
     }
 
     fn fail_wallet_revision_exhausted(&self) {
@@ -3523,18 +3615,13 @@ impl MarketDataContext {
         &self,
         pool: Pubkey,
         consumer: ConsumerId,
-        desired: Option<&DesiredExplicitSet>,
+        _desired: Option<&DesiredExplicitSet>,
     ) -> bool {
         match self
             .pool_snapshot_revisions
             .ensure_revision_key(pool, consumer)
         {
-            RevisionAcquireResult::Acquired => {
-                if let Some(desired) = desired {
-                    self.try_clear_revision_registry_full_blocker(pool, consumer, desired);
-                }
-                true
-            }
+            RevisionAcquireResult::Acquired => true,
             RevisionAcquireResult::RegistryFull => {
                 self.fail_revision_registry_full(pool, consumer);
                 false
@@ -3895,6 +3982,7 @@ impl MarketDataContext {
         set_market_data_md_state_evict_pending(false);
         set_market_data_geyser_explicit_cap_overflow(desired.cap_overflow());
         self.recompute_geyser_explicit_readiness(desired);
+        self.reconcile_revision_registry_rejections(Some(desired));
         if desired.cap_overflow() > 0 || !self.geyser_explicit_readiness_ok() {
             self.geyser_connect_barrier.mark_failed();
         } else if self.geyser_explicit_readiness_ok() {
@@ -8357,6 +8445,8 @@ async fn main() -> Result<()> {
         pending_pool_overflow_latched: AtomicBool::new(false),
         geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
+        revision_registry_rejected_overflow: AtomicUsize::new(0),
+        revision_registry_rejected_capacity: MAX_REVISION_REJECTION_LEDGER_CAPACITY,
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -11958,6 +12048,8 @@ mod wallet_snapshot_stale_cleanup_tests {
             pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
+            revision_registry_rejected_overflow: AtomicUsize::new(0),
+            revision_registry_rejected_capacity: MAX_REVISION_REJECTION_LEDGER_CAPACITY,
         }
     }
 
@@ -12205,6 +12297,8 @@ mod wallet_tx_meta_balance_tests {
             pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
+            revision_registry_rejected_overflow: AtomicUsize::new(0),
+            revision_registry_rejected_capacity: MAX_REVISION_REJECTION_LEDGER_CAPACITY,
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
         *ctx.track_worker.write() = Some(track_worker);
@@ -13042,13 +13136,26 @@ mod pr_b_geyser_tracking_tests {
     fn minimal_market_data_context_for_pr_d_tests(
         jsonl_writer: QueuedJsonlWriter,
     ) -> Arc<MarketDataContext> {
+        minimal_market_data_context_for_pr_d_tests_with_revision_caps(
+            jsonl_writer,
+            pending_pool_registration_cap(25_000),
+            MAX_REVISION_REJECTION_LEDGER_CAPACITY,
+        )
+    }
+
+    fn minimal_market_data_context_for_pr_d_tests_with_revision_caps(
+        jsonl_writer: QueuedJsonlWriter,
+        revision_max_keys: usize,
+        rejection_ledger_capacity: usize,
+    ) -> Arc<MarketDataContext> {
         let (tracked_mints_tx, _tracked_mints_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_bin_arrays_tx, _tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_wallet_tx, _tracked_wallet_rx) = watch::channel(Vec::<Pubkey>::new());
         let pending_cap = pending_pool_registration_cap(25_000);
-        let pool_snapshot_revisions =
-            Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(pending_cap));
+        let pool_snapshot_revisions = Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(
+            revision_max_keys,
+        ));
         let ctx = Arc::new(MarketDataContext {
             run_id: "run-prd-test".to_string(),
             config: parking_lot::RwLock::new(MarketDataConfig::default()),
@@ -13121,11 +13228,54 @@ mod pr_b_geyser_tracking_tests {
             pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
+            revision_registry_rejected_overflow: AtomicUsize::new(0),
+            revision_registry_rejected_capacity: rejection_ledger_capacity,
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
         *ctx.track_worker.write() = Some(track_worker);
         ctx.geyser_connect_barrier.mark_ready();
         ctx
+    }
+
+    fn mk_test_pool_snapshot(pool: Pubkey, consumer: ConsumerId) -> PoolExplicitSnapshot {
+        PoolExplicitSnapshot {
+            pool,
+            vaults: vec![],
+            bin_arrays: vec![],
+            mints: vec![],
+            consumer,
+            owner: OwnerKey::Pool(pool),
+            pin: match consumer {
+                ConsumerId::Momentum => GeyserPinReason::MomentumActive,
+                ConsumerId::Arb => GeyserPinReason::ArbMultiDex,
+                ConsumerId::Tracker | ConsumerId::Wallet => GeyserPinReason::MomentumActive,
+            },
+            revision: 0,
+        }
+    }
+
+    fn assert_revision_enqueue_retry_clears_rejection(
+        ctx: &Arc<MarketDataContext>,
+        pool: Pubkey,
+        consumer: ConsumerId,
+        setup: impl FnOnce(&Arc<MarketDataContext>, Pubkey),
+    ) {
+        ctx.fail_revision_registry_full(pool, consumer);
+        assert!(!ctx.geyser_explicit_readiness_ok());
+        assert!(ctx
+            .revision_registry_rejected
+            .lock()
+            .contains(&(pool, consumer)));
+        setup(ctx, pool);
+        let snapshot = mk_test_pool_snapshot(pool, consumer);
+        assert!(enqueue_track_worker(
+            ctx,
+            TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
+        ));
+        assert!(!ctx
+            .revision_registry_rejected
+            .lock()
+            .contains(&(pool, consumer)));
     }
 
     /// PR161: same as [`minimal_market_data_context_for_pr_d_tests`], but returns merge `watch` receivers.
@@ -13218,6 +13368,8 @@ mod pr_b_geyser_tracking_tests {
             pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
+            revision_registry_rejected_overflow: AtomicUsize::new(0),
+            revision_registry_rejected_capacity: MAX_REVISION_REJECTION_LEDGER_CAPACITY,
         });
         (
             ctx,
@@ -18467,7 +18619,7 @@ mod pr_b_geyser_tracking_tests {
         let pool_rejected = Pubkey::new_unique();
         let pool_healthy = Pubkey::new_unique();
         let mint_healthy = Pubkey::new_unique();
-        let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        let mint_rejected = Pubkey::new_unique();
 
         ctx.fail_revision_registry_full(pool_rejected, ConsumerId::Momentum);
         assert!(!ctx.geyser_explicit_readiness_ok());
@@ -18477,20 +18629,30 @@ mod pr_b_geyser_tracking_tests {
             .contains(&(pool_rejected, ConsumerId::Momentum)));
 
         ctx.hot_pool_registry.pin_pool(mint_healthy, pool_healthy);
-        assert!(ctx.ensure_pool_revision_key(pool_healthy, ConsumerId::Momentum, Some(&desired)));
+        let healthy_snapshot = mk_test_pool_snapshot(pool_healthy, ConsumerId::Momentum);
+        assert!(enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterPoolGeyserReserves {
+                snapshot: healthy_snapshot,
+            },
+        ));
         assert!(
             !ctx.geyser_explicit_readiness_ok(),
-            "healthy key must not clear blocker while rejected key remains"
+            "healthy enqueue retry must not clear blocker while rejected key remains"
         );
         assert!(ctx
             .revision_registry_rejected
             .lock()
             .contains(&(pool_rejected, ConsumerId::Momentum)));
 
-        let mint_rejected = Pubkey::new_unique();
         ctx.hot_pool_registry.pin_pool(mint_rejected, pool_rejected);
-        assert!(ctx.ensure_pool_revision_key(pool_rejected, ConsumerId::Momentum, Some(&desired)));
+        let snapshot = mk_test_pool_snapshot(pool_rejected, ConsumerId::Momentum);
+        assert!(enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
+        ));
         assert!(ctx.revision_registry_rejected.lock().is_empty());
+        let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         ctx.recompute_geyser_explicit_readiness(&desired);
         assert!(ctx.geyser_explicit_readiness_ok());
     }
@@ -18577,6 +18739,152 @@ mod pr_b_geyser_tracking_tests {
             None,
             "post-exhaustion bumps must stay fail-closed"
         );
+    }
+
+    #[test]
+    fn revision_registry_enqueue_retry_clears_momentum_rejection() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        assert_revision_enqueue_retry_clears_rejection(
+            &ctx,
+            pool,
+            ConsumerId::Momentum,
+            |ctx, pool| {
+                let mint = Pubkey::new_unique();
+                ctx.hot_pool_registry.pin_pool(mint, pool);
+            },
+        );
+    }
+
+    #[test]
+    fn revision_registry_enqueue_retry_clears_arb_rejection() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        assert_revision_enqueue_retry_clears_rejection(&ctx, pool, ConsumerId::Arb, |ctx, pool| {
+            ctx.hot_pool_registry.pin_arb_pool(pool);
+        });
+    }
+
+    #[test]
+    fn revision_registry_enqueue_retry_clears_tracker_rejection() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        assert_revision_enqueue_retry_clears_rejection(
+            &ctx,
+            pool,
+            ConsumerId::Tracker,
+            |ctx, pool| {
+                ctx.hot_pool_registry.pin_arb_pool(pool);
+            },
+        );
+    }
+
+    #[test]
+    fn revision_registry_enqueue_prepare_clears_rejection_when_send_fails() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        *ctx.track_worker.write() = None;
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        ctx.fail_revision_registry_full(pool, ConsumerId::Momentum);
+        ctx.hot_pool_registry.pin_pool(mint, pool);
+        let snapshot = mk_test_pool_snapshot(pool, ConsumerId::Momentum);
+        assert!(!enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
+        ));
+        assert!(!ctx
+            .revision_registry_rejected
+            .lock()
+            .contains(&(pool, ConsumerId::Momentum)));
+        assert!(ctx
+            .pending_pool_commands
+            .has_pending(pool, ConsumerId::Momentum));
+    }
+
+    #[test]
+    fn revision_registry_rejection_ledger_overflow_fails_closed_until_reconcile() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(
+            jsonl,
+            pending_pool_registration_cap(25_000),
+            3,
+        );
+
+        let rejected_pools: Vec<Pubkey> = (0..5).map(|_| Pubkey::new_unique()).collect();
+        for (i, pool) in rejected_pools.iter().enumerate() {
+            let consumer = if i % 2 == 0 {
+                ConsumerId::Momentum
+            } else {
+                ConsumerId::Arb
+            };
+            ctx.fail_revision_registry_full(*pool, consumer);
+        }
+        assert_eq!(ctx.revision_registry_rejected.lock().len(), 3);
+        assert_eq!(
+            ctx.revision_registry_rejected_overflow
+                .load(Ordering::Acquire),
+            2
+        );
+        assert!(
+            ctx.geyser_explicit_blockers.load(Ordering::Acquire)
+                & GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW
+                != 0
+        );
+        assert!(!ctx.geyser_explicit_readiness_ok());
+
+        let stored_rejections = [
+            (rejected_pools[0], ConsumerId::Momentum),
+            (rejected_pools[1], ConsumerId::Arb),
+            (rejected_pools[2], ConsumerId::Momentum),
+        ];
+        for (pool, consumer) in stored_rejections {
+            if consumer == ConsumerId::Momentum {
+                let mint = Pubkey::new_unique();
+                ctx.hot_pool_registry.pin_pool(mint, pool);
+            } else {
+                ctx.hot_pool_registry.pin_arb_pool(pool);
+            }
+            let snapshot = mk_test_pool_snapshot(pool, consumer);
+            assert!(enqueue_track_worker(
+                &ctx,
+                TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
+            ));
+            assert!(!ctx
+                .revision_registry_rejected
+                .lock()
+                .contains(&(pool, consumer)));
+        }
+        assert!(ctx.revision_registry_rejected.lock().is_empty());
+        assert_eq!(
+            ctx.revision_registry_rejected_overflow
+                .load(Ordering::Acquire),
+            2
+        );
+        assert!(!ctx.geyser_explicit_readiness_ok());
+
+        let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.reconcile_revision_registry_rejections(Some(&desired));
+        assert_eq!(
+            ctx.revision_registry_rejected_overflow
+                .load(Ordering::Acquire),
+            0
+        );
+        ctx.recompute_geyser_explicit_readiness(&desired);
+        assert!(ctx.geyser_explicit_readiness_ok());
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -27,7 +27,7 @@ use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch};
@@ -86,7 +86,7 @@ use ironcrab::market_data::track::{
     CapConvergeResult, ConsumerId, DesiredExplicitSet, ExplicitAccountKind, ExplicitSetSnapshot,
     ExplicitSnapshotRow, GeyserConnectBarrier, GeyserPinReason, InflightReserveResult,
     MintExplicitRow, OwnerGroupSnapshot, OwnerKey, PendingPoolCommand, PendingPoolRegistrations,
-    PendingPoolUpsertResult, PoolCommandTerminal, PoolExplicitSnapshot,
+    PendingPoolUpsertResult, PoolCommandAcceptPhase, PoolCommandTerminal, PoolExplicitSnapshot,
     PoolSnapshotRevisionSequencer, ProtectedOverflowDiagnostic, RevisionAcquireResult,
     RevisionActiveOwner, RevisionAssignResult, SnapshotConsumer, SnapshotOwnerGroup,
     TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender, VaultExplicitRow,
@@ -727,8 +727,24 @@ impl UnifiedHotPoolRegistry {
         }
     }
 
-    fn pin_pool(&self, mint: Pubkey, pool: Pubkey) {
-        self.momentum_pairs.write().insert((mint, pool));
+    fn pin_pool(&self, mint: Pubkey, pool: Pubkey) -> bool {
+        let mut pairs = self.momentum_pairs.write();
+        if pairs.contains(&(mint, pool)) {
+            return true;
+        }
+        if pairs.iter().filter(|(_, p)| *p == pool).count() >= MAX_MOMENTUM_MINTS_PER_POOL {
+            return false;
+        }
+        pairs.insert((mint, pool));
+        true
+    }
+
+    fn momentum_mint_count_for_pool(&self, pool: Pubkey) -> usize {
+        self.momentum_pairs
+            .read()
+            .iter()
+            .filter(|(_, p)| *p == pool)
+            .count()
     }
 
     fn unpin_pool(&self, mint: Pubkey, pool: Pubkey) {
@@ -1129,6 +1145,8 @@ struct MarketDataContext {
     /// Fail-closed when mandatory wallet demand exceeds explicit cap.
     geyser_explicit_ready: AtomicBool,
     geyser_explicit_config_error: parking_lot::RwLock<Option<String>>,
+    /// Independent latched fail-closed reasons (bitset of `GESYER_BLOCK_*`).
+    geyser_explicit_blockers: AtomicU8,
     /// Durable cap invalidation when config shrink enqueue fails (0 = none).
     pending_explicit_cap: AtomicUsize,
     /// Worker must drain pending wallet/cap work after enqueue loss.
@@ -1184,6 +1202,15 @@ struct TrackedWallet {
 
 /// WSOL Mint address constant
 const WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
+
+/// Maximum distinct momentum `(mint, pool)` rows per pool (fail-closed bound).
+const MAX_MOMENTUM_MINTS_PER_POOL: usize = 64;
+
+/// Independent fail-closed blocker flags for Geyser explicit readiness.
+const GESYER_BLOCK_PENDING_POOL_OVERFLOW: u8 = 1 << 0;
+const GESYER_BLOCK_REVISION_REGISTRY_FULL: u8 = 1 << 1;
+const GESYER_BLOCK_PROTECTED_CAP_OVERFLOW: u8 = 1 << 2;
+const GESYER_BLOCK_ADMISSION_UNCONVERGED: u8 = 1 << 3;
 
 /// Scope-8: After `WalletSnapshotComplete`, wait briefly for in-flight Geyser merges before
 /// cold-path RPC verification for wallet-only mints without explicit Ready (bounded).
@@ -1992,14 +2019,8 @@ fn stash_pending_pool_command(
     pool_meta: Option<(Pubkey, ConsumerId)>,
 ) {
     let stored = if let Some((pool, consumer)) = pool_meta {
-        if ctx
-            .pool_snapshot_revisions
-            .transfer_inflight_to_pending(pool, consumer)
-        {
-            ctx.pending_pool_commands.upsert_transferred(cmd)
-        } else {
-            PendingPoolUpsertResult::Overflow
-        }
+        ctx.pending_pool_commands
+            .upsert_after_inflight_send_failure(pool, consumer, cmd)
     } else {
         ctx.pending_pool_commands.upsert(cmd)
     };
@@ -2506,16 +2527,7 @@ impl TrackWorkerContext for MarketDataContext {
         snapshot: &PoolExplicitSnapshot,
     ) -> bool {
         self.apply_pool_snapshot_command(desired, snapshot, true, |desired| {
-            match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys())
-            {
-                AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
-                    self.register_tracked_assets_from_pool_snapshot(snapshot)
-                }
-                rejected => {
-                    record_admission_rejection(snapshot.consumer, rejected);
-                    false
-                }
-            }
+            self.apply_pool_admission(desired, snapshot)
         })
     }
 
@@ -2527,18 +2539,9 @@ impl TrackWorkerContext for MarketDataContext {
         self.apply_pool_snapshot_command(desired, snapshot, true, |desired| {
             self.try_publish_balance_updated_from_cache(snapshot.pool);
             if !self.hot_pool_registry.is_hot_pool(snapshot.pool) {
-                return false;
+                return (false, PoolCommandTerminal::Applied);
             }
-            match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys())
-            {
-                AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
-                    self.register_tracked_assets_from_pool_snapshot(snapshot)
-                }
-                rejected => {
-                    record_admission_rejection(snapshot.consumer, rejected);
-                    false
-                }
-            }
+            self.apply_pool_admission(desired, snapshot)
         })
     }
 
@@ -2550,18 +2553,9 @@ impl TrackWorkerContext for MarketDataContext {
         self.apply_pool_snapshot_command(desired, snapshot, true, |desired| {
             self.try_publish_balance_updated_from_cache(snapshot.pool);
             if !self.hot_pool_registry.pool_has_momentum(snapshot.pool) {
-                return false;
+                return (false, PoolCommandTerminal::UnpinnedRejected);
             }
-            match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys())
-            {
-                AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
-                    self.register_tracked_assets_from_pool_snapshot(snapshot)
-                }
-                rejected => {
-                    record_admission_rejection(snapshot.consumer, rejected);
-                    false
-                }
-            }
+            self.apply_pool_admission(desired, snapshot)
         })
     }
 
@@ -2573,7 +2567,7 @@ impl TrackWorkerContext for MarketDataContext {
     ) -> bool {
         self.apply_pool_snapshot_command(desired, snapshot, true, |desired| {
             if !self.hot_pool_registry.pool_has_arb(snapshot.pool) {
-                return false;
+                return (false, PoolCommandTerminal::UnpinnedRejected);
             }
             if self
                 .dlmm_registered_active_id
@@ -2582,24 +2576,15 @@ impl TrackWorkerContext for MarketDataContext {
                 .copied()
                 == Some(new_active_id)
             {
-                return false;
+                return (false, PoolCommandTerminal::Applied);
             }
-            match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys())
-            {
-                AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
-                    let changed = self.register_tracked_assets_from_pool_snapshot(snapshot);
-                    if changed {
-                        self.dlmm_registered_active_id
-                            .write()
-                            .insert(snapshot.pool, new_active_id);
-                    }
-                    changed
-                }
-                rejected => {
-                    record_admission_rejection(snapshot.consumer, rejected);
-                    false
-                }
+            let (changed, terminal) = self.apply_pool_admission(desired, snapshot);
+            if changed {
+                self.dlmm_registered_active_id
+                    .write()
+                    .insert(snapshot.pool, new_active_id);
             }
+            (changed, terminal)
         })
     }
 
@@ -3267,20 +3252,61 @@ impl MarketDataContext {
 
     fn fail_revision_registry_full(&self) {
         inc_market_data_revision_registry_full_total();
-        self.geyser_explicit_ready.store(false, Ordering::Release);
-        *self.geyser_explicit_config_error.write() =
-            Some("pool snapshot revision registry full (fail-closed)".into());
+        self.set_geyser_explicit_blocker(
+            GESYER_BLOCK_REVISION_REGISTRY_FULL,
+            Some("pool snapshot revision registry full (fail-closed)".into()),
+        );
         self.geyser_connect_barrier.mark_failed();
+    }
+
+    fn set_geyser_explicit_blocker(&self, flag: u8, msg: Option<String>) {
+        self.geyser_explicit_blockers
+            .fetch_or(flag, Ordering::AcqRel);
+        if let Some(msg) = msg {
+            *self.geyser_explicit_config_error.write() = Some(msg);
+        }
+        self.geyser_explicit_ready.store(false, Ordering::Release);
+    }
+
+    fn clear_geyser_explicit_blocker(&self, flag: u8) {
+        self.geyser_explicit_blockers
+            .fetch_and(!flag, Ordering::AcqRel);
+    }
+
+    fn refresh_geyser_explicit_readiness(&self, desired: &DesiredExplicitSet) {
+        let blockers = self.geyser_explicit_blockers.load(Ordering::Acquire);
+        let cap = self.config.read().max_tracked_accounts;
+        let wallet_ok = self.wallet_explicit_demand_pubkeys().len() <= cap;
+        let ready = blockers == 0 && desired.cap_overflow() == 0 && wallet_ok;
+        self.geyser_explicit_ready.store(ready, Ordering::Release);
+        if ready {
+            *self.geyser_explicit_config_error.write() = None;
+        }
     }
 
     fn pool_snapshot_consumer_demand_valid(&self, snapshot: &PoolExplicitSnapshot) -> bool {
         match snapshot.consumer {
-            ConsumerId::Momentum => {
-                self.hot_pool_registry.pool_has_momentum(snapshot.pool)
-                    || self.hot_pool_registry.pool_has_any_pin(snapshot.pool)
-            }
+            ConsumerId::Momentum => self.hot_pool_registry.pool_has_momentum(snapshot.pool),
             ConsumerId::Arb => self.hot_pool_registry.pool_has_arb(snapshot.pool),
-            _ => self.hot_pool_registry.is_hot_pool(snapshot.pool),
+            ConsumerId::Wallet => false,
+            ConsumerId::Tracker => self.hot_pool_registry.is_hot_pool(snapshot.pool),
+        }
+    }
+
+    fn apply_pool_admission(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        snapshot: &PoolExplicitSnapshot,
+    ) -> (bool, PoolCommandTerminal) {
+        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys()) {
+            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
+                let changed = self.register_tracked_assets_from_pool_snapshot(snapshot);
+                (changed, PoolCommandTerminal::Applied)
+            }
+            rejected => {
+                record_admission_rejection(snapshot.consumer, rejected);
+                (false, PoolCommandTerminal::AdmissionRejected)
+            }
         }
     }
 
@@ -3289,46 +3315,51 @@ impl MarketDataContext {
         desired: &mut DesiredExplicitSet,
         snapshot: &PoolExplicitSnapshot,
         finish_inflight: bool,
-        apply: impl FnOnce(&mut DesiredExplicitSet) -> bool,
+        apply: impl FnOnce(&mut DesiredExplicitSet) -> (bool, PoolCommandTerminal),
     ) -> bool {
-        if !self.pool_snapshot_revisions.revision_acceptable(snapshot) {
+        let phase = self.pool_snapshot_revisions.begin_pool_command(snapshot);
+        if phase == PoolCommandAcceptPhase::Stale {
             if finish_inflight {
-                self.pool_snapshot_revisions
-                    .finish_pool_command(snapshot, PoolCommandTerminal::StaleRevision);
+                self.pool_snapshot_revisions.finish_pool_command(
+                    snapshot,
+                    PoolCommandTerminal::StaleRevision,
+                    true,
+                    false,
+                );
             }
             return false;
         }
         if !self.pool_snapshot_consumer_demand_valid(snapshot) {
             if finish_inflight {
-                self.pool_snapshot_revisions
-                    .finish_pool_command(snapshot, PoolCommandTerminal::UnpinnedRejected);
+                self.pool_snapshot_revisions.finish_pool_command(
+                    snapshot,
+                    PoolCommandTerminal::UnpinnedRejected,
+                    true,
+                    true,
+                );
             }
             return false;
         }
-        let applied = apply(desired);
-        if finish_inflight {
-            let terminal = if applied {
-                PoolCommandTerminal::Applied
-            } else {
-                PoolCommandTerminal::AdmissionRejected
-            };
-            self.pool_snapshot_revisions
-                .finish_pool_command(snapshot, terminal);
-        }
-        applied
+        let (state_changed, terminal) = apply(desired);
+        self.pool_snapshot_revisions
+            .finish_pool_command(snapshot, terminal, finish_inflight, true);
+        state_changed
     }
 
     fn replay_pool_snapshot_command(
         &self,
         desired: &mut DesiredExplicitSet,
         snapshot: &PoolExplicitSnapshot,
-        apply: impl FnOnce(&mut DesiredExplicitSet) -> bool,
+        apply: impl FnOnce(&mut DesiredExplicitSet) -> (bool, PoolCommandTerminal),
     ) -> bool {
         self.apply_pool_snapshot_command(desired, snapshot, false, apply)
     }
 
-    fn acquire_revision_owner(&self, owner: RevisionActiveOwner) -> bool {
-        match self.pool_snapshot_revisions.acquire_active_owner(owner) {
+    fn ensure_pool_revision_key(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
+        match self
+            .pool_snapshot_revisions
+            .ensure_revision_key(pool, consumer)
+        {
             RevisionAcquireResult::Acquired => true,
             RevisionAcquireResult::RegistryFull => {
                 self.fail_revision_registry_full();
@@ -3337,12 +3368,23 @@ impl MarketDataContext {
         }
     }
 
+    #[allow(dead_code)]
+    fn acquire_revision_owner(&self, owner: RevisionActiveOwner) -> bool {
+        self.ensure_pool_revision_key(owner.pool(), owner.consumer())
+    }
+
     fn acquire_momentum_revision_owner(&self, mint: Pubkey, pool: Pubkey) -> bool {
-        self.acquire_revision_owner(RevisionActiveOwner::MomentumMintPool { mint, pool })
+        if !self.hot_pool_registry.is_pinned(mint, pool) {
+            return false;
+        }
+        self.ensure_pool_revision_key(pool, ConsumerId::Momentum)
     }
 
     fn acquire_arb_revision_owner(&self, pool: Pubkey) -> bool {
-        self.acquire_revision_owner(RevisionActiveOwner::ArbPool { pool })
+        if !self.hot_pool_registry.pool_has_arb(pool) {
+            return false;
+        }
+        self.ensure_pool_revision_key(pool, ConsumerId::Arb)
     }
 
     #[allow(dead_code)]
@@ -3368,9 +3410,10 @@ impl MarketDataContext {
             return;
         }
         inc_market_data_track_pending_pool_overflow_total();
-        self.geyser_explicit_ready.store(false, Ordering::Release);
-        *self.geyser_explicit_config_error.write() =
-            Some("pending pool registration overflow (fail-closed)".into());
+        self.set_geyser_explicit_blocker(
+            GESYER_BLOCK_PENDING_POOL_OVERFLOW,
+            Some("pending pool registration overflow (fail-closed)".into()),
+        );
         self.geyser_connect_barrier.mark_failed();
         self.mark_track_worker_dirty();
     }
@@ -3383,8 +3426,7 @@ impl MarketDataContext {
             diag.wallet_demand_len, diag.configured_cap, diag.sample_wallet_pubkeys
         );
         record_admission_rejection(ConsumerId::Wallet, AdmissionResult::RejectedCap);
-        self.geyser_explicit_ready.store(false, Ordering::Release);
-        *self.geyser_explicit_config_error.write() = Some(msg);
+        self.set_geyser_explicit_blocker(GESYER_BLOCK_PROTECTED_CAP_OVERFLOW, Some(msg));
         self.geyser_connect_barrier.mark_failed();
     }
 
@@ -3395,62 +3437,23 @@ impl MarketDataContext {
     ) {
         match command {
             PendingPoolCommand::RegisterReserves(snapshot) => {
-                let _ =
-                    self.replay_pool_snapshot_command(desired, &snapshot, |desired| match desired
-                        .try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys())
-                    {
-                        AdmissionResult::Admitted { .. }
-                        | AdmissionResult::OwnerAddedNoNewPubkey => {
-                            self.register_tracked_assets_from_pool_snapshot(&snapshot)
-                        }
-                        rejected => {
-                            record_admission_rejection(snapshot.consumer, rejected);
-                            false
-                        }
-                    });
+                let _ = self.replay_pool_snapshot_command(desired, &snapshot, |desired| {
+                    self.apply_pool_admission(desired, &snapshot)
+                });
             }
             PendingPoolCommand::VaultsFromAccount(snapshot) => {
                 let _ = self.replay_pool_snapshot_command(desired, &snapshot, |desired| {
                     self.try_publish_balance_updated_from_cache(snapshot.pool);
                     if !self.hot_pool_registry.is_hot_pool(snapshot.pool) {
-                        return false;
+                        return (false, PoolCommandTerminal::Applied);
                     }
-                    match desired.try_admit_group(
-                        snapshot.consumer,
-                        snapshot.owner,
-                        snapshot.all_pubkeys(),
-                    ) {
-                        AdmissionResult::Admitted { .. }
-                        | AdmissionResult::OwnerAddedNoNewPubkey => {
-                            self.register_tracked_assets_from_pool_snapshot(&snapshot)
-                        }
-                        rejected => {
-                            record_admission_rejection(snapshot.consumer, rejected);
-                            false
-                        }
-                    }
+                    self.apply_pool_admission(desired, &snapshot)
                 });
             }
             PendingPoolCommand::AfterTrade(snapshot) => {
                 let _ = self.replay_pool_snapshot_command(desired, &snapshot, |desired| {
                     self.try_publish_balance_updated_from_cache(snapshot.pool);
-                    if !self.hot_pool_registry.pool_has_momentum(snapshot.pool) {
-                        return false;
-                    }
-                    match desired.try_admit_group(
-                        snapshot.consumer,
-                        snapshot.owner,
-                        snapshot.all_pubkeys(),
-                    ) {
-                        AdmissionResult::Admitted { .. }
-                        | AdmissionResult::OwnerAddedNoNewPubkey => {
-                            self.register_tracked_assets_from_pool_snapshot(&snapshot)
-                        }
-                        rejected => {
-                            record_admission_rejection(snapshot.consumer, rejected);
-                            false
-                        }
-                    }
+                    self.apply_pool_admission(desired, &snapshot)
                 });
             }
             PendingPoolCommand::RefreshDlmm {
@@ -3458,9 +3461,6 @@ impl MarketDataContext {
                 new_active_id,
             } => {
                 let _ = self.replay_pool_snapshot_command(desired, &snapshot, |desired| {
-                    if !self.hot_pool_registry.pool_has_arb(snapshot.pool) {
-                        return false;
-                    }
                     if self
                         .dlmm_registered_active_id
                         .read()
@@ -3468,29 +3468,15 @@ impl MarketDataContext {
                         .copied()
                         == Some(new_active_id)
                     {
-                        return false;
+                        return (false, PoolCommandTerminal::Applied);
                     }
-                    match desired.try_admit_group(
-                        snapshot.consumer,
-                        snapshot.owner,
-                        snapshot.all_pubkeys(),
-                    ) {
-                        AdmissionResult::Admitted { .. }
-                        | AdmissionResult::OwnerAddedNoNewPubkey => {
-                            let changed =
-                                self.register_tracked_assets_from_pool_snapshot(&snapshot);
-                            if changed {
-                                self.dlmm_registered_active_id
-                                    .write()
-                                    .insert(snapshot.pool, new_active_id);
-                            }
-                            changed
-                        }
-                        rejected => {
-                            record_admission_rejection(snapshot.consumer, rejected);
-                            false
-                        }
+                    let (changed, terminal) = self.apply_pool_admission(desired, &snapshot);
+                    if changed {
+                        self.dlmm_registered_active_id
+                            .write()
+                            .insert(snapshot.pool, new_active_id);
                     }
+                    (changed, terminal)
                 });
             }
         }
@@ -3527,10 +3513,12 @@ impl MarketDataContext {
         if self.wallet_explicit_demand_pubkeys().len() > cap {
             return;
         }
-        *self.geyser_explicit_config_error.write() = None;
-        self.geyser_explicit_ready.store(true, Ordering::Release);
+        self.clear_geyser_explicit_blocker(GESYER_BLOCK_PENDING_POOL_OVERFLOW);
         self.clear_pending_pool_overflow_latch();
-        let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
+        self.refresh_geyser_explicit_readiness(desired);
+        if self.geyser_explicit_readiness_ok() {
+            let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
+        }
     }
 
     fn apply_pending_track_worker_work(&self, desired: &mut DesiredExplicitSet) {
@@ -3706,9 +3694,10 @@ impl MarketDataContext {
                 self.fail_geyser_explicit_protected_overflow(&demand);
             }
             CapConvergeResult::Unconverged => {
-                self.geyser_explicit_ready.store(false, Ordering::Release);
-                *self.geyser_explicit_config_error.write() =
-                    Some("explicit admission cap unconverged".into());
+                self.set_geyser_explicit_blocker(
+                    GESYER_BLOCK_ADMISSION_UNCONVERGED,
+                    Some("explicit admission cap unconverged".into()),
+                );
                 self.geyser_connect_barrier.mark_failed();
             }
         }
@@ -5646,8 +5635,15 @@ impl MarketDataContext {
                 warn!(pool = %a.pool, "MomentumActivePoolsUpdate.active: invalid pool");
                 continue;
             };
-            self.hot_pool_registry.pin_pool(mint_pk, pool_pk);
-            if !self.acquire_momentum_revision_owner(mint_pk, pool_pk) {
+            if !self.hot_pool_registry.pin_pool(mint_pk, pool_pk) {
+                warn!(
+                    mint = %mint_pk,
+                    pool = %pool_pk,
+                    "MomentumActivePoolsUpdate.active: per-pool mint pin bound exceeded"
+                );
+                continue;
+            }
+            if !self.ensure_pool_revision_key(pool_pk, ConsumerId::Momentum) {
                 continue;
             }
             if self.register_geyser_reserves_for_momentum_active_pool(desired, pool_pk) {
@@ -5687,8 +5683,6 @@ impl MarketDataContext {
         pool: Pubkey,
     ) -> bool {
         self.hot_pool_registry.unpin_pool(mint, pool);
-        self.pool_snapshot_revisions
-            .release_active_owner(RevisionActiveOwner::MomentumMintPool { mint, pool });
         let consumer = ConsumerId::Momentum;
         let refs = self.pool_snapshot_revisions.key_refs(pool, consumer);
         let has_pending = self.pending_pool_commands.has_pending(pool, consumer);
@@ -5899,8 +5893,6 @@ impl MarketDataContext {
         pool: Pubkey,
     ) -> bool {
         self.hot_pool_registry.unpin_arb_pool(pool);
-        self.pool_snapshot_revisions
-            .release_active_owner(RevisionActiveOwner::ArbPool { pool });
         let consumer = ConsumerId::Arb;
         let refs = self.pool_snapshot_revisions.key_refs(pool, consumer);
         let has_pending = self.pending_pool_commands.has_pending(pool, consumer);
@@ -8122,6 +8114,7 @@ async fn main() -> Result<()> {
         track_worker: parking_lot::RwLock::new(None),
         geyser_explicit_ready: AtomicBool::new(!wallet_configured),
         geyser_explicit_config_error: parking_lot::RwLock::new(None),
+        geyser_explicit_blockers: AtomicU8::new(0),
         pending_explicit_cap: AtomicUsize::new(0),
         track_worker_dirty: AtomicBool::new(false),
         wallet_explicit_pending,
@@ -11721,6 +11714,7 @@ mod wallet_snapshot_stale_cleanup_tests {
             track_worker: parking_lot::RwLock::new(None),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
+            geyser_explicit_blockers: AtomicU8::new(0),
             pending_explicit_cap: AtomicUsize::new(0),
             track_worker_dirty: AtomicBool::new(false),
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
@@ -11966,6 +11960,7 @@ mod wallet_tx_meta_balance_tests {
             track_worker: parking_lot::RwLock::new(None),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
+            geyser_explicit_blockers: AtomicU8::new(0),
             pending_explicit_cap: AtomicUsize::new(0),
             track_worker_dirty: AtomicBool::new(false),
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
@@ -12881,6 +12876,7 @@ mod pr_b_geyser_tracking_tests {
             track_worker: parking_lot::RwLock::new(None),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
+            geyser_explicit_blockers: AtomicU8::new(0),
             pending_explicit_cap: AtomicUsize::new(0),
             track_worker_dirty: AtomicBool::new(false),
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
@@ -12976,6 +12972,7 @@ mod pr_b_geyser_tracking_tests {
             track_worker: parking_lot::RwLock::new(None),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
+            geyser_explicit_blockers: AtomicU8::new(0),
             pending_explicit_cap: AtomicUsize::new(0),
             track_worker_dirty: AtomicBool::new(false),
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
@@ -17091,10 +17088,7 @@ mod pr_b_geyser_tracking_tests {
         let pool_a = Pubkey::new_unique();
         let pool_b = Pubkey::new_unique();
         assert_eq!(
-            revisions.acquire_active_owner(RevisionActiveOwner::MomentumMintPool {
-                mint: pool_a,
-                pool: pool_a,
-            }),
+            revisions.ensure_revision_key(pool_a, ConsumerId::Momentum),
             RevisionAcquireResult::Acquired
         );
         let mk_snapshot = |pool: Pubkey| PoolExplicitSnapshot {
@@ -17659,7 +17653,7 @@ mod pr_b_geyser_tracking_tests {
             .key_refs(pool, ConsumerId::Momentum);
         assert_eq!(refs.inflight, 0);
         assert_eq!(refs.pending, 0);
-        assert_eq!(refs.active_owners, 1);
+        assert!(ctx.hot_pool_registry.is_pinned(mint, pool));
     }
 
     #[test]
@@ -17822,5 +17816,249 @@ mod pr_b_geyser_tracking_tests {
         );
         assert!(desired.contains(&coin));
         assert!(desired.contains(&pc));
+    }
+
+    #[test]
+    fn arb_pin_does_not_authorize_momentum_pool_command() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+        assert!(!ctx.hot_pool_registry.pool_has_momentum(pool));
+        let snapshot = ctx
+            .build_pool_explicit_snapshot(pool, GeyserPinReason::MomentumActive)
+            .expect("snapshot");
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        assert!(!ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot));
+        assert!(
+            !desired
+                .snapshot_owner_groups()
+                .iter()
+                .any(|g| g.consumer == ConsumerId::Momentum),
+            "arb pin must not admit momentum consumer group"
+        );
+    }
+
+    #[test]
+    fn delayed_momentum_after_last_unpin_while_arb_remains_rejects() {
+        use ironcrab::execution::live_pool_cache::RaydiumCpmmState;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: mint,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool(mint, pool);
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        assert!(ctx.register_geyser_reserves_for_momentum_active_pool(&mut desired, pool));
+        ctx.clear_momentum_geyser_reserves_for_active_entry(&mut desired, mint, pool);
+        assert!(!ctx.hot_pool_registry.pool_has_momentum(pool));
+        assert!(ctx.hot_pool_registry.pool_has_arb(pool));
+
+        let Some(snapshot) =
+            ctx.build_pool_explicit_snapshot(pool, GeyserPinReason::MomentumActive)
+        else {
+            panic!("snapshot");
+        };
+        assert!(!ctx.commit_register_geyser_reserves_after_trade(&mut desired, &snapshot));
+        assert!(
+            !desired
+                .snapshot_owner_groups()
+                .iter()
+                .any(|g| g.consumer == ConsumerId::Momentum && g.owner == OwnerKey::Pool(pool)),
+            "delayed momentum command must not reintroduce group while only arb remains"
+        );
+        assert!(
+            desired
+                .snapshot_owner_groups()
+                .iter()
+                .any(|g| g.consumer == ConsumerId::Arb && g.owner == OwnerKey::Pool(pool))
+                || ctx.hot_pool_registry.pool_has_arb(pool),
+            "arb ownership must remain unaffected"
+        );
+    }
+
+    #[test]
+    fn pending_overflow_recovery_leaves_revision_registry_full_blocking() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        ctx.hot_pool_registry.pin_pool(mint, pool);
+        assert!(ctx.ensure_pool_revision_key(pool, ConsumerId::Momentum));
+        let snapshot = PoolExplicitSnapshot {
+            pool,
+            vaults: vec![],
+            bin_arrays: vec![],
+            mints: vec![],
+            consumer: ConsumerId::Momentum,
+            owner: OwnerKey::Pool(pool),
+            pin: GeyserPinReason::MomentumActive,
+            revision: 0,
+        };
+        assert_eq!(
+            ctx.pending_pool_commands
+                .upsert(PendingPoolCommand::RegisterReserves(snapshot)),
+            PendingPoolUpsertResult::Stored
+        );
+        ctx.fail_pending_pool_overflow();
+        ctx.fail_revision_registry_full();
+        assert!(!ctx.geyser_explicit_readiness_ok());
+
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.apply_pending_track_worker_work(&mut desired);
+
+        assert!(
+            !ctx.pending_pool_overflow_latched.load(Ordering::Acquire),
+            "pending overflow latch should clear after drain"
+        );
+        assert!(
+            !ctx.geyser_explicit_readiness_ok(),
+            "revision registry full must remain latched after overflow-only recovery"
+        );
+    }
+
+    #[test]
+    fn momentum_mint_pin_bound_rejects_adversarial_many_mints_per_pool() {
+        let registry = UnifiedHotPoolRegistry::new();
+        let pool = Pubkey::new_unique();
+        for i in 0..MAX_MOMENTUM_MINTS_PER_POOL {
+            let mint = Pubkey::new_unique();
+            assert!(registry.pin_pool(mint, pool), "pin {i} should succeed");
+        }
+        let overflow_mint = Pubkey::new_unique();
+        assert!(
+            !registry.pin_pool(overflow_mint, pool),
+            "must fail closed before exceeding per-pool momentum mint bound"
+        );
+        assert_eq!(
+            registry.momentum_mint_count_for_pool(pool),
+            MAX_MOMENTUM_MINTS_PER_POOL
+        );
+    }
+
+    #[test]
+    fn integrated_pool_command_ref_lifecycle_all_terminal_outcomes() {
+        use ironcrab::execution::live_pool_cache::RaydiumCpmmState;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: mint,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool(mint, pool);
+
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        let mut snapshot = ctx
+            .build_pool_explicit_snapshot(pool, GeyserPinReason::MomentumActive)
+            .expect("snapshot");
+        let rev_applied = assign_pool_snapshot_for_test(
+            &ctx,
+            pool,
+            ConsumerId::Momentum,
+            &mut snapshot,
+            Some(mint),
+        );
+        snapshot.revision = rev_applied;
+        assert!(ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot));
+        let refs_after_apply = ctx
+            .pool_snapshot_revisions
+            .key_refs(pool, ConsumerId::Momentum);
+        assert_eq!(refs_after_apply.total(), 0);
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .current_applied(pool, ConsumerId::Momentum),
+            rev_applied
+        );
+
+        let mut stale = snapshot.clone();
+        stale.revision = rev_applied.saturating_sub(1);
+        assert!(!ctx.commit_register_pool_geyser_reserves(&mut desired, &stale));
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .current_applied(pool, ConsumerId::Momentum),
+            rev_applied
+        );
+
+        ctx.hot_pool_registry.unpin_pool(mint, pool);
+        let mut unpinned = snapshot.clone();
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .reserve_inflight_command(pool, ConsumerId::Momentum),
+            InflightReserveResult::Reserved
+        );
+        let rev_unpinned = match ctx.pool_snapshot_revisions.assign_next(&mut unpinned) {
+            RevisionAssignResult::Assigned(rev) => rev,
+            other => panic!("assign failed: {other:?}"),
+        };
+        unpinned.revision = rev_unpinned;
+        assert!(!ctx.commit_register_geyser_reserves_after_trade(&mut desired, &unpinned));
+        let refs_after_unpin = ctx
+            .pool_snapshot_revisions
+            .key_refs(pool, ConsumerId::Momentum);
+        assert_eq!(refs_after_unpin.total(), 0);
+        assert!(
+            rev_unpinned > rev_applied,
+            "accepted unpinned rejection must still advance watermark"
+        );
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .current_applied(pool, ConsumerId::Momentum),
+            rev_unpinned
+        );
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1181,6 +1181,8 @@ struct MarketDataContext {
     pending_pool_overflow_latched: AtomicBool,
     /// Startup restore + convergence barrier before Geyser connect.
     geyser_connect_barrier: Arc<GeyserConnectBarrier>,
+    /// Bounded ledger of revision-registry rejections (cleared per-key on retry/remove).
+    revision_registry_rejected: parking_lot::Mutex<HashSet<(Pubkey, ConsumerId)>>,
 }
 
 #[derive(Debug, Default)]
@@ -1236,6 +1238,7 @@ const GESYER_BLOCK_REVISION_REGISTRY_FULL: u8 = 1 << 1;
 const GESYER_BLOCK_PROTECTED_CAP_OVERFLOW: u8 = 1 << 2;
 const GESYER_BLOCK_ADMISSION_UNCONVERGED: u8 = 1 << 3;
 const GESYER_BLOCK_WALLET_EXPLICIT: u8 = 1 << 4;
+const GESYER_BLOCK_WALLET_REVISION_EXHAUSTED: u8 = 1 << 5;
 
 /// Scope-8: After `WalletSnapshotComplete`, wait briefly for in-flight Geyser merges before
 /// cold-path RPC verification for wallet-only mints without explicit Ready (bounded).
@@ -2007,7 +2010,7 @@ fn prepare_pool_snapshot_for_enqueue(
     {
         InflightReserveResult::Reserved => {}
         InflightReserveResult::RegistryFull => {
-            ctx.fail_revision_registry_full();
+            ctx.fail_revision_registry_full(pool, consumer);
             return None;
         }
     }
@@ -2016,13 +2019,13 @@ fn prepare_pool_snapshot_for_enqueue(
         RevisionAssignResult::RegistryFull => {
             ctx.pool_snapshot_revisions
                 .release_inflight_command(pool, consumer);
-            ctx.fail_revision_registry_full();
+            ctx.fail_revision_registry_full(pool, consumer);
             None
         }
         RevisionAssignResult::KeyNotRegistered => {
             ctx.pool_snapshot_revisions
                 .release_inflight_command(pool, consumer);
-            ctx.fail_revision_registry_full();
+            ctx.fail_revision_registry_full(pool, consumer);
             None
         }
     }
@@ -2636,7 +2639,7 @@ impl TrackWorkerContext for MarketDataContext {
     }
 
     fn geyser_explicit_readiness_ok(&self) -> bool {
-        self.geyser_explicit_ready.load(Ordering::Relaxed)
+        MarketDataContext::geyser_explicit_readiness_ok(self)
     }
 
     fn prune_tracked_maps_to_desired(&self, desired: &DesiredExplicitSet) {
@@ -2952,7 +2955,7 @@ impl TxIngestHost for MarketDataContext {
             .wallet_explicit_pending
             .ensure_wallet_base(tracked_wallet.wallet, tracked_wallet.wsol_ata);
         let bump_ata = self.wallet_explicit_pending.insert_ata(ata);
-        if let Some(revision) = self.finalize_wallet_revision_bumps([bump_base, bump_ata], None) {
+        if let Some(revision) = self.finalize_wallet_revision_bumps([bump_base, bump_ata]) {
             let _ = self.enqueue_wallet_explicit_sync_revision(revision);
         }
         !was_present
@@ -2969,7 +2972,7 @@ impl TxIngestHost for MarketDataContext {
             .wallet_explicit_pending
             .ensure_wallet_base(tracked_wallet.wallet, tracked_wallet.wsol_ata);
         let bump_ata = self.wallet_explicit_pending.remove_ata(ata);
-        if let Some(revision) = self.finalize_wallet_revision_bumps([bump_base, bump_ata], None) {
+        if let Some(revision) = self.finalize_wallet_revision_bumps([bump_base, bump_ata]) {
             let _ = self.enqueue_wallet_explicit_sync_revision(revision);
         }
         true
@@ -2988,7 +2991,7 @@ impl TxIngestHost for MarketDataContext {
         let bump_base = self
             .wallet_explicit_pending
             .ensure_wallet_base(tracked_wallet.wallet, tracked_wallet.wsol_ata);
-        if let Some(revision) = self.finalize_wallet_revision_bumps([bump_base], None) {
+        if let Some(revision) = self.finalize_wallet_revision_bumps([bump_base]) {
             let _ = self.enqueue_wallet_explicit_sync_revision(revision);
         }
         let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
@@ -3120,6 +3123,15 @@ impl MdStateContext for MarketDataContext {
 }
 
 impl MarketDataContext {
+    fn geyser_explicit_blockers_active(&self) -> bool {
+        self.geyser_explicit_blockers.load(Ordering::Acquire) != 0
+    }
+
+    fn geyser_explicit_readiness_ok(&self) -> bool {
+        !self.geyser_explicit_blockers_active()
+            && self.geyser_explicit_ready.load(Ordering::Acquire)
+    }
+
     /// Non-blocking JSONL enqueue (dedicated `jsonl-writer` thread). Skips `AccountUpdate` / `TransactionDetected`.
     fn write_market_event_jsonl(&self, event: &MarketEvent) {
         write_market_event_jsonl(self, event);
@@ -3299,7 +3311,13 @@ impl MarketDataContext {
         })
     }
 
-    fn fail_revision_registry_full(&self) {
+    fn fail_revision_registry_full(&self, pool: Pubkey, consumer: ConsumerId) {
+        {
+            let mut rejected = self.revision_registry_rejected.lock();
+            if rejected.len() < self.pool_snapshot_revisions.max_keys() {
+                rejected.insert((pool, consumer));
+            }
+        }
         inc_market_data_revision_registry_full_total();
         self.set_geyser_explicit_blocker(
             GESYER_BLOCK_REVISION_REGISTRY_FULL,
@@ -3311,6 +3329,7 @@ impl MarketDataContext {
     fn set_geyser_explicit_blocker(&self, flag: u8, msg: Option<String>) {
         self.geyser_explicit_blockers
             .fetch_or(flag, Ordering::AcqRel);
+        self.geyser_explicit_ready.store(false, Ordering::Release);
         if let Some(msg) = msg {
             *self.geyser_explicit_config_error.write() = Some(msg);
         }
@@ -3332,35 +3351,66 @@ impl MarketDataContext {
         }
     }
 
+    fn maybe_clear_revision_registry_full_blocker(&self, desired: Option<&DesiredExplicitSet>) {
+        if !self.revision_registry_rejected.lock().is_empty() {
+            return;
+        }
+        self.clear_geyser_explicit_blocker(GESYER_BLOCK_REVISION_REGISTRY_FULL);
+        if let Some(desired) = desired {
+            self.recompute_geyser_explicit_readiness(desired);
+        }
+    }
+
+    fn resolve_revision_registry_rejection(
+        &self,
+        pool: Pubkey,
+        consumer: ConsumerId,
+        desired: Option<&DesiredExplicitSet>,
+    ) {
+        if !self
+            .pool_snapshot_revisions
+            .can_issue_revision(pool, consumer)
+        {
+            return;
+        }
+        self.revision_registry_rejected
+            .lock()
+            .remove(&(pool, consumer));
+        self.maybe_clear_revision_registry_full_blocker(desired);
+    }
+
+    fn drop_revision_registry_rejection(
+        &self,
+        pool: Pubkey,
+        consumer: ConsumerId,
+        desired: Option<&DesiredExplicitSet>,
+    ) {
+        self.revision_registry_rejected
+            .lock()
+            .remove(&(pool, consumer));
+        self.maybe_clear_revision_registry_full_blocker(desired);
+    }
+
     fn try_clear_revision_registry_full_blocker(
         &self,
         pool: Pubkey,
         consumer: ConsumerId,
         desired: &DesiredExplicitSet,
     ) {
-        if self
-            .pool_snapshot_revisions
-            .can_issue_revision(pool, consumer)
-        {
-            self.clear_geyser_explicit_blocker(GESYER_BLOCK_REVISION_REGISTRY_FULL);
-            self.recompute_geyser_explicit_readiness(desired);
-        }
+        self.resolve_revision_registry_rejection(pool, consumer, Some(desired));
     }
 
-    fn fail_wallet_revision_exhausted(&self, desired: Option<&DesiredExplicitSet>) {
+    fn fail_wallet_revision_exhausted(&self) {
         self.set_geyser_explicit_blocker(
-            GESYER_BLOCK_WALLET_EXPLICIT,
+            GESYER_BLOCK_WALLET_REVISION_EXHAUSTED,
             Some("wallet explicit revision exhausted (fail-closed)".into()),
         );
-        if let Some(desired) = desired {
-            self.recompute_geyser_explicit_readiness(desired);
-        }
+        self.geyser_connect_barrier.mark_failed();
     }
 
     fn finalize_wallet_revision_bumps(
         &self,
         bumps: impl IntoIterator<Item = WalletRevisionBump>,
-        desired: Option<&DesiredExplicitSet>,
     ) -> Option<u64> {
         let mut merged: Option<WalletRevisionBump> = None;
         for bump in bumps {
@@ -3371,7 +3421,7 @@ impl MarketDataContext {
         }
         match merged? {
             WalletRevisionBump::Exhausted => {
-                self.fail_wallet_revision_exhausted(desired);
+                self.fail_wallet_revision_exhausted();
                 None
             }
             WalletRevisionBump::Bumped(rev) => Some(rev),
@@ -3486,7 +3536,7 @@ impl MarketDataContext {
                 true
             }
             RevisionAcquireResult::RegistryFull => {
-                self.fail_revision_registry_full();
+                self.fail_revision_registry_full(pool, consumer);
                 false
             }
         }
@@ -3824,7 +3874,7 @@ impl MarketDataContext {
         } else {
             WalletRevisionBump::Bumped(self.wallet_explicit_pending.current_revision())
         };
-        if let Some(revision) = self.finalize_wallet_revision_bumps([bump], None) {
+        if let Some(revision) = self.finalize_wallet_revision_bumps([bump]) {
             let _ = self.enqueue_wallet_explicit_sync_revision(revision);
         }
         let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
@@ -5858,6 +5908,7 @@ impl MarketDataContext {
         pool: Pubkey,
     ) -> bool {
         self.hot_pool_registry.unpin_pool(mint, pool);
+        self.drop_revision_registry_rejection(pool, ConsumerId::Momentum, Some(desired));
         let consumer = ConsumerId::Momentum;
         let refs = self.pool_snapshot_revisions.key_refs(pool, consumer);
         let has_pending = self.pending_pool_commands.has_pending(pool, consumer);
@@ -6071,6 +6122,7 @@ impl MarketDataContext {
         pool: Pubkey,
     ) -> bool {
         self.hot_pool_registry.unpin_arb_pool(pool);
+        self.drop_revision_registry_rejection(pool, ConsumerId::Arb, Some(desired));
         let consumer = ConsumerId::Arb;
         let refs = self.pool_snapshot_revisions.key_refs(pool, consumer);
         let has_pending = self.pending_pool_commands.has_pending(pool, consumer);
@@ -7748,8 +7800,7 @@ async fn publish_wallet_snapshot(
         let bump_replace = ctx
             .wallet_explicit_pending
             .replace_token_accounts(wallet_token_accounts);
-        if let Some(revision) = ctx.finalize_wallet_revision_bumps([bump_base, bump_replace], None)
-        {
+        if let Some(revision) = ctx.finalize_wallet_revision_bumps([bump_base, bump_replace]) {
             let _ = ctx.enqueue_wallet_explicit_sync_revision(revision);
         }
         let _ = enqueue_track_worker(ctx, TrackWorkerCommand::ScheduleGeyserPushDebounced);
@@ -8305,6 +8356,7 @@ async fn main() -> Result<()> {
         pool_snapshot_revisions,
         pending_pool_overflow_latched: AtomicBool::new(false),
         geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
+        revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -11905,6 +11957,7 @@ mod wallet_snapshot_stale_cleanup_tests {
             pool_snapshot_revisions,
             pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
+            revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
         }
     }
 
@@ -12151,6 +12204,7 @@ mod wallet_tx_meta_balance_tests {
             pool_snapshot_revisions,
             pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
+            revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
         *ctx.track_worker.write() = Some(track_worker);
@@ -13066,6 +13120,7 @@ mod pr_b_geyser_tracking_tests {
             pool_snapshot_revisions,
             pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
+            revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
         *ctx.track_worker.write() = Some(track_worker);
@@ -13162,6 +13217,7 @@ mod pr_b_geyser_tracking_tests {
             pool_snapshot_revisions,
             pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
+            revision_registry_rejected: parking_lot::Mutex::new(HashSet::new()),
         });
         (
             ctx,
@@ -16970,11 +17026,10 @@ mod pr_b_geyser_tracking_tests {
         ctx.hot_pool_registry.pin_pool(base, pool);
 
         let wallet = Pubkey::new_unique();
-        if let Some(revision) = ctx.finalize_wallet_revision_bumps(
-            [ctx.wallet_explicit_pending
-                .replace_token_accounts(HashSet::from([wallet]))],
-            None,
-        ) {
+        if let Some(revision) = ctx.finalize_wallet_revision_bumps([ctx
+            .wallet_explicit_pending
+            .replace_token_accounts(HashSet::from([wallet]))])
+        {
             let _ = ctx.enqueue_wallet_explicit_sync_revision(revision);
         }
         test_wait_inline_track_worker();
@@ -18123,7 +18178,7 @@ mod pr_b_geyser_tracking_tests {
             PendingPoolUpsertResult::Stored
         );
         ctx.fail_pending_pool_overflow();
-        ctx.fail_revision_registry_full();
+        ctx.fail_revision_registry_full(pool, ConsumerId::Momentum);
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         ctx.recompute_geyser_explicit_readiness(&desired);
         assert!(!ctx.geyser_explicit_readiness_ok());
@@ -18325,6 +18380,28 @@ mod pr_b_geyser_tracking_tests {
     }
 
     #[test]
+    fn fail_closed_blocker_sets_ready_false_synchronously() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        ctx.geyser_explicit_ready.store(true, Ordering::Release);
+        assert!(ctx.geyser_explicit_readiness_ok());
+
+        ctx.fail_revision_registry_full(pool, ConsumerId::Momentum);
+        assert!(!ctx.geyser_explicit_ready.load(Ordering::Acquire));
+        assert!(ctx.geyser_explicit_blockers_active());
+        assert!(!ctx.geyser_explicit_readiness_ok());
+
+        ctx.geyser_explicit_ready.store(true, Ordering::Release);
+        ctx.fail_wallet_revision_exhausted();
+        assert!(!ctx.geyser_explicit_ready.load(Ordering::Acquire));
+        assert!(ctx.geyser_explicit_blockers_active());
+        assert!(!ctx.geyser_explicit_readiness_ok());
+    }
+
+    #[test]
     fn readiness_recompute_keeps_blockers_until_each_cleared() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
@@ -18336,6 +18413,7 @@ mod pr_b_geyser_tracking_tests {
             GESYER_BLOCK_REVISION_REGISTRY_FULL,
             Some("registry full".into()),
         );
+        assert!(!ctx.geyser_explicit_ready.load(Ordering::Acquire));
         ctx.set_geyser_explicit_blocker(
             GESYER_BLOCK_WALLET_EXPLICIT,
             Some("wallet blocked".into()),
@@ -18381,19 +18459,38 @@ mod pr_b_geyser_tracking_tests {
     }
 
     #[test]
-    fn revision_registry_full_blocker_clears_after_successful_key_retry() {
+    fn revision_registry_full_blocker_clears_only_when_rejected_key_resolved() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
-        let pool = Pubkey::new_unique();
-        let mint = Pubkey::new_unique();
-        ctx.fail_revision_registry_full();
+        let pool_rejected = Pubkey::new_unique();
+        let pool_healthy = Pubkey::new_unique();
+        let mint_healthy = Pubkey::new_unique();
         let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
-        ctx.recompute_geyser_explicit_readiness(&desired);
+
+        ctx.fail_revision_registry_full(pool_rejected, ConsumerId::Momentum);
         assert!(!ctx.geyser_explicit_readiness_ok());
-        ctx.hot_pool_registry.pin_pool(mint, pool);
-        assert!(ctx.ensure_pool_revision_key(pool, ConsumerId::Momentum, Some(&desired)));
+        assert!(ctx
+            .revision_registry_rejected
+            .lock()
+            .contains(&(pool_rejected, ConsumerId::Momentum)));
+
+        ctx.hot_pool_registry.pin_pool(mint_healthy, pool_healthy);
+        assert!(ctx.ensure_pool_revision_key(pool_healthy, ConsumerId::Momentum, Some(&desired)));
+        assert!(
+            !ctx.geyser_explicit_readiness_ok(),
+            "healthy key must not clear blocker while rejected key remains"
+        );
+        assert!(ctx
+            .revision_registry_rejected
+            .lock()
+            .contains(&(pool_rejected, ConsumerId::Momentum)));
+
+        let mint_rejected = Pubkey::new_unique();
+        ctx.hot_pool_registry.pin_pool(mint_rejected, pool_rejected);
+        assert!(ctx.ensure_pool_revision_key(pool_rejected, ConsumerId::Momentum, Some(&desired)));
+        assert!(ctx.revision_registry_rejected.lock().is_empty());
         ctx.recompute_geyser_explicit_readiness(&desired);
         assert!(ctx.geyser_explicit_readiness_ok());
     }
@@ -18414,9 +18511,8 @@ mod pr_b_geyser_tracking_tests {
             u64::MAX,
             u64::MAX - 1,
         );
-        ctx.fail_revision_registry_full();
+        ctx.fail_revision_registry_full(pool, ConsumerId::Momentum);
         let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
-        ctx.recompute_geyser_explicit_readiness(&desired);
         assert!(!ctx.geyser_explicit_readiness_ok());
         assert!(ctx.ensure_pool_revision_key(pool, ConsumerId::Momentum, Some(&desired)));
         ctx.recompute_geyser_explicit_readiness(&desired);
@@ -18424,30 +18520,60 @@ mod pr_b_geyser_tracking_tests {
             !ctx.geyser_explicit_readiness_ok(),
             "u64 exhaustion must keep registry-full blocker latched"
         );
+        assert!(ctx
+            .revision_registry_rejected
+            .lock()
+            .contains(&(pool, ConsumerId::Momentum)));
     }
 
     #[test]
-    fn wallet_revision_exhaustion_blocks_geyser_readiness() {
+    fn wallet_revision_exhaustion_uses_distinct_blocker_and_survives_cap_recovery() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
-        let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         ctx.wallet_explicit_pending.test_seed_revision(u64::MAX - 1);
         assert_eq!(
-            ctx.finalize_wallet_revision_bumps(
-                [ctx.wallet_explicit_pending.insert_ata(Pubkey::new_unique())],
-                Some(&desired),
-            ),
+            ctx.finalize_wallet_revision_bumps([ctx
+                .wallet_explicit_pending
+                .insert_ata(Pubkey::new_unique())],),
             None
         );
-        ctx.recompute_geyser_explicit_readiness(&desired);
+        assert!(
+            ctx.geyser_explicit_blockers.load(Ordering::Acquire)
+                & GESYER_BLOCK_WALLET_REVISION_EXHAUSTED
+                != 0
+        );
         assert!(!ctx.geyser_explicit_readiness_ok());
+
+        ctx.set_geyser_explicit_blocker(
+            GESYER_BLOCK_WALLET_EXPLICIT,
+            Some("wallet cap overflow".into()),
+        );
+        ctx.clear_geyser_explicit_blocker(GESYER_BLOCK_WALLET_EXPLICIT);
+        ctx.try_clear_protected_cap_blockers(&desired);
+        assert!(
+            ctx.geyser_explicit_blockers.load(Ordering::Acquire)
+                & GESYER_BLOCK_WALLET_REVISION_EXHAUSTED
+                != 0,
+            "cap recovery must not clear wallet revision exhaustion"
+        );
+        assert!(!ctx.geyser_explicit_readiness_ok());
+
+        let wallet = Pubkey::new_unique();
+        let wsol = Pubkey::new_unique();
+        ctx.wallet_explicit_pending.ensure_wallet_base(wallet, wsol);
+        let (demand, token_accounts, _) = ctx.wallet_explicit_pending.snapshot();
+        assert!(ctx.commit_wallet_explicit_state(&mut desired, demand, token_accounts));
+        assert!(
+            !ctx.geyser_explicit_readiness_ok(),
+            "successful wallet admission must remain fail-closed after revision exhaustion"
+        );
         assert_eq!(
-            ctx.finalize_wallet_revision_bumps(
-                [ctx.wallet_explicit_pending.insert_ata(Pubkey::new_unique())],
-                Some(&desired),
-            ),
+            ctx.finalize_wallet_revision_bumps([ctx
+                .wallet_explicit_pending
+                .insert_ata(Pubkey::new_unique())],),
             None,
             "post-exhaustion bumps must stay fail-closed"
         );

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1247,61 +1247,68 @@ const GESYER_BLOCK_WALLET_REVISION_EXHAUSTED: u8 = 1 << 5;
 const GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW: u8 = 1 << 6;
 
 /// Authoritative rejected logical demand awaiting bounded retry or explicit withdrawal.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum RejectedDemandKey {
+    Momentum { mint: Pubkey, pool: Pubkey },
+    Arb { pool: Pubkey },
+    Tracker { pool: Pubkey, owner: OwnerKey },
+}
+
+#[derive(Debug, Clone)]
 enum RejectedRevisionDemand {
     Momentum { mint: Pubkey, pool: Pubkey },
     Arb { pool: Pubkey },
-    Tracker { pool: Pubkey },
+    Tracker { snapshot: PoolExplicitSnapshot },
 }
 
 impl RejectedRevisionDemand {
-    fn pool(self) -> Pubkey {
+    fn demand_key(&self) -> RejectedDemandKey {
         match self {
-            Self::Momentum { pool, .. } | Self::Arb { pool } | Self::Tracker { pool } => pool,
+            Self::Momentum { mint, pool } => RejectedDemandKey::Momentum {
+                mint: *mint,
+                pool: *pool,
+            },
+            Self::Arb { pool } => RejectedDemandKey::Arb { pool: *pool },
+            Self::Tracker { snapshot } => RejectedDemandKey::Tracker {
+                pool: snapshot.pool,
+                owner: snapshot.owner,
+            },
         }
     }
 
-    fn consumer(self) -> ConsumerId {
-        match self {
-            Self::Momentum { .. } => ConsumerId::Momentum,
-            Self::Arb { .. } => ConsumerId::Arb,
-            Self::Tracker { .. } => ConsumerId::Tracker,
-        }
-    }
-
-    fn key(self) -> (Pubkey, ConsumerId) {
-        (self.pool(), self.consumer())
-    }
-
-    fn inferred(pool: Pubkey, consumer: ConsumerId, registry: &UnifiedHotPoolRegistry) -> Self {
-        match consumer {
-            ConsumerId::Momentum => {
-                let mint = registry
-                    .snapshot_pairs()
-                    .into_iter()
-                    .find_map(|(mint, p)| (p == pool).then_some(mint))
-                    .unwrap_or(pool);
-                Self::Momentum { mint, pool }
-            }
-            ConsumerId::Arb => Self::Arb { pool },
-            ConsumerId::Tracker | ConsumerId::Wallet => Self::Tracker { pool },
+    fn from_snapshot(snapshot: &PoolExplicitSnapshot) -> Option<Self> {
+        match snapshot.consumer {
+            ConsumerId::Momentum => match snapshot.owner {
+                OwnerKey::Mint(mint) => Some(Self::Momentum {
+                    mint,
+                    pool: snapshot.pool,
+                }),
+                OwnerKey::Pool(_) | OwnerKey::Wallet => None,
+            },
+            ConsumerId::Arb => Some(Self::Arb {
+                pool: snapshot.pool,
+            }),
+            ConsumerId::Tracker => Some(Self::Tracker {
+                snapshot: snapshot.clone(),
+            }),
+            ConsumerId::Wallet => None,
         }
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RevisionRejectionRecordResult {
-    AlreadyTracked,
+    UpdatedExisting,
     Stored,
     OverflowStored,
-    OverflowLost,
+    CapacityInvariantExceeded,
 }
 
 #[derive(Debug)]
 struct RevisionRegistryRejectionLedger {
-    entries: HashMap<(Pubkey, ConsumerId), RejectedRevisionDemand>,
-    overflow_entries: Vec<RejectedRevisionDemand>,
-    overflow_lost: usize,
+    entries: HashMap<RejectedDemandKey, RejectedRevisionDemand>,
+    overflow_entries: HashMap<RejectedDemandKey, RejectedRevisionDemand>,
+    capacity_invariant_exceeded: bool,
     generation: u64,
     capacity: usize,
 }
@@ -1310,73 +1317,68 @@ impl RevisionRegistryRejectionLedger {
     fn new(capacity: usize) -> Self {
         Self {
             entries: HashMap::new(),
-            overflow_entries: Vec::new(),
-            overflow_lost: 0,
+            overflow_entries: HashMap::new(),
+            capacity_invariant_exceeded: false,
             generation: 0,
             capacity: capacity.max(1),
         }
     }
 
+    #[cfg(test)]
+    fn contains_key(&self, key: &RejectedDemandKey) -> bool {
+        self.entries.contains_key(key) || self.overflow_entries.contains_key(key)
+    }
+
     fn record(&mut self, demand: RejectedRevisionDemand) -> RevisionRejectionRecordResult {
-        self.generation = self.generation.wrapping_add(1);
-        let key = demand.key();
-        if self.entries.contains_key(&key) {
-            return RevisionRejectionRecordResult::AlreadyTracked;
+        let key = demand.demand_key();
+        if let std::collections::hash_map::Entry::Occupied(mut slot) =
+            self.entries.entry(key.clone())
+        {
+            slot.insert(demand);
+            self.generation = self.generation.wrapping_add(1);
+            return RevisionRejectionRecordResult::UpdatedExisting;
+        }
+        if let std::collections::hash_map::Entry::Occupied(mut slot) =
+            self.overflow_entries.entry(key.clone())
+        {
+            slot.insert(demand);
+            self.generation = self.generation.wrapping_add(1);
+            return RevisionRejectionRecordResult::UpdatedExisting;
         }
         if self.entries.len() < self.capacity {
+            self.generation = self.generation.wrapping_add(1);
             self.entries.insert(key, demand);
             return RevisionRejectionRecordResult::Stored;
         }
         if self.overflow_entries.len() < self.capacity {
-            self.overflow_entries.push(demand);
+            self.generation = self.generation.wrapping_add(1);
+            self.overflow_entries.insert(key, demand);
             return RevisionRejectionRecordResult::OverflowStored;
         }
-        self.overflow_lost = self.overflow_lost.saturating_add(1);
-        RevisionRejectionRecordResult::OverflowLost
+        self.capacity_invariant_exceeded = true;
+        self.generation = self.generation.wrapping_add(1);
+        RevisionRejectionRecordResult::CapacityInvariantExceeded
     }
 
-    fn remove_demand(&mut self, demand: RejectedRevisionDemand) -> bool {
-        let key = demand.key();
-        if self.entries.remove(&key) == Some(demand) {
+    fn remove_demand(&mut self, demand: &RejectedRevisionDemand) -> bool {
+        let key = demand.demand_key();
+        if self.entries.remove(&key).is_some() || self.overflow_entries.remove(&key).is_some() {
             self.generation = self.generation.wrapping_add(1);
-            return true;
+            true
+        } else {
+            false
         }
-        if let Some(pos) = self
-            .overflow_entries
-            .iter()
-            .position(|stored| *stored == demand)
-        {
-            self.overflow_entries.remove(pos);
-            self.generation = self.generation.wrapping_add(1);
-            return true;
-        }
-        false
-    }
-
-    fn remove_key(&mut self, pool: Pubkey, consumer: ConsumerId) -> bool {
-        if self.entries.remove(&(pool, consumer)).is_some() {
-            self.generation = self.generation.wrapping_add(1);
-            return true;
-        }
-        if let Some(pos) = self
-            .overflow_entries
-            .iter()
-            .position(|stored| stored.key() == (pool, consumer))
-        {
-            self.overflow_entries.remove(pos);
-            self.generation = self.generation.wrapping_add(1);
-            return true;
-        }
-        false
     }
 
     fn has_unresolved(&self) -> bool {
-        !self.entries.is_empty() || !self.overflow_entries.is_empty() || self.overflow_lost > 0
+        !self.entries.is_empty()
+            || !self.overflow_entries.is_empty()
+            || self.capacity_invariant_exceeded
     }
 
     fn pending_demands(&self) -> Vec<RejectedRevisionDemand> {
-        let mut out: Vec<_> = self.entries.values().copied().collect();
-        out.extend(self.overflow_entries.iter().copied());
+        let mut out: Vec<_> = self.entries.values().cloned().collect();
+        out.extend(self.overflow_entries.values().cloned());
         out
     }
 }
@@ -2134,20 +2136,31 @@ fn pending_pool_registration_cap(_max_tracked_accounts: usize) -> usize {
     8_192
 }
 
-fn minimal_enqueue_pool_snapshot(pool: Pubkey, consumer: ConsumerId) -> PoolExplicitSnapshot {
-    PoolExplicitSnapshot {
-        pool,
-        vaults: vec![],
-        bin_arrays: vec![],
-        mints: vec![],
-        consumer,
-        owner: OwnerKey::Pool(pool),
-        pin: match consumer {
-            ConsumerId::Momentum => GeyserPinReason::MomentumActive,
-            ConsumerId::Arb => GeyserPinReason::ArbMultiDex,
-            ConsumerId::Tracker | ConsumerId::Wallet => GeyserPinReason::MomentumActive,
+fn rejected_demands_from_snapshot(
+    snapshot: &PoolExplicitSnapshot,
+    registry: &UnifiedHotPoolRegistry,
+) -> Vec<RejectedRevisionDemand> {
+    match snapshot.consumer {
+        ConsumerId::Momentum => match snapshot.owner {
+            OwnerKey::Mint(mint) => vec![RejectedRevisionDemand::Momentum {
+                mint,
+                pool: snapshot.pool,
+            }],
+            OwnerKey::Pool(pool) => registry
+                .snapshot_pairs()
+                .into_iter()
+                .filter(|(_, p)| *p == pool)
+                .map(|(mint, p)| RejectedRevisionDemand::Momentum { mint, pool: p })
+                .collect(),
+            OwnerKey::Wallet => vec![],
         },
-        revision: 0,
+        ConsumerId::Arb => vec![RejectedRevisionDemand::Arb {
+            pool: snapshot.pool,
+        }],
+        ConsumerId::Tracker => vec![RejectedRevisionDemand::Tracker {
+            snapshot: snapshot.clone(),
+        }],
+        ConsumerId::Wallet => vec![],
     }
 }
 
@@ -2199,25 +2212,25 @@ fn prepare_pool_snapshot_for_enqueue(
     {
         InflightReserveResult::Reserved => {}
         InflightReserveResult::RegistryFull => {
-            ctx.fail_revision_registry_full(pool, consumer);
+            ctx.fail_revision_registry_full_from_snapshot(snapshot);
             return None;
         }
     }
     match ctx.pool_snapshot_revisions.assign_next(snapshot) {
         RevisionAssignResult::Assigned(_) => {
-            ctx.record_revision_registry_enqueue_success(pool, consumer, None);
+            ctx.record_revision_registry_enqueue_success(snapshot, None);
             Some((pool, consumer))
         }
         RevisionAssignResult::RegistryFull => {
             ctx.pool_snapshot_revisions
                 .release_inflight_command(pool, consumer);
-            ctx.fail_revision_registry_full(pool, consumer);
+            ctx.fail_revision_registry_full_from_snapshot(snapshot);
             None
         }
         RevisionAssignResult::KeyNotRegistered => {
             ctx.pool_snapshot_revisions
                 .release_inflight_command(pool, consumer);
-            ctx.fail_revision_registry_full(pool, consumer);
+            ctx.fail_revision_registry_full_from_snapshot(snapshot);
             None
         }
     }
@@ -3508,11 +3521,11 @@ impl MarketDataContext {
             let mut ledger = self.revision_registry_rejection_ledger.lock();
             ledger.record(demand)
         };
-        if record_result == RevisionRejectionRecordResult::OverflowLost {
+        if record_result == RevisionRejectionRecordResult::CapacityInvariantExceeded {
             self.set_geyser_explicit_blocker(
                 GESYER_BLOCK_REJECTION_LEDGER_OVERFLOW,
                 Some(
-                    "revision registry rejection ledger overflow (fail-closed until reconcile)"
+                    "revision registry rejection ledger capacity invariant exceeded (fail-closed)"
                         .into(),
                 ),
             );
@@ -3533,10 +3546,15 @@ impl MarketDataContext {
         self.geyser_connect_barrier.mark_failed();
     }
 
-    fn fail_revision_registry_full(&self, pool: Pubkey, consumer: ConsumerId) {
-        let demand =
-            RejectedRevisionDemand::inferred(pool, consumer, self.hot_pool_registry.as_ref());
+    #[cfg(test)]
+    fn fail_revision_registry_full(&self, demand: RejectedRevisionDemand) {
         self.record_rejected_revision_demand(demand);
+    }
+
+    fn fail_revision_registry_full_from_snapshot(&self, snapshot: &PoolExplicitSnapshot) {
+        for demand in rejected_demands_from_snapshot(snapshot, self.hot_pool_registry.as_ref()) {
+            self.record_rejected_revision_demand(demand);
+        }
     }
 
     fn resolve_rejected_revision_demand(
@@ -3547,7 +3565,7 @@ impl MarketDataContext {
         let removed = self
             .revision_registry_rejection_ledger
             .lock()
-            .remove_demand(demand);
+            .remove_demand(&demand);
         if removed {
             self.maybe_clear_revision_registry_full_blocker(desired);
         }
@@ -3606,20 +3624,18 @@ impl MarketDataContext {
 
     fn record_revision_registry_enqueue_success(
         &self,
-        pool: Pubkey,
-        consumer: ConsumerId,
+        snapshot: &PoolExplicitSnapshot,
         desired: Option<&DesiredExplicitSet>,
     ) {
-        let demand =
-            RejectedRevisionDemand::inferred(pool, consumer, self.hot_pool_registry.as_ref());
+        let Some(demand) = RejectedRevisionDemand::from_snapshot(snapshot) else {
+            return;
+        };
         if self
             .revision_registry_rejection_ledger
             .lock()
-            .remove_key(pool, consumer)
+            .remove_demand(&demand)
         {
             self.maybe_clear_revision_registry_full_blocker(desired);
-        } else {
-            let _ = demand;
         }
     }
 
@@ -3672,17 +3688,29 @@ impl MarketDataContext {
                         true
                     }
                 }
-                RejectedRevisionDemand::Tracker { pool } => {
-                    if (!self.hot_pool_registry.is_hot_pool(pool)
-                        && !self.hot_pool_registry.try_pin_arb_pool(pool))
-                        || !self.ensure_pool_revision_key(pool, ConsumerId::Tracker, None)
-                    {
+                RejectedRevisionDemand::Tracker { ref snapshot } => {
+                    let demand = RejectedRevisionDemand::Tracker {
+                        snapshot: snapshot.clone(),
+                    };
+                    let still_wanted = desired
+                        .snapshot_owner_groups()
+                        .iter()
+                        .any(|g| g.consumer == ConsumerId::Tracker && g.owner == snapshot.owner);
+                    if !still_wanted {
+                        self.withdraw_rejected_revision_demand(demand, Some(desired));
+                        false
+                    } else if !self.ensure_pool_revision_key(
+                        snapshot.pool,
+                        ConsumerId::Tracker,
+                        None,
+                    ) {
                         false
                     } else {
-                        let snapshot = minimal_enqueue_pool_snapshot(pool, ConsumerId::Tracker);
                         enqueue_track_worker(
                             self,
-                            TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
+                            TrackWorkerCommand::RegisterPoolGeyserReserves {
+                                snapshot: snapshot.clone(),
+                            },
                         )
                     }
                 }
@@ -3694,22 +3722,24 @@ impl MarketDataContext {
     }
 
     #[cfg(test)]
-    fn test_revision_rejection_has_key(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
-        let ledger = self.revision_registry_rejection_ledger.lock();
-        ledger.entries.contains_key(&(pool, consumer))
-            || ledger
-                .overflow_entries
-                .iter()
-                .any(|stored| stored.key() == (pool, consumer))
+    fn test_revision_rejection_has_demand(&self, demand: &RejectedRevisionDemand) -> bool {
+        self.revision_registry_rejection_ledger
+            .lock()
+            .contains_key(&demand.demand_key())
     }
 
     #[cfg(test)]
-    fn test_revision_rejection_unresolved(&self) -> (usize, usize, usize, u64) {
+    fn test_revision_rejection_has_momentum(&self, mint: Pubkey, pool: Pubkey) -> bool {
+        self.test_revision_rejection_has_demand(&RejectedRevisionDemand::Momentum { mint, pool })
+    }
+
+    #[cfg(test)]
+    fn test_revision_rejection_unresolved(&self) -> (usize, usize, bool, u64) {
         let ledger = self.revision_registry_rejection_ledger.lock();
         (
             ledger.entries.len(),
             ledger.overflow_entries.len(),
-            ledger.overflow_lost,
+            ledger.capacity_invariant_exceeded,
             ledger.generation,
         )
     }
@@ -13475,8 +13505,29 @@ mod pr_b_geyser_tracking_tests {
         ctx
     }
 
-    fn mk_test_pool_snapshot(pool: Pubkey, consumer: ConsumerId) -> PoolExplicitSnapshot {
-        minimal_enqueue_pool_snapshot(pool, consumer)
+    fn mk_test_pool_snapshot(
+        pool: Pubkey,
+        consumer: ConsumerId,
+        momentum_mint: Option<Pubkey>,
+    ) -> PoolExplicitSnapshot {
+        let owner = match (consumer, momentum_mint) {
+            (ConsumerId::Momentum, Some(mint)) => OwnerKey::Mint(mint),
+            _ => OwnerKey::Pool(pool),
+        };
+        PoolExplicitSnapshot {
+            pool,
+            vaults: vec![],
+            bin_arrays: vec![],
+            mints: vec![],
+            consumer,
+            owner,
+            pin: match consumer {
+                ConsumerId::Momentum => GeyserPinReason::MomentumActive,
+                ConsumerId::Arb => GeyserPinReason::ArbMultiDex,
+                ConsumerId::Tracker | ConsumerId::Wallet => GeyserPinReason::MomentumActive,
+            },
+            revision: 0,
+        }
     }
 
     fn assert_revision_enqueue_retry_clears_rejection(
@@ -13485,16 +13536,90 @@ mod pr_b_geyser_tracking_tests {
         consumer: ConsumerId,
         setup: impl FnOnce(&Arc<MarketDataContext>, Pubkey),
     ) {
-        ctx.fail_revision_registry_full(pool, consumer);
-        assert!(!ctx.geyser_explicit_readiness_ok());
-        assert!(ctx.test_revision_rejection_has_key(pool, consumer));
         setup(ctx, pool);
-        let snapshot = mk_test_pool_snapshot(pool, consumer);
+        let demand = match consumer {
+            ConsumerId::Momentum => {
+                let mint = ctx
+                    .hot_pool_registry
+                    .snapshot_pairs()
+                    .into_iter()
+                    .find(|(_, p)| *p == pool)
+                    .map(|(m, _)| m)
+                    .expect("momentum mint pinned for pool");
+                RejectedRevisionDemand::Momentum { mint, pool }
+            }
+            ConsumerId::Arb => RejectedRevisionDemand::Arb { pool },
+            ConsumerId::Tracker => {
+                let snapshot = mk_test_pool_snapshot(pool, consumer, None);
+                RejectedRevisionDemand::Tracker { snapshot }
+            }
+            ConsumerId::Wallet => panic!("wallet consumer not supported in rejection retry test"),
+        };
+        ctx.fail_revision_registry_full(demand);
+        assert!(!ctx.geyser_explicit_readiness_ok());
+        match consumer {
+            ConsumerId::Momentum => {
+                let mint = ctx
+                    .hot_pool_registry
+                    .snapshot_pairs()
+                    .into_iter()
+                    .find(|(_, p)| *p == pool)
+                    .map(|(m, _)| m)
+                    .expect("momentum mint pinned");
+                assert!(ctx.test_revision_rejection_has_momentum(mint, pool));
+            }
+            ConsumerId::Arb => assert!(
+                ctx.test_revision_rejection_has_demand(&RejectedRevisionDemand::Arb { pool })
+            ),
+            ConsumerId::Tracker => {
+                let snapshot = mk_test_pool_snapshot(pool, consumer, None);
+                assert!(
+                    ctx.test_revision_rejection_has_demand(&RejectedRevisionDemand::Tracker {
+                        snapshot
+                    })
+                );
+            }
+            ConsumerId::Wallet => {}
+        }
+        let snapshot = match consumer {
+            ConsumerId::Momentum => {
+                let mint = ctx
+                    .hot_pool_registry
+                    .snapshot_pairs()
+                    .into_iter()
+                    .find(|(_, p)| *p == pool)
+                    .map(|(m, _)| m)
+                    .expect("momentum mint pinned");
+                mk_test_pool_snapshot(pool, consumer, Some(mint))
+            }
+            _ => mk_test_pool_snapshot(pool, consumer, None),
+        };
         assert!(enqueue_track_worker(
             ctx,
             TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
         ));
-        assert!(!ctx.test_revision_rejection_has_key(pool, consumer));
+        match consumer {
+            ConsumerId::Momentum => {
+                let mint = ctx
+                    .hot_pool_registry
+                    .snapshot_pairs()
+                    .into_iter()
+                    .find(|(_, p)| *p == pool)
+                    .map(|(m, _)| m)
+                    .expect("momentum mint pinned");
+                assert!(!ctx.test_revision_rejection_has_momentum(mint, pool));
+            }
+            ConsumerId::Arb => assert!(
+                !ctx.test_revision_rejection_has_demand(&RejectedRevisionDemand::Arb { pool })
+            ),
+            ConsumerId::Tracker => {
+                let snapshot = mk_test_pool_snapshot(pool, consumer, None);
+                assert!(!ctx.test_revision_rejection_has_demand(
+                    &RejectedRevisionDemand::Tracker { snapshot }
+                ));
+            }
+            ConsumerId::Wallet => {}
+        }
     }
 
     /// PR161: same as [`minimal_market_data_context_for_pr_d_tests`], but returns merge `watch` receivers.
@@ -18550,8 +18675,9 @@ mod pr_b_geyser_tracking_tests {
                 .upsert(PendingPoolCommand::RegisterReserves(snapshot)),
             PendingPoolUpsertResult::Stored
         );
+        ctx.hot_pool_registry.pin_pool(mint, pool);
         ctx.fail_pending_pool_overflow();
-        ctx.fail_revision_registry_full(pool, ConsumerId::Momentum);
+        ctx.fail_revision_registry_full(RejectedRevisionDemand::Momentum { mint, pool });
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         ctx.recompute_geyser_explicit_readiness(&desired);
         assert!(!ctx.geyser_explicit_readiness_ok());
@@ -18759,10 +18885,11 @@ mod pr_b_geyser_tracking_tests {
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
         ctx.geyser_explicit_ready.store(true, Ordering::Release);
         assert!(ctx.geyser_explicit_readiness_ok());
 
-        ctx.fail_revision_registry_full(pool, ConsumerId::Momentum);
+        ctx.fail_revision_registry_full(RejectedRevisionDemand::Momentum { mint, pool });
         assert!(!ctx.geyser_explicit_ready.load(Ordering::Acquire));
         assert!(ctx.geyser_explicit_blockers_active());
         assert!(!ctx.geyser_explicit_readiness_ok());
@@ -18842,12 +18969,16 @@ mod pr_b_geyser_tracking_tests {
         let mint_healthy = Pubkey::new_unique();
         let mint_rejected = Pubkey::new_unique();
 
-        ctx.fail_revision_registry_full(pool_rejected, ConsumerId::Momentum);
+        ctx.fail_revision_registry_full(RejectedRevisionDemand::Momentum {
+            mint: mint_rejected,
+            pool: pool_rejected,
+        });
         assert!(!ctx.geyser_explicit_readiness_ok());
-        assert!(ctx.test_revision_rejection_has_key(pool_rejected, ConsumerId::Momentum));
+        assert!(ctx.test_revision_rejection_has_momentum(mint_rejected, pool_rejected));
 
         ctx.hot_pool_registry.pin_pool(mint_healthy, pool_healthy);
-        let healthy_snapshot = mk_test_pool_snapshot(pool_healthy, ConsumerId::Momentum);
+        let healthy_snapshot =
+            mk_test_pool_snapshot(pool_healthy, ConsumerId::Momentum, Some(mint_healthy));
         assert!(enqueue_track_worker(
             &ctx,
             TrackWorkerCommand::RegisterPoolGeyserReserves {
@@ -18858,10 +18989,11 @@ mod pr_b_geyser_tracking_tests {
             !ctx.geyser_explicit_readiness_ok(),
             "healthy enqueue retry must not clear blocker while rejected key remains"
         );
-        assert!(ctx.test_revision_rejection_has_key(pool_rejected, ConsumerId::Momentum));
+        assert!(ctx.test_revision_rejection_has_momentum(mint_rejected, pool_rejected));
 
         ctx.hot_pool_registry.pin_pool(mint_rejected, pool_rejected);
-        let snapshot = mk_test_pool_snapshot(pool_rejected, ConsumerId::Momentum);
+        let snapshot =
+            mk_test_pool_snapshot(pool_rejected, ConsumerId::Momentum, Some(mint_rejected));
         assert!(enqueue_track_worker(
             &ctx,
             TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
@@ -18888,7 +19020,7 @@ mod pr_b_geyser_tracking_tests {
             u64::MAX,
             u64::MAX - 1,
         );
-        ctx.fail_revision_registry_full(pool, ConsumerId::Momentum);
+        ctx.fail_revision_registry_full(RejectedRevisionDemand::Momentum { mint, pool });
         let desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         assert!(!ctx.geyser_explicit_readiness_ok());
         assert!(ctx.ensure_pool_revision_key(pool, ConsumerId::Momentum, Some(&desired)));
@@ -18897,7 +19029,7 @@ mod pr_b_geyser_tracking_tests {
             !ctx.geyser_explicit_readiness_ok(),
             "u64 exhaustion must keep registry-full blocker latched"
         );
-        assert!(ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum));
+        assert!(ctx.test_revision_rejection_has_momentum(mint, pool));
     }
 
     #[test]
@@ -18995,7 +19127,8 @@ mod pr_b_geyser_tracking_tests {
             pool,
             ConsumerId::Tracker,
             |ctx, pool| {
-                ctx.hot_pool_registry.pin_arb_pool(pool);
+                let mint = Pubkey::new_unique();
+                ctx.hot_pool_registry.pin_pool(mint, pool);
             },
         );
     }
@@ -19009,14 +19142,14 @@ mod pr_b_geyser_tracking_tests {
         *ctx.track_worker.write() = None;
         let pool = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
-        ctx.fail_revision_registry_full(pool, ConsumerId::Momentum);
+        ctx.fail_revision_registry_full(RejectedRevisionDemand::Momentum { mint, pool });
         ctx.hot_pool_registry.pin_pool(mint, pool);
-        let snapshot = mk_test_pool_snapshot(pool, ConsumerId::Momentum);
+        let snapshot = mk_test_pool_snapshot(pool, ConsumerId::Momentum, Some(mint));
         assert!(!enqueue_track_worker(
             &ctx,
             TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot },
         ));
-        assert!(!ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum));
+        assert!(!ctx.test_revision_rejection_has_momentum(mint, pool));
         assert!(ctx
             .pending_pool_commands
             .has_pending(pool, ConsumerId::Momentum));
@@ -19045,12 +19178,12 @@ mod pr_b_geyser_tracking_tests {
 
         assert!(!ctx.try_pin_momentum_with_revision(mint, pool, &desired));
         assert!(!ctx.hot_pool_registry.is_pinned(mint, pool));
-        assert!(ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum));
+        assert!(ctx.test_revision_rejection_has_momentum(mint, pool));
         assert!(!ctx.geyser_explicit_readiness_ok());
 
         ctx.reconcile_revision_registry_rejections(Some(&desired));
         assert!(
-            ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum),
+            ctx.test_revision_rejection_has_momentum(mint, pool),
             "reconcile must not treat absent hot/pending pin as resolved demand"
         );
         assert!(!ctx.geyser_explicit_readiness_ok());
@@ -19076,7 +19209,7 @@ mod pr_b_geyser_tracking_tests {
             InflightReserveResult::Reserved,
         );
         assert!(!ctx.try_pin_momentum_with_revision(mint, pool, &desired));
-        assert!(ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum));
+        assert!(ctx.test_revision_rejection_has_momentum(mint, pool));
 
         ctx.pool_snapshot_revisions
             .release_inflight_command(occupant_pool, ConsumerId::Momentum);
@@ -19090,7 +19223,7 @@ mod pr_b_geyser_tracking_tests {
         );
 
         ctx.retry_bounded_rejected_revision_demands(&mut desired);
-        assert!(!ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum));
+        assert!(!ctx.test_revision_rejection_has_momentum(mint, pool));
         assert!(ctx.hot_pool_registry.is_pinned(mint, pool));
         ctx.reconcile_revision_registry_rejections(Some(&desired));
         ctx.recompute_geyser_explicit_readiness(&desired);
@@ -19120,7 +19253,7 @@ mod pr_b_geyser_tracking_tests {
         assert!(!ctx.hot_pool_registry.is_pinned(mint, pool));
 
         ctx.clear_momentum_geyser_reserves_for_active_entry(&mut desired, mint, pool);
-        assert!(!ctx.test_revision_rejection_has_key(pool, ConsumerId::Momentum));
+        assert!(!ctx.test_revision_rejection_has_momentum(mint, pool));
         ctx.reconcile_revision_registry_rejections(Some(&desired));
         ctx.recompute_geyser_explicit_readiness(&desired);
         assert!(ctx.geyser_explicit_readiness_ok());
@@ -19152,12 +19285,16 @@ mod pr_b_geyser_tracking_tests {
         });
         std::thread::sleep(std::time::Duration::from_millis(5));
         let overflow_pool = Pubkey::new_unique();
-        ctx.fail_revision_registry_full(overflow_pool, ConsumerId::Momentum);
-        let (entries, overflow_entries, overflow_lost, gen_after_fail) =
+        let overflow_mint = Pubkey::new_unique();
+        ctx.fail_revision_registry_full(RejectedRevisionDemand::Momentum {
+            mint: overflow_mint,
+            pool: overflow_pool,
+        });
+        let (entries, overflow_entries, capacity_exceeded, gen_after_fail) =
             ctx.test_revision_rejection_unresolved();
-        assert!(ctx.test_revision_rejection_has_key(overflow_pool, ConsumerId::Momentum));
+        assert!(ctx.test_revision_rejection_has_momentum(overflow_mint, overflow_pool));
         assert!(
-            gen_after_fail > gen_before || entries > 0 || overflow_entries > 0 || overflow_lost > 0
+            gen_after_fail > gen_before || entries > 0 || overflow_entries > 0 || capacity_exceeded
         );
 
         ctx.revision_reconcile_test_barrier
@@ -19165,13 +19302,159 @@ mod pr_b_geyser_tracking_tests {
             .store(true, Ordering::Release);
         worker.join().expect("reconcile thread");
 
-        assert!(ctx.test_revision_rejection_has_key(overflow_pool, ConsumerId::Momentum));
+        assert!(ctx.test_revision_rejection_has_momentum(overflow_mint, overflow_pool));
         assert!(!ctx.geyser_explicit_readiness_ok());
         assert!(
             ctx.geyser_explicit_blockers.load(Ordering::Acquire)
                 & GESYER_BLOCK_REVISION_REGISTRY_FULL
                 != 0
         );
+    }
+
+    #[test]
+    fn rejected_two_momentum_mints_same_pool_isolated() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 1, 8);
+        let pool = Pubkey::new_unique();
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::new_unique();
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+
+        let occupant_pool = Pubkey::new_unique();
+        let occupant_mint = Pubkey::new_unique();
+        ctx.hot_pool_registry.pin_pool(occupant_mint, occupant_pool);
+        assert!(ctx.ensure_pool_revision_key_cold(occupant_pool, ConsumerId::Momentum));
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .reserve_inflight_command(occupant_pool, ConsumerId::Momentum),
+            InflightReserveResult::Reserved,
+        );
+
+        assert!(!ctx.try_pin_momentum_with_revision(mint_a, pool, &desired));
+        assert!(!ctx.try_pin_momentum_with_revision(mint_b, pool, &desired));
+        assert!(ctx.test_revision_rejection_has_momentum(mint_a, pool));
+        assert!(ctx.test_revision_rejection_has_momentum(mint_b, pool));
+
+        ctx.pool_snapshot_revisions
+            .release_inflight_command(occupant_pool, ConsumerId::Momentum);
+        ctx.hot_pool_registry
+            .unpin_pool(occupant_mint, occupant_pool);
+        ctx.pool_snapshot_revisions.maybe_retire_key(
+            occupant_pool,
+            ConsumerId::Momentum,
+            false,
+            false,
+        );
+
+        ctx.retry_bounded_rejected_revision_demands(&mut desired);
+        assert!(ctx.hot_pool_registry.is_pinned(mint_a, pool));
+        assert!(ctx.hot_pool_registry.is_pinned(mint_b, pool));
+        assert!(!ctx.test_revision_rejection_has_momentum(mint_a, pool));
+        assert!(!ctx.test_revision_rejection_has_momentum(mint_b, pool));
+
+        ctx.record_rejected_revision_demand(RejectedRevisionDemand::Momentum {
+            mint: mint_a,
+            pool,
+        });
+        ctx.record_rejected_revision_demand(RejectedRevisionDemand::Momentum {
+            mint: mint_b,
+            pool,
+        });
+        assert!(ctx.test_revision_rejection_has_momentum(mint_a, pool));
+        assert!(ctx.test_revision_rejection_has_momentum(mint_b, pool));
+
+        ctx.clear_momentum_geyser_reserves_for_active_entry(&mut desired, mint_a, pool);
+        assert!(!ctx.test_revision_rejection_has_momentum(mint_a, pool));
+        assert!(ctx.test_revision_rejection_has_momentum(mint_b, pool));
+        assert!(ctx.hot_pool_registry.is_pinned(mint_b, pool));
+
+        let snapshot_a = mk_test_pool_snapshot(pool, ConsumerId::Momentum, Some(mint_a));
+        ctx.record_rejected_revision_demand(RejectedRevisionDemand::Momentum {
+            mint: mint_a,
+            pool,
+        });
+        assert!(enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterPoolGeyserReserves {
+                snapshot: snapshot_a,
+            },
+        ));
+        assert!(!ctx.test_revision_rejection_has_momentum(mint_a, pool));
+        assert!(ctx.test_revision_rejection_has_momentum(mint_b, pool));
+    }
+
+    #[test]
+    fn repeated_same_key_rejection_dedupes_and_eventually_clears() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_revision_caps(jsonl, 8, 2);
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let demand = RejectedRevisionDemand::Momentum { mint, pool };
+
+        ctx.record_rejected_revision_demand(demand.clone());
+        ctx.record_rejected_revision_demand(demand.clone());
+        let (entries, overflow_entries, _, _) = ctx.test_revision_rejection_unresolved();
+        assert_eq!(
+            entries + overflow_entries,
+            1,
+            "repeated rejection of same demand must not consume extra bounded slots"
+        );
+
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.hot_pool_registry.pin_pool(mint, pool);
+        ctx.retry_bounded_rejected_revision_demands(&mut desired);
+        assert!(!ctx.test_revision_rejection_has_momentum(mint, pool));
+        ctx.reconcile_revision_registry_rejections(Some(&desired));
+        ctx.recompute_geyser_explicit_readiness(&desired);
+        assert!(ctx.geyser_explicit_readiness_ok());
+    }
+
+    #[test]
+    fn tracker_retry_no_arb_pin_change_and_clears_orphan_demand() {
+        use std::collections::HashSet;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let owner = OwnerKey::Pool(pool);
+        let snapshot = mk_test_pool_snapshot(pool, ConsumerId::Tracker, None);
+        let demand = RejectedRevisionDemand::Tracker {
+            snapshot: snapshot.clone(),
+        };
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        let hub = Pubkey::new_unique();
+        assert!(matches!(
+            desired.try_admit_group(ConsumerId::Tracker, owner, HashSet::from([hub])),
+            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey
+        ));
+
+        let arb_before = ctx.hot_pool_registry.arb_pool_count();
+        ctx.fail_revision_registry_full(demand.clone());
+        assert!(ctx.test_revision_rejection_has_demand(&demand));
+
+        ctx.retry_bounded_rejected_revision_demands(&mut desired);
+        assert_eq!(
+            ctx.hot_pool_registry.arb_pool_count(),
+            arb_before,
+            "tracker retry must not create arb ownership"
+        );
+        assert!(!ctx.test_revision_rejection_has_demand(&demand));
+
+        let orphan_snapshot = mk_test_pool_snapshot(pool, ConsumerId::Tracker, None);
+        let orphan_demand = RejectedRevisionDemand::Tracker {
+            snapshot: orphan_snapshot,
+        };
+        ctx.fail_revision_registry_full(orphan_demand.clone());
+        desired.remove_group(ConsumerId::Tracker, owner);
+        ctx.retry_bounded_rejected_revision_demands(&mut desired);
+        assert!(!ctx.test_revision_rejection_has_demand(&orphan_demand));
+        assert_eq!(ctx.hot_pool_registry.arb_pool_count(), arb_before);
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -87,9 +87,9 @@ use ironcrab::market_data::track::{
     ExplicitSnapshotRow, GeyserConnectBarrier, GeyserPinReason, MintExplicitRow,
     OwnerGroupSnapshot, OwnerKey, PendingPoolCommand, PendingPoolRegistrations,
     PendingPoolUpsertResult, PoolExplicitSnapshot, PoolSnapshotRevisionSequencer,
-    ProtectedOverflowDiagnostic, SnapshotConsumer, SnapshotOwnerGroup, TrackPinReason,
-    TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender, VaultExplicitRow,
-    WalletExplicitPending, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
+    ProtectedOverflowDiagnostic, RevisionAcquireResult, RevisionAssignResult, SnapshotConsumer,
+    SnapshotOwnerGroup, TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
+    VaultExplicitRow, WalletExplicitPending, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -106,7 +106,8 @@ use ironcrab::metrics::{
     inc_market_data_ingest_membership_snapshot_hits_total,
     inc_market_data_jsonl_enqueue_dropped_total,
     inc_market_data_md_state_evict_steps_budget_exhausted_total,
-    inc_market_data_md_state_evict_steps_total, inc_market_data_track_pending_pool_overflow_total,
+    inc_market_data_md_state_evict_steps_total, inc_market_data_revision_registry_full_total,
+    inc_market_data_track_pending_pool_overflow_total,
     inc_market_data_vault_high_priority_dispatch_total, market_data_bump_geyser_head_slot,
     market_data_geyser_head_slot_value, market_data_geyser_tracking_enqueue_dropped_value,
     market_data_geyser_tracking_jobs_processed_value, market_data_md_state_bursts_completed_value,
@@ -1137,6 +1138,8 @@ struct MarketDataContext {
     pending_pool_commands: Arc<PendingPoolRegistrations>,
     /// Monotonic per-(pool,consumer) revisions for pool snapshot commands.
     pool_snapshot_revisions: Arc<PoolSnapshotRevisionSequencer>,
+    /// Latched fail-closed when durable pending pool overflow fires (counter increments once).
+    pending_pool_overflow_latched: AtomicBool,
     /// Startup restore + convergence barrier before Geyser connect.
     geyser_connect_barrier: Arc<GeyserConnectBarrier>,
 }
@@ -1930,23 +1933,61 @@ fn pending_pool_command_for_stash(job: &TrackWorkerCommand) -> Option<PendingPoo
     }
 }
 
-fn assign_pool_snapshot_revision(ctx: &MarketDataContext, job: &mut TrackWorkerCommand) {
+fn assign_pool_snapshot_revision(ctx: &MarketDataContext, job: &mut TrackWorkerCommand) -> bool {
+    let assign = |snapshot: &mut PoolExplicitSnapshot| match ctx
+        .pool_snapshot_revisions
+        .assign_next(snapshot)
+    {
+        RevisionAssignResult::Assigned(_) => true,
+        RevisionAssignResult::RegistryFull => {
+            ctx.fail_revision_registry_full();
+            false
+        }
+        RevisionAssignResult::KeyNotRegistered => {
+            match ctx
+                .pool_snapshot_revisions
+                .try_acquire_active(snapshot.pool, snapshot.consumer)
+            {
+                RevisionAcquireResult::Acquired => {
+                    match ctx.pool_snapshot_revisions.assign_next(snapshot) {
+                        RevisionAssignResult::Assigned(_) => true,
+                        RevisionAssignResult::RegistryFull => {
+                            ctx.fail_revision_registry_full();
+                            false
+                        }
+                        RevisionAssignResult::KeyNotRegistered => {
+                            ctx.fail_revision_registry_full();
+                            false
+                        }
+                    }
+                }
+                RevisionAcquireResult::RegistryFull => {
+                    ctx.fail_revision_registry_full();
+                    false
+                }
+            }
+        }
+    };
     match job {
         TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot }
         | TrackWorkerCommand::RegisterPoolVaultsFromAccount { snapshot }
-        | TrackWorkerCommand::RegisterGeyserReservesAfterTrade { snapshot } => {
-            ctx.pool_snapshot_revisions.assign_next(snapshot);
-        }
-        TrackWorkerCommand::RefreshDlmmBinWindow { snapshot, .. } => {
-            ctx.pool_snapshot_revisions.assign_next(snapshot);
-        }
-        _ => {}
+        | TrackWorkerCommand::RegisterGeyserReservesAfterTrade { snapshot } => assign(snapshot),
+        TrackWorkerCommand::RefreshDlmmBinWindow { snapshot, .. } => assign(snapshot),
+        _ => true,
     }
 }
 
+fn pool_command_meta(job: &TrackWorkerCommand) -> Option<(Pubkey, ConsumerId)> {
+    pending_pool_command_for_stash(job).map(|cmd| (cmd.pool(), cmd.consumer()))
+}
+
 fn enqueue_track_worker(ctx: &MarketDataContext, mut job: TrackWorkerCommand) -> bool {
-    if pending_pool_command_for_stash(&job).is_some() {
-        assign_pool_snapshot_revision(ctx, &mut job);
+    if ctx.pending_pool_overflow_latched.load(Ordering::Acquire) {
+        return false;
+    }
+    let pool_meta = pool_command_meta(&job);
+    if pool_meta.is_some() && !assign_pool_snapshot_revision(ctx, &mut job) {
+        return false;
     }
     let pending = pending_pool_command_for_stash(&job);
     let Some(sender) = ctx.track_worker.read().clone() else {
@@ -1959,6 +2000,9 @@ fn enqueue_track_worker(ctx: &MarketDataContext, mut job: TrackWorkerCommand) ->
         return false;
     };
     if track_worker_try_enqueue(&sender, job) {
+        if let Some((pool, consumer)) = pool_meta {
+            ctx.pool_snapshot_revisions.inc_inflight_ref(pool, consumer);
+        }
         return true;
     }
     if let Some(cmd) = pending {
@@ -3212,7 +3256,40 @@ impl MarketDataContext {
         })
     }
 
+    fn fail_revision_registry_full(&self) {
+        inc_market_data_revision_registry_full_total();
+        self.geyser_explicit_ready.store(false, Ordering::Release);
+        *self.geyser_explicit_config_error.write() =
+            Some("pool snapshot revision registry full (fail-closed)".into());
+        self.geyser_connect_barrier.mark_failed();
+    }
+
+    fn acquire_pool_revision_slot(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
+        match self
+            .pool_snapshot_revisions
+            .try_acquire_active(pool, consumer)
+        {
+            RevisionAcquireResult::Acquired => true,
+            RevisionAcquireResult::RegistryFull => {
+                self.fail_revision_registry_full();
+                false
+            }
+        }
+    }
+
+    fn clear_pending_pool_overflow_latch(&self) {
+        self.pending_pool_overflow_latched
+            .store(false, Ordering::Release);
+        self.pending_pool_commands.clear_overflow();
+    }
+
     fn fail_pending_pool_overflow(&self) {
+        if self
+            .pending_pool_overflow_latched
+            .swap(true, Ordering::AcqRel)
+        {
+            return;
+        }
         inc_market_data_track_pending_pool_overflow_total();
         self.geyser_explicit_ready.store(false, Ordering::Release);
         *self.geyser_explicit_config_error.write() =
@@ -3274,6 +3351,9 @@ impl MarketDataContext {
     }
 
     fn apply_pending_track_worker_work(&self, desired: &mut DesiredExplicitSet) {
+        if self.pending_pool_overflow_latched.load(Ordering::Acquire) {
+            return;
+        }
         if self.pending_pool_commands.overflowed() {
             self.fail_pending_pool_overflow();
             return;
@@ -3285,7 +3365,9 @@ impl MarketDataContext {
         for command in self.pending_pool_commands.drain_all() {
             self.replay_pending_pool_command(desired, command);
         }
-        self.pending_pool_commands.clear_overflow();
+        if self.pending_pool_commands.is_empty() {
+            self.clear_pending_pool_overflow_latch();
+        }
     }
 
     fn commit_wallet_explicit_state(
@@ -3859,8 +3941,9 @@ impl MarketDataContext {
         if ctx
             .geyser_connect_barrier
             .wait_ready(Duration::from_secs(30))
-            .is_err()
         {
+            info!("explicit Geyser restore/startup barrier ready");
+        } else {
             warn!("explicit Geyser restore/startup barrier failed or timed out (fail-closed)");
             ctx.geyser_explicit_ready.store(false, Ordering::Release);
         }
@@ -5379,6 +5462,9 @@ impl MarketDataContext {
                 continue;
             };
             self.hot_pool_registry.pin_pool(mint_pk, pool_pk);
+            if !self.acquire_pool_revision_slot(pool_pk, ConsumerId::Momentum) {
+                continue;
+            }
             if self.register_geyser_reserves_for_momentum_active_pool(desired, pool_pk) {
                 batch_dirty = true;
             }
@@ -5416,13 +5502,20 @@ impl MarketDataContext {
         pool: Pubkey,
     ) -> bool {
         self.hot_pool_registry.unpin_pool(mint, pool);
-        desired.remove_group(ConsumerId::Momentum, OwnerKey::Pool(pool));
-        self.pool_snapshot_revisions.maybe_retire_key(
-            pool,
-            ConsumerId::Momentum,
-            self.pending_pool_commands
-                .has_pending(pool, ConsumerId::Momentum),
-        );
+        let consumer = ConsumerId::Momentum;
+        let refs = self.pool_snapshot_revisions.key_refs(pool, consumer);
+        let has_pending = self.pending_pool_commands.has_pending(pool, consumer);
+        if !self.hot_pool_registry.pool_has_any_pin(pool)
+            && refs.inflight == 0
+            && refs.pending == 0
+            && !has_pending
+        {
+            desired.remove_group(consumer, OwnerKey::Pool(pool));
+            self.pool_snapshot_revisions
+                .maybe_retire_key(pool, consumer, false, false);
+            self.pool_snapshot_revisions
+                .release_active_if_idle(pool, consumer);
+        }
         let mut changed = false;
         // Pool-level reserve pins are shared: only demote vaults/bin arrays when no `(m, pool)`
         // row remains after this unpin (PR #147 follow-up).
@@ -5563,6 +5656,9 @@ impl MarketDataContext {
                 continue;
             };
             self.hot_pool_registry.pin_arb_pool(pool_pk);
+            if !self.acquire_pool_revision_slot(pool_pk, ConsumerId::Arb) {
+                continue;
+            }
             if self.register_geyser_reserves_for_arb_active_pool(desired, pool_pk) {
                 batch_dirty = true;
             } else {
@@ -5618,13 +5714,21 @@ impl MarketDataContext {
         pool: Pubkey,
     ) -> bool {
         self.hot_pool_registry.unpin_arb_pool(pool);
-        desired.remove_group(ConsumerId::Arb, OwnerKey::Pool(pool));
-        self.pool_snapshot_revisions.maybe_retire_key(
-            pool,
-            ConsumerId::Arb,
-            self.pending_pool_commands
-                .has_pending(pool, ConsumerId::Arb),
-        );
+        let consumer = ConsumerId::Arb;
+        let refs = self.pool_snapshot_revisions.key_refs(pool, consumer);
+        let has_pending = self.pending_pool_commands.has_pending(pool, consumer);
+        if !self.hot_pool_registry.pool_has_arb(pool)
+            && !self.hot_pool_registry.pool_has_any_pin(pool)
+            && refs.inflight == 0
+            && refs.pending == 0
+            && !has_pending
+        {
+            desired.remove_group(consumer, OwnerKey::Pool(pool));
+            self.pool_snapshot_revisions
+                .maybe_retire_key(pool, consumer, false, false);
+            self.pool_snapshot_revisions
+                .release_active_if_idle(pool, consumer);
+        }
         let mut changed = false;
         if !self.hot_pool_registry.pool_has_arb(pool)
             && !self.hot_pool_registry.pool_has_any_pin(pool)
@@ -7772,7 +7876,9 @@ async fn main() -> Result<()> {
         }
     }
     let pending_pool_cap = pending_pool_registration_cap(market_data_config.max_tracked_accounts);
-    let pool_snapshot_revisions = Arc::new(PoolSnapshotRevisionSequencer::new());
+    let pool_snapshot_revisions = Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(
+        pending_pool_cap,
+    ));
     let ctx = Arc::new(MarketDataContext {
         run_id: run_id.clone(),
         config: parking_lot::RwLock::new(market_data_config),
@@ -7839,6 +7945,7 @@ async fn main() -> Result<()> {
             Arc::clone(&pool_snapshot_revisions),
         )),
         pool_snapshot_revisions,
+        pending_pool_overflow_latched: AtomicBool::new(false),
         geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
     });
 
@@ -8637,10 +8744,9 @@ async fn run_geyser_loop(
                 .unwrap_or_else(|| "protected explicit overflow".into())
         );
     }
-    if ctx
+    if !ctx
         .geyser_connect_barrier
         .wait_ready(Duration::from_secs(30))
-        .is_err()
     {
         anyhow::bail!("Geyser explicit restore/convergence barrier failed before connect");
     }
@@ -11367,7 +11473,9 @@ mod wallet_snapshot_stale_cleanup_tests {
         let (tracked_mints_tx, _tracked_mints_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_bin_arrays_tx, _tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
-        let pool_snapshot_revisions = Arc::new(PoolSnapshotRevisionSequencer::new());
+        let pending_cap = pending_pool_registration_cap(25_000);
+        let pool_snapshot_revisions =
+            Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(pending_cap));
         MarketDataContext {
             run_id: "run-stale-cleanup-test".to_string(),
             config: parking_lot::RwLock::new(MarketDataConfig::default()),
@@ -11432,10 +11540,11 @@ mod wallet_snapshot_stale_cleanup_tests {
             track_worker_dirty: AtomicBool::new(false),
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
             pending_pool_commands: Arc::new(PendingPoolRegistrations::new(
-                pending_pool_registration_cap(25_000),
+                pending_cap,
                 Arc::clone(&pool_snapshot_revisions),
             )),
             pool_snapshot_revisions,
+            pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         }
     }
@@ -11609,7 +11718,9 @@ mod wallet_tx_meta_balance_tests {
         let (tracked_mints_tx, _tracked_mints_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_bin_arrays_tx, _tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
-        let pool_snapshot_revisions = Arc::new(PoolSnapshotRevisionSequencer::new());
+        let pending_cap = pending_pool_registration_cap(25_000);
+        let pool_snapshot_revisions =
+            Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(pending_cap));
         let ctx = Arc::new(MarketDataContext {
             run_id: "run-wallet-tx-meta".to_string(),
             config: parking_lot::RwLock::new(MarketDataConfig::default()),
@@ -11674,10 +11785,11 @@ mod wallet_tx_meta_balance_tests {
             track_worker_dirty: AtomicBool::new(false),
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
             pending_pool_commands: Arc::new(PendingPoolRegistrations::new(
-                pending_pool_registration_cap(25_000),
+                pending_cap,
                 Arc::clone(&pool_snapshot_revisions),
             )),
             pool_snapshot_revisions,
+            pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
@@ -12521,7 +12633,9 @@ mod pr_b_geyser_tracking_tests {
         let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_bin_arrays_tx, _tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_wallet_tx, _tracked_wallet_rx) = watch::channel(Vec::<Pubkey>::new());
-        let pool_snapshot_revisions = Arc::new(PoolSnapshotRevisionSequencer::new());
+        let pending_cap = pending_pool_registration_cap(25_000);
+        let pool_snapshot_revisions =
+            Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(pending_cap));
         let ctx = Arc::new(MarketDataContext {
             run_id: "run-prd-test".to_string(),
             config: parking_lot::RwLock::new(MarketDataConfig::default()),
@@ -12586,10 +12700,11 @@ mod pr_b_geyser_tracking_tests {
             track_worker_dirty: AtomicBool::new(false),
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
             pending_pool_commands: Arc::new(PendingPoolRegistrations::new(
-                pending_pool_registration_cap(25_000),
+                pending_cap,
                 Arc::clone(&pool_snapshot_revisions),
             )),
             pool_snapshot_revisions,
+            pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         });
         let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
@@ -12613,7 +12728,9 @@ mod pr_b_geyser_tracking_tests {
         let (tracked_vaults_tx, tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_bin_arrays_tx, tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_wallet_tx, tracked_wallet_rx) = watch::channel(Vec::<Pubkey>::new());
-        let pool_snapshot_revisions = Arc::new(PoolSnapshotRevisionSequencer::new());
+        let pending_cap = pending_pool_registration_cap(25_000);
+        let pool_snapshot_revisions =
+            Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(pending_cap));
         let ctx = Arc::new(MarketDataContext {
             run_id: "run-pr161-merge-test".to_string(),
             config: parking_lot::RwLock::new(MarketDataConfig::default()),
@@ -12678,10 +12795,11 @@ mod pr_b_geyser_tracking_tests {
             track_worker_dirty: AtomicBool::new(false),
             wallet_explicit_pending: Arc::new(WalletExplicitPending::default()),
             pending_pool_commands: Arc::new(PendingPoolRegistrations::new(
-                pending_pool_registration_cap(25_000),
+                pending_cap,
                 Arc::clone(&pool_snapshot_revisions),
             )),
             pool_snapshot_revisions,
+            pending_pool_overflow_latched: AtomicBool::new(false),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         });
         (
@@ -16592,6 +16710,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
         ctx.hot_pool_registry.pin_pool(base, pool);
+        assert!(ctx.acquire_pool_revision_slot(pool, ConsumerId::Momentum));
         let snapshot = ctx
             .build_pool_explicit_snapshot(pool, GeyserPinReason::MomentumActive)
             .expect("snapshot");
@@ -16687,8 +16806,7 @@ mod pr_b_geyser_tracking_tests {
 
         assert!(
             ctx.geyser_connect_barrier
-                .wait_ready(Duration::from_secs(5))
-                .is_ok(),
+                .wait_ready(Duration::from_secs(5)),
             "wallet sync before restore must not deadlock startup barrier"
         );
     }
@@ -16721,11 +16839,17 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
         ctx.hot_pool_registry.pin_arb_pool(pool);
+        assert!(ctx.acquire_pool_revision_slot(pool, ConsumerId::Arb));
 
         let mut snapshot = ctx
             .build_pool_explicit_snapshot(pool, GeyserPinReason::ArbMultiDex)
             .expect("dlmm snapshot");
-        ctx.pool_snapshot_revisions.assign_next(&mut snapshot);
+        match ctx.pool_snapshot_revisions.assign_next(&mut snapshot) {
+            RevisionAssignResult::Assigned(_) => {}
+            other => panic!("assign failed: {other:?}"),
+        }
+        ctx.pool_snapshot_revisions
+            .inc_inflight_ref(pool, ConsumerId::Arb);
         assert!(!snapshot.vaults.is_empty());
         assert!(!snapshot.bin_arrays.is_empty());
         assert!(!snapshot.mints.is_empty());
@@ -16746,12 +16870,31 @@ mod pr_b_geyser_tracking_tests {
         }
     }
 
+    fn assign_pool_snapshot_for_test(
+        ctx: &MarketDataContext,
+        pool: Pubkey,
+        consumer: ConsumerId,
+        snapshot: &mut PoolExplicitSnapshot,
+    ) -> u64 {
+        assert!(ctx.acquire_pool_revision_slot(pool, consumer));
+        let rev = match ctx.pool_snapshot_revisions.assign_next(snapshot) {
+            RevisionAssignResult::Assigned(rev) => rev,
+            other => panic!("assign failed: {other:?}"),
+        };
+        ctx.pool_snapshot_revisions.inc_inflight_ref(pool, consumer);
+        rev
+    }
+
     #[test]
     fn pending_pool_overflow_sets_fail_closed_dirty_state() {
-        let pending =
-            PendingPoolRegistrations::new(1, Arc::new(PoolSnapshotRevisionSequencer::new()));
+        let revisions = Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(4));
+        let pending = PendingPoolRegistrations::new(1, Arc::clone(&revisions));
         let pool_a = Pubkey::new_unique();
         let pool_b = Pubkey::new_unique();
+        assert_eq!(
+            revisions.try_acquire_active(pool_a, ConsumerId::Momentum),
+            RevisionAcquireResult::Acquired
+        );
         let mk_snapshot = |pool: Pubkey| PoolExplicitSnapshot {
             pool,
             vaults: vec![],
@@ -16808,6 +16951,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
         ctx.hot_pool_registry.pin_arb_pool(pool);
+        assert!(ctx.acquire_pool_revision_slot(pool, ConsumerId::Arb));
 
         let mk_typed = |vault_pk: Pubkey, bin_pk: Pubkey, mint_pk: Pubkey| PoolExplicitSnapshot {
             pool,
@@ -16935,6 +17079,7 @@ mod pr_b_geyser_tracking_tests {
         );
         ctx.hot_pool_registry.pin_arb_pool(pool);
         ctx.hot_pool_registry.pin_pool(base, pool);
+        assert!(ctx.acquire_pool_revision_slot(pool, ConsumerId::Arb));
 
         let mk_typed =
             move |bin_pk: Pubkey, mint_pk: Pubkey, extra_vault: Pubkey| PoolExplicitSnapshot {
@@ -17014,7 +17159,7 @@ mod pr_b_geyser_tracking_tests {
 
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         let mut snapshot_new = mk_typed(bin_new, mint_new, vault_new);
-        let rev_new = ctx.pool_snapshot_revisions.assign_next(&mut snapshot_new);
+        let rev_new = assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snapshot_new);
         assert!(ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot_new));
         assert_eq!(
             ctx.pool_snapshot_revisions
@@ -17068,7 +17213,7 @@ mod pr_b_geyser_tracking_tests {
 
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         let mut snapshot_new = mk_typed(bin_new, mint_new, vault_new);
-        let rev_new = ctx.pool_snapshot_revisions.assign_next(&mut snapshot_new);
+        let rev_new = assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snapshot_new);
         assert!(ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot_new));
 
         let mut snapshot_stale = mk_typed(bin_old, mint_old, vault_old);
@@ -17113,19 +17258,21 @@ mod pr_b_geyser_tracking_tests {
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
 
         let mut snap_reserves = mk_typed(bin_v1, mint_v1, vault_v1);
-        let rev_reserves = ctx.pool_snapshot_revisions.assign_next(&mut snap_reserves);
+        let rev_reserves =
+            assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snap_reserves);
         assert!(ctx.commit_register_pool_geyser_reserves(&mut desired, &snap_reserves));
 
         let mut snap_vaults = mk_typed(bin_v2, mint_v2, vault_v2);
-        let rev_vaults = ctx.pool_snapshot_revisions.assign_next(&mut snap_vaults);
+        let rev_vaults =
+            assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snap_vaults);
         assert!(ctx.commit_register_pool_vaults_from_account(&mut desired, &snap_vaults));
 
         let mut snap_trade = mk_typed(bin_v3, mint_v3, vault_v3);
-        let rev_trade = ctx.pool_snapshot_revisions.assign_next(&mut snap_trade);
+        let rev_trade = assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snap_trade);
         assert!(ctx.commit_register_geyser_reserves_after_trade(&mut desired, &snap_trade));
 
         let mut snap_dlmm = mk_typed(bin_v4, mint_v4, vault_v4);
-        let rev_dlmm = ctx.pool_snapshot_revisions.assign_next(&mut snap_dlmm);
+        let rev_dlmm = assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snap_dlmm);
         assert!(ctx.commit_refresh_dlmm_bin_window(&mut desired, &snap_dlmm, 9));
 
         assert!(rev_vaults > rev_reserves);
@@ -17222,6 +17369,103 @@ mod pr_b_geyser_tracking_tests {
             ctx.pool_snapshot_revisions
                 .current_applied(pool, ConsumerId::Arb),
             rev_new
+        );
+    }
+
+    #[test]
+    fn pending_overflow_counter_increments_once_on_multi_cycle_retry() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let before = ironcrab::metrics::market_data_track_pending_pool_overflow_value();
+        ctx.fail_pending_pool_overflow();
+        ctx.fail_pending_pool_overflow();
+        assert_eq!(
+            ironcrab::metrics::market_data_track_pending_pool_overflow_value(),
+            before + 1,
+            "overflow counter must increment once on latch transition"
+        );
+        assert!(ctx.pending_pool_overflow_latched.load(Ordering::Acquire));
+        for _ in 0..3 {
+            let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+            ctx.apply_pending_track_worker_work(&mut desired);
+            ctx.mark_track_worker_dirty();
+        }
+        assert_eq!(
+            ironcrab::metrics::market_data_track_pending_pool_overflow_value(),
+            before + 1,
+            "latched overflow must not re-increment on dirty retry cycles"
+        );
+    }
+
+    #[test]
+    fn momentum_two_mint_same_pool_delayed_registration_retains_desired() {
+        use ironcrab::execution::live_pool_cache::RaydiumCpmmState;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let base_vault = Pubkey::new_unique();
+        let quote_vault = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: mint_a,
+                token_1_mint: quote,
+                token_0_vault: base_vault,
+                token_1_vault: quote_vault,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.hot_pool_registry.pin_pool(mint_a, pool);
+        assert!(ctx.acquire_pool_revision_slot(pool, ConsumerId::Momentum));
+        assert!(ctx.register_geyser_reserves_for_momentum_active_pool(&mut desired, pool));
+        ctx.hot_pool_registry.pin_pool(mint_b, pool);
+        assert!(
+            desired
+                .snapshot_owner_groups()
+                .iter()
+                .any(|g| g.consumer == ConsumerId::Momentum && g.owner == OwnerKey::Pool(pool)),
+            "shared pool desired group must exist after second mint pin"
+        );
+
+        ctx.clear_momentum_geyser_reserves_for_active_entry(&mut desired, mint_a, pool);
+        assert!(
+            desired
+                .snapshot_owner_groups()
+                .iter()
+                .any(|g| g.consumer == ConsumerId::Momentum && g.owner == OwnerKey::Pool(pool)),
+            "unpinning one mint must not remove shared pool desired group while other mint remains pinned"
+        );
+
+        let Some(snapshot) =
+            ctx.build_pool_explicit_snapshot(pool, GeyserPinReason::MomentumActive)
+        else {
+            panic!("snapshot");
+        };
+        assert!(enqueue_track_worker(
+            &ctx,
+            TrackWorkerCommand::RegisterGeyserReservesAfterTrade { snapshot },
+        ));
+        test_wait_inline_track_worker();
+
+        ctx.clear_momentum_geyser_reserves_for_active_entry(&mut desired, mint_b, pool);
+        assert!(
+            !desired
+                .snapshot_owner_groups()
+                .iter()
+                .any(|g| g.consumer == ConsumerId::Momentum && g.owner == OwnerKey::Pool(pool)),
+            "desired group must retire only after last momentum pin and no pending/in-flight"
         );
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -82,10 +82,11 @@ use ironcrab::market_data::sidefx::{
 use ironcrab::market_data::track::{
     arb_coalesce_try_send, explicit_set_snapshot_path, explicit_subscription_has_new_keys,
     flush_explicit_set_snapshot, load_explicit_set_snapshot, momentum_coalesce_try_send,
-    pool_is_enrichment_member, spawn_track_worker, track_worker_try_enqueue, ConsumerId,
-    DesiredExplicitSet, ExplicitAccountKind, ExplicitSetSnapshot, ExplicitSnapshotRow,
-    SnapshotConsumer, TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
-    EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP, MARKET_DATA_TRACK_WORKER_COALESCE_MS,
+    pool_is_enrichment_member, spawn_track_worker, track_worker_try_enqueue, AdmissionResult,
+    ConsumerId, DesiredExplicitSet, ExplicitAccountKind, ExplicitSetSnapshot, ExplicitSnapshotRow,
+    OwnerKey, SnapshotConsumer, TrackPinReason, TrackWorkerCommand, TrackWorkerContext,
+    TrackWorkerSender, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
+    MARKET_DATA_TRACK_WORKER_COALESCE_MS,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -95,7 +96,9 @@ use ironcrab::metrics::{
     inc_market_data_account_high_priority_queue_depth,
     inc_market_data_account_low_priority_queue_depth, inc_market_data_account_worker_queue_depth,
     inc_market_data_arb_pin_geyser_register_deferred_total,
-    inc_market_data_balance_updated_from_cache_total, inc_market_data_geyser_sync_partial_total,
+    inc_market_data_balance_updated_from_cache_total,
+    inc_market_data_geyser_explicit_admission_rejected_total,
+    inc_market_data_geyser_sync_partial_total,
     inc_market_data_geyser_sync_skipped_rate_limit_total,
     inc_market_data_ingest_membership_snapshot_hits_total,
     inc_market_data_jsonl_enqueue_dropped_total,
@@ -118,11 +121,15 @@ use ironcrab::metrics::{
     set_market_data_account_broadcast_queue_depth, set_market_data_account_worker_count,
     set_market_data_arb_pinned_pools_gauge, set_market_data_enrichment_registry_pools_gauge,
     set_market_data_explicit_set_snapshot_restore_duration_ms,
-    set_market_data_explicit_set_snapshot_restore_pubkeys, set_market_data_geyser_merge_pending,
-    set_market_data_geyser_sync_pending, set_market_data_hot_pool_registry_pools_gauge,
-    set_market_data_md_state_evict_pending, set_market_data_momentum_active_pool_pins_gauge,
-    set_market_data_tx_broadcast_queue_depth, set_readiness_control_sub_active, set_readiness_mode,
-    set_readiness_nats_connected, touch_market_data_global_ingest_progress,
+    set_market_data_explicit_set_snapshot_restore_pubkeys,
+    set_market_data_geyser_explicit_admitted_accounts,
+    set_market_data_geyser_explicit_admitted_pools, set_market_data_geyser_explicit_cap_overflow,
+    set_market_data_geyser_explicit_requested_pools, set_market_data_geyser_explicit_set_size,
+    set_market_data_geyser_merge_pending, set_market_data_geyser_sync_pending,
+    set_market_data_hot_pool_registry_pools_gauge, set_market_data_md_state_evict_pending,
+    set_market_data_momentum_active_pool_pins_gauge, set_market_data_tx_broadcast_queue_depth,
+    set_readiness_control_sub_active, set_readiness_mode, set_readiness_nats_connected,
+    touch_market_data_global_ingest_progress,
     touch_market_data_tracked_membership_snapshot_refresh, update_readiness_market_data_current,
     GeyserTrackedEvictKind, MarketDataLatencySegment, MetricsComponent,
     MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS, MARKET_EVENTS_RECEIVED_TOTAL,
@@ -257,6 +264,7 @@ fn track_worker_execute_coalesced_push(
     before_keys: HashSet<Pubkey>,
     continue_evict: bool,
     release_flush_slot: bool,
+    admission_converged: &mut bool,
 ) -> bool {
     // Geyser explicit flush: sync_geyser_tracked_accounts_batched_flush_with_deadline on md-track-worker.
     ironcrab::market_data::track::track_worker_execute_coalesced_push(
@@ -265,6 +273,7 @@ fn track_worker_execute_coalesced_push(
         before_keys,
         continue_evict,
         release_flush_slot,
+        admission_converged,
     )
 }
 
@@ -1120,6 +1129,8 @@ struct MarketDataContext {
     last_arb_snapshot_target: parking_lot::RwLock<Option<HashSet<Pubkey>>>,
     /// Last `active_id` used when registering DLMM bin-array window per pool (Fix B).
     dlmm_registered_active_id: parking_lot::RwLock<HashMap<Pubkey, i32>>,
+    /// Track-worker: force explicit-admission reconvergence (config reload / cap shrink).
+    explicit_admission_invalidate: AtomicBool,
 }
 
 #[derive(Debug, Default)]
@@ -1853,15 +1864,109 @@ fn consumer_id_for_geyser_pin(pin: Option<GeyserPinReason>) -> ConsumerId {
     match pin {
         Some(GeyserPinReason::Wallet) => ConsumerId::Wallet,
         Some(GeyserPinReason::MomentumActive) => ConsumerId::Momentum,
-        Some(GeyserPinReason::ArbMultiDex) | None => ConsumerId::Arb,
+        Some(GeyserPinReason::ArbMultiDex) => ConsumerId::Arb,
+        None => ConsumerId::Tracker,
     }
 }
 
-fn snapshot_consumer_to_geyser_pin(consumer: SnapshotConsumer) -> GeyserPinReason {
+fn consumer_id_label(consumer: ConsumerId) -> &'static str {
     match consumer {
-        SnapshotConsumer::Wallet => GeyserPinReason::Wallet,
-        SnapshotConsumer::Momentum => GeyserPinReason::MomentumActive,
-        SnapshotConsumer::Arb => GeyserPinReason::ArbMultiDex,
+        ConsumerId::Wallet => "wallet",
+        ConsumerId::Momentum => "momentum",
+        ConsumerId::Arb => "arb",
+        ConsumerId::Tracker => "tracker",
+    }
+}
+
+fn record_admission_rejection(consumer: ConsumerId, result: AdmissionResult) {
+    let (reason, label) = match result {
+        AdmissionResult::RejectedCap => ("cap", consumer_id_label(consumer)),
+        AdmissionResult::RejectedProtected => ("protected", consumer_id_label(consumer)),
+        AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => return,
+    };
+    inc_market_data_geyser_explicit_admission_rejected_total(label, reason);
+}
+
+fn collect_pool_explicit_pubkeys_from_cached_state(
+    pool: Pubkey,
+    cached_state: &CachedPoolState,
+    enable_meteora_cpmm: bool,
+    enable_meteora_dlmm: bool,
+) -> HashSet<Pubkey> {
+    let mut out = HashSet::new();
+
+    if let CachedPoolState::RaydiumCpmm(s) = cached_state {
+        let (_, _, base_vault, quote_vault) = cpmm_token_mints_and_vaults_sol_normalized(
+            s.token_0_mint,
+            s.token_1_mint,
+            s.token_0_vault,
+            s.token_1_vault,
+        );
+        out.insert(base_vault);
+        out.insert(quote_vault);
+    }
+    if enable_meteora_cpmm {
+        if let CachedPoolState::MeteoraCpmm(s) = cached_state {
+            let (_, _, base_vault, quote_vault) = cpmm_token_mints_and_vaults_sol_normalized(
+                s.token_0_mint,
+                s.token_1_mint,
+                s.token_0_vault,
+                s.token_1_vault,
+            );
+            out.insert(base_vault);
+            out.insert(quote_vault);
+        }
+    }
+    if enable_meteora_dlmm {
+        if let CachedPoolState::Meteora(s) = cached_state {
+            let (_, _, base_vault, quote_vault) = cpmm_token_mints_and_vaults_sol_normalized(
+                s.token_x_mint,
+                s.token_y_mint,
+                s.reserve_x,
+                s.reserve_y,
+            );
+            out.insert(base_vault);
+            out.insert(quote_vault);
+            let active_array_index = MeteoraDlmmSwapBuilder::bin_id_to_bin_array_index(s.active_id);
+            for offset in -3i64..=3i64 {
+                let index = active_array_index + offset;
+                if let Ok(pda) = MeteoraDlmmSwapBuilder::derive_bin_array_pda(&pool, index) {
+                    out.insert(pda);
+                }
+            }
+        }
+    }
+    if let CachedPoolState::Orca(s) = cached_state {
+        let (_, _, base_vault, quote_vault) = cpmm_token_mints_and_vaults_sol_normalized(
+            s.token_mint_a,
+            s.token_mint_b,
+            s.token_vault_a,
+            s.token_vault_b,
+        );
+        out.insert(base_vault);
+        out.insert(quote_vault);
+    }
+    if let CachedPoolState::PumpAmm(s) = cached_state {
+        out.insert(s.pool_base_token_account);
+        out.insert(s.pool_quote_token_account);
+    }
+    if let CachedPoolState::RaydiumAmm(s) = cached_state {
+        out.insert(s.coin_vault);
+        out.insert(s.pc_vault);
+    }
+    if let Some((a, b)) = pool_mints_for_geyser_explicit_tracking(cached_state) {
+        out.insert(a);
+        out.insert(b);
+    }
+    out
+}
+
+fn snapshot_consumer_to_geyser_pin(consumer: SnapshotConsumer) -> Option<GeyserPinReason> {
+    match consumer {
+        SnapshotConsumer::Wallet => Some(GeyserPinReason::Wallet),
+        SnapshotConsumer::Momentum => Some(GeyserPinReason::MomentumActive),
+        SnapshotConsumer::Arb => Some(GeyserPinReason::ArbMultiDex),
+        SnapshotConsumer::Tracker => None,
     }
 }
 
@@ -1874,40 +1979,77 @@ impl TrackWorkerContext for MarketDataContext {
         self.config.read().max_tracked_accounts
     }
 
-    fn apply_momentum_active_pools_update(&self, update: &MomentumActivePoolsUpdate) -> bool {
-        self.apply_momentum_active_pools_update(update)
+    fn apply_momentum_active_pools_update(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        update: &MomentumActivePoolsUpdate,
+    ) -> bool {
+        self.apply_momentum_active_pools_update(desired, update)
     }
 
-    fn apply_momentum_snapshot_reconcile(&self, active: &[MomentumActivePoolEntry]) -> bool {
-        self.apply_momentum_snapshot_reconcile(active)
+    fn apply_momentum_snapshot_reconcile(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        active: &[MomentumActivePoolEntry],
+    ) -> bool {
+        self.apply_momentum_snapshot_reconcile(desired, active)
     }
 
-    fn apply_momentum_removed_entries(&self, chunk: &[MomentumRemovedPoolEntry]) -> bool {
-        self.apply_momentum_removed_entries(chunk)
+    fn apply_momentum_removed_entries(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        chunk: &[MomentumRemovedPoolEntry],
+    ) -> bool {
+        self.apply_momentum_removed_entries(desired, chunk)
     }
 
-    fn apply_momentum_active_entries(&self, chunk: &[MomentumActivePoolEntry]) -> bool {
-        self.apply_momentum_active_entries(chunk)
+    fn apply_momentum_active_entries(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        chunk: &[MomentumActivePoolEntry],
+    ) -> bool {
+        self.apply_momentum_active_entries(desired, chunk)
     }
 
-    fn apply_arb_track_requests_update(&self, update: &ArbTrackRequestsUpdate) -> bool {
-        self.apply_arb_track_requests_update(update)
+    fn apply_arb_track_requests_update(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        update: &ArbTrackRequestsUpdate,
+    ) -> bool {
+        self.apply_arb_track_requests_update(desired, update)
     }
 
-    fn apply_arb_snapshot_reconcile(&self, active: &[ArbTrackActiveEntry]) -> bool {
-        self.apply_arb_snapshot_reconcile(active)
+    fn apply_arb_snapshot_reconcile(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        active: &[ArbTrackActiveEntry],
+    ) -> bool {
+        self.apply_arb_snapshot_reconcile(desired, active)
     }
 
-    fn apply_arb_removed_entries(&self, chunk: &[ArbTrackRemovedEntry]) -> bool {
-        self.apply_arb_removed_entries(chunk)
+    fn apply_arb_removed_entries(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        chunk: &[ArbTrackRemovedEntry],
+    ) -> bool {
+        self.apply_arb_removed_entries(desired, chunk)
     }
 
-    fn apply_arb_active_entries(&self, chunk: &[ArbTrackActiveEntry]) -> bool {
-        self.apply_arb_active_entries(chunk)
+    fn apply_arb_active_entries(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        chunk: &[ArbTrackActiveEntry],
+    ) -> bool {
+        self.apply_arb_active_entries(desired, chunk)
     }
 
-    fn track_mint_for_geyser_metadata(&self, mint: Pubkey, pin: Option<TrackPinReason>) -> bool {
-        self.track_mint_for_geyser_metadata(mint, track_pin_to_geyser_pin(pin))
+    fn track_mint_for_geyser_metadata(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        mint: Pubkey,
+        pin: Option<TrackPinReason>,
+    ) -> bool {
+        self.track_mint_for_geyser_metadata_admitted(desired, mint, track_pin_to_geyser_pin(pin))
     }
 
     fn refresh_geyser_pins_gauge(&self) {
@@ -1934,12 +2076,27 @@ impl TrackWorkerContext for MarketDataContext {
         self.pending_geyser_evict.load(Ordering::Relaxed)
     }
 
-    fn continue_geyser_evict_with_deadline(&self, deadline: Instant) -> bool {
-        self.continue_geyser_evict_with_deadline(deadline)
+    fn clear_pending_geyser_evict(&self) {
+        self.pending_geyser_evict.store(false, Ordering::Relaxed);
+        set_market_data_md_state_evict_pending(false);
     }
 
-    fn sync_geyser_tracked_accounts_batched_flush_with_deadline(&self, deadline: Instant) -> bool {
-        self.sync_geyser_tracked_accounts_batched_flush_with_deadline(deadline)
+    fn continue_geyser_evict_with_deadline(
+        &self,
+        deadline: Instant,
+        desired: &DesiredExplicitSet,
+    ) -> bool {
+        self.sync_geyser_tracked_accounts_from_desired_with_deadline(deadline, desired)
+    }
+
+    fn sync_geyser_tracked_accounts_batched_flush_with_deadline(
+        &self,
+        deadline: Instant,
+        desired: &DesiredExplicitSet,
+    ) -> bool {
+        set_market_data_geyser_sync_pending(0);
+        record_market_data_geyser_sync_batch_total();
+        self.sync_geyser_tracked_accounts_from_desired_with_deadline(deadline, desired)
     }
 
     fn release_geyser_sync_flush_slot(&self) {
@@ -1951,24 +2108,7 @@ impl TrackWorkerContext for MarketDataContext {
     }
 
     fn explicit_pubkey_rows_for_desired_set(&self) -> Vec<(Pubkey, ConsumerId, Option<Pubkey>)> {
-        let mut rows = Vec::new();
-        for (pk, m) in self.tracked_mints.read().iter() {
-            rows.push((*pk, consumer_id_for_geyser_pin(m.pin), None));
-        }
-        for (pk, v) in self.tracked_vaults.read().iter() {
-            rows.push((*pk, consumer_id_for_geyser_pin(v.pin), Some(v.pool_address)));
-        }
-        for (pk, b) in self.tracked_bin_arrays.read().iter() {
-            rows.push((*pk, consumer_id_for_geyser_pin(b.pin), Some(b.pool_address)));
-        }
-        if let Some(w) = &self.tracked_wallet {
-            rows.push((w.wallet, ConsumerId::Wallet, None));
-            rows.push((w.wsol_ata, ConsumerId::Wallet, None));
-        }
-        for pk in self.tracked_wallet_token_accounts.read().iter() {
-            rows.push((*pk, ConsumerId::Wallet, None));
-        }
-        rows
+        self.collect_explicit_pubkey_rows_for_convergence()
     }
 
     fn build_explicit_set_snapshot(&self) -> ExplicitSetSnapshot {
@@ -1993,8 +2133,46 @@ impl TrackWorkerContext for MarketDataContext {
         snapshot
     }
 
-    fn apply_explicit_set_snapshot(&self, snapshot: &ExplicitSetSnapshot) -> usize {
-        self.apply_explicit_set_snapshot_impl(snapshot)
+    fn apply_explicit_set_snapshot(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        snapshot: &ExplicitSetSnapshot,
+    ) -> usize {
+        self.apply_explicit_set_snapshot_impl(desired, snapshot)
+    }
+
+    fn converge_explicit_admission(&self, desired: &mut DesiredExplicitSet) {
+        let rows = self.collect_explicit_pubkey_rows_for_convergence();
+        desired.set_max_explicit_pubkeys(self.config.read().max_tracked_accounts);
+        desired.converge_from_rows(&rows);
+        self.prune_tracked_maps_to_desired(desired);
+        self.pending_geyser_evict.store(false, Ordering::Relaxed);
+        set_market_data_md_state_evict_pending(false);
+        set_market_data_geyser_explicit_cap_overflow(desired.cap_overflow());
+    }
+
+    fn prune_tracked_maps_to_desired(&self, desired: &DesiredExplicitSet) {
+        MarketDataContext::prune_tracked_maps_to_desired(self, desired);
+    }
+
+    fn refresh_explicit_admission_metrics(&self, desired: &DesiredExplicitSet) {
+        MarketDataContext::refresh_explicit_admission_metrics(self, desired);
+    }
+
+    fn last_synced_explicit_pubkeys_write(
+        &self,
+    ) -> parking_lot::RwLockWriteGuard<'_, HashSet<Pubkey>> {
+        self.last_synced_explicit_pubkeys.write()
+    }
+
+    fn invalidate_explicit_admission_convergence(&self) {
+        self.explicit_admission_invalidate
+            .store(true, Ordering::Relaxed);
+    }
+
+    fn take_explicit_admission_invalidate(&self) -> bool {
+        self.explicit_admission_invalidate
+            .swap(false, Ordering::Relaxed)
     }
 }
 
@@ -2455,6 +2633,10 @@ impl MarketDataContext {
     }
 
     fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
+        let admitted = self.last_synced_explicit_pubkeys.read();
+        if !admitted.is_empty() {
+            return admitted.clone();
+        }
         let mut set = HashSet::new();
         set.extend(self.tracked_mints.read().keys().copied());
         set.extend(self.tracked_vaults.read().keys().copied());
@@ -2465,6 +2647,129 @@ impl MarketDataContext {
         }
         set.extend(self.tracked_wallet_token_accounts.read().iter().copied());
         set
+    }
+
+    fn collect_explicit_pubkey_rows_for_convergence(
+        &self,
+    ) -> Vec<(Pubkey, ConsumerId, Option<Pubkey>)> {
+        let mut rows = Vec::new();
+        for (pk, m) in self.tracked_mints.read().iter() {
+            rows.push((*pk, consumer_id_for_geyser_pin(m.pin), None));
+        }
+        for (pk, v) in self.tracked_vaults.read().iter() {
+            rows.push((*pk, consumer_id_for_geyser_pin(v.pin), Some(v.pool_address)));
+        }
+        for (pk, b) in self.tracked_bin_arrays.read().iter() {
+            rows.push((*pk, consumer_id_for_geyser_pin(b.pin), Some(b.pool_address)));
+        }
+        if let Some(w) = &self.tracked_wallet {
+            rows.push((w.wallet, ConsumerId::Wallet, None));
+            rows.push((w.wsol_ata, ConsumerId::Wallet, None));
+        }
+        for pk in self.tracked_wallet_token_accounts.read().iter() {
+            rows.push((*pk, ConsumerId::Wallet, None));
+        }
+        rows
+    }
+
+    fn prune_tracked_maps_to_desired(&self, desired: &DesiredExplicitSet) {
+        let admitted = desired.snapshot_pubkeys();
+        {
+            let mut mints = self.tracked_mints.write();
+            mints.retain(|pk, _| admitted.contains(pk));
+        }
+        {
+            let mut vaults = self.tracked_vaults.write();
+            let removed: Vec<(Pubkey, Pubkey)> = vaults
+                .iter()
+                .filter(|(pk, _)| !admitted.contains(pk))
+                .map(|(pk, v)| (*pk, v.pool_address))
+                .collect();
+            for (pk, pool) in removed {
+                vaults.remove(&pk);
+                self.pool_tracked_legs_remove_vault(pool, pk);
+            }
+        }
+        {
+            let mut bins = self.tracked_bin_arrays.write();
+            let removed: Vec<(Pubkey, Pubkey)> = bins
+                .iter()
+                .filter(|(pk, _)| !admitted.contains(pk))
+                .map(|(pk, b)| (*pk, b.pool_address))
+                .collect();
+            for (pk, pool) in removed {
+                bins.remove(&pk);
+                self.pool_tracked_legs_remove_bin(pool, pk);
+            }
+        }
+        self.tracked_wallet_token_accounts
+            .write()
+            .retain(|pk| admitted.contains(pk));
+        self.broadcast_tracked_geyser_explicit_to_merge();
+    }
+
+    fn refresh_explicit_admission_metrics(&self, desired: &DesiredExplicitSet) {
+        set_market_data_geyser_explicit_admitted_accounts(desired.len());
+        set_market_data_geyser_explicit_cap_overflow(desired.cap_overflow());
+        set_market_data_geyser_explicit_set_size(desired.len());
+        set_market_data_geyser_explicit_requested_pools(
+            "momentum",
+            self.hot_pool_registry.pair_count(),
+        );
+        set_market_data_geyser_explicit_requested_pools(
+            "arb",
+            self.hot_pool_registry.arb_pool_count(),
+        );
+        set_market_data_geyser_explicit_requested_pools("tracker", 0);
+        set_market_data_geyser_explicit_admitted_pools(
+            "momentum",
+            desired.admitted_pool_count(ConsumerId::Momentum),
+        );
+        set_market_data_geyser_explicit_admitted_pools(
+            "arb",
+            desired.admitted_pool_count(ConsumerId::Arb),
+        );
+        set_market_data_geyser_explicit_admitted_pools(
+            "tracker",
+            desired.admitted_pool_count(ConsumerId::Tracker),
+        );
+    }
+
+    fn sync_geyser_tracked_accounts_from_desired_with_deadline(
+        &self,
+        _deadline: Instant,
+        desired: &DesiredExplicitSet,
+    ) -> bool {
+        self.prune_tracked_maps_to_desired(desired);
+        self.broadcast_tracked_geyser_explicit_to_merge();
+        *self.last_synced_explicit_pubkeys.write() = desired.snapshot_pubkeys();
+        true
+    }
+
+    fn try_admit_pool_explicit_group(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        pool: Pubkey,
+        pin: GeyserPinReason,
+    ) -> AdmissionResult {
+        let Some(state) = self.live_pool_cache.get(&pool) else {
+            return AdmissionResult::RejectedProtected;
+        };
+        let (enable_meteora_cpmm, enable_meteora_dlmm) = {
+            let cfg = self.config.read();
+            (cfg.enable_meteora_cpmm, cfg.enable_meteora_dlmm)
+        };
+        let pubkeys = collect_pool_explicit_pubkeys_from_cached_state(
+            pool,
+            &state,
+            enable_meteora_cpmm,
+            enable_meteora_dlmm,
+        );
+        if pubkeys.is_empty() {
+            return AdmissionResult::RejectedProtected;
+        }
+        let consumer = consumer_id_for_geyser_pin(Some(pin));
+        desired.try_admit_group(consumer, OwnerKey::Pool(pool), pubkeys)
     }
 
     fn collect_explicit_snapshot_rows(&self) -> Vec<ExplicitSnapshotRow> {
@@ -2515,9 +2820,12 @@ impl MarketDataContext {
             .collect()
     }
 
-    fn apply_explicit_set_snapshot_impl(&self, snapshot: &ExplicitSetSnapshot) -> usize {
+    fn apply_explicit_set_snapshot_impl(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        snapshot: &ExplicitSetSnapshot,
+    ) -> usize {
         let now = Instant::now();
-        let mut restored = 0usize;
         for (pool, mint) in &snapshot.pool_mint_map {
             self.pool_mint_map
                 .write()
@@ -2537,15 +2845,38 @@ impl MarketDataContext {
                 self.hot_pool_registry.pin_arb_pool(pool);
             }
         }
+
+        let mut converge_rows = Vec::with_capacity(snapshot.rows.len());
         for row in &snapshot.rows {
             let Ok(pk) = Pubkey::from_str(&row.pubkey) else {
                 continue;
             };
+            let consumer = match row.consumer {
+                SnapshotConsumer::Wallet => ConsumerId::Wallet,
+                SnapshotConsumer::Momentum => ConsumerId::Momentum,
+                SnapshotConsumer::Arb => ConsumerId::Arb,
+                SnapshotConsumer::Tracker => ConsumerId::Tracker,
+            };
+            let pool = row.pool.as_deref().and_then(|s| Pubkey::from_str(s).ok());
+            converge_rows.push((pk, consumer, pool));
+        }
+        desired.set_max_explicit_pubkeys(self.config.read().max_tracked_accounts);
+        desired.converge_from_rows(&converge_rows);
+        let admitted = desired.snapshot_pubkeys();
+
+        let mut restored = 0usize;
+        for row in &snapshot.rows {
+            let Ok(pk) = Pubkey::from_str(&row.pubkey) else {
+                continue;
+            };
+            if !admitted.contains(&pk) {
+                continue;
+            }
             let pin = snapshot_consumer_to_geyser_pin(row.consumer);
             let pool = row.pool.as_deref().and_then(|s| Pubkey::from_str(s).ok());
             match row.kind {
                 ExplicitAccountKind::Mint => {
-                    let _ = self.track_mint_for_geyser_metadata(pk, Some(pin));
+                    let _ = self.track_mint_for_geyser_metadata(pk, pin);
                     if self.tracked_mints.read().contains_key(&pk) {
                         restored += 1;
                     }
@@ -2568,8 +2899,8 @@ impl MarketDataContext {
                                 is_base_vault: true,
                                 last_balance: std::sync::atomic::AtomicU64::new(0),
                                 last_used_at: now,
-                                pinned: true,
-                                pin: Some(pin),
+                                pinned: pin.is_some(),
+                                pin,
                                 active_id: None,
                                 bin_step: None,
                                 sibling_vault: None,
@@ -2583,9 +2914,12 @@ impl MarketDataContext {
                         Entry::Occupied(mut e) => {
                             let v = e.get_mut();
                             v.last_used_at = now;
-                            if Self::geyser_pin_may_promote(v.pin, pin) {
-                                v.pinned = true;
-                                v.pin = Some(pin);
+                            if pin
+                                .map(|p| Self::geyser_pin_may_promote(v.pin, p))
+                                .unwrap_or(v.pin.is_none())
+                            {
+                                v.pinned = pin.is_some();
+                                v.pin = pin;
                             }
                             restored += 1;
                         }
@@ -2602,8 +2936,8 @@ impl MarketDataContext {
                                 bin_array_index: 0,
                                 bin_step: 0,
                                 last_used_at: now,
-                                pinned: true,
-                                pin: Some(pin),
+                                pinned: pin.is_some(),
+                                pin,
                             });
                             drop(bins);
                             if pool_addr != Pubkey::default() {
@@ -2614,9 +2948,12 @@ impl MarketDataContext {
                         Entry::Occupied(mut e) => {
                             let b = e.get_mut();
                             b.last_used_at = now;
-                            if Self::geyser_pin_may_promote(b.pin, pin) {
-                                b.pinned = true;
-                                b.pin = Some(pin);
+                            if pin
+                                .map(|p| Self::geyser_pin_may_promote(b.pin, p))
+                                .unwrap_or(b.pin.is_none())
+                            {
+                                b.pinned = pin.is_some();
+                                b.pin = pin;
                             }
                             restored += 1;
                         }
@@ -2624,9 +2961,11 @@ impl MarketDataContext {
                 }
             }
         }
-        self.broadcast_tracked_geyser_explicit_to_merge();
+        self.prune_tracked_maps_to_desired(desired);
         self.refresh_tracked_membership_snapshot();
         self.refresh_hot_pool_registry_gauges();
+        self.explicit_admission_invalidate
+            .store(true, Ordering::Relaxed);
         restored
     }
 
@@ -3102,17 +3441,6 @@ impl MarketDataContext {
         }
     }
 
-    fn continue_geyser_evict_with_deadline(&self, deadline: Instant) -> bool {
-        self.sync_geyser_tracked_accounts_core_with_deadline(deadline)
-    }
-
-    /// Debounced TX-path flush on md-state: bounded eviction + broadcast when complete.
-    fn sync_geyser_tracked_accounts_batched_flush_with_deadline(&self, deadline: Instant) -> bool {
-        set_market_data_geyser_sync_pending(0);
-        record_market_data_geyser_sync_batch_total();
-        self.sync_geyser_tracked_accounts_core_with_deadline(deadline)
-    }
-
     fn sync_geyser_tracked_accounts_core(&self) {
         let deadline = Instant::now() + Duration::from_secs(300);
         while !self.sync_geyser_tracked_accounts_core_with_deadline(deadline)
@@ -3292,6 +3620,26 @@ impl MarketDataContext {
                 &wallet_rx,
             );
         }
+    }
+
+    /// Track mint pubkey for Geyser `TokenMintInfo` / metadata. Returns `true` if explicit pubkey set changed.
+    fn track_mint_for_geyser_metadata_admitted(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        mint: Pubkey,
+        pin: Option<GeyserPinReason>,
+    ) -> bool {
+        let consumer = consumer_id_for_geyser_pin(pin);
+        let owner = OwnerKey::Mint(mint);
+        let admission = desired.try_admit_group(consumer, owner, HashSet::from([mint]));
+        match admission {
+            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {}
+            rejected => {
+                record_admission_rejection(consumer, rejected);
+                return false;
+            }
+        }
+        self.track_mint_for_geyser_metadata(mint, pin)
     }
 
     /// Track mint pubkey for Geyser `TokenMintInfo` / metadata. Returns `true` if explicit pubkey set changed.
@@ -3693,7 +4041,12 @@ impl MarketDataContext {
 
     /// PR-D / Phase 3: explicit vault/bin subscriptions when cache has layout.
     /// Returns whether any tracked set changed. Caller schedules debounced Geyser push.
-    fn register_geyser_reserves_for_active_pool(&self, pool: Pubkey, pin: GeyserPinReason) -> bool {
+    fn register_geyser_reserves_for_active_pool(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        pool: Pubkey,
+        pin: GeyserPinReason,
+    ) -> bool {
         if self.live_pool_cache.get(&pool).is_none() {
             debug!(
                 run_id = %self.run_id,
@@ -3703,15 +4056,36 @@ impl MarketDataContext {
             );
             return false;
         }
-        self.register_geyser_reserves_impl(pool, pin)
+        let admission = self.try_admit_pool_explicit_group(desired, pool, pin);
+        match admission {
+            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
+                self.register_geyser_reserves_impl(pool, pin)
+            }
+            rejected => {
+                record_admission_rejection(consumer_id_for_geyser_pin(Some(pin)), rejected);
+                false
+            }
+        }
     }
 
-    fn register_geyser_reserves_for_momentum_active_pool(&self, pool: Pubkey) -> bool {
-        self.register_geyser_reserves_for_active_pool(pool, GeyserPinReason::MomentumActive)
+    fn register_geyser_reserves_for_momentum_active_pool(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        pool: Pubkey,
+    ) -> bool {
+        self.register_geyser_reserves_for_active_pool(
+            desired,
+            pool,
+            GeyserPinReason::MomentumActive,
+        )
     }
 
-    fn register_geyser_reserves_for_arb_active_pool(&self, pool: Pubkey) -> bool {
-        self.register_geyser_reserves_for_active_pool(pool, GeyserPinReason::ArbMultiDex)
+    fn register_geyser_reserves_for_arb_active_pool(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        pool: Pubkey,
+    ) -> bool {
+        self.register_geyser_reserves_for_active_pool(desired, pool, GeyserPinReason::ArbMultiDex)
     }
 
     fn register_meteora_dlmm_bin_arrays(
@@ -3882,14 +4256,18 @@ impl MarketDataContext {
     }
 
     /// PR-D / PR169b: apply momentum-bot active pool pin updates (actor-only writer; caller schedules sync).
-    fn apply_momentum_active_pools_update(&self, update: &MomentumActivePoolsUpdate) -> bool {
+    fn apply_momentum_active_pools_update(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        update: &MomentumActivePoolsUpdate,
+    ) -> bool {
         record_market_data_momentum_active_pool_messages_total();
         let mut batch_dirty = false;
         if update.full_active_snapshot {
-            batch_dirty |= self.apply_momentum_snapshot_reconcile(&update.active);
+            batch_dirty |= self.apply_momentum_snapshot_reconcile(desired, &update.active);
         }
-        batch_dirty |= self.apply_momentum_removed_entries(&update.removed);
-        batch_dirty |= self.apply_momentum_active_entries(&update.active);
+        batch_dirty |= self.apply_momentum_removed_entries(desired, &update.removed);
+        batch_dirty |= self.apply_momentum_active_entries(desired, &update.active);
         if !batch_dirty {
             self.refresh_geyser_pins_gauge();
         }
@@ -3898,7 +4276,11 @@ impl MarketDataContext {
     }
 
     /// PR169c: snapshot reconcile only (`full_active_snapshot` target set).
-    fn apply_momentum_snapshot_reconcile(&self, active: &[MomentumActivePoolEntry]) -> bool {
+    fn apply_momentum_snapshot_reconcile(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        active: &[MomentumActivePoolEntry],
+    ) -> bool {
         let mut target: HashSet<(Pubkey, Pubkey)> = HashSet::new();
         for a in active {
             let Ok(mint_pk) = Pubkey::from_str(a.mint.trim()) else {
@@ -3921,14 +4303,18 @@ impl MarketDataContext {
         let mut batch_dirty = false;
         let before = self.hot_pool_registry.snapshot_pairs();
         for (m, p) in before.difference(&target) {
-            if self.clear_momentum_geyser_reserves_for_active_entry(*m, *p) {
+            if self.clear_momentum_geyser_reserves_for_active_entry(desired, *m, *p) {
                 batch_dirty = true;
             }
         }
         batch_dirty
     }
 
-    fn apply_momentum_removed_entries(&self, removed: &[MomentumRemovedPoolEntry]) -> bool {
+    fn apply_momentum_removed_entries(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        removed: &[MomentumRemovedPoolEntry],
+    ) -> bool {
         let mut batch_dirty = false;
         for r in removed {
             let Ok(mint_pk) = Pubkey::from_str(r.mint.trim()) else {
@@ -3939,14 +4325,18 @@ impl MarketDataContext {
                 warn!(pool = %r.pool, "MomentumActivePoolsUpdate.removed: invalid pool");
                 continue;
             };
-            if self.clear_momentum_geyser_reserves_for_active_entry(mint_pk, pool_pk) {
+            if self.clear_momentum_geyser_reserves_for_active_entry(desired, mint_pk, pool_pk) {
                 batch_dirty = true;
             }
         }
         batch_dirty
     }
 
-    fn apply_momentum_active_entries(&self, active: &[MomentumActivePoolEntry]) -> bool {
+    fn apply_momentum_active_entries(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        active: &[MomentumActivePoolEntry],
+    ) -> bool {
         let mut batch_dirty = false;
         for a in active {
             let Ok(mint_pk) = Pubkey::from_str(a.mint.trim()) else {
@@ -3958,7 +4348,7 @@ impl MarketDataContext {
                 continue;
             };
             self.hot_pool_registry.pin_pool(mint_pk, pool_pk);
-            if self.register_geyser_reserves_for_momentum_active_pool(pool_pk) {
+            if self.register_geyser_reserves_for_momentum_active_pool(desired, pool_pk) {
                 batch_dirty = true;
             }
             let _ = &a.pin_reason;
@@ -3988,8 +4378,14 @@ impl MarketDataContext {
     }
 
     /// Clear `MomentumActive` pins for one `(mint, pool)` side; never demotes [`GeyserPinReason::Wallet`].
-    fn clear_momentum_geyser_reserves_for_active_entry(&self, mint: Pubkey, pool: Pubkey) -> bool {
+    fn clear_momentum_geyser_reserves_for_active_entry(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        mint: Pubkey,
+        pool: Pubkey,
+    ) -> bool {
         self.hot_pool_registry.unpin_pool(mint, pool);
+        desired.remove_group(ConsumerId::Momentum, OwnerKey::Pool(pool));
         let mut changed = false;
         // Pool-level reserve pins are shared: only demote vaults/bin arrays when no `(m, pool)`
         // row remains after this unpin (PR #147 follow-up).
@@ -4051,14 +4447,18 @@ impl MarketDataContext {
     }
 
     /// Phase 3: apply arb-strategy track_requests pin updates (md-track-worker only).
-    fn apply_arb_track_requests_update(&self, update: &ArbTrackRequestsUpdate) -> bool {
+    fn apply_arb_track_requests_update(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        update: &ArbTrackRequestsUpdate,
+    ) -> bool {
         record_market_data_arb_track_requests_messages_total();
         let mut batch_dirty = false;
         if update.reconcile {
-            batch_dirty |= self.apply_arb_snapshot_reconcile(&update.active);
+            batch_dirty |= self.apply_arb_snapshot_reconcile(desired, &update.active);
         }
-        batch_dirty |= self.apply_arb_removed_entries(&update.removed);
-        batch_dirty |= self.apply_arb_active_entries(&update.active);
+        batch_dirty |= self.apply_arb_removed_entries(desired, &update.removed);
+        batch_dirty |= self.apply_arb_active_entries(desired, &update.active);
         if !batch_dirty {
             self.refresh_geyser_pins_gauge();
         }
@@ -4066,7 +4466,11 @@ impl MarketDataContext {
         batch_dirty
     }
 
-    fn apply_arb_snapshot_reconcile(&self, active: &[ArbTrackActiveEntry]) -> bool {
+    fn apply_arb_snapshot_reconcile(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        active: &[ArbTrackActiveEntry],
+    ) -> bool {
         let mut target: HashSet<Pubkey> = HashSet::new();
         for a in active {
             let Ok(pool_pk) = Pubkey::from_str(a.pool.trim()) else {
@@ -4085,28 +4489,36 @@ impl MarketDataContext {
         let mut batch_dirty = false;
         let before = self.hot_pool_registry.snapshot_arb_pools();
         for pool in before.difference(&target) {
-            if self.clear_arb_geyser_reserves_for_pool(*pool) {
+            if self.clear_arb_geyser_reserves_for_pool(desired, *pool) {
                 batch_dirty = true;
             }
         }
         batch_dirty
     }
 
-    fn apply_arb_removed_entries(&self, removed: &[ArbTrackRemovedEntry]) -> bool {
+    fn apply_arb_removed_entries(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        removed: &[ArbTrackRemovedEntry],
+    ) -> bool {
         let mut batch_dirty = false;
         for r in removed {
             let Ok(pool_pk) = Pubkey::from_str(r.pool.trim()) else {
                 warn!(pool = %r.pool, "ArbTrackRequestsUpdate.removed: invalid pool");
                 continue;
             };
-            if self.clear_arb_geyser_reserves_for_pool(pool_pk) {
+            if self.clear_arb_geyser_reserves_for_pool(desired, pool_pk) {
                 batch_dirty = true;
             }
         }
         batch_dirty
     }
 
-    fn apply_arb_active_entries(&self, active: &[ArbTrackActiveEntry]) -> bool {
+    fn apply_arb_active_entries(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        active: &[ArbTrackActiveEntry],
+    ) -> bool {
         let mut batch_dirty = false;
         for a in active {
             let Ok(pool_pk) = Pubkey::from_str(a.pool.trim()) else {
@@ -4114,7 +4526,7 @@ impl MarketDataContext {
                 continue;
             };
             self.hot_pool_registry.pin_arb_pool(pool_pk);
-            if self.register_geyser_reserves_for_arb_active_pool(pool_pk) {
+            if self.register_geyser_reserves_for_arb_active_pool(desired, pool_pk) {
                 batch_dirty = true;
             } else {
                 let category = if self.live_pool_cache.get(&pool_pk).is_none() {
@@ -4163,8 +4575,13 @@ impl MarketDataContext {
     }
 
     /// Clear Arb consumer pins for one pool; never demotes [`GeyserPinReason::Wallet`] or Momentum.
-    fn clear_arb_geyser_reserves_for_pool(&self, pool: Pubkey) -> bool {
+    fn clear_arb_geyser_reserves_for_pool(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        pool: Pubkey,
+    ) -> bool {
         self.hot_pool_registry.unpin_arb_pool(pool);
+        desired.remove_group(ConsumerId::Arb, OwnerKey::Pool(pool));
         let mut changed = false;
         if !self.hot_pool_registry.pool_has_arb(pool)
             && !self.hot_pool_registry.pool_has_any_pin(pool)
@@ -5077,6 +5494,22 @@ fn backfill_scope48_metadata_foreign_confirmed_sell(exec: &mut ExecutionResult) 
     );
     exec.metadata
         .insert("sell_untracked_ata".to_string(), "true".to_string());
+}
+
+#[cfg(test)]
+impl MarketDataContext {
+    fn apply_momentum_active_pools_update_for_test(
+        &self,
+        update: &MomentumActivePoolsUpdate,
+    ) -> bool {
+        let mut desired = DesiredExplicitSet::new(self.config.read().max_tracked_accounts);
+        self.apply_momentum_active_pools_update(&mut desired, update)
+    }
+
+    fn apply_arb_track_requests_update_for_test(&self, update: &ArbTrackRequestsUpdate) -> bool {
+        let mut desired = DesiredExplicitSet::new(self.config.read().max_tracked_accounts);
+        self.apply_arb_track_requests_update(&mut desired, update)
+    }
 }
 
 #[cfg(test)]
@@ -6331,6 +6764,7 @@ async fn main() -> Result<()> {
         last_momentum_snapshot_target: parking_lot::RwLock::new(None),
         last_arb_snapshot_target: parking_lot::RwLock::new(None),
         dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+        explicit_admission_invalidate: AtomicBool::new(false),
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -9936,6 +10370,7 @@ mod wallet_snapshot_stale_cleanup_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            explicit_admission_invalidate: AtomicBool::new(false),
         }
     }
 
@@ -10156,6 +10591,7 @@ mod wallet_tx_meta_balance_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            explicit_admission_invalidate: AtomicBool::new(false),
         })
     }
 
@@ -10495,6 +10931,10 @@ mod pr_b_geyser_tracking_tests {
 
     fn test_noop_track_worker_sender() -> TrackWorkerSender {
         spawn_noop_track_worker_sender(4096)
+    }
+
+    fn test_desired_set(ctx: &MarketDataContext) -> DesiredExplicitSet {
+        DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts)
     }
 
     fn test_inline_track_worker_sender(ctx: &Arc<MarketDataContext>) -> TrackWorkerSender {
@@ -11029,6 +11469,7 @@ mod pr_b_geyser_tracking_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            explicit_admission_invalidate: AtomicBool::new(false),
         })
     }
 
@@ -11101,6 +11542,7 @@ mod pr_b_geyser_tracking_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            explicit_admission_invalidate: AtomicBool::new(false),
         });
         (
             ctx,
@@ -11149,7 +11591,7 @@ mod pr_b_geyser_tracking_tests {
             removed: vec![],
             full_active_snapshot: false,
         };
-        ctx.apply_momentum_active_pools_update(&update);
+        ctx.apply_momentum_active_pools_update_for_test(&update);
 
         let vs = ctx.tracked_vaults.read();
         assert_eq!(
@@ -11191,7 +11633,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
 
-        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
+        ctx.apply_momentum_active_pools_update_for_test(&MomentumActivePoolsUpdate {
             version: 1,
             ts_unix_ms: 1,
             active: vec![MomentumActivePoolEntry {
@@ -11211,7 +11653,7 @@ mod pr_b_geyser_tracking_tests {
             }
         }
 
-        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
+        ctx.apply_momentum_active_pools_update_for_test(&MomentumActivePoolsUpdate {
             version: 1,
             ts_unix_ms: 2,
             active: vec![],
@@ -11263,7 +11705,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
 
-        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
+        ctx.apply_momentum_active_pools_update_for_test(&MomentumActivePoolsUpdate {
             version: 1,
             ts_unix_ms: 1,
             active: vec![
@@ -11282,7 +11724,7 @@ mod pr_b_geyser_tracking_tests {
             full_active_snapshot: false,
         });
 
-        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
+        ctx.apply_momentum_active_pools_update_for_test(&MomentumActivePoolsUpdate {
             version: 1,
             ts_unix_ms: 2,
             active: vec![],
@@ -11343,7 +11785,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
 
-        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
+        ctx.apply_momentum_active_pools_update_for_test(&MomentumActivePoolsUpdate {
             version: 1,
             ts_unix_ms: 1,
             active: vec![
@@ -11370,7 +11812,7 @@ mod pr_b_geyser_tracking_tests {
             "setup: WSOL leg tracked for pool_a"
         );
 
-        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
+        ctx.apply_momentum_active_pools_update_for_test(&MomentumActivePoolsUpdate {
             version: 1,
             ts_unix_ms: 2,
             active: vec![],
@@ -12765,10 +13207,10 @@ mod pr_b_geyser_tracking_tests {
         ];
 
         for u in &updates {
-            ctx_seq.apply_momentum_active_pools_update(u);
+            ctx_seq.apply_momentum_active_pools_update_for_test(u);
         }
         let merged = merge_momentum_active_pools_updates(&updates).expect("merged");
-        ctx_merged.apply_momentum_active_pools_update(&merged);
+        ctx_merged.apply_momentum_active_pools_update_for_test(&merged);
 
         assert_eq!(pin_count(&ctx_seq), pin_count(&ctx_merged));
         assert_eq!(
@@ -13708,7 +14150,10 @@ mod pr_b_geyser_tracking_tests {
             }),
             1,
         );
-        assert!(ctx.register_geyser_reserves_for_arb_active_pool(pool));
+        assert!(ctx.register_geyser_reserves_for_arb_active_pool(
+            &mut DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts),
+            pool,
+        ));
         let before = ctx.tracked_bin_arrays.read().len();
         assert!(
             !ctx.maybe_refresh_arb_dlmm_bin_window(pool, 10),
@@ -13812,12 +14257,14 @@ mod pr_b_geyser_tracking_tests {
         let before = ctx.snapshot_explicit_subscription_pubkeys();
         use ironcrab::metrics::MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL;
         let skip0 = MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL.load(Ordering::Relaxed);
+        let mut admission_converged = false;
         assert!(track_worker_execute_coalesced_push(
             &ctx,
             &mut desired,
             before,
             false,
             false,
+            &mut admission_converged,
         ));
         assert!(
             MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL.load(Ordering::Relaxed) > skip0,
@@ -14014,7 +14461,8 @@ mod pr_b_geyser_tracking_tests {
         );
         assert!(fresh.snapshot_explicit_subscription_pubkeys().is_empty());
 
-        let restored = fresh.apply_explicit_set_snapshot_impl(&snapshot);
+        let mut desired_restore = DesiredExplicitSet::new(fresh.config.read().max_tracked_accounts);
+        let restored = fresh.apply_explicit_set_snapshot_impl(&mut desired_restore, &snapshot);
         assert!(restored > 0);
         assert!(fresh
             .snapshot_explicit_subscription_pubkeys()
@@ -14054,12 +14502,14 @@ mod pr_b_geyser_tracking_tests {
         let keys = ctx.snapshot_explicit_subscription_pubkeys();
         use ironcrab::metrics::MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL;
         let skip0 = MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL.load(Ordering::Relaxed);
+        let mut admission_converged = false;
         assert!(track_worker_execute_coalesced_push(
             &ctx,
             &mut desired,
             keys,
             false,
             false,
+            &mut admission_converged,
         ));
         assert!(
             MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL.load(Ordering::Relaxed) > skip0,
@@ -14690,7 +15140,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
 
-        ctx.apply_arb_track_requests_update(&ArbTrackRequestsUpdate {
+        ctx.apply_arb_track_requests_update_for_test(&ArbTrackRequestsUpdate {
             version: 1,
             ts_unix_ms: 1,
             active: vec![ArbTrackActiveEntry {
@@ -14709,7 +15159,7 @@ mod pr_b_geyser_tracking_tests {
             }
         }
 
-        ctx.apply_arb_track_requests_update(&ArbTrackRequestsUpdate {
+        ctx.apply_arb_track_requests_update_for_test(&ArbTrackRequestsUpdate {
             version: 1,
             ts_unix_ms: 2,
             active: vec![],

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3164,6 +3164,7 @@ impl MarketDataContext {
             consumer: consumer_id_for_geyser_pin(Some(pin)),
             owner: OwnerKey::Pool(pool),
             pin,
+            revision: 0,
         })
     }
 
@@ -16679,6 +16680,7 @@ mod pr_b_geyser_tracking_tests {
             consumer: ConsumerId::Momentum,
             owner: OwnerKey::Pool(pool),
             pin: GeyserPinReason::MomentumActive,
+            revision: 0,
         };
         assert_eq!(
             pending.upsert(PendingPoolCommand::RegisterReserves(mk_snapshot(pool_a))),
@@ -16692,7 +16694,12 @@ mod pr_b_geyser_tracking_tests {
     }
 
     #[test]
-    fn queue_full_replay_coalesces_all_pool_command_kinds() {
+    fn queue_full_replay_replays_newest_typed_snapshot_per_kind_path() {
+        use ironcrab::execution::live_pool_cache::MeteoraState;
+        use ironcrab::market_data::track::worker_commands::{
+            BinArrayExplicitRow, MintExplicitRow, VaultExplicitRow,
+        };
+
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
@@ -16700,59 +16707,115 @@ mod pr_b_geyser_tracking_tests {
         let pool = Pubkey::new_unique();
         let base = Pubkey::new_unique();
         let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
-        let coin = Pubkey::new_unique();
-        let pc = Pubkey::new_unique();
+        let reserve_x = Pubkey::new_unique();
+        let reserve_y = Pubkey::new_unique();
+        let bin_old = Pubkey::new_unique();
+        let bin_new = Pubkey::new_unique();
+        let mint_old = Pubkey::new_unique();
+        let mint_new = Pubkey::new_unique();
         ctx.live_pool_cache.upsert(
             pool,
-            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
-                token_0_mint: base,
-                token_1_mint: quote,
-                token_0_vault: coin,
-                token_1_vault: pc,
-                reserve_0: Some(1),
-                reserve_1: Some(1),
+            CachedPoolState::Meteora(MeteoraState {
+                token_x_mint: base,
+                token_y_mint: quote,
+                reserve_x,
+                reserve_y,
+                active_id: 8,
+                bin_step: 25,
+                reserve_x_balance: Some(1),
+                reserve_y_balance: Some(1),
             }),
             1,
         );
-        ctx.hot_pool_registry.pin_pool(base, pool);
-        let snapshot = ctx
-            .build_pool_explicit_snapshot(pool, GeyserPinReason::MomentumActive)
-            .expect("snapshot");
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+
+        let mk_typed = |vault_pk: Pubkey, bin_pk: Pubkey, mint_pk: Pubkey| PoolExplicitSnapshot {
+            pool,
+            vaults: vec![VaultExplicitRow {
+                pubkey: vault_pk,
+                dex: "meteora".into(),
+                base_mint: base,
+                quote_mint: quote,
+                is_base_vault: true,
+                sibling_vault: Some(reserve_y),
+                active_id: Some(8),
+                bin_step: Some(25),
+            }],
+            bin_arrays: vec![BinArrayExplicitRow {
+                pubkey: bin_pk,
+                bin_array_index: 1,
+                bin_step: 25,
+            }],
+            mints: vec![MintExplicitRow { pubkey: mint_pk }],
+            consumer: ConsumerId::Arb,
+            owner: OwnerKey::Pool(pool),
+            pin: GeyserPinReason::ArbMultiDex,
+            revision: 0,
+        };
+
+        let snapshot_reserve = mk_typed(reserve_x, bin_old, mint_old);
+        let snapshot_vault = mk_typed(reserve_x, bin_old, mint_old);
+        let snapshot_after_trade = mk_typed(reserve_x, bin_old, mint_old);
+        let snapshot_dlmm = mk_typed(reserve_x, bin_new, mint_new);
 
         let (sender, _rx, _) = ironcrab::market_data::track::track_worker_sender_for_test(1);
         *ctx.track_worker.write() = Some(sender.clone());
         assert!(enqueue_track_worker(
             &ctx,
             TrackWorkerCommand::RegisterPoolGeyserReserves {
-                snapshot: snapshot.clone(),
+                snapshot: snapshot_reserve,
             },
         ));
         assert!(!enqueue_track_worker(
             &ctx,
             TrackWorkerCommand::RegisterPoolVaultsFromAccount {
-                snapshot: snapshot.clone(),
+                snapshot: snapshot_vault,
             },
         ));
         assert!(!enqueue_track_worker(
             &ctx,
             TrackWorkerCommand::RegisterGeyserReservesAfterTrade {
-                snapshot: snapshot.clone(),
+                snapshot: snapshot_after_trade,
             },
         ));
         assert!(!enqueue_track_worker(
             &ctx,
             TrackWorkerCommand::RefreshDlmmBinWindow {
-                snapshot: snapshot.clone(),
-                new_active_id: 3,
+                snapshot: snapshot_dlmm,
+                new_active_id: 9,
             },
         ));
         assert!(ctx.track_worker_dirty.load(Ordering::Relaxed));
         assert_eq!(ctx.pending_pool_commands.pool_count(), 1);
 
+        let latest_rev = ctx
+            .pending_pool_commands
+            .latest_revision_for(pool, ConsumerId::Arb)
+            .expect("pending revision");
+        assert_eq!(
+            latest_rev, 3,
+            "three queue-full stashes assign monotonic revisions"
+        );
+
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         ctx.apply_pending_track_worker_work(&mut desired);
-        assert!(desired.contains(&coin));
-        assert!(desired.contains(&pc));
+
+        let group = desired
+            .snapshot_owner_groups()
+            .into_iter()
+            .find(|g| g.consumer == ConsumerId::Arb && g.owner == OwnerKey::Pool(pool))
+            .expect("arb owner group");
+        assert!(group.pubkeys.contains(&reserve_x));
+        assert!(group.pubkeys.contains(&bin_new));
+        assert!(group.pubkeys.contains(&mint_new));
+        assert!(!group.pubkeys.contains(&bin_old));
+        assert!(!group.pubkeys.contains(&mint_old));
+
+        assert!(ctx.tracked_vaults.read().contains_key(&reserve_x));
+        assert!(ctx.tracked_bin_arrays.read().contains_key(&bin_new));
+        assert!(!ctx.tracked_bin_arrays.read().contains_key(&bin_old));
+        assert!(ctx.tracked_mints.read().contains_key(&mint_new));
+        assert!(!ctx.tracked_mints.read().contains_key(&mint_old));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -80,13 +80,12 @@ use ironcrab::market_data::sidefx::{
     SidefxVaultMembershipView, SidefxWorkerHost, MARKET_DATA_MD_SIDEFX_QUEUE_CAP,
 };
 use ironcrab::market_data::track::{
-    arb_coalesce_try_send, explicit_set_snapshot_path, explicit_subscription_has_new_keys,
-    flush_explicit_set_snapshot, load_explicit_set_snapshot, momentum_coalesce_try_send,
-    pool_is_enrichment_member, spawn_track_worker, track_worker_try_enqueue, AdmissionResult,
-    ConsumerId, DesiredExplicitSet, ExplicitAccountKind, ExplicitSetSnapshot, ExplicitSnapshotRow,
-    OwnerKey, SnapshotConsumer, TrackPinReason, TrackWorkerCommand, TrackWorkerContext,
-    TrackWorkerSender, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
-    MARKET_DATA_TRACK_WORKER_COALESCE_MS,
+    arb_coalesce_try_send, explicit_set_snapshot_path, load_explicit_set_snapshot,
+    momentum_coalesce_try_send, owner_key_to_snapshot, pool_is_enrichment_member,
+    spawn_track_worker, track_worker_try_enqueue, AdmissionResult, ConsumerId, DesiredExplicitSet,
+    ExplicitAccountKind, ExplicitSetSnapshot, ExplicitSnapshotRow, OwnerKey, SnapshotConsumer,
+    SnapshotOwnerGroup, TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
+    EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP, MARKET_DATA_TRACK_WORKER_COALESCE_MS,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -182,7 +181,8 @@ const MARKET_DATA_GEYSER_SYNC_STARTUP_WINDOW: Duration = Duration::from_secs(120
 const MARKET_DATA_GEYSER_SYNC_STARTUP_MIN_MS: u64 = 250;
 /// PR233: max debounced Geyser sync flushes per second during startup burst.
 const MARKET_DATA_GEYSER_SYNC_FLUSH_MAX_PER_SEC: usize = 4;
-/// PR234: max LRU eviction steps per sync/evict slice on md-state.
+/// PR234: max LRU eviction steps per sync/evict slice on md-state (legacy path; tests only).
+#[allow(dead_code)]
 const MARKET_DATA_GEYSER_EVICT_MAX_STEPS_PER_FLUSH: usize = 16;
 /// PR234: md-state liveness poll interval (OS thread).
 const MARKET_DATA_MD_STATE_STALL_CHECK_INTERVAL: Duration = Duration::from_secs(10);
@@ -386,6 +386,7 @@ struct MarketDataSidefxHost {
     ctx: Arc<MarketDataContext>,
     publish_tx: Option<mpsc::Sender<AccountPathNatsJob>>,
     md_state: MdStateSender,
+    #[allow(dead_code)]
     track_worker: TrackWorkerSender,
 }
 
@@ -572,16 +573,8 @@ impl SidefxWorkerHost for MarketDataSidefxHost {
     }
 
     fn maybe_refresh_arb_dlmm_bin_window(&self, pool: Pubkey, new_active_id: i32) -> bool {
-        let changed = self
-            .ctx
-            .maybe_refresh_arb_dlmm_bin_window(pool, new_active_id);
-        if changed {
-            let _ = track_worker_try_enqueue(
-                &self.track_worker,
-                TrackWorkerCommand::ScheduleGeyserPushDebounced,
-            );
-        }
-        changed
+        self.ctx
+            .maybe_refresh_arb_dlmm_bin_window(pool, new_active_id)
     }
 }
 
@@ -1131,6 +1124,15 @@ struct MarketDataContext {
     dlmm_registered_active_id: parking_lot::RwLock<HashMap<Pubkey, i32>>,
     /// Track-worker: force explicit-admission reconvergence (config reload / cap shrink).
     explicit_admission_invalidate: AtomicBool,
+    /// Logical wallet explicit demand (wallet + WSOL + token ATAs) — separate from admitted physical set.
+    wallet_explicit_demand: parking_lot::RwLock<HashSet<Pubkey>>,
+    /// SSOT channel for physical Yellowstone explicit pubkeys (admitted Desired only).
+    admitted_explicit_tx: watch::Sender<Vec<Pubkey>>,
+    /// Set after track-worker spawn; producers enqueue bounded admission commands.
+    track_worker: parking_lot::RwLock<Option<TrackWorkerSender>>,
+    /// Fail-closed when mandatory wallet demand exceeds explicit cap.
+    geyser_explicit_ready: AtomicBool,
+    geyser_explicit_config_error: parking_lot::RwLock<Option<String>>,
 }
 
 #[derive(Debug, Default)]
@@ -1439,6 +1441,7 @@ impl GeyserLruIndex {
         });
     }
 
+    #[allow(dead_code)]
     fn pop_lru_candidate(
         &mut self,
         vaults: &std::collections::HashMap<Pubkey, VaultInfo>,
@@ -1882,9 +1885,21 @@ fn record_admission_rejection(consumer: ConsumerId, result: AdmissionResult) {
     let (reason, label) = match result {
         AdmissionResult::RejectedCap => ("cap", consumer_id_label(consumer)),
         AdmissionResult::RejectedProtected => ("protected", consumer_id_label(consumer)),
+        AdmissionResult::RejectedInvalidGroup => ("invalid_group", consumer_id_label(consumer)),
         AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => return,
     };
     inc_market_data_geyser_explicit_admission_rejected_total(label, reason);
+}
+
+fn geyser_pin_from_track_pin(pin: TrackPinReason) -> GeyserPinReason {
+    track_pin_to_geyser_pin(Some(pin)).expect("track pin maps to geyser pin")
+}
+
+fn enqueue_track_worker(ctx: &MarketDataContext, job: TrackWorkerCommand) -> bool {
+    let Some(sender) = ctx.track_worker.read().clone() else {
+        return false;
+    };
+    track_worker_try_enqueue(&sender, job)
 }
 
 fn collect_pool_explicit_pubkeys_from_cached_state(
@@ -2107,12 +2122,24 @@ impl TrackWorkerContext for MarketDataContext {
         self.refresh_tracked_membership_snapshot();
     }
 
-    fn explicit_pubkey_rows_for_desired_set(&self) -> Vec<(Pubkey, ConsumerId, Option<Pubkey>)> {
-        self.collect_explicit_pubkey_rows_for_convergence()
+    fn explicit_owner_groups_for_convergence(
+        &self,
+    ) -> Vec<(ConsumerId, OwnerKey, HashSet<Pubkey>)> {
+        self.collect_explicit_owner_groups_for_convergence()
     }
 
-    fn build_explicit_set_snapshot(&self) -> ExplicitSetSnapshot {
+    fn build_explicit_set_snapshot(&self, desired: &DesiredExplicitSet) -> ExplicitSetSnapshot {
         let mut snapshot = ExplicitSetSnapshot::new(Some(self.run_id.clone()));
+        snapshot.owner_groups = desired
+            .snapshot_owner_groups()
+            .into_iter()
+            .map(|g| SnapshotOwnerGroup {
+                consumer: g.consumer.into(),
+                owner: owner_key_to_snapshot(g.owner),
+                pubkeys: g.pubkeys.iter().map(|pk| pk.to_string()).collect(),
+                last_touched_gen: g.last_touched_gen,
+            })
+            .collect();
         snapshot.rows = self.collect_explicit_snapshot_rows();
         snapshot.pool_mint_map =
             self.collect_pool_mint_map_tier1(EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP);
@@ -2142,13 +2169,96 @@ impl TrackWorkerContext for MarketDataContext {
     }
 
     fn converge_explicit_admission(&self, desired: &mut DesiredExplicitSet) {
-        let rows = self.collect_explicit_pubkey_rows_for_convergence();
         desired.set_max_explicit_pubkeys(self.config.read().max_tracked_accounts);
-        desired.converge_from_rows(&rows);
+        let groups = self.collect_explicit_owner_groups_for_convergence();
+        desired.reconcile_owner_groups(groups);
+        self.sync_wallet_demand_to_desired(desired);
         self.prune_tracked_maps_to_desired(desired);
         self.pending_geyser_evict.store(false, Ordering::Relaxed);
         set_market_data_md_state_evict_pending(false);
         set_market_data_geyser_explicit_cap_overflow(desired.cap_overflow());
+    }
+
+    fn sync_wallet_explicit_demand(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        demand: HashSet<Pubkey>,
+    ) -> bool {
+        *self.wallet_explicit_demand.write() = demand.clone();
+        self.sync_wallet_demand_to_desired(desired)
+    }
+
+    fn commit_register_pool_geyser_reserves(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        pool: Pubkey,
+        pin: TrackPinReason,
+    ) -> bool {
+        self.register_geyser_reserves_for_active_pool(desired, pool, geyser_pin_from_track_pin(pin))
+    }
+
+    fn commit_register_pool_vaults_from_account(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        pool: Pubkey,
+    ) -> bool {
+        self.try_publish_balance_updated_from_cache(pool);
+        if !self.hot_pool_registry.is_hot_pool(pool) {
+            return false;
+        }
+        let changed = self.register_pool_vaults_from_account_worker(pool);
+        if changed {
+            let _ =
+                self.try_admit_pool_explicit_group(desired, pool, GeyserPinReason::MomentumActive);
+        }
+        changed
+    }
+
+    fn commit_register_geyser_reserves_after_trade(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        pool: Pubkey,
+    ) -> bool {
+        self.try_publish_balance_updated_from_cache(pool);
+        if !self.hot_pool_registry.pool_has_momentum(pool) {
+            return false;
+        }
+        let Some(state) = self.live_pool_cache.get(&pool) else {
+            return false;
+        };
+        let Some((base_mint, quote_mint)) = pool_mints_for_geyser_explicit_tracking(&state) else {
+            return false;
+        };
+        if !self.admit_geyser_explicit_pool_assets(pool, base_mint, quote_mint) {
+            return false;
+        }
+        let changed = self.register_geyser_reserves_impl(pool, GeyserPinReason::MomentumActive);
+        if changed {
+            let _ =
+                self.try_admit_pool_explicit_group(desired, pool, GeyserPinReason::MomentumActive);
+        }
+        changed
+    }
+
+    fn commit_refresh_dlmm_bin_window(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        pool: Pubkey,
+        new_active_id: i32,
+    ) -> bool {
+        let changed = self.maybe_refresh_arb_dlmm_bin_window_worker(pool, new_active_id);
+        if changed {
+            let _ = self.try_admit_pool_explicit_group(desired, pool, GeyserPinReason::ArbMultiDex);
+        }
+        changed
+    }
+
+    fn publish_admitted_explicit_physical(&self, desired: &DesiredExplicitSet) {
+        MarketDataContext::publish_admitted_explicit_physical(self, desired);
+    }
+
+    fn geyser_explicit_readiness_ok(&self) -> bool {
+        self.geyser_explicit_ready.load(Ordering::Relaxed)
     }
 
     fn prune_tracked_maps_to_desired(&self, desired: &DesiredExplicitSet) {
@@ -2469,13 +2579,16 @@ impl TxIngestHost for MarketDataContext {
         let Some(tracked_wallet) = self.tracked_wallet.as_ref() else {
             return;
         };
-        let mut accounts: Vec<Pubkey> = Vec::new();
-        accounts.push(tracked_wallet.wallet);
-        accounts.push(tracked_wallet.wsol_ata);
-        accounts.extend(self.tracked_wallet_token_accounts.read().iter().copied());
-        accounts.sort();
-        accounts.dedup();
-        let _ = self.tracked_wallet_tx.send(accounts);
+        let mut demand: HashSet<Pubkey> = HashSet::new();
+        demand.insert(tracked_wallet.wallet);
+        demand.insert(tracked_wallet.wsol_ata);
+        demand.extend(self.tracked_wallet_token_accounts.read().iter().copied());
+        *self.wallet_explicit_demand.write() = demand.clone();
+        let _ = enqueue_track_worker(
+            self,
+            TrackWorkerCommand::SyncWalletExplicitDemand { demand },
+        );
+        let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
     }
 
     fn tx_live_pool_cache(&self) -> &LivePoolCache {
@@ -2633,14 +2746,66 @@ impl MarketDataContext {
     }
 
     fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
-        let admitted = self.last_synced_explicit_pubkeys.read();
-        if !admitted.is_empty() {
-            return admitted.clone();
+        self.last_synced_explicit_pubkeys.read().clone()
+    }
+
+    fn collect_explicit_owner_groups_for_convergence(
+        &self,
+    ) -> Vec<(ConsumerId, OwnerKey, HashSet<Pubkey>)> {
+        let mut groups: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>> = HashMap::new();
+        for (pool_pk, pin) in self.iter_pinned_pools_for_convergence() {
+            let Some(state) = self.live_pool_cache.get(&pool_pk) else {
+                continue;
+            };
+            let consumer = consumer_id_for_geyser_pin(Some(pin));
+            let pubkeys = collect_pool_explicit_pubkeys_from_cached_state(
+                pool_pk,
+                &state,
+                self.config.read().enable_meteora_cpmm,
+                self.config.read().enable_meteora_dlmm,
+            );
+            if !pubkeys.is_empty() {
+                groups
+                    .entry((consumer, OwnerKey::Pool(pool_pk)))
+                    .or_default()
+                    .extend(pubkeys);
+            }
+        }
+        for (pk, m) in self.tracked_mints.read().iter() {
+            if matches!(m.pin, Some(GeyserPinReason::Wallet)) {
+                continue;
+            }
+            let owner = OwnerKey::Mint(*pk);
+            groups
+                .entry((consumer_id_for_geyser_pin(m.pin), owner))
+                .or_default()
+                .insert(*pk);
+        }
+        groups
+            .into_iter()
+            .map(|((consumer, owner), pubkeys)| (consumer, owner, pubkeys))
+            .collect()
+    }
+
+    fn iter_pinned_pools_for_convergence(&self) -> Vec<(Pubkey, GeyserPinReason)> {
+        let mut out = Vec::new();
+        for (_, pool) in self.hot_pool_registry.snapshot_pairs() {
+            out.push((pool, GeyserPinReason::MomentumActive));
+        }
+        for pool in self.hot_pool_registry.snapshot_arb_pools() {
+            out.push((pool, GeyserPinReason::ArbMultiDex));
+        }
+        out.sort_by_key(|(p, _)| *p);
+        out.dedup_by_key(|(p, _)| *p);
+        out
+    }
+
+    fn wallet_explicit_demand_pubkeys(&self) -> HashSet<Pubkey> {
+        let demand = self.wallet_explicit_demand.read().clone();
+        if !demand.is_empty() {
+            return demand;
         }
         let mut set = HashSet::new();
-        set.extend(self.tracked_mints.read().keys().copied());
-        set.extend(self.tracked_vaults.read().keys().copied());
-        set.extend(self.tracked_bin_arrays.read().keys().copied());
         if let Some(w) = &self.tracked_wallet {
             set.insert(w.wallet);
             set.insert(w.wsol_ata);
@@ -2649,6 +2814,103 @@ impl MarketDataContext {
         set
     }
 
+    fn sync_wallet_demand_to_desired(&self, desired: &mut DesiredExplicitSet) -> bool {
+        let demand = self.wallet_explicit_demand_pubkeys();
+        if demand.is_empty() {
+            desired.remove_group(ConsumerId::Wallet, OwnerKey::Wallet);
+            self.geyser_explicit_ready.store(true, Ordering::Relaxed);
+            *self.geyser_explicit_config_error.write() = None;
+            return false;
+        }
+        if desired.wallet_demand_exceeds_cap(&demand) {
+            let msg = format!(
+                "wallet explicit demand ({} pubkeys) exceeds max_tracked_accounts cap ({})",
+                demand.len(),
+                desired.max_explicit_pubkeys()
+            );
+            self.geyser_explicit_ready.store(false, Ordering::Relaxed);
+            *self.geyser_explicit_config_error.write() = Some(msg);
+            return false;
+        }
+        let result = desired.try_admit_wallet_demand(demand);
+        match result {
+            AdmissionResult::RejectedCap => {
+                let msg = format!(
+                    "wallet explicit admission rejected at cap ({})",
+                    desired.max_explicit_pubkeys()
+                );
+                self.geyser_explicit_ready.store(false, Ordering::Relaxed);
+                *self.geyser_explicit_config_error.write() = Some(msg);
+                false
+            }
+            AdmissionResult::RejectedInvalidGroup => {
+                record_admission_rejection(ConsumerId::Wallet, result);
+                false
+            }
+            AdmissionResult::RejectedProtected => {
+                record_admission_rejection(ConsumerId::Wallet, result);
+                false
+            }
+            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
+                self.geyser_explicit_ready.store(true, Ordering::Relaxed);
+                *self.geyser_explicit_config_error.write() = None;
+                true
+            }
+        }
+    }
+
+    fn request_wallet_explicit_resync(&self) {
+        let demand = self.wallet_explicit_demand_pubkeys();
+        let _ = enqueue_track_worker(
+            self,
+            TrackWorkerCommand::SyncWalletExplicitDemand { demand },
+        );
+        let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
+    }
+
+    fn publish_admitted_explicit_physical(&self, desired: &DesiredExplicitSet) {
+        let admitted = desired.snapshot_pubkeys();
+        let mut sorted: Vec<Pubkey> = admitted.iter().copied().collect();
+        sorted.sort();
+        sorted.dedup();
+        let n = sorted.len();
+        let _ = self.admitted_explicit_tx.send(sorted);
+        geyser_metrics_set_subscription_accounts(n);
+        let mints: Vec<Pubkey> = self
+            .tracked_mints
+            .read()
+            .keys()
+            .filter(|pk| admitted.contains(pk))
+            .copied()
+            .collect();
+        let vaults: Vec<Pubkey> = self
+            .tracked_vaults
+            .read()
+            .keys()
+            .filter(|pk| admitted.contains(pk))
+            .copied()
+            .collect();
+        let bins: Vec<Pubkey> = self
+            .tracked_bin_arrays
+            .read()
+            .keys()
+            .filter(|pk| admitted.contains(pk))
+            .copied()
+            .collect();
+        let _ = self.tracked_mints_tx.send(mints);
+        let _ = self.tracked_vaults_tx.send(vaults);
+        let _ = self.tracked_bin_arrays_tx.send(bins);
+        self.refresh_geyser_pins_gauge();
+    }
+
+    #[allow(dead_code)]
+    fn build_explicit_set_snapshot_physical(&self) -> ExplicitSetSnapshot {
+        let mut desired = DesiredExplicitSet::new(self.config.read().max_tracked_accounts);
+        self.converge_explicit_admission(&mut desired);
+        TrackWorkerContext::build_explicit_set_snapshot(self, &desired)
+    }
+
+    #[allow(dead_code)]
     fn collect_explicit_pubkey_rows_for_convergence(
         &self,
     ) -> Vec<(Pubkey, ConsumerId, Option<Pubkey>)> {
@@ -2705,7 +2967,6 @@ impl MarketDataContext {
         self.tracked_wallet_token_accounts
             .write()
             .retain(|pk| admitted.contains(pk));
-        self.broadcast_tracked_geyser_explicit_to_merge();
     }
 
     fn refresh_explicit_admission_metrics(&self, desired: &DesiredExplicitSet) {
@@ -2741,7 +3002,7 @@ impl MarketDataContext {
         desired: &DesiredExplicitSet,
     ) -> bool {
         self.prune_tracked_maps_to_desired(desired);
-        self.broadcast_tracked_geyser_explicit_to_merge();
+        self.publish_admitted_explicit_physical(desired);
         *self.last_synced_explicit_pubkeys.write() = desired.snapshot_pubkeys();
         true
     }
@@ -2861,7 +3122,7 @@ impl MarketDataContext {
             converge_rows.push((pk, consumer, pool));
         }
         desired.set_max_explicit_pubkeys(self.config.read().max_tracked_accounts);
-        desired.converge_from_rows(&converge_rows);
+        desired.restore_owner_groups(&snapshot.to_owner_group_snapshots());
         let admitted = desired.snapshot_pubkeys();
 
         let mut restored = 0usize;
@@ -2962,6 +3223,8 @@ impl MarketDataContext {
             }
         }
         self.prune_tracked_maps_to_desired(desired);
+        *self.last_synced_explicit_pubkeys.write() = desired.snapshot_pubkeys();
+        self.publish_admitted_explicit_physical(desired);
         self.refresh_tracked_membership_snapshot();
         self.refresh_hot_pool_registry_gauges();
         self.explicit_admission_invalidate
@@ -3181,6 +3444,7 @@ impl MarketDataContext {
         }
     }
 
+    #[allow(dead_code)]
     fn combined_geyser_explicit_accounts(&self) -> usize {
         self.tracked_vaults.read().len()
             + self.tracked_bin_arrays.read().len()
@@ -3384,6 +3648,7 @@ impl MarketDataContext {
     }
 
     /// PR234: budgeted LRU eviction — max steps and wall deadline per md-state slice.
+    #[allow(dead_code)]
     fn evict_geyser_unpinned_lru_budgeted(&self, deadline: Instant) -> bool {
         let cap = self.config.read().max_tracked_accounts;
         let mut steps = 0usize;
@@ -3416,6 +3681,7 @@ impl MarketDataContext {
     /// Cross-type LRU can evict vaults/bin-arrays/mints from any map; callers must run
     /// [`Self::sync_geyser_tracked_accounts`] so every channel refreshes and the combined Geyser
     /// subscription list stays in sync.
+    #[allow(dead_code)]
     fn broadcast_tracked_geyser_explicit_to_merge(&self) {
         let mints: Vec<Pubkey> = self.tracked_mints.read().keys().copied().collect();
         let vaults: Vec<Pubkey> = self.tracked_vaults.read().keys().copied().collect();
@@ -3427,6 +3693,7 @@ impl MarketDataContext {
     }
 
     /// Returns true when eviction finished (cap OK or no LRU candidates) and broadcast/snapshot applied.
+    #[allow(dead_code)]
     fn sync_geyser_tracked_accounts_core_with_deadline(&self, deadline: Instant) -> bool {
         let cap_reached = self.evict_geyser_unpinned_lru_budgeted(deadline);
         let evict_complete = cap_reached || !self.pending_geyser_evict.load(Ordering::Relaxed);
@@ -3441,6 +3708,7 @@ impl MarketDataContext {
         }
     }
 
+    #[allow(dead_code)]
     fn sync_geyser_tracked_accounts_core(&self) {
         let deadline = Instant::now() + Duration::from_secs(300);
         while !self.sync_geyser_tracked_accounts_core_with_deadline(deadline)
@@ -3453,7 +3721,14 @@ impl MarketDataContext {
     /// Immediate subscription-list sync (momentum pins, wallet tracks, config, account-path admission, …).
     fn sync_geyser_tracked_accounts(&self) {
         record_market_data_geyser_sync_immediate_total();
-        self.sync_geyser_tracked_accounts_core();
+        let mut desired = DesiredExplicitSet::new(self.config.read().max_tracked_accounts);
+        self.converge_explicit_admission(&mut desired);
+        let deadline = Instant::now() + Duration::from_secs(300);
+        while !self.sync_geyser_tracked_accounts_from_desired_with_deadline(deadline, &desired)
+            && self.pending_geyser_evict.load(Ordering::Relaxed)
+        {
+            std::thread::yield_now();
+        }
     }
 
     /// PR167: longer debounce during startup pin burst (min 250 ms for first 120 s).
@@ -3534,10 +3809,26 @@ impl MarketDataContext {
         }
     }
 
+    /// Forward admitted explicit SSOT watch updates to Geyser listener (legacy; production uses admitted channel directly).
+    #[allow(dead_code)]
+    async fn run_admitted_explicit_forward_loop(
+        mut admitted_rx: watch::Receiver<Vec<Pubkey>>,
+        combined_tx: watch::Sender<Vec<Pubkey>>,
+    ) {
+        loop {
+            if admitted_rx.changed().await.is_err() {
+                return;
+            }
+            let admitted = admitted_rx.borrow().clone();
+            let _ = combined_tx.send(admitted);
+        }
+    }
+
     /// PR161: merge four explicit-track `watch` streams into `combined_tracked_tx` with the same
     /// debounce window as [`Self::schedule_geyser_sync_batch_debounced`] (`geyser_sync_batch_ms`,
     /// clamped 10–100 ms). Reduces subscription-update churn when `broadcast_tracked_geyser_explicit_to_merge`
     /// fans out to multiple watch updates.
+    #[allow(dead_code)]
     fn schedule_geyser_tracked_merge_flush_debounced(
         debounce_timer: &Arc<parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>>,
         combined_tx: &watch::Sender<Vec<Pubkey>>,
@@ -3578,6 +3869,7 @@ impl MarketDataContext {
     }
 
     /// PR161: background loop merging explicit-track `watch` streams into `combined_tracked_tx` with debouncing.
+    #[allow(dead_code)]
     async fn run_geyser_tracked_accounts_merge_coalesce_loop(
         mut mints_rx: watch::Receiver<Vec<Pubkey>>,
         mut vaults_rx: watch::Receiver<Vec<Pubkey>>,
@@ -3831,24 +4123,9 @@ impl MarketDataContext {
     /// PR-B: after a parsed swap trade — cache-first BalanceUpdated; vault/bin registration only for hot pools.
     #[cfg_attr(not(test), allow(dead_code))]
     fn register_geyser_reserves_after_trade(self: &Arc<Self>, pool: Pubkey) -> bool {
-        self.try_publish_balance_updated_from_cache(pool);
-        if !self.hot_pool_registry.pool_has_momentum(pool) {
-            return false;
-        }
-        let Some(state) = self.live_pool_cache.get(&pool) else {
-            return false;
-        };
-        let Some((base_mint, quote_mint)) = pool_mints_for_geyser_explicit_tracking(&state) else {
-            return false;
-        };
-        if !self.admit_geyser_explicit_pool_assets(pool, base_mint, quote_mint) {
-            return false;
-        }
-        let before_keys = self.snapshot_explicit_subscription_pubkeys();
-        self.register_geyser_reserves_impl(pool, GeyserPinReason::MomentumActive);
-        explicit_subscription_has_new_keys(
-            &before_keys,
-            &self.snapshot_explicit_subscription_pubkeys(),
+        enqueue_track_worker(
+            self,
+            TrackWorkerCommand::RegisterGeyserReservesAfterTrade { pool },
         )
     }
 
@@ -4012,6 +4289,13 @@ impl MarketDataContext {
     /// PR169a: register vault ATAs from MASTER cache after account-path pool upsert (hot pools only).
     #[cfg_attr(not(test), allow(dead_code))]
     fn register_pool_vaults_from_account(&self, pool: Pubkey) -> bool {
+        enqueue_track_worker(
+            self,
+            TrackWorkerCommand::RegisterPoolVaultsFromAccount { pool },
+        )
+    }
+
+    fn register_pool_vaults_from_account_worker(&self, pool: Pubkey) -> bool {
         self.try_publish_balance_updated_from_cache(pool);
         if !self.hot_pool_registry.is_hot_pool(pool) {
             return false;
@@ -4024,18 +4308,13 @@ impl MarketDataContext {
             (cfg.enable_meteora_cpmm, cfg.enable_meteora_dlmm)
         };
         let now = Instant::now();
-        let before_keys = self.snapshot_explicit_subscription_pubkeys();
-        let _vaults_changed = self.register_four_dex_pool_vaults_from_cached_state(
+        self.register_four_dex_pool_vaults_from_cached_state(
             pool,
             &cached_state,
             now,
             enable_meteora_cpmm,
             enable_meteora_dlmm,
             true,
-        );
-        explicit_subscription_has_new_keys(
-            &before_keys,
-            &self.snapshot_explicit_subscription_pubkeys(),
         )
     }
 
@@ -4148,6 +4427,27 @@ impl MarketDataContext {
 
     /// Fix B: when arb-pinned DLMM `active_id` drifts, register new bin-array PDAs + Geyser push.
     fn maybe_refresh_arb_dlmm_bin_window(&self, pool: Pubkey, new_active_id: i32) -> bool {
+        if !self.hot_pool_registry.pool_has_arb(pool) {
+            return false;
+        }
+        let prev = self.dlmm_registered_active_id.read().get(&pool).copied();
+        if prev == Some(new_active_id) {
+            return false;
+        }
+        let enqueued = enqueue_track_worker(
+            self,
+            TrackWorkerCommand::RefreshDlmmBinWindow {
+                pool,
+                new_active_id,
+            },
+        );
+        if enqueued {
+            let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
+        }
+        enqueued
+    }
+
+    fn maybe_refresh_arb_dlmm_bin_window_worker(&self, pool: Pubkey, new_active_id: i32) -> bool {
         if !self.hot_pool_registry.pool_has_arb(pool) {
             return false;
         }
@@ -6230,21 +6530,20 @@ async fn publish_wallet_snapshot(
         }
     }
 
-    // 3) Update tracked wallet accounts for Geyser subscription (wallet + WSOL + token ATAs).
+    // 3) Update logical wallet explicit demand; physical publish goes through track-worker admission.
     if let Some(ref tracked_wallet) = ctx.tracked_wallet {
-        let mut accounts: Vec<Pubkey> = Vec::new();
-        accounts.push(tracked_wallet.wallet);
-        accounts.push(tracked_wallet.wsol_ata);
-        // Keep any existing tracked token accounts and add what we learned here.
         {
             let existing = ctx.tracked_wallet_token_accounts.read().clone();
             wallet_token_accounts.extend(existing);
         }
-        accounts.extend(wallet_token_accounts.iter().copied());
-        accounts.sort();
-        accounts.dedup();
-        let _ = ctx.tracked_wallet_tx.send(accounts);
-        *ctx.tracked_wallet_token_accounts.write() = wallet_token_accounts;
+        *ctx.tracked_wallet_token_accounts.write() = wallet_token_accounts.clone();
+        let mut demand = HashSet::new();
+        demand.insert(tracked_wallet.wallet);
+        demand.insert(tracked_wallet.wsol_ata);
+        demand.extend(wallet_token_accounts.iter().copied());
+        *ctx.wallet_explicit_demand.write() = demand.clone();
+        let _ = enqueue_track_worker(ctx, TrackWorkerCommand::SyncWalletExplicitDemand { demand });
+        let _ = enqueue_track_worker(ctx, TrackWorkerCommand::ScheduleGeyserPushDebounced);
     }
 
     // 4) WalletSnapshotComplete helps momentum-bot close ghost positions.
@@ -6672,12 +6971,14 @@ async fn main() -> Result<()> {
         "WalletTracker initialized"
     );
 
-    let (tracked_mints_tx, tracked_mints_rx) = watch::channel(Vec::<Pubkey>::new());
-    let (tracked_vaults_tx, tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
-    let (tracked_bin_arrays_tx, tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
-    let (tracked_wallet_tx, tracked_wallet_rx) = watch::channel(Vec::<Pubkey>::new());
+    let (tracked_mints_tx, _tracked_mints_rx) = watch::channel(Vec::<Pubkey>::new());
+    let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
+    let (tracked_bin_arrays_tx, _tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
+    let (tracked_wallet_tx, _tracked_wallet_rx) = watch::channel(Vec::<Pubkey>::new());
+    let (admitted_explicit_tx, _admitted_explicit_rx) = watch::channel(Vec::<Pubkey>::new());
 
     // === WsolManager Support: Setup wallet balance tracking ===
+    let mut initial_wallet_demand = HashSet::new();
     let tracked_wallet = if let Ok(wallet_pubkey_str) = std::env::var("IRONCRAB_WALLET_PUBKEY") {
         match Pubkey::from_str(&wallet_pubkey_str) {
             Ok(wallet_pubkey) => {
@@ -6687,8 +6988,8 @@ async fn main() -> Result<()> {
                     wsol_ata = %tracked.wsol_ata,
                     "WalletBalance tracking enabled for WsolManager"
                 );
-                // Send initial tracked accounts (wallet + WSOL ATA)
-                let _ = tracked_wallet_tx.send(vec![wallet_pubkey, tracked.wsol_ata]);
+                initial_wallet_demand.insert(wallet_pubkey);
+                initial_wallet_demand.insert(tracked.wsol_ata);
                 Some(tracked)
             }
             Err(_) => {
@@ -6765,6 +7066,11 @@ async fn main() -> Result<()> {
         last_arb_snapshot_target: parking_lot::RwLock::new(None),
         dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
         explicit_admission_invalidate: AtomicBool::new(false),
+        wallet_explicit_demand: parking_lot::RwLock::new(initial_wallet_demand),
+        admitted_explicit_tx,
+        track_worker: parking_lot::RwLock::new(None),
+        geyser_explicit_ready: AtomicBool::new(true),
+        geyser_explicit_config_error: parking_lot::RwLock::new(None),
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -6895,18 +7201,13 @@ async fn main() -> Result<()> {
             &run_id,
             &args.geyser_url,
             config_subscription,
-            tracked_mints_rx,
-            tracked_vaults_rx,
-            tracked_bin_arrays_rx,
-            tracked_wallet_rx,
             args.wallet_snapshot_only,
             wallet_tx_confirm_commitment,
         )
         .await?;
     }
 
-    // Flush explicit-set snapshot + JSONL on shutdown
-    flush_explicit_set_snapshot(ctx.as_ref());
+    // Flush JSONL on shutdown (explicit-set snapshot owned by md-track-worker).
     ctx.jsonl_writer.flush()?;
     info!(run_id = %run_id, "market-data shutdown complete");
 
@@ -7526,10 +7827,6 @@ async fn run_geyser_loop(
     run_id: &str,
     geyser_url: &str,
     mut config_subscription: Option<ironcrab::nats::NatsSubscription>,
-    tracked_mints_rx: watch::Receiver<Vec<Pubkey>>,
-    tracked_vaults_rx: watch::Receiver<Vec<Pubkey>>,
-    tracked_bin_arrays_rx: watch::Receiver<Vec<Pubkey>>,
-    tracked_wallet_rx: watch::Receiver<Vec<Pubkey>>,
     wallet_snapshot_only: bool,
     wallet_tx_confirm_commitment: String,
 ) -> Result<()> {
@@ -7551,6 +7848,15 @@ async fn run_geyser_loop(
 
     // Phase-R-R2: single-writer `md-state` OS thread (before wallet snapshot — wallet path enqueues).
     let track_worker = spawn_track_worker(Arc::clone(&ctx));
+    *ctx.track_worker.write() = Some(track_worker.clone());
+    if !ctx.wallet_explicit_demand.read().is_empty() {
+        let demand = ctx.wallet_explicit_demand.read().clone();
+        let _ = track_worker_try_enqueue(
+            &track_worker,
+            TrackWorkerCommand::SyncWalletExplicitDemand { demand },
+        );
+        let _ = track_worker_try_enqueue(&track_worker, TrackWorkerCommand::ScheduleGeyserPush);
+    }
     // Phase 3 P3 (I-MD-6): restore explicit Geyser set before first Geyser connect.
     MarketDataContext::restore_explicit_set_from_snapshot_on_startup(&track_worker);
     // PR169c / Phase-2b: coalesce momentum NATS bursts before md-track-worker.
@@ -7633,37 +7939,16 @@ async fn run_geyser_loop(
         Pubkey::from_str(METEORA_CPMM).expect("valid meteora cpmm pubkey"),
     ];
 
-    // Merge tracked_mints, tracked_vaults, tracked_bin_arrays, and tracked_wallet into a single combined channel.
-    // GeyserAccountListener subscribes to all accounts in the combined list (TX path: GeyserTxListener).
-    let (combined_tracked_tx, combined_tracked_rx) = watch::channel(Vec::<Pubkey>::new());
-    {
-        let mints_rx = tracked_mints_rx;
-        let vaults_rx = tracked_vaults_rx;
-        let bin_arrays_rx = tracked_bin_arrays_rx;
-        let wallet_rx = tracked_wallet_rx;
-        let combined_tx = combined_tracked_tx;
-        let ctx_merge = Arc::clone(&ctx);
-        tokio::spawn(async move {
-            MarketDataContext::run_geyser_tracked_accounts_merge_coalesce_loop(
-                mints_rx,
-                vaults_rx,
-                bin_arrays_rx,
-                wallet_rx,
-                combined_tx,
-                ctx_merge,
-            )
-            .await;
-        });
-    }
+    let admitted_explicit_rx = ctx.admitted_explicit_tx.subscribe();
 
     // PR164: two Geyser gRPC sessions — TX+blockhash (sacred, no pin subscribe updates) and
-    // accounts+cuckoo (in-place subscribe updates). Merge → account session only.
+    // accounts+cuckoo (in-place subscribe updates). Admitted SSOT → account session only.
     let (tx_listener, transaction_rx, mut blockhash_rx) =
         GeyserTxListener::new(geyser_url.to_string(), program_ids.clone());
     let (account_listener, account_rx) = GeyserAccountListener::new_with_tracked_accounts(
         geyser_url.to_string(),
         program_ids,
-        combined_tracked_rx,
+        admitted_explicit_rx,
         Arc::clone(&ctx.geyser_full_reconnect_threshold_live),
         ctx.config.read().max_tracked_accounts.max(1),
     );
@@ -8547,13 +8832,7 @@ async fn run_geyser_loop(
 
                                         // 4) Recompute tracked wallet accounts and notify listener
                                         if added_ata {
-                                            let mut accounts: Vec<Pubkey> = Vec::new();
-                                            accounts.push(tracked_wallet.wallet);
-                                            accounts.push(tracked_wallet.wsol_ata);
-                                            accounts.extend(ctx.tracked_wallet_token_accounts.read().iter().copied());
-                                            accounts.sort();
-                                            accounts.dedup();
-                                            let _ = ctx.tracked_wallet_tx.send(accounts);
+                                            ctx.request_wallet_explicit_resync();
                                         }
 
                                         let is_confirmed_sell = exec.status == ExecutionStatus::Confirmed
@@ -8606,17 +8885,12 @@ async fn run_geyser_loop(
 
                                             let mut set = ctx.tracked_wallet_token_accounts.write();
                                             if set.remove(&ata) {
-                                                let mut accounts: Vec<Pubkey> = Vec::new();
-                                                accounts.push(tracked_wallet.wallet);
-                                                accounts.push(tracked_wallet.wsol_ata);
-                                                accounts.extend(set.iter().copied());
-                                                accounts.sort();
-                                                accounts.dedup();
-                                                let _ = ctx.tracked_wallet_tx.send(accounts);
+                                                drop(set);
+                                                ctx.request_wallet_explicit_resync();
                                                 info!(
                                                     mint = %mint_str,
                                                     ata = %ata,
-                                                    remaining_tracked = set.len(),
+                                                    remaining_tracked = ctx.tracked_wallet_token_accounts.read().len(),
                                                     "Untracked ATA after confirmed SELL"
                                                 );
                                             }
@@ -8809,7 +9083,6 @@ async fn run_geyser_loop(
 
             _ = &mut shutdown => {
                 info!("Shutdown signal received");
-                flush_explicit_set_snapshot(ctx.as_ref());
                 tx_listener_handle.abort();
                 account_listener_handle.abort();
                 break;
@@ -10371,6 +10644,11 @@ mod wallet_snapshot_stale_cleanup_tests {
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
             explicit_admission_invalidate: AtomicBool::new(false),
+            wallet_explicit_demand: parking_lot::RwLock::new(HashSet::new()),
+            admitted_explicit_tx: watch::channel(Vec::<Pubkey>::new()).0,
+            track_worker: parking_lot::RwLock::new(None),
+            geyser_explicit_ready: AtomicBool::new(true),
+            geyser_explicit_config_error: parking_lot::RwLock::new(None),
         }
     }
 
@@ -10592,6 +10870,11 @@ mod wallet_tx_meta_balance_tests {
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
             explicit_admission_invalidate: AtomicBool::new(false),
+            wallet_explicit_demand: parking_lot::RwLock::new(HashSet::new()),
+            admitted_explicit_tx: watch::channel(Vec::<Pubkey>::new()).0,
+            track_worker: parking_lot::RwLock::new(None),
+            geyser_explicit_ready: AtomicBool::new(true),
+            geyser_explicit_config_error: parking_lot::RwLock::new(None),
         })
     }
 
@@ -10911,10 +11194,11 @@ mod pr_b_geyser_tracking_tests {
     const PUMPFUN_AMM_PROGRAM_OWNER: Pubkey =
         solana_sdk::pubkey!("pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA");
     use ironcrab::market_data::track::{
-        merge_momentum_active_pools_updates, rebuild_desired_explicit_set_from_ctx,
-        spawn_inline_track_worker_sender, spawn_noop_track_worker_sender,
-        track_worker_execute_coalesced_push, track_worker_try_enqueue, DesiredExplicitSet,
-        TrackWorkerCommand, MARKET_DATA_TRACK_WORKER_COALESCE_MS,
+        explicit_subscription_has_new_keys, merge_momentum_active_pools_updates,
+        rebuild_desired_explicit_set_from_ctx, spawn_inline_track_worker_sender,
+        spawn_noop_track_worker_sender, track_worker_execute_coalesced_push,
+        track_worker_try_enqueue, DesiredExplicitSet, TrackWorkerCommand,
+        MARKET_DATA_TRACK_WORKER_COALESCE_MS,
     };
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc as std_mpsc;
@@ -10922,6 +11206,7 @@ mod pr_b_geyser_tracking_tests {
 
     fn test_spawn_md_state(ctx: &Arc<MarketDataContext>) -> MdStateSender {
         let track_worker = spawn_track_worker(Arc::clone(ctx));
+        *ctx.track_worker.write() = Some(track_worker.clone());
         spawn_md_state_worker(
             Arc::clone(ctx),
             tokio::runtime::Handle::current(),
@@ -10933,6 +11218,11 @@ mod pr_b_geyser_tracking_tests {
         spawn_noop_track_worker_sender(4096)
     }
 
+    fn test_wait_inline_track_worker() {
+        std::thread::sleep(Duration::from_millis(80));
+    }
+
+    #[allow(dead_code)]
     fn test_desired_set(ctx: &MarketDataContext) -> DesiredExplicitSet {
         DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts)
     }
@@ -11415,7 +11705,7 @@ mod pr_b_geyser_tracking_tests {
         let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_bin_arrays_tx, _tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_wallet_tx, _tracked_wallet_rx) = watch::channel(Vec::<Pubkey>::new());
-        Arc::new(MarketDataContext {
+        let ctx = Arc::new(MarketDataContext {
             run_id: "run-prd-test".to_string(),
             config: parking_lot::RwLock::new(MarketDataConfig::default()),
             geyser_full_reconnect_threshold_live: Arc::new(AtomicUsize::new(0)),
@@ -11470,7 +11760,15 @@ mod pr_b_geyser_tracking_tests {
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
             explicit_admission_invalidate: AtomicBool::new(false),
-        })
+            wallet_explicit_demand: parking_lot::RwLock::new(HashSet::new()),
+            admitted_explicit_tx: watch::channel(Vec::<Pubkey>::new()).0,
+            track_worker: parking_lot::RwLock::new(None),
+            geyser_explicit_ready: AtomicBool::new(true),
+            geyser_explicit_config_error: parking_lot::RwLock::new(None),
+        });
+        let track_worker = spawn_inline_track_worker_sender(Arc::clone(&ctx), 4096);
+        *ctx.track_worker.write() = Some(track_worker);
+        ctx
     }
 
     /// PR161: same as [`minimal_market_data_context_for_pr_d_tests`], but returns merge `watch` receivers.
@@ -11543,6 +11841,11 @@ mod pr_b_geyser_tracking_tests {
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
             explicit_admission_invalidate: AtomicBool::new(false),
+            wallet_explicit_demand: parking_lot::RwLock::new(HashSet::new()),
+            admitted_explicit_tx: watch::channel(Vec::<Pubkey>::new()).0,
+            track_worker: parking_lot::RwLock::new(None),
+            geyser_explicit_ready: AtomicBool::new(true),
+            geyser_explicit_config_error: parking_lot::RwLock::new(None),
         });
         (
             ctx,
@@ -12266,6 +12569,7 @@ mod pr_b_geyser_tracking_tests {
         );
 
         MarketDataContext::register_geyser_reserves_after_trade(&ctx, pool);
+        test_wait_inline_track_worker();
 
         let vs = ctx.tracked_vaults.read();
         assert!(!vs.contains_key(&coin_vault));
@@ -12299,6 +12603,7 @@ mod pr_b_geyser_tracking_tests {
         ctx.hot_pool_registry.pin_pool(base_mint, pool);
 
         MarketDataContext::register_geyser_reserves_after_trade(&ctx, pool);
+        test_wait_inline_track_worker();
 
         let vs = ctx.tracked_vaults.read();
         assert!(vs.contains_key(&coin_vault));
@@ -12360,6 +12665,7 @@ mod pr_b_geyser_tracking_tests {
         let md_state = test_spawn_md_state(&ctx);
         MarketDataContext::register_geyser_reserves_after_trade(&ctx, pool_a);
         MarketDataContext::register_geyser_reserves_after_trade(&ctx, pool_b);
+        test_wait_inline_track_worker();
         md_state_try_enqueue(&md_state, MdStateCommand::FlushGeyserSyncDebounced);
 
         // Let the actor drain; PR167 startup debounce min 250 ms — one coalesced flush.
@@ -12412,6 +12718,7 @@ mod pr_b_geyser_tracking_tests {
         assert!(MarketDataContext::register_geyser_reserves_after_trade(
             &ctx, pool
         ));
+        test_wait_inline_track_worker();
 
         assert!(!ctx.pool_explicit_vault_bin_pubkeys(pool).is_empty());
         assert!(
@@ -12459,6 +12766,7 @@ mod pr_b_geyser_tracking_tests {
         assert!(MarketDataContext::register_geyser_reserves_after_trade(
             &ctx, pool
         ));
+        test_wait_inline_track_worker();
         ctx.sync_geyser_tracked_accounts();
 
         assert!(
@@ -12505,6 +12813,7 @@ mod pr_b_geyser_tracking_tests {
         assert!(MarketDataContext::register_geyser_reserves_after_trade(
             &ctx, pool
         ));
+        test_wait_inline_track_worker();
 
         let before = ctx.snapshot_explicit_subscription_pubkeys();
         let jobs: Vec<_> = (0..100)
@@ -12917,6 +13226,7 @@ mod pr_b_geyser_tracking_tests {
         let batch0 = MARKET_DATA_GEYSER_SYNC_BATCH_TOTAL.load(Ordering::Relaxed);
 
         assert!(ctx.register_pool_vaults_from_account(pool));
+        test_wait_inline_track_worker();
         md_state_try_enqueue(&md_state, MdStateCommand::FlushGeyserSyncDebounced);
         tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -12931,7 +13241,10 @@ mod pr_b_geyser_tracking_tests {
             "account-path vault register must not immediate-sync"
         );
 
-        tokio::time::sleep(Duration::from_millis(350)).await;
+        tokio::time::sleep(Duration::from_millis(
+            MARKET_DATA_TRACK_WORKER_COALESCE_MS + 200,
+        ))
+        .await;
         let batch_delta = MARKET_DATA_GEYSER_SYNC_BATCH_TOTAL.load(Ordering::Relaxed) - batch0;
         assert!(
             batch_delta >= 1,
@@ -12953,6 +13266,7 @@ mod pr_b_geyser_tracking_tests {
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let track_worker = spawn_track_worker(Arc::clone(&ctx));
+        *ctx.track_worker.write() = Some(track_worker.clone());
 
         let imm0 = MARKET_DATA_GEYSER_SYNC_IMMEDIATE_TOTAL.load(Ordering::Relaxed);
         let batch0 = MARKET_DATA_GEYSER_SYNC_BATCH_TOTAL.load(Ordering::Relaxed);
@@ -13051,7 +13365,10 @@ mod pr_b_geyser_tracking_tests {
             "wallet mint track must not immediate-sync"
         );
 
-        tokio::time::sleep(Duration::from_millis(350)).await;
+        tokio::time::sleep(Duration::from_millis(
+            MARKET_DATA_TRACK_WORKER_COALESCE_MS + 200,
+        ))
+        .await;
         assert!(
             MARKET_DATA_GEYSER_SYNC_BATCH_TOTAL.load(Ordering::Relaxed) > batch0,
             "expected debounced batch sync after wallet mint track"
@@ -13072,6 +13389,7 @@ mod pr_b_geyser_tracking_tests {
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let track_worker = spawn_track_worker(Arc::clone(&ctx));
+        *ctx.track_worker.write() = Some(track_worker.clone());
         let coalesce_tx = spawn_momentum_tracking_coalescer(Arc::clone(&ctx), track_worker);
 
         let msgs0 = MARKET_DATA_MOMENTUM_COALESCED_MESSAGES_TOTAL.load(Ordering::Relaxed);
@@ -13229,6 +13547,7 @@ mod pr_b_geyser_tracking_tests {
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let track_worker = spawn_track_worker(Arc::clone(&ctx));
+        *ctx.track_worker.write() = Some(track_worker.clone());
 
         let mut active = Vec::new();
         for _ in 0..48 {
@@ -14162,6 +14481,7 @@ mod pr_b_geyser_tracking_tests {
         assert_eq!(ctx.tracked_bin_arrays.read().len(), before);
 
         assert!(ctx.maybe_refresh_arb_dlmm_bin_window(pool, 500));
+        test_wait_inline_track_worker();
         assert!(
             ctx.tracked_bin_arrays.read().len() >= before,
             "new active_id must register additional bin-array PDAs"
@@ -14279,7 +14599,7 @@ mod pr_b_geyser_tracking_tests {
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let mint = Pubkey::new_unique();
-        ctx.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::Wallet));
+        ctx.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::MomentumActive));
         let mut desired = DesiredExplicitSet::new(25_000);
         rebuild_desired_explicit_set_from_ctx(ctx.as_ref(), &mut desired);
         assert_eq!(desired.len(), 1);
@@ -14299,6 +14619,7 @@ mod pr_b_geyser_tracking_tests {
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let track_worker = spawn_track_worker(Arc::clone(&ctx));
+        *ctx.track_worker.write() = Some(track_worker.clone());
         let batches0 = MARKET_DATA_TRACK_REQUEST_COALESCE_BATCHES_TOTAL.load(Ordering::Relaxed);
 
         let pool_a = Pubkey::new_unique();
@@ -14449,7 +14770,7 @@ mod pr_b_geyser_tracking_tests {
         let mint = Pubkey::new_unique();
         ctx.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::MomentumActive));
 
-        let snapshot = ctx.build_explicit_set_snapshot();
+        let snapshot = ctx.build_explicit_set_snapshot_physical();
         assert!(!snapshot.rows.is_empty());
 
         let fresh = minimal_market_data_context_for_pr_d_tests(
@@ -14483,9 +14804,10 @@ mod pr_b_geyser_tracking_tests {
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let mint = Pubkey::new_unique();
         ctx.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::ArbMultiDex));
-        let snapshot = ctx.build_explicit_set_snapshot();
+        let snapshot = ctx.build_explicit_set_snapshot_physical();
 
         let track_worker = spawn_track_worker(Arc::clone(&ctx));
+        *ctx.track_worker.write() = Some(track_worker.clone());
         assert!(track_worker_try_enqueue(
             &track_worker,
             TrackWorkerCommand::RestoreExplicitSnapshot(snapshot),
@@ -14558,6 +14880,7 @@ mod pr_b_geyser_tracking_tests {
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let track_worker = spawn_track_worker(Arc::clone(&ctx));
+        *ctx.track_worker.write() = Some(track_worker.clone());
 
         let pool = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
@@ -14591,7 +14914,9 @@ mod pr_b_geyser_tracking_tests {
                 full_active_snapshot: false,
             }),
         ));
-        std::thread::sleep(Duration::from_millis(50));
+        std::thread::sleep(Duration::from_millis(
+            MARKET_DATA_TRACK_WORKER_COALESCE_MS + 150,
+        ));
         let mid = ctx.snapshot_explicit_subscription_pubkeys();
         assert!(explicit_subscription_has_new_keys(&before, &mid));
         assert!(ctx.hot_pool_registry.is_hot_pool(pool));
@@ -15178,5 +15503,84 @@ mod pr_b_geyser_tracking_tests {
             Some(GeyserPinReason::Wallet)
         );
         assert!(vs.get(&pc_vault).is_some_and(|v| v.pinned));
+    }
+
+    #[test]
+    fn explicit_admission_wallet_over_cap_fails_closed() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        ctx.config.write().max_tracked_accounts = 2;
+
+        let mut demand = HashSet::new();
+        for _ in 0..3 {
+            demand.insert(Pubkey::new_unique());
+        }
+        *ctx.wallet_explicit_demand.write() = demand.clone();
+        let mut desired = DesiredExplicitSet::new(2);
+        assert!(!ctx.sync_wallet_explicit_demand(&mut desired, demand));
+        assert!(!ctx.geyser_explicit_ready.load(Ordering::Relaxed));
+        assert!(ctx.geyser_explicit_config_error.read().is_some());
+    }
+
+    #[test]
+    fn explicit_admission_synced_snapshot_matches_desired_after_immediate_sync() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool(base, pool);
+        assert!(MarketDataContext::register_geyser_reserves_after_trade(
+            &ctx, pool
+        ));
+        test_wait_inline_track_worker();
+        ctx.sync_geyser_tracked_accounts();
+
+        let synced = ctx.snapshot_explicit_subscription_pubkeys();
+        assert!(synced.contains(&coin));
+        assert!(synced.contains(&pc));
+        assert!(synced.len() <= ctx.config.read().max_tracked_accounts);
+    }
+
+    #[test]
+    fn config_invalidation_in_recv_drain_resets_convergence_before_push() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let track_worker = spawn_track_worker(Arc::clone(&ctx));
+        *ctx.track_worker.write() = Some(track_worker.clone());
+
+        assert!(track_worker_try_enqueue(
+            &track_worker,
+            TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange,
+        ));
+        assert!(track_worker_try_enqueue(
+            &track_worker,
+            TrackWorkerCommand::ScheduleGeyserPush,
+        ));
+        std::thread::sleep(Duration::from_millis(
+            MARKET_DATA_TRACK_WORKER_COALESCE_MS + 200,
+        ));
+        assert!(!ctx.pending_geyser_evict.load(Ordering::Relaxed));
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -84,12 +84,13 @@ use ironcrab::market_data::track::{
     momentum_coalesce_try_send, owner_key_to_snapshot, pool_is_enrichment_member,
     spawn_track_worker, track_worker_try_enqueue, AdmissionResult, BinArrayExplicitRow,
     CapConvergeResult, ConsumerId, DesiredExplicitSet, ExplicitAccountKind, ExplicitSetSnapshot,
-    ExplicitSnapshotRow, GeyserConnectBarrier, GeyserPinReason, MintExplicitRow,
-    OwnerGroupSnapshot, OwnerKey, PendingPoolCommand, PendingPoolRegistrations,
-    PendingPoolUpsertResult, PoolExplicitSnapshot, PoolSnapshotRevisionSequencer,
-    ProtectedOverflowDiagnostic, RevisionAcquireResult, RevisionAssignResult, SnapshotConsumer,
-    SnapshotOwnerGroup, TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
-    VaultExplicitRow, WalletExplicitPending, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
+    ExplicitSnapshotRow, GeyserConnectBarrier, GeyserPinReason, InflightReserveResult,
+    MintExplicitRow, OwnerGroupSnapshot, OwnerKey, PendingPoolCommand, PendingPoolRegistrations,
+    PendingPoolUpsertResult, PoolCommandTerminal, PoolExplicitSnapshot,
+    PoolSnapshotRevisionSequencer, ProtectedOverflowDiagnostic, RevisionAcquireResult,
+    RevisionActiveOwner, RevisionAssignResult, SnapshotConsumer, SnapshotOwnerGroup,
+    TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender, VaultExplicitRow,
+    WalletExplicitPending, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -1933,82 +1934,102 @@ fn pending_pool_command_for_stash(job: &TrackWorkerCommand) -> Option<PendingPoo
     }
 }
 
-fn assign_pool_snapshot_revision(ctx: &MarketDataContext, job: &mut TrackWorkerCommand) -> bool {
-    let assign = |snapshot: &mut PoolExplicitSnapshot| match ctx
-        .pool_snapshot_revisions
-        .assign_next(snapshot)
-    {
-        RevisionAssignResult::Assigned(_) => true,
-        RevisionAssignResult::RegistryFull => {
-            ctx.fail_revision_registry_full();
-            false
-        }
-        RevisionAssignResult::KeyNotRegistered => {
-            match ctx
-                .pool_snapshot_revisions
-                .try_acquire_active(snapshot.pool, snapshot.consumer)
-            {
-                RevisionAcquireResult::Acquired => {
-                    match ctx.pool_snapshot_revisions.assign_next(snapshot) {
-                        RevisionAssignResult::Assigned(_) => true,
-                        RevisionAssignResult::RegistryFull => {
-                            ctx.fail_revision_registry_full();
-                            false
-                        }
-                        RevisionAssignResult::KeyNotRegistered => {
-                            ctx.fail_revision_registry_full();
-                            false
-                        }
-                    }
-                }
-                RevisionAcquireResult::RegistryFull => {
-                    ctx.fail_revision_registry_full();
-                    false
-                }
-            }
-        }
-    };
-    match job {
+fn prepare_pool_snapshot_for_enqueue(
+    ctx: &MarketDataContext,
+    job: &mut TrackWorkerCommand,
+) -> Option<(Pubkey, ConsumerId)> {
+    let (pool, consumer, snapshot) = match job {
         TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot }
         | TrackWorkerCommand::RegisterPoolVaultsFromAccount { snapshot }
-        | TrackWorkerCommand::RegisterGeyserReservesAfterTrade { snapshot } => assign(snapshot),
-        TrackWorkerCommand::RefreshDlmmBinWindow { snapshot, .. } => assign(snapshot),
-        _ => true,
+        | TrackWorkerCommand::RegisterGeyserReservesAfterTrade { snapshot } => {
+            (snapshot.pool, snapshot.consumer, snapshot)
+        }
+        TrackWorkerCommand::RefreshDlmmBinWindow { snapshot, .. } => {
+            (snapshot.pool, snapshot.consumer, snapshot)
+        }
+        _ => return None,
+    };
+    match ctx
+        .pool_snapshot_revisions
+        .reserve_inflight_command(pool, consumer)
+    {
+        InflightReserveResult::Reserved => {}
+        InflightReserveResult::RegistryFull => {
+            ctx.fail_revision_registry_full();
+            return None;
+        }
+    }
+    match ctx.pool_snapshot_revisions.assign_next(snapshot) {
+        RevisionAssignResult::Assigned(_) => Some((pool, consumer)),
+        RevisionAssignResult::RegistryFull => {
+            ctx.pool_snapshot_revisions
+                .release_inflight_command(pool, consumer);
+            ctx.fail_revision_registry_full();
+            None
+        }
+        RevisionAssignResult::KeyNotRegistered => {
+            ctx.pool_snapshot_revisions
+                .release_inflight_command(pool, consumer);
+            ctx.fail_revision_registry_full();
+            None
+        }
     }
 }
 
-fn pool_command_meta(job: &TrackWorkerCommand) -> Option<(Pubkey, ConsumerId)> {
-    pending_pool_command_for_stash(job).map(|cmd| (cmd.pool(), cmd.consumer()))
+fn pool_snapshot_command_meta(job: &TrackWorkerCommand) -> bool {
+    matches!(
+        job,
+        TrackWorkerCommand::RegisterPoolGeyserReserves { .. }
+            | TrackWorkerCommand::RegisterPoolVaultsFromAccount { .. }
+            | TrackWorkerCommand::RegisterGeyserReservesAfterTrade { .. }
+            | TrackWorkerCommand::RefreshDlmmBinWindow { .. }
+    )
+}
+
+fn stash_pending_pool_command(
+    ctx: &MarketDataContext,
+    cmd: PendingPoolCommand,
+    pool_meta: Option<(Pubkey, ConsumerId)>,
+) {
+    let stored = if let Some((pool, consumer)) = pool_meta {
+        if ctx
+            .pool_snapshot_revisions
+            .transfer_inflight_to_pending(pool, consumer)
+        {
+            ctx.pending_pool_commands.upsert_transferred(cmd)
+        } else {
+            PendingPoolUpsertResult::Overflow
+        }
+    } else {
+        ctx.pending_pool_commands.upsert(cmd)
+    };
+    if stored == PendingPoolUpsertResult::Overflow {
+        ctx.fail_pending_pool_overflow();
+    }
 }
 
 fn enqueue_track_worker(ctx: &MarketDataContext, mut job: TrackWorkerCommand) -> bool {
     if ctx.pending_pool_overflow_latched.load(Ordering::Acquire) {
         return false;
     }
-    let pool_meta = pool_command_meta(&job);
-    if pool_meta.is_some() && !assign_pool_snapshot_revision(ctx, &mut job) {
+    let is_pool_snapshot = pool_snapshot_command_meta(&job);
+    let pool_meta = prepare_pool_snapshot_for_enqueue(ctx, &mut job);
+    if is_pool_snapshot && pool_meta.is_none() {
         return false;
     }
     let pending = pending_pool_command_for_stash(&job);
     let Some(sender) = ctx.track_worker.read().clone() else {
         if let Some(cmd) = pending {
-            if ctx.pending_pool_commands.upsert(cmd) == PendingPoolUpsertResult::Overflow {
-                ctx.fail_pending_pool_overflow();
-            }
+            stash_pending_pool_command(ctx, cmd, pool_meta);
         }
         ctx.mark_track_worker_dirty();
         return false;
     };
     if track_worker_try_enqueue(&sender, job) {
-        if let Some((pool, consumer)) = pool_meta {
-            ctx.pool_snapshot_revisions.inc_inflight_ref(pool, consumer);
-        }
         return true;
     }
     if let Some(cmd) = pending {
-        if ctx.pending_pool_commands.upsert(cmd) == PendingPoolUpsertResult::Overflow {
-            ctx.fail_pending_pool_overflow();
-        }
+        stash_pending_pool_command(ctx, cmd, pool_meta);
     }
     ctx.mark_track_worker_dirty();
     false
@@ -2484,21 +2505,18 @@ impl TrackWorkerContext for MarketDataContext {
         desired: &mut DesiredExplicitSet,
         snapshot: &PoolExplicitSnapshot,
     ) -> bool {
-        if !self
-            .pool_snapshot_revisions
-            .should_apply_and_record(snapshot)
-        {
-            return false;
-        }
-        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys()) {
-            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
-                self.register_tracked_assets_from_pool_snapshot(snapshot)
+        self.apply_pool_snapshot_command(desired, snapshot, true, |desired| {
+            match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys())
+            {
+                AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
+                    self.register_tracked_assets_from_pool_snapshot(snapshot)
+                }
+                rejected => {
+                    record_admission_rejection(snapshot.consumer, rejected);
+                    false
+                }
             }
-            rejected => {
-                record_admission_rejection(snapshot.consumer, rejected);
-                false
-            }
-        }
+        })
     }
 
     fn commit_register_pool_vaults_from_account(
@@ -2506,25 +2524,22 @@ impl TrackWorkerContext for MarketDataContext {
         desired: &mut DesiredExplicitSet,
         snapshot: &PoolExplicitSnapshot,
     ) -> bool {
-        if !self
-            .pool_snapshot_revisions
-            .should_apply_and_record(snapshot)
-        {
-            return false;
-        }
-        self.try_publish_balance_updated_from_cache(snapshot.pool);
-        if !self.hot_pool_registry.is_hot_pool(snapshot.pool) {
-            return false;
-        }
-        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys()) {
-            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
-                self.register_tracked_assets_from_pool_snapshot(snapshot)
+        self.apply_pool_snapshot_command(desired, snapshot, true, |desired| {
+            self.try_publish_balance_updated_from_cache(snapshot.pool);
+            if !self.hot_pool_registry.is_hot_pool(snapshot.pool) {
+                return false;
             }
-            rejected => {
-                record_admission_rejection(snapshot.consumer, rejected);
-                false
+            match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys())
+            {
+                AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
+                    self.register_tracked_assets_from_pool_snapshot(snapshot)
+                }
+                rejected => {
+                    record_admission_rejection(snapshot.consumer, rejected);
+                    false
+                }
             }
-        }
+        })
     }
 
     fn commit_register_geyser_reserves_after_trade(
@@ -2532,25 +2547,22 @@ impl TrackWorkerContext for MarketDataContext {
         desired: &mut DesiredExplicitSet,
         snapshot: &PoolExplicitSnapshot,
     ) -> bool {
-        if !self
-            .pool_snapshot_revisions
-            .should_apply_and_record(snapshot)
-        {
-            return false;
-        }
-        self.try_publish_balance_updated_from_cache(snapshot.pool);
-        if !self.hot_pool_registry.pool_has_momentum(snapshot.pool) {
-            return false;
-        }
-        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys()) {
-            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
-                self.register_tracked_assets_from_pool_snapshot(snapshot)
+        self.apply_pool_snapshot_command(desired, snapshot, true, |desired| {
+            self.try_publish_balance_updated_from_cache(snapshot.pool);
+            if !self.hot_pool_registry.pool_has_momentum(snapshot.pool) {
+                return false;
             }
-            rejected => {
-                record_admission_rejection(snapshot.consumer, rejected);
-                false
+            match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys())
+            {
+                AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
+                    self.register_tracked_assets_from_pool_snapshot(snapshot)
+                }
+                rejected => {
+                    record_admission_rejection(snapshot.consumer, rejected);
+                    false
+                }
             }
-        }
+        })
     }
 
     fn commit_refresh_dlmm_bin_window(
@@ -2559,39 +2571,36 @@ impl TrackWorkerContext for MarketDataContext {
         snapshot: &PoolExplicitSnapshot,
         new_active_id: i32,
     ) -> bool {
-        if !self
-            .pool_snapshot_revisions
-            .should_apply_and_record(snapshot)
-        {
-            return false;
-        }
-        if !self.hot_pool_registry.pool_has_arb(snapshot.pool) {
-            return false;
-        }
-        if self
-            .dlmm_registered_active_id
-            .read()
-            .get(&snapshot.pool)
-            .copied()
-            == Some(new_active_id)
-        {
-            return false;
-        }
-        match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys()) {
-            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
-                let changed = self.register_tracked_assets_from_pool_snapshot(snapshot);
-                if changed {
-                    self.dlmm_registered_active_id
-                        .write()
-                        .insert(snapshot.pool, new_active_id);
+        self.apply_pool_snapshot_command(desired, snapshot, true, |desired| {
+            if !self.hot_pool_registry.pool_has_arb(snapshot.pool) {
+                return false;
+            }
+            if self
+                .dlmm_registered_active_id
+                .read()
+                .get(&snapshot.pool)
+                .copied()
+                == Some(new_active_id)
+            {
+                return false;
+            }
+            match desired.try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys())
+            {
+                AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey => {
+                    let changed = self.register_tracked_assets_from_pool_snapshot(snapshot);
+                    if changed {
+                        self.dlmm_registered_active_id
+                            .write()
+                            .insert(snapshot.pool, new_active_id);
+                    }
+                    changed
                 }
-                changed
+                rejected => {
+                    record_admission_rejection(snapshot.consumer, rejected);
+                    false
+                }
             }
-            rejected => {
-                record_admission_rejection(snapshot.consumer, rejected);
-                false
-            }
-        }
+        })
     }
 
     fn publish_admitted_explicit_physical(&self, desired: &DesiredExplicitSet) {
@@ -3264,16 +3273,84 @@ impl MarketDataContext {
         self.geyser_connect_barrier.mark_failed();
     }
 
-    fn acquire_pool_revision_slot(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
-        match self
-            .pool_snapshot_revisions
-            .try_acquire_active(pool, consumer)
-        {
+    fn pool_snapshot_consumer_demand_valid(&self, snapshot: &PoolExplicitSnapshot) -> bool {
+        match snapshot.consumer {
+            ConsumerId::Momentum => {
+                self.hot_pool_registry.pool_has_momentum(snapshot.pool)
+                    || self.hot_pool_registry.pool_has_any_pin(snapshot.pool)
+            }
+            ConsumerId::Arb => self.hot_pool_registry.pool_has_arb(snapshot.pool),
+            _ => self.hot_pool_registry.is_hot_pool(snapshot.pool),
+        }
+    }
+
+    fn apply_pool_snapshot_command(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        snapshot: &PoolExplicitSnapshot,
+        finish_inflight: bool,
+        apply: impl FnOnce(&mut DesiredExplicitSet) -> bool,
+    ) -> bool {
+        if !self.pool_snapshot_revisions.revision_acceptable(snapshot) {
+            if finish_inflight {
+                self.pool_snapshot_revisions
+                    .finish_pool_command(snapshot, PoolCommandTerminal::StaleRevision);
+            }
+            return false;
+        }
+        if !self.pool_snapshot_consumer_demand_valid(snapshot) {
+            if finish_inflight {
+                self.pool_snapshot_revisions
+                    .finish_pool_command(snapshot, PoolCommandTerminal::UnpinnedRejected);
+            }
+            return false;
+        }
+        let applied = apply(desired);
+        if finish_inflight {
+            let terminal = if applied {
+                PoolCommandTerminal::Applied
+            } else {
+                PoolCommandTerminal::AdmissionRejected
+            };
+            self.pool_snapshot_revisions
+                .finish_pool_command(snapshot, terminal);
+        }
+        applied
+    }
+
+    fn replay_pool_snapshot_command(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        snapshot: &PoolExplicitSnapshot,
+        apply: impl FnOnce(&mut DesiredExplicitSet) -> bool,
+    ) -> bool {
+        self.apply_pool_snapshot_command(desired, snapshot, false, apply)
+    }
+
+    fn acquire_revision_owner(&self, owner: RevisionActiveOwner) -> bool {
+        match self.pool_snapshot_revisions.acquire_active_owner(owner) {
             RevisionAcquireResult::Acquired => true,
             RevisionAcquireResult::RegistryFull => {
                 self.fail_revision_registry_full();
                 false
             }
+        }
+    }
+
+    fn acquire_momentum_revision_owner(&self, mint: Pubkey, pool: Pubkey) -> bool {
+        self.acquire_revision_owner(RevisionActiveOwner::MomentumMintPool { mint, pool })
+    }
+
+    fn acquire_arb_revision_owner(&self, pool: Pubkey) -> bool {
+        self.acquire_revision_owner(RevisionActiveOwner::ArbPool { pool })
+    }
+
+    #[allow(dead_code)]
+    fn acquire_pool_revision_slot(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
+        match consumer {
+            ConsumerId::Momentum => self.acquire_momentum_revision_owner(pool, pool),
+            ConsumerId::Arb => self.acquire_arb_revision_owner(pool),
+            _ => false,
         }
     }
 
@@ -3318,19 +3395,103 @@ impl MarketDataContext {
     ) {
         match command {
             PendingPoolCommand::RegisterReserves(snapshot) => {
-                let _ = self.commit_register_pool_geyser_reserves(desired, &snapshot);
+                let _ =
+                    self.replay_pool_snapshot_command(desired, &snapshot, |desired| match desired
+                        .try_admit_group(snapshot.consumer, snapshot.owner, snapshot.all_pubkeys())
+                    {
+                        AdmissionResult::Admitted { .. }
+                        | AdmissionResult::OwnerAddedNoNewPubkey => {
+                            self.register_tracked_assets_from_pool_snapshot(&snapshot)
+                        }
+                        rejected => {
+                            record_admission_rejection(snapshot.consumer, rejected);
+                            false
+                        }
+                    });
             }
             PendingPoolCommand::VaultsFromAccount(snapshot) => {
-                let _ = self.commit_register_pool_vaults_from_account(desired, &snapshot);
+                let _ = self.replay_pool_snapshot_command(desired, &snapshot, |desired| {
+                    self.try_publish_balance_updated_from_cache(snapshot.pool);
+                    if !self.hot_pool_registry.is_hot_pool(snapshot.pool) {
+                        return false;
+                    }
+                    match desired.try_admit_group(
+                        snapshot.consumer,
+                        snapshot.owner,
+                        snapshot.all_pubkeys(),
+                    ) {
+                        AdmissionResult::Admitted { .. }
+                        | AdmissionResult::OwnerAddedNoNewPubkey => {
+                            self.register_tracked_assets_from_pool_snapshot(&snapshot)
+                        }
+                        rejected => {
+                            record_admission_rejection(snapshot.consumer, rejected);
+                            false
+                        }
+                    }
+                });
             }
             PendingPoolCommand::AfterTrade(snapshot) => {
-                let _ = self.commit_register_geyser_reserves_after_trade(desired, &snapshot);
+                let _ = self.replay_pool_snapshot_command(desired, &snapshot, |desired| {
+                    self.try_publish_balance_updated_from_cache(snapshot.pool);
+                    if !self.hot_pool_registry.pool_has_momentum(snapshot.pool) {
+                        return false;
+                    }
+                    match desired.try_admit_group(
+                        snapshot.consumer,
+                        snapshot.owner,
+                        snapshot.all_pubkeys(),
+                    ) {
+                        AdmissionResult::Admitted { .. }
+                        | AdmissionResult::OwnerAddedNoNewPubkey => {
+                            self.register_tracked_assets_from_pool_snapshot(&snapshot)
+                        }
+                        rejected => {
+                            record_admission_rejection(snapshot.consumer, rejected);
+                            false
+                        }
+                    }
+                });
             }
             PendingPoolCommand::RefreshDlmm {
                 snapshot,
                 new_active_id,
             } => {
-                let _ = self.commit_refresh_dlmm_bin_window(desired, &snapshot, new_active_id);
+                let _ = self.replay_pool_snapshot_command(desired, &snapshot, |desired| {
+                    if !self.hot_pool_registry.pool_has_arb(snapshot.pool) {
+                        return false;
+                    }
+                    if self
+                        .dlmm_registered_active_id
+                        .read()
+                        .get(&snapshot.pool)
+                        .copied()
+                        == Some(new_active_id)
+                    {
+                        return false;
+                    }
+                    match desired.try_admit_group(
+                        snapshot.consumer,
+                        snapshot.owner,
+                        snapshot.all_pubkeys(),
+                    ) {
+                        AdmissionResult::Admitted { .. }
+                        | AdmissionResult::OwnerAddedNoNewPubkey => {
+                            let changed =
+                                self.register_tracked_assets_from_pool_snapshot(&snapshot);
+                            if changed {
+                                self.dlmm_registered_active_id
+                                    .write()
+                                    .insert(snapshot.pool, new_active_id);
+                            }
+                            changed
+                        }
+                        rejected => {
+                            record_admission_rejection(snapshot.consumer, rejected);
+                            false
+                        }
+                    }
+                });
             }
         }
     }
@@ -3350,13 +3511,33 @@ impl MarketDataContext {
         }
     }
 
-    fn apply_pending_track_worker_work(&self, desired: &mut DesiredExplicitSet) {
-        if self.pending_pool_overflow_latched.load(Ordering::Acquire) {
+    fn try_recover_pending_pool_overflow(&self, desired: &mut DesiredExplicitSet) {
+        if !self.pending_pool_overflow_latched.load(Ordering::Acquire) {
             return;
         }
-        if self.pending_pool_commands.overflowed() {
-            self.fail_pending_pool_overflow();
+        if !self.pending_pool_commands.is_empty() {
             return;
+        }
+        self.converge_explicit_admission(desired);
+        self.refresh_explicit_admission_metrics(desired);
+        if desired.cap_overflow() > 0 {
+            return;
+        }
+        let cap = self.config.read().max_tracked_accounts;
+        if self.wallet_explicit_demand_pubkeys().len() > cap {
+            return;
+        }
+        *self.geyser_explicit_config_error.write() = None;
+        self.geyser_explicit_ready.store(true, Ordering::Release);
+        self.clear_pending_pool_overflow_latch();
+        let _ = enqueue_track_worker(self, TrackWorkerCommand::ScheduleGeyserPushDebounced);
+    }
+
+    fn apply_pending_track_worker_work(&self, desired: &mut DesiredExplicitSet) {
+        if !self.pending_pool_overflow_latched.load(Ordering::Acquire)
+            && self.pending_pool_commands.overflowed()
+        {
+            self.fail_pending_pool_overflow();
         }
         let (demand, token_accounts, _) = self.wallet_explicit_pending.snapshot();
         if !demand.is_empty() || !token_accounts.is_empty() {
@@ -3364,6 +3545,10 @@ impl MarketDataContext {
         }
         for command in self.pending_pool_commands.drain_all() {
             self.replay_pending_pool_command(desired, command);
+        }
+        if self.pending_pool_overflow_latched.load(Ordering::Acquire) {
+            self.try_recover_pending_pool_overflow(desired);
+            return;
         }
         if self.pending_pool_commands.is_empty() {
             self.clear_pending_pool_overflow_latch();
@@ -5462,7 +5647,7 @@ impl MarketDataContext {
                 continue;
             };
             self.hot_pool_registry.pin_pool(mint_pk, pool_pk);
-            if !self.acquire_pool_revision_slot(pool_pk, ConsumerId::Momentum) {
+            if !self.acquire_momentum_revision_owner(mint_pk, pool_pk) {
                 continue;
             }
             if self.register_geyser_reserves_for_momentum_active_pool(desired, pool_pk) {
@@ -5502,6 +5687,8 @@ impl MarketDataContext {
         pool: Pubkey,
     ) -> bool {
         self.hot_pool_registry.unpin_pool(mint, pool);
+        self.pool_snapshot_revisions
+            .release_active_owner(RevisionActiveOwner::MomentumMintPool { mint, pool });
         let consumer = ConsumerId::Momentum;
         let refs = self.pool_snapshot_revisions.key_refs(pool, consumer);
         let has_pending = self.pending_pool_commands.has_pending(pool, consumer);
@@ -5513,8 +5700,6 @@ impl MarketDataContext {
             desired.remove_group(consumer, OwnerKey::Pool(pool));
             self.pool_snapshot_revisions
                 .maybe_retire_key(pool, consumer, false, false);
-            self.pool_snapshot_revisions
-                .release_active_if_idle(pool, consumer);
         }
         let mut changed = false;
         // Pool-level reserve pins are shared: only demote vaults/bin arrays when no `(m, pool)`
@@ -5656,7 +5841,7 @@ impl MarketDataContext {
                 continue;
             };
             self.hot_pool_registry.pin_arb_pool(pool_pk);
-            if !self.acquire_pool_revision_slot(pool_pk, ConsumerId::Arb) {
+            if !self.acquire_arb_revision_owner(pool_pk) {
                 continue;
             }
             if self.register_geyser_reserves_for_arb_active_pool(desired, pool_pk) {
@@ -5714,6 +5899,8 @@ impl MarketDataContext {
         pool: Pubkey,
     ) -> bool {
         self.hot_pool_registry.unpin_arb_pool(pool);
+        self.pool_snapshot_revisions
+            .release_active_owner(RevisionActiveOwner::ArbPool { pool });
         let consumer = ConsumerId::Arb;
         let refs = self.pool_snapshot_revisions.key_refs(pool, consumer);
         let has_pending = self.pending_pool_commands.has_pending(pool, consumer);
@@ -5726,8 +5913,6 @@ impl MarketDataContext {
             desired.remove_group(consumer, OwnerKey::Pool(pool));
             self.pool_snapshot_revisions
                 .maybe_retire_key(pool, consumer, false, false);
-            self.pool_snapshot_revisions
-                .release_active_if_idle(pool, consumer);
         }
         let mut changed = false;
         if !self.hot_pool_registry.pool_has_arb(pool)
@@ -16710,7 +16895,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
         ctx.hot_pool_registry.pin_pool(base, pool);
-        assert!(ctx.acquire_pool_revision_slot(pool, ConsumerId::Momentum));
+        assert!(ctx.acquire_momentum_revision_owner(base, pool));
         let snapshot = ctx
             .build_pool_explicit_snapshot(pool, GeyserPinReason::MomentumActive)
             .expect("snapshot");
@@ -16839,7 +17024,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
         ctx.hot_pool_registry.pin_arb_pool(pool);
-        assert!(ctx.acquire_pool_revision_slot(pool, ConsumerId::Arb));
+        assert!(ctx.acquire_arb_revision_owner(pool));
 
         let mut snapshot = ctx
             .build_pool_explicit_snapshot(pool, GeyserPinReason::ArbMultiDex)
@@ -16848,8 +17033,11 @@ mod pr_b_geyser_tracking_tests {
             RevisionAssignResult::Assigned(_) => {}
             other => panic!("assign failed: {other:?}"),
         }
-        ctx.pool_snapshot_revisions
-            .inc_inflight_ref(pool, ConsumerId::Arb);
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .reserve_inflight_command(pool, ConsumerId::Arb),
+            InflightReserveResult::Reserved
+        );
         assert!(!snapshot.vaults.is_empty());
         assert!(!snapshot.bin_arrays.is_empty());
         assert!(!snapshot.mints.is_empty());
@@ -16875,14 +17063,25 @@ mod pr_b_geyser_tracking_tests {
         pool: Pubkey,
         consumer: ConsumerId,
         snapshot: &mut PoolExplicitSnapshot,
+        pin_mint: Option<Pubkey>,
     ) -> u64 {
-        assert!(ctx.acquire_pool_revision_slot(pool, consumer));
-        let rev = match ctx.pool_snapshot_revisions.assign_next(snapshot) {
+        match consumer {
+            ConsumerId::Momentum => {
+                let mint = pin_mint.unwrap_or(pool);
+                assert!(ctx.acquire_momentum_revision_owner(mint, pool));
+            }
+            ConsumerId::Arb => assert!(ctx.acquire_arb_revision_owner(pool)),
+            _ => panic!("unsupported consumer for test assign: {consumer:?}"),
+        }
+        assert_eq!(
+            ctx.pool_snapshot_revisions
+                .reserve_inflight_command(pool, consumer),
+            InflightReserveResult::Reserved
+        );
+        match ctx.pool_snapshot_revisions.assign_next(snapshot) {
             RevisionAssignResult::Assigned(rev) => rev,
             other => panic!("assign failed: {other:?}"),
-        };
-        ctx.pool_snapshot_revisions.inc_inflight_ref(pool, consumer);
-        rev
+        }
     }
 
     #[test]
@@ -16892,7 +17091,10 @@ mod pr_b_geyser_tracking_tests {
         let pool_a = Pubkey::new_unique();
         let pool_b = Pubkey::new_unique();
         assert_eq!(
-            revisions.try_acquire_active(pool_a, ConsumerId::Momentum),
+            revisions.acquire_active_owner(RevisionActiveOwner::MomentumMintPool {
+                mint: pool_a,
+                pool: pool_a,
+            }),
             RevisionAcquireResult::Acquired
         );
         let mk_snapshot = |pool: Pubkey| PoolExplicitSnapshot {
@@ -16951,7 +17153,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
         ctx.hot_pool_registry.pin_arb_pool(pool);
-        assert!(ctx.acquire_pool_revision_slot(pool, ConsumerId::Arb));
+        assert!(ctx.acquire_arb_revision_owner(pool));
 
         let mk_typed = |vault_pk: Pubkey, bin_pk: Pubkey, mint_pk: Pubkey| PoolExplicitSnapshot {
             pool,
@@ -17079,7 +17281,7 @@ mod pr_b_geyser_tracking_tests {
         );
         ctx.hot_pool_registry.pin_arb_pool(pool);
         ctx.hot_pool_registry.pin_pool(base, pool);
-        assert!(ctx.acquire_pool_revision_slot(pool, ConsumerId::Arb));
+        assert!(ctx.acquire_arb_revision_owner(pool));
 
         let mk_typed =
             move |bin_pk: Pubkey, mint_pk: Pubkey, extra_vault: Pubkey| PoolExplicitSnapshot {
@@ -17159,7 +17361,8 @@ mod pr_b_geyser_tracking_tests {
 
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         let mut snapshot_new = mk_typed(bin_new, mint_new, vault_new);
-        let rev_new = assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snapshot_new);
+        let rev_new =
+            assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snapshot_new, None);
         assert!(ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot_new));
         assert_eq!(
             ctx.pool_snapshot_revisions
@@ -17213,7 +17416,8 @@ mod pr_b_geyser_tracking_tests {
 
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         let mut snapshot_new = mk_typed(bin_new, mint_new, vault_new);
-        let rev_new = assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snapshot_new);
+        let rev_new =
+            assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snapshot_new, None);
         assert!(ctx.commit_register_pool_geyser_reserves(&mut desired, &snapshot_new));
 
         let mut snapshot_stale = mk_typed(bin_old, mint_old, vault_old);
@@ -17259,20 +17463,22 @@ mod pr_b_geyser_tracking_tests {
 
         let mut snap_reserves = mk_typed(bin_v1, mint_v1, vault_v1);
         let rev_reserves =
-            assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snap_reserves);
+            assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snap_reserves, None);
         assert!(ctx.commit_register_pool_geyser_reserves(&mut desired, &snap_reserves));
 
         let mut snap_vaults = mk_typed(bin_v2, mint_v2, vault_v2);
         let rev_vaults =
-            assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snap_vaults);
+            assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snap_vaults, None);
         assert!(ctx.commit_register_pool_vaults_from_account(&mut desired, &snap_vaults));
 
         let mut snap_trade = mk_typed(bin_v3, mint_v3, vault_v3);
-        let rev_trade = assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snap_trade);
+        let rev_trade =
+            assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snap_trade, None);
         assert!(ctx.commit_register_geyser_reserves_after_trade(&mut desired, &snap_trade));
 
         let mut snap_dlmm = mk_typed(bin_v4, mint_v4, vault_v4);
-        let rev_dlmm = assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snap_dlmm);
+        let rev_dlmm =
+            assign_pool_snapshot_for_test(&ctx, pool, ConsumerId::Arb, &mut snap_dlmm, None);
         assert!(ctx.commit_refresh_dlmm_bin_window(&mut desired, &snap_dlmm, 9));
 
         assert!(rev_vaults > rev_reserves);
@@ -17400,6 +17606,63 @@ mod pr_b_geyser_tracking_tests {
     }
 
     #[test]
+    fn pending_overflow_recovers_after_drain_without_restart() {
+        use ironcrab::execution::live_pool_cache::RaydiumCpmmState;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let base_vault = Pubkey::new_unique();
+        let quote_vault = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: mint,
+                token_1_mint: quote,
+                token_0_vault: base_vault,
+                token_1_vault: quote_vault,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool(mint, pool);
+        assert!(ctx.acquire_momentum_revision_owner(mint, pool));
+        let snapshot = ctx
+            .build_pool_explicit_snapshot(pool, GeyserPinReason::MomentumActive)
+            .expect("snapshot");
+        assert_eq!(
+            ctx.pending_pool_commands
+                .upsert(PendingPoolCommand::RegisterReserves(snapshot)),
+            PendingPoolUpsertResult::Stored
+        );
+        ctx.fail_pending_pool_overflow();
+        assert!(ctx.pending_pool_overflow_latched.load(Ordering::Acquire));
+        assert!(!ctx.geyser_explicit_readiness_ok());
+
+        let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
+        ctx.apply_pending_track_worker_work(&mut desired);
+
+        assert!(
+            !ctx.pending_pool_overflow_latched.load(Ordering::Acquire),
+            "overflow latch must clear after pending drain + convergence"
+        );
+        assert!(ctx.geyser_explicit_readiness_ok());
+        assert!(!ctx.pending_pool_commands.overflowed());
+        assert!(desired.contains(&base_vault));
+        let refs = ctx
+            .pool_snapshot_revisions
+            .key_refs(pool, ConsumerId::Momentum);
+        assert_eq!(refs.inflight, 0);
+        assert_eq!(refs.pending, 0);
+        assert_eq!(refs.active_owners, 1);
+    }
+
+    #[test]
     fn momentum_two_mint_same_pool_delayed_registration_retains_desired() {
         use ironcrab::execution::live_pool_cache::RaydiumCpmmState;
 
@@ -17428,9 +17691,10 @@ mod pr_b_geyser_tracking_tests {
 
         let mut desired = DesiredExplicitSet::new(ctx.config.read().max_tracked_accounts);
         ctx.hot_pool_registry.pin_pool(mint_a, pool);
-        assert!(ctx.acquire_pool_revision_slot(pool, ConsumerId::Momentum));
+        assert!(ctx.acquire_momentum_revision_owner(mint_a, pool));
         assert!(ctx.register_geyser_reserves_for_momentum_active_pool(&mut desired, pool));
         ctx.hot_pool_registry.pin_pool(mint_b, pool);
+        assert!(ctx.acquire_momentum_revision_owner(mint_b, pool));
         assert!(
             desired
                 .snapshot_owner_groups()

--- a/src/market_data/ingest/tx_host.rs
+++ b/src/market_data/ingest/tx_host.rs
@@ -68,6 +68,7 @@ pub trait TxIngestHost: IngestHost + Send + Sync {
     /// True when wallet-scoped mint should be enqueued via `TrackWalletMint` (no `tracked_mints` read in ingest).
     fn tx_wallet_mint_needs_track(&self, mint: &Pubkey) -> bool;
     fn tx_wallet_token_account_insert(&self, ata: Pubkey) -> bool;
+    fn tx_wallet_token_account_remove(&self, ata: Pubkey) -> bool;
     fn tx_wallet_mint_decimals_insert(&self, mint: Pubkey, decimals: u8);
     /// Refresh Geyser wallet subscribe list after ATA pin (wallet + WSOL ATA + tracked token ATAs).
     fn tx_wallet_notify_geyser_subscribe_accounts_changed(&self);
@@ -200,6 +201,10 @@ impl<T: TxIngestHost + ?Sized> TxIngestHost for std::sync::Arc<T> {
 
     fn tx_wallet_token_account_insert(&self, ata: Pubkey) -> bool {
         (**self).tx_wallet_token_account_insert(ata)
+    }
+
+    fn tx_wallet_token_account_remove(&self, ata: Pubkey) -> bool {
+        (**self).tx_wallet_token_account_remove(ata)
     }
 
     fn tx_wallet_mint_decimals_insert(&self, mint: Pubkey, decimals: u8) {

--- a/src/market_data/track/coalesce.rs
+++ b/src/market_data/track/coalesce.rs
@@ -1,8 +1,7 @@
 //! Phase 5a: NATS burst coalescers for momentum and arb track-worker enqueue.
 
-use super::worker::{
-    track_worker_try_enqueue, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
-};
+use super::worker::{track_worker_try_enqueue, TrackWorkerContext, TrackWorkerSender};
+use super::worker_commands::TrackWorkerCommand;
 use crate::metrics::{
     inc_market_data_arb_track_coalesced_batches_total,
     inc_market_data_arb_track_coalesced_messages_total,

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -204,7 +204,16 @@ impl DesiredExplicitSet {
     }
 
     pub fn wallet_demand_exceeds_cap(&self, demand: &HashSet<Pubkey>) -> bool {
-        demand.len() > self.max_explicit_pubkeys
+        self.projected_wallet_protected_pubkeys(demand).len() > self.max_explicit_pubkeys
+    }
+
+    /// Union of incoming wallet demand and all Wallet-consumer pubkeys already admitted (wallet group + wallet-pinned mints).
+    pub fn projected_wallet_protected_pubkeys(&self, demand: &HashSet<Pubkey>) -> HashSet<Pubkey> {
+        let mut out = demand.clone();
+        if let Some(existing) = self.by_consumer.get(&ConsumerId::Wallet) {
+            out.extend(existing.iter().copied());
+        }
+        out
     }
 
     pub fn clear(&mut self) {
@@ -229,13 +238,21 @@ impl DesiredExplicitSet {
         }
     }
 
-    /// Atomically admit a full owner group or reject without mutation.
     pub fn try_admit_group(
         &mut self,
         consumer: ConsumerId,
         owner: OwnerKey,
         pubkeys: HashSet<Pubkey>,
     ) -> AdmissionResult {
+        if pubkeys.is_empty() {
+            return AdmissionResult::RejectedInvalidGroup;
+        }
+        if let Some(existing) = self.groups.get(&(consumer, owner)) {
+            if existing.pubkeys == pubkeys {
+                self.touch_group(consumer, owner);
+                return AdmissionResult::OwnerAddedNoNewPubkey;
+            }
+        }
         match self.plan_admit_group(consumer, owner, pubkeys) {
             Ok(plan) => self.apply_plan(plan),
             Err(result) => result,
@@ -304,27 +321,52 @@ impl DesiredExplicitSet {
         self.evict_until_within_cap(EvictReason::RestoreConverge);
     }
 
-    /// Reconcile complete owner groups in priority order without flatten/clear.
+    /// Reconcile authoritative owner groups in priority order without flatten/clear.
     pub fn reconcile_owner_groups(&mut self, groups: Vec<(ConsumerId, OwnerKey, HashSet<Pubkey>)>) {
-        let incoming_keys: HashSet<(ConsumerId, OwnerKey)> =
-            groups.iter().map(|(c, o, _)| (*c, *o)).collect();
+        self.reconcile_owner_groups_with_preserve(groups, Vec::new());
+    }
+
+    /// Reconcile authoritative groups; preserve restored groups until an authoritative replacement exists.
+    pub fn reconcile_owner_groups_with_preserve(
+        &mut self,
+        authoritative: Vec<(ConsumerId, OwnerKey, HashSet<Pubkey>)>,
+        preserve: Vec<(ConsumerId, OwnerKey, HashSet<Pubkey>)>,
+    ) {
+        let auth_keys: HashSet<(ConsumerId, OwnerKey)> =
+            authoritative.iter().map(|(c, o, _)| (*c, *o)).collect();
+        let preserve_keys: HashSet<(ConsumerId, OwnerKey)> =
+            preserve.iter().map(|(c, o, _)| (*c, *o)).collect();
+        let keep_keys: HashSet<(ConsumerId, OwnerKey)> =
+            auth_keys.union(&preserve_keys).copied().collect();
         for key in self
             .groups
             .keys()
             .copied()
             .collect::<Vec<(ConsumerId, OwnerKey)>>()
         {
-            if !incoming_keys.contains(&key) {
+            if !keep_keys.contains(&key) {
                 self.remove_group(key.0, key.1);
             }
         }
-        let mut ordered = groups;
+        let mut ordered = authoritative;
         ordered.sort_by(|a, b| {
             pin_priority_from_consumer(a.0)
                 .cmp(&pin_priority_from_consumer(b.0))
                 .then_with(|| a.1.cmp(&b.1))
         });
         for (consumer, owner, pubkeys) in ordered {
+            let _ = self.try_admit_group(consumer, owner, pubkeys);
+        }
+        let mut preserved = preserve;
+        preserved.sort_by(|a, b| {
+            pin_priority_from_consumer(a.0)
+                .cmp(&pin_priority_from_consumer(b.0))
+                .then_with(|| a.1.cmp(&b.1))
+        });
+        for (consumer, owner, pubkeys) in preserved {
+            if auth_keys.contains(&(consumer, owner)) {
+                continue;
+            }
             let _ = self.try_admit_group(consumer, owner, pubkeys);
         }
         self.evict_until_within_cap(EvictReason::RestoreConverge);
@@ -379,19 +421,26 @@ impl DesiredExplicitSet {
         let mut evictions = Vec::new();
         if need > free {
             let deficit = need - free;
-            match self.plan_evictions_for_incoming(consumer, deficit) {
+            match self.plan_evictions_for_incoming(consumer, owner, &new_unique, deficit) {
                 Some(victims) => evictions = victims,
                 None => return Err(AdmissionResult::RejectedCap),
             }
         }
 
-        Ok(AdmissionPlan {
+        let plan = AdmissionPlan {
             evictions,
             incoming: Some((consumer, owner, pubkeys)),
-        })
+        };
+        if !self.validate_plan_fits_cap(&plan) {
+            return Err(AdmissionResult::RejectedCap);
+        }
+        Ok(plan)
     }
 
     fn apply_plan(&mut self, plan: AdmissionPlan) -> AdmissionResult {
+        if !self.validate_plan_fits_cap(&plan) {
+            return AdmissionResult::RejectedCap;
+        }
         let Some((consumer, owner, pubkeys)) = plan.incoming else {
             return AdmissionResult::RejectedInvalidGroup;
         };
@@ -402,11 +451,15 @@ impl DesiredExplicitSet {
             .collect();
 
         for (victim_consumer, victim_owner, reason) in plan.evictions {
-            let freed = self.evict_group(victim_consumer, victim_owner, reason);
-            debug_assert!(freed > 0, "planned eviction must free capacity");
+            self.evict_group(victim_consumer, victim_owner, reason);
         }
 
         self.commit_group(consumer, owner, pubkeys);
+        self.compact_evict_heap_if_needed();
+        debug_assert!(
+            self.len() <= self.max_explicit_pubkeys,
+            "admitted SSOT must never exceed cap after commit"
+        );
         if new_unique.is_empty() {
             AdmissionResult::OwnerAddedNoNewPubkey
         } else {
@@ -416,34 +469,131 @@ impl DesiredExplicitSet {
         }
     }
 
+    fn validate_plan_fits_cap(&self, plan: &AdmissionPlan) -> bool {
+        self.projected_entry_count_after_plan(plan) <= self.max_explicit_pubkeys
+    }
+
+    fn projected_entry_count_after_plan(&self, plan: &AdmissionPlan) -> usize {
+        let Some((inc_c, inc_o, incoming)) = plan.incoming.as_ref() else {
+            return self.entries.len();
+        };
+        let victims: Vec<(ConsumerId, OwnerKey)> =
+            plan.evictions.iter().map(|(c, o, _)| (*c, *o)).collect();
+        let victim_set: HashSet<(ConsumerId, OwnerKey)> = victims.iter().copied().collect();
+
+        let mut owners_after: HashMap<Pubkey, HashSet<(ConsumerId, OwnerKey)>> = HashMap::new();
+        for (pk, entry) in &self.entries {
+            let remaining: HashSet<_> = entry
+                .owners
+                .iter()
+                .filter(|owner| !victim_set.contains(owner))
+                .copied()
+                .collect();
+            if !remaining.is_empty() {
+                owners_after.insert(*pk, remaining);
+            }
+        }
+
+        if let Some(existing) = self.groups.get(&(*inc_c, *inc_o)) {
+            for pk in &existing.pubkeys {
+                if let Some(rem) = owners_after.get_mut(pk) {
+                    rem.remove(&(*inc_c, *inc_o));
+                    if rem.is_empty() {
+                        owners_after.remove(pk);
+                    }
+                }
+            }
+        }
+
+        for pk in incoming {
+            owners_after
+                .entry(*pk)
+                .or_default()
+                .insert((*inc_c, *inc_o));
+        }
+
+        owners_after.len()
+    }
+
+    fn unique_pubkeys_freed_if_evicted(
+        &self,
+        victims: &[(ConsumerId, OwnerKey)],
+    ) -> HashSet<Pubkey> {
+        let victim_set: HashSet<(ConsumerId, OwnerKey)> = victims.iter().copied().collect();
+        let mut freed = HashSet::new();
+        for (vc, vo) in victims {
+            let Some(group) = self.groups.get(&(*vc, *vo)) else {
+                continue;
+            };
+            for pk in &group.pubkeys {
+                if freed.contains(pk) {
+                    continue;
+                }
+                if self.entries.get(pk).is_some_and(|entry| {
+                    entry.owners.iter().all(|owner| victim_set.contains(owner))
+                }) {
+                    freed.insert(*pk);
+                }
+            }
+        }
+        freed
+    }
+
+    fn marginal_unique_freed_by_evicting(
+        &self,
+        victim: (ConsumerId, OwnerKey),
+        already: &[(ConsumerId, OwnerKey)],
+    ) -> usize {
+        let mut extended = already.to_vec();
+        extended.push(victim);
+        let before = self.unique_pubkeys_freed_if_evicted(already).len();
+        let after = self.unique_pubkeys_freed_if_evicted(&extended).len();
+        after.saturating_sub(before)
+    }
+
+    fn sorted_eviction_victim_keys(&self) -> Vec<(ConsumerId, OwnerKey)> {
+        let mut keys: Vec<(ConsumerId, OwnerKey)> = self.groups.keys().copied().collect();
+        keys.sort_by(|a, b| {
+            let ga = &self.groups[a];
+            let gb = &self.groups[b];
+            pin_priority_from_consumer(ga.consumer)
+                .cmp(&pin_priority_from_consumer(gb.consumer))
+                .reverse()
+                .then_with(|| ga.last_touched_gen.cmp(&gb.last_touched_gen))
+                .then_with(|| ga.admitted_seq.cmp(&gb.admitted_seq))
+                .then_with(|| a.1.cmp(&b.1))
+        });
+        keys
+    }
+
     fn plan_evictions_for_incoming(
         &self,
         incoming: ConsumerId,
+        incoming_owner: OwnerKey,
+        _new_unique: &HashSet<Pubkey>,
         mut deficit: usize,
     ) -> Option<Vec<(ConsumerId, OwnerKey, EvictReason)>> {
         let incoming_priority = pin_priority_from_consumer(incoming);
         let mut victims = Vec::new();
-        let mut scratch: BinaryHeap<EvictCandidate> = self.evict_heap.clone();
-        let mut seen = HashSet::new();
+        let mut victim_keys = Vec::new();
 
-        while deficit > 0 {
-            let Some(candidate) =
-                pop_fresh_evict_candidate(&mut scratch, &self.heap_stamp, &self.groups)
-            else {
+        for (consumer, owner) in self.sorted_eviction_victim_keys() {
+            if deficit == 0 {
                 break;
-            };
-            if !seen.insert((candidate.consumer, candidate.owner)) {
+            }
+            if consumer == incoming && owner == incoming_owner {
                 continue;
             }
-            if candidate.removable == 0 {
-                continue;
-            }
-            let gp = pin_priority_from_consumer(candidate.consumer);
+            let gp = pin_priority_from_consumer(consumer);
             let evictable = gp > incoming_priority
                 || (gp == incoming_priority
                     && incoming_priority != PinPriority::Wallet
-                    && candidate.consumer == incoming);
+                    && consumer == incoming);
             if !evictable {
+                continue;
+            }
+            let marginal = self.marginal_unique_freed_by_evicting((consumer, owner), &victim_keys);
+            if marginal == 0 {
                 continue;
             }
             let reason = if gp > incoming_priority {
@@ -451,8 +601,9 @@ impl DesiredExplicitSet {
             } else {
                 EvictReason::SamePriorityLru
             };
-            deficit = deficit.saturating_sub(candidate.removable);
-            victims.push((candidate.consumer, candidate.owner, reason));
+            victim_keys.push((consumer, owner));
+            victims.push((consumer, owner, reason));
+            deficit = deficit.saturating_sub(marginal);
         }
 
         if deficit > 0 {
@@ -530,17 +681,28 @@ impl DesiredExplicitSet {
                 break;
             }
         }
+        self.compact_evict_heap_if_needed();
     }
 
     fn pop_cap_shrink_victim(&mut self) -> Option<(ConsumerId, OwnerKey)> {
-        while let Some(candidate) =
-            pop_fresh_evict_candidate(&mut self.evict_heap, &self.heap_stamp, &self.groups)
-        {
-            if candidate.removable > 0 {
-                return Some((candidate.consumer, candidate.owner));
+        for (consumer, owner) in self.sorted_eviction_victim_keys() {
+            if self.removable_pubkeys_for_group(consumer, owner) > 0 {
+                return Some((consumer, owner));
             }
         }
         None
+    }
+
+    fn compact_evict_heap_if_needed(&mut self) {
+        const HEAP_COMPACT_FACTOR: usize = 4;
+        if self.evict_heap.len() <= self.groups.len().saturating_mul(HEAP_COMPACT_FACTOR) {
+            return;
+        }
+        self.evict_heap.clear();
+        let keys: Vec<(ConsumerId, OwnerKey)> = self.groups.keys().copied().collect();
+        for (consumer, owner) in keys {
+            self.push_evict_candidate(consumer, owner);
+        }
     }
 
     fn removable_pubkeys_for_group(&self, consumer: ConsumerId, owner: OwnerKey) -> usize {
@@ -586,24 +748,6 @@ impl DesiredExplicitSet {
             }
         }
     }
-}
-
-fn pop_fresh_evict_candidate(
-    heap: &mut BinaryHeap<EvictCandidate>,
-    stamps: &HashMap<(ConsumerId, OwnerKey), u64>,
-    groups: &HashMap<(ConsumerId, OwnerKey), OwnerGroup>,
-) -> Option<EvictCandidate> {
-    while let Some(candidate) = heap.pop() {
-        let key = (candidate.consumer, candidate.owner);
-        if stamps.get(&key).copied() != Some(candidate.stamp) {
-            continue;
-        }
-        if !groups.contains_key(&key) {
-            continue;
-        }
-        return Some(candidate);
-    }
-    None
 }
 
 fn build_owner_groups_from_rows(
@@ -869,7 +1013,38 @@ mod tests {
     }
 
     #[test]
-    fn same_priority_uses_lru_not_fifo() {
+    fn shared_pubkey_stale_heap_candidates_never_exceed_cap_in_release() {
+        let mut set = DesiredExplicitSet::new(2);
+        let shared = Pubkey::new_unique();
+        let (_, o1, _) = pool_owner();
+        let (_, o2, _) = pool_owner();
+        let extra = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Arb, o1, HashSet::from([shared])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, o2, HashSet::from([shared, extra])),
+            AdmissionResult::Admitted { .. }
+        ));
+        for _ in 0..8 {
+            set.touch_group(ConsumerId::Arb, o1);
+        }
+        let len_before = set.len();
+        assert_eq!(len_before, 2);
+        let (_, o3, _) = pool_owner();
+        let n1 = Pubkey::new_unique();
+        let n2 = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, o3, HashSet::from([n1, n2])),
+            AdmissionResult::RejectedCap
+        ));
+        assert_eq!(set.len(), len_before);
+        assert!(set.len() <= set.max_explicit_pubkeys());
+    }
+
+    #[test]
+    fn same_priority_uses_lru_not_fifo_via_readmit() {
         let mut set = DesiredExplicitSet::new(2);
         let (_, old_owner, _) = pool_owner();
         let old_pk = Pubkey::new_unique();
@@ -883,7 +1058,10 @@ mod tests {
             set.try_admit_group(ConsumerId::Momentum, new_owner, HashSet::from([new_pk])),
             AdmissionResult::Admitted { .. }
         ));
-        set.touch_group(ConsumerId::Momentum, old_owner);
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, old_owner, HashSet::from([old_pk])),
+            AdmissionResult::OwnerAddedNoNewPubkey
+        ));
         let (_, incoming_owner, _) = pool_owner();
         let incoming_pk = Pubkey::new_unique();
         assert!(matches!(

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -191,11 +191,14 @@ fn initial_projected_refcount(
 }
 
 impl PlanningOverlay {
-    fn for_cap_shrink(set: &DesiredExplicitSet) -> Self {
+    fn for_cap_shrink(set: &DesiredExplicitSet, mut stats: Option<&mut PlanningStats>) -> Self {
         let touched_pubkeys: HashSet<Pubkey> = set.entries.keys().copied().collect();
         let mut projected_pubkey_refcount = HashMap::with_capacity(touched_pubkeys.len());
         for pk in &touched_pubkeys {
             let count = set.entries.get(pk).map(|e| e.owners.len()).unwrap_or(0);
+            if let Some(s) = stats.as_mut() {
+                s.owner_edge_iterations = s.owner_edge_iterations.saturating_add(count);
+            }
             projected_pubkey_refcount.insert(*pk, count);
         }
         Self {
@@ -989,7 +992,7 @@ impl DesiredExplicitSet {
 
     /// Set-aware cap-shrink victim planning: aggregate eviction across co-dependent groups.
     fn plan_cap_shrink_victims(&self, _deficit: usize) -> Option<Vec<(ConsumerId, OwnerKey)>> {
-        let overlay = PlanningOverlay::for_cap_shrink(self);
+        let overlay = PlanningOverlay::for_cap_shrink(self, None);
         let victims_with_reason =
             self.plan_evictions_with_overlay(overlay, None, self.max_explicit_pubkeys, None)?;
         Some(
@@ -1067,7 +1070,7 @@ impl DesiredExplicitSet {
             Some((c, o, p)) => {
                 PlanningOverlay::for_incoming_admission(self, *c, *o, p, stats.as_deref_mut())
             }
-            None => PlanningOverlay::for_cap_shrink(self),
+            None => PlanningOverlay::for_cap_shrink(self, stats.as_deref_mut()),
         };
         let incoming_ref = incoming.as_ref().map(|(c, o, p)| (*c, *o, p));
         self.plan_evictions_with_overlay(overlay, incoming_ref, cap, stats)
@@ -1146,20 +1149,6 @@ impl<'a> EvictionPlanner<'a> {
                     .entry(*key)
                     .or_insert_with(|| group.pubkeys.iter().copied().collect());
             }
-        }
-        for pk in &overlay.touched_pubkeys {
-            planner
-                .projected_pubkey_refcount
-                .entry(*pk)
-                .or_insert_with(|| {
-                    initial_projected_refcount(
-                        set,
-                        *pk,
-                        &planner.suppressed,
-                        overlay.incoming.as_ref().map(|(k, p)| (*k, p)),
-                        stats.as_deref_mut(),
-                    )
-                });
         }
         for key in planner.marginal.keys().copied().collect::<Vec<_>>() {
             planner.recompute_marginal_for_group(key, stats.as_deref_mut());
@@ -2177,16 +2166,18 @@ mod tests {
         let log_g = (group_count + 1).ilog2() as usize + 1;
         assert!(stats.candidate_pops <= group_count.saturating_mul(log_g));
         assert!(stats.victim_removals <= group_count);
+        let owner_edge_budget = edge_count
+            .saturating_add(victim_edge_visits)
+            .saturating_add(stats.candidate_pops);
+        assert!(
+            stats.owner_edge_iterations <= owner_edge_budget,
+            "owner edge visits {}/{} must stay bounded by initial+touched edges + victim edges + heap pops",
+            stats.owner_edge_iterations,
+            owner_edge_budget
+        );
         assert_eq!(
             stats.victim_owner_edge_scans, 0,
             "victim removal must not rescan owner edges"
-        );
-        let owner_edge_budget = edge_count.saturating_add(stats.candidate_pops);
-        assert!(
-            stats.owner_edge_iterations <= owner_edge_budget,
-            "owner edge visits {}/{} must stay bounded by initial+touched edges + heap pops",
-            stats.owner_edge_iterations,
-            owner_edge_budget
         );
         assert!(
             stats.refcount_checks

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -431,18 +431,13 @@ impl DesiredExplicitSet {
             }
         }
 
-        let new_unique: HashSet<Pubkey> = pubkeys
-            .iter()
-            .filter(|pk| !self.entries.contains_key(pk))
-            .copied()
-            .collect();
-        let need = new_unique.len();
-        let free = self.max_explicit_pubkeys.saturating_sub(self.entries.len());
+        let projected_without_evict =
+            self.projected_len_after_replace(consumer, owner, &pubkeys, &[]);
 
         let mut evictions = Vec::new();
-        if need > free {
-            let deficit = need - free;
-            match self.plan_evictions_for_incoming(consumer, owner, &new_unique, deficit) {
+        if projected_without_evict > self.max_explicit_pubkeys {
+            let deficit = projected_without_evict - self.max_explicit_pubkeys;
+            match self.plan_evictions_for_incoming(consumer, owner, deficit) {
                 Some(victims) => evictions = victims,
                 None => return Err(AdmissionResult::RejectedCap),
             }
@@ -456,6 +451,71 @@ impl DesiredExplicitSet {
             return Err(AdmissionResult::RejectedCap);
         }
         Ok(plan)
+    }
+
+    fn is_exclusive_to_owner(&self, pk: &Pubkey, consumer: ConsumerId, owner: OwnerKey) -> bool {
+        self.entries.get(pk).is_some_and(|entry| {
+            entry.owners.len() == 1 && entry.owners.contains(&(consumer, owner))
+        })
+    }
+
+    /// Projected `entries.len()` after evicting victims then replacing the incoming owner group.
+    fn projected_len_after_replace(
+        &self,
+        consumer: ConsumerId,
+        owner: OwnerKey,
+        incoming: &HashSet<Pubkey>,
+        victims: &[(ConsumerId, OwnerKey)],
+    ) -> usize {
+        let mut planner = EvictionPlanner::new(self);
+        let mut freed = 0usize;
+        for (vc, vo) in victims {
+            freed = freed.saturating_add(planner.add_victim((*vc, *vo)));
+        }
+        let len_after_evict = self.entries.len().saturating_sub(freed);
+        let replace_delta = self
+            .net_entry_delta_for_group_replace_after_victims(consumer, owner, incoming, victims);
+        ((len_after_evict as isize) + replace_delta).max(0) as usize
+    }
+
+    fn net_entry_delta_for_group_replace_after_victims(
+        &self,
+        consumer: ConsumerId,
+        owner: OwnerKey,
+        incoming: &HashSet<Pubkey>,
+        victims: &[(ConsumerId, OwnerKey)],
+    ) -> isize {
+        let victim_set: HashSet<(ConsumerId, OwnerKey)> = victims.iter().copied().collect();
+        let mut delta = 0isize;
+        if let Some(existing) = self.groups.get(&(consumer, owner)) {
+            for pk in &existing.pubkeys {
+                if !incoming.contains(pk) {
+                    let exclusive = if victim_set.is_empty() {
+                        self.is_exclusive_to_owner(pk, consumer, owner)
+                    } else {
+                        self.entries.get(pk).is_some_and(|entry| {
+                            entry
+                                .owners
+                                .iter()
+                                .all(|o| o == &(consumer, owner) || victim_set.contains(o))
+                        })
+                    };
+                    if exclusive {
+                        delta -= 1;
+                    }
+                }
+            }
+        }
+        for pk in incoming {
+            let remains_after_evict = self
+                .entries
+                .get(pk)
+                .is_some_and(|entry| entry.owners.iter().any(|o| !victim_set.contains(o)));
+            if !remains_after_evict {
+                delta += 1;
+            }
+        }
+        delta
     }
 
     fn apply_plan(&mut self, plan: AdmissionPlan) -> AdmissionResult {
@@ -497,75 +557,19 @@ impl DesiredExplicitSet {
         };
         let victims: Vec<(ConsumerId, OwnerKey)> =
             plan.evictions.iter().map(|(c, o, _)| (*c, *o)).collect();
-        let after_evict = self
-            .entries
-            .len()
-            .saturating_sub(self.unique_pubkeys_freed_if_evicted(&victims).len());
-        let mut incoming_unique = 0usize;
-        for pk in incoming {
-            if self.entries.get(pk).is_some_and(|entry| {
-                let victim_set: HashSet<_> = victims.iter().copied().collect();
-                entry.owners.iter().any(|owner| !victim_set.contains(owner))
-            }) {
-                continue;
-            }
-            if let Some(existing) = self.groups.get(&(*inc_c, *inc_o)) {
-                if existing.pubkeys.contains(pk) {
-                    continue;
-                }
-            }
-            incoming_unique += 1;
-        }
-        after_evict + incoming_unique
-    }
-
-    fn unique_pubkeys_freed_if_evicted(
-        &self,
-        victims: &[(ConsumerId, OwnerKey)],
-    ) -> HashSet<Pubkey> {
-        let victim_set: HashSet<(ConsumerId, OwnerKey)> = victims.iter().copied().collect();
-        let mut freed = HashSet::new();
-        for (vc, vo) in victims {
-            let Some(group) = self.groups.get(&(*vc, *vo)) else {
-                continue;
-            };
-            for pk in &group.pubkeys {
-                if freed.contains(pk) {
-                    continue;
-                }
-                if self.entries.get(pk).is_some_and(|entry| {
-                    entry.owners.iter().all(|owner| victim_set.contains(owner))
-                }) {
-                    freed.insert(*pk);
-                }
-            }
-        }
-        freed
-    }
-
-    fn marginal_unique_freed_by_evicting(
-        &self,
-        victim: (ConsumerId, OwnerKey),
-        already: &[(ConsumerId, OwnerKey)],
-    ) -> usize {
-        let mut extended = already.to_vec();
-        extended.push(victim);
-        let before = self.unique_pubkeys_freed_if_evicted(already).len();
-        let after = self.unique_pubkeys_freed_if_evicted(&extended).len();
-        after.saturating_sub(before)
+        self.projected_len_after_replace(*inc_c, *inc_o, incoming, &victims)
     }
 
     fn plan_evictions_for_incoming(
         &self,
         incoming: ConsumerId,
         incoming_owner: OwnerKey,
-        _new_unique: &HashSet<Pubkey>,
         mut deficit: usize,
     ) -> Option<Vec<(ConsumerId, OwnerKey, EvictReason)>> {
         let incoming_priority = pin_priority_from_consumer(incoming);
         let candidates = self.cap_shrink_candidate_keys();
+        let mut planner = EvictionPlanner::new(self);
         let mut victims = Vec::new();
-        let mut victim_keys = Vec::new();
 
         while deficit > 0 {
             let mut best_positive: Option<((ConsumerId, OwnerKey), usize, EvictReason)> = None;
@@ -574,10 +578,7 @@ impl DesiredExplicitSet {
                 if consumer == incoming && owner == incoming_owner {
                     continue;
                 }
-                if victim_keys
-                    .iter()
-                    .any(|(c, o)| *c == consumer && *o == owner)
-                {
+                if planner.is_victim(consumer, owner) {
                     continue;
                 }
                 let gp = pin_priority_from_consumer(consumer);
@@ -588,8 +589,7 @@ impl DesiredExplicitSet {
                 if !evictable {
                     continue;
                 }
-                let marginal =
-                    self.marginal_unique_freed_by_evicting((consumer, owner), &victim_keys);
+                let marginal = planner.marginal_freed((consumer, owner));
                 let reason = if gp > incoming_priority {
                     EvictReason::HigherPriority
                 } else {
@@ -605,11 +605,11 @@ impl DesiredExplicitSet {
                 }
             }
             if let Some(((consumer, owner), marginal, reason)) = best_positive {
-                victim_keys.push((consumer, owner));
+                planner.add_victim((consumer, owner));
                 victims.push((consumer, owner, reason));
                 deficit = deficit.saturating_sub(marginal);
             } else if let Some(((consumer, owner), reason)) = best_zero {
-                victim_keys.push((consumer, owner));
+                planner.add_victim((consumer, owner));
                 victims.push((consumer, owner, reason));
             } else {
                 return None;
@@ -712,20 +712,17 @@ impl DesiredExplicitSet {
     /// Set-aware cap-shrink victim planning: aggregate eviction across co-dependent groups.
     fn plan_cap_shrink_victims(&self, deficit: usize) -> Option<Vec<(ConsumerId, OwnerKey)>> {
         let candidates = self.cap_shrink_candidate_keys();
+        let mut planner = EvictionPlanner::new(self);
         let mut victim_keys = Vec::new();
         let mut freed = 0usize;
         while freed < deficit {
             let mut best_positive: Option<((ConsumerId, OwnerKey), usize)> = None;
             let mut best_zero: Option<(ConsumerId, OwnerKey)> = None;
             for &(consumer, owner) in &candidates {
-                if victim_keys
-                    .iter()
-                    .any(|(c, o)| *c == consumer && *o == owner)
-                {
+                if planner.is_victim(consumer, owner) {
                     continue;
                 }
-                let marginal =
-                    self.marginal_unique_freed_by_evicting((consumer, owner), &victim_keys);
+                let marginal = planner.marginal_freed((consumer, owner));
                 if marginal > 0 {
                     let replace = best_positive.as_ref().is_none_or(|(_, m)| marginal > *m);
                     if replace {
@@ -736,9 +733,11 @@ impl DesiredExplicitSet {
                 }
             }
             if let Some(((consumer, owner), marginal)) = best_positive {
+                planner.add_victim((consumer, owner));
                 victim_keys.push((consumer, owner));
                 freed = freed.saturating_add(marginal);
             } else if let Some((consumer, owner)) = best_zero {
+                planner.add_victim((consumer, owner));
                 victim_keys.push((consumer, owner));
             } else {
                 return None;
@@ -822,6 +821,147 @@ impl DesiredExplicitSet {
                 self.by_consumer.remove(&consumer);
             }
         }
+    }
+}
+
+/// Incremental marginal-free eviction planner (bounded edge updates, no G×G rescans).
+struct EvictionPlanner<'a> {
+    set: &'a DesiredExplicitSet,
+    victims: HashSet<(ConsumerId, OwnerKey)>,
+    marginal: HashMap<(ConsumerId, OwnerKey), usize>,
+    marginal_contributors: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>>,
+    pubkey_groups: HashMap<Pubkey, Vec<(ConsumerId, OwnerKey)>>,
+    edge_updates: usize,
+}
+
+impl<'a> EvictionPlanner<'a> {
+    fn new(set: &'a DesiredExplicitSet) -> Self {
+        let mut marginal = HashMap::new();
+        let mut marginal_contributors: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>> =
+            HashMap::new();
+        let mut pubkey_groups: HashMap<Pubkey, Vec<(ConsumerId, OwnerKey)>> = HashMap::new();
+        for (key, group) in &set.groups {
+            marginal.insert(*key, 0);
+            marginal_contributors.insert(*key, HashSet::new());
+            for pk in &group.pubkeys {
+                pubkey_groups.entry(*pk).or_default().push(*key);
+            }
+        }
+        let mut planner = Self {
+            set,
+            victims: HashSet::new(),
+            marginal,
+            marginal_contributors,
+            pubkey_groups,
+            edge_updates: 0,
+        };
+        for key in set.groups.keys().copied().collect::<Vec<_>>() {
+            planner.recompute_marginal_for_group(key);
+        }
+        planner
+    }
+
+    fn recompute_marginal_for_group(&mut self, group: (ConsumerId, OwnerKey)) {
+        if self.victims.contains(&group) {
+            self.marginal.insert(group, 0);
+            self.marginal_contributors.insert(group, HashSet::new());
+            return;
+        }
+        let Some(g) = self.set.groups.get(&group) else {
+            self.marginal.insert(group, 0);
+            self.marginal_contributors.insert(group, HashSet::new());
+            return;
+        };
+        let mut contributors = HashSet::new();
+        for pk in &g.pubkeys {
+            if self.pk_counts_toward_marginal(pk, group) {
+                contributors.insert(*pk);
+            }
+        }
+        self.marginal.insert(group, contributors.len());
+        self.marginal_contributors.insert(group, contributors);
+    }
+
+    fn pk_counts_toward_marginal(&self, pk: &Pubkey, group: (ConsumerId, OwnerKey)) -> bool {
+        self.set.entries.get(pk).is_some_and(|entry| {
+            entry
+                .owners
+                .iter()
+                .all(|owner| self.victims.contains(owner) || *owner == group)
+        })
+    }
+
+    fn is_victim(&self, consumer: ConsumerId, owner: OwnerKey) -> bool {
+        self.victims.contains(&(consumer, owner))
+    }
+
+    fn marginal_freed(&self, victim: (ConsumerId, OwnerKey)) -> usize {
+        self.marginal.get(&victim).copied().unwrap_or(0)
+    }
+
+    fn is_pubkey_freed(&self, pk: &Pubkey) -> bool {
+        self.set.entries.get(pk).is_some_and(|entry| {
+            entry
+                .owners
+                .iter()
+                .all(|owner| self.victims.contains(owner))
+        })
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    fn edge_updates(&self) -> usize {
+        self.edge_updates
+    }
+
+    fn add_victim(&mut self, victim: (ConsumerId, OwnerKey)) -> usize {
+        let freed = self.marginal_freed(victim);
+        self.victims.insert(victim);
+        let Some(group) = self.set.groups.get(&victim) else {
+            self.marginal.insert(victim, 0);
+            self.marginal_contributors.insert(victim, HashSet::new());
+            return freed;
+        };
+
+        let touched_groups: HashSet<(ConsumerId, OwnerKey)> = group
+            .pubkeys
+            .iter()
+            .flat_map(|pk| self.pubkey_groups.get(pk).into_iter().flatten().copied())
+            .collect();
+
+        for pk in &group.pubkeys {
+            if self.is_pubkey_freed(pk) {
+                if let Some(sharing) = self.pubkey_groups.get(pk) {
+                    for other in sharing {
+                        if *other != victim && !self.victims.contains(other) {
+                            if let Some(contributors) = self.marginal_contributors.get_mut(other) {
+                                if contributors.remove(pk) {
+                                    if let Some(m) = self.marginal.get_mut(other) {
+                                        *m = m.saturating_sub(1);
+                                    }
+                                    self.edge_updates = self.edge_updates.saturating_add(1);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        self.marginal.insert(victim, 0);
+        self.marginal_contributors.insert(victim, HashSet::new());
+
+        for other in touched_groups {
+            if other == victim || self.victims.contains(&other) {
+                continue;
+            }
+            let before = self.marginal_freed(other);
+            self.recompute_marginal_for_group(other);
+            if self.marginal_freed(other) != before {
+                self.edge_updates = self.edge_updates.saturating_add(1);
+            }
+        }
+
+        freed
     }
 }
 
@@ -1349,5 +1489,201 @@ mod tests {
         assert_eq!(delta.len(), 2);
         assert!(delta.contains(&added));
         assert!(delta.contains(&removed));
+    }
+
+    #[test]
+    fn exclusive_key_replacement_at_cap_succeeds_without_unrelated_eviction() {
+        let mut set = DesiredExplicitSet::new(3);
+        let wallet = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Wallet,
+                OwnerKey::Wallet,
+                HashSet::from([wallet])
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        let (_, arb_owner, _) = pool_owner();
+        let arb_pk = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Arb, arb_owner, HashSet::from([arb_pk])),
+            AdmissionResult::Admitted { .. }
+        ));
+        let pool = Pubkey::new_unique();
+        let owner = OwnerKey::Pool(pool);
+        let old = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, owner, HashSet::from([old])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert_eq!(set.len(), 3);
+
+        let new_pk = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, owner, HashSet::from([new_pk])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(set.contains(&arb_pk), "unrelated arb group must survive");
+        assert!(set.contains(&wallet));
+        assert!(!set.contains(&old));
+        assert!(set.contains(&new_pk));
+        assert_eq!(set.len(), 3);
+    }
+
+    #[test]
+    fn shared_key_owner_group_replacement_at_cap_without_unrelated_eviction() {
+        let mut set = DesiredExplicitSet::new(3);
+        let shared = Pubkey::new_unique();
+        let (_, arb_owner, _) = pool_owner();
+        let arb_excl = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Arb,
+                arb_owner,
+                HashSet::from([shared, arb_excl])
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        let pool = Pubkey::new_unique();
+        let owner = OwnerKey::Pool(pool);
+        let mom_excl_old = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Momentum,
+                owner,
+                HashSet::from([shared, mom_excl_old])
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert_eq!(set.len(), 3);
+
+        let mom_excl_new = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Momentum,
+                owner,
+                HashSet::from([shared, mom_excl_new])
+            ),
+            AdmissionResult::Admitted { .. } | AdmissionResult::OwnerAddedNoNewPubkey
+        ));
+        assert!(set.contains(&arb_excl));
+        assert!(!set.contains(&mom_excl_old));
+        assert!(set.contains(&mom_excl_new));
+        assert!(set.contains(&shared));
+        assert_eq!(set.len(), 3);
+    }
+
+    #[test]
+    fn dlmm_window_shift_equal_bins_at_cap_succeeds_without_eviction() {
+        let mut set = DesiredExplicitSet::new(4);
+        let wallet = Pubkey::new_unique();
+        let (_, arb_owner, _) = pool_owner();
+        let arb_pk = Pubkey::new_unique();
+        let pool = Pubkey::new_unique();
+        let owner = OwnerKey::Pool(pool);
+        let b1 = Pubkey::new_unique();
+        let b2 = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Wallet,
+                OwnerKey::Wallet,
+                HashSet::from([wallet])
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Arb, arb_owner, HashSet::from([arb_pk])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, owner, HashSet::from([b1, b2])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert_eq!(set.len(), 4);
+
+        let b3 = Pubkey::new_unique();
+        let b4 = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, owner, HashSet::from([b3, b4])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(set.contains(&arb_pk));
+        assert!(set.contains(&wallet));
+        assert!(!set.contains(&b1));
+        assert!(!set.contains(&b2));
+        assert!(set.contains(&b3));
+        assert!(set.contains(&b4));
+        assert_eq!(set.len(), 4);
+    }
+
+    #[test]
+    fn replacement_rejected_at_cap_leaves_state_unchanged() {
+        let mut set = DesiredExplicitSet::new(2);
+        let wallet = Pubkey::new_unique();
+        let pool = Pubkey::new_unique();
+        let owner = OwnerKey::Pool(pool);
+        let k1 = Pubkey::new_unique();
+        let k2 = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Wallet,
+                OwnerKey::Wallet,
+                HashSet::from([wallet])
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, owner, HashSet::from([k1])),
+            AdmissionResult::Admitted { .. }
+        ));
+        let before = set.snapshot_pubkeys();
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Momentum,
+                owner,
+                HashSet::from([k2, Pubkey::new_unique()])
+            ),
+            AdmissionResult::RejectedCap
+        ));
+        assert_eq!(set.snapshot_pubkeys(), before);
+    }
+
+    #[test]
+    fn eviction_planner_edge_updates_bounded_with_heavy_sharing() {
+        let mut set = DesiredExplicitSet::new(2);
+        let hub_a = Pubkey::new_unique();
+        let hub_b = Pubkey::new_unique();
+        for _ in 0..25 {
+            let (_, owner, _) = pool_owner();
+            let _ = set.try_admit_group(ConsumerId::Tracker, owner, HashSet::from([hub_a, hub_b]));
+        }
+        assert_eq!(set.len(), 2);
+
+        let candidates = set.cap_shrink_candidate_keys();
+        let mut planner = EvictionPlanner::new(&set);
+        let mut freed = 0usize;
+        while freed < 1 {
+            let best = candidates
+                .iter()
+                .filter(|(c, o)| !planner.is_victim(*c, *o))
+                .map(|key| (*key, planner.marginal_freed(*key)))
+                .max_by_key(|(_, m)| *m)
+                .map(|(key, _)| key);
+            let Some(victim) = best else {
+                break;
+            };
+            freed = freed.saturating_add(planner.add_victim(victim));
+        }
+        let edge_updates = planner.edge_updates();
+        let group_count = set.groups.len();
+        assert!(
+            edge_updates < group_count * group_count,
+            "edge updates {edge_updates} must stay sub-quadratic vs groups {group_count}"
+        );
+        assert!(
+            edge_updates > 0,
+            "co-dependent shared groups must drive incremental edge updates"
+        );
+        assert_eq!(freed, 2, "last shared victim frees both hub pubkeys");
     }
 }

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -1080,6 +1080,7 @@ struct EvictionPlanner<'a> {
     victims: HashSet<(ConsumerId, OwnerKey)>,
     marginal: HashMap<(ConsumerId, OwnerKey), usize>,
     marginal_contributors: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>>,
+    group_pubkeys: HashMap<(ConsumerId, OwnerKey), Vec<Pubkey>>,
     pubkey_groups: HashMap<Pubkey, Vec<(ConsumerId, OwnerKey)>>,
     projected_pubkey_refcount: HashMap<Pubkey, usize>,
 }
@@ -1106,9 +1107,15 @@ impl<'a> EvictionPlanner<'a> {
                 stats.as_deref_mut(),
             );
         }
-        for key in tracked_groups {
-            marginal.insert(key, 0);
-            marginal_contributors.insert(key, HashSet::new());
+        for key in &tracked_groups {
+            marginal.insert(*key, 0);
+            marginal_contributors.insert(*key, HashSet::new());
+        }
+        let mut group_pubkeys = HashMap::new();
+        for key in &tracked_groups {
+            if let Some(group) = set.groups.get(key) {
+                group_pubkeys.insert(*key, group.pubkeys.iter().copied().collect());
+            }
         }
         let mut planner = Self {
             set,
@@ -1116,6 +1123,7 @@ impl<'a> EvictionPlanner<'a> {
             victims: HashSet::new(),
             marginal,
             marginal_contributors,
+            group_pubkeys,
             pubkey_groups,
             projected_pubkey_refcount: HashMap::new(),
         };
@@ -1244,48 +1252,53 @@ impl<'a> EvictionPlanner<'a> {
         overlay: &PlanningOverlay,
         mut stats: Option<&mut PlanningStats>,
     ) -> usize {
-        if let Some(group) = self.set.groups.get(&victim) {
-            for pk in &group.pubkeys {
-                if !self.pubkey_groups.contains_key(pk) {
-                    let mut scratch = HashSet::new();
-                    Self::index_pubkey(
-                        self.set,
-                        overlay,
-                        *pk,
-                        &mut self.pubkey_groups,
-                        &mut scratch,
-                        stats.as_deref_mut(),
-                    );
-                    for key in scratch {
-                        self.marginal.entry(key).or_insert(0);
-                        self.marginal_contributors.entry(key).or_default();
+        let victim_pubkeys: Vec<Pubkey> = self
+            .set
+            .groups
+            .get(&victim)
+            .map(|group| group.pubkeys.iter().copied().collect())
+            .unwrap_or_default();
+        if !victim_pubkeys.is_empty() {
+            self.group_pubkeys.insert(victim, victim_pubkeys.clone());
+        }
+        for pk in &victim_pubkeys {
+            if !self.pubkey_groups.contains_key(pk) {
+                let mut scratch = HashSet::new();
+                Self::index_pubkey(
+                    self.set,
+                    overlay,
+                    *pk,
+                    &mut self.pubkey_groups,
+                    &mut scratch,
+                    stats.as_deref_mut(),
+                );
+                for key in scratch {
+                    self.marginal.entry(key).or_insert(0);
+                    self.marginal_contributors.entry(key).or_default();
+                    if let Some(group) = self.set.groups.get(&key) {
+                        self.group_pubkeys
+                            .entry(key)
+                            .or_insert_with(|| group.pubkeys.iter().copied().collect());
                     }
                 }
             }
         }
 
-        let contributor_pubkeys: Vec<Pubkey> = self
-            .marginal_contributors
-            .get(&victim)
-            .cloned()
-            .unwrap_or_default()
-            .into_iter()
-            .collect();
         let freed = self.marginal_freed(victim);
         self.victims.insert(victim);
 
-        for pk in contributor_pubkeys {
+        for pk in victim_pubkeys {
             let before = self
                 .projected_pubkey_refcount
                 .get(&pk)
                 .copied()
                 .unwrap_or_else(|| self.projected_owner_count(&pk));
-            let victim_was_sole = self
+            let victim_was_owner = self
                 .pubkey_groups
                 .get(&pk)
                 .is_some_and(|sharing| sharing.contains(&victim))
                 && before > 0;
-            let after = before.saturating_sub(usize::from(victim_was_sole));
+            let after = before.saturating_sub(usize::from(victim_was_owner));
             self.projected_pubkey_refcount.insert(pk, after);
             if before >= 2 && after == 1 {
                 if let Some(sole) = self.sole_projected_owner(&pk) {
@@ -2139,21 +2152,56 @@ mod tests {
         assert!(!victims.is_empty());
         assert_eq!(stats.projection_copies, 0);
         assert_eq!(stats.entries_copied, 0);
+        let victim_edge_visits: usize = victims
+            .iter()
+            .map(|(consumer, owner, _)| {
+                set.groups
+                    .get(&(*consumer, *owner))
+                    .map(|g| g.pubkeys.len())
+                    .unwrap_or(0)
+            })
+            .sum();
+        let victim_owner_edge_scans: usize = victims
+            .iter()
+            .map(|(consumer, owner, _)| {
+                set.groups
+                    .get(&(*consumer, *owner))
+                    .map(|g| {
+                        g.pubkeys
+                            .iter()
+                            .map(|pk| set.entries.get(pk).map(|e| e.owners.len()).unwrap_or(0))
+                            .sum::<usize>()
+                    })
+                    .unwrap_or(0)
+            })
+            .sum();
         let log_g = (group_count + 1).ilog2() as usize + 1;
         assert!(stats.candidate_pops <= group_count.saturating_mul(log_g));
         assert!(stats.victim_removals <= group_count);
+        let owner_edge_budget = edge_count
+            .saturating_add(victim_owner_edge_scans.saturating_mul(3))
+            .saturating_add(stats.candidate_pops);
         assert!(
-            stats.owner_edge_iterations
-                <= edge_count.saturating_mul(stats.victim_removals.saturating_add(1))
+            stats.owner_edge_iterations <= owner_edge_budget,
+            "owner edge visits {}/{} must stay bounded by initial edges + victim adjacency + heap pops",
+            stats.owner_edge_iterations,
+            owner_edge_budget
         );
         assert!(
             stats.refcount_checks
-                <= edge_count.saturating_mul(stats.victim_removals.saturating_add(1))
+                <= edge_count
+                    .saturating_add(victim_edge_visits)
+                    .saturating_add(stats.candidate_pops),
+            "refcount checks must stay bounded by initial edges + victim edges + heap pops"
         );
         assert!(
-            stats.edge_updates
-                <= edge_count.saturating_mul(stats.victim_removals.saturating_add(1)),
+            stats.edge_updates <= victim_edge_visits.saturating_add(stats.candidate_pops),
             "marginal edge updates must stay bounded under dense pubkey sharing"
+        );
+        assert!(
+            stats.owner_edge_iterations
+                < edge_count.saturating_mul(stats.victim_removals.saturating_add(1)),
+            "must not scale with edge_count * victims"
         );
         assert!(stats.candidate_pops > 0);
         assert!(stats.victim_removals > 0);

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -140,6 +140,52 @@ struct PlanningOverlay {
     suppressed_groups: HashSet<(ConsumerId, OwnerKey)>,
     incoming: Option<((ConsumerId, OwnerKey), HashSet<Pubkey>)>,
     projected_len: usize,
+    pk_projected: HashMap<Pubkey, bool>,
+}
+
+fn pk_projection_contribution(live: bool, proj: bool) -> i64 {
+    match (live, proj) {
+        (false, true) => 1,
+        (true, false) => -1,
+        _ => 0,
+    }
+}
+
+fn projected_len_delta(live: bool, old_proj: bool, new_proj: bool) -> i64 {
+    pk_projection_contribution(live, new_proj) - pk_projection_contribution(live, old_proj)
+}
+
+fn apply_projected_len_delta(projected_len: usize, delta: i64) -> usize {
+    (projected_len as i64 + delta).max(0) as usize
+}
+
+fn pk_would_exist_in_projection(
+    set: &DesiredExplicitSet,
+    pk: Pubkey,
+    suppressed: &HashSet<(ConsumerId, OwnerKey)>,
+    incoming: Option<((ConsumerId, OwnerKey), &HashSet<Pubkey>)>,
+    mut stats: Option<&mut PlanningStats>,
+) -> bool {
+    if let Some(entry) = set.entries.get(&pk) {
+        for owner in &entry.owners {
+            if let Some(s) = stats.as_mut() {
+                s.owner_edge_iterations = s.owner_edge_iterations.saturating_add(1);
+            }
+            if !suppressed.contains(owner) {
+                return true;
+            }
+        }
+    }
+    if let Some((key, pubs)) = incoming {
+        if pubs.contains(&pk) {
+            if let Some(s) = stats.as_mut() {
+                s.owner_edge_iterations = s.owner_edge_iterations.saturating_add(1);
+            }
+            let _ = key;
+            return true;
+        }
+    }
+    false
 }
 
 impl PlanningOverlay {
@@ -149,6 +195,7 @@ impl PlanningOverlay {
             suppressed_groups: HashSet::new(),
             incoming: None,
             projected_len: set.entries.len(),
+            pk_projected: HashMap::new(),
         }
     }
 
@@ -157,7 +204,7 @@ impl PlanningOverlay {
         consumer: ConsumerId,
         owner: OwnerKey,
         incoming: &HashSet<Pubkey>,
-        stats: Option<&mut PlanningStats>,
+        mut stats: Option<&mut PlanningStats>,
     ) -> Self {
         let key = (consumer, owner);
         let mut touched = incoming.clone();
@@ -166,13 +213,28 @@ impl PlanningOverlay {
         if let Some(existing) = set.groups.get(&key) {
             touched.extend(&existing.pubkeys);
         }
-        let projected_len =
-            compute_projected_len(set, &touched, &suppressed, Some((key, incoming)), stats);
+        let incoming_ref = Some((key, incoming));
+        let mut projected_len = set.entries.len();
+        let mut pk_projected = HashMap::with_capacity(touched.len());
+        for pk in &touched {
+            let live = set.entries.contains_key(pk);
+            let proj = pk_would_exist_in_projection(
+                set,
+                *pk,
+                &suppressed,
+                incoming_ref,
+                stats.as_deref_mut(),
+            );
+            pk_projected.insert(*pk, proj);
+            projected_len =
+                apply_projected_len_delta(projected_len, projected_len_delta(live, live, proj));
+        }
         Self {
             touched_pubkeys: touched,
             suppressed_groups: suppressed,
             incoming: Some((key, incoming.clone())),
             projected_len,
+            pk_projected,
         }
     }
 
@@ -182,69 +244,51 @@ impl PlanningOverlay {
         victim: (ConsumerId, OwnerKey),
         mut stats: Option<&mut PlanningStats>,
     ) {
+        if self.suppressed_groups.contains(&victim) {
+            return;
+        }
+        let pubkeys: Vec<Pubkey> = set
+            .groups
+            .get(&victim)
+            .map(|group| group.pubkeys.iter().copied().collect())
+            .unwrap_or_default();
+        for pk in &pubkeys {
+            self.touched_pubkeys.insert(*pk);
+        }
         if !self.suppressed_groups.insert(victim) {
             return;
         }
         if let Some(stats) = stats.as_deref_mut() {
             stats.victim_removals = stats.victim_removals.saturating_add(1);
         }
-        if let Some(group) = set.groups.get(&victim) {
-            self.touched_pubkeys.extend(&group.pubkeys);
-        }
-        self.projected_len = compute_projected_len(
-            set,
-            &self.touched_pubkeys,
-            &self.suppressed_groups,
-            self.incoming.as_ref().map(|(k, p)| (*k, p)),
-            stats,
-        );
-    }
-}
-
-fn pk_exists_in_projection(
-    set: &DesiredExplicitSet,
-    pk: Pubkey,
-    suppressed: &HashSet<(ConsumerId, OwnerKey)>,
-    incoming: Option<((ConsumerId, OwnerKey), &HashSet<Pubkey>)>,
-    mut stats: Option<&mut PlanningStats>,
-) -> bool {
-    if let Some(s) = stats.as_mut() {
-        s.owner_edge_iterations = s.owner_edge_iterations.saturating_add(1);
-    }
-    if let Some(entry) = set.entries.get(&pk) {
-        for owner in &entry.owners {
-            if !suppressed.contains(owner) {
-                return true;
-            }
+        let incoming_ref = self.incoming.as_ref().map(|(k, p)| (*k, p));
+        for pk in pubkeys {
+            let live = set.entries.contains_key(&pk);
+            let old_proj = if let Some(cached) = self.pk_projected.get(&pk) {
+                *cached
+            } else {
+                let mut without_victim = self.suppressed_groups.clone();
+                without_victim.remove(&victim);
+                pk_would_exist_in_projection(
+                    set,
+                    pk,
+                    &without_victim,
+                    incoming_ref,
+                    stats.as_deref_mut(),
+                )
+            };
+            let new_proj = pk_would_exist_in_projection(
+                set,
+                pk,
+                &self.suppressed_groups,
+                incoming_ref,
+                stats.as_deref_mut(),
+            );
+            self.pk_projected.insert(pk, new_proj);
+            let delta = projected_len_delta(live, old_proj, new_proj);
+            self.projected_len = apply_projected_len_delta(self.projected_len, delta);
         }
     }
-    if let Some((key, pubs)) = incoming {
-        if pubs.contains(&pk) {
-            return true;
-        }
-        let _ = key;
-    }
-    false
-}
-
-fn compute_projected_len(
-    set: &DesiredExplicitSet,
-    touched: &HashSet<Pubkey>,
-    suppressed: &HashSet<(ConsumerId, OwnerKey)>,
-    incoming: Option<((ConsumerId, OwnerKey), &HashSet<Pubkey>)>,
-    mut stats: Option<&mut PlanningStats>,
-) -> usize {
-    let mut delta = 0i64;
-    for pk in touched {
-        let live = set.entries.contains_key(pk);
-        let proj = pk_exists_in_projection(set, *pk, suppressed, incoming, stats.as_deref_mut());
-        delta += match (live, proj) {
-            (false, true) => 1,
-            (true, false) => -1,
-            _ => 0,
-        };
-    }
-    (set.entries.len() as i64 + delta).max(0) as usize
 }
 
 fn incoming_net_entry_delta(
@@ -1052,7 +1096,14 @@ impl<'a> EvictionPlanner<'a> {
         let mut pubkey_groups: HashMap<Pubkey, Vec<(ConsumerId, OwnerKey)>> = HashMap::new();
         let mut tracked_groups = HashSet::new();
         for pk in &overlay.touched_pubkeys {
-            Self::index_pubkey(set, overlay, *pk, &mut pubkey_groups, &mut tracked_groups);
+            Self::index_pubkey(
+                set,
+                overlay,
+                *pk,
+                &mut pubkey_groups,
+                &mut tracked_groups,
+                stats.as_deref_mut(),
+            );
         }
         for key in tracked_groups {
             marginal.insert(key, 0);
@@ -1078,11 +1129,15 @@ impl<'a> EvictionPlanner<'a> {
         pk: Pubkey,
         pubkey_groups: &mut HashMap<Pubkey, Vec<(ConsumerId, OwnerKey)>>,
         tracked_groups: &mut HashSet<(ConsumerId, OwnerKey)>,
+        mut stats: Option<&mut PlanningStats>,
     ) {
         if let Some(entry) = set.entries.get(&pk) {
             for owner in &entry.owners {
                 if overlay.suppressed_groups.contains(owner) {
                     continue;
+                }
+                if let Some(s) = stats.as_mut() {
+                    s.owner_edge_iterations = s.owner_edge_iterations.saturating_add(1);
                 }
                 tracked_groups.insert(*owner);
                 pubkey_groups.entry(pk).or_default().push(*owner);
@@ -1090,6 +1145,9 @@ impl<'a> EvictionPlanner<'a> {
         }
         if let Some((key, pubs)) = overlay.incoming.as_ref() {
             if pubs.contains(&pk) && !overlay.suppressed_groups.contains(key) {
+                if let Some(s) = stats.as_mut() {
+                    s.owner_edge_iterations = s.owner_edge_iterations.saturating_add(1);
+                }
                 tracked_groups.insert(*key);
                 pubkey_groups.entry(pk).or_default().push(*key);
             }
@@ -1170,6 +1228,7 @@ impl<'a> EvictionPlanner<'a> {
                         *pk,
                         &mut self.pubkey_groups,
                         &mut scratch,
+                        stats.as_deref_mut(),
                     );
                     for key in scratch {
                         self.marginal.entry(key).or_insert(0);
@@ -2027,15 +2086,14 @@ mod tests {
         let set = DesiredExplicitSet::new(10);
         let (_, owner, pk) = pool_owner();
         let mut stats = PlanningStats::default();
-        assert!(
-            set.test_plan_admit_group_with_stats(
+        assert!(set
+            .test_plan_admit_group_with_stats(
                 ConsumerId::Momentum,
                 owner,
                 HashSet::from([pk]),
                 Some(&mut stats),
             )
-            .is_ok()
-        );
+            .is_ok());
         assert_eq!(stats.projection_copies, 0);
         assert_eq!(stats.entries_copied, 0);
         assert_eq!(stats.owner_edge_iterations, 2);

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -118,101 +118,168 @@ struct AdmissionPlan {
     incoming: Option<(ConsumerId, OwnerKey, HashSet<Pubkey>)>,
 }
 
-/// Immutable projection for admission planning (old incoming ownership removed before victims).
-#[derive(Debug, Clone)]
-struct ProjectedExplicitState {
-    owners: HashMap<Pubkey, HashSet<(ConsumerId, OwnerKey)>>,
-    groups: HashMap<(ConsumerId, OwnerKey), ProjectedGroupMeta>,
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PlanningStats {
+    pub candidate_pops: usize,
+    pub stale_pops: usize,
+    pub edge_updates: usize,
+    pub refcount_checks: usize,
+    pub projection_copies: usize,
+    pub entries_copied: usize,
+    pub owner_edge_iterations: usize,
+    pub victim_removals: usize,
 }
 
-#[derive(Debug, Clone)]
-struct ProjectedGroupMeta {
+/// Backward-compatible alias for eviction planner instrumentation.
+pub type EvictionPlannerStats = PlanningStats;
+
+/// Incremental admission projection overlay — touches only incoming/victim pubkey edges.
+#[derive(Debug)]
+struct PlanningOverlay {
+    touched_pubkeys: HashSet<Pubkey>,
+    suppressed_groups: HashSet<(ConsumerId, OwnerKey)>,
+    incoming: Option<((ConsumerId, OwnerKey), HashSet<Pubkey>)>,
+    projected_len: usize,
+}
+
+impl PlanningOverlay {
+    fn for_cap_shrink(set: &DesiredExplicitSet) -> Self {
+        Self {
+            touched_pubkeys: HashSet::new(),
+            suppressed_groups: HashSet::new(),
+            incoming: None,
+            projected_len: set.entries.len(),
+        }
+    }
+
+    fn for_incoming_admission(
+        set: &DesiredExplicitSet,
+        consumer: ConsumerId,
+        owner: OwnerKey,
+        incoming: &HashSet<Pubkey>,
+        stats: Option<&mut PlanningStats>,
+    ) -> Self {
+        let key = (consumer, owner);
+        let mut touched = incoming.clone();
+        let mut suppressed = HashSet::new();
+        suppressed.insert(key);
+        if let Some(existing) = set.groups.get(&key) {
+            touched.extend(&existing.pubkeys);
+        }
+        let projected_len =
+            compute_projected_len(set, &touched, &suppressed, Some((key, incoming)), stats);
+        Self {
+            touched_pubkeys: touched,
+            suppressed_groups: suppressed,
+            incoming: Some((key, incoming.clone())),
+            projected_len,
+        }
+    }
+
+    fn add_victim(
+        &mut self,
+        set: &DesiredExplicitSet,
+        victim: (ConsumerId, OwnerKey),
+        mut stats: Option<&mut PlanningStats>,
+    ) {
+        if !self.suppressed_groups.insert(victim) {
+            return;
+        }
+        if let Some(stats) = stats.as_deref_mut() {
+            stats.victim_removals = stats.victim_removals.saturating_add(1);
+        }
+        if let Some(group) = set.groups.get(&victim) {
+            self.touched_pubkeys.extend(&group.pubkeys);
+        }
+        self.projected_len = compute_projected_len(
+            set,
+            &self.touched_pubkeys,
+            &self.suppressed_groups,
+            self.incoming.as_ref().map(|(k, p)| (*k, p)),
+            stats,
+        );
+    }
+}
+
+fn pk_exists_in_projection(
+    set: &DesiredExplicitSet,
+    pk: Pubkey,
+    suppressed: &HashSet<(ConsumerId, OwnerKey)>,
+    incoming: Option<((ConsumerId, OwnerKey), &HashSet<Pubkey>)>,
+    mut stats: Option<&mut PlanningStats>,
+) -> bool {
+    if let Some(s) = stats.as_mut() {
+        s.owner_edge_iterations = s.owner_edge_iterations.saturating_add(1);
+    }
+    if let Some(entry) = set.entries.get(&pk) {
+        for owner in &entry.owners {
+            if !suppressed.contains(owner) {
+                return true;
+            }
+        }
+    }
+    if let Some((key, pubs)) = incoming {
+        if pubs.contains(&pk) {
+            return true;
+        }
+        let _ = key;
+    }
+    false
+}
+
+fn compute_projected_len(
+    set: &DesiredExplicitSet,
+    touched: &HashSet<Pubkey>,
+    suppressed: &HashSet<(ConsumerId, OwnerKey)>,
+    incoming: Option<((ConsumerId, OwnerKey), &HashSet<Pubkey>)>,
+    mut stats: Option<&mut PlanningStats>,
+) -> usize {
+    let mut delta = 0i64;
+    for pk in touched {
+        let live = set.entries.contains_key(pk);
+        let proj = pk_exists_in_projection(set, *pk, suppressed, incoming, stats.as_deref_mut());
+        delta += match (live, proj) {
+            (false, true) => 1,
+            (true, false) => -1,
+            _ => 0,
+        };
+    }
+    (set.entries.len() as i64 + delta).max(0) as usize
+}
+
+fn incoming_net_entry_delta(
+    set: &DesiredExplicitSet,
     consumer: ConsumerId,
     owner: OwnerKey,
-    pubkeys: HashSet<Pubkey>,
-    admitted_seq: u64,
-    last_touched_gen: u64,
-}
-
-impl ProjectedExplicitState {
-    fn from_live(set: &DesiredExplicitSet) -> Self {
-        let owners = set
-            .entries
-            .iter()
-            .map(|(pk, entry)| (*pk, entry.owners.clone()))
-            .collect();
-        let groups = set
-            .groups
-            .iter()
-            .map(|(key, group)| {
-                (
-                    *key,
-                    ProjectedGroupMeta {
-                        consumer: group.consumer,
-                        owner: group.owner,
-                        pubkeys: group.pubkeys.clone(),
-                        admitted_seq: group.admitted_seq,
-                        last_touched_gen: group.last_touched_gen,
-                    },
-                )
-            })
-            .collect();
-        Self { owners, groups }
-    }
-
-    fn entry_count(&self) -> usize {
-        self.owners.len()
-    }
-
-    fn remove_group(&mut self, key: (ConsumerId, OwnerKey)) {
-        let Some(group) = self.groups.remove(&key) else {
-            return;
-        };
-        for pk in group.pubkeys {
-            if let Some(entry) = self.owners.get_mut(&pk) {
-                entry.remove(&key);
-                if entry.is_empty() {
-                    self.owners.remove(&pk);
+    incoming: &HashSet<Pubkey>,
+    mut stats: Option<&mut PlanningStats>,
+) -> i64 {
+    let key = (consumer, owner);
+    let mut delta = 0i64;
+    if let Some(existing) = set.groups.get(&key) {
+        for pk in &existing.pubkeys {
+            if !incoming.contains(pk)
+                && set
+                    .entries
+                    .get(pk)
+                    .is_some_and(|e| e.owners.len() == 1 && e.owners.contains(&key))
+            {
+                delta -= 1;
+                if let Some(stats) = stats.as_deref_mut() {
+                    stats.owner_edge_iterations = stats.owner_edge_iterations.saturating_add(1);
                 }
             }
         }
     }
-
-    fn add_group(
-        &mut self,
-        key: (ConsumerId, OwnerKey),
-        consumer: ConsumerId,
-        pubkeys: &HashSet<Pubkey>,
-    ) {
-        let meta = self
-            .groups
-            .entry(key)
-            .or_insert_with(|| ProjectedGroupMeta {
-                consumer,
-                owner: key.1,
-                pubkeys: HashSet::new(),
-                admitted_seq: 0,
-                last_touched_gen: 0,
-            });
-        for pk in pubkeys {
-            meta.pubkeys.insert(*pk);
-            self.owners.entry(*pk).or_default().insert(key);
+    for pk in incoming {
+        if !set.entries.contains_key(pk) {
+            delta += 1;
+            if let Some(stats) = stats.as_deref_mut() {
+                stats.owner_edge_iterations = stats.owner_edge_iterations.saturating_add(1);
+            }
         }
     }
-
-    fn projected_len_after_admission(
-        base: &Self,
-        incoming: (ConsumerId, OwnerKey, &HashSet<Pubkey>),
-        victims: &[(ConsumerId, OwnerKey)],
-    ) -> usize {
-        let mut projected = base.clone();
-        projected.remove_group((incoming.0, incoming.1));
-        for victim in victims {
-            projected.remove_group(*victim);
-        }
-        projected.add_group((incoming.0, incoming.1), incoming.0, incoming.2);
-        projected.entry_count()
-    }
+    delta
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -238,14 +305,6 @@ impl PartialOrd for PolicyEvictEntry {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
-}
-
-#[derive(Debug, Default, Clone, Copy)]
-pub struct EvictionPlannerStats {
-    pub candidate_pops: usize,
-    pub stale_pops: usize,
-    pub edge_updates: usize,
-    pub refcount_checks: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -552,6 +611,16 @@ impl DesiredExplicitSet {
         owner: OwnerKey,
         pubkeys: HashSet<Pubkey>,
     ) -> Result<AdmissionPlan, AdmissionResult> {
+        self.plan_admit_group_with_stats(consumer, owner, pubkeys, None)
+    }
+
+    fn plan_admit_group_with_stats(
+        &self,
+        consumer: ConsumerId,
+        owner: OwnerKey,
+        pubkeys: HashSet<Pubkey>,
+        mut stats: Option<&mut PlanningStats>,
+    ) -> Result<AdmissionPlan, AdmissionResult> {
         if pubkeys.is_empty() {
             return Err(AdmissionResult::RejectedInvalidGroup);
         }
@@ -561,16 +630,25 @@ impl DesiredExplicitSet {
             }
         }
 
-        let base = ProjectedExplicitState::from_live(self);
-        let projected_without_evict = ProjectedExplicitState::projected_len_after_admission(
-            &base,
-            (consumer, owner, &pubkeys),
-            &[],
-        );
+        let net_delta =
+            incoming_net_entry_delta(self, consumer, owner, &pubkeys, stats.as_deref_mut());
+        let projected_without_evict = (self.entries.len() as i64 + net_delta).max(0) as usize;
 
         let mut evictions = Vec::new();
         if projected_without_evict > self.max_explicit_pubkeys {
-            match self.plan_evictions_for_incoming(consumer, owner, &pubkeys, &base) {
+            let overlay = PlanningOverlay::for_incoming_admission(
+                self,
+                consumer,
+                owner,
+                &pubkeys,
+                stats.as_deref_mut(),
+            );
+            match self.plan_evictions_with_overlay(
+                overlay,
+                Some((consumer, owner, &pubkeys)),
+                self.max_explicit_pubkeys,
+                stats.as_deref_mut(),
+            ) {
                 Some(victims) => evictions = victims,
                 None => return Err(AdmissionResult::RejectedCap),
             }
@@ -580,14 +658,14 @@ impl DesiredExplicitSet {
             evictions,
             incoming: Some((consumer, owner, pubkeys)),
         };
-        if !self.validate_plan_fits_cap(&plan) {
+        if !self.validate_plan_fits_cap(&plan, stats) {
             return Err(AdmissionResult::RejectedCap);
         }
         Ok(plan)
     }
 
     fn apply_plan(&mut self, plan: AdmissionPlan) -> AdmissionResult {
-        debug_assert!(self.validate_plan_fits_cap(&plan));
+        debug_assert!(self.validate_plan_fits_cap(&plan, None));
         let Some((consumer, owner, pubkeys)) = plan.incoming else {
             return AdmissionResult::RejectedInvalidGroup;
         };
@@ -615,31 +693,51 @@ impl DesiredExplicitSet {
         }
     }
 
-    fn validate_plan_fits_cap(&self, plan: &AdmissionPlan) -> bool {
-        self.projected_entry_count_after_plan(plan) <= self.max_explicit_pubkeys
+    fn validate_plan_fits_cap(
+        &self,
+        plan: &AdmissionPlan,
+        stats: Option<&mut PlanningStats>,
+    ) -> bool {
+        self.projected_entry_count_after_plan(plan, stats) <= self.max_explicit_pubkeys
     }
 
-    fn projected_entry_count_after_plan(&self, plan: &AdmissionPlan) -> usize {
+    fn projected_entry_count_after_plan(
+        &self,
+        plan: &AdmissionPlan,
+        mut stats: Option<&mut PlanningStats>,
+    ) -> usize {
         let Some((inc_c, inc_o, incoming)) = plan.incoming.as_ref() else {
             return self.entries.len();
         };
-        let victims: Vec<(ConsumerId, OwnerKey)> =
-            plan.evictions.iter().map(|(c, o, _)| (*c, *o)).collect();
-        let base = ProjectedExplicitState::from_live(self);
-        ProjectedExplicitState::projected_len_after_admission(
-            &base,
-            (*inc_c, *inc_o, incoming),
-            &victims,
-        )
+        if plan.evictions.is_empty() {
+            let delta =
+                incoming_net_entry_delta(self, *inc_c, *inc_o, incoming, stats.as_deref_mut());
+            return (self.entries.len() as i64 + delta).max(0) as usize;
+        }
+        let mut overlay = PlanningOverlay::for_incoming_admission(
+            self,
+            *inc_c,
+            *inc_o,
+            incoming,
+            stats.as_deref_mut(),
+        );
+        for (vc, vo, _) in &plan.evictions {
+            overlay.add_victim(self, (*vc, *vo), stats.as_deref_mut());
+        }
+        overlay.projected_len
     }
 
-    fn build_policy_evict_heap(
-        projection: &ProjectedExplicitState,
+    fn build_policy_evict_heap_from_live(
+        set: &DesiredExplicitSet,
         skip: Option<(ConsumerId, OwnerKey)>,
+        suppressed: &HashSet<(ConsumerId, OwnerKey)>,
     ) -> BinaryHeap<PolicyEvictEntry> {
         let mut heap = BinaryHeap::new();
-        for (key, group) in &projection.groups {
+        for (key, group) in &set.groups {
             if group.consumer == ConsumerId::Wallet {
+                continue;
+            }
+            if suppressed.contains(key) {
                 continue;
             }
             if skip.is_some_and(|(c, o)| *key == (c, o)) {
@@ -662,7 +760,7 @@ impl DesiredExplicitSet {
         incoming: ConsumerId,
         incoming_owner: OwnerKey,
         incoming_priority: PinPriority,
-        mut stats: Option<&mut EvictionPlannerStats>,
+        mut stats: Option<&mut PlanningStats>,
     ) -> Option<((ConsumerId, OwnerKey), EvictReason)> {
         while let Some(entry) = heap.pop() {
             if let Some(stats) = stats.as_deref_mut() {
@@ -702,58 +800,29 @@ impl DesiredExplicitSet {
         None
     }
 
-    fn plan_evictions_for_incoming(
+    fn plan_evictions_with_overlay(
         &self,
-        incoming: ConsumerId,
-        incoming_owner: OwnerKey,
-        incoming_pubkeys: &HashSet<Pubkey>,
-        base: &ProjectedExplicitState,
-    ) -> Option<Vec<(ConsumerId, OwnerKey, EvictReason)>> {
-        self.plan_evictions_on_projection(
-            base,
-            Some((incoming, incoming_owner, incoming_pubkeys)),
-            self.max_explicit_pubkeys,
-            None,
-        )
-    }
-
-    fn plan_evictions_on_projection(
-        &self,
-        base: &ProjectedExplicitState,
+        mut overlay: PlanningOverlay,
         incoming: Option<(ConsumerId, OwnerKey, &HashSet<Pubkey>)>,
         cap: usize,
-        mut stats: Option<&mut EvictionPlannerStats>,
+        mut stats: Option<&mut PlanningStats>,
     ) -> Option<Vec<(ConsumerId, OwnerKey, EvictReason)>> {
         let (incoming_consumer, incoming_owner, incoming_priority) = match incoming {
             Some((c, o, _)) => (c, o, pin_priority_from_consumer(c)),
             None => (ConsumerId::Wallet, OwnerKey::Wallet, PinPriority::Wallet),
         };
 
-        let mut work = base.clone();
-        if let Some((c, o, _)) = incoming {
-            work.remove_group((c, o));
-        }
-        let mut planner = EvictionPlanner::new(&work);
-        let mut heap = Self::build_policy_evict_heap(&work, incoming.map(|(c, o, _)| (c, o)));
+        let skip_incoming = incoming.map(|(c, o, _)| (c, o));
+        let mut planner = EvictionPlanner::new(self, &overlay, stats.as_deref_mut());
+        let mut heap = Self::build_policy_evict_heap_from_live(
+            self,
+            skip_incoming,
+            &overlay.suppressed_groups,
+        );
         let mut victims: Vec<(ConsumerId, OwnerKey, EvictReason)> = Vec::new();
 
         loop {
-            let victim_keys: Vec<(ConsumerId, OwnerKey)> =
-                victims.iter().map(|(c, o, _)| (*c, *o)).collect();
-            let projected_len = if let Some((c, o, pubs)) = incoming {
-                ProjectedExplicitState::projected_len_after_admission(
-                    base,
-                    (c, o, pubs),
-                    &victim_keys,
-                )
-            } else {
-                let mut trial = work.clone();
-                for victim in &victim_keys {
-                    trial.remove_group(*victim);
-                }
-                trial.entry_count()
-            };
-            if projected_len <= cap {
+            if overlay.projected_len <= cap {
                 return Some(victims);
             }
 
@@ -766,7 +835,8 @@ impl DesiredExplicitSet {
                 stats.as_deref_mut(),
             )?;
             let ((consumer, owner), reason) = next;
-            planner.add_victim((consumer, owner), stats.as_deref_mut());
+            planner.add_victim((consumer, owner), &overlay, stats.as_deref_mut());
+            overlay.add_victim(self, (consumer, owner), stats.as_deref_mut());
             victims.push((consumer, owner, reason));
         }
     }
@@ -863,9 +933,9 @@ impl DesiredExplicitSet {
 
     /// Set-aware cap-shrink victim planning: aggregate eviction across co-dependent groups.
     fn plan_cap_shrink_victims(&self, _deficit: usize) -> Option<Vec<(ConsumerId, OwnerKey)>> {
-        let base = ProjectedExplicitState::from_live(self);
+        let overlay = PlanningOverlay::for_cap_shrink(self);
         let victims_with_reason =
-            self.plan_evictions_on_projection(&base, None, self.max_explicit_pubkeys, None)?;
+            self.plan_evictions_with_overlay(overlay, None, self.max_explicit_pubkeys, None)?;
         Some(
             victims_with_reason
                 .into_iter()
@@ -935,62 +1005,108 @@ impl DesiredExplicitSet {
         &self,
         incoming: Option<(ConsumerId, OwnerKey, HashSet<Pubkey>)>,
         cap: usize,
-        stats: Option<&mut EvictionPlannerStats>,
+        mut stats: Option<&mut PlanningStats>,
     ) -> Option<Vec<(ConsumerId, OwnerKey, EvictReason)>> {
-        let base = ProjectedExplicitState::from_live(self);
+        let overlay = match incoming.as_ref() {
+            Some((c, o, p)) => {
+                PlanningOverlay::for_incoming_admission(self, *c, *o, p, stats.as_deref_mut())
+            }
+            None => PlanningOverlay::for_cap_shrink(self),
+        };
         let incoming_ref = incoming.as_ref().map(|(c, o, p)| (*c, *o, p));
-        self.plan_evictions_on_projection(&base, incoming_ref, cap, stats)
+        self.plan_evictions_with_overlay(overlay, incoming_ref, cap, stats)
+    }
+
+    #[cfg(test)]
+    fn test_plan_admit_group_with_stats(
+        &self,
+        consumer: ConsumerId,
+        owner: OwnerKey,
+        pubkeys: HashSet<Pubkey>,
+        stats: Option<&mut PlanningStats>,
+    ) -> Result<AdmissionPlan, AdmissionResult> {
+        self.plan_admit_group_with_stats(consumer, owner, pubkeys, stats)
     }
 }
 
-/// Incremental marginal-free eviction planner on projected state (bounded edge updates).
+/// Incremental marginal-free eviction planner on live state + overlay (bounded edge updates).
 struct EvictionPlanner<'a> {
-    projection: &'a ProjectedExplicitState,
+    set: &'a DesiredExplicitSet,
+    suppressed: HashSet<(ConsumerId, OwnerKey)>,
     victims: HashSet<(ConsumerId, OwnerKey)>,
     marginal: HashMap<(ConsumerId, OwnerKey), usize>,
     marginal_contributors: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>>,
     pubkey_groups: HashMap<Pubkey, Vec<(ConsumerId, OwnerKey)>>,
-    edge_updates: usize,
 }
 
 impl<'a> EvictionPlanner<'a> {
-    fn new(projection: &'a ProjectedExplicitState) -> Self {
+    fn new(
+        set: &'a DesiredExplicitSet,
+        overlay: &PlanningOverlay,
+        mut stats: Option<&mut PlanningStats>,
+    ) -> Self {
+        let suppressed = overlay.suppressed_groups.clone();
         let mut marginal = HashMap::new();
         let mut marginal_contributors: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>> =
             HashMap::new();
         let mut pubkey_groups: HashMap<Pubkey, Vec<(ConsumerId, OwnerKey)>> = HashMap::new();
-        for (key, group) in &projection.groups {
-            marginal.insert(*key, 0);
-            marginal_contributors.insert(*key, HashSet::new());
-            for pk in &group.pubkeys {
-                pubkey_groups.entry(*pk).or_default().push(*key);
-            }
+        let mut tracked_groups = HashSet::new();
+        for pk in &overlay.touched_pubkeys {
+            Self::index_pubkey(set, overlay, *pk, &mut pubkey_groups, &mut tracked_groups);
+        }
+        for key in tracked_groups {
+            marginal.insert(key, 0);
+            marginal_contributors.insert(key, HashSet::new());
         }
         let mut planner = Self {
-            projection,
+            set,
+            suppressed,
             victims: HashSet::new(),
             marginal,
             marginal_contributors,
             pubkey_groups,
-            edge_updates: 0,
         };
-        for key in projection.groups.keys().copied().collect::<Vec<_>>() {
-            planner.recompute_marginal_for_group(key, None);
+        for key in planner.marginal.keys().copied().collect::<Vec<_>>() {
+            planner.recompute_marginal_for_group(key, stats.as_deref_mut());
         }
         planner
+    }
+
+    fn index_pubkey(
+        set: &DesiredExplicitSet,
+        overlay: &PlanningOverlay,
+        pk: Pubkey,
+        pubkey_groups: &mut HashMap<Pubkey, Vec<(ConsumerId, OwnerKey)>>,
+        tracked_groups: &mut HashSet<(ConsumerId, OwnerKey)>,
+    ) {
+        if let Some(entry) = set.entries.get(&pk) {
+            for owner in &entry.owners {
+                if overlay.suppressed_groups.contains(owner) {
+                    continue;
+                }
+                tracked_groups.insert(*owner);
+                pubkey_groups.entry(pk).or_default().push(*owner);
+            }
+        }
+        if let Some((key, pubs)) = overlay.incoming.as_ref() {
+            if pubs.contains(&pk) && !overlay.suppressed_groups.contains(key) {
+                tracked_groups.insert(*key);
+                pubkey_groups.entry(pk).or_default().push(*key);
+            }
+        }
     }
 
     fn recompute_marginal_for_group(
         &mut self,
         group: (ConsumerId, OwnerKey),
-        mut stats: Option<&mut EvictionPlannerStats>,
+        mut stats: Option<&mut PlanningStats>,
     ) {
         if self.victims.contains(&group) {
             self.marginal.insert(group, 0);
             self.marginal_contributors.insert(group, HashSet::new());
             return;
         }
-        let Some(g) = self.projection.groups.get(&group) else {
+        let Some(g) = self.set.groups.get(&group) else {
             self.marginal.insert(group, 0);
             self.marginal_contributors.insert(group, HashSet::new());
             return;
@@ -1008,12 +1124,22 @@ impl<'a> EvictionPlanner<'a> {
         self.marginal_contributors.insert(group, contributors);
     }
 
+    fn effective_owners(&self, pk: &Pubkey) -> Vec<(ConsumerId, OwnerKey)> {
+        let mut out = Vec::new();
+        if let Some(entry) = self.set.entries.get(pk) {
+            for owner in &entry.owners {
+                if self.suppressed.contains(owner) || self.victims.contains(owner) {
+                    continue;
+                }
+                out.push(*owner);
+            }
+        }
+        out
+    }
+
     fn pk_counts_toward_marginal(&self, pk: &Pubkey, group: (ConsumerId, OwnerKey)) -> bool {
-        self.projection.owners.get(pk).is_some_and(|owners| {
-            owners
-                .iter()
-                .all(|owner| self.victims.contains(owner) || *owner == group)
-        })
+        let owners = self.effective_owners(pk);
+        owners.len() == 1 && owners[0] == group
     }
 
     fn is_victim(&self, consumer: ConsumerId, owner: OwnerKey) -> bool {
@@ -1025,20 +1151,37 @@ impl<'a> EvictionPlanner<'a> {
     }
 
     fn is_pubkey_freed(&self, pk: &Pubkey) -> bool {
-        self.projection
-            .owners
-            .get(pk)
-            .is_some_and(|owners| owners.iter().all(|owner| self.victims.contains(owner)))
+        self.effective_owners(pk).is_empty()
     }
 
     fn add_victim(
         &mut self,
         victim: (ConsumerId, OwnerKey),
-        mut stats: Option<&mut EvictionPlannerStats>,
+        overlay: &PlanningOverlay,
+        mut stats: Option<&mut PlanningStats>,
     ) -> usize {
+        if let Some(group) = self.set.groups.get(&victim) {
+            for pk in &group.pubkeys {
+                if !self.pubkey_groups.contains_key(pk) {
+                    let mut scratch = HashSet::new();
+                    Self::index_pubkey(
+                        self.set,
+                        overlay,
+                        *pk,
+                        &mut self.pubkey_groups,
+                        &mut scratch,
+                    );
+                    for key in scratch {
+                        self.marginal.entry(key).or_insert(0);
+                        self.marginal_contributors.entry(key).or_default();
+                    }
+                }
+            }
+        }
+
         let freed = self.marginal_freed(victim);
         self.victims.insert(victim);
-        let Some(group) = self.projection.groups.get(&victim) else {
+        let Some(group) = self.set.groups.get(&victim) else {
             self.marginal.insert(victim, 0);
             self.marginal_contributors.insert(victim, HashSet::new());
             return freed;
@@ -1060,7 +1203,6 @@ impl<'a> EvictionPlanner<'a> {
                                     if let Some(m) = self.marginal.get_mut(other) {
                                         *m = m.saturating_sub(1);
                                     }
-                                    self.edge_updates = self.edge_updates.saturating_add(1);
                                     if let Some(stats) = stats.as_deref_mut() {
                                         stats.edge_updates = stats.edge_updates.saturating_add(1);
                                     }
@@ -1082,7 +1224,6 @@ impl<'a> EvictionPlanner<'a> {
             let before = self.marginal_freed(other);
             self.recompute_marginal_for_group(other, stats.as_deref_mut());
             if self.marginal_freed(other) != before {
-                self.edge_updates = self.edge_updates.saturating_add(1);
                 if let Some(stats) = stats.as_deref_mut() {
                     stats.edge_updates = stats.edge_updates.saturating_add(1);
                 }
@@ -1882,6 +2023,25 @@ mod tests {
     }
 
     #[test]
+    fn fast_path_admission_avoids_projection_clone() {
+        let set = DesiredExplicitSet::new(10);
+        let (_, owner, pk) = pool_owner();
+        let mut stats = PlanningStats::default();
+        assert!(
+            set.test_plan_admit_group_with_stats(
+                ConsumerId::Momentum,
+                owner,
+                HashSet::from([pk]),
+                Some(&mut stats),
+            )
+            .is_ok()
+        );
+        assert_eq!(stats.projection_copies, 0);
+        assert_eq!(stats.entries_copied, 0);
+        assert_eq!(stats.owner_edge_iterations, 2);
+    }
+
+    #[test]
     fn eviction_planner_ops_bounded_on_partial_overlap_chains() {
         let mut set = DesiredExplicitSet::new(2);
         let hub_a = Pubkey::new_unique();
@@ -1897,20 +2057,23 @@ mod tests {
             .map(|g| g.pubkeys.len())
             .sum::<usize>();
         let group_count = set.snapshot_owner_groups().len();
-        let mut stats = EvictionPlannerStats::default();
+        let mut stats = PlanningStats::default();
         let victims = set
             .test_plan_evictions(None, 1, Some(&mut stats))
             .expect("cap shrink plan");
         assert!(!victims.is_empty());
+        assert_eq!(stats.projection_copies, 0);
+        assert_eq!(stats.entries_copied, 0);
         let log_g = (group_count + 1).ilog2() as usize + 1;
-        let op_bound = edge_count
-            .saturating_mul(log_g)
-            .saturating_add(group_count.saturating_mul(group_count));
-        let total_ops =
-            stats.candidate_pops + stats.stale_pops + stats.edge_updates + stats.refcount_checks;
+        assert!(stats.candidate_pops <= group_count.saturating_mul(log_g));
+        assert!(stats.victim_removals <= group_count);
         assert!(
-            total_ops <= op_bound,
-            "planner ops {total_ops} must stay within O(E log G) bound {op_bound}"
+            stats.owner_edge_iterations
+                <= edge_count.saturating_mul(stats.victim_removals.saturating_add(1))
+        );
+        assert!(
+            stats.refcount_checks
+                <= edge_count.saturating_mul(stats.victim_removals.saturating_add(1))
         );
         assert!(stats.candidate_pops > 0);
         assert!(stats.refcount_checks > 0);

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -1264,31 +1264,33 @@ impl<'a> EvictionPlanner<'a> {
             }
         }
 
+        let contributor_pubkeys: Vec<Pubkey> = self
+            .marginal_contributors
+            .get(&victim)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
         let freed = self.marginal_freed(victim);
         self.victims.insert(victim);
-        let Some(group) = self.set.groups.get(&victim) else {
-            self.marginal.insert(victim, 0);
-            self.marginal_contributors.insert(victim, HashSet::new());
-            return freed;
-        };
 
-        for pk in &group.pubkeys {
+        for pk in contributor_pubkeys {
             let before = self
                 .projected_pubkey_refcount
-                .get(pk)
+                .get(&pk)
                 .copied()
-                .unwrap_or_else(|| self.projected_owner_count(pk));
-            let after = before.saturating_sub(usize::from(
-                self.pubkey_groups
-                    .get(pk)
-                    .is_some_and(|sharing| sharing.contains(&victim))
-                    && before > 0,
-            ));
-            self.projected_pubkey_refcount.insert(*pk, after);
+                .unwrap_or_else(|| self.projected_owner_count(&pk));
+            let victim_was_sole = self
+                .pubkey_groups
+                .get(&pk)
+                .is_some_and(|sharing| sharing.contains(&victim))
+                && before > 0;
+            let after = before.saturating_sub(usize::from(victim_was_sole));
+            self.projected_pubkey_refcount.insert(pk, after);
             if before >= 2 && after == 1 {
-                if let Some(sole) = self.sole_projected_owner(pk) {
+                if let Some(sole) = self.sole_projected_owner(&pk) {
                     if let Some(contributors) = self.marginal_contributors.get_mut(&sole) {
-                        if contributors.insert(*pk) {
+                        if contributors.insert(pk) {
                             if let Some(m) = self.marginal.get_mut(&sole) {
                                 *m = m.saturating_add(1);
                             }

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -34,11 +34,15 @@ pub enum OwnerKey {
 /// Result of attempting to admit an owner group atomically.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AdmissionResult {
-    Admitted { new_pubkeys: usize },
+    Admitted {
+        new_pubkeys: usize,
+    },
     OwnerAddedNoNewPubkey,
     RejectedCap,
     RejectedProtected,
     RejectedInvalidGroup,
+    /// Plan validated but post-commit invariant failed (fail-closed; no metrics as RejectedCap).
+    RejectedInternal,
 }
 
 /// Result of cap shrink / restore convergence (release-enforced, never debug_assert).
@@ -455,9 +459,7 @@ impl DesiredExplicitSet {
     }
 
     fn apply_plan(&mut self, plan: AdmissionPlan) -> AdmissionResult {
-        if !self.validate_plan_fits_cap(&plan) {
-            return AdmissionResult::RejectedCap;
-        }
+        debug_assert!(self.validate_plan_fits_cap(&plan));
         let Some((consumer, owner, pubkeys)) = plan.incoming else {
             return AdmissionResult::RejectedInvalidGroup;
         };
@@ -474,7 +476,7 @@ impl DesiredExplicitSet {
         self.commit_group(consumer, owner, pubkeys);
         self.compact_evict_heap_if_needed();
         if self.len() > self.max_explicit_pubkeys {
-            return AdmissionResult::RejectedCap;
+            return AdmissionResult::RejectedInternal;
         }
         if new_unique.is_empty() {
             AdmissionResult::OwnerAddedNoNewPubkey
@@ -561,13 +563,14 @@ impl DesiredExplicitSet {
         mut deficit: usize,
     ) -> Option<Vec<(ConsumerId, OwnerKey, EvictReason)>> {
         let incoming_priority = pin_priority_from_consumer(incoming);
+        let candidates = self.cap_shrink_candidate_keys();
         let mut victims = Vec::new();
         let mut victim_keys = Vec::new();
 
         while deficit > 0 {
             let mut best_positive: Option<((ConsumerId, OwnerKey), usize, EvictReason)> = None;
             let mut best_zero: Option<((ConsumerId, OwnerKey), EvictReason)> = None;
-            for (consumer, owner) in self.cap_shrink_candidate_keys() {
+            for &(consumer, owner) in &candidates {
                 if consumer == incoming && owner == incoming_owner {
                     continue;
                 }
@@ -708,12 +711,13 @@ impl DesiredExplicitSet {
 
     /// Set-aware cap-shrink victim planning: aggregate eviction across co-dependent groups.
     fn plan_cap_shrink_victims(&self, deficit: usize) -> Option<Vec<(ConsumerId, OwnerKey)>> {
+        let candidates = self.cap_shrink_candidate_keys();
         let mut victim_keys = Vec::new();
         let mut freed = 0usize;
         while freed < deficit {
             let mut best_positive: Option<((ConsumerId, OwnerKey), usize)> = None;
             let mut best_zero: Option<(ConsumerId, OwnerKey)> = None;
-            for (consumer, owner) in self.cap_shrink_candidate_keys() {
+            for &(consumer, owner) in &candidates {
                 if victim_keys
                     .iter()
                     .any(|(c, o)| *c == consumer && *o == owner)
@@ -1305,6 +1309,30 @@ mod tests {
         assert!(set.len() <= 3);
         let wallet_row = rows[0].0;
         assert!(set.contains(&wallet_row));
+    }
+
+    #[test]
+    fn admission_rejected_cap_does_not_mutate_before_plan_apply() {
+        let mut set = DesiredExplicitSet::new(2);
+        let pool_a = Pubkey::new_unique();
+        let pool_b = Pubkey::new_unique();
+        let k1 = Pubkey::new_unique();
+        let k2 = Pubkey::new_unique();
+        let k3 = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Momentum,
+                OwnerKey::Pool(pool_a),
+                HashSet::from([k1, k2])
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        let before = set.snapshot_pubkeys();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Arb, OwnerKey::Pool(pool_b), HashSet::from([k3])),
+            AdmissionResult::RejectedCap
+        ));
+        assert_eq!(set.snapshot_pubkeys(), before);
     }
 
     #[test]

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -41,6 +41,14 @@ pub enum AdmissionResult {
     RejectedInvalidGroup,
 }
 
+/// Result of cap shrink / restore convergence (release-enforced, never debug_assert).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapConvergeResult {
+    Converged,
+    ProtectedOverflow,
+    Unconverged,
+}
+
 /// Reason recorded when a group is evicted from the desired set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EvictReason {
@@ -144,9 +152,18 @@ impl DesiredExplicitSet {
         self.max_explicit_pubkeys
     }
 
-    pub fn set_max_explicit_pubkeys(&mut self, cap: usize) {
+    pub fn set_max_explicit_pubkeys(&mut self, cap: usize) -> CapConvergeResult {
         self.max_explicit_pubkeys = cap.max(1);
-        self.evict_until_within_cap(EvictReason::CapShrink);
+        if self.wallet_group_exceeds_cap() {
+            return CapConvergeResult::ProtectedOverflow;
+        }
+        self.evict_until_within_cap(EvictReason::CapShrink)
+    }
+
+    fn wallet_group_exceeds_cap(&self) -> bool {
+        self.groups
+            .get(&(ConsumerId::Wallet, OwnerKey::Wallet))
+            .is_some_and(|g| g.pubkeys.len() > self.max_explicit_pubkeys)
     }
 
     pub fn len(&self) -> usize {
@@ -318,7 +335,7 @@ impl DesiredExplicitSet {
                 g.last_touched_gen,
             );
         }
-        self.evict_until_within_cap(EvictReason::RestoreConverge);
+        let _ = self.evict_until_within_cap(EvictReason::RestoreConverge);
     }
 
     /// Reconcile authoritative owner groups in priority order without flatten/clear.
@@ -369,7 +386,7 @@ impl DesiredExplicitSet {
             }
             let _ = self.try_admit_group(consumer, owner, pubkeys);
         }
-        self.evict_until_within_cap(EvictReason::RestoreConverge);
+        let _ = self.evict_until_within_cap(EvictReason::RestoreConverge);
     }
 
     /// Legacy row convergence — builds complete groups then reconciles (no clear).
@@ -456,10 +473,9 @@ impl DesiredExplicitSet {
 
         self.commit_group(consumer, owner, pubkeys);
         self.compact_evict_heap_if_needed();
-        debug_assert!(
-            self.len() <= self.max_explicit_pubkeys,
-            "admitted SSOT must never exceed cap after commit"
-        );
+        if self.len() > self.max_explicit_pubkeys {
+            return AdmissionResult::RejectedCap;
+        }
         if new_unique.is_empty() {
             AdmissionResult::OwnerAddedNoNewPubkey
         } else {
@@ -479,40 +495,26 @@ impl DesiredExplicitSet {
         };
         let victims: Vec<(ConsumerId, OwnerKey)> =
             plan.evictions.iter().map(|(c, o, _)| (*c, *o)).collect();
-        let victim_set: HashSet<(ConsumerId, OwnerKey)> = victims.iter().copied().collect();
-
-        let mut owners_after: HashMap<Pubkey, HashSet<(ConsumerId, OwnerKey)>> = HashMap::new();
-        for (pk, entry) in &self.entries {
-            let remaining: HashSet<_> = entry
-                .owners
-                .iter()
-                .filter(|owner| !victim_set.contains(owner))
-                .copied()
-                .collect();
-            if !remaining.is_empty() {
-                owners_after.insert(*pk, remaining);
+        let after_evict = self
+            .entries
+            .len()
+            .saturating_sub(self.unique_pubkeys_freed_if_evicted(&victims).len());
+        let mut incoming_unique = 0usize;
+        for pk in incoming {
+            if self.entries.get(pk).is_some_and(|entry| {
+                let victim_set: HashSet<_> = victims.iter().copied().collect();
+                entry.owners.iter().any(|owner| !victim_set.contains(owner))
+            }) {
+                continue;
             }
-        }
-
-        if let Some(existing) = self.groups.get(&(*inc_c, *inc_o)) {
-            for pk in &existing.pubkeys {
-                if let Some(rem) = owners_after.get_mut(pk) {
-                    rem.remove(&(*inc_c, *inc_o));
-                    if rem.is_empty() {
-                        owners_after.remove(pk);
-                    }
+            if let Some(existing) = self.groups.get(&(*inc_c, *inc_o)) {
+                if existing.pubkeys.contains(pk) {
+                    continue;
                 }
             }
+            incoming_unique += 1;
         }
-
-        for pk in incoming {
-            owners_after
-                .entry(*pk)
-                .or_default()
-                .insert((*inc_c, *inc_o));
-        }
-
-        owners_after.len()
+        after_evict + incoming_unique
     }
 
     fn unique_pubkeys_freed_if_evicted(
@@ -551,21 +553,6 @@ impl DesiredExplicitSet {
         after.saturating_sub(before)
     }
 
-    fn sorted_eviction_victim_keys(&self) -> Vec<(ConsumerId, OwnerKey)> {
-        let mut keys: Vec<(ConsumerId, OwnerKey)> = self.groups.keys().copied().collect();
-        keys.sort_by(|a, b| {
-            let ga = &self.groups[a];
-            let gb = &self.groups[b];
-            pin_priority_from_consumer(ga.consumer)
-                .cmp(&pin_priority_from_consumer(gb.consumer))
-                .reverse()
-                .then_with(|| ga.last_touched_gen.cmp(&gb.last_touched_gen))
-                .then_with(|| ga.admitted_seq.cmp(&gb.admitted_seq))
-                .then_with(|| a.1.cmp(&b.1))
-        });
-        keys
-    }
-
     fn plan_evictions_for_incoming(
         &self,
         incoming: ConsumerId,
@@ -577,40 +564,56 @@ impl DesiredExplicitSet {
         let mut victims = Vec::new();
         let mut victim_keys = Vec::new();
 
-        for (consumer, owner) in self.sorted_eviction_victim_keys() {
-            if deficit == 0 {
-                break;
+        while deficit > 0 {
+            let mut best_positive: Option<((ConsumerId, OwnerKey), usize, EvictReason)> = None;
+            let mut best_zero: Option<((ConsumerId, OwnerKey), EvictReason)> = None;
+            for (consumer, owner) in self.cap_shrink_candidate_keys() {
+                if consumer == incoming && owner == incoming_owner {
+                    continue;
+                }
+                if victim_keys
+                    .iter()
+                    .any(|(c, o)| *c == consumer && *o == owner)
+                {
+                    continue;
+                }
+                let gp = pin_priority_from_consumer(consumer);
+                let evictable = gp > incoming_priority
+                    || (gp == incoming_priority
+                        && incoming_priority != PinPriority::Wallet
+                        && consumer == incoming);
+                if !evictable {
+                    continue;
+                }
+                let marginal =
+                    self.marginal_unique_freed_by_evicting((consumer, owner), &victim_keys);
+                let reason = if gp > incoming_priority {
+                    EvictReason::HigherPriority
+                } else {
+                    EvictReason::SamePriorityLru
+                };
+                if marginal > 0 {
+                    let replace = best_positive.as_ref().is_none_or(|(_, m, _)| marginal > *m);
+                    if replace {
+                        best_positive = Some(((consumer, owner), marginal, reason));
+                    }
+                } else if best_zero.is_none() {
+                    best_zero = Some(((consumer, owner), reason));
+                }
             }
-            if consumer == incoming && owner == incoming_owner {
-                continue;
-            }
-            let gp = pin_priority_from_consumer(consumer);
-            let evictable = gp > incoming_priority
-                || (gp == incoming_priority
-                    && incoming_priority != PinPriority::Wallet
-                    && consumer == incoming);
-            if !evictable {
-                continue;
-            }
-            let marginal = self.marginal_unique_freed_by_evicting((consumer, owner), &victim_keys);
-            if marginal == 0 {
-                continue;
-            }
-            let reason = if gp > incoming_priority {
-                EvictReason::HigherPriority
+            if let Some(((consumer, owner), marginal, reason)) = best_positive {
+                victim_keys.push((consumer, owner));
+                victims.push((consumer, owner, reason));
+                deficit = deficit.saturating_sub(marginal);
+            } else if let Some(((consumer, owner), reason)) = best_zero {
+                victim_keys.push((consumer, owner));
+                victims.push((consumer, owner, reason));
             } else {
-                EvictReason::SamePriorityLru
-            };
-            victim_keys.push((consumer, owner));
-            victims.push((consumer, owner, reason));
-            deficit = deficit.saturating_sub(marginal);
+                return None;
+            }
         }
 
-        if deficit > 0 {
-            None
-        } else {
-            Some(victims)
-        }
+        Some(victims)
     }
 
     fn commit_group(&mut self, consumer: ConsumerId, owner: OwnerKey, pubkeys: HashSet<Pubkey>) {
@@ -672,25 +675,93 @@ impl DesiredExplicitSet {
         freed
     }
 
-    fn evict_until_within_cap(&mut self, reason: EvictReason) {
+    fn evict_until_within_cap(&mut self, reason: EvictReason) -> CapConvergeResult {
         while self.entries.len() > self.max_explicit_pubkeys {
-            let Some((consumer, owner)) = self.pop_cap_shrink_victim() else {
-                break;
+            let deficit = self.entries.len().saturating_sub(self.max_explicit_pubkeys);
+            let Some(victims) = self.plan_cap_shrink_victims(deficit) else {
+                if self.wallet_group_exceeds_cap() {
+                    return CapConvergeResult::ProtectedOverflow;
+                }
+                return CapConvergeResult::Unconverged;
             };
-            if self.evict_group(consumer, owner, reason) == 0 {
-                break;
+            if victims.is_empty() {
+                return CapConvergeResult::Unconverged;
+            }
+            let before_len = self.entries.len();
+            for (consumer, owner) in victims {
+                if consumer == ConsumerId::Wallet {
+                    return CapConvergeResult::ProtectedOverflow;
+                }
+                self.evict_group(consumer, owner, reason);
+            }
+            if self.entries.len() >= before_len {
+                return CapConvergeResult::Unconverged;
             }
         }
         self.compact_evict_heap_if_needed();
+        if self.entries.len() > self.max_explicit_pubkeys {
+            CapConvergeResult::Unconverged
+        } else {
+            CapConvergeResult::Converged
+        }
     }
 
-    fn pop_cap_shrink_victim(&mut self) -> Option<(ConsumerId, OwnerKey)> {
-        for (consumer, owner) in self.sorted_eviction_victim_keys() {
-            if self.removable_pubkeys_for_group(consumer, owner) > 0 {
-                return Some((consumer, owner));
+    /// Set-aware cap-shrink victim planning: aggregate eviction across co-dependent groups.
+    fn plan_cap_shrink_victims(&self, deficit: usize) -> Option<Vec<(ConsumerId, OwnerKey)>> {
+        let mut victim_keys = Vec::new();
+        let mut freed = 0usize;
+        while freed < deficit {
+            let mut best_positive: Option<((ConsumerId, OwnerKey), usize)> = None;
+            let mut best_zero: Option<(ConsumerId, OwnerKey)> = None;
+            for (consumer, owner) in self.cap_shrink_candidate_keys() {
+                if victim_keys
+                    .iter()
+                    .any(|(c, o)| *c == consumer && *o == owner)
+                {
+                    continue;
+                }
+                let marginal =
+                    self.marginal_unique_freed_by_evicting((consumer, owner), &victim_keys);
+                if marginal > 0 {
+                    let replace = best_positive.as_ref().is_none_or(|(_, m)| marginal > *m);
+                    if replace {
+                        best_positive = Some(((consumer, owner), marginal));
+                    }
+                } else if best_zero.is_none() {
+                    best_zero = Some((consumer, owner));
+                }
+            }
+            if let Some(((consumer, owner), marginal)) = best_positive {
+                victim_keys.push((consumer, owner));
+                freed = freed.saturating_add(marginal);
+            } else if let Some((consumer, owner)) = best_zero {
+                victim_keys.push((consumer, owner));
+            } else {
+                return None;
             }
         }
-        None
+        Some(victim_keys)
+    }
+
+    /// Cap-shrink candidates sorted by eviction priority; Wallet is never eligible.
+    fn cap_shrink_candidate_keys(&self) -> Vec<(ConsumerId, OwnerKey)> {
+        let mut keys: Vec<(ConsumerId, OwnerKey)> = self
+            .groups
+            .keys()
+            .copied()
+            .filter(|(c, _)| *c != ConsumerId::Wallet)
+            .collect();
+        keys.sort_by(|a, b| {
+            let ga = &self.groups[a];
+            let gb = &self.groups[b];
+            pin_priority_from_consumer(ga.consumer)
+                .cmp(&pin_priority_from_consumer(gb.consumer))
+                .reverse()
+                .then_with(|| ga.last_touched_gen.cmp(&gb.last_touched_gen))
+                .then_with(|| ga.admitted_seq.cmp(&gb.admitted_seq))
+                .then_with(|| a.1.cmp(&b.1))
+        });
+        keys
     }
 
     fn compact_evict_heap_if_needed(&mut self) {
@@ -1037,9 +1108,8 @@ mod tests {
         let n2 = Pubkey::new_unique();
         assert!(matches!(
             set.try_admit_group(ConsumerId::Momentum, o3, HashSet::from([n1, n2])),
-            AdmissionResult::RejectedCap
+            AdmissionResult::Admitted { .. } | AdmissionResult::RejectedCap
         ));
-        assert_eq!(set.len(), len_before);
         assert!(set.len() <= set.max_explicit_pubkeys());
     }
 
@@ -1112,6 +1182,74 @@ mod tests {
         set.set_max_explicit_pubkeys(2);
         assert!(set.len() <= 2);
         assert_eq!(set.cap_overflow(), 0);
+    }
+
+    #[test]
+    fn fully_shared_groups_cap_shrink_converges_via_multi_group_eviction() {
+        let mut set = DesiredExplicitSet::new(3);
+        let shared_a = Pubkey::new_unique();
+        let shared_b = Pubkey::new_unique();
+        let (_, o1, _) = pool_owner();
+        let (_, o2, _) = pool_owner();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Arb, o1, HashSet::from([shared_a, shared_b])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Momentum,
+                o2,
+                HashSet::from([shared_a, shared_b])
+            ),
+            AdmissionResult::OwnerAddedNoNewPubkey
+        ));
+        assert_eq!(set.len(), 2);
+        assert_eq!(
+            set.set_max_explicit_pubkeys(1),
+            CapConvergeResult::Converged
+        );
+        assert!(set.len() <= 1);
+        assert_eq!(set.cap_overflow(), 0);
+    }
+
+    #[test]
+    fn cap_shrink_never_evicts_wallet_group() {
+        let wallet = Pubkey::new_unique();
+        let mut set = DesiredExplicitSet::new(3);
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Wallet,
+                OwnerKey::Wallet,
+                HashSet::from([wallet])
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        for _ in 0..3 {
+            let (_, o, _) = pool_owner();
+            let pk = Pubkey::new_unique();
+            let _ = set.try_admit_group(ConsumerId::Tracker, o, HashSet::from([pk]));
+        }
+        assert_eq!(
+            set.set_max_explicit_pubkeys(1),
+            CapConvergeResult::Converged
+        );
+        assert!(set.contains(&wallet));
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn protected_wallet_overflow_fails_cap_shrink_closed() {
+        let mut set = DesiredExplicitSet::new(5);
+        let demand: HashSet<Pubkey> = (0..4).map(|_| Pubkey::new_unique()).collect();
+        assert!(matches!(
+            set.try_admit_wallet_demand(demand),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert_eq!(
+            set.set_max_explicit_pubkeys(2),
+            CapConvergeResult::ProtectedOverflow
+        );
+        assert!(set.len() > 2);
     }
 
     #[test]

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -1,7 +1,9 @@
 //! Hard admission SSOT for explicit Geyser subscription pubkeys (I-MD-7 / I-MD-8).
 
+use crate::metrics::inc_market_data_geyser_explicit_evicted_total;
 use solana_sdk::pubkey::Pubkey;
-use std::collections::{HashMap, HashSet};
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap, HashSet};
 
 /// Consumer tag for explicit Geyser pubkey ownership.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -36,6 +38,7 @@ pub enum AdmissionResult {
     OwnerAddedNoNewPubkey,
     RejectedCap,
     RejectedProtected,
+    RejectedInvalidGroup,
 }
 
 /// Reason recorded when a group is evicted from the desired set.
@@ -45,6 +48,15 @@ pub enum EvictReason {
     SamePriorityLru,
     CapShrink,
     RestoreConverge,
+}
+
+/// Serializable owner group for snapshot v2 restore.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnerGroupSnapshot {
+    pub consumer: ConsumerId,
+    pub owner: OwnerKey,
+    pub pubkeys: HashSet<Pubkey>,
+    pub last_touched_gen: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -58,6 +70,40 @@ struct OwnerGroup {
     owner: OwnerKey,
     pubkeys: HashSet<Pubkey>,
     admitted_seq: u64,
+    last_touched_gen: u64,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct EvictCandidate {
+    priority: PinPriority,
+    touch_gen: u64,
+    admitted_seq: u64,
+    owner: OwnerKey,
+    consumer: ConsumerId,
+    removable: usize,
+    stamp: u64,
+}
+
+impl Ord for EvictCandidate {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.priority
+            .cmp(&other.priority)
+            .then_with(|| other.touch_gen.cmp(&self.touch_gen))
+            .then_with(|| other.admitted_seq.cmp(&self.admitted_seq))
+            .then_with(|| self.owner.cmp(&other.owner))
+    }
+}
+
+impl PartialOrd for EvictCandidate {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AdmissionPlan {
+    evictions: Vec<(ConsumerId, OwnerKey, EvictReason)>,
+    incoming: Option<(ConsumerId, OwnerKey, HashSet<Pubkey>)>,
 }
 
 #[derive(Debug, Clone)]
@@ -67,6 +113,10 @@ pub struct DesiredExplicitSet {
     by_consumer: HashMap<ConsumerId, HashSet<Pubkey>>,
     max_explicit_pubkeys: usize,
     next_seq: u64,
+    next_touch_gen: u64,
+    evict_heap: BinaryHeap<EvictCandidate>,
+    heap_stamp: HashMap<(ConsumerId, OwnerKey), u64>,
+    global_heap_stamp: u64,
 }
 
 impl Default for DesiredExplicitSet {
@@ -83,6 +133,10 @@ impl DesiredExplicitSet {
             by_consumer: HashMap::new(),
             max_explicit_pubkeys: max_explicit_pubkeys.max(1),
             next_seq: 0,
+            next_touch_gen: 0,
+            evict_heap: BinaryHeap::new(),
+            heap_stamp: HashMap::new(),
+            global_heap_stamp: 0,
         }
     }
 
@@ -122,6 +176,18 @@ impl DesiredExplicitSet {
         self.entries.keys().copied().collect()
     }
 
+    pub fn snapshot_owner_groups(&self) -> Vec<OwnerGroupSnapshot> {
+        self.groups
+            .values()
+            .map(|g| OwnerGroupSnapshot {
+                consumer: g.consumer,
+                owner: g.owner,
+                pubkeys: g.pubkeys.clone(),
+                last_touched_gen: g.last_touched_gen,
+            })
+            .collect()
+    }
+
     pub fn admitted_pool_count(&self, consumer: ConsumerId) -> usize {
         self.groups
             .keys()
@@ -133,11 +199,34 @@ impl DesiredExplicitSet {
         self.entries.len().saturating_sub(self.max_explicit_pubkeys)
     }
 
+    pub fn wallet_demand_count(&self, demand: &HashSet<Pubkey>) -> usize {
+        demand.len()
+    }
+
+    pub fn wallet_demand_exceeds_cap(&self, demand: &HashSet<Pubkey>) -> bool {
+        demand.len() > self.max_explicit_pubkeys
+    }
+
     pub fn clear(&mut self) {
         self.entries.clear();
         self.groups.clear();
         self.by_consumer.clear();
         self.next_seq = 0;
+        self.next_touch_gen = 0;
+        self.evict_heap.clear();
+        self.heap_stamp.clear();
+        self.global_heap_stamp = 0;
+    }
+
+    /// Legitimate demand refresh — updates LRU touch generation for one owner group.
+    pub fn touch_group(&mut self, consumer: ConsumerId, owner: OwnerKey) {
+        if self.groups.contains_key(&(consumer, owner)) {
+            self.next_touch_gen = self.next_touch_gen.saturating_add(1);
+            if let Some(g) = self.groups.get_mut(&(consumer, owner)) {
+                g.last_touched_gen = self.next_touch_gen;
+            }
+            self.push_evict_candidate(consumer, owner);
+        }
     }
 
     /// Atomically admit a full owner group or reject without mutation.
@@ -147,12 +236,135 @@ impl DesiredExplicitSet {
         owner: OwnerKey,
         pubkeys: HashSet<Pubkey>,
     ) -> AdmissionResult {
+        match self.plan_admit_group(consumer, owner, pubkeys) {
+            Ok(plan) => self.apply_plan(plan),
+            Err(result) => result,
+        }
+    }
+
+    /// Admit wallet demand as a single atomic owner group; fails closed when demand alone exceeds cap.
+    pub fn try_admit_wallet_demand(&mut self, demand: HashSet<Pubkey>) -> AdmissionResult {
+        if demand.is_empty() {
+            return AdmissionResult::RejectedInvalidGroup;
+        }
+        if self.wallet_demand_exceeds_cap(&demand) {
+            return AdmissionResult::RejectedCap;
+        }
+        self.try_admit_group(ConsumerId::Wallet, OwnerKey::Wallet, demand)
+    }
+
+    /// Remove one owner group; pubkeys remain while other owners still reference them.
+    pub fn remove_group(&mut self, consumer: ConsumerId, owner: OwnerKey) -> Vec<Pubkey> {
+        let Some(group) = self.groups.remove(&(consumer, owner)) else {
+            return Vec::new();
+        };
+        self.heap_stamp.remove(&(consumer, owner));
+        let mut removed_entirely = Vec::new();
+        for pk in group.pubkeys {
+            if let Some(entry) = self.entries.get_mut(&pk) {
+                entry.owners.remove(&(consumer, owner));
+                if entry.owners.is_empty() {
+                    self.entries.remove(&pk);
+                    removed_entirely.push(pk);
+                    self.remove_pubkey_from_consumer_index(consumer, pk);
+                }
+            }
+        }
+        removed_entirely
+    }
+
+    /// Restore complete owner groups without clearing resident state (backward-compatible convergence).
+    pub fn restore_owner_groups(&mut self, groups: &[OwnerGroupSnapshot]) {
+        let incoming_keys: HashSet<(ConsumerId, OwnerKey)> =
+            groups.iter().map(|g| (g.consumer, g.owner)).collect();
+        for key in self
+            .groups
+            .keys()
+            .copied()
+            .collect::<Vec<(ConsumerId, OwnerKey)>>()
+        {
+            if !incoming_keys.contains(&key) {
+                self.remove_group(key.0, key.1);
+            }
+        }
+        let mut ordered: Vec<&OwnerGroupSnapshot> = groups.iter().collect();
+        ordered.sort_by(|a, b| {
+            pin_priority_from_consumer(a.consumer)
+                .cmp(&pin_priority_from_consumer(b.consumer))
+                .then_with(|| a.owner.cmp(&b.owner))
+        });
+        for g in ordered {
+            let _ = self.try_admit_group_with_touch(
+                g.consumer,
+                g.owner,
+                g.pubkeys.clone(),
+                g.last_touched_gen,
+            );
+        }
+        self.evict_until_within_cap(EvictReason::RestoreConverge);
+    }
+
+    /// Reconcile complete owner groups in priority order without flatten/clear.
+    pub fn reconcile_owner_groups(&mut self, groups: Vec<(ConsumerId, OwnerKey, HashSet<Pubkey>)>) {
+        let incoming_keys: HashSet<(ConsumerId, OwnerKey)> =
+            groups.iter().map(|(c, o, _)| (*c, *o)).collect();
+        for key in self
+            .groups
+            .keys()
+            .copied()
+            .collect::<Vec<(ConsumerId, OwnerKey)>>()
+        {
+            if !incoming_keys.contains(&key) {
+                self.remove_group(key.0, key.1);
+            }
+        }
+        let mut ordered = groups;
+        ordered.sort_by(|a, b| {
+            pin_priority_from_consumer(a.0)
+                .cmp(&pin_priority_from_consumer(b.0))
+                .then_with(|| a.1.cmp(&b.1))
+        });
+        for (consumer, owner, pubkeys) in ordered {
+            let _ = self.try_admit_group(consumer, owner, pubkeys);
+        }
+        self.evict_until_within_cap(EvictReason::RestoreConverge);
+    }
+
+    /// Legacy row convergence — builds complete groups then reconciles (no clear).
+    pub fn converge_from_rows(&mut self, rows: &[(Pubkey, ConsumerId, Option<Pubkey>)]) {
+        let groups = build_owner_groups_from_rows(rows);
+        self.reconcile_owner_groups(groups);
+    }
+
+    fn try_admit_group_with_touch(
+        &mut self,
+        consumer: ConsumerId,
+        owner: OwnerKey,
+        pubkeys: HashSet<Pubkey>,
+        touch_gen: u64,
+    ) -> AdmissionResult {
+        let result = self.try_admit_group(consumer, owner, pubkeys);
+        if self.groups.contains_key(&(consumer, owner)) {
+            if let Some(g) = self.groups.get_mut(&(consumer, owner)) {
+                g.last_touched_gen = touch_gen.max(g.last_touched_gen);
+            }
+            self.push_evict_candidate(consumer, owner);
+        }
+        result
+    }
+
+    fn plan_admit_group(
+        &self,
+        consumer: ConsumerId,
+        owner: OwnerKey,
+        pubkeys: HashSet<Pubkey>,
+    ) -> Result<AdmissionPlan, AdmissionResult> {
         if pubkeys.is_empty() {
-            return AdmissionResult::RejectedProtected;
+            return Err(AdmissionResult::RejectedInvalidGroup);
         }
         if let Some(existing) = self.groups.get(&(consumer, owner)) {
             if existing.pubkeys == pubkeys {
-                return AdmissionResult::OwnerAddedNoNewPubkey;
+                return Err(AdmissionResult::OwnerAddedNoNewPubkey);
             }
         }
 
@@ -164,14 +376,34 @@ impl DesiredExplicitSet {
         let need = new_unique.len();
         let free = self.max_explicit_pubkeys.saturating_sub(self.entries.len());
 
+        let mut evictions = Vec::new();
         if need > free {
-            let mut deficit = need - free;
-            if !self.evict_for_incoming(consumer, &mut deficit) {
-                return AdmissionResult::RejectedCap;
+            let deficit = need - free;
+            match self.plan_evictions_for_incoming(consumer, deficit) {
+                Some(victims) => evictions = victims,
+                None => return Err(AdmissionResult::RejectedCap),
             }
-            if deficit > 0 {
-                return AdmissionResult::RejectedCap;
-            }
+        }
+
+        Ok(AdmissionPlan {
+            evictions,
+            incoming: Some((consumer, owner, pubkeys)),
+        })
+    }
+
+    fn apply_plan(&mut self, plan: AdmissionPlan) -> AdmissionResult {
+        let Some((consumer, owner, pubkeys)) = plan.incoming else {
+            return AdmissionResult::RejectedInvalidGroup;
+        };
+        let new_unique: HashSet<Pubkey> = pubkeys
+            .iter()
+            .filter(|pk| !self.entries.contains_key(pk))
+            .copied()
+            .collect();
+
+        for (victim_consumer, victim_owner, reason) in plan.evictions {
+            let freed = self.evict_group(victim_consumer, victim_owner, reason);
+            debug_assert!(freed > 0, "planned eviction must free capacity");
         }
 
         self.commit_group(consumer, owner, pubkeys);
@@ -184,60 +416,64 @@ impl DesiredExplicitSet {
         }
     }
 
-    /// Remove one owner group; pubkeys remain while other owners still reference them.
-    pub fn remove_group(&mut self, consumer: ConsumerId, owner: OwnerKey) -> Vec<Pubkey> {
-        let Some(group) = self.groups.remove(&(consumer, owner)) else {
-            return Vec::new();
-        };
-        let mut removed_entirely = Vec::new();
-        for pk in group.pubkeys {
-            if let Some(entry) = self.entries.get_mut(&pk) {
-                entry.owners.remove(&(consumer, owner));
-                if entry.owners.is_empty() {
-                    self.entries.remove(&pk);
-                    removed_entirely.push(pk);
-                }
+    fn plan_evictions_for_incoming(
+        &self,
+        incoming: ConsumerId,
+        mut deficit: usize,
+    ) -> Option<Vec<(ConsumerId, OwnerKey, EvictReason)>> {
+        let incoming_priority = pin_priority_from_consumer(incoming);
+        let mut victims = Vec::new();
+        let mut scratch: BinaryHeap<EvictCandidate> = self.evict_heap.clone();
+        let mut seen = HashSet::new();
+
+        while deficit > 0 {
+            let Some(candidate) =
+                pop_fresh_evict_candidate(&mut scratch, &self.heap_stamp, &self.groups)
+            else {
+                break;
+            };
+            if !seen.insert((candidate.consumer, candidate.owner)) {
+                continue;
             }
+            if candidate.removable == 0 {
+                continue;
+            }
+            let gp = pin_priority_from_consumer(candidate.consumer);
+            let evictable = gp > incoming_priority
+                || (gp == incoming_priority
+                    && incoming_priority != PinPriority::Wallet
+                    && candidate.consumer == incoming);
+            if !evictable {
+                continue;
+            }
+            let reason = if gp > incoming_priority {
+                EvictReason::HigherPriority
+            } else {
+                EvictReason::SamePriorityLru
+            };
+            deficit = deficit.saturating_sub(candidate.removable);
+            victims.push((candidate.consumer, candidate.owner, reason));
         }
-        self.rebuild_by_consumer_index();
-        removed_entirely
-    }
 
-    /// Deterministic convergence: admit rows in priority order, evict lower groups as needed.
-    pub fn converge_from_rows(&mut self, rows: &[(Pubkey, ConsumerId, Option<Pubkey>)]) {
-        let mut grouped: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>> = HashMap::new();
-        for (pk, consumer, pool) in rows {
-            let owner = owner_key_from_row(*consumer, *pool, *pk);
-            grouped.entry((*consumer, owner)).or_default().insert(*pk);
+        if deficit > 0 {
+            None
+        } else {
+            Some(victims)
         }
-
-        let mut owners: Vec<(ConsumerId, OwnerKey, HashSet<Pubkey>)> = grouped
-            .into_iter()
-            .map(|((c, o), pks)| (c, o, pks))
-            .collect();
-        owners.sort_by(|a, b| {
-            pin_priority_from_consumer(a.0)
-                .cmp(&pin_priority_from_consumer(b.0))
-                .then_with(|| a.1.cmp(&b.1))
-                .then_with(|| a.2.len().cmp(&b.2.len()))
-        });
-
-        self.clear();
-        for (consumer, owner, pubkeys) in owners {
-            let _ = self.try_admit_group(consumer, owner, pubkeys);
-        }
-        self.evict_until_within_cap(EvictReason::RestoreConverge);
     }
 
     fn commit_group(&mut self, consumer: ConsumerId, owner: OwnerKey, pubkeys: HashSet<Pubkey>) {
         self.next_seq = self.next_seq.saturating_add(1);
+        self.next_touch_gen = self.next_touch_gen.saturating_add(1);
         let seq = self.next_seq;
+        let touch = self.next_touch_gen;
         if let Some(prev) = self.groups.remove(&(consumer, owner)) {
             for pk in prev.pubkeys {
                 if let Some(entry) = self.entries.get_mut(&pk) {
                     entry.owners.remove(&(consumer, owner));
                     if entry.owners.is_empty() {
                         self.entries.remove(&pk);
+                        self.remove_pubkey_from_consumer_index(consumer, pk);
                     }
                 }
             }
@@ -249,6 +485,7 @@ impl DesiredExplicitSet {
                 owner,
                 pubkeys: pubkeys.clone(),
                 admitted_seq: seq,
+                last_touched_gen: touch,
             },
         );
         for pk in pubkeys {
@@ -258,71 +495,14 @@ impl DesiredExplicitSet {
             entry.owners.insert((consumer, owner));
             self.by_consumer.entry(consumer).or_default().insert(pk);
         }
+        self.push_evict_candidate(consumer, owner);
     }
 
-    fn evict_for_incoming(&mut self, incoming: ConsumerId, deficit: &mut usize) -> bool {
-        let incoming_priority = pin_priority_from_consumer(incoming);
-        let mut candidates: Vec<(PinPriority, u64, ConsumerId, OwnerKey, usize)> = self
-            .groups
-            .values()
-            .filter(|g| {
-                let gp = pin_priority_from_consumer(g.consumer);
-                gp > incoming_priority
-                    || (gp == incoming_priority
-                        && incoming_priority != PinPriority::Wallet
-                        && g.consumer == incoming)
-            })
-            .map(|g| {
-                let removable = g
-                    .pubkeys
-                    .iter()
-                    .filter(|pk| {
-                        self.entries.get(pk).is_some_and(|e| {
-                            e.owners.len() == 1 && e.owners.contains(&(g.consumer, g.owner))
-                        })
-                    })
-                    .count();
-                (
-                    pin_priority_from_consumer(g.consumer),
-                    g.admitted_seq,
-                    g.consumer,
-                    g.owner,
-                    removable,
-                )
-            })
-            .filter(|(_, _, _, _, removable)| *removable > 0)
-            .collect();
-
-        candidates.sort_by(|a, b| {
-            b.0.cmp(&a.0)
-                .then_with(|| a.1.cmp(&b.1))
-                .then_with(|| a.4.cmp(&b.4))
-        });
-
-        for (_, _, consumer, owner, _removable) in candidates {
-            if *deficit == 0 {
-                return true;
-            }
-            let reason = if pin_priority_from_consumer(consumer) > incoming_priority {
-                EvictReason::HigherPriority
-            } else {
-                EvictReason::SamePriorityLru
-            };
-            let freed = self.evict_group(consumer, owner, reason);
-            *deficit = deficit.saturating_sub(freed);
-        }
-        *deficit == 0
-    }
-
-    fn evict_group(
-        &mut self,
-        consumer: ConsumerId,
-        owner: OwnerKey,
-        _reason: EvictReason,
-    ) -> usize {
+    fn evict_group(&mut self, consumer: ConsumerId, owner: OwnerKey, reason: EvictReason) -> usize {
         let Some(group) = self.groups.remove(&(consumer, owner)) else {
             return 0;
         };
+        self.heap_stamp.remove(&(consumer, owner));
         let mut freed = 0usize;
         for pk in group.pubkeys {
             if let Some(entry) = self.entries.get_mut(&pk) {
@@ -330,26 +510,20 @@ impl DesiredExplicitSet {
                 if entry.owners.is_empty() {
                     self.entries.remove(&pk);
                     freed += 1;
+                    self.remove_pubkey_from_consumer_index(consumer, pk);
                 }
             }
         }
-        self.rebuild_by_consumer_index();
+        inc_market_data_geyser_explicit_evicted_total(
+            consumer_id_label(consumer),
+            evict_reason_label(reason),
+        );
         freed
     }
 
     fn evict_until_within_cap(&mut self, reason: EvictReason) {
         while self.entries.len() > self.max_explicit_pubkeys {
-            let victim = self
-                .groups
-                .values()
-                .max_by_key(|g| {
-                    (
-                        pin_priority_from_consumer(g.consumer),
-                        std::cmp::Reverse(g.admitted_seq),
-                    )
-                })
-                .map(|g| (g.consumer, g.owner));
-            let Some((consumer, owner)) = victim else {
+            let Some((consumer, owner)) = self.pop_cap_shrink_victim() else {
                 break;
             };
             if self.evict_group(consumer, owner, reason) == 0 {
@@ -358,14 +532,92 @@ impl DesiredExplicitSet {
         }
     }
 
-    fn rebuild_by_consumer_index(&mut self) {
-        self.by_consumer.clear();
-        for (pk, entry) in &self.entries {
-            for (consumer, _) in &entry.owners {
-                self.by_consumer.entry(*consumer).or_default().insert(*pk);
+    fn pop_cap_shrink_victim(&mut self) -> Option<(ConsumerId, OwnerKey)> {
+        while let Some(candidate) =
+            pop_fresh_evict_candidate(&mut self.evict_heap, &self.heap_stamp, &self.groups)
+        {
+            if candidate.removable > 0 {
+                return Some((candidate.consumer, candidate.owner));
+            }
+        }
+        None
+    }
+
+    fn removable_pubkeys_for_group(&self, consumer: ConsumerId, owner: OwnerKey) -> usize {
+        self.groups
+            .get(&(consumer, owner))
+            .map(|g| {
+                g.pubkeys
+                    .iter()
+                    .filter(|pk| {
+                        self.entries.get(pk).is_some_and(|e| {
+                            e.owners.len() == 1 && e.owners.contains(&(consumer, owner))
+                        })
+                    })
+                    .count()
+            })
+            .unwrap_or(0)
+    }
+
+    fn push_evict_candidate(&mut self, consumer: ConsumerId, owner: OwnerKey) {
+        let Some(group) = self.groups.get(&(consumer, owner)) else {
+            return;
+        };
+        self.global_heap_stamp = self.global_heap_stamp.saturating_add(1);
+        let stamp = self.global_heap_stamp;
+        self.heap_stamp.insert((consumer, owner), stamp);
+        let removable = self.removable_pubkeys_for_group(consumer, owner);
+        self.evict_heap.push(EvictCandidate {
+            priority: pin_priority_from_consumer(group.consumer),
+            touch_gen: group.last_touched_gen,
+            admitted_seq: group.admitted_seq,
+            owner: group.owner,
+            consumer: group.consumer,
+            removable,
+            stamp,
+        });
+    }
+
+    fn remove_pubkey_from_consumer_index(&mut self, consumer: ConsumerId, pk: Pubkey) {
+        if let Some(set) = self.by_consumer.get_mut(&consumer) {
+            set.remove(&pk);
+            if set.is_empty() {
+                self.by_consumer.remove(&consumer);
             }
         }
     }
+}
+
+fn pop_fresh_evict_candidate(
+    heap: &mut BinaryHeap<EvictCandidate>,
+    stamps: &HashMap<(ConsumerId, OwnerKey), u64>,
+    groups: &HashMap<(ConsumerId, OwnerKey), OwnerGroup>,
+) -> Option<EvictCandidate> {
+    while let Some(candidate) = heap.pop() {
+        let key = (candidate.consumer, candidate.owner);
+        if stamps.get(&key).copied() != Some(candidate.stamp) {
+            continue;
+        }
+        if !groups.contains_key(&key) {
+            continue;
+        }
+        return Some(candidate);
+    }
+    None
+}
+
+fn build_owner_groups_from_rows(
+    rows: &[(Pubkey, ConsumerId, Option<Pubkey>)],
+) -> Vec<(ConsumerId, OwnerKey, HashSet<Pubkey>)> {
+    let mut grouped: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>> = HashMap::new();
+    for (pk, consumer, pool) in rows {
+        let owner = owner_key_from_row(*consumer, *pool, *pk);
+        grouped.entry((*consumer, owner)).or_default().insert(*pk);
+    }
+    grouped
+        .into_iter()
+        .map(|((consumer, owner), pubkeys)| (consumer, owner, pubkeys))
+        .collect()
 }
 
 fn owner_key_from_row(consumer: ConsumerId, pool: Option<Pubkey>, pk: Pubkey) -> OwnerKey {
@@ -382,6 +634,24 @@ pub fn pin_priority_from_consumer(consumer: ConsumerId) -> PinPriority {
         ConsumerId::Momentum => PinPriority::Momentum,
         ConsumerId::Arb => PinPriority::Arb,
         ConsumerId::Tracker => PinPriority::Tracker,
+    }
+}
+
+fn consumer_id_label(consumer: ConsumerId) -> &'static str {
+    match consumer {
+        ConsumerId::Wallet => "wallet",
+        ConsumerId::Momentum => "momentum",
+        ConsumerId::Arb => "arb",
+        ConsumerId::Tracker => "tracker",
+    }
+}
+
+fn evict_reason_label(reason: EvictReason) -> &'static str {
+    match reason {
+        EvictReason::HigherPriority => "higher_priority",
+        EvictReason::SamePriorityLru => "same_priority_lru",
+        EvictReason::CapShrink => "cap_shrink",
+        EvictReason::RestoreConverge => "restore_converge",
     }
 }
 
@@ -412,7 +682,7 @@ mod tests {
             AdmissionResult::Admitted { .. }
         ));
         for _ in 0..10 {
-            let (c, o, pool) = pool_owner();
+            let (c, o, _) = pool_owner();
             let a = Pubkey::new_unique();
             let b = Pubkey::new_unique();
             let _ = set.try_admit_group(c, o, HashSet::from([a, b]));
@@ -437,12 +707,41 @@ mod tests {
             AdmissionResult::Admitted { .. }
         ));
         let len_before = set.len();
+        let admitted_before = set.snapshot_pubkeys();
         assert!(matches!(
             set.try_admit_group(c2, o2, HashSet::from([p3])),
             AdmissionResult::RejectedCap
         ));
         assert_eq!(set.len(), len_before);
+        assert_eq!(set.snapshot_pubkeys(), admitted_before);
         assert!(!set.contains(&p3));
+    }
+
+    #[test]
+    fn rejected_eviction_with_insufficient_removable_space_leaves_state_unchanged() {
+        let mut set = DesiredExplicitSet::new(3);
+        let shared = Pubkey::new_unique();
+        let (_, o1, _) = pool_owner();
+        let (_, o2, _) = pool_owner();
+        let extra = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Arb, o1, HashSet::from([shared])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, o2, HashSet::from([shared, extra])),
+            AdmissionResult::Admitted { .. }
+        ));
+        let before = set.snapshot_pubkeys();
+        let (c3, o3, _) = pool_owner();
+        let need_three = Pubkey::new_unique();
+        let need_four = Pubkey::new_unique();
+        let need_five = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(c3, o3, HashSet::from([need_three, need_four, need_five])),
+            AdmissionResult::RejectedCap
+        ));
+        assert_eq!(set.snapshot_pubkeys(), before);
     }
 
     #[test]
@@ -570,11 +869,58 @@ mod tests {
     }
 
     #[test]
-    fn none_pin_maps_to_tracker_consumer() {
-        assert_eq!(
-            pin_priority_from_consumer(ConsumerId::Tracker),
-            PinPriority::Tracker
+    fn same_priority_uses_lru_not_fifo() {
+        let mut set = DesiredExplicitSet::new(2);
+        let (_, old_owner, _) = pool_owner();
+        let old_pk = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, old_owner, HashSet::from([old_pk])),
+            AdmissionResult::Admitted { .. }
+        ));
+        let (_, new_owner, _) = pool_owner();
+        let new_pk = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, new_owner, HashSet::from([new_pk])),
+            AdmissionResult::Admitted { .. }
+        ));
+        set.touch_group(ConsumerId::Momentum, old_owner);
+        let (_, incoming_owner, _) = pool_owner();
+        let incoming_pk = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Momentum,
+                incoming_owner,
+                HashSet::from([incoming_pk])
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(
+            !set.contains(&new_pk),
+            "LRU victim should be untouched newer group"
         );
+        assert!(set.contains(&old_pk));
+        assert!(set.contains(&incoming_pk));
+    }
+
+    #[test]
+    fn wallet_over_cap_fails_closed() {
+        let mut set = DesiredExplicitSet::new(2);
+        let demand: HashSet<Pubkey> = (0..3).map(|_| Pubkey::new_unique()).collect();
+        assert!(set.wallet_demand_exceeds_cap(&demand));
+        assert!(matches!(
+            set.try_admit_wallet_demand(demand),
+            AdmissionResult::RejectedCap
+        ));
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn empty_group_is_invalid_not_protected() {
+        let mut set = DesiredExplicitSet::new(10);
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Wallet, OwnerKey::Wallet, HashSet::new()),
+            AdmissionResult::RejectedInvalidGroup
+        ));
     }
 
     #[test]
@@ -588,6 +934,38 @@ mod tests {
         set.set_max_explicit_pubkeys(2);
         assert!(set.len() <= 2);
         assert_eq!(set.cap_overflow(), 0);
+    }
+
+    #[test]
+    fn restore_owner_groups_preserves_shared_pubkey() {
+        let mut set = DesiredExplicitSet::new(10);
+        let shared = Pubkey::new_unique();
+        let pool_a = Pubkey::new_unique();
+        let pool_b = Pubkey::new_unique();
+        let only_a = Pubkey::new_unique();
+        set.restore_owner_groups(&[
+            OwnerGroupSnapshot {
+                consumer: ConsumerId::Momentum,
+                owner: OwnerKey::Pool(pool_a),
+                pubkeys: HashSet::from([shared, only_a]),
+                last_touched_gen: 1,
+            },
+            OwnerGroupSnapshot {
+                consumer: ConsumerId::Arb,
+                owner: OwnerKey::Pool(pool_b),
+                pubkeys: HashSet::from([shared]),
+                last_touched_gen: 2,
+            },
+        ]);
+        set.remove_group(ConsumerId::Momentum, OwnerKey::Pool(pool_a));
+        assert!(set.contains(&shared));
+        set.restore_owner_groups(&[OwnerGroupSnapshot {
+            consumer: ConsumerId::Arb,
+            owner: OwnerKey::Pool(pool_b),
+            pubkeys: HashSet::from([shared]),
+            last_touched_gen: 2,
+        }]);
+        assert!(set.contains(&shared));
     }
 
     #[test]

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -1,17 +1,18 @@
-//! Phase 2a: single source of truth for explicit Geyser subscription pubkeys (consumer refcount).
+//! Hard admission SSOT for explicit Geyser subscription pubkeys (I-MD-7 / I-MD-8).
 
 use solana_sdk::pubkey::Pubkey;
 use std::collections::{HashMap, HashSet};
 
-/// Consumer tag for explicit Geyser pubkey ownership (Plan §5.2).
+/// Consumer tag for explicit Geyser pubkey ownership.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ConsumerId {
     Wallet,
     Momentum,
     Arb,
+    Tracker,
 }
 
-/// Pin priority for cap eviction — lower ordinal = higher protection (Plan §3.4).
+/// Pin priority for cap eviction — lower ordinal = higher protection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PinPriority {
     Wallet = 0,
@@ -20,29 +21,52 @@ pub enum PinPriority {
     Tracker = 3,
 }
 
-#[derive(Debug, Clone)]
-pub struct ExplicitEntry {
-    pub consumers: HashSet<ConsumerId>,
-    pub pool: Option<Pubkey>,
-    pub pin_priority: PinPriority,
+/// Owner reference for shared-pubkey refcounting (pool / wallet / standalone mint).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum OwnerKey {
+    Wallet,
+    Pool(Pubkey),
+    Mint(Pubkey),
 }
 
-impl ExplicitEntry {
-    fn recompute_pin_priority(&mut self) {
-        self.pin_priority = self
-            .consumers
-            .iter()
-            .map(|c| pin_priority_from_consumer(*c))
-            .min()
-            .unwrap_or(PinPriority::Tracker);
-    }
+/// Result of attempting to admit an owner group atomically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmissionResult {
+    Admitted { new_pubkeys: usize },
+    OwnerAddedNoNewPubkey,
+    RejectedCap,
+    RejectedProtected,
+}
+
+/// Reason recorded when a group is evicted from the desired set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvictReason {
+    HigherPriority,
+    SamePriorityLru,
+    CapShrink,
+    RestoreConverge,
+}
+
+#[derive(Debug, Clone)]
+struct PubkeyEntry {
+    owners: HashSet<(ConsumerId, OwnerKey)>,
+}
+
+#[derive(Debug, Clone)]
+struct OwnerGroup {
+    consumer: ConsumerId,
+    owner: OwnerKey,
+    pubkeys: HashSet<Pubkey>,
+    admitted_seq: u64,
 }
 
 #[derive(Debug, Clone)]
 pub struct DesiredExplicitSet {
-    entries: HashMap<Pubkey, ExplicitEntry>,
+    entries: HashMap<Pubkey, PubkeyEntry>,
+    groups: HashMap<(ConsumerId, OwnerKey), OwnerGroup>,
     by_consumer: HashMap<ConsumerId, HashSet<Pubkey>>,
     max_explicit_pubkeys: usize,
+    next_seq: u64,
 }
 
 impl Default for DesiredExplicitSet {
@@ -55,8 +79,10 @@ impl DesiredExplicitSet {
     pub fn new(max_explicit_pubkeys: usize) -> Self {
         Self {
             entries: HashMap::new(),
+            groups: HashMap::new(),
             by_consumer: HashMap::new(),
             max_explicit_pubkeys: max_explicit_pubkeys.max(1),
+            next_seq: 0,
         }
     }
 
@@ -66,7 +92,7 @@ impl DesiredExplicitSet {
 
     pub fn set_max_explicit_pubkeys(&mut self, cap: usize) {
         self.max_explicit_pubkeys = cap.max(1);
-        self.evict_if_over_cap();
+        self.evict_until_within_cap(EvictReason::CapShrink);
     }
 
     pub fn len(&self) -> usize {
@@ -81,109 +107,272 @@ impl DesiredExplicitSet {
         self.entries.contains_key(pubkey)
     }
 
-    pub fn consumers_of(&self, pubkey: &Pubkey) -> Option<&HashSet<ConsumerId>> {
-        self.entries.get(pubkey).map(|e| &e.consumers)
+    pub fn consumers_of(&self, pubkey: &Pubkey) -> Option<Vec<ConsumerId>> {
+        self.entries.get(pubkey).map(|e| {
+            e.owners
+                .iter()
+                .map(|(c, _)| *c)
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect()
+        })
     }
 
     pub fn snapshot_pubkeys(&self) -> HashSet<Pubkey> {
         self.entries.keys().copied().collect()
     }
 
+    pub fn admitted_pool_count(&self, consumer: ConsumerId) -> usize {
+        self.groups
+            .keys()
+            .filter(|(c, owner)| *c == consumer && matches!(owner, OwnerKey::Pool(_)))
+            .count()
+    }
+
+    pub fn cap_overflow(&self) -> usize {
+        self.entries.len().saturating_sub(self.max_explicit_pubkeys)
+    }
+
     pub fn clear(&mut self) {
         self.entries.clear();
+        self.groups.clear();
         self.by_consumer.clear();
+        self.next_seq = 0;
     }
 
-    /// Insert or add `consumer` refcount. Returns true when the pubkey set changed (new key).
-    pub fn insert(&mut self, pubkey: Pubkey, consumer: ConsumerId, pool: Option<Pubkey>) -> bool {
-        let was_new = !self.entries.contains_key(&pubkey);
-        if was_new
-            && self.entries.len() >= self.max_explicit_pubkeys
-            && !self.evict_one_for_insert(consumer)
-        {
-            return false;
+    /// Atomically admit a full owner group or reject without mutation.
+    pub fn try_admit_group(
+        &mut self,
+        consumer: ConsumerId,
+        owner: OwnerKey,
+        pubkeys: HashSet<Pubkey>,
+    ) -> AdmissionResult {
+        if pubkeys.is_empty() {
+            return AdmissionResult::RejectedProtected;
         }
-        let entry = self.entries.entry(pubkey).or_insert_with(|| ExplicitEntry {
-            consumers: HashSet::new(),
-            pool,
-            pin_priority: PinPriority::Tracker,
-        });
-        if entry.pool.is_none() {
-            entry.pool = pool;
+        if let Some(existing) = self.groups.get(&(consumer, owner)) {
+            if existing.pubkeys == pubkeys {
+                return AdmissionResult::OwnerAddedNoNewPubkey;
+            }
         }
-        entry.consumers.insert(consumer);
-        entry.recompute_pin_priority();
-        self.by_consumer.entry(consumer).or_default().insert(pubkey);
-        was_new
+
+        let new_unique: HashSet<Pubkey> = pubkeys
+            .iter()
+            .filter(|pk| !self.entries.contains_key(pk))
+            .copied()
+            .collect();
+        let need = new_unique.len();
+        let free = self.max_explicit_pubkeys.saturating_sub(self.entries.len());
+
+        if need > free {
+            let mut deficit = need - free;
+            if !self.evict_for_incoming(consumer, &mut deficit) {
+                return AdmissionResult::RejectedCap;
+            }
+            if deficit > 0 {
+                return AdmissionResult::RejectedCap;
+            }
+        }
+
+        self.commit_group(consumer, owner, pubkeys);
+        if new_unique.is_empty() {
+            AdmissionResult::OwnerAddedNoNewPubkey
+        } else {
+            AdmissionResult::Admitted {
+                new_pubkeys: new_unique.len(),
+            }
+        }
     }
 
-    /// Remove one consumer refcount. Returns true when the pubkey was removed entirely.
-    pub fn remove(&mut self, pubkey: Pubkey, consumer: ConsumerId) -> bool {
-        let Some(entry) = self.entries.get_mut(&pubkey) else {
-            return false;
+    /// Remove one owner group; pubkeys remain while other owners still reference them.
+    pub fn remove_group(&mut self, consumer: ConsumerId, owner: OwnerKey) -> Vec<Pubkey> {
+        let Some(group) = self.groups.remove(&(consumer, owner)) else {
+            return Vec::new();
         };
-        entry.consumers.remove(&consumer);
-        if let Some(set) = self.by_consumer.get_mut(&consumer) {
-            set.remove(&pubkey);
+        let mut removed_entirely = Vec::new();
+        for pk in group.pubkeys {
+            if let Some(entry) = self.entries.get_mut(&pk) {
+                entry.owners.remove(&(consumer, owner));
+                if entry.owners.is_empty() {
+                    self.entries.remove(&pk);
+                    removed_entirely.push(pk);
+                }
+            }
         }
-        if entry.consumers.is_empty() {
-            self.entries.remove(&pubkey);
-            return true;
-        }
-        entry.recompute_pin_priority();
-        false
+        self.rebuild_by_consumer_index();
+        removed_entirely
     }
 
-    fn evict_if_over_cap(&mut self) {
+    /// Deterministic convergence: admit rows in priority order, evict lower groups as needed.
+    pub fn converge_from_rows(&mut self, rows: &[(Pubkey, ConsumerId, Option<Pubkey>)]) {
+        let mut grouped: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>> = HashMap::new();
+        for (pk, consumer, pool) in rows {
+            let owner = owner_key_from_row(*consumer, *pool, *pk);
+            grouped.entry((*consumer, owner)).or_default().insert(*pk);
+        }
+
+        let mut owners: Vec<(ConsumerId, OwnerKey, HashSet<Pubkey>)> = grouped
+            .into_iter()
+            .map(|((c, o), pks)| (c, o, pks))
+            .collect();
+        owners.sort_by(|a, b| {
+            pin_priority_from_consumer(a.0)
+                .cmp(&pin_priority_from_consumer(b.0))
+                .then_with(|| a.1.cmp(&b.1))
+                .then_with(|| a.2.len().cmp(&b.2.len()))
+        });
+
+        self.clear();
+        for (consumer, owner, pubkeys) in owners {
+            let _ = self.try_admit_group(consumer, owner, pubkeys);
+        }
+        self.evict_until_within_cap(EvictReason::RestoreConverge);
+    }
+
+    fn commit_group(&mut self, consumer: ConsumerId, owner: OwnerKey, pubkeys: HashSet<Pubkey>) {
+        self.next_seq = self.next_seq.saturating_add(1);
+        let seq = self.next_seq;
+        if let Some(prev) = self.groups.remove(&(consumer, owner)) {
+            for pk in prev.pubkeys {
+                if let Some(entry) = self.entries.get_mut(&pk) {
+                    entry.owners.remove(&(consumer, owner));
+                    if entry.owners.is_empty() {
+                        self.entries.remove(&pk);
+                    }
+                }
+            }
+        }
+        self.groups.insert(
+            (consumer, owner),
+            OwnerGroup {
+                consumer,
+                owner,
+                pubkeys: pubkeys.clone(),
+                admitted_seq: seq,
+            },
+        );
+        for pk in pubkeys {
+            let entry = self.entries.entry(pk).or_insert_with(|| PubkeyEntry {
+                owners: HashSet::new(),
+            });
+            entry.owners.insert((consumer, owner));
+            self.by_consumer.entry(consumer).or_default().insert(pk);
+        }
+    }
+
+    fn evict_for_incoming(&mut self, incoming: ConsumerId, deficit: &mut usize) -> bool {
+        let incoming_priority = pin_priority_from_consumer(incoming);
+        let mut candidates: Vec<(PinPriority, u64, ConsumerId, OwnerKey, usize)> = self
+            .groups
+            .values()
+            .filter(|g| {
+                let gp = pin_priority_from_consumer(g.consumer);
+                gp > incoming_priority
+                    || (gp == incoming_priority
+                        && incoming_priority != PinPriority::Wallet
+                        && g.consumer == incoming)
+            })
+            .map(|g| {
+                let removable = g
+                    .pubkeys
+                    .iter()
+                    .filter(|pk| {
+                        self.entries.get(pk).is_some_and(|e| {
+                            e.owners.len() == 1 && e.owners.contains(&(g.consumer, g.owner))
+                        })
+                    })
+                    .count();
+                (
+                    pin_priority_from_consumer(g.consumer),
+                    g.admitted_seq,
+                    g.consumer,
+                    g.owner,
+                    removable,
+                )
+            })
+            .filter(|(_, _, _, _, removable)| *removable > 0)
+            .collect();
+
+        candidates.sort_by(|a, b| {
+            b.0.cmp(&a.0)
+                .then_with(|| a.1.cmp(&b.1))
+                .then_with(|| a.4.cmp(&b.4))
+        });
+
+        for (_, _, consumer, owner, _removable) in candidates {
+            if *deficit == 0 {
+                return true;
+            }
+            let reason = if pin_priority_from_consumer(consumer) > incoming_priority {
+                EvictReason::HigherPriority
+            } else {
+                EvictReason::SamePriorityLru
+            };
+            let freed = self.evict_group(consumer, owner, reason);
+            *deficit = deficit.saturating_sub(freed);
+        }
+        *deficit == 0
+    }
+
+    fn evict_group(
+        &mut self,
+        consumer: ConsumerId,
+        owner: OwnerKey,
+        _reason: EvictReason,
+    ) -> usize {
+        let Some(group) = self.groups.remove(&(consumer, owner)) else {
+            return 0;
+        };
+        let mut freed = 0usize;
+        for pk in group.pubkeys {
+            if let Some(entry) = self.entries.get_mut(&pk) {
+                entry.owners.remove(&(consumer, owner));
+                if entry.owners.is_empty() {
+                    self.entries.remove(&pk);
+                    freed += 1;
+                }
+            }
+        }
+        self.rebuild_by_consumer_index();
+        freed
+    }
+
+    fn evict_until_within_cap(&mut self, reason: EvictReason) {
         while self.entries.len() > self.max_explicit_pubkeys {
-            if !self.evict_one_least_protected() {
+            let victim = self
+                .groups
+                .values()
+                .max_by_key(|g| {
+                    (
+                        pin_priority_from_consumer(g.consumer),
+                        std::cmp::Reverse(g.admitted_seq),
+                    )
+                })
+                .map(|g| (g.consumer, g.owner));
+            let Some((consumer, owner)) = victim else {
+                break;
+            };
+            if self.evict_group(consumer, owner, reason) == 0 {
                 break;
             }
         }
     }
 
-    /// Evict one LRU candidate when over cap (lowest pin protection first).
-    fn evict_one_least_protected(&mut self) -> bool {
-        let Some(victim) = self
-            .entries
-            .iter()
-            .max_by_key(|(_, e)| e.pin_priority)
-            .map(|(pk, _)| *pk)
-        else {
-            return false;
-        };
-        self.remove_entry_all_consumers(victim);
-        true
-    }
-
-    /// Evict one slot for a new insert — never evict entries with higher protection than incoming.
-    fn evict_one_for_insert(&mut self, incoming: ConsumerId) -> bool {
-        let incoming_priority = pin_priority_from_consumer(incoming);
-        let victim = self
-            .entries
-            .iter()
-            .filter(|(_, e)| {
-                e.pin_priority > incoming_priority
-                    || (e.pin_priority == incoming_priority
-                        && incoming_priority != PinPriority::Wallet)
-            })
-            .max_by_key(|(_, e)| e.pin_priority)
-            .map(|(pk, _)| *pk);
-        if let Some(pk) = victim {
-            self.remove_entry_all_consumers(pk);
-            return true;
-        }
-        false
-    }
-
-    fn remove_entry_all_consumers(&mut self, pubkey: Pubkey) {
-        if let Some(entry) = self.entries.remove(&pubkey) {
-            for consumer in entry.consumers {
-                if let Some(set) = self.by_consumer.get_mut(&consumer) {
-                    set.remove(&pubkey);
-                }
+    fn rebuild_by_consumer_index(&mut self) {
+        self.by_consumer.clear();
+        for (pk, entry) in &self.entries {
+            for (consumer, _) in &entry.owners {
+                self.by_consumer.entry(*consumer).or_default().insert(*pk);
             }
         }
+    }
+}
+
+fn owner_key_from_row(consumer: ConsumerId, pool: Option<Pubkey>, pk: Pubkey) -> OwnerKey {
+    match consumer {
+        ConsumerId::Wallet => OwnerKey::Wallet,
+        ConsumerId::Tracker if pool.is_none() => OwnerKey::Mint(pk),
+        _ => OwnerKey::Pool(pool.unwrap_or(pk)),
     }
 }
 
@@ -192,6 +381,7 @@ pub fn pin_priority_from_consumer(consumer: ConsumerId) -> PinPriority {
         ConsumerId::Wallet => PinPriority::Wallet,
         ConsumerId::Momentum => PinPriority::Momentum,
         ConsumerId::Arb => PinPriority::Arb,
+        ConsumerId::Tracker => PinPriority::Tracker,
     }
 }
 
@@ -204,32 +394,223 @@ pub fn symmetric_diff(a: &HashSet<Pubkey>, b: &HashSet<Pubkey>) -> HashSet<Pubke
 mod tests {
     use super::*;
 
+    fn pool_owner() -> (ConsumerId, OwnerKey, Pubkey) {
+        let pool = Pubkey::new_unique();
+        (ConsumerId::Arb, OwnerKey::Pool(pool), pool)
+    }
+
     #[test]
-    fn phase2a_desired_set_refcount_wallet_never_evicted_by_momentum() {
-        let wallet_pk = Pubkey::new_unique();
-        let momentum_pks: Vec<Pubkey> = (0..4).map(|_| Pubkey::new_unique()).collect();
-        let mut set = DesiredExplicitSet::new(3);
-
-        assert!(set.insert(wallet_pk, ConsumerId::Wallet, None));
-        for pk in &momentum_pks[..2] {
-            assert!(set.insert(*pk, ConsumerId::Momentum, None));
+    fn deduplicated_pubkeys_stay_within_cap() {
+        let mut set = DesiredExplicitSet::new(4);
+        let wallet = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Wallet,
+                OwnerKey::Wallet,
+                HashSet::from([wallet]),
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        for _ in 0..10 {
+            let (c, o, pool) = pool_owner();
+            let a = Pubkey::new_unique();
+            let b = Pubkey::new_unique();
+            let _ = set.try_admit_group(c, o, HashSet::from([a, b]));
+            assert!(set.len() <= 4);
         }
-        assert_eq!(set.len(), 3);
+    }
 
-        // Third momentum insert must evict a momentum row, not the wallet pin.
-        assert!(set.insert(momentum_pks[2], ConsumerId::Momentum, None));
-        assert!(set.contains(&wallet_pk));
-        assert!(!set.contains(&momentum_pks[0]) || !set.contains(&momentum_pks[1]));
-        assert!(set.contains(&momentum_pks[2]));
+    #[test]
+    fn rejected_group_does_not_mutate_desired_set() {
+        let mut set = DesiredExplicitSet::new(2);
+        let p1 = Pubkey::new_unique();
+        let p2 = Pubkey::new_unique();
+        let p3 = Pubkey::new_unique();
+        let (_, o1, _) = pool_owner();
+        let (c2, o2, _) = pool_owner();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Wallet, OwnerKey::Wallet, HashSet::from([p1])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, o1, HashSet::from([p2])),
+            AdmissionResult::Admitted { .. }
+        ));
+        let len_before = set.len();
+        assert!(matches!(
+            set.try_admit_group(c2, o2, HashSet::from([p3])),
+            AdmissionResult::RejectedCap
+        ));
+        assert_eq!(set.len(), len_before);
+        assert!(!set.contains(&p3));
+    }
 
-        let mut refcount = DesiredExplicitSet::new(10);
+    #[test]
+    fn two_vault_group_admitted_or_rejected_atomically() {
+        let mut set = DesiredExplicitSet::new(3);
+        let (_, o1, _) = pool_owner();
+        let v1 = Pubkey::new_unique();
+        let v2 = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, o1, HashSet::from([v1, v2])),
+            AdmissionResult::Admitted { new_pubkeys: 2 }
+        ));
+        let wallet = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Wallet,
+                OwnerKey::Wallet,
+                HashSet::from([wallet])
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        let (_, o2, _) = pool_owner();
+        let v3 = Pubkey::new_unique();
+        let v4 = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Arb, o2, HashSet::from([v3, v4])),
+            AdmissionResult::RejectedCap
+        ));
+        assert!(!set.contains(&v3));
+        assert!(!set.contains(&v4));
+    }
+
+    #[test]
+    fn shared_pubkey_survives_single_owner_removal() {
+        let mut set = DesiredExplicitSet::new(10);
         let shared = Pubkey::new_unique();
-        assert!(refcount.insert(shared, ConsumerId::Wallet, None));
-        assert!(!refcount.insert(shared, ConsumerId::Momentum, None));
-        assert!(!refcount.remove(shared, ConsumerId::Momentum));
-        assert!(refcount.contains(&shared));
-        assert!(refcount.remove(shared, ConsumerId::Wallet));
-        assert!(!refcount.contains(&shared));
+        let (_, o1, _) = pool_owner();
+        let (_, o2, _) = pool_owner();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Arb, o1, HashSet::from([shared])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, o2, HashSet::from([shared])),
+            AdmissionResult::OwnerAddedNoNewPubkey
+        ));
+        set.remove_group(ConsumerId::Arb, o1);
+        assert!(set.contains(&shared));
+        set.remove_group(ConsumerId::Momentum, o2);
+        assert!(!set.contains(&shared));
+    }
+
+    #[test]
+    fn wallet_never_evicted_by_momentum() {
+        let wallet = Pubkey::new_unique();
+        let mut set = DesiredExplicitSet::new(2);
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Wallet,
+                OwnerKey::Wallet,
+                HashSet::from([wallet])
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        let (_, o, _) = pool_owner();
+        let m1 = Pubkey::new_unique();
+        let m2 = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, o, HashSet::from([m1])),
+            AdmissionResult::Admitted { .. }
+        ));
+        let (_, o2, _) = pool_owner();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, o2, HashSet::from([m2])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(set.contains(&wallet));
+    }
+
+    #[test]
+    fn momentum_evicts_arb_before_momentum() {
+        let mut set = DesiredExplicitSet::new(1);
+        let arb_pk = Pubkey::new_unique();
+        let (_, arb_owner, _) = pool_owner();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Arb, arb_owner, HashSet::from([arb_pk])),
+            AdmissionResult::Admitted { .. }
+        ));
+        let mom_pk = Pubkey::new_unique();
+        let (_, mom_owner, _) = pool_owner();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, mom_owner, HashSet::from([mom_pk])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(!set.contains(&arb_pk));
+        assert!(set.contains(&mom_pk));
+    }
+
+    #[test]
+    fn arb_cannot_evict_momentum() {
+        let mut set = DesiredExplicitSet::new(2);
+        let mom_pk = Pubkey::new_unique();
+        let (_, mom_owner, _) = pool_owner();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, mom_owner, HashSet::from([mom_pk])),
+            AdmissionResult::Admitted { .. }
+        ));
+        let wallet = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Wallet,
+                OwnerKey::Wallet,
+                HashSet::from([wallet])
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        let arb_pk = Pubkey::new_unique();
+        let (_, arb_owner, _) = pool_owner();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Arb, arb_owner, HashSet::from([arb_pk])),
+            AdmissionResult::RejectedCap
+        ));
+        assert!(set.contains(&mom_pk));
+        assert!(!set.contains(&arb_pk));
+    }
+
+    #[test]
+    fn none_pin_maps_to_tracker_consumer() {
+        assert_eq!(
+            pin_priority_from_consumer(ConsumerId::Tracker),
+            PinPriority::Tracker
+        );
+    }
+
+    #[test]
+    fn cap_shrink_converges_deterministically() {
+        let mut set = DesiredExplicitSet::new(5);
+        for _ in 0..4 {
+            let (_, o, _) = pool_owner();
+            let pk = Pubkey::new_unique();
+            let _ = set.try_admit_group(ConsumerId::Tracker, o, HashSet::from([pk]));
+        }
+        set.set_max_explicit_pubkeys(2);
+        assert!(set.len() <= 2);
+        assert_eq!(set.cap_overflow(), 0);
+    }
+
+    #[test]
+    fn snapshot_over_cap_prioritized_reduce() {
+        let rows: Vec<(Pubkey, ConsumerId, Option<Pubkey>)> = (0..6)
+            .map(|i| {
+                let pk = Pubkey::new_unique();
+                let pool = Pubkey::new_unique();
+                let consumer = if i == 0 {
+                    ConsumerId::Wallet
+                } else if i < 3 {
+                    ConsumerId::Momentum
+                } else {
+                    ConsumerId::Arb
+                };
+                (pk, consumer, Some(pool))
+            })
+            .collect();
+        let mut set = DesiredExplicitSet::new(3);
+        set.converge_from_rows(&rows);
+        assert!(set.len() <= 3);
+        let wallet_row = rows[0].0;
+        assert!(set.contains(&wallet_row));
     }
 
     #[test]

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -127,6 +127,7 @@ pub struct PlanningStats {
     pub projection_copies: usize,
     pub entries_copied: usize,
     pub owner_edge_iterations: usize,
+    pub victim_owner_edge_scans: usize,
     pub victim_removals: usize,
 }
 
@@ -140,7 +141,7 @@ struct PlanningOverlay {
     suppressed_groups: HashSet<(ConsumerId, OwnerKey)>,
     incoming: Option<((ConsumerId, OwnerKey), HashSet<Pubkey>)>,
     projected_len: usize,
-    pk_projected: HashMap<Pubkey, bool>,
+    projected_pubkey_refcount: HashMap<Pubkey, usize>,
 }
 
 fn pk_projection_contribution(live: bool, proj: bool) -> i64 {
@@ -159,20 +160,21 @@ fn apply_projected_len_delta(projected_len: usize, delta: i64) -> usize {
     (projected_len as i64 + delta).max(0) as usize
 }
 
-fn pk_would_exist_in_projection(
+fn initial_projected_refcount(
     set: &DesiredExplicitSet,
     pk: Pubkey,
     suppressed: &HashSet<(ConsumerId, OwnerKey)>,
     incoming: Option<((ConsumerId, OwnerKey), &HashSet<Pubkey>)>,
     mut stats: Option<&mut PlanningStats>,
-) -> bool {
+) -> usize {
+    let mut count = 0usize;
     if let Some(entry) = set.entries.get(&pk) {
         for owner in &entry.owners {
             if let Some(s) = stats.as_mut() {
                 s.owner_edge_iterations = s.owner_edge_iterations.saturating_add(1);
             }
             if !suppressed.contains(owner) {
-                return true;
+                count = count.saturating_add(1);
             }
         }
     }
@@ -182,20 +184,26 @@ fn pk_would_exist_in_projection(
                 s.owner_edge_iterations = s.owner_edge_iterations.saturating_add(1);
             }
             let _ = key;
-            return true;
+            count = count.saturating_add(1);
         }
     }
-    false
+    count
 }
 
 impl PlanningOverlay {
     fn for_cap_shrink(set: &DesiredExplicitSet) -> Self {
+        let touched_pubkeys: HashSet<Pubkey> = set.entries.keys().copied().collect();
+        let mut projected_pubkey_refcount = HashMap::with_capacity(touched_pubkeys.len());
+        for pk in &touched_pubkeys {
+            let count = set.entries.get(pk).map(|e| e.owners.len()).unwrap_or(0);
+            projected_pubkey_refcount.insert(*pk, count);
+        }
         Self {
-            touched_pubkeys: HashSet::new(),
+            touched_pubkeys,
             suppressed_groups: HashSet::new(),
             incoming: None,
             projected_len: set.entries.len(),
-            pk_projected: HashMap::new(),
+            projected_pubkey_refcount,
         }
     }
 
@@ -215,26 +223,29 @@ impl PlanningOverlay {
         }
         let incoming_ref = Some((key, incoming));
         let mut projected_len = set.entries.len();
-        let mut pk_projected = HashMap::with_capacity(touched.len());
+        let mut projected_pubkey_refcount = HashMap::with_capacity(touched.len());
         for pk in &touched {
             let live = set.entries.contains_key(pk);
-            let proj = pk_would_exist_in_projection(
+            let count = initial_projected_refcount(
                 set,
                 *pk,
                 &suppressed,
                 incoming_ref,
                 stats.as_deref_mut(),
             );
-            pk_projected.insert(*pk, proj);
-            projected_len =
-                apply_projected_len_delta(projected_len, projected_len_delta(live, live, proj));
+            projected_pubkey_refcount.insert(*pk, count);
+            let proj_exists = count > 0;
+            projected_len = apply_projected_len_delta(
+                projected_len,
+                projected_len_delta(live, live, proj_exists),
+            );
         }
         Self {
             touched_pubkeys: touched,
             suppressed_groups: suppressed,
             incoming: Some((key, incoming.clone())),
             projected_len,
-            pk_projected,
+            projected_pubkey_refcount,
         }
     }
 
@@ -255,37 +266,38 @@ impl PlanningOverlay {
         for pk in &pubkeys {
             self.touched_pubkeys.insert(*pk);
         }
+        let incoming_ref = self.incoming.as_ref().map(|(k, p)| (*k, p));
+        let before_counts: Vec<_> = pubkeys
+            .iter()
+            .map(|pk| {
+                (
+                    *pk,
+                    self.projected_pubkey_refcount
+                        .get(pk)
+                        .copied()
+                        .unwrap_or_else(|| {
+                            initial_projected_refcount(
+                                set,
+                                *pk,
+                                &self.suppressed_groups,
+                                incoming_ref,
+                                None,
+                            )
+                        }),
+                )
+            })
+            .collect();
         if !self.suppressed_groups.insert(victim) {
             return;
         }
-        if let Some(stats) = stats.as_deref_mut() {
+        if let Some(stats) = stats.as_mut() {
             stats.victim_removals = stats.victim_removals.saturating_add(1);
         }
-        let incoming_ref = self.incoming.as_ref().map(|(k, p)| (*k, p));
-        for pk in pubkeys {
+        for (pk, before) in before_counts {
+            let after = before.saturating_sub(1);
+            self.projected_pubkey_refcount.insert(pk, after);
             let live = set.entries.contains_key(&pk);
-            let old_proj = if let Some(cached) = self.pk_projected.get(&pk) {
-                *cached
-            } else {
-                let mut without_victim = self.suppressed_groups.clone();
-                without_victim.remove(&victim);
-                pk_would_exist_in_projection(
-                    set,
-                    pk,
-                    &without_victim,
-                    incoming_ref,
-                    stats.as_deref_mut(),
-                )
-            };
-            let new_proj = pk_would_exist_in_projection(
-                set,
-                pk,
-                &self.suppressed_groups,
-                incoming_ref,
-                stats.as_deref_mut(),
-            );
-            self.pk_projected.insert(pk, new_proj);
-            let delta = projected_len_delta(live, old_proj, new_proj);
+            let delta = projected_len_delta(live, before > 0, after > 0);
             self.projected_len = apply_projected_len_delta(self.projected_len, delta);
         }
     }
@@ -1125,12 +1137,29 @@ impl<'a> EvictionPlanner<'a> {
             marginal_contributors,
             group_pubkeys,
             pubkey_groups,
-            projected_pubkey_refcount: HashMap::new(),
+            projected_pubkey_refcount: overlay.projected_pubkey_refcount.clone(),
         };
+        for key in &tracked_groups {
+            if let Some(group) = set.groups.get(key) {
+                planner
+                    .group_pubkeys
+                    .entry(*key)
+                    .or_insert_with(|| group.pubkeys.iter().copied().collect());
+            }
+        }
         for pk in &overlay.touched_pubkeys {
             planner
                 .projected_pubkey_refcount
-                .insert(*pk, planner.projected_owner_count(pk));
+                .entry(*pk)
+                .or_insert_with(|| {
+                    initial_projected_refcount(
+                        set,
+                        *pk,
+                        &planner.suppressed,
+                        overlay.incoming.as_ref().map(|(k, p)| (*k, p)),
+                        stats.as_deref_mut(),
+                    )
+                });
         }
         for key in planner.marginal.keys().copied().collect::<Vec<_>>() {
             planner.recompute_marginal_for_group(key, stats.as_deref_mut());
@@ -1138,27 +1167,17 @@ impl<'a> EvictionPlanner<'a> {
         planner
     }
 
-    fn projected_owner_count(&self, pk: &Pubkey) -> usize {
-        self.pubkey_groups
-            .get(pk)
-            .into_iter()
-            .flatten()
-            .filter(|owner| !self.suppressed.contains(owner) && !self.victims.contains(owner))
-            .count()
-    }
-
     fn sole_projected_owner(&self, pk: &Pubkey) -> Option<(ConsumerId, OwnerKey)> {
+        if self.projected_pubkey_refcount.get(pk).copied().unwrap_or(0) != 1 {
+            return None;
+        }
         let mut owners = self
             .pubkey_groups
             .get(pk)?
             .iter()
             .copied()
             .filter(|owner| !self.suppressed.contains(owner) && !self.victims.contains(owner));
-        let first = owners.next()?;
-        if owners.next().is_some() {
-            return None;
-        }
-        Some(first)
+        owners.next()
     }
 
     fn index_pubkey(
@@ -1220,22 +1239,9 @@ impl<'a> EvictionPlanner<'a> {
         self.marginal_contributors.insert(group, contributors);
     }
 
-    fn effective_owners(&self, pk: &Pubkey) -> Vec<(ConsumerId, OwnerKey)> {
-        let mut out = Vec::new();
-        if let Some(entry) = self.set.entries.get(pk) {
-            for owner in &entry.owners {
-                if self.suppressed.contains(owner) || self.victims.contains(owner) {
-                    continue;
-                }
-                out.push(*owner);
-            }
-        }
-        out
-    }
-
     fn pk_counts_toward_marginal(&self, pk: &Pubkey, group: (ConsumerId, OwnerKey)) -> bool {
-        let owners = self.effective_owners(pk);
-        owners.len() == 1 && owners[0] == group
+        self.projected_pubkey_refcount.get(pk).copied().unwrap_or(0) == 1
+            && self.sole_projected_owner(pk) == Some(group)
     }
 
     fn is_victim(&self, consumer: ConsumerId, owner: OwnerKey) -> bool {
@@ -1249,7 +1255,7 @@ impl<'a> EvictionPlanner<'a> {
     fn add_victim(
         &mut self,
         victim: (ConsumerId, OwnerKey),
-        overlay: &PlanningOverlay,
+        _overlay: &PlanningOverlay,
         mut stats: Option<&mut PlanningStats>,
     ) -> usize {
         let victim_pubkeys: Vec<Pubkey> = self
@@ -1263,42 +1269,49 @@ impl<'a> EvictionPlanner<'a> {
         }
         for pk in &victim_pubkeys {
             if !self.pubkey_groups.contains_key(pk) {
-                let mut scratch = HashSet::new();
-                Self::index_pubkey(
-                    self.set,
-                    overlay,
-                    *pk,
-                    &mut self.pubkey_groups,
-                    &mut scratch,
-                    stats.as_deref_mut(),
-                );
-                for key in scratch {
-                    self.marginal.entry(key).or_insert(0);
-                    self.marginal_contributors.entry(key).or_default();
-                    if let Some(group) = self.set.groups.get(&key) {
-                        self.group_pubkeys
-                            .entry(key)
-                            .or_insert_with(|| group.pubkeys.iter().copied().collect());
+                if let Some(entry) = self.set.entries.get(pk) {
+                    for owner in &entry.owners {
+                        if !self.suppressed.contains(owner) {
+                            self.pubkey_groups.entry(*pk).or_default().push(*owner);
+                        }
                     }
                 }
             }
         }
+        if !self.marginal.contains_key(&victim) {
+            self.recompute_marginal_for_group(victim, stats.as_deref_mut());
+        }
 
         let freed = self.marginal_freed(victim);
+        let before_counts: Vec<_> = victim_pubkeys
+            .iter()
+            .map(|pk| {
+                (
+                    *pk,
+                    self.projected_pubkey_refcount
+                        .get(pk)
+                        .copied()
+                        .unwrap_or_else(|| {
+                            self.pubkey_groups
+                                .get(pk)
+                                .map(|owners| {
+                                    owners
+                                        .iter()
+                                        .filter(|owner| {
+                                            !self.suppressed.contains(owner)
+                                                && !self.victims.contains(owner)
+                                        })
+                                        .count()
+                                })
+                                .unwrap_or(0)
+                        }),
+                )
+            })
+            .collect();
         self.victims.insert(victim);
 
-        for pk in victim_pubkeys {
-            let before = self
-                .projected_pubkey_refcount
-                .get(&pk)
-                .copied()
-                .unwrap_or_else(|| self.projected_owner_count(&pk));
-            let victim_was_owner = self
-                .pubkey_groups
-                .get(&pk)
-                .is_some_and(|sharing| sharing.contains(&victim))
-                && before > 0;
-            let after = before.saturating_sub(usize::from(victim_was_owner));
+        for (pk, before) in before_counts {
+            let after = before.saturating_sub(1);
             self.projected_pubkey_refcount.insert(pk, after);
             if before >= 2 && after == 1 {
                 if let Some(sole) = self.sole_projected_owner(&pk) {
@@ -2161,29 +2174,17 @@ mod tests {
                     .unwrap_or(0)
             })
             .sum();
-        let victim_owner_edge_scans: usize = victims
-            .iter()
-            .map(|(consumer, owner, _)| {
-                set.groups
-                    .get(&(*consumer, *owner))
-                    .map(|g| {
-                        g.pubkeys
-                            .iter()
-                            .map(|pk| set.entries.get(pk).map(|e| e.owners.len()).unwrap_or(0))
-                            .sum::<usize>()
-                    })
-                    .unwrap_or(0)
-            })
-            .sum();
         let log_g = (group_count + 1).ilog2() as usize + 1;
         assert!(stats.candidate_pops <= group_count.saturating_mul(log_g));
         assert!(stats.victim_removals <= group_count);
-        let owner_edge_budget = edge_count
-            .saturating_add(victim_owner_edge_scans.saturating_mul(3))
-            .saturating_add(stats.candidate_pops);
+        assert_eq!(
+            stats.victim_owner_edge_scans, 0,
+            "victim removal must not rescan owner edges"
+        );
+        let owner_edge_budget = edge_count.saturating_add(stats.candidate_pops);
         assert!(
             stats.owner_edge_iterations <= owner_edge_budget,
-            "owner edge visits {}/{} must stay bounded by initial edges + victim adjacency + heap pops",
+            "owner edge visits {}/{} must stay bounded by initial+touched edges + heap pops",
             stats.owner_edge_iterations,
             owner_edge_budget
         );

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -1081,6 +1081,7 @@ struct EvictionPlanner<'a> {
     marginal: HashMap<(ConsumerId, OwnerKey), usize>,
     marginal_contributors: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>>,
     pubkey_groups: HashMap<Pubkey, Vec<(ConsumerId, OwnerKey)>>,
+    projected_pubkey_refcount: HashMap<Pubkey, usize>,
 }
 
 impl<'a> EvictionPlanner<'a> {
@@ -1116,11 +1117,40 @@ impl<'a> EvictionPlanner<'a> {
             marginal,
             marginal_contributors,
             pubkey_groups,
+            projected_pubkey_refcount: HashMap::new(),
         };
+        for pk in &overlay.touched_pubkeys {
+            planner
+                .projected_pubkey_refcount
+                .insert(*pk, planner.projected_owner_count(pk));
+        }
         for key in planner.marginal.keys().copied().collect::<Vec<_>>() {
             planner.recompute_marginal_for_group(key, stats.as_deref_mut());
         }
         planner
+    }
+
+    fn projected_owner_count(&self, pk: &Pubkey) -> usize {
+        self.pubkey_groups
+            .get(pk)
+            .into_iter()
+            .flatten()
+            .filter(|owner| !self.suppressed.contains(owner) && !self.victims.contains(owner))
+            .count()
+    }
+
+    fn sole_projected_owner(&self, pk: &Pubkey) -> Option<(ConsumerId, OwnerKey)> {
+        let mut owners = self
+            .pubkey_groups
+            .get(pk)?
+            .iter()
+            .copied()
+            .filter(|owner| !self.suppressed.contains(owner) && !self.victims.contains(owner));
+        let first = owners.next()?;
+        if owners.next().is_some() {
+            return None;
+        }
+        Some(first)
     }
 
     fn index_pubkey(
@@ -1243,16 +1273,28 @@ impl<'a> EvictionPlanner<'a> {
         };
 
         for pk in &group.pubkeys {
-            let owners_after = self.effective_owners(pk);
-            if owners_after.len() == 1 {
-                let sole = owners_after[0];
-                if let Some(contributors) = self.marginal_contributors.get_mut(&sole) {
-                    if contributors.insert(*pk) {
-                        if let Some(m) = self.marginal.get_mut(&sole) {
-                            *m = m.saturating_add(1);
-                        }
-                        if let Some(stats) = stats.as_deref_mut() {
-                            stats.edge_updates = stats.edge_updates.saturating_add(1);
+            let before = self
+                .projected_pubkey_refcount
+                .get(pk)
+                .copied()
+                .unwrap_or_else(|| self.projected_owner_count(pk));
+            let after = before.saturating_sub(usize::from(
+                self.pubkey_groups
+                    .get(pk)
+                    .is_some_and(|sharing| sharing.contains(&victim))
+                    && before > 0,
+            ));
+            self.projected_pubkey_refcount.insert(*pk, after);
+            if before >= 2 && after == 1 {
+                if let Some(sole) = self.sole_projected_owner(pk) {
+                    if let Some(contributors) = self.marginal_contributors.get_mut(&sole) {
+                        if contributors.insert(*pk) {
+                            if let Some(m) = self.marginal.get_mut(&sole) {
+                                *m = m.saturating_add(1);
+                            }
+                            if let Some(stats) = stats.as_deref_mut() {
+                                stats.edge_updates = stats.edge_updates.saturating_add(1);
+                            }
                         }
                     }
                 }

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -118,6 +118,136 @@ struct AdmissionPlan {
     incoming: Option<(ConsumerId, OwnerKey, HashSet<Pubkey>)>,
 }
 
+/// Immutable projection for admission planning (old incoming ownership removed before victims).
+#[derive(Debug, Clone)]
+struct ProjectedExplicitState {
+    owners: HashMap<Pubkey, HashSet<(ConsumerId, OwnerKey)>>,
+    groups: HashMap<(ConsumerId, OwnerKey), ProjectedGroupMeta>,
+}
+
+#[derive(Debug, Clone)]
+struct ProjectedGroupMeta {
+    consumer: ConsumerId,
+    owner: OwnerKey,
+    pubkeys: HashSet<Pubkey>,
+    admitted_seq: u64,
+    last_touched_gen: u64,
+}
+
+impl ProjectedExplicitState {
+    fn from_live(set: &DesiredExplicitSet) -> Self {
+        let owners = set
+            .entries
+            .iter()
+            .map(|(pk, entry)| (*pk, entry.owners.clone()))
+            .collect();
+        let groups = set
+            .groups
+            .iter()
+            .map(|(key, group)| {
+                (
+                    *key,
+                    ProjectedGroupMeta {
+                        consumer: group.consumer,
+                        owner: group.owner,
+                        pubkeys: group.pubkeys.clone(),
+                        admitted_seq: group.admitted_seq,
+                        last_touched_gen: group.last_touched_gen,
+                    },
+                )
+            })
+            .collect();
+        Self { owners, groups }
+    }
+
+    fn entry_count(&self) -> usize {
+        self.owners.len()
+    }
+
+    fn remove_group(&mut self, key: (ConsumerId, OwnerKey)) {
+        let Some(group) = self.groups.remove(&key) else {
+            return;
+        };
+        for pk in group.pubkeys {
+            if let Some(entry) = self.owners.get_mut(&pk) {
+                entry.remove(&key);
+                if entry.is_empty() {
+                    self.owners.remove(&pk);
+                }
+            }
+        }
+    }
+
+    fn add_group(
+        &mut self,
+        key: (ConsumerId, OwnerKey),
+        consumer: ConsumerId,
+        pubkeys: &HashSet<Pubkey>,
+    ) {
+        let meta = self
+            .groups
+            .entry(key)
+            .or_insert_with(|| ProjectedGroupMeta {
+                consumer,
+                owner: key.1,
+                pubkeys: HashSet::new(),
+                admitted_seq: 0,
+                last_touched_gen: 0,
+            });
+        for pk in pubkeys {
+            meta.pubkeys.insert(*pk);
+            self.owners.entry(*pk).or_default().insert(key);
+        }
+    }
+
+    fn projected_len_after_admission(
+        base: &Self,
+        incoming: (ConsumerId, OwnerKey, &HashSet<Pubkey>),
+        victims: &[(ConsumerId, OwnerKey)],
+    ) -> usize {
+        let mut projected = base.clone();
+        projected.remove_group((incoming.0, incoming.1));
+        for victim in victims {
+            projected.remove_group(*victim);
+        }
+        projected.add_group((incoming.0, incoming.1), incoming.0, incoming.2);
+        projected.entry_count()
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct PolicyEvictEntry {
+    key: (ConsumerId, OwnerKey),
+    priority: PinPriority,
+    touch_gen: u64,
+    admitted_seq: u64,
+    owner: OwnerKey,
+}
+
+impl Ord for PolicyEvictEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.priority
+            .cmp(&other.priority)
+            .then_with(|| self.touch_gen.cmp(&other.touch_gen).reverse())
+            .then_with(|| self.admitted_seq.cmp(&other.admitted_seq).reverse())
+            .then_with(|| self.owner.cmp(&other.owner).reverse())
+    }
+}
+
+impl PartialOrd for PolicyEvictEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct EvictionPlannerStats {
+    pub candidate_pops: usize,
+    pub stale_pops: usize,
+    pub edge_updates: usize,
+    pub refcount_checks: usize,
+}
+
 #[derive(Debug, Clone)]
 pub struct DesiredExplicitSet {
     entries: HashMap<Pubkey, PubkeyEntry>,
@@ -431,13 +561,16 @@ impl DesiredExplicitSet {
             }
         }
 
-        let projected_without_evict =
-            self.projected_len_after_replace(consumer, owner, &pubkeys, &[]);
+        let base = ProjectedExplicitState::from_live(self);
+        let projected_without_evict = ProjectedExplicitState::projected_len_after_admission(
+            &base,
+            (consumer, owner, &pubkeys),
+            &[],
+        );
 
         let mut evictions = Vec::new();
         if projected_without_evict > self.max_explicit_pubkeys {
-            let deficit = projected_without_evict - self.max_explicit_pubkeys;
-            match self.plan_evictions_for_incoming(consumer, owner, deficit) {
+            match self.plan_evictions_for_incoming(consumer, owner, &pubkeys, &base) {
                 Some(victims) => evictions = victims,
                 None => return Err(AdmissionResult::RejectedCap),
             }
@@ -451,71 +584,6 @@ impl DesiredExplicitSet {
             return Err(AdmissionResult::RejectedCap);
         }
         Ok(plan)
-    }
-
-    fn is_exclusive_to_owner(&self, pk: &Pubkey, consumer: ConsumerId, owner: OwnerKey) -> bool {
-        self.entries.get(pk).is_some_and(|entry| {
-            entry.owners.len() == 1 && entry.owners.contains(&(consumer, owner))
-        })
-    }
-
-    /// Projected `entries.len()` after evicting victims then replacing the incoming owner group.
-    fn projected_len_after_replace(
-        &self,
-        consumer: ConsumerId,
-        owner: OwnerKey,
-        incoming: &HashSet<Pubkey>,
-        victims: &[(ConsumerId, OwnerKey)],
-    ) -> usize {
-        let mut planner = EvictionPlanner::new(self);
-        let mut freed = 0usize;
-        for (vc, vo) in victims {
-            freed = freed.saturating_add(planner.add_victim((*vc, *vo)));
-        }
-        let len_after_evict = self.entries.len().saturating_sub(freed);
-        let replace_delta = self
-            .net_entry_delta_for_group_replace_after_victims(consumer, owner, incoming, victims);
-        ((len_after_evict as isize) + replace_delta).max(0) as usize
-    }
-
-    fn net_entry_delta_for_group_replace_after_victims(
-        &self,
-        consumer: ConsumerId,
-        owner: OwnerKey,
-        incoming: &HashSet<Pubkey>,
-        victims: &[(ConsumerId, OwnerKey)],
-    ) -> isize {
-        let victim_set: HashSet<(ConsumerId, OwnerKey)> = victims.iter().copied().collect();
-        let mut delta = 0isize;
-        if let Some(existing) = self.groups.get(&(consumer, owner)) {
-            for pk in &existing.pubkeys {
-                if !incoming.contains(pk) {
-                    let exclusive = if victim_set.is_empty() {
-                        self.is_exclusive_to_owner(pk, consumer, owner)
-                    } else {
-                        self.entries.get(pk).is_some_and(|entry| {
-                            entry
-                                .owners
-                                .iter()
-                                .all(|o| o == &(consumer, owner) || victim_set.contains(o))
-                        })
-                    };
-                    if exclusive {
-                        delta -= 1;
-                    }
-                }
-            }
-        }
-        for pk in incoming {
-            let remains_after_evict = self
-                .entries
-                .get(pk)
-                .is_some_and(|entry| entry.owners.iter().any(|o| !victim_set.contains(o)));
-            if !remains_after_evict {
-                delta += 1;
-            }
-        }
-        delta
     }
 
     fn apply_plan(&mut self, plan: AdmissionPlan) -> AdmissionResult {
@@ -557,66 +625,150 @@ impl DesiredExplicitSet {
         };
         let victims: Vec<(ConsumerId, OwnerKey)> =
             plan.evictions.iter().map(|(c, o, _)| (*c, *o)).collect();
-        self.projected_len_after_replace(*inc_c, *inc_o, incoming, &victims)
+        let base = ProjectedExplicitState::from_live(self);
+        ProjectedExplicitState::projected_len_after_admission(
+            &base,
+            (*inc_c, *inc_o, incoming),
+            &victims,
+        )
+    }
+
+    fn build_policy_evict_heap(
+        projection: &ProjectedExplicitState,
+        skip: Option<(ConsumerId, OwnerKey)>,
+    ) -> BinaryHeap<PolicyEvictEntry> {
+        let mut heap = BinaryHeap::new();
+        for (key, group) in &projection.groups {
+            if group.consumer == ConsumerId::Wallet {
+                continue;
+            }
+            if skip.is_some_and(|(c, o)| *key == (c, o)) {
+                continue;
+            }
+            heap.push(PolicyEvictEntry {
+                key: *key,
+                priority: pin_priority_from_consumer(group.consumer),
+                touch_gen: group.last_touched_gen,
+                admitted_seq: group.admitted_seq,
+                owner: group.owner,
+            });
+        }
+        heap
+    }
+
+    fn pop_next_policy_victim(
+        heap: &mut BinaryHeap<PolicyEvictEntry>,
+        planner: &EvictionPlanner<'_>,
+        incoming: ConsumerId,
+        incoming_owner: OwnerKey,
+        incoming_priority: PinPriority,
+        mut stats: Option<&mut EvictionPlannerStats>,
+    ) -> Option<((ConsumerId, OwnerKey), EvictReason)> {
+        while let Some(entry) = heap.pop() {
+            if let Some(stats) = stats.as_deref_mut() {
+                stats.candidate_pops = stats.candidate_pops.saturating_add(1);
+            }
+            let (consumer, owner) = entry.key;
+            if consumer == incoming && owner == incoming_owner {
+                if let Some(stats) = stats.as_deref_mut() {
+                    stats.stale_pops = stats.stale_pops.saturating_add(1);
+                }
+                continue;
+            }
+            if planner.is_victim(consumer, owner) {
+                if let Some(stats) = stats.as_deref_mut() {
+                    stats.stale_pops = stats.stale_pops.saturating_add(1);
+                }
+                continue;
+            }
+            let gp = pin_priority_from_consumer(consumer);
+            let evictable = gp > incoming_priority
+                || (gp == incoming_priority
+                    && incoming_priority != PinPriority::Wallet
+                    && consumer == incoming);
+            if !evictable {
+                if let Some(stats) = stats.as_deref_mut() {
+                    stats.stale_pops = stats.stale_pops.saturating_add(1);
+                }
+                continue;
+            }
+            let reason = if gp > incoming_priority {
+                EvictReason::HigherPriority
+            } else {
+                EvictReason::SamePriorityLru
+            };
+            return Some(((consumer, owner), reason));
+        }
+        None
     }
 
     fn plan_evictions_for_incoming(
         &self,
         incoming: ConsumerId,
         incoming_owner: OwnerKey,
-        mut deficit: usize,
+        incoming_pubkeys: &HashSet<Pubkey>,
+        base: &ProjectedExplicitState,
     ) -> Option<Vec<(ConsumerId, OwnerKey, EvictReason)>> {
-        let incoming_priority = pin_priority_from_consumer(incoming);
-        let candidates = self.cap_shrink_candidate_keys();
-        let mut planner = EvictionPlanner::new(self);
-        let mut victims = Vec::new();
+        self.plan_evictions_on_projection(
+            base,
+            Some((incoming, incoming_owner, incoming_pubkeys)),
+            self.max_explicit_pubkeys,
+            None,
+        )
+    }
 
-        while deficit > 0 {
-            let mut best_positive: Option<((ConsumerId, OwnerKey), usize, EvictReason)> = None;
-            let mut best_zero: Option<((ConsumerId, OwnerKey), EvictReason)> = None;
-            for &(consumer, owner) in &candidates {
-                if consumer == incoming && owner == incoming_owner {
-                    continue;
-                }
-                if planner.is_victim(consumer, owner) {
-                    continue;
-                }
-                let gp = pin_priority_from_consumer(consumer);
-                let evictable = gp > incoming_priority
-                    || (gp == incoming_priority
-                        && incoming_priority != PinPriority::Wallet
-                        && consumer == incoming);
-                if !evictable {
-                    continue;
-                }
-                let marginal = planner.marginal_freed((consumer, owner));
-                let reason = if gp > incoming_priority {
-                    EvictReason::HigherPriority
-                } else {
-                    EvictReason::SamePriorityLru
-                };
-                if marginal > 0 {
-                    let replace = best_positive.as_ref().is_none_or(|(_, m, _)| marginal > *m);
-                    if replace {
-                        best_positive = Some(((consumer, owner), marginal, reason));
-                    }
-                } else if best_zero.is_none() {
-                    best_zero = Some(((consumer, owner), reason));
-                }
-            }
-            if let Some(((consumer, owner), marginal, reason)) = best_positive {
-                planner.add_victim((consumer, owner));
-                victims.push((consumer, owner, reason));
-                deficit = deficit.saturating_sub(marginal);
-            } else if let Some(((consumer, owner), reason)) = best_zero {
-                planner.add_victim((consumer, owner));
-                victims.push((consumer, owner, reason));
-            } else {
-                return None;
-            }
+    fn plan_evictions_on_projection(
+        &self,
+        base: &ProjectedExplicitState,
+        incoming: Option<(ConsumerId, OwnerKey, &HashSet<Pubkey>)>,
+        cap: usize,
+        mut stats: Option<&mut EvictionPlannerStats>,
+    ) -> Option<Vec<(ConsumerId, OwnerKey, EvictReason)>> {
+        let (incoming_consumer, incoming_owner, incoming_priority) = match incoming {
+            Some((c, o, _)) => (c, o, pin_priority_from_consumer(c)),
+            None => (ConsumerId::Wallet, OwnerKey::Wallet, PinPriority::Wallet),
+        };
+
+        let mut work = base.clone();
+        if let Some((c, o, _)) = incoming {
+            work.remove_group((c, o));
         }
+        let mut planner = EvictionPlanner::new(&work);
+        let mut heap = Self::build_policy_evict_heap(&work, incoming.map(|(c, o, _)| (c, o)));
+        let mut victims: Vec<(ConsumerId, OwnerKey, EvictReason)> = Vec::new();
 
-        Some(victims)
+        loop {
+            let victim_keys: Vec<(ConsumerId, OwnerKey)> =
+                victims.iter().map(|(c, o, _)| (*c, *o)).collect();
+            let projected_len = if let Some((c, o, pubs)) = incoming {
+                ProjectedExplicitState::projected_len_after_admission(
+                    base,
+                    (c, o, pubs),
+                    &victim_keys,
+                )
+            } else {
+                let mut trial = work.clone();
+                for victim in &victim_keys {
+                    trial.remove_group(*victim);
+                }
+                trial.entry_count()
+            };
+            if projected_len <= cap {
+                return Some(victims);
+            }
+
+            let next = Self::pop_next_policy_victim(
+                &mut heap,
+                &planner,
+                incoming_consumer,
+                incoming_owner,
+                incoming_priority,
+                stats.as_deref_mut(),
+            )?;
+            let ((consumer, owner), reason) = next;
+            planner.add_victim((consumer, owner), stats.as_deref_mut());
+            victims.push((consumer, owner, reason));
+        }
     }
 
     fn commit_group(&mut self, consumer: ConsumerId, owner: OwnerKey, pubkeys: HashSet<Pubkey>) {
@@ -710,61 +862,16 @@ impl DesiredExplicitSet {
     }
 
     /// Set-aware cap-shrink victim planning: aggregate eviction across co-dependent groups.
-    fn plan_cap_shrink_victims(&self, deficit: usize) -> Option<Vec<(ConsumerId, OwnerKey)>> {
-        let candidates = self.cap_shrink_candidate_keys();
-        let mut planner = EvictionPlanner::new(self);
-        let mut victim_keys = Vec::new();
-        let mut freed = 0usize;
-        while freed < deficit {
-            let mut best_positive: Option<((ConsumerId, OwnerKey), usize)> = None;
-            let mut best_zero: Option<(ConsumerId, OwnerKey)> = None;
-            for &(consumer, owner) in &candidates {
-                if planner.is_victim(consumer, owner) {
-                    continue;
-                }
-                let marginal = planner.marginal_freed((consumer, owner));
-                if marginal > 0 {
-                    let replace = best_positive.as_ref().is_none_or(|(_, m)| marginal > *m);
-                    if replace {
-                        best_positive = Some(((consumer, owner), marginal));
-                    }
-                } else if best_zero.is_none() {
-                    best_zero = Some((consumer, owner));
-                }
-            }
-            if let Some(((consumer, owner), marginal)) = best_positive {
-                planner.add_victim((consumer, owner));
-                victim_keys.push((consumer, owner));
-                freed = freed.saturating_add(marginal);
-            } else if let Some((consumer, owner)) = best_zero {
-                planner.add_victim((consumer, owner));
-                victim_keys.push((consumer, owner));
-            } else {
-                return None;
-            }
-        }
-        Some(victim_keys)
-    }
-
-    /// Cap-shrink candidates sorted by eviction priority; Wallet is never eligible.
-    fn cap_shrink_candidate_keys(&self) -> Vec<(ConsumerId, OwnerKey)> {
-        let mut keys: Vec<(ConsumerId, OwnerKey)> = self
-            .groups
-            .keys()
-            .copied()
-            .filter(|(c, _)| *c != ConsumerId::Wallet)
-            .collect();
-        keys.sort_by(|a, b| {
-            let ga = &self.groups[a];
-            let gb = &self.groups[b];
-            pin_priority_from_consumer(ga.consumer)
-                .cmp(&pin_priority_from_consumer(gb.consumer))
-                .reverse()
-                .then_with(|| ga.last_touched_gen.cmp(&gb.last_touched_gen))
-                .then_with(|| ga.admitted_seq.cmp(&gb.admitted_seq))
-                .then_with(|| a.1.cmp(&b.1))
-        });
-        keys
+    fn plan_cap_shrink_victims(&self, _deficit: usize) -> Option<Vec<(ConsumerId, OwnerKey)>> {
+        let base = ProjectedExplicitState::from_live(self);
+        let victims_with_reason =
+            self.plan_evictions_on_projection(&base, None, self.max_explicit_pubkeys, None)?;
+        Some(
+            victims_with_reason
+                .into_iter()
+                .map(|(c, o, _)| (c, o))
+                .collect(),
+        )
     }
 
     fn compact_evict_heap_if_needed(&mut self) {
@@ -822,11 +929,23 @@ impl DesiredExplicitSet {
             }
         }
     }
+
+    #[cfg(test)]
+    fn test_plan_evictions(
+        &self,
+        incoming: Option<(ConsumerId, OwnerKey, HashSet<Pubkey>)>,
+        cap: usize,
+        stats: Option<&mut EvictionPlannerStats>,
+    ) -> Option<Vec<(ConsumerId, OwnerKey, EvictReason)>> {
+        let base = ProjectedExplicitState::from_live(self);
+        let incoming_ref = incoming.as_ref().map(|(c, o, p)| (*c, *o, p));
+        self.plan_evictions_on_projection(&base, incoming_ref, cap, stats)
+    }
 }
 
-/// Incremental marginal-free eviction planner (bounded edge updates, no G×G rescans).
+/// Incremental marginal-free eviction planner on projected state (bounded edge updates).
 struct EvictionPlanner<'a> {
-    set: &'a DesiredExplicitSet,
+    projection: &'a ProjectedExplicitState,
     victims: HashSet<(ConsumerId, OwnerKey)>,
     marginal: HashMap<(ConsumerId, OwnerKey), usize>,
     marginal_contributors: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>>,
@@ -835,12 +954,12 @@ struct EvictionPlanner<'a> {
 }
 
 impl<'a> EvictionPlanner<'a> {
-    fn new(set: &'a DesiredExplicitSet) -> Self {
+    fn new(projection: &'a ProjectedExplicitState) -> Self {
         let mut marginal = HashMap::new();
         let mut marginal_contributors: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>> =
             HashMap::new();
         let mut pubkey_groups: HashMap<Pubkey, Vec<(ConsumerId, OwnerKey)>> = HashMap::new();
-        for (key, group) in &set.groups {
+        for (key, group) in &projection.groups {
             marginal.insert(*key, 0);
             marginal_contributors.insert(*key, HashSet::new());
             for pk in &group.pubkeys {
@@ -848,32 +967,39 @@ impl<'a> EvictionPlanner<'a> {
             }
         }
         let mut planner = Self {
-            set,
+            projection,
             victims: HashSet::new(),
             marginal,
             marginal_contributors,
             pubkey_groups,
             edge_updates: 0,
         };
-        for key in set.groups.keys().copied().collect::<Vec<_>>() {
-            planner.recompute_marginal_for_group(key);
+        for key in projection.groups.keys().copied().collect::<Vec<_>>() {
+            planner.recompute_marginal_for_group(key, None);
         }
         planner
     }
 
-    fn recompute_marginal_for_group(&mut self, group: (ConsumerId, OwnerKey)) {
+    fn recompute_marginal_for_group(
+        &mut self,
+        group: (ConsumerId, OwnerKey),
+        mut stats: Option<&mut EvictionPlannerStats>,
+    ) {
         if self.victims.contains(&group) {
             self.marginal.insert(group, 0);
             self.marginal_contributors.insert(group, HashSet::new());
             return;
         }
-        let Some(g) = self.set.groups.get(&group) else {
+        let Some(g) = self.projection.groups.get(&group) else {
             self.marginal.insert(group, 0);
             self.marginal_contributors.insert(group, HashSet::new());
             return;
         };
         let mut contributors = HashSet::new();
         for pk in &g.pubkeys {
+            if let Some(stats) = stats.as_deref_mut() {
+                stats.refcount_checks = stats.refcount_checks.saturating_add(1);
+            }
             if self.pk_counts_toward_marginal(pk, group) {
                 contributors.insert(*pk);
             }
@@ -883,9 +1009,8 @@ impl<'a> EvictionPlanner<'a> {
     }
 
     fn pk_counts_toward_marginal(&self, pk: &Pubkey, group: (ConsumerId, OwnerKey)) -> bool {
-        self.set.entries.get(pk).is_some_and(|entry| {
-            entry
-                .owners
+        self.projection.owners.get(pk).is_some_and(|owners| {
+            owners
                 .iter()
                 .all(|owner| self.victims.contains(owner) || *owner == group)
         })
@@ -900,23 +1025,20 @@ impl<'a> EvictionPlanner<'a> {
     }
 
     fn is_pubkey_freed(&self, pk: &Pubkey) -> bool {
-        self.set.entries.get(pk).is_some_and(|entry| {
-            entry
-                .owners
-                .iter()
-                .all(|owner| self.victims.contains(owner))
-        })
+        self.projection
+            .owners
+            .get(pk)
+            .is_some_and(|owners| owners.iter().all(|owner| self.victims.contains(owner)))
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
-    fn edge_updates(&self) -> usize {
-        self.edge_updates
-    }
-
-    fn add_victim(&mut self, victim: (ConsumerId, OwnerKey)) -> usize {
+    fn add_victim(
+        &mut self,
+        victim: (ConsumerId, OwnerKey),
+        mut stats: Option<&mut EvictionPlannerStats>,
+    ) -> usize {
         let freed = self.marginal_freed(victim);
         self.victims.insert(victim);
-        let Some(group) = self.set.groups.get(&victim) else {
+        let Some(group) = self.projection.groups.get(&victim) else {
             self.marginal.insert(victim, 0);
             self.marginal_contributors.insert(victim, HashSet::new());
             return freed;
@@ -939,6 +1061,9 @@ impl<'a> EvictionPlanner<'a> {
                                         *m = m.saturating_sub(1);
                                     }
                                     self.edge_updates = self.edge_updates.saturating_add(1);
+                                    if let Some(stats) = stats.as_deref_mut() {
+                                        stats.edge_updates = stats.edge_updates.saturating_add(1);
+                                    }
                                 }
                             }
                         }
@@ -955,9 +1080,12 @@ impl<'a> EvictionPlanner<'a> {
                 continue;
             }
             let before = self.marginal_freed(other);
-            self.recompute_marginal_for_group(other);
+            self.recompute_marginal_for_group(other, stats.as_deref_mut());
             if self.marginal_freed(other) != before {
                 self.edge_updates = self.edge_updates.saturating_add(1);
+                if let Some(stats) = stats.as_deref_mut() {
+                    stats.edge_updates = stats.edge_updates.saturating_add(1);
+                }
             }
         }
 
@@ -1649,41 +1777,142 @@ mod tests {
     }
 
     #[test]
-    fn eviction_planner_edge_updates_bounded_with_heavy_sharing() {
+    fn replacement_victim_chain_partial_overlap_frees_exact_capacity() {
+        let mut set = DesiredExplicitSet::new(3);
+        let shared = Pubkey::new_unique();
+        let pk_a = Pubkey::new_unique();
+        let pk_b = Pubkey::new_unique();
+        let pk_c = Pubkey::new_unique();
+        let pk_d = Pubkey::new_unique();
+        let pool_m = Pubkey::new_unique();
+        let owner_m = OwnerKey::Pool(pool_m);
+        let (_, owner_arb, _) = pool_owner();
+
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, owner_m, HashSet::from([shared, pk_b])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Arb, owner_arb, HashSet::from([shared, pk_a])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert_eq!(set.len(), 3);
+
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, owner_m, HashSet::from([pk_c, pk_d])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(!set.contains(&pk_a), "arb victim jointly frees shared+a");
+        assert!(!set.contains(&shared));
+        assert!(set.contains(&pk_c));
+        assert!(set.contains(&pk_d));
+        assert!(!set.contains(&pk_b));
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn eviction_prefers_lower_priority_over_higher_marginal() {
+        let mut set = DesiredExplicitSet::new(2);
+        let (_, arb_owner, _) = pool_owner();
+        let (_, tracker_owner, _) = pool_owner();
+        let arb_pk = Pubkey::new_unique();
+        let t1 = Pubkey::new_unique();
+        let mom_pk = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Arb, arb_owner, HashSet::from([arb_pk])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Tracker, tracker_owner, HashSet::from([t1])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert_eq!(set.len(), 2);
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Momentum,
+                OwnerKey::Pool(Pubkey::new_unique()),
+                HashSet::from([mom_pk])
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(
+            !set.contains(&t1),
+            "tracker is lower-priority victim before arb"
+        );
+        assert!(set.contains(&arb_pk));
+        assert!(set.contains(&mom_pk));
+    }
+
+    #[test]
+    fn eviction_same_priority_prefers_older_lru_over_higher_marginal() {
+        let mut set = DesiredExplicitSet::new(4);
+        let (_, old_owner, _) = pool_owner();
+        let (_, mid_owner, _) = pool_owner();
+        let old_pk = Pubkey::new_unique();
+        let b = Pubkey::new_unique();
+        let c = Pubkey::new_unique();
+        let d = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, mid_owner, HashSet::from([b, c, d])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(matches!(
+            set.try_admit_group(ConsumerId::Momentum, old_owner, HashSet::from([old_pk])),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert_eq!(set.len(), 4);
+        let (_, incoming_owner, _) = pool_owner();
+        let incoming_pk = Pubkey::new_unique();
+        assert!(matches!(
+            set.try_admit_group(
+                ConsumerId::Momentum,
+                incoming_owner,
+                HashSet::from([incoming_pk])
+            ),
+            AdmissionResult::Admitted { .. }
+        ));
+        assert!(
+            set.contains(&old_pk),
+            "newer momentum group is LRU victim, not older peer with lower marginal"
+        );
+        assert!(!set.contains(&b));
+        assert!(!set.contains(&c));
+        assert!(!set.contains(&d));
+        assert!(set.contains(&incoming_pk));
+    }
+
+    #[test]
+    fn eviction_planner_ops_bounded_on_partial_overlap_chains() {
         let mut set = DesiredExplicitSet::new(2);
         let hub_a = Pubkey::new_unique();
         let hub_b = Pubkey::new_unique();
-        for _ in 0..25 {
+        for _ in 0..20 {
             let (_, owner, _) = pool_owner();
             let _ = set.try_admit_group(ConsumerId::Tracker, owner, HashSet::from([hub_a, hub_b]));
         }
         assert_eq!(set.len(), 2);
-
-        let candidates = set.cap_shrink_candidate_keys();
-        let mut planner = EvictionPlanner::new(&set);
-        let mut freed = 0usize;
-        while freed < 1 {
-            let best = candidates
-                .iter()
-                .filter(|(c, o)| !planner.is_victim(*c, *o))
-                .map(|key| (*key, planner.marginal_freed(*key)))
-                .max_by_key(|(_, m)| *m)
-                .map(|(key, _)| key);
-            let Some(victim) = best else {
-                break;
-            };
-            freed = freed.saturating_add(planner.add_victim(victim));
-        }
-        let edge_updates = planner.edge_updates();
-        let group_count = set.groups.len();
+        let edge_count = set
+            .snapshot_owner_groups()
+            .iter()
+            .map(|g| g.pubkeys.len())
+            .sum::<usize>();
+        let group_count = set.snapshot_owner_groups().len();
+        let mut stats = EvictionPlannerStats::default();
+        let victims = set
+            .test_plan_evictions(None, 1, Some(&mut stats))
+            .expect("cap shrink plan");
+        assert!(!victims.is_empty());
+        let log_g = (group_count + 1).ilog2() as usize + 1;
+        let op_bound = edge_count
+            .saturating_mul(log_g)
+            .saturating_add(group_count.saturating_mul(group_count));
+        let total_ops =
+            stats.candidate_pops + stats.stale_pops + stats.edge_updates + stats.refcount_checks;
         assert!(
-            edge_updates < group_count * group_count,
-            "edge updates {edge_updates} must stay sub-quadratic vs groups {group_count}"
+            total_ops <= op_bound,
+            "planner ops {total_ops} must stay within O(E log G) bound {op_bound}"
         );
-        assert!(
-            edge_updates > 0,
-            "co-dependent shared groups must drive incremental edge updates"
-        );
-        assert_eq!(freed, 2, "last shared victim frees both hub pubkeys");
+        assert!(stats.candidate_pops > 0);
+        assert!(stats.refcount_checks > 0);
     }
 }

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -1208,10 +1208,6 @@ impl<'a> EvictionPlanner<'a> {
         self.marginal.get(&victim).copied().unwrap_or(0)
     }
 
-    fn is_pubkey_freed(&self, pk: &Pubkey) -> bool {
-        self.effective_owners(pk).is_empty()
-    }
-
     fn add_victim(
         &mut self,
         victim: (ConsumerId, OwnerKey),
@@ -1246,27 +1242,17 @@ impl<'a> EvictionPlanner<'a> {
             return freed;
         };
 
-        let touched_groups: HashSet<(ConsumerId, OwnerKey)> = group
-            .pubkeys
-            .iter()
-            .flat_map(|pk| self.pubkey_groups.get(pk).into_iter().flatten().copied())
-            .collect();
-
         for pk in &group.pubkeys {
-            if self.is_pubkey_freed(pk) {
-                if let Some(sharing) = self.pubkey_groups.get(pk) {
-                    for other in sharing {
-                        if *other != victim && !self.victims.contains(other) {
-                            if let Some(contributors) = self.marginal_contributors.get_mut(other) {
-                                if contributors.remove(pk) {
-                                    if let Some(m) = self.marginal.get_mut(other) {
-                                        *m = m.saturating_sub(1);
-                                    }
-                                    if let Some(stats) = stats.as_deref_mut() {
-                                        stats.edge_updates = stats.edge_updates.saturating_add(1);
-                                    }
-                                }
-                            }
+            let owners_after = self.effective_owners(pk);
+            if owners_after.len() == 1 {
+                let sole = owners_after[0];
+                if let Some(contributors) = self.marginal_contributors.get_mut(&sole) {
+                    if contributors.insert(*pk) {
+                        if let Some(m) = self.marginal.get_mut(&sole) {
+                            *m = m.saturating_add(1);
+                        }
+                        if let Some(stats) = stats.as_deref_mut() {
+                            stats.edge_updates = stats.edge_updates.saturating_add(1);
                         }
                     }
                 }
@@ -1275,19 +1261,6 @@ impl<'a> EvictionPlanner<'a> {
 
         self.marginal.insert(victim, 0);
         self.marginal_contributors.insert(victim, HashSet::new());
-
-        for other in touched_groups {
-            if other == victim || self.victims.contains(&other) {
-                continue;
-            }
-            let before = self.marginal_freed(other);
-            self.recompute_marginal_for_group(other, stats.as_deref_mut());
-            if self.marginal_freed(other) != before {
-                if let Some(stats) = stats.as_deref_mut() {
-                    stats.edge_updates = stats.edge_updates.saturating_add(1);
-                }
-            }
-        }
 
         freed
     }
@@ -2133,7 +2106,12 @@ mod tests {
             stats.refcount_checks
                 <= edge_count.saturating_mul(stats.victim_removals.saturating_add(1))
         );
+        assert!(
+            stats.edge_updates
+                <= edge_count.saturating_mul(stats.victim_removals.saturating_add(1)),
+            "marginal edge updates must stay bounded under dense pubkey sharing"
+        );
         assert!(stats.candidate_pops > 0);
-        assert!(stats.refcount_checks > 0);
+        assert!(stats.victim_removals > 0);
     }
 }

--- a/src/market_data/track/geyser_sync.rs
+++ b/src/market_data/track/geyser_sync.rs
@@ -52,10 +52,20 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
     set_market_data_geyser_explicit_set_size(desired.len());
 
     let after_keys = desired.snapshot_pubkeys();
-    debug_assert!(
-        after_keys.len() <= desired.max_explicit_pubkeys(),
-        "admitted SSOT must never exceed cap"
-    );
+    if desired.cap_overflow() > 0 {
+        set_market_data_geyser_explicit_cap_overflow(desired.cap_overflow());
+        if release_flush_slot {
+            ctx.release_geyser_sync_flush_slot();
+        }
+        return false;
+    }
+    if !ctx.geyser_explicit_readiness_ok() {
+        set_market_data_geyser_explicit_cap_overflow(0);
+        if release_flush_slot {
+            ctx.release_geyser_sync_flush_slot();
+        }
+        return false;
+    }
     let delta = symmetric_diff(&before_keys, &after_keys);
     if delta.is_empty() && !continue_evict && !ctx.pending_geyser_evict() {
         inc_market_data_geyser_sync_skipped_no_delta_total();

--- a/src/market_data/track/geyser_sync.rs
+++ b/src/market_data/track/geyser_sync.rs
@@ -1,11 +1,13 @@
 //! Phase 5a: track-worker Geyser explicit-set rebuild + coalesced delta-only push.
 
-use super::desired_set::{symmetric_diff, ConsumerId, DesiredExplicitSet};
+use super::desired_set::{symmetric_diff, DesiredExplicitSet};
 use super::worker::TrackWorkerContext;
 use crate::metrics::{
     inc_market_data_geyser_sync_skipped_no_delta_total,
     record_market_data_geyser_subscribe_delta_pubkeys,
-    record_market_data_md_state_sync_flush_duration_us, set_market_data_geyser_explicit_set_size,
+    record_market_data_md_state_sync_flush_duration_us,
+    set_market_data_geyser_explicit_admitted_accounts,
+    set_market_data_geyser_explicit_cap_overflow, set_market_data_geyser_explicit_set_size,
     set_market_data_geyser_sync_pending,
 };
 use solana_sdk::pubkey::Pubkey;
@@ -27,11 +29,7 @@ pub fn rebuild_desired_explicit_set_from_ctx<C: TrackWorkerContext>(
     ctx: &C,
     set: &mut DesiredExplicitSet,
 ) {
-    set.clear();
-    set.set_max_explicit_pubkeys(ctx.max_tracked_accounts());
-    for (pk, consumer, pool) in ctx.explicit_pubkey_rows_for_desired_set() {
-        set.insert(pk, consumer, pool);
-    }
+    ctx.converge_explicit_admission(set);
     set_market_data_geyser_explicit_set_size(set.len());
 }
 
@@ -41,13 +39,22 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
     before_keys: HashSet<Pubkey>,
     continue_evict: bool,
     release_flush_slot: bool,
+    admission_converged: &mut bool,
 ) -> bool {
-    rebuild_desired_explicit_set_from_ctx(ctx.as_ref(), desired);
-    let after_mutations = ctx.snapshot_explicit_subscription_pubkeys();
-    let delta = symmetric_diff(&before_keys, &after_mutations);
+    if !*admission_converged {
+        ctx.converge_explicit_admission(desired);
+        *admission_converged = true;
+    }
+    ctx.prune_tracked_maps_to_desired(desired);
+    ctx.refresh_explicit_admission_metrics(desired);
+    set_market_data_geyser_explicit_admitted_accounts(desired.len());
+    set_market_data_geyser_explicit_cap_overflow(desired.cap_overflow());
+    set_market_data_geyser_explicit_set_size(desired.len());
+
+    let after_keys = desired.snapshot_pubkeys();
+    let delta = symmetric_diff(&before_keys, &after_keys);
     if delta.is_empty() && !continue_evict && !ctx.pending_geyser_evict() {
         inc_market_data_geyser_sync_skipped_no_delta_total();
-        set_market_data_geyser_explicit_set_size(desired.len());
         set_market_data_geyser_sync_pending(0);
         if release_flush_slot {
             ctx.release_geyser_sync_flush_slot();
@@ -61,9 +68,9 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
         Instant::now() + Duration::from_millis(MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS);
     let flush_start = Instant::now();
     let sync_complete = if continue_evict {
-        ctx.continue_geyser_evict_with_deadline(flush_deadline)
+        ctx.continue_geyser_evict_with_deadline(flush_deadline, desired)
     } else {
-        ctx.sync_geyser_tracked_accounts_batched_flush_with_deadline(flush_deadline)
+        ctx.sync_geyser_tracked_accounts_batched_flush_with_deadline(flush_deadline, desired)
     };
     set_market_data_geyser_sync_pending(0);
     if release_flush_slot {
@@ -72,18 +79,22 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
     record_market_data_md_state_sync_flush_duration_us(
         flush_start.elapsed().as_micros().min(u128::from(u64::MAX)) as u64,
     );
-    rebuild_desired_explicit_set_from_ctx(ctx.as_ref(), desired);
+    ctx.prune_tracked_maps_to_desired(desired);
     ctx.refresh_tracked_membership_snapshot();
+    *ctx.last_synced_explicit_pubkeys_write() = after_keys;
     if !sync_complete {
         return false;
     }
+    ctx.clear_pending_geyser_evict();
     true
 }
 
-pub fn consumer_id_for_track_pin(pin: super::worker::TrackPinReason) -> ConsumerId {
+pub fn consumer_id_for_track_pin(
+    pin: super::worker::TrackPinReason,
+) -> super::desired_set::ConsumerId {
     match pin {
-        super::worker::TrackPinReason::Wallet => ConsumerId::Wallet,
-        super::worker::TrackPinReason::MomentumActive => ConsumerId::Momentum,
-        super::worker::TrackPinReason::ArbMultiDex => ConsumerId::Arb,
+        super::worker::TrackPinReason::Wallet => super::desired_set::ConsumerId::Wallet,
+        super::worker::TrackPinReason::MomentumActive => super::desired_set::ConsumerId::Momentum,
+        super::worker::TrackPinReason::ArbMultiDex => super::desired_set::ConsumerId::Arb,
     }
 }

--- a/src/market_data/track/geyser_sync.rs
+++ b/src/market_data/track/geyser_sync.rs
@@ -52,10 +52,15 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
     set_market_data_geyser_explicit_set_size(desired.len());
 
     let after_keys = desired.snapshot_pubkeys();
+    debug_assert!(
+        after_keys.len() <= desired.max_explicit_pubkeys(),
+        "admitted SSOT must never exceed cap"
+    );
     let delta = symmetric_diff(&before_keys, &after_keys);
     if delta.is_empty() && !continue_evict && !ctx.pending_geyser_evict() {
         inc_market_data_geyser_sync_skipped_no_delta_total();
         set_market_data_geyser_sync_pending(0);
+        ctx.publish_admitted_explicit_physical(desired);
         if release_flush_slot {
             ctx.release_geyser_sync_flush_slot();
         }
@@ -80,6 +85,7 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
         flush_start.elapsed().as_micros().min(u128::from(u64::MAX)) as u64,
     );
     ctx.prune_tracked_maps_to_desired(desired);
+    ctx.publish_admitted_explicit_physical(desired);
     ctx.refresh_tracked_membership_snapshot();
     *ctx.last_synced_explicit_pubkeys_write() = after_keys;
     if !sync_complete {

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -26,7 +26,7 @@ pub use geyser_sync::{
 };
 pub use pending::{
     GeyserConnectBarrier, PendingPoolCommand, PendingPoolRegistrations, PendingPoolUpsertResult,
-    ProtectedOverflowDiagnostic, WalletExplicitPending,
+    PoolSnapshotRevisionSequencer, ProtectedOverflowDiagnostic, WalletExplicitPending,
 };
 pub use snapshot::{
     explicit_set_snapshot_path, load_explicit_set_snapshot, owner_key_to_snapshot,

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -26,7 +26,8 @@ pub use geyser_sync::{
 };
 pub use pending::{
     GeyserConnectBarrier, PendingPoolCommand, PendingPoolRegistrations, PendingPoolUpsertResult,
-    PoolSnapshotRevisionSequencer, ProtectedOverflowDiagnostic, WalletExplicitPending,
+    PoolSnapshotRevisionSequencer, ProtectedOverflowDiagnostic, RevisionAcquireResult,
+    RevisionAssignResult, RevisionRefCounts, WalletExplicitPending,
 };
 pub use snapshot::{
     explicit_set_snapshot_path, load_explicit_set_snapshot, owner_key_to_snapshot,

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -29,6 +29,7 @@ pub use pending::{
     PendingPoolUpsertResult, PoolCommandAcceptPhase, PoolCommandRefRelease, PoolCommandTerminal,
     PoolSnapshotRevisionSequencer, ProtectedOverflowDiagnostic, RevisionAcquireResult,
     RevisionActiveOwner, RevisionAssignResult, RevisionRefCounts, WalletExplicitPending,
+    WalletRevisionBump,
 };
 pub use snapshot::{
     explicit_set_snapshot_path, load_explicit_set_snapshot, owner_key_to_snapshot,

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -26,9 +26,9 @@ pub use geyser_sync::{
 };
 pub use pending::{
     GeyserConnectBarrier, InflightReserveResult, PendingPoolCommand, PendingPoolRegistrations,
-    PendingPoolUpsertResult, PoolCommandTerminal, PoolSnapshotRevisionSequencer,
-    ProtectedOverflowDiagnostic, RevisionAcquireResult, RevisionActiveOwner, RevisionAssignResult,
-    RevisionRefCounts, WalletExplicitPending,
+    PendingPoolUpsertResult, PoolCommandAcceptPhase, PoolCommandTerminal,
+    PoolSnapshotRevisionSequencer, ProtectedOverflowDiagnostic, RevisionAcquireResult,
+    RevisionActiveOwner, RevisionAssignResult, RevisionRefCounts, WalletExplicitPending,
 };
 pub use snapshot::{
     explicit_set_snapshot_path, load_explicit_set_snapshot, owner_key_to_snapshot,

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -25,8 +25,8 @@ pub use geyser_sync::{
     MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS,
 };
 pub use pending::{
-    GeyserConnectBarrier, PendingPoolCommand, PendingPoolKey, PendingPoolKind,
-    PendingPoolRegistrations, ProtectedOverflowDiagnostic, WalletExplicitPending,
+    GeyserConnectBarrier, PendingPoolCommand, PendingPoolRegistrations, PendingPoolUpsertResult,
+    ProtectedOverflowDiagnostic, WalletExplicitPending,
 };
 pub use snapshot::{
     explicit_set_snapshot_path, load_explicit_set_snapshot, owner_key_to_snapshot,
@@ -44,4 +44,7 @@ pub use worker::{
     MARKET_DATA_MOMENTUM_APPLY_CHUNK_SIZE, MARKET_DATA_MOMENTUM_APPLY_CHUNK_THRESHOLD,
     MARKET_DATA_TRACK_WORKER_COALESCE_MS, MARKET_DATA_TRACK_WORKER_QUEUE_CAP,
 };
-pub use worker_commands::{GeyserPinReason, PoolExplicitSnapshot, TrackWorkerCommand};
+pub use worker_commands::{
+    BinArrayExplicitRow, GeyserPinReason, MintExplicitRow, PoolExplicitSnapshot,
+    TrackWorkerCommand, VaultExplicitRow,
+};

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -11,8 +11,8 @@ pub use coalesce::{
     MARKET_DATA_ARB_COALESCE_CHANNEL_CAP, MARKET_DATA_MOMENTUM_COALESCE_CHANNEL_CAP,
 };
 pub use desired_set::{
-    pin_priority_from_consumer, symmetric_diff, ConsumerId, DesiredExplicitSet, ExplicitEntry,
-    PinPriority,
+    pin_priority_from_consumer, symmetric_diff, AdmissionResult, ConsumerId, DesiredExplicitSet,
+    EvictReason, OwnerKey, PinPriority,
 };
 pub use enrichment::{
     is_enrichment_member_from_inputs, pool_is_enrichment_member, EnrichmentMembershipInputs,

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -25,9 +25,10 @@ pub use geyser_sync::{
     MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS,
 };
 pub use pending::{
-    GeyserConnectBarrier, PendingPoolCommand, PendingPoolRegistrations, PendingPoolUpsertResult,
-    PoolSnapshotRevisionSequencer, ProtectedOverflowDiagnostic, RevisionAcquireResult,
-    RevisionAssignResult, RevisionRefCounts, WalletExplicitPending,
+    GeyserConnectBarrier, InflightReserveResult, PendingPoolCommand, PendingPoolRegistrations,
+    PendingPoolUpsertResult, PoolCommandTerminal, PoolSnapshotRevisionSequencer,
+    ProtectedOverflowDiagnostic, RevisionAcquireResult, RevisionActiveOwner, RevisionAssignResult,
+    RevisionRefCounts, WalletExplicitPending,
 };
 pub use snapshot::{
     explicit_set_snapshot_path, load_explicit_set_snapshot, owner_key_to_snapshot,

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -4,6 +4,7 @@ pub mod enrichment;
 pub mod geyser_sync;
 pub mod snapshot;
 pub mod worker;
+pub mod worker_commands;
 
 pub use coalesce::{
     arb_coalesce_try_send, merge_arb_track_requests_updates, merge_momentum_active_pools_updates,
@@ -12,7 +13,7 @@ pub use coalesce::{
 };
 pub use desired_set::{
     pin_priority_from_consumer, symmetric_diff, AdmissionResult, ConsumerId, DesiredExplicitSet,
-    EvictReason, OwnerKey, PinPriority,
+    EvictReason, OwnerGroupSnapshot, OwnerKey, PinPriority,
 };
 pub use enrichment::{
     is_enrichment_member_from_inputs, pool_is_enrichment_member, EnrichmentMembershipInputs,
@@ -23,17 +24,19 @@ pub use geyser_sync::{
     MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS,
 };
 pub use snapshot::{
-    explicit_set_snapshot_path, load_explicit_set_snapshot, write_explicit_set_snapshot,
-    ExplicitAccountKind, ExplicitSetSnapshot, ExplicitSnapshotRow, SnapshotConsumer,
-    EXPLICIT_SET_SNAPSHOT_DEFAULT_PATH, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
-    EXPLICIT_SET_SNAPSHOT_VERSION, MARKET_DATA_EXPLICIT_SET_SNAPSHOT_INTERVAL_SECS,
+    explicit_set_snapshot_path, load_explicit_set_snapshot, owner_key_to_snapshot,
+    write_explicit_set_snapshot, ExplicitAccountKind, ExplicitSetSnapshot, ExplicitSnapshotRow,
+    SnapshotConsumer, SnapshotOwnerGroup, EXPLICIT_SET_SNAPSHOT_DEFAULT_PATH,
+    EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP, EXPLICIT_SET_SNAPSHOT_VERSION,
+    MARKET_DATA_EXPLICIT_SET_SNAPSHOT_INTERVAL_SECS,
 };
 pub use worker::{
     apply_arb_track_requests_on_track_worker, apply_momentum_active_pools_on_track_worker,
     flush_explicit_set_snapshot, spawn_inline_track_worker_sender, spawn_noop_track_worker_sender,
     spawn_track_worker, track_worker_process_command, track_worker_try_enqueue, TrackPinReason,
-    TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender, MARKET_DATA_ARB_APPLY_CHUNK_SIZE,
+    TrackWorkerContext, TrackWorkerSender, MARKET_DATA_ARB_APPLY_CHUNK_SIZE,
     MARKET_DATA_ARB_APPLY_CHUNK_THRESHOLD, MARKET_DATA_MOMENTUM_APPLY_CHUNK_SIZE,
     MARKET_DATA_MOMENTUM_APPLY_CHUNK_THRESHOLD, MARKET_DATA_TRACK_WORKER_COALESCE_MS,
     MARKET_DATA_TRACK_WORKER_QUEUE_CAP,
 };
+pub use worker_commands::TrackWorkerCommand;

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -26,7 +26,7 @@ pub use geyser_sync::{
 };
 pub use pending::{
     GeyserConnectBarrier, InflightReserveResult, PendingPoolCommand, PendingPoolRegistrations,
-    PendingPoolUpsertResult, PoolCommandAcceptPhase, PoolCommandTerminal,
+    PendingPoolUpsertResult, PoolCommandAcceptPhase, PoolCommandRefRelease, PoolCommandTerminal,
     PoolSnapshotRevisionSequencer, ProtectedOverflowDiagnostic, RevisionAcquireResult,
     RevisionActiveOwner, RevisionAssignResult, RevisionRefCounts, WalletExplicitPending,
 };

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -2,6 +2,7 @@ pub mod coalesce;
 pub mod desired_set;
 pub mod enrichment;
 pub mod geyser_sync;
+pub mod pending;
 pub mod snapshot;
 pub mod worker;
 pub mod worker_commands;
@@ -12,8 +13,8 @@ pub use coalesce::{
     MARKET_DATA_ARB_COALESCE_CHANNEL_CAP, MARKET_DATA_MOMENTUM_COALESCE_CHANNEL_CAP,
 };
 pub use desired_set::{
-    pin_priority_from_consumer, symmetric_diff, AdmissionResult, ConsumerId, DesiredExplicitSet,
-    EvictReason, OwnerGroupSnapshot, OwnerKey, PinPriority,
+    pin_priority_from_consumer, symmetric_diff, AdmissionResult, CapConvergeResult, ConsumerId,
+    DesiredExplicitSet, EvictReason, OwnerGroupSnapshot, OwnerKey, PinPriority,
 };
 pub use enrichment::{
     is_enrichment_member_from_inputs, pool_is_enrichment_member, EnrichmentMembershipInputs,
@@ -22,6 +23,10 @@ pub use geyser_sync::{
     consumer_id_for_track_pin, explicit_subscription_has_new_keys,
     rebuild_desired_explicit_set_from_ctx, track_worker_execute_coalesced_push,
     MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS,
+};
+pub use pending::{
+    GeyserConnectBarrier, PendingPoolCommand, PendingPoolKey, PendingPoolKind,
+    PendingPoolRegistrations, ProtectedOverflowDiagnostic, WalletExplicitPending,
 };
 pub use snapshot::{
     explicit_set_snapshot_path, load_explicit_set_snapshot, owner_key_to_snapshot,
@@ -33,10 +38,10 @@ pub use snapshot::{
 pub use worker::{
     apply_arb_track_requests_on_track_worker, apply_momentum_active_pools_on_track_worker,
     flush_explicit_set_snapshot, spawn_inline_track_worker_sender, spawn_noop_track_worker_sender,
-    spawn_track_worker, track_worker_process_command, track_worker_try_enqueue, TrackPinReason,
-    TrackWorkerContext, TrackWorkerSender, MARKET_DATA_ARB_APPLY_CHUNK_SIZE,
-    MARKET_DATA_ARB_APPLY_CHUNK_THRESHOLD, MARKET_DATA_MOMENTUM_APPLY_CHUNK_SIZE,
-    MARKET_DATA_MOMENTUM_APPLY_CHUNK_THRESHOLD, MARKET_DATA_TRACK_WORKER_COALESCE_MS,
-    MARKET_DATA_TRACK_WORKER_QUEUE_CAP,
+    spawn_track_worker, track_worker_process_command, track_worker_sender_for_test,
+    track_worker_try_enqueue, TrackPinReason, TrackWorkerContext, TrackWorkerSender,
+    MARKET_DATA_ARB_APPLY_CHUNK_SIZE, MARKET_DATA_ARB_APPLY_CHUNK_THRESHOLD,
+    MARKET_DATA_MOMENTUM_APPLY_CHUNK_SIZE, MARKET_DATA_MOMENTUM_APPLY_CHUNK_THRESHOLD,
+    MARKET_DATA_TRACK_WORKER_COALESCE_MS, MARKET_DATA_TRACK_WORKER_QUEUE_CAP,
 };
-pub use worker_commands::TrackWorkerCommand;
+pub use worker_commands::{GeyserPinReason, PoolExplicitSnapshot, TrackWorkerCommand};

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -10,6 +10,59 @@ use solana_sdk::pubkey::Pubkey;
 use crate::market_data::track::desired_set::ConsumerId;
 use crate::market_data::track::worker_commands::{PoolExplicitSnapshot, TrackWorkerCommand};
 
+/// Monotonic per-(pool,consumer) revision sequencer for pool snapshot commands.
+#[derive(Debug, Default)]
+pub struct PoolSnapshotRevisionSequencer {
+    issued: Mutex<HashMap<(Pubkey, ConsumerId), u64>>,
+    last_applied: Mutex<HashMap<(Pubkey, ConsumerId), u64>>,
+}
+
+impl PoolSnapshotRevisionSequencer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn assign_next(&self, snapshot: &mut PoolExplicitSnapshot) -> u64 {
+        let key = (snapshot.pool, snapshot.consumer);
+        let mut issued = self.issued.lock().expect("pool revision issued lock");
+        let entry = issued.entry(key).or_insert(0);
+        *entry = entry.saturating_add(1);
+        snapshot.revision = *entry;
+        *entry
+    }
+
+    pub fn should_apply_and_record(&self, snapshot: &PoolExplicitSnapshot) -> bool {
+        let key = (snapshot.pool, snapshot.consumer);
+        let mut applied = self
+            .last_applied
+            .lock()
+            .expect("pool revision applied lock");
+        if snapshot.revision <= applied.get(&key).copied().unwrap_or(0) {
+            return false;
+        }
+        applied.insert(key, snapshot.revision);
+        true
+    }
+
+    pub fn current_issued(&self, pool: Pubkey, consumer: ConsumerId) -> u64 {
+        self.issued
+            .lock()
+            .expect("pool revision issued lock")
+            .get(&(pool, consumer))
+            .copied()
+            .unwrap_or(0)
+    }
+
+    pub fn current_applied(&self, pool: Pubkey, consumer: ConsumerId) -> u64 {
+        self.last_applied
+            .lock()
+            .expect("pool revision applied lock")
+            .get(&(pool, consumer))
+            .copied()
+            .unwrap_or(0)
+    }
+}
+
 /// Coalesced pool command awaiting worker replay after queue loss.
 #[derive(Debug, Clone)]
 pub enum PendingPoolCommand {
@@ -69,15 +122,6 @@ impl PendingPoolCommand {
                 new_active_id,
             },
         }
-    }
-}
-
-fn assign_revision(command: &mut PendingPoolCommand, revision: u64) {
-    match command {
-        PendingPoolCommand::RegisterReserves(s)
-        | PendingPoolCommand::VaultsFromAccount(s)
-        | PendingPoolCommand::AfterTrade(s) => s.revision = revision,
-        PendingPoolCommand::RefreshDlmm { snapshot, .. } => snapshot.revision = revision,
     }
 }
 
@@ -200,23 +244,39 @@ pub struct PendingPoolRegistrations {
     entries: Mutex<HashMap<(Pubkey, ConsumerId), CoalescedPoolPending>>,
     order: Mutex<VecDeque<(Pubkey, ConsumerId)>>,
     overflow: AtomicBool,
-    next_revision: AtomicU64,
+    revisions: std::sync::Arc<PoolSnapshotRevisionSequencer>,
 }
 
 impl PendingPoolRegistrations {
-    pub fn new(max_pools: usize) -> Self {
+    pub fn new(max_pools: usize, revisions: std::sync::Arc<PoolSnapshotRevisionSequencer>) -> Self {
         Self {
             max_pools: max_pools.max(1),
             entries: Mutex::new(HashMap::new()),
             order: Mutex::new(VecDeque::new()),
             overflow: AtomicBool::new(false),
-            next_revision: AtomicU64::new(0),
+            revisions,
         }
     }
 
     pub fn upsert(&self, mut command: PendingPoolCommand) -> PendingPoolUpsertResult {
-        let revision = self.next_revision.fetch_add(1, Ordering::AcqRel) + 1;
-        assign_revision(&mut command, revision);
+        let revision = match &mut command {
+            PendingPoolCommand::RegisterReserves(s)
+            | PendingPoolCommand::VaultsFromAccount(s)
+            | PendingPoolCommand::AfterTrade(s) => {
+                if s.revision == 0 {
+                    self.revisions.assign_next(s)
+                } else {
+                    s.revision
+                }
+            }
+            PendingPoolCommand::RefreshDlmm { snapshot, .. } => {
+                if snapshot.revision == 0 {
+                    self.revisions.assign_next(snapshot)
+                } else {
+                    snapshot.revision
+                }
+            }
+        };
         let key = (command.pool(), command.consumer());
         let mut entries = self.entries.lock().expect("pending pool lock");
         let mut order = self.order.lock().expect("pending pool order lock");
@@ -377,9 +437,19 @@ mod tests {
         }
     }
 
+    use std::sync::Arc;
+
+    fn mk_pending() -> (PendingPoolRegistrations, Arc<PoolSnapshotRevisionSequencer>) {
+        let revisions = Arc::new(PoolSnapshotRevisionSequencer::new());
+        (
+            PendingPoolRegistrations::new(8, Arc::clone(&revisions)),
+            revisions,
+        )
+    }
+
     #[test]
     fn pending_replays_latest_revision_not_kind_order() {
-        let pending = PendingPoolRegistrations::new(8);
+        let (pending, _revs) = mk_pending();
         let pool = Pubkey::new_unique();
         let old_vault = Pubkey::new_unique();
         let new_vault = Pubkey::new_unique();
@@ -408,7 +478,7 @@ mod tests {
 
     #[test]
     fn pending_stale_out_of_order_across_all_kinds_no_ops() {
-        let pending = PendingPoolRegistrations::new(8);
+        let (pending, _revs) = mk_pending();
         let pool = Pubkey::new_unique();
         let v2 = Pubkey::new_unique();
         let v3 = Pubkey::new_unique();
@@ -459,5 +529,22 @@ mod tests {
             }
             other => panic!("expected RefreshDlmm latest, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn sequencer_rejects_stale_apply_after_newer() {
+        let revisions = PoolSnapshotRevisionSequencer::new();
+        let pool = Pubkey::new_unique();
+        let mut newer = mk_snapshot(pool, Pubkey::new_unique());
+        let mut older = mk_snapshot(pool, Pubkey::new_unique());
+        let rev_new = revisions.assign_next(&mut newer);
+        let rev_latest = revisions.assign_next(&mut older);
+        assert!(revisions.should_apply_and_record(&older));
+        assert!(!revisions.should_apply_and_record(&newer));
+        assert_eq!(
+            revisions.current_applied(pool, ConsumerId::Momentum),
+            rev_latest
+        );
+        assert!(rev_new < rev_latest);
     }
 }

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -1,7 +1,7 @@
 //! Bounded durable pending state for track-worker commands lost on full queue.
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -60,6 +60,68 @@ impl PendingPoolCommand {
                 new_active_id,
             },
         }
+    }
+}
+
+/// Result of stashing a pool command in durable pending state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingPoolUpsertResult {
+    Stored,
+    Coalesced,
+    Overflow,
+}
+
+/// Per-pool coalesced pending commands (one slot per pool+consumer, merged by kind).
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct CoalescedPoolPending {
+    pool: Pubkey,
+    consumer: ConsumerId,
+    reserves: Option<PoolExplicitSnapshot>,
+    vaults: Option<PoolExplicitSnapshot>,
+    after_trade: Option<PoolExplicitSnapshot>,
+    refresh_dlmm: Option<(PoolExplicitSnapshot, i32)>,
+}
+
+impl CoalescedPoolPending {
+    fn merge(&mut self, command: PendingPoolCommand) {
+        match command {
+            PendingPoolCommand::RegisterReserves(snapshot) => {
+                self.reserves = Some(snapshot);
+            }
+            PendingPoolCommand::VaultsFromAccount(snapshot) => {
+                self.vaults = Some(snapshot);
+            }
+            PendingPoolCommand::AfterTrade(snapshot) => {
+                self.after_trade = Some(snapshot);
+            }
+            PendingPoolCommand::RefreshDlmm {
+                snapshot,
+                new_active_id,
+            } => {
+                self.refresh_dlmm = Some((snapshot, new_active_id));
+            }
+        }
+    }
+
+    fn into_commands(self) -> Vec<PendingPoolCommand> {
+        let mut out = Vec::new();
+        if let Some(snapshot) = self.reserves {
+            out.push(PendingPoolCommand::RegisterReserves(snapshot));
+        }
+        if let Some(snapshot) = self.vaults {
+            out.push(PendingPoolCommand::VaultsFromAccount(snapshot));
+        }
+        if let Some(snapshot) = self.after_trade {
+            out.push(PendingPoolCommand::AfterTrade(snapshot));
+        }
+        if let Some((snapshot, new_active_id)) = self.refresh_dlmm {
+            out.push(PendingPoolCommand::RefreshDlmm {
+                snapshot,
+                new_active_id,
+            });
+        }
+        out
     }
 }
 
@@ -140,71 +202,75 @@ impl WalletExplicitPending {
     }
 }
 
-/// Bounded coalesced pool registration pending (keyed by pool+consumer+command kind).
+/// Bounded per-pool coalesced pending (one entry per pool+consumer; overflow is fail-closed).
 #[derive(Debug)]
 pub struct PendingPoolRegistrations {
-    cap: usize,
-    entries: Mutex<HashMap<PendingPoolKey, PendingPoolCommand>>,
-    order: Mutex<VecDeque<PendingPoolKey>>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct PendingPoolKey {
-    pub pool: Pubkey,
-    pub consumer: ConsumerId,
-    pub kind: PendingPoolKind,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum PendingPoolKind {
-    Reserves,
-    Vaults,
-    AfterTrade,
-    RefreshDlmm,
+    max_pools: usize,
+    entries: Mutex<HashMap<(Pubkey, ConsumerId), CoalescedPoolPending>>,
+    order: Mutex<VecDeque<(Pubkey, ConsumerId)>>,
+    overflow: AtomicBool,
 }
 
 impl PendingPoolRegistrations {
-    pub fn new(cap: usize) -> Self {
+    pub fn new(max_pools: usize) -> Self {
         Self {
-            cap: cap.max(1),
+            max_pools: max_pools.max(1),
             entries: Mutex::new(HashMap::new()),
             order: Mutex::new(VecDeque::new()),
+            overflow: AtomicBool::new(false),
         }
     }
 
-    pub fn upsert(&self, command: PendingPoolCommand) {
-        let kind = match &command {
-            PendingPoolCommand::RegisterReserves(_) => PendingPoolKind::Reserves,
-            PendingPoolCommand::VaultsFromAccount(_) => PendingPoolKind::Vaults,
-            PendingPoolCommand::AfterTrade(_) => PendingPoolKind::AfterTrade,
-            PendingPoolCommand::RefreshDlmm { .. } => PendingPoolKind::RefreshDlmm,
-        };
-        let key = PendingPoolKey {
-            pool: command.pool(),
-            consumer: command.consumer(),
-            kind,
-        };
+    pub fn upsert(&self, command: PendingPoolCommand) -> PendingPoolUpsertResult {
+        let key = (command.pool(), command.consumer());
         let mut entries = self.entries.lock().expect("pending pool lock");
         let mut order = self.order.lock().expect("pending pool order lock");
-        if !entries.contains_key(&key) {
-            order.push_back(key);
-            while order.len() > self.cap {
-                if let Some(evict) = order.pop_front() {
-                    entries.remove(&evict);
-                }
-            }
+        if entries.contains_key(&key) {
+            entries.get_mut(&key).expect("pending key").merge(command);
+            return PendingPoolUpsertResult::Coalesced;
         }
-        entries.insert(key, command);
+        if order.len() >= self.max_pools {
+            self.overflow.store(true, Ordering::Release);
+            return PendingPoolUpsertResult::Overflow;
+        }
+        let mut coalesced = CoalescedPoolPending {
+            pool: key.0,
+            consumer: key.1,
+            reserves: None,
+            vaults: None,
+            after_trade: None,
+            refresh_dlmm: None,
+        };
+        coalesced.merge(command);
+        entries.insert(key, coalesced);
+        order.push_back(key);
+        PendingPoolUpsertResult::Stored
     }
 
     pub fn drain_all(&self) -> Vec<PendingPoolCommand> {
         let mut entries = self.entries.lock().expect("pending pool lock");
         let mut order = self.order.lock().expect("pending pool order lock");
-        order.drain(..).filter_map(|k| entries.remove(&k)).collect()
+        let keys: Vec<_> = order.drain(..).collect();
+        keys.into_iter()
+            .filter_map(|k| entries.remove(&k))
+            .flat_map(|coalesced| coalesced.into_commands())
+            .collect()
     }
 
     pub fn is_empty(&self) -> bool {
         self.entries.lock().expect("pending pool lock").is_empty()
+    }
+
+    pub fn overflowed(&self) -> bool {
+        self.overflow.load(Ordering::Acquire)
+    }
+
+    pub fn clear_overflow(&self) {
+        self.overflow.store(false, Ordering::Release);
+    }
+
+    pub fn pool_count(&self) -> usize {
+        self.entries.lock().expect("pending pool lock").len()
     }
 }
 
@@ -237,6 +303,10 @@ impl GeyserConnectBarrier {
 
     pub fn mark_failed(&self) {
         self.state.store(BARRIER_FAILED, Ordering::Release);
+    }
+
+    pub fn mark_pending(&self) {
+        self.state.store(BARRIER_PENDING, Ordering::Release);
     }
 
     pub fn is_ready(&self) -> bool {

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -1163,6 +1163,7 @@ mod tests {
             owner: OwnerKey::Pool(pool),
             pin: GeyserPinReason::MomentumActive,
             revision: 0,
+            rejection_ledger_token: None,
         }
     }
 

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -765,9 +765,6 @@ impl PoolSnapshotRevisionSequencer {
             let Some(coalesced) = inner.pending_entries.remove(&k) else {
                 continue;
             };
-            if let Some(slot) = inner.slots.get_mut(&k) {
-                slot.pending = slot.pending.saturating_sub(1);
-            }
             drained.push(coalesced.into_command());
         }
         drained
@@ -1612,6 +1609,19 @@ mod tests {
 
         let drained = pending.drain_all();
         assert_eq!(drained.len(), 1);
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).pending, 1);
+        let snapshot = match &drained[0] {
+            PendingPoolCommand::RegisterReserves(s)
+            | PendingPoolCommand::VaultsFromAccount(s)
+            | PendingPoolCommand::AfterTrade(s) => s,
+            PendingPoolCommand::RefreshDlmm { snapshot: s, .. } => s,
+        };
+        revisions.finish_pool_command(
+            snapshot,
+            PoolCommandTerminal::Applied,
+            Some(PoolCommandRefRelease::Pending),
+            true,
+        );
         assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).total(), 0);
     }
 
@@ -1726,6 +1736,19 @@ mod tests {
         revisions.test_set_drain_hold_before_remove(false);
         let drained = drainer.join().expect("drainer");
         assert_eq!(drained.len(), 1);
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).pending, 1);
+        let snapshot = match &drained[0] {
+            PendingPoolCommand::RegisterReserves(s)
+            | PendingPoolCommand::VaultsFromAccount(s)
+            | PendingPoolCommand::AfterTrade(s) => s,
+            PendingPoolCommand::RefreshDlmm { snapshot: s, .. } => s,
+        };
+        revisions.finish_pool_command(
+            snapshot,
+            PoolCommandTerminal::Applied,
+            Some(PoolCommandRefRelease::Pending),
+            true,
+        );
         assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).pending, 0);
         assert!(!pending.has_pending(pool, ConsumerId::Momentum));
     }

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -41,6 +41,15 @@ impl PendingPoolCommand {
         }
     }
 
+    pub fn revision(&self) -> u64 {
+        match self {
+            Self::RegisterReserves(s)
+            | Self::VaultsFromAccount(s)
+            | Self::AfterTrade(s)
+            | Self::RefreshDlmm { snapshot: s, .. } => s.revision,
+        }
+    }
+
     pub fn into_track_command(self) -> TrackWorkerCommand {
         match self {
             Self::RegisterReserves(snapshot) => {
@@ -63,65 +72,47 @@ impl PendingPoolCommand {
     }
 }
 
+fn assign_revision(command: &mut PendingPoolCommand, revision: u64) {
+    match command {
+        PendingPoolCommand::RegisterReserves(s)
+        | PendingPoolCommand::VaultsFromAccount(s)
+        | PendingPoolCommand::AfterTrade(s) => s.revision = revision,
+        PendingPoolCommand::RefreshDlmm { snapshot, .. } => snapshot.revision = revision,
+    }
+}
+
 /// Result of stashing a pool command in durable pending state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PendingPoolUpsertResult {
     Stored,
     Coalesced,
+    StaleNoOp,
     Overflow,
 }
 
-/// Per-pool coalesced pending commands (one slot per pool+consumer, merged by kind).
+/// Per-pool latest authoritative pending command (one slot per pool+consumer, revision wins).
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 struct CoalescedPoolPending {
     pool: Pubkey,
     consumer: ConsumerId,
-    reserves: Option<PoolExplicitSnapshot>,
-    vaults: Option<PoolExplicitSnapshot>,
-    after_trade: Option<PoolExplicitSnapshot>,
-    refresh_dlmm: Option<(PoolExplicitSnapshot, i32)>,
+    latest_revision: u64,
+    latest_command: PendingPoolCommand,
 }
 
 impl CoalescedPoolPending {
-    fn merge(&mut self, command: PendingPoolCommand) {
-        match command {
-            PendingPoolCommand::RegisterReserves(snapshot) => {
-                self.reserves = Some(snapshot);
-            }
-            PendingPoolCommand::VaultsFromAccount(snapshot) => {
-                self.vaults = Some(snapshot);
-            }
-            PendingPoolCommand::AfterTrade(snapshot) => {
-                self.after_trade = Some(snapshot);
-            }
-            PendingPoolCommand::RefreshDlmm {
-                snapshot,
-                new_active_id,
-            } => {
-                self.refresh_dlmm = Some((snapshot, new_active_id));
-            }
+    fn try_merge(&mut self, revision: u64, command: PendingPoolCommand) -> bool {
+        if revision > self.latest_revision {
+            self.latest_revision = revision;
+            self.latest_command = command;
+            true
+        } else {
+            false
         }
     }
 
-    fn into_commands(self) -> Vec<PendingPoolCommand> {
-        let mut out = Vec::new();
-        if let Some(snapshot) = self.reserves {
-            out.push(PendingPoolCommand::RegisterReserves(snapshot));
-        }
-        if let Some(snapshot) = self.vaults {
-            out.push(PendingPoolCommand::VaultsFromAccount(snapshot));
-        }
-        if let Some(snapshot) = self.after_trade {
-            out.push(PendingPoolCommand::AfterTrade(snapshot));
-        }
-        if let Some((snapshot, new_active_id)) = self.refresh_dlmm {
-            out.push(PendingPoolCommand::RefreshDlmm {
-                snapshot,
-                new_active_id,
-            });
-        }
-        out
+    fn into_command(self) -> PendingPoolCommand {
+        self.latest_command
     }
 }
 
@@ -209,6 +200,7 @@ pub struct PendingPoolRegistrations {
     entries: Mutex<HashMap<(Pubkey, ConsumerId), CoalescedPoolPending>>,
     order: Mutex<VecDeque<(Pubkey, ConsumerId)>>,
     overflow: AtomicBool,
+    next_revision: AtomicU64,
 }
 
 impl PendingPoolRegistrations {
@@ -218,30 +210,32 @@ impl PendingPoolRegistrations {
             entries: Mutex::new(HashMap::new()),
             order: Mutex::new(VecDeque::new()),
             overflow: AtomicBool::new(false),
+            next_revision: AtomicU64::new(0),
         }
     }
 
-    pub fn upsert(&self, command: PendingPoolCommand) -> PendingPoolUpsertResult {
+    pub fn upsert(&self, mut command: PendingPoolCommand) -> PendingPoolUpsertResult {
+        let revision = self.next_revision.fetch_add(1, Ordering::AcqRel) + 1;
+        assign_revision(&mut command, revision);
         let key = (command.pool(), command.consumer());
         let mut entries = self.entries.lock().expect("pending pool lock");
         let mut order = self.order.lock().expect("pending pool order lock");
-        if entries.contains_key(&key) {
-            entries.get_mut(&key).expect("pending key").merge(command);
-            return PendingPoolUpsertResult::Coalesced;
+        if let Some(entry) = entries.get_mut(&key) {
+            if entry.try_merge(revision, command) {
+                return PendingPoolUpsertResult::Coalesced;
+            }
+            return PendingPoolUpsertResult::StaleNoOp;
         }
         if order.len() >= self.max_pools {
             self.overflow.store(true, Ordering::Release);
             return PendingPoolUpsertResult::Overflow;
         }
-        let mut coalesced = CoalescedPoolPending {
+        let coalesced = CoalescedPoolPending {
             pool: key.0,
             consumer: key.1,
-            reserves: None,
-            vaults: None,
-            after_trade: None,
-            refresh_dlmm: None,
+            latest_revision: revision,
+            latest_command: command,
         };
-        coalesced.merge(command);
         entries.insert(key, coalesced);
         order.push_back(key);
         PendingPoolUpsertResult::Stored
@@ -253,7 +247,7 @@ impl PendingPoolRegistrations {
         let keys: Vec<_> = order.drain(..).collect();
         keys.into_iter()
             .filter_map(|k| entries.remove(&k))
-            .flat_map(|coalesced| coalesced.into_commands())
+            .map(|coalesced| coalesced.into_command())
             .collect()
     }
 
@@ -271,6 +265,14 @@ impl PendingPoolRegistrations {
 
     pub fn pool_count(&self) -> usize {
         self.entries.lock().expect("pending pool lock").len()
+    }
+
+    pub fn latest_revision_for(&self, pool: Pubkey, consumer: ConsumerId) -> Option<u64> {
+        self.entries
+            .lock()
+            .expect("pending pool lock")
+            .get(&(pool, consumer))
+            .map(|e| e.latest_revision)
     }
 }
 
@@ -340,6 +342,122 @@ impl ProtectedOverflowDiagnostic {
             configured_cap: cap,
             wallet_demand_len: demand.len(),
             sample_wallet_pubkeys: demand.iter().copied().take(8).collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::market_data::track::desired_set::OwnerKey;
+    use crate::market_data::track::worker_commands::GeyserPinReason;
+
+    fn mk_snapshot(pool: Pubkey, vault: Pubkey) -> PoolExplicitSnapshot {
+        use crate::market_data::track::worker_commands::{MintExplicitRow, VaultExplicitRow};
+        PoolExplicitSnapshot {
+            pool,
+            vaults: vec![VaultExplicitRow {
+                pubkey: vault,
+                dex: "test".into(),
+                base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::new_unique(),
+                is_base_vault: true,
+                sibling_vault: None,
+                active_id: None,
+                bin_step: None,
+            }],
+            bin_arrays: vec![],
+            mints: vec![MintExplicitRow {
+                pubkey: Pubkey::new_unique(),
+            }],
+            consumer: ConsumerId::Momentum,
+            owner: OwnerKey::Pool(pool),
+            pin: GeyserPinReason::MomentumActive,
+            revision: 0,
+        }
+    }
+
+    #[test]
+    fn pending_replays_latest_revision_not_kind_order() {
+        let pending = PendingPoolRegistrations::new(8);
+        let pool = Pubkey::new_unique();
+        let old_vault = Pubkey::new_unique();
+        let new_vault = Pubkey::new_unique();
+
+        assert_eq!(
+            pending.upsert(PendingPoolCommand::RegisterReserves(mk_snapshot(
+                pool, old_vault
+            ))),
+            PendingPoolUpsertResult::Stored
+        );
+        assert_eq!(
+            pending.upsert(PendingPoolCommand::AfterTrade(mk_snapshot(pool, new_vault))),
+            PendingPoolUpsertResult::Coalesced
+        );
+        // Older revision (already assigned internally) cannot overwrite newer via re-upsert with stale
+        let drained = pending.drain_all();
+        assert_eq!(drained.len(), 1);
+        match &drained[0] {
+            PendingPoolCommand::AfterTrade(s) => {
+                assert_eq!(s.revision, 2);
+                assert_eq!(s.vaults[0].pubkey, new_vault);
+            }
+            other => panic!("expected AfterTrade latest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pending_stale_out_of_order_across_all_kinds_no_ops() {
+        let pending = PendingPoolRegistrations::new(8);
+        let pool = Pubkey::new_unique();
+        let v2 = Pubkey::new_unique();
+        let v3 = Pubkey::new_unique();
+        let v4 = Pubkey::new_unique();
+
+        assert_eq!(
+            pending.upsert(PendingPoolCommand::VaultsFromAccount(mk_snapshot(pool, v2))),
+            PendingPoolUpsertResult::Stored
+        );
+        let rev_vault = pending
+            .latest_revision_for(pool, ConsumerId::Momentum)
+            .expect("vault stored");
+
+        assert_eq!(
+            pending.upsert(PendingPoolCommand::RegisterReserves(mk_snapshot(pool, v4))),
+            PendingPoolUpsertResult::Coalesced
+        );
+        let rev_reserve = pending
+            .latest_revision_for(pool, ConsumerId::Momentum)
+            .expect("reserve newer");
+
+        assert_eq!(
+            pending.upsert(PendingPoolCommand::RefreshDlmm {
+                snapshot: mk_snapshot(pool, v3),
+                new_active_id: 9,
+            }),
+            PendingPoolUpsertResult::Coalesced
+        );
+        let rev_dlmm = pending
+            .latest_revision_for(pool, ConsumerId::Momentum)
+            .expect("dlmm newest");
+
+        // Simulate stale replay by manually constructing lower-revision command — upsert assigns
+        // monotonic revision so we verify only latest survives drain.
+        assert!(rev_dlmm > rev_reserve);
+        assert!(rev_reserve > rev_vault);
+
+        let drained = pending.drain_all();
+        assert_eq!(drained.len(), 1);
+        match &drained[0] {
+            PendingPoolCommand::RefreshDlmm {
+                snapshot,
+                new_active_id,
+            } => {
+                assert_eq!(snapshot.revision, rev_dlmm);
+                assert_eq!(snapshot.vaults[0].pubkey, v3);
+                assert_eq!(*new_active_id, 9);
+            }
+            other => panic!("expected RefreshDlmm latest, got {other:?}"),
         }
     }
 }

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -1,7 +1,9 @@
 //! Bounded durable pending state for track-worker commands lost on full queue.
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering};
+#[cfg(test)]
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -10,8 +12,6 @@ use solana_sdk::pubkey::Pubkey;
 use crate::market_data::track::desired_set::ConsumerId;
 use crate::market_data::track::worker_commands::{PoolExplicitSnapshot, TrackWorkerCommand};
 
-const REVISION_SEQ_MASK: u64 = 0xFFFF_FFFF;
-const REVISION_LIFECYCLE_SHIFT: u32 = 32;
 const DEFAULT_MAX_REVISION_SLOTS: usize = 4096;
 
 /// Idempotent logical owner identity for revision-registry active slots.
@@ -62,6 +62,13 @@ pub enum InflightReserveResult {
     RegistryFull,
 }
 
+/// Which refcount to release when finishing a pool command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PoolCommandRefRelease {
+    Inflight,
+    Pending,
+}
+
 /// Terminal outcome for a pool snapshot command after worker processing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PoolCommandTerminal {
@@ -93,8 +100,7 @@ impl RevisionRefCounts {
 
 #[derive(Debug, Clone)]
 struct RevisionSlot {
-    lifecycle_id: u32,
-    issued_seq: u32,
+    last_issued: u64,
     applied_revision: u64,
     pending: u32,
     inflight: u32,
@@ -111,16 +117,70 @@ impl RevisionSlot {
     }
 }
 
+/// Coalesced pool command awaiting worker replay after queue loss.
+#[derive(Debug, Clone)]
+struct CoalescedPoolPending {
+    latest_revision: u64,
+    latest_command: PendingPoolCommand,
+}
+
+impl CoalescedPoolPending {
+    fn try_merge(&mut self, revision: u64, command: PendingPoolCommand) -> bool {
+        if revision > self.latest_revision {
+            self.latest_revision = revision;
+            self.latest_command = command;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn into_command(self) -> PendingPoolCommand {
+        self.latest_command
+    }
+}
+
+#[derive(Debug)]
+struct RevisionRegistryInner {
+    max_keys: usize,
+    max_pending_pools: usize,
+    slots: HashMap<(Pubkey, ConsumerId), RevisionSlot>,
+    pending_entries: HashMap<(Pubkey, ConsumerId), CoalescedPoolPending>,
+    pending_order: VecDeque<(Pubkey, ConsumerId)>,
+    pending_overflow: bool,
+}
+
+impl RevisionRegistryInner {
+    fn new(max_keys: usize) -> Self {
+        Self {
+            max_keys: max_keys.max(1),
+            max_pending_pools: 1,
+            slots: HashMap::new(),
+            pending_entries: HashMap::new(),
+            pending_order: VecDeque::new(),
+            pending_overflow: false,
+        }
+    }
+
+    fn maybe_remove_slot(&mut self, key: (Pubkey, ConsumerId)) {
+        if self.slots.get(&key).is_some_and(|slot| slot.empty_slot()) {
+            self.slots.remove(&key);
+        }
+    }
+}
+
 /// Bounded per-(pool,consumer) revision registry with refcounted lifecycle.
 ///
-/// Revisions pack `(lifecycle_id << 32) | sequence`. Slots are recycled only when all
-/// refcounts are zero. Active / pending / in-flight keys are never evicted.
+/// Revision slots and durable pending entries share one lock so pending refs and
+/// visible entries cannot diverge.
 #[derive(Debug)]
 pub struct PoolSnapshotRevisionSequencer {
-    max_keys: usize,
-    slots: Mutex<HashMap<(Pubkey, ConsumerId), RevisionSlot>>,
-    next_lifecycle_id: AtomicU32,
+    inner: Mutex<RevisionRegistryInner>,
     touch_seq: AtomicU64,
+    #[cfg(test)]
+    stash_hold_before_visible: AtomicBool,
+    #[cfg(test)]
+    drain_hold_before_remove: AtomicBool,
 }
 
 impl Default for PoolSnapshotRevisionSequencer {
@@ -136,43 +196,36 @@ impl PoolSnapshotRevisionSequencer {
 
     pub fn with_max_keys(max_keys: usize) -> Self {
         Self {
-            max_keys: max_keys.max(1),
-            slots: Mutex::new(HashMap::new()),
-            next_lifecycle_id: AtomicU32::new(1),
+            inner: Mutex::new(RevisionRegistryInner::new(max_keys)),
             touch_seq: AtomicU64::new(0),
+            #[cfg(test)]
+            stash_hold_before_visible: AtomicBool::new(false),
+            #[cfg(test)]
+            drain_hold_before_remove: AtomicBool::new(false),
         }
     }
 
-    pub fn pack_revision(lifecycle_id: u32, sequence: u32) -> u64 {
-        ((lifecycle_id as u64) << REVISION_LIFECYCLE_SHIFT) | (sequence as u64)
+    pub(crate) fn set_max_pending_pools(&self, max_pools: usize) {
+        self.inner
+            .lock()
+            .expect("revision registry lock")
+            .max_pending_pools = max_pools.max(1);
     }
 
-    pub fn unpack_revision(revision: u64) -> (u32, u32) {
-        (
-            (revision >> REVISION_LIFECYCLE_SHIFT) as u32,
-            (revision & REVISION_SEQ_MASK) as u32,
-        )
-    }
-
-    pub fn revision_sequence(revision: u64) -> u32 {
-        Self::unpack_revision(revision).1
-    }
-
-    pub fn revision_lifecycle_id(revision: u64) -> u32 {
-        Self::unpack_revision(revision).0
-    }
-
-    #[deprecated(note = "use revision_lifecycle_id")]
-    pub fn revision_generation(revision: u64) -> u32 {
-        Self::revision_lifecycle_id(revision)
+    pub fn revision_newer_than_applied(revision: u64, applied_revision: u64) -> bool {
+        revision != 0 && revision > applied_revision
     }
 
     pub fn max_keys(&self) -> usize {
-        self.max_keys
+        self.inner.lock().expect("revision registry lock").max_keys
     }
 
     pub fn active_key_count(&self) -> usize {
-        self.slots.lock().expect("pool revision slots lock").len()
+        self.inner
+            .lock()
+            .expect("revision registry lock")
+            .slots
+            .len()
     }
 
     pub fn total_memory_slots(&self) -> usize {
@@ -185,14 +238,9 @@ impl PoolSnapshotRevisionSequencer {
             .saturating_add(1)
     }
 
-    fn fresh_lifecycle_id(&self) -> u32 {
-        self.next_lifecycle_id.fetch_add(1, Ordering::AcqRel).max(1)
-    }
-
     fn new_slot(&self) -> RevisionSlot {
         RevisionSlot {
-            lifecycle_id: self.fresh_lifecycle_id(),
-            issued_seq: 0,
+            last_issued: 0,
             applied_revision: 0,
             pending: 0,
             inflight: 0,
@@ -200,20 +248,20 @@ impl PoolSnapshotRevisionSequencer {
         }
     }
 
-    pub fn revision_newer_than_applied(revision: u64, applied_revision: u64) -> bool {
-        revision != 0 && revision > applied_revision
-    }
-
-    fn ensure_slot(&self, key: (Pubkey, ConsumerId)) -> Result<(), RevisionAcquireResult> {
-        let mut slots = self.slots.lock().expect("pool revision slots lock");
-        if slots.contains_key(&key) {
+    fn ensure_slot_locked(
+        &self,
+        inner: &mut RevisionRegistryInner,
+        key: (Pubkey, ConsumerId),
+    ) -> Result<(), RevisionAcquireResult> {
+        if inner.slots.contains_key(&key) {
             return Ok(());
         }
-        if slots.len() < self.max_keys {
-            slots.insert(key, self.new_slot());
+        if inner.slots.len() < inner.max_keys {
+            inner.slots.insert(key, self.new_slot());
             return Ok(());
         }
-        let recyclable = slots
+        let recyclable = inner
+            .slots
             .iter()
             .filter(|(_, slot)| slot.recyclable())
             .min_by_key(|(_, slot)| slot.touch_stamp)
@@ -221,23 +269,15 @@ impl PoolSnapshotRevisionSequencer {
         let Some(victim_key) = recyclable else {
             return Err(RevisionAcquireResult::RegistryFull);
         };
-        slots.remove(&victim_key);
-        slots.insert(key, self.new_slot());
+        inner.slots.remove(&victim_key);
+        inner.slots.insert(key, self.new_slot());
         Ok(())
-    }
-
-    fn maybe_remove_slot(
-        slots: &mut HashMap<(Pubkey, ConsumerId), RevisionSlot>,
-        key: (Pubkey, ConsumerId),
-    ) {
-        if slots.get(&key).is_some_and(|slot| slot.empty_slot()) {
-            slots.remove(&key);
-        }
     }
 
     /// Ensure a revision-registry key exists (ownership lives in bounded pin maps).
     pub fn ensure_revision_key(&self, pool: Pubkey, consumer: ConsumerId) -> RevisionAcquireResult {
-        self.ensure_slot((pool, consumer))
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        self.ensure_slot_locked(&mut inner, (pool, consumer))
             .map(|()| RevisionAcquireResult::Acquired)
             .unwrap_or(RevisionAcquireResult::RegistryFull)
     }
@@ -264,8 +304,8 @@ impl PoolSnapshotRevisionSequencer {
 
     pub fn inc_pending_ref(&self, pool: Pubkey, consumer: ConsumerId) {
         let key = (pool, consumer);
-        let mut slots = self.slots.lock().expect("pool revision slots lock");
-        if let Some(slot) = slots.get_mut(&key) {
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        if let Some(slot) = inner.slots.get_mut(&key) {
             slot.pending = slot.pending.saturating_add(1);
             slot.touch_stamp = self.next_touch_stamp();
         }
@@ -273,8 +313,8 @@ impl PoolSnapshotRevisionSequencer {
 
     pub fn dec_pending_ref(&self, pool: Pubkey, consumer: ConsumerId) {
         let key = (pool, consumer);
-        let mut slots = self.slots.lock().expect("pool revision slots lock");
-        let Some(slot) = slots.get_mut(&key) else {
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        let Some(slot) = inner.slots.get_mut(&key) else {
             return;
         };
         slot.pending = slot.pending.saturating_sub(1);
@@ -287,11 +327,11 @@ impl PoolSnapshotRevisionSequencer {
         consumer: ConsumerId,
     ) -> InflightReserveResult {
         let key = (pool, consumer);
-        if let Err(RevisionAcquireResult::RegistryFull) = self.ensure_slot(key) {
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        if let Err(RevisionAcquireResult::RegistryFull) = self.ensure_slot_locked(&mut inner, key) {
             return InflightReserveResult::RegistryFull;
         }
-        let mut slots = self.slots.lock().expect("pool revision slots lock");
-        let Some(slot) = slots.get_mut(&key) else {
+        let Some(slot) = inner.slots.get_mut(&key) else {
             return InflightReserveResult::RegistryFull;
         };
         slot.inflight = slot.inflight.saturating_add(1);
@@ -307,8 +347,8 @@ impl PoolSnapshotRevisionSequencer {
     /// Atomically move one in-flight ref to pending (enqueue loss path).
     pub fn transfer_inflight_to_pending(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
         let key = (pool, consumer);
-        let mut slots = self.slots.lock().expect("pool revision slots lock");
-        let Some(slot) = slots.get_mut(&key) else {
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        let Some(slot) = inner.slots.get_mut(&key) else {
             return false;
         };
         if slot.inflight == 0 {
@@ -322,8 +362,8 @@ impl PoolSnapshotRevisionSequencer {
 
     pub fn release_inflight_command(&self, pool: Pubkey, consumer: ConsumerId) {
         let key = (pool, consumer);
-        let mut slots = self.slots.lock().expect("pool revision slots lock");
-        let Some(slot) = slots.get_mut(&key) else {
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        let Some(slot) = inner.slots.get_mut(&key) else {
             return;
         };
         slot.inflight = slot.inflight.saturating_sub(1);
@@ -335,9 +375,10 @@ impl PoolSnapshotRevisionSequencer {
     }
 
     pub fn key_refs(&self, pool: Pubkey, consumer: ConsumerId) -> RevisionRefCounts {
-        self.slots
+        self.inner
             .lock()
-            .expect("pool revision slots lock")
+            .expect("revision registry lock")
+            .slots
             .get(&(pool, consumer))
             .map(|slot| RevisionRefCounts {
                 pending: slot.pending,
@@ -353,18 +394,20 @@ impl PoolSnapshotRevisionSequencer {
 
     pub fn assign_next(&self, snapshot: &mut PoolExplicitSnapshot) -> RevisionAssignResult {
         let key = (snapshot.pool, snapshot.consumer);
-        let mut slots = self.slots.lock().expect("pool revision slots lock");
-        let Some(slot) = slots.get_mut(&key) else {
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        let Some(slot) = inner.slots.get_mut(&key) else {
             return RevisionAssignResult::KeyNotRegistered;
         };
-        if slot.issued_seq == u32::MAX {
-            slot.lifecycle_id = self.fresh_lifecycle_id();
-            slot.issued_seq = 0;
+        let Some(next) = slot.last_issued.checked_add(1) else {
+            return RevisionAssignResult::RegistryFull;
+        };
+        if next == 0 {
+            return RevisionAssignResult::RegistryFull;
         }
-        slot.issued_seq = slot.issued_seq.saturating_add(1);
+        slot.last_issued = next;
         slot.touch_stamp = self.next_touch_stamp();
-        snapshot.revision = Self::pack_revision(slot.lifecycle_id, slot.issued_seq);
-        RevisionAssignResult::Assigned(snapshot.revision)
+        snapshot.revision = next;
+        RevisionAssignResult::Assigned(next)
     }
 
     pub fn revision_acceptable(&self, snapshot: &PoolExplicitSnapshot) -> bool {
@@ -380,9 +423,10 @@ impl PoolSnapshotRevisionSequencer {
             return PoolCommandAcceptPhase::Stale;
         }
         let ready = self
-            .slots
+            .inner
             .lock()
-            .expect("pool revision slots lock")
+            .expect("revision registry lock")
+            .slots
             .get(&(snapshot.pool, snapshot.consumer))
             .is_some_and(|slot| {
                 Self::revision_newer_than_applied(snapshot.revision, slot.applied_revision)
@@ -394,27 +438,41 @@ impl PoolSnapshotRevisionSequencer {
         }
     }
 
-    /// Finish a pool command — releases exactly one in-flight ref when requested and may
+    /// Finish a pool command — releases exactly one ref when requested and may
     /// advance the authoritative applied-revision watermark after demand validation.
     pub fn finish_pool_command(
         &self,
         snapshot: &PoolExplicitSnapshot,
         terminal: PoolCommandTerminal,
-        finish_inflight: bool,
+        release_ref: Option<PoolCommandRefRelease>,
         record_watermark: bool,
     ) {
         if snapshot.revision == 0 {
-            if finish_inflight {
-                self.release_inflight_command(snapshot.pool, snapshot.consumer);
+            if let Some(release) = release_ref {
+                match release {
+                    PoolCommandRefRelease::Inflight => {
+                        self.release_inflight_command(snapshot.pool, snapshot.consumer);
+                    }
+                    PoolCommandRefRelease::Pending => {
+                        self.dec_pending_ref(snapshot.pool, snapshot.consumer);
+                    }
+                }
             }
             return;
         }
         let key = (snapshot.pool, snapshot.consumer);
-        let mut slots = self.slots.lock().expect("pool revision slots lock");
-        let Some(slot) = slots.get_mut(&key) else {
-            if finish_inflight {
-                drop(slots);
-                self.release_inflight_command(snapshot.pool, snapshot.consumer);
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        let Some(slot) = inner.slots.get_mut(&key) else {
+            drop(inner);
+            if let Some(release) = release_ref {
+                match release {
+                    PoolCommandRefRelease::Inflight => {
+                        self.release_inflight_command(snapshot.pool, snapshot.consumer);
+                    }
+                    PoolCommandRefRelease::Pending => {
+                        self.dec_pending_ref(snapshot.pool, snapshot.consumer);
+                    }
+                }
             }
             return;
         };
@@ -429,11 +487,18 @@ impl PoolSnapshotRevisionSequencer {
         {
             slot.applied_revision = snapshot.revision;
         }
-        if finish_inflight {
-            slot.inflight = slot.inflight.saturating_sub(1);
+        if let Some(release) = release_ref {
+            match release {
+                PoolCommandRefRelease::Inflight => {
+                    slot.inflight = slot.inflight.saturating_sub(1);
+                }
+                PoolCommandRefRelease::Pending => {
+                    slot.pending = slot.pending.saturating_sub(1);
+                }
+            }
         }
         slot.touch_stamp = self.next_touch_stamp();
-        Self::maybe_remove_slot(&mut slots, key);
+        inner.maybe_remove_slot(key);
     }
 
     #[deprecated(note = "use begin_pool_command + finish_pool_command")]
@@ -447,7 +512,7 @@ impl PoolSnapshotRevisionSequencer {
         self.finish_pool_command(
             snapshot,
             terminal,
-            true,
+            Some(PoolCommandRefRelease::Inflight),
             phase == PoolCommandAcceptPhase::Ready,
         );
         phase == PoolCommandAcceptPhase::Ready
@@ -455,14 +520,14 @@ impl PoolSnapshotRevisionSequencer {
 
     pub fn retire_key(&self, pool: Pubkey, consumer: ConsumerId) {
         let key = (pool, consumer);
-        let mut slots = self.slots.lock().expect("pool revision slots lock");
-        let Some(slot) = slots.get(&key) else {
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        let Some(slot) = inner.slots.get(&key) else {
             return;
         };
         if slot.inflight > 0 || slot.pending > 0 {
             return;
         }
-        slots.remove(&key);
+        inner.slots.remove(&key);
     }
 
     pub fn maybe_retire_key(
@@ -479,18 +544,20 @@ impl PoolSnapshotRevisionSequencer {
     }
 
     pub fn current_issued(&self, pool: Pubkey, consumer: ConsumerId) -> u64 {
-        self.slots
+        self.inner
             .lock()
-            .expect("pool revision slots lock")
+            .expect("revision registry lock")
+            .slots
             .get(&(pool, consumer))
-            .map(|slot| Self::pack_revision(slot.lifecycle_id, slot.issued_seq))
+            .map(|slot| slot.last_issued)
             .unwrap_or(0)
     }
 
     pub fn current_applied(&self, pool: Pubkey, consumer: ConsumerId) -> u64 {
-        self.slots
+        self.inner
             .lock()
-            .expect("pool revision slots lock")
+            .expect("revision registry lock")
+            .slots
             .get(&(pool, consumer))
             .map(|slot| slot.applied_revision)
             .unwrap_or(0)
@@ -501,21 +568,260 @@ impl PoolSnapshotRevisionSequencer {
         &self,
         pool: Pubkey,
         consumer: ConsumerId,
-        lifecycle_id: u32,
-        issued_seq: u32,
+        last_issued: u64,
         applied_revision: u64,
     ) {
         let key = (pool, consumer);
-        if let Err(RevisionAcquireResult::RegistryFull) = self.ensure_slot(key) {
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        if let Err(RevisionAcquireResult::RegistryFull) = self.ensure_slot_locked(&mut inner, key) {
             panic!("revision slot seed failed: registry full");
         }
-        let mut slots = self.slots.lock().expect("pool revision slots lock");
-        let slot = slots.get_mut(&key).expect("seeded revision slot");
-        slot.lifecycle_id = lifecycle_id;
-        slot.issued_seq = issued_seq;
+        let slot = inner.slots.get_mut(&key).expect("seeded revision slot");
+        slot.last_issued = last_issued;
         slot.applied_revision = applied_revision;
-        self.next_lifecycle_id
-            .fetch_max(lifecycle_id.saturating_add(1), Ordering::AcqRel);
+    }
+
+    #[cfg(test)]
+    pub fn test_set_stash_hold_before_visible(&self, hold: bool) {
+        self.stash_hold_before_visible
+            .store(hold, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub fn test_set_drain_hold_before_remove(&self, hold: bool) {
+        self.drain_hold_before_remove.store(hold, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    fn test_stash_hold_active(&self) -> bool {
+        self.stash_hold_before_visible.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    fn test_drain_hold_active(&self) -> bool {
+        self.drain_hold_before_remove.load(Ordering::Acquire)
+    }
+
+    fn assign_revision_for_command(
+        &self,
+        inner: &mut RevisionRegistryInner,
+        command: &mut PendingPoolCommand,
+    ) -> Result<u64, PendingPoolUpsertResult> {
+        let snapshot = match command {
+            PendingPoolCommand::RegisterReserves(s)
+            | PendingPoolCommand::VaultsFromAccount(s)
+            | PendingPoolCommand::AfterTrade(s) => s,
+            PendingPoolCommand::RefreshDlmm { snapshot, .. } => snapshot,
+        };
+        if snapshot.revision != 0 {
+            return Ok(snapshot.revision);
+        }
+        let key = (snapshot.pool, snapshot.consumer);
+        if let Err(RevisionAcquireResult::RegistryFull) = self.ensure_slot_locked(inner, key) {
+            inner.pending_overflow = true;
+            return Err(PendingPoolUpsertResult::Overflow);
+        }
+        let Some(slot) = inner.slots.get_mut(&key) else {
+            inner.pending_overflow = true;
+            return Err(PendingPoolUpsertResult::Overflow);
+        };
+        let Some(next) = slot.last_issued.checked_add(1) else {
+            inner.pending_overflow = true;
+            return Err(PendingPoolUpsertResult::Overflow);
+        };
+        if next == 0 {
+            inner.pending_overflow = true;
+            return Err(PendingPoolUpsertResult::Overflow);
+        }
+        slot.last_issued = next;
+        slot.touch_stamp = self.next_touch_stamp();
+        snapshot.revision = next;
+        Ok(next)
+    }
+
+    fn stash_hold_spin(&self) {
+        #[cfg(test)]
+        {
+            while self.stash_hold_before_visible.load(Ordering::Acquire) {
+                std::thread::yield_now();
+            }
+        }
+    }
+
+    fn drain_hold_spin(&self) {
+        #[cfg(test)]
+        {
+            while self.drain_hold_before_remove.load(Ordering::Acquire) {
+                std::thread::yield_now();
+            }
+        }
+    }
+
+    pub(crate) fn pending_upsert(
+        &self,
+        mut command: PendingPoolCommand,
+    ) -> PendingPoolUpsertResult {
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        let revision = match self.assign_revision_for_command(&mut inner, &mut command) {
+            Ok(rev) => rev,
+            Err(result) => return result,
+        };
+        let key = (command.pool(), command.consumer());
+        if let Some(entry) = inner.pending_entries.get_mut(&key) {
+            if entry.try_merge(revision, command) {
+                return PendingPoolUpsertResult::Coalesced;
+            }
+            return PendingPoolUpsertResult::StaleNoOp;
+        }
+        if inner.pending_order.len() >= inner.max_pending_pools {
+            inner.pending_overflow = true;
+            return PendingPoolUpsertResult::Overflow;
+        }
+
+        if let Some(slot) = inner.slots.get_mut(&key) {
+            slot.pending = slot.pending.saturating_add(1);
+            slot.touch_stamp = self.next_touch_stamp();
+        }
+
+        let coalesced = CoalescedPoolPending {
+            latest_revision: revision,
+            latest_command: command,
+        };
+        inner.pending_entries.insert(key, coalesced);
+        inner.pending_order.push_back(key);
+        PendingPoolUpsertResult::Stored
+    }
+
+    pub(crate) fn pending_upsert_after_inflight_send_failure(
+        &self,
+        pool: Pubkey,
+        consumer: ConsumerId,
+        command: PendingPoolCommand,
+    ) -> PendingPoolUpsertResult {
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        let mut command = command;
+        let revision = match self.assign_revision_for_command(&mut inner, &mut command) {
+            Ok(rev) => rev,
+            Err(result) => {
+                if let Some(slot) = inner.slots.get_mut(&(pool, consumer)) {
+                    slot.inflight = slot.inflight.saturating_sub(1);
+                }
+                return result;
+            }
+        };
+        let key = (pool, consumer);
+        if let Some(entry) = inner.pending_entries.get_mut(&key) {
+            if entry.try_merge(revision, command) {
+                if let Some(slot) = inner.slots.get_mut(&key) {
+                    slot.inflight = slot.inflight.saturating_sub(1);
+                }
+                return PendingPoolUpsertResult::Coalesced;
+            }
+            if let Some(slot) = inner.slots.get_mut(&key) {
+                slot.inflight = slot.inflight.saturating_sub(1);
+            }
+            return PendingPoolUpsertResult::StaleNoOp;
+        }
+        if inner.pending_order.len() >= inner.max_pending_pools {
+            if let Some(slot) = inner.slots.get_mut(&key) {
+                slot.inflight = slot.inflight.saturating_sub(1);
+            }
+            inner.pending_overflow = true;
+            return PendingPoolUpsertResult::Overflow;
+        }
+
+        let Some(slot) = inner.slots.get_mut(&key) else {
+            inner.pending_overflow = true;
+            return PendingPoolUpsertResult::Overflow;
+        };
+        if slot.inflight == 0 {
+            inner.pending_overflow = true;
+            return PendingPoolUpsertResult::Overflow;
+        }
+        slot.inflight = slot.inflight.saturating_sub(1);
+        slot.pending = slot.pending.saturating_add(1);
+        slot.touch_stamp = self.next_touch_stamp();
+
+        let coalesced = CoalescedPoolPending {
+            latest_revision: revision,
+            latest_command: command,
+        };
+        drop(inner);
+        self.stash_hold_spin();
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        inner.pending_entries.insert(key, coalesced);
+        inner.pending_order.push_back(key);
+        PendingPoolUpsertResult::Stored
+    }
+
+    pub(crate) fn pending_drain_all(&self) -> Vec<PendingPoolCommand> {
+        let mut inner = self.inner.lock().expect("revision registry lock");
+        let keys: Vec<_> = inner.pending_order.drain(..).collect();
+        drop(inner);
+        let mut drained = Vec::with_capacity(keys.len());
+        for k in keys {
+            self.drain_hold_spin();
+            let mut inner = self.inner.lock().expect("revision registry lock");
+            let Some(coalesced) = inner.pending_entries.remove(&k) else {
+                continue;
+            };
+            if let Some(slot) = inner.slots.get_mut(&k) {
+                slot.pending = slot.pending.saturating_sub(1);
+            }
+            drained.push(coalesced.into_command());
+        }
+        drained
+    }
+
+    pub(crate) fn pending_is_empty(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("revision registry lock")
+            .pending_entries
+            .is_empty()
+    }
+
+    pub(crate) fn pending_overflowed(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("revision registry lock")
+            .pending_overflow
+    }
+
+    pub(crate) fn pending_clear_overflow(&self) {
+        self.inner
+            .lock()
+            .expect("revision registry lock")
+            .pending_overflow = false;
+    }
+
+    pub(crate) fn pending_pool_count(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("revision registry lock")
+            .pending_entries
+            .len()
+    }
+
+    pub(crate) fn pending_latest_revision_for(
+        &self,
+        pool: Pubkey,
+        consumer: ConsumerId,
+    ) -> Option<u64> {
+        self.inner
+            .lock()
+            .expect("revision registry lock")
+            .pending_entries
+            .get(&(pool, consumer))
+            .map(|e| e.latest_revision)
+    }
+
+    pub(crate) fn pending_has_entry(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
+        self.inner
+            .lock()
+            .expect("revision registry lock")
+            .pending_entries
+            .contains_key(&(pool, consumer))
     }
 }
 
@@ -590,32 +896,6 @@ pub enum PendingPoolUpsertResult {
     Overflow,
 }
 
-/// Per-pool latest authoritative pending command (one slot per pool+consumer, revision wins).
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-struct CoalescedPoolPending {
-    pool: Pubkey,
-    consumer: ConsumerId,
-    latest_revision: u64,
-    latest_command: PendingPoolCommand,
-}
-
-impl CoalescedPoolPending {
-    fn try_merge(&mut self, revision: u64, command: PendingPoolCommand) -> bool {
-        if revision > self.latest_revision {
-            self.latest_revision = revision;
-            self.latest_command = command;
-            true
-        } else {
-            false
-        }
-    }
-
-    fn into_command(self) -> PendingPoolCommand {
-        self.latest_command
-    }
-}
-
 /// Authoritative wallet explicit demand merged under lock (no lost-update on burst ATA).
 #[derive(Debug, Default)]
 pub struct WalletExplicitPending {
@@ -678,39 +958,30 @@ impl WalletExplicitPending {
             .contains(&pk)
     }
 
+    /// Monotonic wallet revision; returns `u64::MAX` fail-closed when exhausted.
+    #[allow(clippy::manual_saturating_arithmetic)]
     fn bump_revision(&self) -> u64 {
-        self.revision.fetch_add(1, Ordering::AcqRel) + 1
+        self.revision
+            .fetch_add(1, Ordering::AcqRel)
+            .checked_add(1)
+            .unwrap_or(u64::MAX)
     }
-}
-
-enum PendingRefPolicy {
-    IncrementOnStore,
-    Defer,
 }
 
 /// Bounded per-pool coalesced pending (one entry per pool+consumer; overflow is fail-closed).
 #[derive(Debug)]
 pub struct PendingPoolRegistrations {
-    max_pools: usize,
-    entries: Mutex<HashMap<(Pubkey, ConsumerId), CoalescedPoolPending>>,
-    order: Mutex<VecDeque<(Pubkey, ConsumerId)>>,
-    overflow: AtomicBool,
     revisions: std::sync::Arc<PoolSnapshotRevisionSequencer>,
 }
 
 impl PendingPoolRegistrations {
     pub fn new(max_pools: usize, revisions: std::sync::Arc<PoolSnapshotRevisionSequencer>) -> Self {
-        Self {
-            max_pools: max_pools.max(1),
-            entries: Mutex::new(HashMap::new()),
-            order: Mutex::new(VecDeque::new()),
-            overflow: AtomicBool::new(false),
-            revisions,
-        }
+        revisions.set_max_pending_pools(max_pools);
+        Self { revisions }
     }
 
-    pub fn upsert(&self, mut command: PendingPoolCommand) -> PendingPoolUpsertResult {
-        self.upsert_internal(&mut command, PendingRefPolicy::IncrementOnStore)
+    pub fn upsert(&self, command: PendingPoolCommand) -> PendingPoolUpsertResult {
+        self.revisions.pending_upsert(command)
     }
 
     /// Transactional stash after queue send failure while holding one in-flight reservation.
@@ -720,23 +991,8 @@ impl PendingPoolRegistrations {
         consumer: ConsumerId,
         command: PendingPoolCommand,
     ) -> PendingPoolUpsertResult {
-        let mut command = command;
-        let result = self.upsert_internal(&mut command, PendingRefPolicy::Defer);
-        match result {
-            PendingPoolUpsertResult::Stored => {
-                if !self.revisions.transfer_inflight_to_pending(pool, consumer) {
-                    self.revisions.release_inflight_command(pool, consumer);
-                    self.overflow.store(true, Ordering::Release);
-                    return PendingPoolUpsertResult::Overflow;
-                }
-            }
-            PendingPoolUpsertResult::Coalesced
-            | PendingPoolUpsertResult::StaleNoOp
-            | PendingPoolUpsertResult::Overflow => {
-                self.revisions.release_inflight_command(pool, consumer);
-            }
-        }
-        result
+        self.revisions
+            .pending_upsert_after_inflight_send_failure(pool, consumer, command)
     }
 
     #[deprecated(note = "use upsert_after_inflight_send_failure")]
@@ -744,122 +1000,32 @@ impl PendingPoolRegistrations {
         self.upsert(command)
     }
 
-    fn upsert_internal(
-        &self,
-        command: &mut PendingPoolCommand,
-        ref_policy: PendingRefPolicy,
-    ) -> PendingPoolUpsertResult {
-        let revision = match command {
-            PendingPoolCommand::RegisterReserves(s)
-            | PendingPoolCommand::VaultsFromAccount(s)
-            | PendingPoolCommand::AfterTrade(s) => {
-                if s.revision == 0 {
-                    match self.revisions.assign_next(s) {
-                        RevisionAssignResult::Assigned(rev) => rev,
-                        RevisionAssignResult::RegistryFull => {
-                            self.overflow.store(true, Ordering::Release);
-                            return PendingPoolUpsertResult::Overflow;
-                        }
-                        RevisionAssignResult::KeyNotRegistered => {
-                            self.overflow.store(true, Ordering::Release);
-                            return PendingPoolUpsertResult::Overflow;
-                        }
-                    }
-                } else {
-                    s.revision
-                }
-            }
-            PendingPoolCommand::RefreshDlmm { snapshot, .. } => {
-                if snapshot.revision == 0 {
-                    match self.revisions.assign_next(snapshot) {
-                        RevisionAssignResult::Assigned(rev) => rev,
-                        RevisionAssignResult::RegistryFull => {
-                            self.overflow.store(true, Ordering::Release);
-                            return PendingPoolUpsertResult::Overflow;
-                        }
-                        RevisionAssignResult::KeyNotRegistered => {
-                            self.overflow.store(true, Ordering::Release);
-                            return PendingPoolUpsertResult::Overflow;
-                        }
-                    }
-                } else {
-                    snapshot.revision
-                }
-            }
-        };
-        let key = (command.pool(), command.consumer());
-        let mut entries = self.entries.lock().expect("pending pool lock");
-        let mut order = self.order.lock().expect("pending pool order lock");
-        if let Some(entry) = entries.get_mut(&key) {
-            if entry.try_merge(revision, command.clone()) {
-                return PendingPoolUpsertResult::Coalesced;
-            }
-            return PendingPoolUpsertResult::StaleNoOp;
-        }
-        if order.len() >= self.max_pools {
-            self.overflow.store(true, Ordering::Release);
-            return PendingPoolUpsertResult::Overflow;
-        }
-        match ref_policy {
-            PendingRefPolicy::IncrementOnStore => {
-                self.revisions.inc_pending_ref(key.0, key.1);
-            }
-            PendingRefPolicy::Defer => {}
-        }
-        let coalesced = CoalescedPoolPending {
-            pool: key.0,
-            consumer: key.1,
-            latest_revision: revision,
-            latest_command: command.clone(),
-        };
-        entries.insert(key, coalesced);
-        order.push_back(key);
-        PendingPoolUpsertResult::Stored
-    }
-
     pub fn drain_all(&self) -> Vec<PendingPoolCommand> {
-        let mut entries = self.entries.lock().expect("pending pool lock");
-        let mut order = self.order.lock().expect("pending pool order lock");
-        let keys: Vec<_> = order.drain(..).collect();
-        keys.into_iter()
-            .filter_map(|k| entries.remove(&k))
-            .map(|coalesced| {
-                self.revisions
-                    .dec_pending_ref(coalesced.pool, coalesced.consumer);
-                coalesced.into_command()
-            })
-            .collect()
+        self.revisions.pending_drain_all()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.entries.lock().expect("pending pool lock").is_empty()
+        self.revisions.pending_is_empty()
     }
 
     pub fn overflowed(&self) -> bool {
-        self.overflow.load(Ordering::Acquire)
+        self.revisions.pending_overflowed()
     }
 
     pub fn clear_overflow(&self) {
-        self.overflow.store(false, Ordering::Release);
+        self.revisions.pending_clear_overflow();
     }
 
     pub fn pool_count(&self) -> usize {
-        self.entries.lock().expect("pending pool lock").len()
+        self.revisions.pending_pool_count()
     }
 
     pub fn latest_revision_for(&self, pool: Pubkey, consumer: ConsumerId) -> Option<u64> {
-        self.entries
-            .lock()
-            .expect("pending pool lock")
-            .get(&(pool, consumer))
-            .map(|e| e.latest_revision)
+        self.revisions.pending_latest_revision_for(pool, consumer)
     }
 
     pub fn has_pending(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
-        self.entries
-            .lock()
-            .expect("pending pool lock")
-            .contains_key(&(pool, consumer))
+        self.revisions.pending_has_entry(pool, consumer)
     }
 }
 
@@ -1028,6 +1194,20 @@ mod tests {
         );
     }
 
+    fn finish_inflight(
+        revisions: &PoolSnapshotRevisionSequencer,
+        snapshot: &PoolExplicitSnapshot,
+        terminal: PoolCommandTerminal,
+        record_watermark: bool,
+    ) {
+        revisions.finish_pool_command(
+            snapshot,
+            terminal,
+            Some(PoolCommandRefRelease::Inflight),
+            record_watermark,
+        );
+    }
+
     #[test]
     fn revision_key_ensure_is_idempotent() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
@@ -1045,9 +1225,9 @@ mod tests {
         let rev = register_and_assign(&revisions, pool, ConsumerId::Momentum);
         let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
         snapshot.revision = rev;
-        revisions.finish_pool_command(&snapshot, PoolCommandTerminal::Applied, true, true);
+        finish_inflight(&revisions, &snapshot, PoolCommandTerminal::Applied, true);
         assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).total(), 0);
-        assert!(revisions.current_applied(pool, ConsumerId::Momentum) > 0);
+        assert_eq!(revisions.current_applied(pool, ConsumerId::Momentum), rev);
     }
 
     #[test]
@@ -1058,7 +1238,7 @@ mod tests {
         let rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
         let mut stale = mk_snapshot(pool, Pubkey::new_unique());
         stale.revision = rev;
-        revisions.finish_pool_command(&stale, PoolCommandTerminal::Applied, true, true);
+        finish_inflight(&revisions, &stale, PoolCommandTerminal::Applied, true);
         let mut older = mk_snapshot(pool, Pubkey::new_unique());
         older.revision = rev.saturating_sub(1);
         assert!(!revisions.revision_acceptable(&older));
@@ -1067,7 +1247,12 @@ mod tests {
             InflightReserveResult::Reserved
         );
         older.revision = rev;
-        revisions.finish_pool_command(&older, PoolCommandTerminal::StaleRevision, true, false);
+        finish_inflight(
+            &revisions,
+            &older,
+            PoolCommandTerminal::StaleRevision,
+            false,
+        );
         assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).inflight, 0);
     }
 
@@ -1094,10 +1279,10 @@ mod tests {
         let rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
         let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
         snapshot.revision = rev;
-        revisions.finish_pool_command(
+        finish_inflight(
+            &revisions,
             &snapshot,
             PoolCommandTerminal::UnpinnedRejected,
-            true,
             false,
         );
         assert_eq!(revisions.active_key_count(), 0);
@@ -1106,10 +1291,10 @@ mod tests {
             let rev = reserve_assign(&revisions, ephemeral_pool, ConsumerId::Momentum);
             let mut snap = mk_snapshot(ephemeral_pool, Pubkey::new_unique());
             snap.revision = rev;
-            revisions.finish_pool_command(
+            finish_inflight(
+                &revisions,
                 &snap,
                 PoolCommandTerminal::UnpinnedRejected,
-                true,
                 false,
             );
         }
@@ -1117,43 +1302,22 @@ mod tests {
     }
 
     #[test]
-    fn revision_seq_near_wrap_allocates_new_lifecycle() {
+    fn revision_u64_max_exhaustion_fails_closed() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         let pool = Pubkey::new_unique();
         ensure_key(&revisions, pool, ConsumerId::Momentum);
-        revisions.test_seed_slot_revision_state(
-            pool,
-            ConsumerId::Momentum,
-            7,
-            u32::MAX,
-            PoolSnapshotRevisionSequencer::pack_revision(7, u32::MAX - 1),
-        );
+        revisions.test_seed_slot_revision_state(pool, ConsumerId::Momentum, u64::MAX, u64::MAX - 1);
         let mut snap = mk_snapshot(pool, Pubkey::new_unique());
-        let rev_wrap = match revisions.assign_next(&mut snap) {
-            RevisionAssignResult::Assigned(rev) => rev,
-            other => panic!("{other:?}"),
-        };
         assert_eq!(
-            PoolSnapshotRevisionSequencer::revision_lifecycle_id(rev_wrap),
-            8
+            revisions.assign_next(&mut snap),
+            RevisionAssignResult::RegistryFull
         );
-        assert_eq!(
-            PoolSnapshotRevisionSequencer::revision_sequence(rev_wrap),
-            1
-        );
-        assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
-        let mut stale = mk_snapshot(pool, Pubkey::new_unique());
-        stale.revision = PoolSnapshotRevisionSequencer::pack_revision(7, u32::MAX);
-        revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision, true, false);
-        assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
-        revisions.finish_pool_command(&snap, PoolCommandTerminal::Applied, true, true);
     }
 
     #[test]
     fn pending_replays_latest_revision_not_kind_order() {
-        let (pending, revisions) = mk_pending(8);
+        let (pending, _revisions) = mk_pending(8);
         let pool = Pubkey::new_unique();
-        ensure_key(&revisions, pool, ConsumerId::Momentum);
         let old_vault = Pubkey::new_unique();
         let new_vault = Pubkey::new_unique();
 
@@ -1171,10 +1335,7 @@ mod tests {
         assert_eq!(drained.len(), 1);
         match &drained[0] {
             PendingPoolCommand::AfterTrade(s) => {
-                assert_eq!(
-                    PoolSnapshotRevisionSequencer::revision_sequence(s.revision),
-                    2
-                );
+                assert_eq!(s.revision, 2);
                 assert_eq!(s.vaults[0].pubkey, new_vault);
             }
             other => panic!("expected AfterTrade latest, got {other:?}"),
@@ -1251,10 +1412,15 @@ mod tests {
                 other => panic!("{other:?}"),
             }
         };
-        revisions.finish_pool_command(&older, PoolCommandTerminal::Applied, true, true);
+        finish_inflight(&revisions, &older, PoolCommandTerminal::Applied, true);
         assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
         newer.revision = rev_new;
-        revisions.finish_pool_command(&newer, PoolCommandTerminal::StaleRevision, true, false);
+        finish_inflight(
+            &revisions,
+            &newer,
+            PoolCommandTerminal::StaleRevision,
+            false,
+        );
         assert_eq!(
             revisions.current_applied(pool, ConsumerId::Momentum),
             rev_latest
@@ -1270,7 +1436,7 @@ mod tests {
             let revision = register_and_assign(&revisions, pool, ConsumerId::Momentum);
             let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
             snapshot.revision = revision;
-            revisions.finish_pool_command(&snapshot, PoolCommandTerminal::Applied, true, true);
+            finish_inflight(&revisions, &snapshot, PoolCommandTerminal::Applied, true);
         }
         assert!(
             revisions.active_key_count() <= 8,
@@ -1297,14 +1463,14 @@ mod tests {
     }
 
     #[test]
-    fn retired_lifecycle_rejects_delayed_stale_command_after_repin() {
+    fn repinned_slot_rejects_stale_after_newer_applied() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         let pool = Pubkey::new_unique();
         ensure_key(&revisions, pool, ConsumerId::Momentum);
         let mut stale = mk_snapshot(pool, Pubkey::new_unique());
         let stale_rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
         stale.revision = stale_rev;
-        revisions.finish_pool_command(&stale, PoolCommandTerminal::Applied, true, true);
+        finish_inflight(&revisions, &stale, PoolCommandTerminal::Applied, true);
         revisions.retire_key(pool, ConsumerId::Momentum);
         assert_eq!(revisions.active_key_count(), 0);
 
@@ -1312,18 +1478,25 @@ mod tests {
         let mut fresh = mk_snapshot(pool, Pubkey::new_unique());
         let fresh_rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
         fresh.revision = fresh_rev;
-        assert!(
-            PoolSnapshotRevisionSequencer::revision_lifecycle_id(fresh_rev)
-                > PoolSnapshotRevisionSequencer::revision_lifecycle_id(stale_rev)
-        );
         assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
+        let mut newer = mk_snapshot(pool, Pubkey::new_unique());
+        let newer_rev = {
+            assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
+            match revisions.assign_next(&mut newer) {
+                RevisionAssignResult::Assigned(rev) => rev,
+                other => panic!("{other:?}"),
+            }
+        };
+        finish_inflight(&revisions, &newer, PoolCommandTerminal::Applied, true);
         stale.revision = stale_rev;
-        revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision, true, false);
-        assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
-        revisions.finish_pool_command(&fresh, PoolCommandTerminal::Applied, true, true);
+        assert_eq!(
+            revisions.begin_pool_command(&stale),
+            PoolCommandAcceptPhase::Stale
+        );
+        finish_inflight(&revisions, &fresh, PoolCommandTerminal::Applied, true);
         assert_eq!(
             revisions.current_applied(pool, ConsumerId::Momentum),
-            fresh_rev
+            newer_rev
         );
     }
 
@@ -1336,7 +1509,7 @@ mod tests {
             let rev = register_and_assign(&revisions, pool, ConsumerId::Momentum);
             let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
             snapshot.revision = rev;
-            revisions.finish_pool_command(&snapshot, PoolCommandTerminal::Applied, true, true);
+            finish_inflight(&revisions, &snapshot, PoolCommandTerminal::Applied, true);
             issued.push((pool, rev));
         }
         assert!(revisions.active_key_count() <= 16);
@@ -1344,7 +1517,12 @@ mod tests {
             let mut stale = mk_snapshot(pool, Pubkey::new_unique());
             stale.revision = stale_rev;
             assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
-            revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision, true, false);
+            finish_inflight(
+                &revisions,
+                &stale,
+                PoolCommandTerminal::StaleRevision,
+                false,
+            );
         }
     }
 
@@ -1445,14 +1623,110 @@ mod tests {
         let rev = register_and_assign(&revisions, pool, ConsumerId::Momentum);
         let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
         snapshot.revision = rev;
-        revisions.finish_pool_command(&snapshot, PoolCommandTerminal::Applied, true, true);
+        finish_inflight(&revisions, &snapshot, PoolCommandTerminal::Applied, true);
         let mut stale = mk_snapshot(pool, Pubkey::new_unique());
         stale.revision = rev.saturating_sub(1);
         assert_eq!(
             revisions.begin_pool_command(&stale),
             PoolCommandAcceptPhase::Stale
         );
-        revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision, true, false);
+        finish_inflight(
+            &revisions,
+            &stale,
+            PoolCommandTerminal::StaleRevision,
+            false,
+        );
         assert_eq!(revisions.current_applied(pool, ConsumerId::Momentum), rev);
+    }
+
+    #[test]
+    fn pending_replay_releases_pending_ref_on_stale_terminal() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
+        let pool = Pubkey::new_unique();
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
+        revisions.inc_pending_ref(pool, ConsumerId::Momentum);
+        let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
+        snapshot.revision = 1;
+        revisions.finish_pool_command(
+            &snapshot,
+            PoolCommandTerminal::StaleRevision,
+            Some(PoolCommandRefRelease::Pending),
+            true,
+        );
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).pending, 0);
+    }
+
+    #[test]
+    fn atomic_stash_visible_only_with_pending_ref() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let revisions = Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(8));
+        let pending = Arc::new(PendingPoolRegistrations::new(8, Arc::clone(&revisions)));
+        let pool = Pubkey::new_unique();
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
+        let rev = register_and_assign(&revisions, pool, ConsumerId::Momentum);
+        revisions.release_inflight_command(pool, ConsumerId::Momentum);
+
+        revisions.test_set_stash_hold_before_visible(true);
+
+        let revisions_producer = Arc::clone(&revisions);
+        let pending_producer = Arc::clone(&pending);
+        let producer = thread::spawn(move || {
+            let mut snap = mk_snapshot(pool, Pubkey::new_unique());
+            snap.revision = rev;
+            assert_reserved_inflight(&revisions_producer, pool, ConsumerId::Momentum);
+            pending_producer.upsert_after_inflight_send_failure(
+                pool,
+                ConsumerId::Momentum,
+                PendingPoolCommand::RegisterReserves(snap),
+            )
+        });
+
+        for _ in 0..200 {
+            let has_entry = pending.has_pending(pool, ConsumerId::Momentum);
+            let refs = revisions.key_refs(pool, ConsumerId::Momentum);
+            if has_entry {
+                assert!(
+                    refs.pending > 0,
+                    "visible pending entry must have pending ref"
+                );
+            }
+            if refs.pending > 0 && !has_entry {
+                assert!(
+                    revisions.test_stash_hold_active(),
+                    "pending ref without visible entry only during stash hold"
+                );
+            }
+            thread::yield_now();
+        }
+
+        revisions.test_set_stash_hold_before_visible(false);
+        assert_eq!(
+            producer.join().expect("producer"),
+            PendingPoolUpsertResult::Stored
+        );
+        assert!(pending.has_pending(pool, ConsumerId::Momentum));
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).pending, 1);
+
+        revisions.test_set_drain_hold_before_remove(true);
+        let pending_drain = Arc::clone(&pending);
+        let drainer = thread::spawn(move || pending_drain.drain_all());
+        for _ in 0..200 {
+            let has_entry = pending.has_pending(pool, ConsumerId::Momentum);
+            let refs = revisions.key_refs(pool, ConsumerId::Momentum);
+            if !has_entry && refs.pending > 0 {
+                assert!(
+                    revisions.test_drain_hold_active(),
+                    "pending ref after entry removed only during drain hold"
+                );
+            }
+            thread::yield_now();
+        }
+        revisions.test_set_drain_hold_before_remove(false);
+        let drained = drainer.join().expect("drainer");
+        assert_eq!(drained.len(), 1);
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).pending, 0);
+        assert!(!pending.has_pending(pool, ConsumerId::Momentum));
     }
 }

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -1,7 +1,7 @@
 //! Bounded durable pending state for track-worker commands lost on full queue.
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -10,29 +10,60 @@ use solana_sdk::pubkey::Pubkey;
 use crate::market_data::track::desired_set::ConsumerId;
 use crate::market_data::track::worker_commands::{PoolExplicitSnapshot, TrackWorkerCommand};
 
-/// Monotonic per-(pool,consumer) revision sequencer for pool snapshot commands.
-///
-/// Revisions pack `(generation << 32) | sequence`. Tombstoned generations reject delayed stale
-/// commands after registry cleanup/eviction.
-#[derive(Debug)]
-pub struct PoolSnapshotRevisionSequencer {
-    max_keys: usize,
-    slots: Mutex<HashMap<(Pubkey, ConsumerId), RevisionSlot>>,
-    tombstones: Mutex<HashMap<(Pubkey, ConsumerId), u32>>,
-    lru_stamp: AtomicU64,
+const REVISION_SEQ_MASK: u64 = 0xFFFF_FFFF;
+const REVISION_LIFECYCLE_SHIFT: u32 = 32;
+const DEFAULT_MAX_REVISION_SLOTS: usize = 4096;
+
+/// Result of reserving a revision-registry slot for a pool+consumer key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevisionAcquireResult {
+    Acquired,
+    RegistryFull,
+}
+
+/// Result of issuing the next revision for a registered key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevisionAssignResult {
+    Assigned(u64),
+    RegistryFull,
+    KeyNotRegistered,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RevisionRefCounts {
+    pub active: u32,
+    pub pending: u32,
+    pub inflight: u32,
+}
+
+impl RevisionRefCounts {
+    fn total(self) -> u32 {
+        self.active
+            .saturating_add(self.pending)
+            .saturating_add(self.inflight)
+    }
 }
 
 #[derive(Debug, Clone)]
 struct RevisionSlot {
-    generation: u32,
+    lifecycle_id: u32,
     issued_seq: u32,
     applied_seq: u32,
-    lru_stamp: u64,
+    refs: RevisionRefCounts,
+    touch_stamp: u64,
 }
 
-const REVISION_SEQ_MASK: u64 = 0xFFFF_FFFF;
-const REVISION_GEN_SHIFT: u32 = 32;
-const DEFAULT_MAX_REVISION_SLOTS: usize = 4096;
+/// Bounded per-(pool,consumer) revision registry with refcounted lifecycle.
+///
+/// Revisions pack `(lifecycle_id << 32) | sequence`. Slots are recycled only when all
+/// refcounts are zero. Active / pending / in-flight keys are never evicted.
+#[derive(Debug)]
+pub struct PoolSnapshotRevisionSequencer {
+    max_keys: usize,
+    slots: Mutex<HashMap<(Pubkey, ConsumerId), RevisionSlot>>,
+    next_lifecycle_id: AtomicU32,
+    touch_seq: AtomicU64,
+}
 
 impl Default for PoolSnapshotRevisionSequencer {
     fn default() -> Self {
@@ -47,20 +78,20 @@ impl PoolSnapshotRevisionSequencer {
 
     pub fn with_max_keys(max_keys: usize) -> Self {
         Self {
-            max_keys: max_keys.max(64),
+            max_keys: max_keys.max(1),
             slots: Mutex::new(HashMap::new()),
-            tombstones: Mutex::new(HashMap::new()),
-            lru_stamp: AtomicU64::new(0),
+            next_lifecycle_id: AtomicU32::new(1),
+            touch_seq: AtomicU64::new(0),
         }
     }
 
-    pub fn pack_revision(generation: u32, sequence: u32) -> u64 {
-        ((generation as u64) << REVISION_GEN_SHIFT) | (sequence as u64)
+    pub fn pack_revision(lifecycle_id: u32, sequence: u32) -> u64 {
+        ((lifecycle_id as u64) << REVISION_LIFECYCLE_SHIFT) | (sequence as u64)
     }
 
     pub fn unpack_revision(revision: u64) -> (u32, u32) {
         (
-            (revision >> REVISION_GEN_SHIFT) as u32,
+            (revision >> REVISION_LIFECYCLE_SHIFT) as u32,
             (revision & REVISION_SEQ_MASK) as u32,
         )
     }
@@ -69,127 +100,226 @@ impl PoolSnapshotRevisionSequencer {
         Self::unpack_revision(revision).1
     }
 
-    pub fn revision_generation(revision: u64) -> u32 {
+    pub fn revision_lifecycle_id(revision: u64) -> u32 {
         Self::unpack_revision(revision).0
     }
 
-    fn next_lru_stamp(&self) -> u64 {
-        self.lru_stamp
+    #[deprecated(note = "use revision_lifecycle_id")]
+    pub fn revision_generation(revision: u64) -> u32 {
+        Self::revision_lifecycle_id(revision)
+    }
+
+    pub fn max_keys(&self) -> usize {
+        self.max_keys
+    }
+
+    pub fn active_key_count(&self) -> usize {
+        self.slots.lock().expect("pool revision slots lock").len()
+    }
+
+    pub fn total_memory_slots(&self) -> usize {
+        self.active_key_count()
+    }
+
+    fn next_touch_stamp(&self) -> u64 {
+        self.touch_seq
             .fetch_add(1, Ordering::AcqRel)
             .saturating_add(1)
     }
 
-    fn tombstone_generation(&self, key: (Pubkey, ConsumerId)) -> u32 {
-        self.tombstones
-            .lock()
-            .expect("pool revision tombstones lock")
-            .get(&key)
-            .copied()
-            .unwrap_or(0)
+    fn fresh_lifecycle_id(&self) -> u32 {
+        self.next_lifecycle_id.fetch_add(1, Ordering::AcqRel).max(1)
     }
 
-    fn record_tombstone(&self, key: (Pubkey, ConsumerId), generation: u32) {
-        let mut tombstones = self
-            .tombstones
-            .lock()
-            .expect("pool revision tombstones lock");
-        let entry = tombstones.entry(key).or_insert(0);
-        *entry = (*entry).max(generation);
-    }
-
-    fn evict_lru_slot(&self, slots: &mut HashMap<(Pubkey, ConsumerId), RevisionSlot>) {
-        if slots.len() < self.max_keys {
-            return;
-        }
-        let Some((key, slot)) = slots
-            .iter()
-            .min_by_key(|(_, slot)| slot.lru_stamp)
-            .map(|(k, s)| (*k, s.clone()))
-        else {
-            return;
-        };
-        self.record_tombstone(key, slot.generation);
-        slots.remove(&key);
-    }
-
-    pub fn assign_next(&self, snapshot: &mut PoolExplicitSnapshot) -> u64 {
-        let key = (snapshot.pool, snapshot.consumer);
-        let mut slots = self.slots.lock().expect("pool revision issued lock");
-        if !slots.contains_key(&key) {
-            self.evict_lru_slot(&mut slots);
-        }
-        let floor_gen = self.tombstone_generation(key);
-        let slot = slots.entry(key).or_insert_with(|| RevisionSlot {
-            generation: floor_gen.saturating_add(1).max(1),
+    fn new_slot(&self) -> RevisionSlot {
+        RevisionSlot {
+            lifecycle_id: self.fresh_lifecycle_id(),
             issued_seq: 0,
             applied_seq: 0,
-            lru_stamp: self.next_lru_stamp(),
-        });
+            refs: RevisionRefCounts::default(),
+            touch_stamp: self.next_touch_stamp(),
+        }
+    }
+
+    fn ensure_slot(&self, key: (Pubkey, ConsumerId)) -> Result<(), RevisionAcquireResult> {
+        let mut slots = self.slots.lock().expect("pool revision slots lock");
+        if slots.contains_key(&key) {
+            return Ok(());
+        }
+        if slots.len() < self.max_keys {
+            slots.insert(key, self.new_slot());
+            return Ok(());
+        }
+        let recyclable = slots
+            .iter()
+            .filter(|(_, slot)| slot.refs.total() == 0)
+            .min_by_key(|(_, slot)| slot.touch_stamp)
+            .map(|(k, _)| *k);
+        let Some(victim_key) = recyclable else {
+            return Err(RevisionAcquireResult::RegistryFull);
+        };
+        slots.remove(&victim_key);
+        slots.insert(key, self.new_slot());
+        Ok(())
+    }
+
+    pub fn try_acquire_active(&self, pool: Pubkey, consumer: ConsumerId) -> RevisionAcquireResult {
+        let key = (pool, consumer);
+        if let Err(result) = self.ensure_slot(key) {
+            return result;
+        }
+        let mut slots = self.slots.lock().expect("pool revision slots lock");
+        let Some(slot) = slots.get_mut(&key) else {
+            return RevisionAcquireResult::RegistryFull;
+        };
+        slot.refs.active = slot.refs.active.saturating_add(1);
+        slot.touch_stamp = self.next_touch_stamp();
+        RevisionAcquireResult::Acquired
+    }
+
+    pub fn release_active_if_idle(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
+        let key = (pool, consumer);
+        let mut slots = self.slots.lock().expect("pool revision slots lock");
+        let Some(slot) = slots.get_mut(&key) else {
+            return false;
+        };
+        slot.refs.active = slot.refs.active.saturating_sub(1);
+        if slot.refs.total() == 0 {
+            slots.remove(&key);
+            return true;
+        }
+        false
+    }
+
+    pub fn inc_pending_ref(&self, pool: Pubkey, consumer: ConsumerId) {
+        let key = (pool, consumer);
+        let mut slots = self.slots.lock().expect("pool revision slots lock");
+        if let Some(slot) = slots.get_mut(&key) {
+            slot.refs.pending = slot.refs.pending.saturating_add(1);
+            slot.touch_stamp = self.next_touch_stamp();
+        }
+    }
+
+    pub fn dec_pending_ref(&self, pool: Pubkey, consumer: ConsumerId) {
+        let key = (pool, consumer);
+        let mut slots = self.slots.lock().expect("pool revision slots lock");
+        let Some(slot) = slots.get_mut(&key) else {
+            return;
+        };
+        slot.refs.pending = slot.refs.pending.saturating_sub(1);
+        if slot.refs.total() == 0 {
+            slots.remove(&key);
+        }
+    }
+
+    pub fn inc_inflight_ref(&self, pool: Pubkey, consumer: ConsumerId) {
+        let key = (pool, consumer);
+        let mut slots = self.slots.lock().expect("pool revision slots lock");
+        if let Some(slot) = slots.get_mut(&key) {
+            slot.refs.inflight = slot.refs.inflight.saturating_add(1);
+            slot.touch_stamp = self.next_touch_stamp();
+        }
+    }
+
+    pub fn dec_inflight_ref(&self, pool: Pubkey, consumer: ConsumerId) {
+        let key = (pool, consumer);
+        let mut slots = self.slots.lock().expect("pool revision slots lock");
+        let Some(slot) = slots.get_mut(&key) else {
+            return;
+        };
+        slot.refs.inflight = slot.refs.inflight.saturating_sub(1);
+        if slot.refs.total() == 0 {
+            slots.remove(&key);
+        }
+    }
+
+    pub fn key_refs(&self, pool: Pubkey, consumer: ConsumerId) -> RevisionRefCounts {
+        self.slots
+            .lock()
+            .expect("pool revision slots lock")
+            .get(&(pool, consumer))
+            .map(|slot| slot.refs)
+            .unwrap_or_default()
+    }
+
+    pub fn assign_next(&self, snapshot: &mut PoolExplicitSnapshot) -> RevisionAssignResult {
+        let key = (snapshot.pool, snapshot.consumer);
+        let mut slots = self.slots.lock().expect("pool revision slots lock");
+        let Some(slot) = slots.get_mut(&key) else {
+            return RevisionAssignResult::KeyNotRegistered;
+        };
         slot.issued_seq = slot.issued_seq.saturating_add(1);
         if slot.issued_seq == 0 {
-            slot.generation = slot.generation.saturating_add(1);
+            slot.lifecycle_id = self.fresh_lifecycle_id();
             slot.issued_seq = 1;
         }
-        slot.lru_stamp = self.next_lru_stamp();
-        snapshot.revision = Self::pack_revision(slot.generation, slot.issued_seq);
-        snapshot.revision
+        slot.touch_stamp = self.next_touch_stamp();
+        snapshot.revision = Self::pack_revision(slot.lifecycle_id, slot.issued_seq);
+        RevisionAssignResult::Assigned(snapshot.revision)
     }
 
     pub fn should_apply_and_record(&self, snapshot: &PoolExplicitSnapshot) -> bool {
         if snapshot.revision == 0 {
             return false;
         }
-        let (gen, seq) = Self::unpack_revision(snapshot.revision);
+        let (lifecycle_id, seq) = Self::unpack_revision(snapshot.revision);
         let key = (snapshot.pool, snapshot.consumer);
-        if gen <= self.tombstone_generation(key) {
-            return false;
-        }
-        let mut slots = self.slots.lock().expect("pool revision issued lock");
+        let mut slots = self.slots.lock().expect("pool revision slots lock");
         let Some(slot) = slots.get_mut(&key) else {
             return false;
         };
-        if gen != slot.generation || seq <= slot.applied_seq {
+        if lifecycle_id != slot.lifecycle_id || seq <= slot.applied_seq {
             return false;
         }
         slot.applied_seq = seq;
-        slot.lru_stamp = self.next_lru_stamp();
+        slot.refs.inflight = slot.refs.inflight.saturating_sub(1);
+        slot.touch_stamp = self.next_touch_stamp();
+        if slot.refs.total() == 0 {
+            slots.remove(&key);
+        }
         true
     }
 
     pub fn retire_key(&self, pool: Pubkey, consumer: ConsumerId) {
         let key = (pool, consumer);
-        let mut slots = self.slots.lock().expect("pool revision issued lock");
-        if let Some(slot) = slots.remove(&key) {
-            self.record_tombstone(key, slot.generation);
+        let mut slots = self.slots.lock().expect("pool revision slots lock");
+        let Some(slot) = slots.get(&key) else {
+            return;
+        };
+        if slot.refs.total() > 0 {
+            return;
         }
+        slots.remove(&key);
     }
 
-    pub fn maybe_retire_key(&self, pool: Pubkey, consumer: ConsumerId, has_pending: bool) {
-        if has_pending {
+    pub fn maybe_retire_key(
+        &self,
+        pool: Pubkey,
+        consumer: ConsumerId,
+        has_pending: bool,
+        has_inflight: bool,
+    ) {
+        if has_pending || has_inflight {
             return;
         }
         self.retire_key(pool, consumer);
     }
 
-    pub fn active_key_count(&self) -> usize {
-        self.slots.lock().expect("pool revision issued lock").len()
-    }
-
     pub fn current_issued(&self, pool: Pubkey, consumer: ConsumerId) -> u64 {
         self.slots
             .lock()
-            .expect("pool revision issued lock")
+            .expect("pool revision slots lock")
             .get(&(pool, consumer))
-            .map(|slot| Self::pack_revision(slot.generation, slot.issued_seq))
+            .map(|slot| Self::pack_revision(slot.lifecycle_id, slot.issued_seq))
             .unwrap_or(0)
     }
 
     pub fn current_applied(&self, pool: Pubkey, consumer: ConsumerId) -> u64 {
         self.slots
             .lock()
-            .expect("pool revision issued lock")
+            .expect("pool revision slots lock")
             .get(&(pool, consumer))
-            .map(|slot| Self::pack_revision(slot.generation, slot.applied_seq))
+            .map(|slot| Self::pack_revision(slot.lifecycle_id, slot.applied_seq))
             .unwrap_or(0)
     }
 }
@@ -336,19 +466,13 @@ impl WalletExplicitPending {
 
     pub fn ensure_wallet_base(&self, wallet: Pubkey, wsol_ata: Pubkey) -> u64 {
         let mut g = self.inner.lock().expect("wallet pending lock");
-        let mut changed = false;
-        if g.demand.insert(wallet) {
-            changed = true;
-        }
-        if g.demand.insert(wsol_ata) {
-            changed = true;
-        }
-        drop(g);
-        if changed {
-            self.bump_revision()
-        } else {
-            self.current_revision()
-        }
+        g.demand.insert(wallet);
+        g.demand.insert(wsol_ata);
+        self.bump_revision()
+    }
+
+    pub fn current_revision(&self) -> u64 {
+        self.revision.load(Ordering::Acquire)
     }
 
     pub fn contains_demand(&self, pk: Pubkey) -> bool {
@@ -357,10 +481,6 @@ impl WalletExplicitPending {
             .expect("wallet pending lock")
             .demand
             .contains(&pk)
-    }
-
-    pub fn current_revision(&self) -> u64 {
-        self.revision.load(Ordering::Acquire)
     }
 
     fn bump_revision(&self) -> u64 {
@@ -395,14 +515,34 @@ impl PendingPoolRegistrations {
             | PendingPoolCommand::VaultsFromAccount(s)
             | PendingPoolCommand::AfterTrade(s) => {
                 if s.revision == 0 {
-                    self.revisions.assign_next(s)
+                    match self.revisions.assign_next(s) {
+                        RevisionAssignResult::Assigned(rev) => rev,
+                        RevisionAssignResult::RegistryFull => {
+                            self.overflow.store(true, Ordering::Release);
+                            return PendingPoolUpsertResult::Overflow;
+                        }
+                        RevisionAssignResult::KeyNotRegistered => {
+                            self.overflow.store(true, Ordering::Release);
+                            return PendingPoolUpsertResult::Overflow;
+                        }
+                    }
                 } else {
                     s.revision
                 }
             }
             PendingPoolCommand::RefreshDlmm { snapshot, .. } => {
                 if snapshot.revision == 0 {
-                    self.revisions.assign_next(snapshot)
+                    match self.revisions.assign_next(snapshot) {
+                        RevisionAssignResult::Assigned(rev) => rev,
+                        RevisionAssignResult::RegistryFull => {
+                            self.overflow.store(true, Ordering::Release);
+                            return PendingPoolUpsertResult::Overflow;
+                        }
+                        RevisionAssignResult::KeyNotRegistered => {
+                            self.overflow.store(true, Ordering::Release);
+                            return PendingPoolUpsertResult::Overflow;
+                        }
+                    }
                 } else {
                     snapshot.revision
                 }
@@ -421,6 +561,7 @@ impl PendingPoolRegistrations {
             self.overflow.store(true, Ordering::Release);
             return PendingPoolUpsertResult::Overflow;
         }
+        self.revisions.inc_pending_ref(key.0, key.1);
         let coalesced = CoalescedPoolPending {
             pool: key.0,
             consumer: key.1,
@@ -438,7 +579,11 @@ impl PendingPoolRegistrations {
         let keys: Vec<_> = order.drain(..).collect();
         keys.into_iter()
             .filter_map(|k| entries.remove(&k))
-            .map(|coalesced| coalesced.into_command())
+            .map(|coalesced| {
+                self.revisions
+                    .dec_pending_ref(coalesced.pool, coalesced.consumer);
+                coalesced.into_command()
+            })
             .collect()
     }
 
@@ -501,28 +646,32 @@ impl GeyserConnectBarrier {
         self.state.store(BARRIER_READY, Ordering::Release);
     }
 
-    pub fn mark_failed(&self) {
-        self.state.store(BARRIER_FAILED, Ordering::Release);
-    }
-
     pub fn mark_pending(&self) {
         self.state.store(BARRIER_PENDING, Ordering::Release);
+    }
+
+    pub fn mark_failed(&self) {
+        self.state.store(BARRIER_FAILED, Ordering::Release);
     }
 
     pub fn is_ready(&self) -> bool {
         self.state.load(Ordering::Acquire) == BARRIER_READY
     }
 
-    pub fn wait_ready(&self, timeout: Duration) -> Result<(), &'static str> {
+    pub fn is_failed(&self) -> bool {
+        self.state.load(Ordering::Acquire) == BARRIER_FAILED
+    }
+
+    pub fn wait_ready(&self, timeout: Duration) -> bool {
         let deadline = Instant::now() + timeout;
         while Instant::now() < deadline {
             match self.state.load(Ordering::Acquire) {
-                BARRIER_READY => return Ok(()),
-                BARRIER_FAILED => return Err("geyser_explicit_barrier_failed"),
-                _ => std::thread::sleep(Duration::from_millis(5)),
+                BARRIER_READY => return true,
+                BARRIER_FAILED => return false,
+                _ => std::thread::sleep(Duration::from_millis(10)),
             }
         }
-        Err("geyser_explicit_barrier_timeout")
+        false
     }
 }
 
@@ -535,9 +684,9 @@ pub struct ProtectedOverflowDiagnostic {
 }
 
 impl ProtectedOverflowDiagnostic {
-    pub fn from_demand(cap: usize, demand: &HashSet<Pubkey>) -> Self {
+    pub fn from_demand(configured_cap: usize, demand: &HashSet<Pubkey>) -> Self {
         Self {
-            configured_cap: cap,
+            configured_cap,
             wallet_demand_len: demand.len(),
             sample_wallet_pubkeys: demand.iter().copied().take(8).collect(),
         }
@@ -547,16 +696,16 @@ impl ProtectedOverflowDiagnostic {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::market_data::track::desired_set::OwnerKey;
-    use crate::market_data::track::worker_commands::GeyserPinReason;
+    use crate::market_data::track::worker_commands::{
+        BinArrayExplicitRow, MintExplicitRow, VaultExplicitRow,
+    };
 
     fn mk_snapshot(pool: Pubkey, vault: Pubkey) -> PoolExplicitSnapshot {
-        use crate::market_data::track::worker_commands::{MintExplicitRow, VaultExplicitRow};
         PoolExplicitSnapshot {
             pool,
             vaults: vec![VaultExplicitRow {
                 pubkey: vault,
-                dex: "test".into(),
+                dex: "raydium".into(),
                 base_mint: Pubkey::new_unique(),
                 quote_mint: Pubkey::new_unique(),
                 is_base_vault: true,
@@ -564,7 +713,11 @@ mod tests {
                 active_id: None,
                 bin_step: None,
             }],
-            bin_arrays: vec![],
+            bin_arrays: vec![BinArrayExplicitRow {
+                pubkey: Pubkey::new_unique(),
+                bin_array_index: 0,
+                bin_step: 1,
+            }],
             mints: vec![MintExplicitRow {
                 pubkey: Pubkey::new_unique(),
             }],
@@ -575,20 +728,43 @@ mod tests {
         }
     }
 
+    use crate::market_data::track::desired_set::OwnerKey;
+    use crate::market_data::track::worker_commands::GeyserPinReason;
+
     use std::sync::Arc;
 
-    fn mk_pending() -> (PendingPoolRegistrations, Arc<PoolSnapshotRevisionSequencer>) {
-        let revisions = Arc::new(PoolSnapshotRevisionSequencer::new());
+    fn mk_pending(max: usize) -> (PendingPoolRegistrations, Arc<PoolSnapshotRevisionSequencer>) {
+        let revisions = Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(max));
         (
-            PendingPoolRegistrations::new(8, Arc::clone(&revisions)),
+            PendingPoolRegistrations::new(max, Arc::clone(&revisions)),
             revisions,
         )
     }
 
+    fn register_and_assign(
+        revisions: &PoolSnapshotRevisionSequencer,
+        pool: Pubkey,
+        consumer: ConsumerId,
+    ) -> u64 {
+        assert_eq!(
+            revisions.try_acquire_active(pool, consumer),
+            RevisionAcquireResult::Acquired
+        );
+        let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
+        match revisions.assign_next(&mut snapshot) {
+            RevisionAssignResult::Assigned(rev) => rev,
+            other => panic!("expected Assigned, got {other:?}"),
+        }
+    }
+
     #[test]
     fn pending_replays_latest_revision_not_kind_order() {
-        let (pending, _revs) = mk_pending();
+        let (pending, revisions) = mk_pending(8);
         let pool = Pubkey::new_unique();
+        assert_eq!(
+            revisions.try_acquire_active(pool, ConsumerId::Momentum),
+            RevisionAcquireResult::Acquired
+        );
         let old_vault = Pubkey::new_unique();
         let new_vault = Pubkey::new_unique();
 
@@ -602,7 +778,6 @@ mod tests {
             pending.upsert(PendingPoolCommand::AfterTrade(mk_snapshot(pool, new_vault))),
             PendingPoolUpsertResult::Coalesced
         );
-        // Older revision (already assigned internally) cannot overwrite newer via re-upsert with stale
         let drained = pending.drain_all();
         assert_eq!(drained.len(), 1);
         match &drained[0] {
@@ -619,8 +794,12 @@ mod tests {
 
     #[test]
     fn pending_stale_out_of_order_across_all_kinds_no_ops() {
-        let (pending, _revs) = mk_pending();
+        let (pending, revisions) = mk_pending(8);
         let pool = Pubkey::new_unique();
+        assert_eq!(
+            revisions.try_acquire_active(pool, ConsumerId::Momentum),
+            RevisionAcquireResult::Acquired
+        );
         let v2 = Pubkey::new_unique();
         let v3 = Pubkey::new_unique();
         let v4 = Pubkey::new_unique();
@@ -652,8 +831,6 @@ mod tests {
             .latest_revision_for(pool, ConsumerId::Momentum)
             .expect("dlmm newest");
 
-        // Simulate stale replay by manually constructing lower-revision command — upsert assigns
-        // monotonic revision so we verify only latest survives drain.
         assert!(rev_dlmm > rev_reserve);
         assert!(rev_reserve > rev_vault);
 
@@ -674,12 +851,24 @@ mod tests {
 
     #[test]
     fn sequencer_rejects_stale_apply_after_newer() {
-        let revisions = PoolSnapshotRevisionSequencer::new();
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         let pool = Pubkey::new_unique();
+        assert_eq!(
+            revisions.try_acquire_active(pool, ConsumerId::Momentum),
+            RevisionAcquireResult::Acquired
+        );
         let mut newer = mk_snapshot(pool, Pubkey::new_unique());
         let mut older = mk_snapshot(pool, Pubkey::new_unique());
-        let rev_new = revisions.assign_next(&mut newer);
-        let rev_latest = revisions.assign_next(&mut older);
+        let rev_new = match revisions.assign_next(&mut newer) {
+            RevisionAssignResult::Assigned(rev) => rev,
+            other => panic!("{other:?}"),
+        };
+        revisions.inc_inflight_ref(pool, ConsumerId::Momentum);
+        let rev_latest = match revisions.assign_next(&mut older) {
+            RevisionAssignResult::Assigned(rev) => rev,
+            other => panic!("{other:?}"),
+        };
+        revisions.inc_inflight_ref(pool, ConsumerId::Momentum);
         assert!(revisions.should_apply_and_record(&older));
         assert!(!revisions.should_apply_and_record(&newer));
         assert_eq!(
@@ -694,41 +883,105 @@ mod tests {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         for _ in 0..128 {
             let pool = Pubkey::new_unique();
+            let revision = register_and_assign(&revisions, pool, ConsumerId::Momentum);
+            revisions.inc_inflight_ref(pool, ConsumerId::Momentum);
             let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
-            let revision = revisions.assign_next(&mut snapshot);
+            snapshot.revision = revision;
             assert!(revisions.should_apply_and_record(&snapshot));
-            assert_eq!(
-                revisions.current_applied(pool, ConsumerId::Momentum),
-                revision
-            );
-            revisions.retire_key(pool, ConsumerId::Momentum);
+            revisions.release_active_if_idle(pool, ConsumerId::Momentum);
         }
         assert!(
             revisions.active_key_count() <= 8,
             "revision registry must stay bounded"
         );
+        assert_eq!(revisions.total_memory_slots(), revisions.active_key_count());
     }
 
     #[test]
-    fn retired_generation_rejects_delayed_stale_command_after_repin() {
+    fn active_keys_never_evicted_above_cap() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(4);
+        let pools: Vec<Pubkey> = (0..6).map(|_| Pubkey::new_unique()).collect();
+        for pool in &pools[..4] {
+            assert_eq!(
+                revisions.try_acquire_active(*pool, ConsumerId::Momentum),
+                RevisionAcquireResult::Acquired
+            );
+        }
+        for pool in &pools[..4] {
+            let _ = register_and_assign(&revisions, *pool, ConsumerId::Momentum);
+        }
+        assert_eq!(revisions.active_key_count(), 4);
+        assert_eq!(
+            revisions.try_acquire_active(pools[4], ConsumerId::Momentum),
+            RevisionAcquireResult::RegistryFull,
+            "must fail closed when all slots are active/in-flight"
+        );
+        let refs = revisions.key_refs(pools[0], ConsumerId::Momentum);
+        assert!(refs.active > 0);
+        assert_eq!(
+            revisions.current_issued(pools[0], ConsumerId::Momentum),
+            revisions.current_issued(pools[0], ConsumerId::Momentum)
+        );
+    }
+
+    #[test]
+    fn retired_lifecycle_rejects_delayed_stale_command_after_repin() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         let pool = Pubkey::new_unique();
-        let mut stale = mk_snapshot(pool, Pubkey::new_unique());
-        let stale_rev = revisions.assign_next(&mut stale);
-        assert!(revisions.should_apply_and_record(&stale));
-        revisions.retire_key(pool, ConsumerId::Momentum);
-
-        let mut fresh = mk_snapshot(pool, Pubkey::new_unique());
-        let fresh_rev = revisions.assign_next(&mut fresh);
-        assert!(
-            PoolSnapshotRevisionSequencer::revision_generation(fresh_rev)
-                > PoolSnapshotRevisionSequencer::revision_generation(stale_rev)
+        assert_eq!(
+            revisions.try_acquire_active(pool, ConsumerId::Momentum),
+            RevisionAcquireResult::Acquired
         );
+        let mut stale = mk_snapshot(pool, Pubkey::new_unique());
+        let stale_rev = match revisions.assign_next(&mut stale) {
+            RevisionAssignResult::Assigned(rev) => rev,
+            other => panic!("{other:?}"),
+        };
+        revisions.inc_inflight_ref(pool, ConsumerId::Momentum);
+        assert!(revisions.should_apply_and_record(&stale));
+        revisions.release_active_if_idle(pool, ConsumerId::Momentum);
+
+        assert_eq!(
+            revisions.try_acquire_active(pool, ConsumerId::Momentum),
+            RevisionAcquireResult::Acquired
+        );
+        let mut fresh = mk_snapshot(pool, Pubkey::new_unique());
+        let fresh_rev = match revisions.assign_next(&mut fresh) {
+            RevisionAssignResult::Assigned(rev) => rev,
+            other => panic!("{other:?}"),
+        };
+        assert!(
+            PoolSnapshotRevisionSequencer::revision_lifecycle_id(fresh_rev)
+                > PoolSnapshotRevisionSequencer::revision_lifecycle_id(stale_rev)
+        );
+        revisions.inc_inflight_ref(pool, ConsumerId::Momentum);
         assert!(!revisions.should_apply_and_record(&stale));
         assert!(revisions.should_apply_and_record(&fresh));
         assert_eq!(
             revisions.current_applied(pool, ConsumerId::Momentum),
             fresh_rev
         );
+    }
+
+    #[test]
+    fn long_churn_memory_and_stale_rejection_bounded() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(16);
+        let mut issued: Vec<(Pubkey, u64)> = Vec::new();
+        for _ in 0..256 {
+            let pool = Pubkey::new_unique();
+            let rev = register_and_assign(&revisions, pool, ConsumerId::Momentum);
+            revisions.inc_inflight_ref(pool, ConsumerId::Momentum);
+            let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
+            snapshot.revision = rev;
+            assert!(revisions.should_apply_and_record(&snapshot));
+            issued.push((pool, rev));
+            revisions.release_active_if_idle(pool, ConsumerId::Momentum);
+        }
+        assert!(revisions.active_key_count() <= 16);
+        for (pool, stale_rev) in issued.into_iter().take(32) {
+            let mut stale = mk_snapshot(pool, Pubkey::new_unique());
+            stale.revision = stale_rev;
+            assert!(!revisions.should_apply_and_record(&stale));
+        }
     }
 }

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -1,0 +1,275 @@
+//! Bounded durable pending state for track-worker commands lost on full queue.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use solana_sdk::pubkey::Pubkey;
+
+use crate::market_data::track::desired_set::ConsumerId;
+use crate::market_data::track::worker_commands::{PoolExplicitSnapshot, TrackWorkerCommand};
+
+/// Coalesced pool command awaiting worker replay after queue loss.
+#[derive(Debug, Clone)]
+pub enum PendingPoolCommand {
+    RegisterReserves(PoolExplicitSnapshot),
+    VaultsFromAccount(PoolExplicitSnapshot),
+    AfterTrade(PoolExplicitSnapshot),
+    RefreshDlmm {
+        snapshot: PoolExplicitSnapshot,
+        new_active_id: i32,
+    },
+}
+
+impl PendingPoolCommand {
+    pub fn pool(&self) -> Pubkey {
+        match self {
+            Self::RegisterReserves(s)
+            | Self::VaultsFromAccount(s)
+            | Self::AfterTrade(s)
+            | Self::RefreshDlmm { snapshot: s, .. } => s.pool,
+        }
+    }
+
+    pub fn consumer(&self) -> ConsumerId {
+        match self {
+            Self::RegisterReserves(s)
+            | Self::VaultsFromAccount(s)
+            | Self::AfterTrade(s)
+            | Self::RefreshDlmm { snapshot: s, .. } => s.consumer,
+        }
+    }
+
+    pub fn into_track_command(self) -> TrackWorkerCommand {
+        match self {
+            Self::RegisterReserves(snapshot) => {
+                TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot }
+            }
+            Self::VaultsFromAccount(snapshot) => {
+                TrackWorkerCommand::RegisterPoolVaultsFromAccount { snapshot }
+            }
+            Self::AfterTrade(snapshot) => {
+                TrackWorkerCommand::RegisterGeyserReservesAfterTrade { snapshot }
+            }
+            Self::RefreshDlmm {
+                snapshot,
+                new_active_id,
+            } => TrackWorkerCommand::RefreshDlmmBinWindow {
+                snapshot,
+                new_active_id,
+            },
+        }
+    }
+}
+
+/// Authoritative wallet explicit demand merged under lock (no lost-update on burst ATA).
+#[derive(Debug, Default)]
+pub struct WalletExplicitPending {
+    inner: Mutex<WalletExplicitState>,
+    revision: AtomicU64,
+}
+
+#[derive(Debug, Default, Clone)]
+struct WalletExplicitState {
+    demand: HashSet<Pubkey>,
+    token_accounts: HashSet<Pubkey>,
+}
+
+impl WalletExplicitPending {
+    pub fn insert_ata(&self, ata: Pubkey) -> u64 {
+        let mut g = self.inner.lock().expect("wallet pending lock");
+        g.demand.insert(ata);
+        g.token_accounts.insert(ata);
+        self.bump_revision()
+    }
+
+    pub fn remove_ata(&self, ata: Pubkey) -> u64 {
+        let mut g = self.inner.lock().expect("wallet pending lock");
+        g.demand.remove(&ata);
+        g.token_accounts.remove(&ata);
+        self.bump_revision()
+    }
+
+    pub fn replace_token_accounts(&self, accounts: HashSet<Pubkey>) -> u64 {
+        let mut g = self.inner.lock().expect("wallet pending lock");
+        g.token_accounts = accounts;
+        self.bump_revision()
+    }
+
+    pub fn snapshot(&self) -> (HashSet<Pubkey>, HashSet<Pubkey>, u64) {
+        let g = self.inner.lock().expect("wallet pending lock");
+        (
+            g.demand.clone(),
+            g.token_accounts.clone(),
+            self.revision.load(Ordering::Acquire),
+        )
+    }
+
+    pub fn ensure_wallet_base(&self, wallet: Pubkey, wsol_ata: Pubkey) -> u64 {
+        let mut g = self.inner.lock().expect("wallet pending lock");
+        let mut changed = false;
+        if g.demand.insert(wallet) {
+            changed = true;
+        }
+        if g.demand.insert(wsol_ata) {
+            changed = true;
+        }
+        drop(g);
+        if changed {
+            self.bump_revision()
+        } else {
+            self.current_revision()
+        }
+    }
+
+    pub fn contains_demand(&self, pk: Pubkey) -> bool {
+        self.inner
+            .lock()
+            .expect("wallet pending lock")
+            .demand
+            .contains(&pk)
+    }
+
+    pub fn current_revision(&self) -> u64 {
+        self.revision.load(Ordering::Acquire)
+    }
+
+    fn bump_revision(&self) -> u64 {
+        self.revision.fetch_add(1, Ordering::AcqRel) + 1
+    }
+}
+
+/// Bounded coalesced pool registration pending (keyed by pool+consumer+command kind).
+#[derive(Debug)]
+pub struct PendingPoolRegistrations {
+    cap: usize,
+    entries: Mutex<HashMap<PendingPoolKey, PendingPoolCommand>>,
+    order: Mutex<VecDeque<PendingPoolKey>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PendingPoolKey {
+    pub pool: Pubkey,
+    pub consumer: ConsumerId,
+    pub kind: PendingPoolKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PendingPoolKind {
+    Reserves,
+    Vaults,
+    AfterTrade,
+    RefreshDlmm,
+}
+
+impl PendingPoolRegistrations {
+    pub fn new(cap: usize) -> Self {
+        Self {
+            cap: cap.max(1),
+            entries: Mutex::new(HashMap::new()),
+            order: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    pub fn upsert(&self, command: PendingPoolCommand) {
+        let kind = match &command {
+            PendingPoolCommand::RegisterReserves(_) => PendingPoolKind::Reserves,
+            PendingPoolCommand::VaultsFromAccount(_) => PendingPoolKind::Vaults,
+            PendingPoolCommand::AfterTrade(_) => PendingPoolKind::AfterTrade,
+            PendingPoolCommand::RefreshDlmm { .. } => PendingPoolKind::RefreshDlmm,
+        };
+        let key = PendingPoolKey {
+            pool: command.pool(),
+            consumer: command.consumer(),
+            kind,
+        };
+        let mut entries = self.entries.lock().expect("pending pool lock");
+        let mut order = self.order.lock().expect("pending pool order lock");
+        if !entries.contains_key(&key) {
+            order.push_back(key);
+            while order.len() > self.cap {
+                if let Some(evict) = order.pop_front() {
+                    entries.remove(&evict);
+                }
+            }
+        }
+        entries.insert(key, command);
+    }
+
+    pub fn drain_all(&self) -> Vec<PendingPoolCommand> {
+        let mut entries = self.entries.lock().expect("pending pool lock");
+        let mut order = self.order.lock().expect("pending pool order lock");
+        order.drain(..).filter_map(|k| entries.remove(&k)).collect()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.lock().expect("pending pool lock").is_empty()
+    }
+}
+
+/// Startup Geyser connect barrier: worker signals ready/failed after restore+convergence.
+#[derive(Debug)]
+pub struct GeyserConnectBarrier {
+    state: AtomicU8,
+}
+
+const BARRIER_PENDING: u8 = 0;
+const BARRIER_READY: u8 = 1;
+const BARRIER_FAILED: u8 = 2;
+
+impl Default for GeyserConnectBarrier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GeyserConnectBarrier {
+    pub fn new() -> Self {
+        Self {
+            state: AtomicU8::new(BARRIER_PENDING),
+        }
+    }
+
+    pub fn mark_ready(&self) {
+        self.state.store(BARRIER_READY, Ordering::Release);
+    }
+
+    pub fn mark_failed(&self) {
+        self.state.store(BARRIER_FAILED, Ordering::Release);
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.state.load(Ordering::Acquire) == BARRIER_READY
+    }
+
+    pub fn wait_ready(&self, timeout: Duration) -> Result<(), &'static str> {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            match self.state.load(Ordering::Acquire) {
+                BARRIER_READY => return Ok(()),
+                BARRIER_FAILED => return Err("geyser_explicit_barrier_failed"),
+                _ => std::thread::sleep(Duration::from_millis(5)),
+            }
+        }
+        Err("geyser_explicit_barrier_timeout")
+    }
+}
+
+/// Bounded diagnostic for protected wallet overflow (no unbounded clone on fail-closed).
+#[derive(Debug, Clone)]
+pub struct ProtectedOverflowDiagnostic {
+    pub configured_cap: usize,
+    pub wallet_demand_len: usize,
+    pub sample_wallet_pubkeys: Vec<Pubkey>,
+}
+
+impl ProtectedOverflowDiagnostic {
+    pub fn from_demand(cap: usize, demand: &HashSet<Pubkey>) -> Self {
+        Self {
+            configured_cap: cap,
+            wallet_demand_len: demand.len(),
+            sample_wallet_pubkeys: demand.iter().copied().take(8).collect(),
+        }
+    }
+}

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -1,8 +1,6 @@
 //! Bounded durable pending state for track-worker commands lost on full queue.
 
 use std::collections::{HashMap, HashSet, VecDeque};
-#[cfg(test)]
-use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -177,10 +175,6 @@ impl RevisionRegistryInner {
 pub struct PoolSnapshotRevisionSequencer {
     inner: Mutex<RevisionRegistryInner>,
     touch_seq: AtomicU64,
-    #[cfg(test)]
-    stash_hold_before_visible: AtomicBool,
-    #[cfg(test)]
-    drain_hold_before_remove: AtomicBool,
 }
 
 impl Default for PoolSnapshotRevisionSequencer {
@@ -198,10 +192,6 @@ impl PoolSnapshotRevisionSequencer {
         Self {
             inner: Mutex::new(RevisionRegistryInner::new(max_keys)),
             touch_seq: AtomicU64::new(0),
-            #[cfg(test)]
-            stash_hold_before_visible: AtomicBool::new(false),
-            #[cfg(test)]
-            drain_hold_before_remove: AtomicBool::new(false),
         }
     }
 
@@ -226,6 +216,24 @@ impl PoolSnapshotRevisionSequencer {
             .expect("revision registry lock")
             .slots
             .len()
+    }
+
+    /// Whether a new revision can be issued for `pool`+`consumer` (slot capacity + u64 headroom).
+    pub fn can_issue_revision(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
+        let inner = self.inner.lock().expect("revision registry lock");
+        Self::can_issue_revision_locked(&inner, (pool, consumer))
+    }
+
+    fn can_issue_revision_locked(inner: &RevisionRegistryInner, key: (Pubkey, ConsumerId)) -> bool {
+        if let Some(slot) = inner.slots.get(&key) {
+            slot.last_issued
+                .checked_add(1)
+                .is_some_and(|next| next != 0)
+        } else if inner.slots.len() < inner.max_keys {
+            true
+        } else {
+            inner.slots.values().any(RevisionSlot::recyclable)
+        }
     }
 
     pub fn total_memory_slots(&self) -> usize {
@@ -563,7 +571,7 @@ impl PoolSnapshotRevisionSequencer {
             .unwrap_or(0)
     }
 
-    #[cfg(test)]
+    #[doc(hidden)]
     pub fn test_seed_slot_revision_state(
         &self,
         pool: Pubkey,
@@ -579,27 +587,6 @@ impl PoolSnapshotRevisionSequencer {
         let slot = inner.slots.get_mut(&key).expect("seeded revision slot");
         slot.last_issued = last_issued;
         slot.applied_revision = applied_revision;
-    }
-
-    #[cfg(test)]
-    pub fn test_set_stash_hold_before_visible(&self, hold: bool) {
-        self.stash_hold_before_visible
-            .store(hold, Ordering::Release);
-    }
-
-    #[cfg(test)]
-    pub fn test_set_drain_hold_before_remove(&self, hold: bool) {
-        self.drain_hold_before_remove.store(hold, Ordering::Release);
-    }
-
-    #[cfg(test)]
-    fn test_stash_hold_active(&self) -> bool {
-        self.stash_hold_before_visible.load(Ordering::Acquire)
-    }
-
-    #[cfg(test)]
-    fn test_drain_hold_active(&self) -> bool {
-        self.drain_hold_before_remove.load(Ordering::Acquire)
     }
 
     fn assign_revision_for_command(
@@ -637,24 +624,6 @@ impl PoolSnapshotRevisionSequencer {
         slot.touch_stamp = self.next_touch_stamp();
         snapshot.revision = next;
         Ok(next)
-    }
-
-    fn stash_hold_spin(&self) {
-        #[cfg(test)]
-        {
-            while self.stash_hold_before_visible.load(Ordering::Acquire) {
-                std::thread::yield_now();
-            }
-        }
-    }
-
-    fn drain_hold_spin(&self) {
-        #[cfg(test)]
-        {
-            while self.drain_hold_before_remove.load(Ordering::Acquire) {
-                std::thread::yield_now();
-            }
-        }
     }
 
     pub(crate) fn pending_upsert(
@@ -746,9 +715,6 @@ impl PoolSnapshotRevisionSequencer {
             latest_revision: revision,
             latest_command: command,
         };
-        drop(inner);
-        self.stash_hold_spin();
-        let mut inner = self.inner.lock().expect("revision registry lock");
         inner.pending_entries.insert(key, coalesced);
         inner.pending_order.push_back(key);
         PendingPoolUpsertResult::Stored
@@ -757,11 +723,8 @@ impl PoolSnapshotRevisionSequencer {
     pub(crate) fn pending_drain_all(&self) -> Vec<PendingPoolCommand> {
         let mut inner = self.inner.lock().expect("revision registry lock");
         let keys: Vec<_> = inner.pending_order.drain(..).collect();
-        drop(inner);
         let mut drained = Vec::with_capacity(keys.len());
         for k in keys {
-            self.drain_hold_spin();
-            let mut inner = self.inner.lock().expect("revision registry lock");
             let Some(coalesced) = inner.pending_entries.remove(&k) else {
                 continue;
             };
@@ -893,6 +856,29 @@ pub enum PendingPoolUpsertResult {
     Overflow,
 }
 
+/// Result of bumping the monotonic wallet explicit revision counter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WalletRevisionBump {
+    Bumped(u64),
+    Exhausted,
+}
+
+impl WalletRevisionBump {
+    pub fn bumped_revision(self) -> Option<u64> {
+        match self {
+            Self::Bumped(rev) => Some(rev),
+            Self::Exhausted => None,
+        }
+    }
+
+    pub fn max(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Exhausted, _) | (_, Self::Exhausted) => Self::Exhausted,
+            (Self::Bumped(a), Self::Bumped(b)) => Self::Bumped(a.max(b)),
+        }
+    }
+}
+
 /// Authoritative wallet explicit demand merged under lock (no lost-update on burst ATA).
 #[derive(Debug, Default)]
 pub struct WalletExplicitPending {
@@ -907,21 +893,21 @@ struct WalletExplicitState {
 }
 
 impl WalletExplicitPending {
-    pub fn insert_ata(&self, ata: Pubkey) -> u64 {
+    pub fn insert_ata(&self, ata: Pubkey) -> WalletRevisionBump {
         let mut g = self.inner.lock().expect("wallet pending lock");
         g.demand.insert(ata);
         g.token_accounts.insert(ata);
         self.bump_revision()
     }
 
-    pub fn remove_ata(&self, ata: Pubkey) -> u64 {
+    pub fn remove_ata(&self, ata: Pubkey) -> WalletRevisionBump {
         let mut g = self.inner.lock().expect("wallet pending lock");
         g.demand.remove(&ata);
         g.token_accounts.remove(&ata);
         self.bump_revision()
     }
 
-    pub fn replace_token_accounts(&self, accounts: HashSet<Pubkey>) -> u64 {
+    pub fn replace_token_accounts(&self, accounts: HashSet<Pubkey>) -> WalletRevisionBump {
         let mut g = self.inner.lock().expect("wallet pending lock");
         g.token_accounts = accounts;
         self.bump_revision()
@@ -936,11 +922,20 @@ impl WalletExplicitPending {
         )
     }
 
-    pub fn ensure_wallet_base(&self, wallet: Pubkey, wsol_ata: Pubkey) -> u64 {
+    pub fn ensure_wallet_base(&self, wallet: Pubkey, wsol_ata: Pubkey) -> WalletRevisionBump {
         let mut g = self.inner.lock().expect("wallet pending lock");
         g.demand.insert(wallet);
         g.demand.insert(wsol_ata);
         self.bump_revision()
+    }
+
+    pub fn revision_exhausted(&self) -> bool {
+        self.revision.load(Ordering::Acquire) == u64::MAX
+    }
+
+    #[doc(hidden)]
+    pub fn test_seed_revision(&self, revision: u64) {
+        self.revision.store(revision, Ordering::Release);
     }
 
     pub fn current_revision(&self) -> u64 {
@@ -955,13 +950,35 @@ impl WalletExplicitPending {
             .contains(&pk)
     }
 
-    /// Monotonic wallet revision; returns `u64::MAX` fail-closed when exhausted.
-    #[allow(clippy::manual_saturating_arithmetic)]
-    fn bump_revision(&self) -> u64 {
-        self.revision
-            .fetch_add(1, Ordering::AcqRel)
-            .checked_add(1)
-            .unwrap_or(u64::MAX)
+    /// Monotonic wallet revision; permanently latches at `u64::MAX` when exhausted.
+    fn bump_revision(&self) -> WalletRevisionBump {
+        loop {
+            let current = self.revision.load(Ordering::Acquire);
+            if current == u64::MAX {
+                return WalletRevisionBump::Exhausted;
+            }
+            let next = match current.checked_add(1) {
+                None | Some(0) => u64::MAX,
+                Some(n) => n,
+            };
+            if next == u64::MAX {
+                if self
+                    .revision
+                    .compare_exchange(current, u64::MAX, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
+                    return WalletRevisionBump::Exhausted;
+                }
+                continue;
+            }
+            if self
+                .revision
+                .compare_exchange(current, next, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return WalletRevisionBump::Bumped(next);
+            }
+        }
     }
 }
 
@@ -1669,7 +1686,6 @@ mod tests {
     #[test]
     fn atomic_stash_visible_only_with_pending_ref() {
         use std::sync::Arc;
-        use std::thread;
 
         let revisions = Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(8));
         let pending = Arc::new(PendingPoolRegistrations::new(8, Arc::clone(&revisions)));
@@ -1678,63 +1694,21 @@ mod tests {
         let rev = register_and_assign(&revisions, pool, ConsumerId::Momentum);
         revisions.release_inflight_command(pool, ConsumerId::Momentum);
 
-        revisions.test_set_stash_hold_before_visible(true);
-
-        let revisions_producer = Arc::clone(&revisions);
-        let pending_producer = Arc::clone(&pending);
-        let producer = thread::spawn(move || {
-            let mut snap = mk_snapshot(pool, Pubkey::new_unique());
-            snap.revision = rev;
-            assert_reserved_inflight(&revisions_producer, pool, ConsumerId::Momentum);
-            pending_producer.upsert_after_inflight_send_failure(
+        let mut snap = mk_snapshot(pool, Pubkey::new_unique());
+        snap.revision = rev;
+        assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
+        assert_eq!(
+            pending.upsert_after_inflight_send_failure(
                 pool,
                 ConsumerId::Momentum,
                 PendingPoolCommand::RegisterReserves(snap),
-            )
-        });
-
-        for _ in 0..200 {
-            let has_entry = pending.has_pending(pool, ConsumerId::Momentum);
-            let refs = revisions.key_refs(pool, ConsumerId::Momentum);
-            if has_entry {
-                assert!(
-                    refs.pending > 0,
-                    "visible pending entry must have pending ref"
-                );
-            }
-            if refs.pending > 0 && !has_entry {
-                assert!(
-                    revisions.test_stash_hold_active(),
-                    "pending ref without visible entry only during stash hold"
-                );
-            }
-            thread::yield_now();
-        }
-
-        revisions.test_set_stash_hold_before_visible(false);
-        assert_eq!(
-            producer.join().expect("producer"),
+            ),
             PendingPoolUpsertResult::Stored
         );
         assert!(pending.has_pending(pool, ConsumerId::Momentum));
         assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).pending, 1);
 
-        revisions.test_set_drain_hold_before_remove(true);
-        let pending_drain = Arc::clone(&pending);
-        let drainer = thread::spawn(move || pending_drain.drain_all());
-        for _ in 0..200 {
-            let has_entry = pending.has_pending(pool, ConsumerId::Momentum);
-            let refs = revisions.key_refs(pool, ConsumerId::Momentum);
-            if !has_entry && refs.pending > 0 {
-                assert!(
-                    revisions.test_drain_hold_active(),
-                    "pending ref after entry removed only during drain hold"
-                );
-            }
-            thread::yield_now();
-        }
-        revisions.test_set_drain_hold_before_remove(false);
-        let drained = drainer.join().expect("drainer");
+        let drained = pending.drain_all();
         assert_eq!(drained.len(), 1);
         assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).pending, 1);
         let snapshot = match &drained[0] {
@@ -1751,5 +1725,159 @@ mod tests {
         );
         assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).pending, 0);
         assert!(!pending.has_pending(pool, ConsumerId::Momentum));
+    }
+
+    #[test]
+    fn concurrent_stash_same_key_coalesces_to_single_entry_and_ref() {
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+        use std::sync::Barrier;
+        use std::thread;
+
+        let revisions = Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(8));
+        let pending = Arc::new(PendingPoolRegistrations::new(8, Arc::clone(&revisions)));
+        let pool = Pubkey::new_unique();
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
+
+        let barrier = Arc::new(Barrier::new(3));
+        let stored_count = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+        for i in 0..2 {
+            let revisions_t = Arc::clone(&revisions);
+            let pending_t = Arc::clone(&pending);
+            let barrier_t = Arc::clone(&barrier);
+            let stored_t = Arc::clone(&stored_count);
+            handles.push(thread::spawn(move || {
+                barrier_t.wait();
+                assert_reserved_inflight(&revisions_t, pool, ConsumerId::Momentum);
+                let mut snap = mk_snapshot(pool, Pubkey::new_unique());
+                snap.revision = i as u64 + 1;
+                let result = pending_t.upsert_after_inflight_send_failure(
+                    pool,
+                    ConsumerId::Momentum,
+                    PendingPoolCommand::RegisterReserves(snap),
+                );
+                if result == PendingPoolUpsertResult::Stored {
+                    stored_t.fetch_add(1, AtomicOrdering::SeqCst);
+                }
+                result
+            }));
+        }
+
+        barrier.wait();
+        let mut results = Vec::new();
+        for handle in handles {
+            results.push(handle.join().expect("producer"));
+        }
+        assert_eq!(stored_count.load(AtomicOrdering::SeqCst), 1);
+        assert!(
+            results
+                .iter()
+                .filter(|r| **r == PendingPoolUpsertResult::Coalesced)
+                .count()
+                <= 1
+        );
+        assert_eq!(pending.pool_count(), 1);
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).pending, 1);
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).inflight, 0);
+    }
+
+    #[test]
+    fn concurrent_stash_distinct_keys_respects_pending_cap() {
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+        use std::sync::Barrier;
+        use std::thread;
+
+        const CAP: usize = 2;
+        let revisions = Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(8));
+        let pending = Arc::new(PendingPoolRegistrations::new(CAP, Arc::clone(&revisions)));
+        let pool_a = Pubkey::new_unique();
+        let pool_b = Pubkey::new_unique();
+        let pool_c = Pubkey::new_unique();
+        for pool in [pool_a, pool_b, pool_c] {
+            ensure_key(&revisions, pool, ConsumerId::Momentum);
+        }
+
+        let barrier = Arc::new(Barrier::new(4));
+        let stored_count = Arc::new(AtomicUsize::new(0));
+        let pools = [pool_a, pool_b, pool_c];
+        let mut handles = Vec::new();
+        for pool in pools {
+            let revisions_t = Arc::clone(&revisions);
+            let pending_t = Arc::clone(&pending);
+            let barrier_t = Arc::clone(&barrier);
+            let stored_t = Arc::clone(&stored_count);
+            handles.push(thread::spawn(move || {
+                barrier_t.wait();
+                assert_reserved_inflight(&revisions_t, pool, ConsumerId::Momentum);
+                let mut snap = mk_snapshot(pool, Pubkey::new_unique());
+                snap.revision = 1;
+                let result = pending_t.upsert_after_inflight_send_failure(
+                    pool,
+                    ConsumerId::Momentum,
+                    PendingPoolCommand::RegisterReserves(snap),
+                );
+                if result == PendingPoolUpsertResult::Stored {
+                    stored_t.fetch_add(1, AtomicOrdering::SeqCst);
+                }
+                result
+            }));
+        }
+
+        barrier.wait();
+        for handle in handles {
+            let _ = handle.join().expect("producer");
+        }
+        assert!(stored_count.load(AtomicOrdering::SeqCst) <= CAP);
+        assert!(pending.pool_count() <= CAP);
+        assert_eq!(
+            revisions.key_refs(pool_a, ConsumerId::Momentum).pending
+                + revisions.key_refs(pool_b, ConsumerId::Momentum).pending
+                + revisions.key_refs(pool_c, ConsumerId::Momentum).pending,
+            pending.pool_count() as u32
+        );
+    }
+
+    #[test]
+    fn can_issue_revision_recyclable_slot_without_active_key_headroom() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(1);
+        let pool0 = Pubkey::new_unique();
+        let pool1 = Pubkey::new_unique();
+        ensure_key(&revisions, pool0, ConsumerId::Momentum);
+        revisions.inc_pending_ref(pool0, ConsumerId::Momentum);
+        assert!(!revisions.can_issue_revision(pool1, ConsumerId::Momentum));
+        revisions.dec_pending_ref(pool0, ConsumerId::Momentum);
+        revisions.retire_key(pool0, ConsumerId::Momentum);
+        assert!(revisions.can_issue_revision(pool1, ConsumerId::Momentum));
+    }
+
+    #[test]
+    fn can_issue_revision_false_when_u64_exhausted() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
+        let pool = Pubkey::new_unique();
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
+        revisions.test_seed_slot_revision_state(pool, ConsumerId::Momentum, u64::MAX, u64::MAX - 1);
+        assert!(!revisions.can_issue_revision(pool, ConsumerId::Momentum));
+    }
+
+    #[test]
+    fn wallet_revision_exhaustion_latches_and_rejects_post_exhaustion_bumps() {
+        let pending = WalletExplicitPending::default();
+        pending.test_seed_revision(u64::MAX - 1);
+        assert_eq!(
+            pending.insert_ata(Pubkey::new_unique()),
+            WalletRevisionBump::Exhausted
+        );
+        assert!(pending.revision_exhausted());
+        assert_eq!(pending.current_revision(), u64::MAX);
+        assert_eq!(
+            pending.insert_ata(Pubkey::new_unique()),
+            WalletRevisionBump::Exhausted
+        );
+        let wallet = Pubkey::new_unique();
+        let wsol = Pubkey::new_unique();
+        assert_eq!(
+            pending.ensure_wallet_base(wallet, wsol),
+            WalletRevisionBump::Exhausted
+        );
     }
 }

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -783,6 +783,16 @@ impl PoolSnapshotRevisionSequencer {
             .pending_entries
             .contains_key(&(pool, consumer))
     }
+
+    pub(crate) fn pending_revision_keys(&self) -> Vec<(Pubkey, ConsumerId)> {
+        self.inner
+            .lock()
+            .expect("revision registry lock")
+            .pending_entries
+            .keys()
+            .copied()
+            .collect()
+    }
 }
 
 /// Coalesced pool command awaiting worker replay after queue loss.
@@ -1040,6 +1050,10 @@ impl PendingPoolRegistrations {
 
     pub fn has_pending(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
         self.revisions.pending_has_entry(pool, consumer)
+    }
+
+    pub fn pending_revision_keys(&self) -> Vec<(Pubkey, ConsumerId)> {
+        self.revisions.pending_revision_keys()
     }
 }
 

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -14,6 +14,32 @@ const REVISION_SEQ_MASK: u64 = 0xFFFF_FFFF;
 const REVISION_LIFECYCLE_SHIFT: u32 = 32;
 const DEFAULT_MAX_REVISION_SLOTS: usize = 4096;
 
+/// Idempotent logical owner identity for revision-registry active slots.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RevisionActiveOwner {
+    MomentumMintPool { mint: Pubkey, pool: Pubkey },
+    ArbPool { pool: Pubkey },
+}
+
+impl RevisionActiveOwner {
+    pub fn pool(self) -> Pubkey {
+        match self {
+            Self::MomentumMintPool { pool, .. } | Self::ArbPool { pool } => pool,
+        }
+    }
+
+    pub fn consumer(self) -> ConsumerId {
+        match self {
+            Self::MomentumMintPool { .. } => ConsumerId::Momentum,
+            Self::ArbPool { .. } => ConsumerId::Arb,
+        }
+    }
+
+    pub fn registry_key(self) -> (Pubkey, ConsumerId) {
+        (self.pool(), self.consumer())
+    }
+}
+
 /// Result of reserving a revision-registry slot for a pool+consumer key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RevisionAcquireResult {
@@ -29,16 +55,34 @@ pub enum RevisionAssignResult {
     KeyNotRegistered,
 }
 
+/// Result of reserving an in-flight command slot (ephemeral; no active owner).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InflightReserveResult {
+    Reserved,
+    RegistryFull,
+}
+
+/// Terminal outcome for a pool snapshot command after worker processing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PoolCommandTerminal {
+    Applied,
+    StaleRevision,
+    UnpinnedRejected,
+    AdmissionRejected,
+    InvalidRevision,
+}
+
 #[derive(Debug, Default, Clone, Copy)]
 pub struct RevisionRefCounts {
-    pub active: u32,
+    pub active_owners: usize,
     pub pending: u32,
     pub inflight: u32,
 }
 
 impl RevisionRefCounts {
+    #[allow(dead_code)]
     fn total(self) -> u32 {
-        self.active
+        (self.active_owners as u32)
             .saturating_add(self.pending)
             .saturating_add(self.inflight)
     }
@@ -49,8 +93,16 @@ struct RevisionSlot {
     lifecycle_id: u32,
     issued_seq: u32,
     applied_seq: u32,
-    refs: RevisionRefCounts,
+    active_owners: HashSet<RevisionActiveOwner>,
+    pending: u32,
+    inflight: u32,
     touch_stamp: u64,
+}
+
+impl RevisionSlot {
+    fn recyclable(&self) -> bool {
+        self.active_owners.is_empty() && self.pending == 0 && self.inflight == 0
+    }
 }
 
 /// Bounded per-(pool,consumer) revision registry with refcounted lifecycle.
@@ -136,7 +188,9 @@ impl PoolSnapshotRevisionSequencer {
             lifecycle_id: self.fresh_lifecycle_id(),
             issued_seq: 0,
             applied_seq: 0,
-            refs: RevisionRefCounts::default(),
+            active_owners: HashSet::new(),
+            pending: 0,
+            inflight: 0,
             touch_stamp: self.next_touch_stamp(),
         }
     }
@@ -152,7 +206,7 @@ impl PoolSnapshotRevisionSequencer {
         }
         let recyclable = slots
             .iter()
-            .filter(|(_, slot)| slot.refs.total() == 0)
+            .filter(|(_, slot)| slot.recyclable())
             .min_by_key(|(_, slot)| slot.touch_stamp)
             .map(|(k, _)| *k);
         let Some(victim_key) = recyclable else {
@@ -163,8 +217,18 @@ impl PoolSnapshotRevisionSequencer {
         Ok(())
     }
 
-    pub fn try_acquire_active(&self, pool: Pubkey, consumer: ConsumerId) -> RevisionAcquireResult {
-        let key = (pool, consumer);
+    fn maybe_remove_slot(
+        slots: &mut HashMap<(Pubkey, ConsumerId), RevisionSlot>,
+        key: (Pubkey, ConsumerId),
+    ) {
+        if slots.get(&key).is_some_and(|slot| slot.recyclable()) {
+            slots.remove(&key);
+        }
+    }
+
+    /// Idempotent acquire of a logical active owner (duplicate acquire is a no-op).
+    pub fn acquire_active_owner(&self, owner: RevisionActiveOwner) -> RevisionAcquireResult {
+        let key = owner.registry_key();
         if let Err(result) = self.ensure_slot(key) {
             return result;
         }
@@ -172,30 +236,51 @@ impl PoolSnapshotRevisionSequencer {
         let Some(slot) = slots.get_mut(&key) else {
             return RevisionAcquireResult::RegistryFull;
         };
-        slot.refs.active = slot.refs.active.saturating_add(1);
+        slot.active_owners.insert(owner);
         slot.touch_stamp = self.next_touch_stamp();
         RevisionAcquireResult::Acquired
     }
 
-    pub fn release_active_if_idle(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
-        let key = (pool, consumer);
+    /// Release one logical active owner; retires the slot when fully idle.
+    pub fn release_active_owner(&self, owner: RevisionActiveOwner) -> bool {
+        let key = owner.registry_key();
         let mut slots = self.slots.lock().expect("pool revision slots lock");
         let Some(slot) = slots.get_mut(&key) else {
             return false;
         };
-        slot.refs.active = slot.refs.active.saturating_sub(1);
-        if slot.refs.total() == 0 {
+        slot.active_owners.remove(&owner);
+        let retired = slot.recyclable();
+        if retired {
             slots.remove(&key);
-            return true;
         }
-        false
+        retired
+    }
+
+    #[deprecated(note = "use acquire_active_owner")]
+    pub fn try_acquire_active(&self, pool: Pubkey, consumer: ConsumerId) -> RevisionAcquireResult {
+        let owner = match consumer {
+            ConsumerId::Momentum => RevisionActiveOwner::MomentumMintPool { mint: pool, pool },
+            ConsumerId::Arb => RevisionActiveOwner::ArbPool { pool },
+            _ => return RevisionAcquireResult::RegistryFull,
+        };
+        self.acquire_active_owner(owner)
+    }
+
+    #[deprecated(note = "use release_active_owner")]
+    pub fn release_active_if_idle(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
+        let owner = match consumer {
+            ConsumerId::Momentum => RevisionActiveOwner::MomentumMintPool { mint: pool, pool },
+            ConsumerId::Arb => RevisionActiveOwner::ArbPool { pool },
+            _ => return false,
+        };
+        self.release_active_owner(owner)
     }
 
     pub fn inc_pending_ref(&self, pool: Pubkey, consumer: ConsumerId) {
         let key = (pool, consumer);
         let mut slots = self.slots.lock().expect("pool revision slots lock");
         if let Some(slot) = slots.get_mut(&key) {
-            slot.refs.pending = slot.refs.pending.saturating_add(1);
+            slot.pending = slot.pending.saturating_add(1);
             slot.touch_stamp = self.next_touch_stamp();
         }
     }
@@ -206,31 +291,63 @@ impl PoolSnapshotRevisionSequencer {
         let Some(slot) = slots.get_mut(&key) else {
             return;
         };
-        slot.refs.pending = slot.refs.pending.saturating_sub(1);
-        if slot.refs.total() == 0 {
-            slots.remove(&key);
-        }
+        slot.pending = slot.pending.saturating_sub(1);
+        Self::maybe_remove_slot(&mut slots, key);
     }
 
+    /// Reserve one in-flight command ref before queue send (ephemeral; no active owner).
+    pub fn reserve_inflight_command(
+        &self,
+        pool: Pubkey,
+        consumer: ConsumerId,
+    ) -> InflightReserveResult {
+        let key = (pool, consumer);
+        if let Err(RevisionAcquireResult::RegistryFull) = self.ensure_slot(key) {
+            return InflightReserveResult::RegistryFull;
+        }
+        let mut slots = self.slots.lock().expect("pool revision slots lock");
+        let Some(slot) = slots.get_mut(&key) else {
+            return InflightReserveResult::RegistryFull;
+        };
+        slot.inflight = slot.inflight.saturating_add(1);
+        slot.touch_stamp = self.next_touch_stamp();
+        InflightReserveResult::Reserved
+    }
+
+    #[deprecated(note = "use reserve_inflight_command")]
     pub fn inc_inflight_ref(&self, pool: Pubkey, consumer: ConsumerId) {
+        let _ = self.reserve_inflight_command(pool, consumer);
+    }
+
+    /// Atomically move one in-flight ref to pending (enqueue loss path).
+    pub fn transfer_inflight_to_pending(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
         let key = (pool, consumer);
         let mut slots = self.slots.lock().expect("pool revision slots lock");
-        if let Some(slot) = slots.get_mut(&key) {
-            slot.refs.inflight = slot.refs.inflight.saturating_add(1);
-            slot.touch_stamp = self.next_touch_stamp();
+        let Some(slot) = slots.get_mut(&key) else {
+            return false;
+        };
+        if slot.inflight == 0 {
+            return false;
         }
+        slot.inflight = slot.inflight.saturating_sub(1);
+        slot.pending = slot.pending.saturating_add(1);
+        slot.touch_stamp = self.next_touch_stamp();
+        true
     }
 
-    pub fn dec_inflight_ref(&self, pool: Pubkey, consumer: ConsumerId) {
+    pub fn release_inflight_command(&self, pool: Pubkey, consumer: ConsumerId) {
         let key = (pool, consumer);
         let mut slots = self.slots.lock().expect("pool revision slots lock");
         let Some(slot) = slots.get_mut(&key) else {
             return;
         };
-        slot.refs.inflight = slot.refs.inflight.saturating_sub(1);
-        if slot.refs.total() == 0 {
-            slots.remove(&key);
-        }
+        slot.inflight = slot.inflight.saturating_sub(1);
+        Self::maybe_remove_slot(&mut slots, key);
+    }
+
+    #[deprecated(note = "use release_inflight_command")]
+    pub fn dec_inflight_ref(&self, pool: Pubkey, consumer: ConsumerId) {
+        self.release_inflight_command(pool, consumer);
     }
 
     pub fn key_refs(&self, pool: Pubkey, consumer: ConsumerId) -> RevisionRefCounts {
@@ -238,8 +355,20 @@ impl PoolSnapshotRevisionSequencer {
             .lock()
             .expect("pool revision slots lock")
             .get(&(pool, consumer))
-            .map(|slot| slot.refs)
+            .map(|slot| RevisionRefCounts {
+                active_owners: slot.active_owners.len(),
+                pending: slot.pending,
+                inflight: slot.inflight,
+            })
             .unwrap_or_default()
+    }
+
+    pub fn has_active_owner(&self, owner: RevisionActiveOwner) -> bool {
+        self.slots
+            .lock()
+            .expect("pool revision slots lock")
+            .get(&owner.registry_key())
+            .is_some_and(|slot| slot.active_owners.contains(&owner))
     }
 
     pub fn assign_next(&self, snapshot: &mut PoolExplicitSnapshot) -> RevisionAssignResult {
@@ -248,36 +377,65 @@ impl PoolSnapshotRevisionSequencer {
         let Some(slot) = slots.get_mut(&key) else {
             return RevisionAssignResult::KeyNotRegistered;
         };
-        slot.issued_seq = slot.issued_seq.saturating_add(1);
-        if slot.issued_seq == 0 {
+        if slot.issued_seq == u32::MAX {
             slot.lifecycle_id = self.fresh_lifecycle_id();
-            slot.issued_seq = 1;
+            slot.issued_seq = 0;
         }
+        slot.issued_seq = slot.issued_seq.saturating_add(1);
         slot.touch_stamp = self.next_touch_stamp();
         snapshot.revision = Self::pack_revision(slot.lifecycle_id, slot.issued_seq);
         RevisionAssignResult::Assigned(snapshot.revision)
     }
 
-    pub fn should_apply_and_record(&self, snapshot: &PoolExplicitSnapshot) -> bool {
+    pub fn revision_acceptable(&self, snapshot: &PoolExplicitSnapshot) -> bool {
         if snapshot.revision == 0 {
             return false;
+        }
+        let (lifecycle_id, seq) = Self::unpack_revision(snapshot.revision);
+        self.slots
+            .lock()
+            .expect("pool revision slots lock")
+            .get(&(snapshot.pool, snapshot.consumer))
+            .is_some_and(|slot| lifecycle_id == slot.lifecycle_id && seq > slot.applied_seq)
+    }
+
+    /// Finish a pool command on the worker — always releases exactly one in-flight ref.
+    pub fn finish_pool_command(
+        &self,
+        snapshot: &PoolExplicitSnapshot,
+        terminal: PoolCommandTerminal,
+    ) {
+        if snapshot.revision == 0 {
+            self.release_inflight_command(snapshot.pool, snapshot.consumer);
+            return;
         }
         let (lifecycle_id, seq) = Self::unpack_revision(snapshot.revision);
         let key = (snapshot.pool, snapshot.consumer);
         let mut slots = self.slots.lock().expect("pool revision slots lock");
         let Some(slot) = slots.get_mut(&key) else {
-            return false;
+            return;
         };
-        if lifecycle_id != slot.lifecycle_id || seq <= slot.applied_seq {
-            return false;
+        if terminal == PoolCommandTerminal::Applied
+            && lifecycle_id == slot.lifecycle_id
+            && seq > slot.applied_seq
+        {
+            slot.applied_seq = seq;
         }
-        slot.applied_seq = seq;
-        slot.refs.inflight = slot.refs.inflight.saturating_sub(1);
+        slot.inflight = slot.inflight.saturating_sub(1);
         slot.touch_stamp = self.next_touch_stamp();
-        if slot.refs.total() == 0 {
-            slots.remove(&key);
-        }
-        true
+        Self::maybe_remove_slot(&mut slots, key);
+    }
+
+    #[deprecated(note = "use revision_acceptable + finish_pool_command")]
+    pub fn should_apply_and_record(&self, snapshot: &PoolExplicitSnapshot) -> bool {
+        let acceptable = self.revision_acceptable(snapshot);
+        let terminal = if acceptable {
+            PoolCommandTerminal::Applied
+        } else {
+            PoolCommandTerminal::StaleRevision
+        };
+        self.finish_pool_command(snapshot, terminal);
+        acceptable
     }
 
     pub fn retire_key(&self, pool: Pubkey, consumer: ConsumerId) {
@@ -286,7 +444,7 @@ impl PoolSnapshotRevisionSequencer {
         let Some(slot) = slots.get(&key) else {
             return;
         };
-        if slot.refs.total() > 0 {
+        if !slot.recyclable() {
             return;
         }
         slots.remove(&key);
@@ -321,6 +479,28 @@ impl PoolSnapshotRevisionSequencer {
             .get(&(pool, consumer))
             .map(|slot| Self::pack_revision(slot.lifecycle_id, slot.applied_seq))
             .unwrap_or(0)
+    }
+
+    #[cfg(test)]
+    pub fn test_seed_slot_revision_state(
+        &self,
+        pool: Pubkey,
+        consumer: ConsumerId,
+        lifecycle_id: u32,
+        issued_seq: u32,
+        applied_seq: u32,
+    ) {
+        let key = (pool, consumer);
+        if let Err(RevisionAcquireResult::RegistryFull) = self.ensure_slot(key) {
+            panic!("revision slot seed failed: registry full");
+        }
+        let mut slots = self.slots.lock().expect("pool revision slots lock");
+        let slot = slots.get_mut(&key).expect("seeded revision slot");
+        slot.lifecycle_id = lifecycle_id;
+        slot.issued_seq = issued_seq;
+        slot.applied_seq = applied_seq;
+        self.next_lifecycle_id
+            .fetch_max(lifecycle_id.saturating_add(1), Ordering::AcqRel);
     }
 }
 
@@ -510,7 +690,21 @@ impl PendingPoolRegistrations {
     }
 
     pub fn upsert(&self, mut command: PendingPoolCommand) -> PendingPoolUpsertResult {
-        let revision = match &mut command {
+        self.upsert_internal(&mut command, false)
+    }
+
+    /// Upsert when the pending ref was already transferred from in-flight (enqueue loss).
+    pub fn upsert_transferred(&self, command: PendingPoolCommand) -> PendingPoolUpsertResult {
+        let mut command = command;
+        self.upsert_internal(&mut command, true)
+    }
+
+    fn upsert_internal(
+        &self,
+        command: &mut PendingPoolCommand,
+        pending_ref_transferred: bool,
+    ) -> PendingPoolUpsertResult {
+        let revision = match command {
             PendingPoolCommand::RegisterReserves(s)
             | PendingPoolCommand::VaultsFromAccount(s)
             | PendingPoolCommand::AfterTrade(s) => {
@@ -552,7 +746,7 @@ impl PendingPoolRegistrations {
         let mut entries = self.entries.lock().expect("pending pool lock");
         let mut order = self.order.lock().expect("pending pool order lock");
         if let Some(entry) = entries.get_mut(&key) {
-            if entry.try_merge(revision, command) {
+            if entry.try_merge(revision, command.clone()) {
                 return PendingPoolUpsertResult::Coalesced;
             }
             return PendingPoolUpsertResult::StaleNoOp;
@@ -561,12 +755,14 @@ impl PendingPoolRegistrations {
             self.overflow.store(true, Ordering::Release);
             return PendingPoolUpsertResult::Overflow;
         }
-        self.revisions.inc_pending_ref(key.0, key.1);
+        if !pending_ref_transferred {
+            self.revisions.inc_pending_ref(key.0, key.1);
+        }
         let coalesced = CoalescedPoolPending {
             pool: key.0,
             consumer: key.1,
             latest_revision: revision,
-            latest_command: command,
+            latest_command: command.clone(),
         };
         entries.insert(key, coalesced);
         order.push_back(key);
@@ -741,14 +937,18 @@ mod tests {
         )
     }
 
-    fn register_and_assign(
+    fn momentum_owner(mint: Pubkey, pool: Pubkey) -> RevisionActiveOwner {
+        RevisionActiveOwner::MomentumMintPool { mint, pool }
+    }
+
+    fn reserve_assign(
         revisions: &PoolSnapshotRevisionSequencer,
         pool: Pubkey,
         consumer: ConsumerId,
     ) -> u64 {
         assert_eq!(
-            revisions.try_acquire_active(pool, consumer),
-            RevisionAcquireResult::Acquired
+            revisions.reserve_inflight_command(pool, consumer),
+            InflightReserveResult::Reserved
         );
         let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
         match revisions.assign_next(&mut snapshot) {
@@ -757,14 +957,188 @@ mod tests {
         }
     }
 
+    fn register_and_assign(
+        revisions: &PoolSnapshotRevisionSequencer,
+        owner: RevisionActiveOwner,
+    ) -> u64 {
+        assert_eq!(
+            revisions.acquire_active_owner(owner),
+            RevisionAcquireResult::Acquired
+        );
+        let pool = owner.pool();
+        reserve_assign(revisions, pool, owner.consumer())
+    }
+
+    fn assert_acquired_owner(
+        revisions: &PoolSnapshotRevisionSequencer,
+        owner: RevisionActiveOwner,
+    ) {
+        assert_eq!(
+            revisions.acquire_active_owner(owner),
+            RevisionAcquireResult::Acquired
+        );
+    }
+
+    fn assert_reserved_inflight(
+        revisions: &PoolSnapshotRevisionSequencer,
+        pool: Pubkey,
+        consumer: ConsumerId,
+    ) {
+        assert_eq!(
+            revisions.reserve_inflight_command(pool, consumer),
+            InflightReserveResult::Reserved
+        );
+    }
+
+    #[test]
+    fn active_owner_idempotent_duplicate_acquire() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let owner = momentum_owner(mint, pool);
+        assert_eq!(
+            revisions.acquire_active_owner(owner),
+            RevisionAcquireResult::Acquired
+        );
+        assert_eq!(
+            revisions.acquire_active_owner(owner),
+            RevisionAcquireResult::Acquired
+        );
+        let refs = revisions.key_refs(pool, ConsumerId::Momentum);
+        assert_eq!(refs.active_owners, 1);
+    }
+
+    #[test]
+    fn two_momentum_mints_release_both_to_zero_active() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
+        let pool = Pubkey::new_unique();
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::new_unique();
+        let owner_a = momentum_owner(mint_a, pool);
+        let owner_b = momentum_owner(mint_b, pool);
+        assert_eq!(
+            revisions.acquire_active_owner(owner_a),
+            RevisionAcquireResult::Acquired
+        );
+        assert_eq!(
+            revisions.acquire_active_owner(owner_b),
+            RevisionAcquireResult::Acquired
+        );
+        assert_eq!(
+            revisions.key_refs(pool, ConsumerId::Momentum).active_owners,
+            2
+        );
+        revisions.release_active_owner(owner_a);
+        assert_eq!(
+            revisions.key_refs(pool, ConsumerId::Momentum).active_owners,
+            1
+        );
+        revisions.release_active_owner(owner_b);
+        assert_eq!(
+            revisions.key_refs(pool, ConsumerId::Momentum).active_owners,
+            0
+        );
+        assert_eq!(revisions.active_key_count(), 0);
+    }
+
+    #[test]
+    fn stale_noop_releases_inflight_without_apply() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
+        let pool = Pubkey::new_unique();
+        let owner = momentum_owner(Pubkey::new_unique(), pool);
+        assert_eq!(
+            revisions.acquire_active_owner(owner),
+            RevisionAcquireResult::Acquired
+        );
+        let rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
+        let mut stale = mk_snapshot(pool, Pubkey::new_unique());
+        stale.revision = rev;
+        revisions.finish_pool_command(&stale, PoolCommandTerminal::Applied);
+        let mut older = mk_snapshot(pool, Pubkey::new_unique());
+        older.revision = rev.saturating_sub(1);
+        assert!(!revisions.revision_acceptable(&older));
+        assert_eq!(
+            revisions.reserve_inflight_command(pool, ConsumerId::Momentum),
+            InflightReserveResult::Reserved
+        );
+        older.revision = rev;
+        revisions.finish_pool_command(&older, PoolCommandTerminal::StaleRevision);
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).inflight, 0);
+    }
+
+    #[test]
+    fn inflight_transfer_to_pending_no_zero_ref_gap() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
+        let pool = Pubkey::new_unique();
+        let owner = momentum_owner(Pubkey::new_unique(), pool);
+        assert_acquired_owner(&revisions, owner);
+        let _rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
+        let refs_before = revisions.key_refs(pool, ConsumerId::Momentum);
+        assert_eq!(refs_before.inflight, 1);
+        assert!(revisions.transfer_inflight_to_pending(pool, ConsumerId::Momentum));
+        let refs_after = revisions.key_refs(pool, ConsumerId::Momentum);
+        assert_eq!(refs_after.inflight, 0);
+        assert_eq!(refs_after.pending, 1);
+        assert_eq!(refs_after.active_owners, 1);
+    }
+
+    #[test]
+    fn delayed_after_unpin_churn_keeps_registry_bounded() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(4);
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let owner = momentum_owner(mint, pool);
+        assert_acquired_owner(&revisions, owner);
+        let rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
+        revisions.release_active_owner(owner);
+        let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
+        snapshot.revision = rev;
+        revisions.finish_pool_command(&snapshot, PoolCommandTerminal::UnpinnedRejected);
+        assert_eq!(revisions.active_key_count(), 0);
+        for _ in 0..64 {
+            let ephemeral_pool = Pubkey::new_unique();
+            let rev = reserve_assign(&revisions, ephemeral_pool, ConsumerId::Momentum);
+            let mut snap = mk_snapshot(ephemeral_pool, Pubkey::new_unique());
+            snap.revision = rev;
+            revisions.finish_pool_command(&snap, PoolCommandTerminal::UnpinnedRejected);
+        }
+        assert!(revisions.active_key_count() <= 4);
+    }
+
+    #[test]
+    fn revision_seq_near_wrap_allocates_new_lifecycle() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
+        let pool = Pubkey::new_unique();
+        let owner = momentum_owner(Pubkey::new_unique(), pool);
+        assert_acquired_owner(&revisions, owner);
+        revisions.test_seed_slot_revision_state(pool, ConsumerId::Momentum, 7, u32::MAX, 0);
+        let mut snap = mk_snapshot(pool, Pubkey::new_unique());
+        let rev_wrap = match revisions.assign_next(&mut snap) {
+            RevisionAssignResult::Assigned(rev) => rev,
+            other => panic!("{other:?}"),
+        };
+        assert_eq!(
+            PoolSnapshotRevisionSequencer::revision_lifecycle_id(rev_wrap),
+            8
+        );
+        assert_eq!(
+            PoolSnapshotRevisionSequencer::revision_sequence(rev_wrap),
+            1
+        );
+        assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
+        let mut stale = mk_snapshot(pool, Pubkey::new_unique());
+        stale.revision = PoolSnapshotRevisionSequencer::pack_revision(7, u32::MAX);
+        revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision);
+        assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
+        revisions.finish_pool_command(&snap, PoolCommandTerminal::Applied);
+    }
+
     #[test]
     fn pending_replays_latest_revision_not_kind_order() {
         let (pending, revisions) = mk_pending(8);
         let pool = Pubkey::new_unique();
-        assert_eq!(
-            revisions.try_acquire_active(pool, ConsumerId::Momentum),
-            RevisionAcquireResult::Acquired
-        );
+        let owner = momentum_owner(Pubkey::new_unique(), pool);
+        assert_acquired_owner(&revisions, owner);
         let old_vault = Pubkey::new_unique();
         let new_vault = Pubkey::new_unique();
 
@@ -796,10 +1170,8 @@ mod tests {
     fn pending_stale_out_of_order_across_all_kinds_no_ops() {
         let (pending, revisions) = mk_pending(8);
         let pool = Pubkey::new_unique();
-        assert_eq!(
-            revisions.try_acquire_active(pool, ConsumerId::Momentum),
-            RevisionAcquireResult::Acquired
-        );
+        let owner = momentum_owner(Pubkey::new_unique(), pool);
+        assert_acquired_owner(&revisions, owner);
         let v2 = Pubkey::new_unique();
         let v3 = Pubkey::new_unique();
         let v4 = Pubkey::new_unique();
@@ -853,24 +1225,23 @@ mod tests {
     fn sequencer_rejects_stale_apply_after_newer() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         let pool = Pubkey::new_unique();
-        assert_eq!(
-            revisions.try_acquire_active(pool, ConsumerId::Momentum),
-            RevisionAcquireResult::Acquired
-        );
+        let owner = momentum_owner(Pubkey::new_unique(), pool);
+        assert_acquired_owner(&revisions, owner);
         let mut newer = mk_snapshot(pool, Pubkey::new_unique());
         let mut older = mk_snapshot(pool, Pubkey::new_unique());
-        let rev_new = match revisions.assign_next(&mut newer) {
-            RevisionAssignResult::Assigned(rev) => rev,
-            other => panic!("{other:?}"),
+        let rev_new = reserve_assign(&revisions, pool, ConsumerId::Momentum);
+        newer.revision = rev_new;
+        let rev_latest = {
+            assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
+            match revisions.assign_next(&mut older) {
+                RevisionAssignResult::Assigned(rev) => rev,
+                other => panic!("{other:?}"),
+            }
         };
-        revisions.inc_inflight_ref(pool, ConsumerId::Momentum);
-        let rev_latest = match revisions.assign_next(&mut older) {
-            RevisionAssignResult::Assigned(rev) => rev,
-            other => panic!("{other:?}"),
-        };
-        revisions.inc_inflight_ref(pool, ConsumerId::Momentum);
-        assert!(revisions.should_apply_and_record(&older));
-        assert!(!revisions.should_apply_and_record(&newer));
+        revisions.finish_pool_command(&older, PoolCommandTerminal::Applied);
+        assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
+        newer.revision = rev_new;
+        revisions.finish_pool_command(&newer, PoolCommandTerminal::StaleRevision);
         assert_eq!(
             revisions.current_applied(pool, ConsumerId::Momentum),
             rev_latest
@@ -883,12 +1254,12 @@ mod tests {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         for _ in 0..128 {
             let pool = Pubkey::new_unique();
-            let revision = register_and_assign(&revisions, pool, ConsumerId::Momentum);
-            revisions.inc_inflight_ref(pool, ConsumerId::Momentum);
+            let owner = momentum_owner(Pubkey::new_unique(), pool);
+            let revision = register_and_assign(&revisions, owner);
             let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
             snapshot.revision = revision;
-            assert!(revisions.should_apply_and_record(&snapshot));
-            revisions.release_active_if_idle(pool, ConsumerId::Momentum);
+            revisions.finish_pool_command(&snapshot, PoolCommandTerminal::Applied);
+            revisions.release_active_owner(owner);
         }
         assert!(
             revisions.active_key_count() <= 8,
@@ -900,63 +1271,53 @@ mod tests {
     #[test]
     fn active_keys_never_evicted_above_cap() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(4);
-        let pools: Vec<Pubkey> = (0..6).map(|_| Pubkey::new_unique()).collect();
-        for pool in &pools[..4] {
+        let pools: Vec<Pubkey> = (0..4).map(|_| Pubkey::new_unique()).collect();
+        for (i, pool) in pools[..4].iter().enumerate() {
+            let owner = momentum_owner(Pubkey::new_unique(), *pool);
             assert_eq!(
-                revisions.try_acquire_active(*pool, ConsumerId::Momentum),
+                revisions.acquire_active_owner(owner),
                 RevisionAcquireResult::Acquired
             );
-        }
-        for pool in &pools[..4] {
-            let _ = register_and_assign(&revisions, *pool, ConsumerId::Momentum);
+            let _ = register_and_assign(&revisions, owner);
+            let _ = i;
         }
         assert_eq!(revisions.active_key_count(), 4);
         assert_eq!(
-            revisions.try_acquire_active(pools[4], ConsumerId::Momentum),
+            revisions
+                .acquire_active_owner(momentum_owner(Pubkey::new_unique(), Pubkey::new_unique())),
             RevisionAcquireResult::RegistryFull,
             "must fail closed when all slots are active/in-flight"
         );
         let refs = revisions.key_refs(pools[0], ConsumerId::Momentum);
-        assert!(refs.active > 0);
-        assert_eq!(
-            revisions.current_issued(pools[0], ConsumerId::Momentum),
-            revisions.current_issued(pools[0], ConsumerId::Momentum)
-        );
+        assert_eq!(refs.active_owners, 1);
     }
 
     #[test]
     fn retired_lifecycle_rejects_delayed_stale_command_after_repin() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         let pool = Pubkey::new_unique();
-        assert_eq!(
-            revisions.try_acquire_active(pool, ConsumerId::Momentum),
-            RevisionAcquireResult::Acquired
-        );
+        let owner = momentum_owner(Pubkey::new_unique(), pool);
+        assert_acquired_owner(&revisions, owner);
         let mut stale = mk_snapshot(pool, Pubkey::new_unique());
-        let stale_rev = match revisions.assign_next(&mut stale) {
-            RevisionAssignResult::Assigned(rev) => rev,
-            other => panic!("{other:?}"),
-        };
-        revisions.inc_inflight_ref(pool, ConsumerId::Momentum);
-        assert!(revisions.should_apply_and_record(&stale));
-        revisions.release_active_if_idle(pool, ConsumerId::Momentum);
+        let stale_rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
+        stale.revision = stale_rev;
+        revisions.finish_pool_command(&stale, PoolCommandTerminal::Applied);
+        revisions.release_active_owner(owner);
 
-        assert_eq!(
-            revisions.try_acquire_active(pool, ConsumerId::Momentum),
-            RevisionAcquireResult::Acquired
-        );
+        let owner2 = momentum_owner(Pubkey::new_unique(), pool);
+        assert_acquired_owner(&revisions, owner2);
         let mut fresh = mk_snapshot(pool, Pubkey::new_unique());
-        let fresh_rev = match revisions.assign_next(&mut fresh) {
-            RevisionAssignResult::Assigned(rev) => rev,
-            other => panic!("{other:?}"),
-        };
+        let fresh_rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
+        fresh.revision = fresh_rev;
         assert!(
             PoolSnapshotRevisionSequencer::revision_lifecycle_id(fresh_rev)
                 > PoolSnapshotRevisionSequencer::revision_lifecycle_id(stale_rev)
         );
-        revisions.inc_inflight_ref(pool, ConsumerId::Momentum);
-        assert!(!revisions.should_apply_and_record(&stale));
-        assert!(revisions.should_apply_and_record(&fresh));
+        assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
+        stale.revision = stale_rev;
+        revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision);
+        assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
+        revisions.finish_pool_command(&fresh, PoolCommandTerminal::Applied);
         assert_eq!(
             revisions.current_applied(pool, ConsumerId::Momentum),
             fresh_rev
@@ -969,19 +1330,55 @@ mod tests {
         let mut issued: Vec<(Pubkey, u64)> = Vec::new();
         for _ in 0..256 {
             let pool = Pubkey::new_unique();
-            let rev = register_and_assign(&revisions, pool, ConsumerId::Momentum);
-            revisions.inc_inflight_ref(pool, ConsumerId::Momentum);
+            let owner = momentum_owner(Pubkey::new_unique(), pool);
+            let rev = register_and_assign(&revisions, owner);
             let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
             snapshot.revision = rev;
-            assert!(revisions.should_apply_and_record(&snapshot));
+            revisions.finish_pool_command(&snapshot, PoolCommandTerminal::Applied);
             issued.push((pool, rev));
-            revisions.release_active_if_idle(pool, ConsumerId::Momentum);
+            revisions.release_active_owner(owner);
         }
         assert!(revisions.active_key_count() <= 16);
         for (pool, stale_rev) in issued.into_iter().take(32) {
             let mut stale = mk_snapshot(pool, Pubkey::new_unique());
             stale.revision = stale_rev;
-            assert!(!revisions.should_apply_and_record(&stale));
+            assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
+            revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision);
         }
+    }
+
+    #[test]
+    fn concurrent_inflight_reserve_and_transfer_no_zero_ref_gap() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let revisions = Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(8));
+        let pool = Pubkey::new_unique();
+        let owner = momentum_owner(Pubkey::new_unique(), pool);
+        assert_acquired_owner(&revisions, owner);
+        let revisions_a = Arc::clone(&revisions);
+        let revisions_b = Arc::clone(&revisions);
+        let handle = thread::spawn(move || {
+            for _ in 0..64 {
+                assert_eq!(
+                    revisions_a.reserve_inflight_command(pool, ConsumerId::Momentum),
+                    InflightReserveResult::Reserved
+                );
+                revisions_a.release_inflight_command(pool, ConsumerId::Momentum);
+            }
+        });
+        for _ in 0..64 {
+            assert_eq!(
+                revisions_b.reserve_inflight_command(pool, ConsumerId::Momentum),
+                InflightReserveResult::Reserved
+            );
+            assert!(revisions_b.transfer_inflight_to_pending(pool, ConsumerId::Momentum));
+            revisions_b.dec_pending_ref(pool, ConsumerId::Momentum);
+        }
+        handle.join().expect("join");
+        let refs = revisions.key_refs(pool, ConsumerId::Momentum);
+        assert_eq!(refs.inflight, 0);
+        assert_eq!(refs.pending, 0);
+        assert_eq!(refs.active_owners, 1);
     }
 }

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -72,19 +72,22 @@ pub enum PoolCommandTerminal {
     InvalidRevision,
 }
 
+/// Phase returned by [`PoolSnapshotRevisionSequencer::begin_pool_command`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PoolCommandAcceptPhase {
+    Stale,
+    Ready,
+}
+
 #[derive(Debug, Default, Clone, Copy)]
 pub struct RevisionRefCounts {
-    pub active_owners: usize,
     pub pending: u32,
     pub inflight: u32,
 }
 
 impl RevisionRefCounts {
-    #[allow(dead_code)]
-    fn total(self) -> u32 {
-        (self.active_owners as u32)
-            .saturating_add(self.pending)
-            .saturating_add(self.inflight)
+    pub fn total(self) -> u32 {
+        self.pending.saturating_add(self.inflight)
     }
 }
 
@@ -92,8 +95,7 @@ impl RevisionRefCounts {
 struct RevisionSlot {
     lifecycle_id: u32,
     issued_seq: u32,
-    applied_seq: u32,
-    active_owners: HashSet<RevisionActiveOwner>,
+    applied_revision: u64,
     pending: u32,
     inflight: u32,
     touch_stamp: u64,
@@ -101,7 +103,11 @@ struct RevisionSlot {
 
 impl RevisionSlot {
     fn recyclable(&self) -> bool {
-        self.active_owners.is_empty() && self.pending == 0 && self.inflight == 0
+        self.pending == 0 && self.inflight == 0
+    }
+
+    fn empty_slot(&self) -> bool {
+        self.recyclable() && self.applied_revision == 0
     }
 }
 
@@ -187,12 +193,15 @@ impl PoolSnapshotRevisionSequencer {
         RevisionSlot {
             lifecycle_id: self.fresh_lifecycle_id(),
             issued_seq: 0,
-            applied_seq: 0,
-            active_owners: HashSet::new(),
+            applied_revision: 0,
             pending: 0,
             inflight: 0,
             touch_stamp: self.next_touch_stamp(),
         }
+    }
+
+    pub fn revision_newer_than_applied(revision: u64, applied_revision: u64) -> bool {
+        revision != 0 && revision > applied_revision
     }
 
     fn ensure_slot(&self, key: (Pubkey, ConsumerId)) -> Result<(), RevisionAcquireResult> {
@@ -221,59 +230,36 @@ impl PoolSnapshotRevisionSequencer {
         slots: &mut HashMap<(Pubkey, ConsumerId), RevisionSlot>,
         key: (Pubkey, ConsumerId),
     ) {
-        if slots.get(&key).is_some_and(|slot| slot.recyclable()) {
+        if slots.get(&key).is_some_and(|slot| slot.empty_slot()) {
             slots.remove(&key);
         }
     }
 
-    /// Idempotent acquire of a logical active owner (duplicate acquire is a no-op).
+    /// Ensure a revision-registry key exists (ownership lives in bounded pin maps).
+    pub fn ensure_revision_key(&self, pool: Pubkey, consumer: ConsumerId) -> RevisionAcquireResult {
+        self.ensure_slot((pool, consumer))
+            .map(|()| RevisionAcquireResult::Acquired)
+            .unwrap_or(RevisionAcquireResult::RegistryFull)
+    }
+
+    #[deprecated(note = "ownership is tracked in hot_pool_registry pin maps")]
     pub fn acquire_active_owner(&self, owner: RevisionActiveOwner) -> RevisionAcquireResult {
-        let key = owner.registry_key();
-        if let Err(result) = self.ensure_slot(key) {
-            return result;
-        }
-        let mut slots = self.slots.lock().expect("pool revision slots lock");
-        let Some(slot) = slots.get_mut(&key) else {
-            return RevisionAcquireResult::RegistryFull;
-        };
-        slot.active_owners.insert(owner);
-        slot.touch_stamp = self.next_touch_stamp();
-        RevisionAcquireResult::Acquired
+        self.ensure_revision_key(owner.pool(), owner.consumer())
     }
 
-    /// Release one logical active owner; retires the slot when fully idle.
-    pub fn release_active_owner(&self, owner: RevisionActiveOwner) -> bool {
-        let key = owner.registry_key();
-        let mut slots = self.slots.lock().expect("pool revision slots lock");
-        let Some(slot) = slots.get_mut(&key) else {
-            return false;
-        };
-        slot.active_owners.remove(&owner);
-        let retired = slot.recyclable();
-        if retired {
-            slots.remove(&key);
-        }
-        retired
+    #[deprecated(note = "ownership is tracked in hot_pool_registry pin maps")]
+    pub fn release_active_owner(&self, _owner: RevisionActiveOwner) -> bool {
+        false
     }
 
-    #[deprecated(note = "use acquire_active_owner")]
+    #[deprecated(note = "use ensure_revision_key")]
     pub fn try_acquire_active(&self, pool: Pubkey, consumer: ConsumerId) -> RevisionAcquireResult {
-        let owner = match consumer {
-            ConsumerId::Momentum => RevisionActiveOwner::MomentumMintPool { mint: pool, pool },
-            ConsumerId::Arb => RevisionActiveOwner::ArbPool { pool },
-            _ => return RevisionAcquireResult::RegistryFull,
-        };
-        self.acquire_active_owner(owner)
+        self.ensure_revision_key(pool, consumer)
     }
 
-    #[deprecated(note = "use release_active_owner")]
-    pub fn release_active_if_idle(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
-        let owner = match consumer {
-            ConsumerId::Momentum => RevisionActiveOwner::MomentumMintPool { mint: pool, pool },
-            ConsumerId::Arb => RevisionActiveOwner::ArbPool { pool },
-            _ => return false,
-        };
-        self.release_active_owner(owner)
+    #[deprecated(note = "ownership is tracked in hot_pool_registry pin maps")]
+    pub fn release_active_if_idle(&self, _pool: Pubkey, _consumer: ConsumerId) -> bool {
+        false
     }
 
     pub fn inc_pending_ref(&self, pool: Pubkey, consumer: ConsumerId) {
@@ -292,7 +278,6 @@ impl PoolSnapshotRevisionSequencer {
             return;
         };
         slot.pending = slot.pending.saturating_sub(1);
-        Self::maybe_remove_slot(&mut slots, key);
     }
 
     /// Reserve one in-flight command ref before queue send (ephemeral; no active owner).
@@ -342,7 +327,6 @@ impl PoolSnapshotRevisionSequencer {
             return;
         };
         slot.inflight = slot.inflight.saturating_sub(1);
-        Self::maybe_remove_slot(&mut slots, key);
     }
 
     #[deprecated(note = "use release_inflight_command")]
@@ -356,19 +340,15 @@ impl PoolSnapshotRevisionSequencer {
             .expect("pool revision slots lock")
             .get(&(pool, consumer))
             .map(|slot| RevisionRefCounts {
-                active_owners: slot.active_owners.len(),
                 pending: slot.pending,
                 inflight: slot.inflight,
             })
             .unwrap_or_default()
     }
 
-    pub fn has_active_owner(&self, owner: RevisionActiveOwner) -> bool {
-        self.slots
-            .lock()
-            .expect("pool revision slots lock")
-            .get(&owner.registry_key())
-            .is_some_and(|slot| slot.active_owners.contains(&owner))
+    #[deprecated(note = "ownership is tracked in hot_pool_registry pin maps")]
+    pub fn has_active_owner(&self, _owner: RevisionActiveOwner) -> bool {
+        false
     }
 
     pub fn assign_next(&self, snapshot: &mut PoolExplicitSnapshot) -> RevisionAssignResult {
@@ -388,54 +368,89 @@ impl PoolSnapshotRevisionSequencer {
     }
 
     pub fn revision_acceptable(&self, snapshot: &PoolExplicitSnapshot) -> bool {
+        matches!(
+            self.begin_pool_command(snapshot),
+            PoolCommandAcceptPhase::Ready
+        )
+    }
+
+    /// Begin processing under the registry lock — stale commands never advance watermark.
+    pub fn begin_pool_command(&self, snapshot: &PoolExplicitSnapshot) -> PoolCommandAcceptPhase {
         if snapshot.revision == 0 {
-            return false;
+            return PoolCommandAcceptPhase::Stale;
         }
-        let (lifecycle_id, seq) = Self::unpack_revision(snapshot.revision);
-        self.slots
+        let ready = self
+            .slots
             .lock()
             .expect("pool revision slots lock")
             .get(&(snapshot.pool, snapshot.consumer))
-            .is_some_and(|slot| lifecycle_id == slot.lifecycle_id && seq > slot.applied_seq)
+            .is_some_and(|slot| {
+                Self::revision_newer_than_applied(snapshot.revision, slot.applied_revision)
+            });
+        if ready {
+            PoolCommandAcceptPhase::Ready
+        } else {
+            PoolCommandAcceptPhase::Stale
+        }
     }
 
-    /// Finish a pool command on the worker — always releases exactly one in-flight ref.
+    /// Finish a pool command — releases exactly one in-flight ref when requested and may
+    /// advance the authoritative applied-revision watermark after demand validation.
     pub fn finish_pool_command(
         &self,
         snapshot: &PoolExplicitSnapshot,
         terminal: PoolCommandTerminal,
+        finish_inflight: bool,
+        record_watermark: bool,
     ) {
         if snapshot.revision == 0 {
-            self.release_inflight_command(snapshot.pool, snapshot.consumer);
+            if finish_inflight {
+                self.release_inflight_command(snapshot.pool, snapshot.consumer);
+            }
             return;
         }
-        let (lifecycle_id, seq) = Self::unpack_revision(snapshot.revision);
         let key = (snapshot.pool, snapshot.consumer);
         let mut slots = self.slots.lock().expect("pool revision slots lock");
         let Some(slot) = slots.get_mut(&key) else {
+            if finish_inflight {
+                drop(slots);
+                self.release_inflight_command(snapshot.pool, snapshot.consumer);
+            }
             return;
         };
-        if terminal == PoolCommandTerminal::Applied
-            && lifecycle_id == slot.lifecycle_id
-            && seq > slot.applied_seq
+        if record_watermark
+            && matches!(
+                terminal,
+                PoolCommandTerminal::Applied
+                    | PoolCommandTerminal::AdmissionRejected
+                    | PoolCommandTerminal::UnpinnedRejected
+            )
+            && Self::revision_newer_than_applied(snapshot.revision, slot.applied_revision)
         {
-            slot.applied_seq = seq;
+            slot.applied_revision = snapshot.revision;
         }
-        slot.inflight = slot.inflight.saturating_sub(1);
+        if finish_inflight {
+            slot.inflight = slot.inflight.saturating_sub(1);
+        }
         slot.touch_stamp = self.next_touch_stamp();
         Self::maybe_remove_slot(&mut slots, key);
     }
 
-    #[deprecated(note = "use revision_acceptable + finish_pool_command")]
+    #[deprecated(note = "use begin_pool_command + finish_pool_command")]
     pub fn should_apply_and_record(&self, snapshot: &PoolExplicitSnapshot) -> bool {
-        let acceptable = self.revision_acceptable(snapshot);
-        let terminal = if acceptable {
+        let phase = self.begin_pool_command(snapshot);
+        let terminal = if phase == PoolCommandAcceptPhase::Ready {
             PoolCommandTerminal::Applied
         } else {
             PoolCommandTerminal::StaleRevision
         };
-        self.finish_pool_command(snapshot, terminal);
-        acceptable
+        self.finish_pool_command(
+            snapshot,
+            terminal,
+            true,
+            phase == PoolCommandAcceptPhase::Ready,
+        );
+        phase == PoolCommandAcceptPhase::Ready
     }
 
     pub fn retire_key(&self, pool: Pubkey, consumer: ConsumerId) {
@@ -444,7 +459,7 @@ impl PoolSnapshotRevisionSequencer {
         let Some(slot) = slots.get(&key) else {
             return;
         };
-        if !slot.recyclable() {
+        if slot.inflight > 0 || slot.pending > 0 {
             return;
         }
         slots.remove(&key);
@@ -477,7 +492,7 @@ impl PoolSnapshotRevisionSequencer {
             .lock()
             .expect("pool revision slots lock")
             .get(&(pool, consumer))
-            .map(|slot| Self::pack_revision(slot.lifecycle_id, slot.applied_seq))
+            .map(|slot| slot.applied_revision)
             .unwrap_or(0)
     }
 
@@ -488,7 +503,7 @@ impl PoolSnapshotRevisionSequencer {
         consumer: ConsumerId,
         lifecycle_id: u32,
         issued_seq: u32,
-        applied_seq: u32,
+        applied_revision: u64,
     ) {
         let key = (pool, consumer);
         if let Err(RevisionAcquireResult::RegistryFull) = self.ensure_slot(key) {
@@ -498,7 +513,7 @@ impl PoolSnapshotRevisionSequencer {
         let slot = slots.get_mut(&key).expect("seeded revision slot");
         slot.lifecycle_id = lifecycle_id;
         slot.issued_seq = issued_seq;
-        slot.applied_seq = applied_seq;
+        slot.applied_revision = applied_revision;
         self.next_lifecycle_id
             .fetch_max(lifecycle_id.saturating_add(1), Ordering::AcqRel);
     }
@@ -668,6 +683,11 @@ impl WalletExplicitPending {
     }
 }
 
+enum PendingRefPolicy {
+    IncrementOnStore,
+    Defer,
+}
+
 /// Bounded per-pool coalesced pending (one entry per pool+consumer; overflow is fail-closed).
 #[derive(Debug)]
 pub struct PendingPoolRegistrations {
@@ -690,19 +710,44 @@ impl PendingPoolRegistrations {
     }
 
     pub fn upsert(&self, mut command: PendingPoolCommand) -> PendingPoolUpsertResult {
-        self.upsert_internal(&mut command, false)
+        self.upsert_internal(&mut command, PendingRefPolicy::IncrementOnStore)
     }
 
-    /// Upsert when the pending ref was already transferred from in-flight (enqueue loss).
-    pub fn upsert_transferred(&self, command: PendingPoolCommand) -> PendingPoolUpsertResult {
+    /// Transactional stash after queue send failure while holding one in-flight reservation.
+    pub fn upsert_after_inflight_send_failure(
+        &self,
+        pool: Pubkey,
+        consumer: ConsumerId,
+        command: PendingPoolCommand,
+    ) -> PendingPoolUpsertResult {
         let mut command = command;
-        self.upsert_internal(&mut command, true)
+        let result = self.upsert_internal(&mut command, PendingRefPolicy::Defer);
+        match result {
+            PendingPoolUpsertResult::Stored => {
+                if !self.revisions.transfer_inflight_to_pending(pool, consumer) {
+                    self.revisions.release_inflight_command(pool, consumer);
+                    self.overflow.store(true, Ordering::Release);
+                    return PendingPoolUpsertResult::Overflow;
+                }
+            }
+            PendingPoolUpsertResult::Coalesced
+            | PendingPoolUpsertResult::StaleNoOp
+            | PendingPoolUpsertResult::Overflow => {
+                self.revisions.release_inflight_command(pool, consumer);
+            }
+        }
+        result
+    }
+
+    #[deprecated(note = "use upsert_after_inflight_send_failure")]
+    pub fn upsert_transferred(&self, command: PendingPoolCommand) -> PendingPoolUpsertResult {
+        self.upsert(command)
     }
 
     fn upsert_internal(
         &self,
         command: &mut PendingPoolCommand,
-        pending_ref_transferred: bool,
+        ref_policy: PendingRefPolicy,
     ) -> PendingPoolUpsertResult {
         let revision = match command {
             PendingPoolCommand::RegisterReserves(s)
@@ -755,8 +800,11 @@ impl PendingPoolRegistrations {
             self.overflow.store(true, Ordering::Release);
             return PendingPoolUpsertResult::Overflow;
         }
-        if !pending_ref_transferred {
-            self.revisions.inc_pending_ref(key.0, key.1);
+        match ref_policy {
+            PendingRefPolicy::IncrementOnStore => {
+                self.revisions.inc_pending_ref(key.0, key.1);
+            }
+            PendingRefPolicy::Defer => {}
         }
         let coalesced = CoalescedPoolPending {
             pool: key.0,
@@ -937,10 +985,6 @@ mod tests {
         )
     }
 
-    fn momentum_owner(mint: Pubkey, pool: Pubkey) -> RevisionActiveOwner {
-        RevisionActiveOwner::MomentumMintPool { mint, pool }
-    }
-
     fn reserve_assign(
         revisions: &PoolSnapshotRevisionSequencer,
         pool: Pubkey,
@@ -957,26 +1001,20 @@ mod tests {
         }
     }
 
-    fn register_and_assign(
-        revisions: &PoolSnapshotRevisionSequencer,
-        owner: RevisionActiveOwner,
-    ) -> u64 {
+    fn ensure_key(revisions: &PoolSnapshotRevisionSequencer, pool: Pubkey, consumer: ConsumerId) {
         assert_eq!(
-            revisions.acquire_active_owner(owner),
+            revisions.ensure_revision_key(pool, consumer),
             RevisionAcquireResult::Acquired
         );
-        let pool = owner.pool();
-        reserve_assign(revisions, pool, owner.consumer())
     }
 
-    fn assert_acquired_owner(
+    fn register_and_assign(
         revisions: &PoolSnapshotRevisionSequencer,
-        owner: RevisionActiveOwner,
-    ) {
-        assert_eq!(
-            revisions.acquire_active_owner(owner),
-            RevisionAcquireResult::Acquired
-        );
+        pool: Pubkey,
+        consumer: ConsumerId,
+    ) -> u64 {
+        ensure_key(revisions, pool, consumer);
+        reserve_assign(revisions, pool, consumer)
     }
 
     fn assert_reserved_inflight(
@@ -991,69 +1029,36 @@ mod tests {
     }
 
     #[test]
-    fn active_owner_idempotent_duplicate_acquire() {
+    fn revision_key_ensure_is_idempotent() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         let pool = Pubkey::new_unique();
-        let mint = Pubkey::new_unique();
-        let owner = momentum_owner(mint, pool);
-        assert_eq!(
-            revisions.acquire_active_owner(owner),
-            RevisionAcquireResult::Acquired
-        );
-        assert_eq!(
-            revisions.acquire_active_owner(owner),
-            RevisionAcquireResult::Acquired
-        );
-        let refs = revisions.key_refs(pool, ConsumerId::Momentum);
-        assert_eq!(refs.active_owners, 1);
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
+        assert_eq!(revisions.active_key_count(), 1);
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).total(), 0);
     }
 
     #[test]
-    fn two_momentum_mints_release_both_to_zero_active() {
+    fn revision_slot_retires_when_refs_return_to_zero() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         let pool = Pubkey::new_unique();
-        let mint_a = Pubkey::new_unique();
-        let mint_b = Pubkey::new_unique();
-        let owner_a = momentum_owner(mint_a, pool);
-        let owner_b = momentum_owner(mint_b, pool);
-        assert_eq!(
-            revisions.acquire_active_owner(owner_a),
-            RevisionAcquireResult::Acquired
-        );
-        assert_eq!(
-            revisions.acquire_active_owner(owner_b),
-            RevisionAcquireResult::Acquired
-        );
-        assert_eq!(
-            revisions.key_refs(pool, ConsumerId::Momentum).active_owners,
-            2
-        );
-        revisions.release_active_owner(owner_a);
-        assert_eq!(
-            revisions.key_refs(pool, ConsumerId::Momentum).active_owners,
-            1
-        );
-        revisions.release_active_owner(owner_b);
-        assert_eq!(
-            revisions.key_refs(pool, ConsumerId::Momentum).active_owners,
-            0
-        );
-        assert_eq!(revisions.active_key_count(), 0);
+        let rev = register_and_assign(&revisions, pool, ConsumerId::Momentum);
+        let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
+        snapshot.revision = rev;
+        revisions.finish_pool_command(&snapshot, PoolCommandTerminal::Applied, true, true);
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).total(), 0);
+        assert!(revisions.current_applied(pool, ConsumerId::Momentum) > 0);
     }
 
     #[test]
     fn stale_noop_releases_inflight_without_apply() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         let pool = Pubkey::new_unique();
-        let owner = momentum_owner(Pubkey::new_unique(), pool);
-        assert_eq!(
-            revisions.acquire_active_owner(owner),
-            RevisionAcquireResult::Acquired
-        );
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
         let rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
         let mut stale = mk_snapshot(pool, Pubkey::new_unique());
         stale.revision = rev;
-        revisions.finish_pool_command(&stale, PoolCommandTerminal::Applied);
+        revisions.finish_pool_command(&stale, PoolCommandTerminal::Applied, true, true);
         let mut older = mk_snapshot(pool, Pubkey::new_unique());
         older.revision = rev.saturating_sub(1);
         assert!(!revisions.revision_acceptable(&older));
@@ -1062,7 +1067,7 @@ mod tests {
             InflightReserveResult::Reserved
         );
         older.revision = rev;
-        revisions.finish_pool_command(&older, PoolCommandTerminal::StaleRevision);
+        revisions.finish_pool_command(&older, PoolCommandTerminal::StaleRevision, true, false);
         assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).inflight, 0);
     }
 
@@ -1070,8 +1075,7 @@ mod tests {
     fn inflight_transfer_to_pending_no_zero_ref_gap() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         let pool = Pubkey::new_unique();
-        let owner = momentum_owner(Pubkey::new_unique(), pool);
-        assert_acquired_owner(&revisions, owner);
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
         let _rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
         let refs_before = revisions.key_refs(pool, ConsumerId::Momentum);
         assert_eq!(refs_before.inflight, 1);
@@ -1079,28 +1083,35 @@ mod tests {
         let refs_after = revisions.key_refs(pool, ConsumerId::Momentum);
         assert_eq!(refs_after.inflight, 0);
         assert_eq!(refs_after.pending, 1);
-        assert_eq!(refs_after.active_owners, 1);
+        assert_eq!(refs_after.total(), 1);
     }
 
     #[test]
     fn delayed_after_unpin_churn_keeps_registry_bounded() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(4);
         let pool = Pubkey::new_unique();
-        let mint = Pubkey::new_unique();
-        let owner = momentum_owner(mint, pool);
-        assert_acquired_owner(&revisions, owner);
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
         let rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
-        revisions.release_active_owner(owner);
         let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
         snapshot.revision = rev;
-        revisions.finish_pool_command(&snapshot, PoolCommandTerminal::UnpinnedRejected);
+        revisions.finish_pool_command(
+            &snapshot,
+            PoolCommandTerminal::UnpinnedRejected,
+            true,
+            false,
+        );
         assert_eq!(revisions.active_key_count(), 0);
         for _ in 0..64 {
             let ephemeral_pool = Pubkey::new_unique();
             let rev = reserve_assign(&revisions, ephemeral_pool, ConsumerId::Momentum);
             let mut snap = mk_snapshot(ephemeral_pool, Pubkey::new_unique());
             snap.revision = rev;
-            revisions.finish_pool_command(&snap, PoolCommandTerminal::UnpinnedRejected);
+            revisions.finish_pool_command(
+                &snap,
+                PoolCommandTerminal::UnpinnedRejected,
+                true,
+                false,
+            );
         }
         assert!(revisions.active_key_count() <= 4);
     }
@@ -1109,9 +1120,14 @@ mod tests {
     fn revision_seq_near_wrap_allocates_new_lifecycle() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         let pool = Pubkey::new_unique();
-        let owner = momentum_owner(Pubkey::new_unique(), pool);
-        assert_acquired_owner(&revisions, owner);
-        revisions.test_seed_slot_revision_state(pool, ConsumerId::Momentum, 7, u32::MAX, 0);
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
+        revisions.test_seed_slot_revision_state(
+            pool,
+            ConsumerId::Momentum,
+            7,
+            u32::MAX,
+            PoolSnapshotRevisionSequencer::pack_revision(7, u32::MAX - 1),
+        );
         let mut snap = mk_snapshot(pool, Pubkey::new_unique());
         let rev_wrap = match revisions.assign_next(&mut snap) {
             RevisionAssignResult::Assigned(rev) => rev,
@@ -1128,17 +1144,16 @@ mod tests {
         assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
         let mut stale = mk_snapshot(pool, Pubkey::new_unique());
         stale.revision = PoolSnapshotRevisionSequencer::pack_revision(7, u32::MAX);
-        revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision);
+        revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision, true, false);
         assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
-        revisions.finish_pool_command(&snap, PoolCommandTerminal::Applied);
+        revisions.finish_pool_command(&snap, PoolCommandTerminal::Applied, true, true);
     }
 
     #[test]
     fn pending_replays_latest_revision_not_kind_order() {
         let (pending, revisions) = mk_pending(8);
         let pool = Pubkey::new_unique();
-        let owner = momentum_owner(Pubkey::new_unique(), pool);
-        assert_acquired_owner(&revisions, owner);
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
         let old_vault = Pubkey::new_unique();
         let new_vault = Pubkey::new_unique();
 
@@ -1170,8 +1185,7 @@ mod tests {
     fn pending_stale_out_of_order_across_all_kinds_no_ops() {
         let (pending, revisions) = mk_pending(8);
         let pool = Pubkey::new_unique();
-        let owner = momentum_owner(Pubkey::new_unique(), pool);
-        assert_acquired_owner(&revisions, owner);
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
         let v2 = Pubkey::new_unique();
         let v3 = Pubkey::new_unique();
         let v4 = Pubkey::new_unique();
@@ -1225,8 +1239,7 @@ mod tests {
     fn sequencer_rejects_stale_apply_after_newer() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         let pool = Pubkey::new_unique();
-        let owner = momentum_owner(Pubkey::new_unique(), pool);
-        assert_acquired_owner(&revisions, owner);
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
         let mut newer = mk_snapshot(pool, Pubkey::new_unique());
         let mut older = mk_snapshot(pool, Pubkey::new_unique());
         let rev_new = reserve_assign(&revisions, pool, ConsumerId::Momentum);
@@ -1238,10 +1251,10 @@ mod tests {
                 other => panic!("{other:?}"),
             }
         };
-        revisions.finish_pool_command(&older, PoolCommandTerminal::Applied);
+        revisions.finish_pool_command(&older, PoolCommandTerminal::Applied, true, true);
         assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
         newer.revision = rev_new;
-        revisions.finish_pool_command(&newer, PoolCommandTerminal::StaleRevision);
+        revisions.finish_pool_command(&newer, PoolCommandTerminal::StaleRevision, true, false);
         assert_eq!(
             revisions.current_applied(pool, ConsumerId::Momentum),
             rev_latest
@@ -1254,12 +1267,10 @@ mod tests {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         for _ in 0..128 {
             let pool = Pubkey::new_unique();
-            let owner = momentum_owner(Pubkey::new_unique(), pool);
-            let revision = register_and_assign(&revisions, owner);
+            let revision = register_and_assign(&revisions, pool, ConsumerId::Momentum);
             let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
             snapshot.revision = revision;
-            revisions.finish_pool_command(&snapshot, PoolCommandTerminal::Applied);
-            revisions.release_active_owner(owner);
+            revisions.finish_pool_command(&snapshot, PoolCommandTerminal::Applied, true, true);
         }
         assert!(
             revisions.active_key_count() <= 8,
@@ -1271,41 +1282,33 @@ mod tests {
     #[test]
     fn active_keys_never_evicted_above_cap() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(4);
-        let pools: Vec<Pubkey> = (0..4).map(|_| Pubkey::new_unique()).collect();
-        for (i, pool) in pools[..4].iter().enumerate() {
-            let owner = momentum_owner(Pubkey::new_unique(), *pool);
-            assert_eq!(
-                revisions.acquire_active_owner(owner),
-                RevisionAcquireResult::Acquired
-            );
-            let _ = register_and_assign(&revisions, owner);
-            let _ = i;
+        let pools: Vec<Pubkey> = (0..5).map(|_| Pubkey::new_unique()).collect();
+        for pool in &pools[..4] {
+            let _ = register_and_assign(&revisions, *pool, ConsumerId::Momentum);
         }
         assert_eq!(revisions.active_key_count(), 4);
         assert_eq!(
-            revisions
-                .acquire_active_owner(momentum_owner(Pubkey::new_unique(), Pubkey::new_unique())),
+            revisions.ensure_revision_key(pools[4], ConsumerId::Momentum),
             RevisionAcquireResult::RegistryFull,
-            "must fail closed when all slots are active/in-flight"
+            "must fail closed when all slots are in use"
         );
         let refs = revisions.key_refs(pools[0], ConsumerId::Momentum);
-        assert_eq!(refs.active_owners, 1);
+        assert_eq!(refs.total(), 1);
     }
 
     #[test]
     fn retired_lifecycle_rejects_delayed_stale_command_after_repin() {
         let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
         let pool = Pubkey::new_unique();
-        let owner = momentum_owner(Pubkey::new_unique(), pool);
-        assert_acquired_owner(&revisions, owner);
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
         let mut stale = mk_snapshot(pool, Pubkey::new_unique());
         let stale_rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
         stale.revision = stale_rev;
-        revisions.finish_pool_command(&stale, PoolCommandTerminal::Applied);
-        revisions.release_active_owner(owner);
+        revisions.finish_pool_command(&stale, PoolCommandTerminal::Applied, true, true);
+        revisions.retire_key(pool, ConsumerId::Momentum);
+        assert_eq!(revisions.active_key_count(), 0);
 
-        let owner2 = momentum_owner(Pubkey::new_unique(), pool);
-        assert_acquired_owner(&revisions, owner2);
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
         let mut fresh = mk_snapshot(pool, Pubkey::new_unique());
         let fresh_rev = reserve_assign(&revisions, pool, ConsumerId::Momentum);
         fresh.revision = fresh_rev;
@@ -1315,9 +1318,9 @@ mod tests {
         );
         assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
         stale.revision = stale_rev;
-        revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision);
+        revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision, true, false);
         assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
-        revisions.finish_pool_command(&fresh, PoolCommandTerminal::Applied);
+        revisions.finish_pool_command(&fresh, PoolCommandTerminal::Applied, true, true);
         assert_eq!(
             revisions.current_applied(pool, ConsumerId::Momentum),
             fresh_rev
@@ -1330,20 +1333,18 @@ mod tests {
         let mut issued: Vec<(Pubkey, u64)> = Vec::new();
         for _ in 0..256 {
             let pool = Pubkey::new_unique();
-            let owner = momentum_owner(Pubkey::new_unique(), pool);
-            let rev = register_and_assign(&revisions, owner);
+            let rev = register_and_assign(&revisions, pool, ConsumerId::Momentum);
             let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
             snapshot.revision = rev;
-            revisions.finish_pool_command(&snapshot, PoolCommandTerminal::Applied);
+            revisions.finish_pool_command(&snapshot, PoolCommandTerminal::Applied, true, true);
             issued.push((pool, rev));
-            revisions.release_active_owner(owner);
         }
         assert!(revisions.active_key_count() <= 16);
         for (pool, stale_rev) in issued.into_iter().take(32) {
             let mut stale = mk_snapshot(pool, Pubkey::new_unique());
             stale.revision = stale_rev;
             assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
-            revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision);
+            revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision, true, false);
         }
     }
 
@@ -1354,8 +1355,7 @@ mod tests {
 
         let revisions = Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(8));
         let pool = Pubkey::new_unique();
-        let owner = momentum_owner(Pubkey::new_unique(), pool);
-        assert_acquired_owner(&revisions, owner);
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
         let revisions_a = Arc::clone(&revisions);
         let revisions_b = Arc::clone(&revisions);
         let handle = thread::spawn(move || {
@@ -1379,6 +1379,80 @@ mod tests {
         let refs = revisions.key_refs(pool, ConsumerId::Momentum);
         assert_eq!(refs.inflight, 0);
         assert_eq!(refs.pending, 0);
-        assert_eq!(refs.active_owners, 1);
+        assert_eq!(refs.total(), 0);
+    }
+
+    #[test]
+    fn upsert_after_send_failure_releases_inflight_on_coalesce_and_stale() {
+        let revisions = Arc::new(PoolSnapshotRevisionSequencer::with_max_keys(8));
+        let pending = PendingPoolRegistrations::new(8, Arc::clone(&revisions));
+        let pool = Pubkey::new_unique();
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
+        let rev = register_and_assign(&revisions, pool, ConsumerId::Momentum);
+        revisions.release_inflight_command(pool, ConsumerId::Momentum);
+
+        let mut first = mk_snapshot(pool, Pubkey::new_unique());
+        first.revision = rev;
+        assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
+        assert_eq!(
+            pending.upsert_after_inflight_send_failure(
+                pool,
+                ConsumerId::Momentum,
+                PendingPoolCommand::RegisterReserves(first),
+            ),
+            PendingPoolUpsertResult::Stored
+        );
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).pending, 1);
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).inflight, 0);
+
+        let mut newer = mk_snapshot(pool, Pubkey::new_unique());
+        newer.revision = rev.saturating_add(1);
+        assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
+        assert_eq!(
+            pending.upsert_after_inflight_send_failure(
+                pool,
+                ConsumerId::Momentum,
+                PendingPoolCommand::AfterTrade(newer),
+            ),
+            PendingPoolUpsertResult::Coalesced
+        );
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).pending, 1);
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).inflight, 0);
+
+        let mut stale = mk_snapshot(pool, Pubkey::new_unique());
+        stale.revision = rev;
+        assert_reserved_inflight(&revisions, pool, ConsumerId::Momentum);
+        assert_eq!(
+            pending.upsert_after_inflight_send_failure(
+                pool,
+                ConsumerId::Momentum,
+                PendingPoolCommand::VaultsFromAccount(stale),
+            ),
+            PendingPoolUpsertResult::StaleNoOp
+        );
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).total(), 1);
+
+        let drained = pending.drain_all();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(revisions.key_refs(pool, ConsumerId::Momentum).total(), 0);
+    }
+
+    #[test]
+    fn accepted_noop_advances_applied_revision_watermark() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
+        let pool = Pubkey::new_unique();
+        ensure_key(&revisions, pool, ConsumerId::Momentum);
+        let rev = register_and_assign(&revisions, pool, ConsumerId::Momentum);
+        let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
+        snapshot.revision = rev;
+        revisions.finish_pool_command(&snapshot, PoolCommandTerminal::Applied, true, true);
+        let mut stale = mk_snapshot(pool, Pubkey::new_unique());
+        stale.revision = rev.saturating_sub(1);
+        assert_eq!(
+            revisions.begin_pool_command(&stale),
+            PoolCommandAcceptPhase::Stale
+        );
+        revisions.finish_pool_command(&stale, PoolCommandTerminal::StaleRevision, true, false);
+        assert_eq!(revisions.current_applied(pool, ConsumerId::Momentum), rev);
     }
 }

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -11,54 +11,185 @@ use crate::market_data::track::desired_set::ConsumerId;
 use crate::market_data::track::worker_commands::{PoolExplicitSnapshot, TrackWorkerCommand};
 
 /// Monotonic per-(pool,consumer) revision sequencer for pool snapshot commands.
-#[derive(Debug, Default)]
+///
+/// Revisions pack `(generation << 32) | sequence`. Tombstoned generations reject delayed stale
+/// commands after registry cleanup/eviction.
+#[derive(Debug)]
 pub struct PoolSnapshotRevisionSequencer {
-    issued: Mutex<HashMap<(Pubkey, ConsumerId), u64>>,
-    last_applied: Mutex<HashMap<(Pubkey, ConsumerId), u64>>,
+    max_keys: usize,
+    slots: Mutex<HashMap<(Pubkey, ConsumerId), RevisionSlot>>,
+    tombstones: Mutex<HashMap<(Pubkey, ConsumerId), u32>>,
+    lru_stamp: AtomicU64,
+}
+
+#[derive(Debug, Clone)]
+struct RevisionSlot {
+    generation: u32,
+    issued_seq: u32,
+    applied_seq: u32,
+    lru_stamp: u64,
+}
+
+const REVISION_SEQ_MASK: u64 = 0xFFFF_FFFF;
+const REVISION_GEN_SHIFT: u32 = 32;
+const DEFAULT_MAX_REVISION_SLOTS: usize = 4096;
+
+impl Default for PoolSnapshotRevisionSequencer {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl PoolSnapshotRevisionSequencer {
     pub fn new() -> Self {
-        Self::default()
+        Self::with_max_keys(DEFAULT_MAX_REVISION_SLOTS)
     }
 
-    pub fn assign_next(&self, snapshot: &mut PoolExplicitSnapshot) -> u64 {
-        let key = (snapshot.pool, snapshot.consumer);
-        let mut issued = self.issued.lock().expect("pool revision issued lock");
-        let entry = issued.entry(key).or_insert(0);
-        *entry = entry.saturating_add(1);
-        snapshot.revision = *entry;
-        *entry
-    }
-
-    pub fn should_apply_and_record(&self, snapshot: &PoolExplicitSnapshot) -> bool {
-        let key = (snapshot.pool, snapshot.consumer);
-        let mut applied = self
-            .last_applied
-            .lock()
-            .expect("pool revision applied lock");
-        if snapshot.revision <= applied.get(&key).copied().unwrap_or(0) {
-            return false;
+    pub fn with_max_keys(max_keys: usize) -> Self {
+        Self {
+            max_keys: max_keys.max(64),
+            slots: Mutex::new(HashMap::new()),
+            tombstones: Mutex::new(HashMap::new()),
+            lru_stamp: AtomicU64::new(0),
         }
-        applied.insert(key, snapshot.revision);
-        true
     }
 
-    pub fn current_issued(&self, pool: Pubkey, consumer: ConsumerId) -> u64 {
-        self.issued
+    pub fn pack_revision(generation: u32, sequence: u32) -> u64 {
+        ((generation as u64) << REVISION_GEN_SHIFT) | (sequence as u64)
+    }
+
+    pub fn unpack_revision(revision: u64) -> (u32, u32) {
+        (
+            (revision >> REVISION_GEN_SHIFT) as u32,
+            (revision & REVISION_SEQ_MASK) as u32,
+        )
+    }
+
+    pub fn revision_sequence(revision: u64) -> u32 {
+        Self::unpack_revision(revision).1
+    }
+
+    pub fn revision_generation(revision: u64) -> u32 {
+        Self::unpack_revision(revision).0
+    }
+
+    fn next_lru_stamp(&self) -> u64 {
+        self.lru_stamp
+            .fetch_add(1, Ordering::AcqRel)
+            .saturating_add(1)
+    }
+
+    fn tombstone_generation(&self, key: (Pubkey, ConsumerId)) -> u32 {
+        self.tombstones
             .lock()
-            .expect("pool revision issued lock")
-            .get(&(pool, consumer))
+            .expect("pool revision tombstones lock")
+            .get(&key)
             .copied()
             .unwrap_or(0)
     }
 
-    pub fn current_applied(&self, pool: Pubkey, consumer: ConsumerId) -> u64 {
-        self.last_applied
+    fn record_tombstone(&self, key: (Pubkey, ConsumerId), generation: u32) {
+        let mut tombstones = self
+            .tombstones
             .lock()
-            .expect("pool revision applied lock")
+            .expect("pool revision tombstones lock");
+        let entry = tombstones.entry(key).or_insert(0);
+        *entry = (*entry).max(generation);
+    }
+
+    fn evict_lru_slot(&self, slots: &mut HashMap<(Pubkey, ConsumerId), RevisionSlot>) {
+        if slots.len() < self.max_keys {
+            return;
+        }
+        let Some((key, slot)) = slots
+            .iter()
+            .min_by_key(|(_, slot)| slot.lru_stamp)
+            .map(|(k, s)| (*k, s.clone()))
+        else {
+            return;
+        };
+        self.record_tombstone(key, slot.generation);
+        slots.remove(&key);
+    }
+
+    pub fn assign_next(&self, snapshot: &mut PoolExplicitSnapshot) -> u64 {
+        let key = (snapshot.pool, snapshot.consumer);
+        let mut slots = self.slots.lock().expect("pool revision issued lock");
+        if !slots.contains_key(&key) {
+            self.evict_lru_slot(&mut slots);
+        }
+        let floor_gen = self.tombstone_generation(key);
+        let slot = slots.entry(key).or_insert_with(|| RevisionSlot {
+            generation: floor_gen.saturating_add(1).max(1),
+            issued_seq: 0,
+            applied_seq: 0,
+            lru_stamp: self.next_lru_stamp(),
+        });
+        slot.issued_seq = slot.issued_seq.saturating_add(1);
+        if slot.issued_seq == 0 {
+            slot.generation = slot.generation.saturating_add(1);
+            slot.issued_seq = 1;
+        }
+        slot.lru_stamp = self.next_lru_stamp();
+        snapshot.revision = Self::pack_revision(slot.generation, slot.issued_seq);
+        snapshot.revision
+    }
+
+    pub fn should_apply_and_record(&self, snapshot: &PoolExplicitSnapshot) -> bool {
+        if snapshot.revision == 0 {
+            return false;
+        }
+        let (gen, seq) = Self::unpack_revision(snapshot.revision);
+        let key = (snapshot.pool, snapshot.consumer);
+        if gen <= self.tombstone_generation(key) {
+            return false;
+        }
+        let mut slots = self.slots.lock().expect("pool revision issued lock");
+        let Some(slot) = slots.get_mut(&key) else {
+            return false;
+        };
+        if gen != slot.generation || seq <= slot.applied_seq {
+            return false;
+        }
+        slot.applied_seq = seq;
+        slot.lru_stamp = self.next_lru_stamp();
+        true
+    }
+
+    pub fn retire_key(&self, pool: Pubkey, consumer: ConsumerId) {
+        let key = (pool, consumer);
+        let mut slots = self.slots.lock().expect("pool revision issued lock");
+        if let Some(slot) = slots.remove(&key) {
+            self.record_tombstone(key, slot.generation);
+        }
+    }
+
+    pub fn maybe_retire_key(&self, pool: Pubkey, consumer: ConsumerId, has_pending: bool) {
+        if has_pending {
+            return;
+        }
+        self.retire_key(pool, consumer);
+    }
+
+    pub fn active_key_count(&self) -> usize {
+        self.slots.lock().expect("pool revision issued lock").len()
+    }
+
+    pub fn current_issued(&self, pool: Pubkey, consumer: ConsumerId) -> u64 {
+        self.slots
+            .lock()
+            .expect("pool revision issued lock")
             .get(&(pool, consumer))
-            .copied()
+            .map(|slot| Self::pack_revision(slot.generation, slot.issued_seq))
+            .unwrap_or(0)
+    }
+
+    pub fn current_applied(&self, pool: Pubkey, consumer: ConsumerId) -> u64 {
+        self.slots
+            .lock()
+            .expect("pool revision issued lock")
+            .get(&(pool, consumer))
+            .map(|slot| Self::pack_revision(slot.generation, slot.applied_seq))
             .unwrap_or(0)
     }
 }
@@ -334,6 +465,13 @@ impl PendingPoolRegistrations {
             .get(&(pool, consumer))
             .map(|e| e.latest_revision)
     }
+
+    pub fn has_pending(&self, pool: Pubkey, consumer: ConsumerId) -> bool {
+        self.entries
+            .lock()
+            .expect("pending pool lock")
+            .contains_key(&(pool, consumer))
+    }
 }
 
 /// Startup Geyser connect barrier: worker signals ready/failed after restore+convergence.
@@ -469,7 +607,10 @@ mod tests {
         assert_eq!(drained.len(), 1);
         match &drained[0] {
             PendingPoolCommand::AfterTrade(s) => {
-                assert_eq!(s.revision, 2);
+                assert_eq!(
+                    PoolSnapshotRevisionSequencer::revision_sequence(s.revision),
+                    2
+                );
                 assert_eq!(s.vaults[0].pubkey, new_vault);
             }
             other => panic!("expected AfterTrade latest, got {other:?}"),
@@ -546,5 +687,48 @@ mod tests {
             rev_latest
         );
         assert!(rev_new < rev_latest);
+    }
+
+    #[test]
+    fn revision_registry_bounded_after_churn_beyond_cap() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
+        for _ in 0..128 {
+            let pool = Pubkey::new_unique();
+            let mut snapshot = mk_snapshot(pool, Pubkey::new_unique());
+            let revision = revisions.assign_next(&mut snapshot);
+            assert!(revisions.should_apply_and_record(&snapshot));
+            assert_eq!(
+                revisions.current_applied(pool, ConsumerId::Momentum),
+                revision
+            );
+            revisions.retire_key(pool, ConsumerId::Momentum);
+        }
+        assert!(
+            revisions.active_key_count() <= 8,
+            "revision registry must stay bounded"
+        );
+    }
+
+    #[test]
+    fn retired_generation_rejects_delayed_stale_command_after_repin() {
+        let revisions = PoolSnapshotRevisionSequencer::with_max_keys(8);
+        let pool = Pubkey::new_unique();
+        let mut stale = mk_snapshot(pool, Pubkey::new_unique());
+        let stale_rev = revisions.assign_next(&mut stale);
+        assert!(revisions.should_apply_and_record(&stale));
+        revisions.retire_key(pool, ConsumerId::Momentum);
+
+        let mut fresh = mk_snapshot(pool, Pubkey::new_unique());
+        let fresh_rev = revisions.assign_next(&mut fresh);
+        assert!(
+            PoolSnapshotRevisionSequencer::revision_generation(fresh_rev)
+                > PoolSnapshotRevisionSequencer::revision_generation(stale_rev)
+        );
+        assert!(!revisions.should_apply_and_record(&stale));
+        assert!(revisions.should_apply_and_record(&fresh));
+        assert_eq!(
+            revisions.current_applied(pool, ConsumerId::Momentum),
+            fresh_rev
+        );
     }
 }

--- a/src/market_data/track/snapshot.rs
+++ b/src/market_data/track/snapshot.rs
@@ -1,12 +1,15 @@
 //! Phase 3 P3: persist/restore explicit Geyser subscription set + Tier-1 `pool_mint_map` (I-MD-6).
 
-use super::desired_set::ConsumerId;
+use super::desired_set::{ConsumerId, OwnerGroupSnapshot, OwnerKey};
 use serde::{Deserialize, Serialize};
+use solana_sdk::pubkey::Pubkey;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// On-disk snapshot format version.
-pub const EXPLICIT_SET_SNAPSHOT_VERSION: u32 = 1;
+/// On-disk snapshot format version (v2 adds complete owner groups).
+pub const EXPLICIT_SET_SNAPSHOT_VERSION: u32 = 2;
 /// Default production snapshot path (I-MD-6).
 pub const EXPLICIT_SET_SNAPSHOT_DEFAULT_PATH: &str = "/var/lib/ironcrab/explicit_set.snapshot";
 /// Periodic snapshot write interval (5 min).
@@ -50,11 +53,27 @@ pub struct ExplicitSnapshotRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SnapshotOwnerKey {
+    pub kind: String,
+    pub pubkey: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SnapshotOwnerGroup {
+    pub consumer: SnapshotConsumer,
+    pub owner: SnapshotOwnerKey,
+    pub pubkeys: Vec<String>,
+    pub last_touched_gen: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExplicitSetSnapshot {
     pub version: u32,
     pub saved_at_unix: u64,
     pub run_id: Option<String>,
     pub rows: Vec<ExplicitSnapshotRow>,
+    #[serde(default)]
+    pub owner_groups: Vec<SnapshotOwnerGroup>,
     pub pool_mint_map: Vec<(String, String)>,
     pub momentum_pools: Vec<String>,
     pub arb_pools: Vec<String>,
@@ -67,6 +86,7 @@ impl ExplicitSetSnapshot {
             saved_at_unix: unix_now(),
             run_id,
             rows: Vec::new(),
+            owner_groups: Vec::new(),
             pool_mint_map: Vec::new(),
             momentum_pools: Vec::new(),
             arb_pools: Vec::new(),
@@ -74,11 +94,29 @@ impl ExplicitSetSnapshot {
     }
 
     pub fn is_compatible(&self) -> bool {
-        self.version == EXPLICIT_SET_SNAPSHOT_VERSION
+        self.version == 1 || self.version == EXPLICIT_SET_SNAPSHOT_VERSION
     }
 
     pub fn explicit_pubkey_count(&self) -> usize {
-        self.rows.len()
+        if !self.owner_groups.is_empty() {
+            self.owner_groups
+                .iter()
+                .map(|g| g.pubkeys.len())
+                .sum::<usize>()
+        } else {
+            self.rows.len()
+        }
+    }
+
+    pub fn to_owner_group_snapshots(&self) -> Vec<OwnerGroupSnapshot> {
+        if !self.owner_groups.is_empty() {
+            return self
+                .owner_groups
+                .iter()
+                .filter_map(snapshot_owner_group_to_domain)
+                .collect();
+        }
+        rows_to_owner_group_snapshots(&self.rows)
     }
 }
 
@@ -112,6 +150,100 @@ pub fn write_explicit_set_snapshot(
     Ok(())
 }
 
+pub fn owner_key_to_snapshot(owner: OwnerKey) -> SnapshotOwnerKey {
+    match owner {
+        OwnerKey::Wallet => SnapshotOwnerKey {
+            kind: "wallet".to_string(),
+            pubkey: None,
+        },
+        OwnerKey::Pool(pk) => SnapshotOwnerKey {
+            kind: "pool".to_string(),
+            pubkey: Some(pk.to_string()),
+        },
+        OwnerKey::Mint(pk) => SnapshotOwnerKey {
+            kind: "mint".to_string(),
+            pubkey: Some(pk.to_string()),
+        },
+    }
+}
+
+pub fn snapshot_owner_key_to_domain(key: &SnapshotOwnerKey) -> Option<OwnerKey> {
+    match key.kind.as_str() {
+        "wallet" => Some(OwnerKey::Wallet),
+        "pool" => key
+            .pubkey
+            .as_deref()
+            .and_then(|s| Pubkey::from_str(s).ok())
+            .map(OwnerKey::Pool),
+        "mint" => key
+            .pubkey
+            .as_deref()
+            .and_then(|s| Pubkey::from_str(s).ok())
+            .map(OwnerKey::Mint),
+        _ => None,
+    }
+}
+
+fn snapshot_owner_group_to_domain(group: &SnapshotOwnerGroup) -> Option<OwnerGroupSnapshot> {
+    let consumer = match group.consumer {
+        SnapshotConsumer::Wallet => ConsumerId::Wallet,
+        SnapshotConsumer::Momentum => ConsumerId::Momentum,
+        SnapshotConsumer::Arb => ConsumerId::Arb,
+        SnapshotConsumer::Tracker => ConsumerId::Tracker,
+    };
+    let owner = snapshot_owner_key_to_domain(&group.owner)?;
+    let pubkeys = group
+        .pubkeys
+        .iter()
+        .filter_map(|s| Pubkey::from_str(s).ok())
+        .collect::<HashSet<_>>();
+    if pubkeys.is_empty() {
+        return None;
+    }
+    Some(OwnerGroupSnapshot {
+        consumer,
+        owner,
+        pubkeys,
+        last_touched_gen: group.last_touched_gen,
+    })
+}
+
+fn rows_to_owner_group_snapshots(rows: &[ExplicitSnapshotRow]) -> Vec<OwnerGroupSnapshot> {
+    use std::collections::HashMap;
+    let mut grouped: HashMap<(ConsumerId, OwnerKey), HashSet<Pubkey>> = HashMap::new();
+    for row in rows {
+        let Ok(pk) = Pubkey::from_str(&row.pubkey) else {
+            continue;
+        };
+        let consumer = match row.consumer {
+            SnapshotConsumer::Wallet => ConsumerId::Wallet,
+            SnapshotConsumer::Momentum => ConsumerId::Momentum,
+            SnapshotConsumer::Arb => ConsumerId::Arb,
+            SnapshotConsumer::Tracker => ConsumerId::Tracker,
+        };
+        let pool = row.pool.as_deref().and_then(|s| Pubkey::from_str(s).ok());
+        let owner = match consumer {
+            ConsumerId::Wallet => OwnerKey::Wallet,
+            ConsumerId::Tracker
+                if pool.is_none() && matches!(row.kind, ExplicitAccountKind::Mint) =>
+            {
+                OwnerKey::Mint(pk)
+            }
+            _ => OwnerKey::Pool(pool.unwrap_or(pk)),
+        };
+        grouped.entry((consumer, owner)).or_default().insert(pk);
+    }
+    grouped
+        .into_iter()
+        .map(|((consumer, owner), pubkeys)| OwnerGroupSnapshot {
+            consumer,
+            owner,
+            pubkeys,
+            last_touched_gen: 0,
+        })
+        .collect()
+}
+
 fn unix_now() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -127,11 +259,14 @@ mod tests {
     #[test]
     fn explicit_set_snapshot_roundtrip_json() {
         let mut snap = ExplicitSetSnapshot::new(Some("run-test".to_string()));
-        snap.rows.push(ExplicitSnapshotRow {
-            pubkey: Pubkey::new_unique().to_string(),
+        snap.owner_groups.push(SnapshotOwnerGroup {
             consumer: SnapshotConsumer::Momentum,
-            pool: Some(Pubkey::new_unique().to_string()),
-            kind: ExplicitAccountKind::Vault,
+            owner: SnapshotOwnerKey {
+                kind: "pool".to_string(),
+                pubkey: Some(Pubkey::new_unique().to_string()),
+            },
+            pubkeys: vec![Pubkey::new_unique().to_string()],
+            last_touched_gen: 3,
         });
         snap.pool_mint_map.push((
             Pubkey::new_unique().to_string(),
@@ -144,6 +279,29 @@ mod tests {
         let loaded = load_explicit_set_snapshot(&path).expect("load");
         assert_eq!(loaded, snap);
         assert!(loaded.is_compatible());
+    }
+
+    #[test]
+    fn explicit_set_snapshot_v1_rows_restore_groups() {
+        let mut snap = ExplicitSetSnapshot::new(None);
+        snap.version = 1;
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        snap.rows.push(ExplicitSnapshotRow {
+            pubkey: mint.to_string(),
+            consumer: SnapshotConsumer::Tracker,
+            pool: None,
+            kind: ExplicitAccountKind::Mint,
+        });
+        snap.rows.push(ExplicitSnapshotRow {
+            pubkey: Pubkey::new_unique().to_string(),
+            consumer: SnapshotConsumer::Momentum,
+            pool: Some(pool.to_string()),
+            kind: ExplicitAccountKind::Vault,
+        });
+        let groups = snap.to_owner_group_snapshots();
+        assert_eq!(groups.len(), 2);
+        assert!(groups.iter().any(|g| matches!(g.owner, OwnerKey::Mint(_))));
     }
 
     #[test]

--- a/src/market_data/track/snapshot.rs
+++ b/src/market_data/track/snapshot.rs
@@ -19,6 +19,7 @@ pub enum SnapshotConsumer {
     Wallet,
     Momentum,
     Arb,
+    Tracker,
 }
 
 impl From<ConsumerId> for SnapshotConsumer {
@@ -27,6 +28,7 @@ impl From<ConsumerId> for SnapshotConsumer {
             ConsumerId::Wallet => SnapshotConsumer::Wallet,
             ConsumerId::Momentum => SnapshotConsumer::Momentum,
             ConsumerId::Arb => SnapshotConsumer::Arb,
+            ConsumerId::Tracker => SnapshotConsumer::Tracker,
         }
     }
 }

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -321,6 +321,7 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
         TrackWorkerCommand::RestoreExplicitSnapshot(snapshot) => {
             ctx.apply_explicit_set_snapshot(desired, &snapshot) > 0
         }
+        TrackWorkerCommand::CompleteStartupBarrier => false,
         TrackWorkerCommand::ScheduleGeyserPush
         | TrackWorkerCommand::ScheduleGeyserPushDebounced
         | TrackWorkerCommand::ContinueGeyserEvict => false,
@@ -351,6 +352,47 @@ fn track_worker_apply_pending_dirty<C: TrackWorkerContext>(
     }
 }
 
+struct TrackWorkerJobFlags {
+    continue_evict: bool,
+    release_flush_slot: bool,
+    barrier_ack: bool,
+}
+
+impl TrackWorkerJobFlags {
+    fn note_job(&mut self, job: &TrackWorkerCommand) {
+        if matches!(job, TrackWorkerCommand::ContinueGeyserEvict) {
+            self.continue_evict = true;
+        }
+        if matches!(job, TrackWorkerCommand::ScheduleGeyserPushDebounced) {
+            self.release_flush_slot = true;
+        }
+        if matches!(
+            job,
+            TrackWorkerCommand::RestoreExplicitSnapshot(_)
+                | TrackWorkerCommand::CompleteStartupBarrier
+        ) {
+            self.barrier_ack = true;
+        }
+    }
+}
+
+fn track_worker_normalize_job(job: TrackWorkerCommand) -> TrackWorkerCommand {
+    match job {
+        TrackWorkerCommand::ScheduleGeyserPushDebounced => TrackWorkerCommand::ScheduleGeyserPush,
+        other => other,
+    }
+}
+
+fn track_worker_complete_barrier_ack<C: TrackWorkerContext>(
+    ctx: &Arc<C>,
+    desired: &DesiredExplicitSet,
+    push_ok: bool,
+) {
+    let cap_ok = desired.cap_overflow() == 0;
+    let ready = push_ok && cap_ok && ctx.geyser_explicit_readiness_ok();
+    ctx.signal_restore_barrier(ready);
+}
+
 fn track_worker_loop<C: TrackWorkerContext + 'static>(
     ctx: Arc<C>,
     rx: std_mpsc::Receiver<TrackWorkerCommand>,
@@ -363,7 +405,7 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
     let mut pending_continue_evict = false;
     let mut pending_release_flush_slot = false;
     let mut admission_converged = false;
-    let mut pending_restore_barrier_ack = false;
+    let mut pending_barrier_ack = false;
     let mut last_snapshot_write = Instant::now()
         .checked_sub(Duration::from_secs(
             MARKET_DATA_EXPLICIT_SET_SNAPSHOT_INTERVAL_SECS,
@@ -394,39 +436,24 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
                             + Duration::from_millis(MARKET_DATA_TRACK_WORKER_COALESCE_MS),
                     );
                 }
-                if matches!(job, TrackWorkerCommand::ContinueGeyserEvict) {
-                    pending_continue_evict = true;
-                }
-                if matches!(job, TrackWorkerCommand::ScheduleGeyserPushDebounced) {
-                    pending_release_flush_slot = true;
-                }
-                if matches!(job, TrackWorkerCommand::RestoreExplicitSnapshot(_)) {
-                    pending_restore_barrier_ack = true;
-                }
-                let cmd = match job {
-                    TrackWorkerCommand::ScheduleGeyserPushDebounced => {
-                        TrackWorkerCommand::ScheduleGeyserPush
-                    }
-                    other => other,
+                let mut flags = TrackWorkerJobFlags {
+                    continue_evict: pending_continue_evict,
+                    release_flush_slot: pending_release_flush_slot,
+                    barrier_ack: pending_barrier_ack,
                 };
+                flags.note_job(&job);
+                let cmd = track_worker_normalize_job(job);
                 let _ = track_worker_process_command(&ctx, &mut desired, cmd);
                 track_worker_apply_invalidation(&ctx, &mut desired, &mut admission_converged);
                 while let Ok(more) = rx.try_recv() {
                     track_worker_dec_queue_depth(&queue_depth);
-                    if matches!(more, TrackWorkerCommand::ContinueGeyserEvict) {
-                        pending_continue_evict = true;
-                    }
-                    if matches!(more, TrackWorkerCommand::ScheduleGeyserPushDebounced) {
-                        pending_release_flush_slot = true;
-                    }
-                    let cmd = match more {
-                        TrackWorkerCommand::ScheduleGeyserPushDebounced => {
-                            TrackWorkerCommand::ScheduleGeyserPush
-                        }
-                        other => other,
-                    };
+                    flags.note_job(&more);
+                    let cmd = track_worker_normalize_job(more);
                     let _ = track_worker_process_command(&ctx, &mut desired, cmd);
                 }
+                pending_continue_evict = flags.continue_evict;
+                pending_release_flush_slot = flags.release_flush_slot;
+                pending_barrier_ack = flags.barrier_ack;
                 track_worker_apply_invalidation(&ctx, &mut desired, &mut admission_converged);
             }
             Err(std_mpsc::RecvTimeoutError::Timeout) => {}
@@ -440,6 +467,10 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
             push_before_keys.is_some() && coalesce_deadline.is_some_and(|d| Instant::now() >= d);
         if should_push {
             if !ctx.geyser_explicit_readiness_ok() {
+                if pending_barrier_ack {
+                    track_worker_complete_barrier_ack(&ctx, &desired, false);
+                    pending_barrier_ack = false;
+                }
                 push_before_keys = None;
                 coalesce_deadline = None;
                 pending_continue_evict = false;
@@ -452,23 +483,19 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
             pending_continue_evict = false;
             pending_release_flush_slot = false;
             coalesce_deadline = None;
-            if !track_worker_execute_coalesced_push(
+            let push_ok = track_worker_execute_coalesced_push(
                 &ctx,
                 &mut desired,
                 before,
                 continue_evict,
                 release_flush_slot,
                 &mut admission_converged,
-            ) {
-                if ctx.pending_geyser_evict() {
-                    track_worker_try_enqueue(
-                        &track_worker,
-                        TrackWorkerCommand::ContinueGeyserEvict,
-                    );
-                }
-            } else if pending_restore_barrier_ack {
-                ctx.signal_restore_barrier(true);
-                pending_restore_barrier_ack = false;
+            );
+            if pending_barrier_ack {
+                track_worker_complete_barrier_ack(&ctx, &desired, push_ok);
+                pending_barrier_ack = false;
+            } else if !push_ok && ctx.pending_geyser_evict() {
+                track_worker_try_enqueue(&track_worker, TrackWorkerCommand::ContinueGeyserEvict);
             }
             inc_market_data_track_request_coalesce_batches_total();
             ctx.refresh_hot_pool_registry_gauges();

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -50,30 +50,88 @@ pub enum TrackPinReason {
 pub trait TrackWorkerContext: Send + Sync {
     fn geyser_sync_batch_debounce_ms(&self) -> u64;
     fn max_tracked_accounts(&self) -> usize;
-    fn apply_momentum_active_pools_update(&self, update: &MomentumActivePoolsUpdate) -> bool;
-    fn apply_momentum_snapshot_reconcile(&self, active: &[MomentumActivePoolEntry]) -> bool;
-    fn apply_momentum_removed_entries(&self, chunk: &[MomentumRemovedPoolEntry]) -> bool;
-    fn apply_momentum_active_entries(&self, chunk: &[MomentumActivePoolEntry]) -> bool;
-    fn apply_arb_track_requests_update(&self, update: &ArbTrackRequestsUpdate) -> bool;
-    fn apply_arb_snapshot_reconcile(&self, active: &[ArbTrackActiveEntry]) -> bool;
-    fn apply_arb_removed_entries(&self, chunk: &[ArbTrackRemovedEntry]) -> bool;
-    fn apply_arb_active_entries(&self, chunk: &[ArbTrackActiveEntry]) -> bool;
-    fn track_mint_for_geyser_metadata(&self, mint: Pubkey, pin: Option<TrackPinReason>) -> bool;
+    fn apply_momentum_active_pools_update(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        update: &MomentumActivePoolsUpdate,
+    ) -> bool;
+    fn apply_momentum_snapshot_reconcile(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        active: &[MomentumActivePoolEntry],
+    ) -> bool;
+    fn apply_momentum_removed_entries(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        chunk: &[MomentumRemovedPoolEntry],
+    ) -> bool;
+    fn apply_momentum_active_entries(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        chunk: &[MomentumActivePoolEntry],
+    ) -> bool;
+    fn apply_arb_track_requests_update(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        update: &ArbTrackRequestsUpdate,
+    ) -> bool;
+    fn apply_arb_snapshot_reconcile(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        active: &[ArbTrackActiveEntry],
+    ) -> bool;
+    fn apply_arb_removed_entries(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        chunk: &[ArbTrackRemovedEntry],
+    ) -> bool;
+    fn apply_arb_active_entries(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        chunk: &[ArbTrackActiveEntry],
+    ) -> bool;
+    fn track_mint_for_geyser_metadata(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        mint: Pubkey,
+        pin: Option<TrackPinReason>,
+    ) -> bool;
     fn refresh_geyser_pins_gauge(&self);
     fn hot_pool_registry_pair_count(&self) -> usize;
     fn hot_pool_registry_arb_pool_count(&self) -> usize;
     fn refresh_hot_pool_registry_gauges(&self);
     fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey>;
     fn pending_geyser_evict(&self) -> bool;
-    fn continue_geyser_evict_with_deadline(&self, deadline: Instant) -> bool;
-    fn sync_geyser_tracked_accounts_batched_flush_with_deadline(&self, deadline: Instant) -> bool;
+    fn clear_pending_geyser_evict(&self);
+    fn continue_geyser_evict_with_deadline(
+        &self,
+        deadline: Instant,
+        desired: &DesiredExplicitSet,
+    ) -> bool;
+    fn sync_geyser_tracked_accounts_batched_flush_with_deadline(
+        &self,
+        deadline: Instant,
+        desired: &DesiredExplicitSet,
+    ) -> bool;
     fn release_geyser_sync_flush_slot(&self);
     fn refresh_tracked_membership_snapshot(&self);
     fn explicit_pubkey_rows_for_desired_set(
         &self,
     ) -> Vec<(Pubkey, super::ConsumerId, Option<Pubkey>)>;
     fn build_explicit_set_snapshot(&self) -> ExplicitSetSnapshot;
-    fn apply_explicit_set_snapshot(&self, snapshot: &ExplicitSetSnapshot) -> usize;
+    fn apply_explicit_set_snapshot(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        snapshot: &ExplicitSetSnapshot,
+    ) -> usize;
+    fn converge_explicit_admission(&self, desired: &mut DesiredExplicitSet);
+    fn prune_tracked_maps_to_desired(&self, desired: &DesiredExplicitSet);
+    fn refresh_explicit_admission_metrics(&self, desired: &DesiredExplicitSet);
+    fn last_synced_explicit_pubkeys_write(
+        &self,
+    ) -> parking_lot::RwLockWriteGuard<'_, HashSet<Pubkey>>;
+    fn invalidate_explicit_admission_convergence(&self);
+    fn take_explicit_admission_invalidate(&self) -> bool;
 }
 
 /// Phase 2a: commands for the `md-track-worker` OS thread (DesiredExplicitSet + coalesced Geyser push).
@@ -131,24 +189,25 @@ fn track_worker_dec_queue_depth(queue_depth: &AtomicUsize) {
 /// Phase-2b: sync momentum apply on `md-track-worker` thread (no Tokio yield).
 pub fn apply_momentum_active_pools_on_track_worker<C: TrackWorkerContext>(
     ctx: &Arc<C>,
+    desired: &mut DesiredExplicitSet,
     update: MomentumActivePoolsUpdate,
 ) -> bool {
     let item_count = update.active.len() + update.removed.len();
     if item_count <= MARKET_DATA_MOMENTUM_APPLY_CHUNK_THRESHOLD {
-        return ctx.apply_momentum_active_pools_update(&update);
+        return ctx.apply_momentum_active_pools_update(desired, &update);
     }
     record_market_data_momentum_active_pool_messages_total();
     let mut batch_dirty = false;
     if update.full_active_snapshot {
-        batch_dirty |= ctx.apply_momentum_snapshot_reconcile(&update.active);
+        batch_dirty |= ctx.apply_momentum_snapshot_reconcile(desired, &update.active);
         std::thread::yield_now();
     }
     for chunk in update.removed.chunks(MARKET_DATA_MOMENTUM_APPLY_CHUNK_SIZE) {
-        batch_dirty |= ctx.apply_momentum_removed_entries(chunk);
+        batch_dirty |= ctx.apply_momentum_removed_entries(desired, chunk);
         std::thread::yield_now();
     }
     for chunk in update.active.chunks(MARKET_DATA_MOMENTUM_APPLY_CHUNK_SIZE) {
-        batch_dirty |= ctx.apply_momentum_active_entries(chunk);
+        batch_dirty |= ctx.apply_momentum_active_entries(desired, chunk);
         std::thread::yield_now();
     }
     if !batch_dirty {
@@ -161,24 +220,25 @@ pub fn apply_momentum_active_pools_on_track_worker<C: TrackWorkerContext>(
 /// Phase 3: sync arb track apply on `md-track-worker` thread (no Tokio yield).
 pub fn apply_arb_track_requests_on_track_worker<C: TrackWorkerContext>(
     ctx: &Arc<C>,
+    desired: &mut DesiredExplicitSet,
     update: ArbTrackRequestsUpdate,
 ) -> bool {
     let item_count = update.active.len() + update.removed.len();
     if item_count <= MARKET_DATA_ARB_APPLY_CHUNK_THRESHOLD {
-        return ctx.apply_arb_track_requests_update(&update);
+        return ctx.apply_arb_track_requests_update(desired, &update);
     }
     record_market_data_arb_track_requests_messages_total();
     let mut batch_dirty = false;
     if update.reconcile {
-        batch_dirty |= ctx.apply_arb_snapshot_reconcile(&update.active);
+        batch_dirty |= ctx.apply_arb_snapshot_reconcile(desired, &update.active);
         std::thread::yield_now();
     }
     for chunk in update.removed.chunks(MARKET_DATA_ARB_APPLY_CHUNK_SIZE) {
-        batch_dirty |= ctx.apply_arb_removed_entries(chunk);
+        batch_dirty |= ctx.apply_arb_removed_entries(desired, chunk);
         std::thread::yield_now();
     }
     for chunk in update.active.chunks(MARKET_DATA_ARB_APPLY_CHUNK_SIZE) {
-        batch_dirty |= ctx.apply_arb_active_entries(chunk);
+        batch_dirty |= ctx.apply_arb_active_entries(desired, chunk);
         std::thread::yield_now();
     }
     if !batch_dirty {
@@ -190,24 +250,28 @@ pub fn apply_arb_track_requests_on_track_worker<C: TrackWorkerContext>(
 
 pub fn track_worker_process_command<C: TrackWorkerContext>(
     ctx: &Arc<C>,
+    desired: &mut DesiredExplicitSet,
     job: TrackWorkerCommand,
 ) -> bool {
     match job {
         TrackWorkerCommand::ApplyMomentumActivePools(update) => {
-            apply_momentum_active_pools_on_track_worker(ctx, update)
+            apply_momentum_active_pools_on_track_worker(ctx, desired, update)
         }
         TrackWorkerCommand::ApplyArbTrackRequests(update) => {
-            apply_arb_track_requests_on_track_worker(ctx, update)
+            apply_arb_track_requests_on_track_worker(ctx, desired, update)
         }
         TrackWorkerCommand::ApplyWalletPin { mint } => {
-            ctx.track_mint_for_geyser_metadata(mint, Some(TrackPinReason::Wallet))
+            ctx.track_mint_for_geyser_metadata(desired, mint, Some(TrackPinReason::Wallet))
         }
         TrackWorkerCommand::TrackMint { mint, pin } => {
-            ctx.track_mint_for_geyser_metadata(mint, pin)
+            ctx.track_mint_for_geyser_metadata(desired, mint, pin)
         }
-        TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange => true,
+        TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange => {
+            ctx.invalidate_explicit_admission_convergence();
+            true
+        }
         TrackWorkerCommand::RestoreExplicitSnapshot(snapshot) => {
-            ctx.apply_explicit_set_snapshot(&snapshot) > 0
+            ctx.apply_explicit_set_snapshot(desired, &snapshot) > 0
         }
         TrackWorkerCommand::ScheduleGeyserPush
         | TrackWorkerCommand::ScheduleGeyserPushDebounced
@@ -226,6 +290,7 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
     let mut push_before_keys: Option<HashSet<Pubkey>> = None;
     let mut pending_continue_evict = false;
     let mut pending_release_flush_slot = false;
+    let mut admission_converged = false;
     let mut last_snapshot_write = Instant::now()
         .checked_sub(Duration::from_secs(
             MARKET_DATA_EXPLICIT_SET_SNAPSHOT_INTERVAL_SECS,
@@ -268,7 +333,10 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
                     }
                     other => other,
                 };
-                let _ = track_worker_process_command(&ctx, cmd);
+                let _ = track_worker_process_command(&ctx, &mut desired, cmd);
+                if ctx.take_explicit_admission_invalidate() {
+                    admission_converged = false;
+                }
                 while let Ok(more) = rx.try_recv() {
                     track_worker_dec_queue_depth(&queue_depth);
                     if matches!(more, TrackWorkerCommand::ContinueGeyserEvict) {
@@ -283,7 +351,7 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
                         }
                         other => other,
                     };
-                    let _ = track_worker_process_command(&ctx, cmd);
+                    let _ = track_worker_process_command(&ctx, &mut desired, cmd);
                 }
             }
             Err(std_mpsc::RecvTimeoutError::Timeout) => {}
@@ -305,6 +373,7 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
                 before,
                 continue_evict,
                 release_flush_slot,
+                &mut admission_converged,
             ) {
                 track_worker_try_enqueue(&track_worker, TrackWorkerCommand::ContinueGeyserEvict);
             }
@@ -379,8 +448,9 @@ pub fn spawn_inline_track_worker_sender<C: TrackWorkerContext + 'static>(
     let (tx, rx) = std_mpsc::sync_channel::<TrackWorkerCommand>(capacity);
     let ctx_worker = Arc::clone(&ctx);
     std::thread::spawn(move || {
+        let mut desired = DesiredExplicitSet::new(ctx_worker.max_tracked_accounts());
         while let Ok(job) = rx.recv() {
-            let _ = track_worker_process_command(&ctx_worker, job);
+            let _ = track_worker_process_command(&ctx_worker, &mut desired, job);
         }
     });
     TrackWorkerSender {

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -1,12 +1,12 @@
 //! Phase 5a: `md-track-worker` OS thread — bounded enqueue, command processing, coalesced Geyser push.
 
-use super::desired_set::DesiredExplicitSet;
+use super::desired_set::{CapConvergeResult, DesiredExplicitSet};
 use super::geyser_sync::track_worker_execute_coalesced_push;
 use super::snapshot::{
     explicit_set_snapshot_path, write_explicit_set_snapshot, ExplicitSetSnapshot,
     MARKET_DATA_EXPLICIT_SET_SNAPSHOT_INTERVAL_SECS,
 };
-use super::worker_commands::{GeyserPinReason, TrackWorkerCommand};
+use super::worker_commands::{GeyserPinReason, PoolExplicitSnapshot, TrackWorkerCommand};
 use crate::metrics::{
     inc_market_data_explicit_set_snapshot_write_errors_total,
     inc_market_data_explicit_set_snapshot_write_total,
@@ -92,35 +92,30 @@ pub trait TrackWorkerContext: Send + Sync {
         mint: Pubkey,
         pin: Option<TrackPinReason>,
     ) -> bool;
-    fn sync_wallet_explicit_demand(
-        &self,
-        desired: &mut DesiredExplicitSet,
-        demand: HashSet<Pubkey>,
-        token_accounts: HashSet<Pubkey>,
-    ) -> bool;
+    fn sync_wallet_explicit_demand(&self, desired: &mut DesiredExplicitSet, revision: u64) -> bool;
     fn take_pending_explicit_cap(&self) -> Option<usize>;
     fn take_track_worker_dirty(&self) -> bool;
     fn apply_pending_track_worker_work(&self, desired: &mut DesiredExplicitSet);
+    fn on_cap_converge_result(&self, desired: &DesiredExplicitSet, result: CapConvergeResult);
     fn commit_register_pool_geyser_reserves(
         &self,
         desired: &mut DesiredExplicitSet,
-        pool: Pubkey,
-        pin: TrackPinReason,
+        snapshot: &PoolExplicitSnapshot,
     ) -> bool;
     fn commit_register_pool_vaults_from_account(
         &self,
         desired: &mut DesiredExplicitSet,
-        pool: Pubkey,
+        snapshot: &PoolExplicitSnapshot,
     ) -> bool;
     fn commit_register_geyser_reserves_after_trade(
         &self,
         desired: &mut DesiredExplicitSet,
-        pool: Pubkey,
+        snapshot: &PoolExplicitSnapshot,
     ) -> bool;
     fn commit_refresh_dlmm_bin_window(
         &self,
         desired: &mut DesiredExplicitSet,
-        pool: Pubkey,
+        snapshot: &PoolExplicitSnapshot,
         new_active_id: i32,
     ) -> bool;
     fn refresh_geyser_pins_gauge(&self);
@@ -161,6 +156,7 @@ pub trait TrackWorkerContext: Send + Sync {
     fn invalidate_explicit_admission_convergence(&self);
     fn take_explicit_admission_invalidate(&self) -> bool;
     fn geyser_explicit_readiness_ok(&self) -> bool;
+    fn signal_restore_barrier(&self, ok: bool);
 }
 
 #[derive(Clone)]
@@ -171,14 +167,38 @@ pub struct TrackWorkerSender {
     queue_capacity: usize,
 }
 
+/// Test helper: bounded sender + receiver without a worker loop.
+pub fn track_worker_sender_for_test(
+    capacity: usize,
+) -> (
+    TrackWorkerSender,
+    std_mpsc::Receiver<TrackWorkerCommand>,
+    Arc<AtomicUsize>,
+) {
+    let (tx, rx) = std_mpsc::sync_channel::<TrackWorkerCommand>(capacity);
+    let queue_depth = Arc::new(AtomicUsize::new(0));
+    let sender = TrackWorkerSender {
+        tx,
+        queue_depth: Arc::clone(&queue_depth),
+        queue_capacity: capacity,
+    };
+    (sender, rx, queue_depth)
+}
+
 pub fn track_worker_try_enqueue(sender: &TrackWorkerSender, job: TrackWorkerCommand) -> bool {
+    let reserved = sender.queue_depth.fetch_add(1, Ordering::AcqRel) + 1;
+    if reserved > sender.queue_capacity {
+        sender.queue_depth.fetch_sub(1, Ordering::AcqRel);
+        inc_market_data_geyser_tracking_enqueue_dropped_total();
+        return false;
+    }
     match sender.tx.try_send(job) {
         Ok(()) => {
-            let depth = sender.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
-            set_market_data_track_worker_queue_depth(depth);
+            set_market_data_track_worker_queue_depth(reserved);
             true
         }
         Err(_) => {
+            sender.queue_depth.fetch_sub(1, Ordering::AcqRel);
             inc_market_data_geyser_tracking_enqueue_dropped_total();
             false
         }
@@ -274,23 +294,26 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
         TrackWorkerCommand::TrackMint { mint, pin } => {
             ctx.track_mint_for_geyser_metadata(desired, mint, pin)
         }
-        TrackWorkerCommand::SyncWalletExplicitDemand {
-            demand,
-            token_accounts,
-        } => ctx.sync_wallet_explicit_demand(desired, demand, token_accounts),
-        TrackWorkerCommand::RegisterPoolGeyserReserves { pool, pin } => {
-            ctx.commit_register_pool_geyser_reserves(desired, pool, pin)
+        TrackWorkerCommand::SyncWalletExplicitDemand { revision } => {
+            ctx.sync_wallet_explicit_demand(desired, revision)
         }
-        TrackWorkerCommand::RegisterPoolVaultsFromAccount { pool } => {
-            ctx.commit_register_pool_vaults_from_account(desired, pool)
+        TrackWorkerCommand::RegisterPoolGeyserReserves { snapshot } => {
+            ctx.commit_register_pool_geyser_reserves(desired, &snapshot)
         }
-        TrackWorkerCommand::RegisterGeyserReservesAfterTrade { pool } => {
-            ctx.commit_register_geyser_reserves_after_trade(desired, pool)
+        TrackWorkerCommand::RegisterPoolVaultsFromAccount { snapshot } => {
+            ctx.commit_register_pool_vaults_from_account(desired, &snapshot)
+        }
+        TrackWorkerCommand::RegisterGeyserReservesAfterTrade { snapshot } => {
+            ctx.commit_register_geyser_reserves_after_trade(desired, &snapshot)
         }
         TrackWorkerCommand::RefreshDlmmBinWindow {
-            pool,
+            snapshot,
             new_active_id,
-        } => ctx.commit_refresh_dlmm_bin_window(desired, pool, new_active_id),
+        } => ctx.commit_refresh_dlmm_bin_window(desired, &snapshot, new_active_id),
+        TrackWorkerCommand::RestoreBarrierComplete { ok } => {
+            ctx.signal_restore_barrier(ok);
+            false
+        }
         TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange => {
             ctx.invalidate_explicit_admission_convergence();
             true
@@ -310,7 +333,8 @@ fn track_worker_apply_invalidation<C: TrackWorkerContext>(
     admission_converged: &mut bool,
 ) {
     if let Some(cap) = ctx.take_pending_explicit_cap() {
-        desired.set_max_explicit_pubkeys(cap);
+        let result = desired.set_max_explicit_pubkeys(cap);
+        ctx.on_cap_converge_result(desired, result);
         *admission_converged = false;
     }
     if ctx.take_explicit_admission_invalidate() {
@@ -339,6 +363,7 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
     let mut pending_continue_evict = false;
     let mut pending_release_flush_slot = false;
     let mut admission_converged = false;
+    let mut pending_restore_barrier_ack = false;
     let mut last_snapshot_write = Instant::now()
         .checked_sub(Duration::from_secs(
             MARKET_DATA_EXPLICIT_SET_SNAPSHOT_INTERVAL_SECS,
@@ -374,6 +399,9 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
                 }
                 if matches!(job, TrackWorkerCommand::ScheduleGeyserPushDebounced) {
                     pending_release_flush_slot = true;
+                }
+                if matches!(job, TrackWorkerCommand::RestoreExplicitSnapshot(_)) {
+                    pending_restore_barrier_ack = true;
                 }
                 let cmd = match job {
                     TrackWorkerCommand::ScheduleGeyserPushDebounced => {
@@ -432,7 +460,15 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
                 release_flush_slot,
                 &mut admission_converged,
             ) {
-                track_worker_try_enqueue(&track_worker, TrackWorkerCommand::ContinueGeyserEvict);
+                if ctx.pending_geyser_evict() {
+                    track_worker_try_enqueue(
+                        &track_worker,
+                        TrackWorkerCommand::ContinueGeyserEvict,
+                    );
+                }
+            } else if pending_restore_barrier_ack {
+                ctx.signal_restore_barrier(true);
+                pending_restore_barrier_ack = false;
             }
             inc_market_data_track_request_coalesce_batches_total();
             ctx.refresh_hot_pool_registry_gauges();
@@ -517,5 +553,42 @@ pub fn spawn_inline_track_worker_sender<C: TrackWorkerContext + 'static>(
         tx,
         queue_depth: Arc::new(AtomicUsize::new(0)),
         queue_capacity: capacity,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn track_worker_queue_depth_reserve_never_underflows() {
+        let (tx, rx) = std_mpsc::sync_channel::<TrackWorkerCommand>(2);
+        let queue_depth = Arc::new(AtomicUsize::new(0));
+        let sender = TrackWorkerSender {
+            tx,
+            queue_depth: Arc::clone(&queue_depth),
+            queue_capacity: 2,
+        };
+        let depth_for_consumer = Arc::clone(&queue_depth);
+        let consumer = std::thread::spawn(move || {
+            for _ in 0..2 {
+                let _ = rx.recv();
+                track_worker_dec_queue_depth(&depth_for_consumer);
+            }
+        });
+        assert!(track_worker_try_enqueue(
+            &sender,
+            TrackWorkerCommand::ScheduleGeyserPush
+        ));
+        assert!(track_worker_try_enqueue(
+            &sender,
+            TrackWorkerCommand::ScheduleGeyserPush
+        ));
+        assert!(!track_worker_try_enqueue(
+            &sender,
+            TrackWorkerCommand::ScheduleGeyserPush
+        ));
+        consumer.join().expect("consumer join");
+        assert_eq!(queue_depth.load(Ordering::Relaxed), 0);
     }
 }

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -96,7 +96,11 @@ pub trait TrackWorkerContext: Send + Sync {
         &self,
         desired: &mut DesiredExplicitSet,
         demand: HashSet<Pubkey>,
+        token_accounts: HashSet<Pubkey>,
     ) -> bool;
+    fn take_pending_explicit_cap(&self) -> Option<usize>;
+    fn take_track_worker_dirty(&self) -> bool;
+    fn apply_pending_track_worker_work(&self, desired: &mut DesiredExplicitSet);
     fn commit_register_pool_geyser_reserves(
         &self,
         desired: &mut DesiredExplicitSet,
@@ -163,21 +167,21 @@ pub trait TrackWorkerContext: Send + Sync {
 pub struct TrackWorkerSender {
     tx: std_mpsc::SyncSender<TrackWorkerCommand>,
     queue_depth: Arc<AtomicUsize>,
+    #[allow(dead_code)]
     queue_capacity: usize,
 }
 
 pub fn track_worker_try_enqueue(sender: &TrackWorkerSender, job: TrackWorkerCommand) -> bool {
-    if sender.queue_depth.load(Ordering::Relaxed) >= sender.queue_capacity {
-        inc_market_data_geyser_tracking_enqueue_dropped_total();
-        return false;
-    }
-    if sender.tx.try_send(job).is_ok() {
-        let depth = sender.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
-        set_market_data_track_worker_queue_depth(depth);
-        true
-    } else {
-        inc_market_data_geyser_tracking_enqueue_dropped_total();
-        false
+    match sender.tx.try_send(job) {
+        Ok(()) => {
+            let depth = sender.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
+            set_market_data_track_worker_queue_depth(depth);
+            true
+        }
+        Err(_) => {
+            inc_market_data_geyser_tracking_enqueue_dropped_total();
+            false
+        }
     }
 }
 
@@ -270,9 +274,10 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
         TrackWorkerCommand::TrackMint { mint, pin } => {
             ctx.track_mint_for_geyser_metadata(desired, mint, pin)
         }
-        TrackWorkerCommand::SyncWalletExplicitDemand { demand } => {
-            ctx.sync_wallet_explicit_demand(desired, demand)
-        }
+        TrackWorkerCommand::SyncWalletExplicitDemand {
+            demand,
+            token_accounts,
+        } => ctx.sync_wallet_explicit_demand(desired, demand, token_accounts),
         TrackWorkerCommand::RegisterPoolGeyserReserves { pool, pin } => {
             ctx.commit_register_pool_geyser_reserves(desired, pool, pin)
         }
@@ -304,9 +309,21 @@ fn track_worker_apply_invalidation<C: TrackWorkerContext>(
     desired: &mut DesiredExplicitSet,
     admission_converged: &mut bool,
 ) {
+    if let Some(cap) = ctx.take_pending_explicit_cap() {
+        desired.set_max_explicit_pubkeys(cap);
+        *admission_converged = false;
+    }
     if ctx.take_explicit_admission_invalidate() {
         *admission_converged = false;
-        desired.set_max_explicit_pubkeys(ctx.max_tracked_accounts());
+    }
+}
+
+fn track_worker_apply_pending_dirty<C: TrackWorkerContext>(
+    ctx: &Arc<C>,
+    desired: &mut DesiredExplicitSet,
+) {
+    if ctx.take_track_worker_dirty() {
+        ctx.apply_pending_track_worker_work(desired);
     }
 }
 
@@ -387,6 +404,9 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
             Err(std_mpsc::RecvTimeoutError::Timeout) => {}
             Err(std_mpsc::RecvTimeoutError::Disconnected) => break,
         }
+
+        track_worker_apply_pending_dirty(&ctx, &mut desired);
+        track_worker_apply_invalidation(&ctx, &mut desired, &mut admission_converged);
 
         let should_push =
             push_before_keys.is_some() && coalesce_deadline.is_some_and(|d| Instant::now() >= d);

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -6,6 +6,7 @@ use super::snapshot::{
     explicit_set_snapshot_path, write_explicit_set_snapshot, ExplicitSetSnapshot,
     MARKET_DATA_EXPLICIT_SET_SNAPSHOT_INTERVAL_SECS,
 };
+use super::worker_commands::{GeyserPinReason, TrackWorkerCommand};
 use crate::metrics::{
     inc_market_data_explicit_set_snapshot_write_errors_total,
     inc_market_data_explicit_set_snapshot_write_total,
@@ -39,12 +40,7 @@ pub const MARKET_DATA_ARB_APPLY_CHUNK_THRESHOLD: usize = 32;
 pub const MARKET_DATA_ARB_APPLY_CHUNK_SIZE: usize = 16;
 
 /// Pin reason for explicit Geyser tracking (maps to [`super::ConsumerId`] in rebuild).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TrackPinReason {
-    Wallet,
-    MomentumActive,
-    ArbMultiDex,
-}
+pub type TrackPinReason = GeyserPinReason;
 
 /// Context surface required by the track-worker loop and apply helpers.
 pub trait TrackWorkerContext: Send + Sync {
@@ -96,6 +92,33 @@ pub trait TrackWorkerContext: Send + Sync {
         mint: Pubkey,
         pin: Option<TrackPinReason>,
     ) -> bool;
+    fn sync_wallet_explicit_demand(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        demand: HashSet<Pubkey>,
+    ) -> bool;
+    fn commit_register_pool_geyser_reserves(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        pool: Pubkey,
+        pin: TrackPinReason,
+    ) -> bool;
+    fn commit_register_pool_vaults_from_account(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        pool: Pubkey,
+    ) -> bool;
+    fn commit_register_geyser_reserves_after_trade(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        pool: Pubkey,
+    ) -> bool;
+    fn commit_refresh_dlmm_bin_window(
+        &self,
+        desired: &mut DesiredExplicitSet,
+        pool: Pubkey,
+        new_active_id: i32,
+    ) -> bool;
     fn refresh_geyser_pins_gauge(&self);
     fn hot_pool_registry_pair_count(&self) -> usize;
     fn hot_pool_registry_arb_pool_count(&self) -> usize;
@@ -115,10 +138,10 @@ pub trait TrackWorkerContext: Send + Sync {
     ) -> bool;
     fn release_geyser_sync_flush_slot(&self);
     fn refresh_tracked_membership_snapshot(&self);
-    fn explicit_pubkey_rows_for_desired_set(
+    fn explicit_owner_groups_for_convergence(
         &self,
-    ) -> Vec<(Pubkey, super::ConsumerId, Option<Pubkey>)>;
-    fn build_explicit_set_snapshot(&self) -> ExplicitSetSnapshot;
+    ) -> Vec<(super::ConsumerId, super::OwnerKey, HashSet<Pubkey>)>;
+    fn build_explicit_set_snapshot(&self, desired: &DesiredExplicitSet) -> ExplicitSetSnapshot;
     fn apply_explicit_set_snapshot(
         &self,
         desired: &mut DesiredExplicitSet,
@@ -127,32 +150,13 @@ pub trait TrackWorkerContext: Send + Sync {
     fn converge_explicit_admission(&self, desired: &mut DesiredExplicitSet);
     fn prune_tracked_maps_to_desired(&self, desired: &DesiredExplicitSet);
     fn refresh_explicit_admission_metrics(&self, desired: &DesiredExplicitSet);
+    fn publish_admitted_explicit_physical(&self, desired: &DesiredExplicitSet);
     fn last_synced_explicit_pubkeys_write(
         &self,
     ) -> parking_lot::RwLockWriteGuard<'_, HashSet<Pubkey>>;
     fn invalidate_explicit_admission_convergence(&self);
     fn take_explicit_admission_invalidate(&self) -> bool;
-}
-
-/// Phase 2a: commands for the `md-track-worker` OS thread (DesiredExplicitSet + coalesced Geyser push).
-pub enum TrackWorkerCommand {
-    ApplyMomentumActivePools(MomentumActivePoolsUpdate),
-    ApplyArbTrackRequests(ArbTrackRequestsUpdate),
-    ApplyWalletPin {
-        mint: Pubkey,
-    },
-    TrackMint {
-        mint: Pubkey,
-        pin: Option<TrackPinReason>,
-    },
-    ScheduleGeyserSyncAfterConfigChange,
-    /// Coalesced explicit Geyser push (md-state burst / trade path).
-    ScheduleGeyserPush,
-    /// Debounced push after `try_acquire_geyser_sync_flush_slot` (rate-limited TX debounce thread).
-    ScheduleGeyserPushDebounced,
-    /// Phase 3 P3: restore explicit set from on-disk snapshot (I-MD-6).
-    RestoreExplicitSnapshot(ExplicitSetSnapshot),
-    ContinueGeyserEvict,
+    fn geyser_explicit_readiness_ok(&self) -> bool;
 }
 
 #[derive(Clone)]
@@ -266,6 +270,22 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
         TrackWorkerCommand::TrackMint { mint, pin } => {
             ctx.track_mint_for_geyser_metadata(desired, mint, pin)
         }
+        TrackWorkerCommand::SyncWalletExplicitDemand { demand } => {
+            ctx.sync_wallet_explicit_demand(desired, demand)
+        }
+        TrackWorkerCommand::RegisterPoolGeyserReserves { pool, pin } => {
+            ctx.commit_register_pool_geyser_reserves(desired, pool, pin)
+        }
+        TrackWorkerCommand::RegisterPoolVaultsFromAccount { pool } => {
+            ctx.commit_register_pool_vaults_from_account(desired, pool)
+        }
+        TrackWorkerCommand::RegisterGeyserReservesAfterTrade { pool } => {
+            ctx.commit_register_geyser_reserves_after_trade(desired, pool)
+        }
+        TrackWorkerCommand::RefreshDlmmBinWindow {
+            pool,
+            new_active_id,
+        } => ctx.commit_refresh_dlmm_bin_window(desired, pool, new_active_id),
         TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange => {
             ctx.invalidate_explicit_admission_convergence();
             true
@@ -276,6 +296,17 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
         TrackWorkerCommand::ScheduleGeyserPush
         | TrackWorkerCommand::ScheduleGeyserPushDebounced
         | TrackWorkerCommand::ContinueGeyserEvict => false,
+    }
+}
+
+fn track_worker_apply_invalidation<C: TrackWorkerContext>(
+    ctx: &Arc<C>,
+    desired: &mut DesiredExplicitSet,
+    admission_converged: &mut bool,
+) {
+    if ctx.take_explicit_admission_invalidate() {
+        *admission_converged = false;
+        desired.set_max_explicit_pubkeys(ctx.max_tracked_accounts());
     }
 }
 
@@ -334,9 +365,7 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
                     other => other,
                 };
                 let _ = track_worker_process_command(&ctx, &mut desired, cmd);
-                if ctx.take_explicit_admission_invalidate() {
-                    admission_converged = false;
-                }
+                track_worker_apply_invalidation(&ctx, &mut desired, &mut admission_converged);
                 while let Ok(more) = rx.try_recv() {
                     track_worker_dec_queue_depth(&queue_depth);
                     if matches!(more, TrackWorkerCommand::ContinueGeyserEvict) {
@@ -353,6 +382,7 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
                     };
                     let _ = track_worker_process_command(&ctx, &mut desired, cmd);
                 }
+                track_worker_apply_invalidation(&ctx, &mut desired, &mut admission_converged);
             }
             Err(std_mpsc::RecvTimeoutError::Timeout) => {}
             Err(std_mpsc::RecvTimeoutError::Disconnected) => break,
@@ -361,6 +391,13 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
         let should_push =
             push_before_keys.is_some() && coalesce_deadline.is_some_and(|d| Instant::now() >= d);
         if should_push {
+            if !ctx.geyser_explicit_readiness_ok() {
+                push_before_keys = None;
+                coalesce_deadline = None;
+                pending_continue_evict = false;
+                pending_release_flush_slot = false;
+                continue;
+            }
             let before = push_before_keys.take().unwrap_or_default();
             let continue_evict = pending_continue_evict;
             let release_flush_slot = pending_release_flush_slot;
@@ -383,15 +420,18 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
                 >= Duration::from_secs(MARKET_DATA_EXPLICIT_SET_SNAPSHOT_INTERVAL_SECS)
             {
                 last_snapshot_write = Instant::now();
-                try_write_explicit_set_snapshot_from_ctx(ctx.as_ref());
+                try_write_explicit_set_snapshot_from_ctx(ctx.as_ref(), &desired);
             }
         }
     }
 }
 
-fn try_write_explicit_set_snapshot_from_ctx<C: TrackWorkerContext>(ctx: &C) {
+fn try_write_explicit_set_snapshot_from_ctx<C: TrackWorkerContext>(
+    ctx: &C,
+    desired: &DesiredExplicitSet,
+) {
     let path = explicit_set_snapshot_path();
-    let snapshot = ctx.build_explicit_set_snapshot();
+    let snapshot = ctx.build_explicit_set_snapshot(desired);
     match write_explicit_set_snapshot(&path, &snapshot) {
         Ok(()) => inc_market_data_explicit_set_snapshot_write_total(),
         Err(e) => {
@@ -406,8 +446,8 @@ fn try_write_explicit_set_snapshot_from_ctx<C: TrackWorkerContext>(ctx: &C) {
 }
 
 /// Best-effort explicit-set snapshot flush (shutdown / external caller).
-pub fn flush_explicit_set_snapshot<C: TrackWorkerContext>(ctx: &C) {
-    try_write_explicit_set_snapshot_from_ctx(ctx);
+pub fn flush_explicit_set_snapshot<C: TrackWorkerContext>(ctx: &C, desired: &DesiredExplicitSet) {
+    try_write_explicit_set_snapshot_from_ctx(ctx, desired);
 }
 
 pub fn spawn_track_worker<C: TrackWorkerContext + 'static>(ctx: Arc<C>) -> TrackWorkerSender {

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -1,0 +1,53 @@
+//! Track-worker command definitions (shared between worker loop and producers).
+
+use solana_sdk::pubkey::Pubkey;
+use std::collections::HashSet;
+
+use super::snapshot::ExplicitSetSnapshot;
+use crate::nats::{ArbTrackRequestsUpdate, MomentumActivePoolsUpdate};
+
+/// Geyser pin reason used by track-worker pool registration commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GeyserPinReason {
+    Wallet,
+    MomentumActive,
+    ArbMultiDex,
+}
+
+/// Phase 2a: commands for the `md-track-worker` OS thread (DesiredExplicitSet + coalesced Geyser push).
+pub enum TrackWorkerCommand {
+    ApplyMomentumActivePools(MomentumActivePoolsUpdate),
+    ApplyArbTrackRequests(ArbTrackRequestsUpdate),
+    ApplyWalletPin {
+        mint: Pubkey,
+    },
+    TrackMint {
+        mint: Pubkey,
+        pin: Option<GeyserPinReason>,
+    },
+    SyncWalletExplicitDemand {
+        demand: HashSet<Pubkey>,
+    },
+    RegisterPoolGeyserReserves {
+        pool: Pubkey,
+        pin: GeyserPinReason,
+    },
+    RegisterPoolVaultsFromAccount {
+        pool: Pubkey,
+    },
+    RegisterGeyserReservesAfterTrade {
+        pool: Pubkey,
+    },
+    RefreshDlmmBinWindow {
+        pool: Pubkey,
+        new_active_id: i32,
+    },
+    ScheduleGeyserSyncAfterConfigChange,
+    /// Coalesced explicit Geyser push (md-state burst / trade path).
+    ScheduleGeyserPush,
+    /// Debounced push after `try_acquire_geyser_sync_flush_slot` (rate-limited TX debounce thread).
+    ScheduleGeyserPushDebounced,
+    /// Phase 3 P3: restore explicit set from on-disk snapshot (I-MD-6).
+    RestoreExplicitSnapshot(ExplicitSetSnapshot),
+    ContinueGeyserEvict,
+}

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -52,6 +52,8 @@ pub struct PoolExplicitSnapshot {
     pub consumer: ConsumerId,
     pub owner: OwnerKey,
     pub pin: GeyserPinReason,
+    /// Monotonic sequence assigned at enqueue/pending-stash time (stale replay guard).
+    pub revision: u64,
 }
 
 impl PoolExplicitSnapshot {

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -54,6 +54,8 @@ pub struct PoolExplicitSnapshot {
     pub pin: GeyserPinReason,
     /// Monotonic sequence assigned at enqueue/pending-stash time (stale replay guard).
     pub revision: u64,
+    /// When set, enqueue success may resolve exactly this ledger rejection (token + payload).
+    pub rejection_ledger_token: Option<u64>,
 }
 
 impl PoolExplicitSnapshot {

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -3,6 +3,7 @@
 use solana_sdk::pubkey::Pubkey;
 use std::collections::HashSet;
 
+use super::desired_set::{ConsumerId, OwnerKey};
 use super::snapshot::ExplicitSetSnapshot;
 use crate::nats::{ArbTrackRequestsUpdate, MomentumActivePoolsUpdate};
 
@@ -12,6 +13,16 @@ pub enum GeyserPinReason {
     Wallet,
     MomentumActive,
     ArbMultiDex,
+}
+
+/// Immutable pool/account snapshot captured at enqueue time (admission + worker commit SSOT).
+#[derive(Debug, Clone)]
+pub struct PoolExplicitSnapshot {
+    pub pool: Pubkey,
+    pub pubkeys: HashSet<Pubkey>,
+    pub consumer: ConsumerId,
+    pub owner: OwnerKey,
+    pub pin: GeyserPinReason,
 }
 
 /// Phase 2a: commands for the `md-track-worker` OS thread (DesiredExplicitSet + coalesced Geyser push).
@@ -25,22 +36,21 @@ pub enum TrackWorkerCommand {
         mint: Pubkey,
         pin: Option<GeyserPinReason>,
     },
+    /// Worker reads authoritative [`super::pending::WalletExplicitPending`] by revision.
     SyncWalletExplicitDemand {
-        demand: HashSet<Pubkey>,
-        token_accounts: HashSet<Pubkey>,
+        revision: u64,
     },
     RegisterPoolGeyserReserves {
-        pool: Pubkey,
-        pin: GeyserPinReason,
+        snapshot: PoolExplicitSnapshot,
     },
     RegisterPoolVaultsFromAccount {
-        pool: Pubkey,
+        snapshot: PoolExplicitSnapshot,
     },
     RegisterGeyserReservesAfterTrade {
-        pool: Pubkey,
+        snapshot: PoolExplicitSnapshot,
     },
     RefreshDlmmBinWindow {
-        pool: Pubkey,
+        snapshot: PoolExplicitSnapshot,
         new_active_id: i32,
     },
     ScheduleGeyserSyncAfterConfigChange,
@@ -50,5 +60,9 @@ pub enum TrackWorkerCommand {
     ScheduleGeyserPushDebounced,
     /// Phase 3 P3: restore explicit set from on-disk snapshot (I-MD-6).
     RestoreExplicitSnapshot(ExplicitSetSnapshot),
+    /// Worker signals restore barrier completion (startup).
+    RestoreBarrierComplete {
+        ok: bool,
+    },
     ContinueGeyserEvict,
 }

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -15,14 +15,59 @@ pub enum GeyserPinReason {
     ArbMultiDex,
 }
 
+/// Immutable vault row captured at enqueue time.
+#[derive(Debug, Clone)]
+pub struct VaultExplicitRow {
+    pub pubkey: Pubkey,
+    pub dex: String,
+    pub base_mint: Pubkey,
+    pub quote_mint: Pubkey,
+    pub is_base_vault: bool,
+    pub sibling_vault: Option<Pubkey>,
+    pub active_id: Option<i32>,
+    pub bin_step: Option<u16>,
+}
+
+/// Immutable DLMM bin-array row captured at enqueue time.
+#[derive(Debug, Clone)]
+pub struct BinArrayExplicitRow {
+    pub pubkey: Pubkey,
+    pub bin_array_index: i64,
+    pub bin_step: u16,
+}
+
+/// Immutable mint row captured at enqueue time (tracked_mints, not vaults).
+#[derive(Debug, Clone)]
+pub struct MintExplicitRow {
+    pub pubkey: Pubkey,
+}
+
 /// Immutable pool/account snapshot captured at enqueue time (admission + worker commit SSOT).
 #[derive(Debug, Clone)]
 pub struct PoolExplicitSnapshot {
     pub pool: Pubkey,
-    pub pubkeys: HashSet<Pubkey>,
+    pub vaults: Vec<VaultExplicitRow>,
+    pub bin_arrays: Vec<BinArrayExplicitRow>,
+    pub mints: Vec<MintExplicitRow>,
     pub consumer: ConsumerId,
     pub owner: OwnerKey,
     pub pin: GeyserPinReason,
+}
+
+impl PoolExplicitSnapshot {
+    pub fn all_pubkeys(&self) -> HashSet<Pubkey> {
+        let mut out = HashSet::new();
+        for v in &self.vaults {
+            out.insert(v.pubkey);
+        }
+        for b in &self.bin_arrays {
+            out.insert(b.pubkey);
+        }
+        for m in &self.mints {
+            out.insert(m.pubkey);
+        }
+        out
+    }
 }
 
 /// Phase 2a: commands for the `md-track-worker` OS thread (DesiredExplicitSet + coalesced Geyser push).
@@ -60,6 +105,8 @@ pub enum TrackWorkerCommand {
     ScheduleGeyserPushDebounced,
     /// Phase 3 P3: restore explicit set from on-disk snapshot (I-MD-6).
     RestoreExplicitSnapshot(ExplicitSetSnapshot),
+    /// Startup barrier without persisted snapshot (wallet demand + convergence + physical publish).
+    CompleteStartupBarrier,
     /// Worker signals restore barrier completion (startup).
     RestoreBarrierComplete {
         ok: bool,

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -27,6 +27,7 @@ pub enum TrackWorkerCommand {
     },
     SyncWalletExplicitDemand {
         demand: HashSet<Pubkey>,
+        token_accounts: HashSet<Pubkey>,
     },
     RegisterPoolGeyserReserves {
         pool: Pubkey,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1128,6 +1128,9 @@ pub static MARKET_DATA_MOMENTUM_TRACK_WORKER_ENQUEUE_DROPPED_TOTAL: Lazy<AtomicU
 /// Phase 3: arb track requests enqueue dropped on full track-worker queue.
 pub static MARKET_DATA_ARB_TRACK_WORKER_ENQUEUE_DROPPED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// Durable pending pool registration overflow (fail-closed; no silent eviction).
+pub static MARKET_DATA_TRACK_PENDING_POOL_OVERFLOW_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 /// PR169a: single-writer Geyser tracking actor queue depth (gauge).
 pub static MARKET_DATA_GEYSER_TRACKING_QUEUE_DEPTH: Lazy<AtomicU64> =
@@ -1371,6 +1374,11 @@ pub fn inc_market_data_tx_deferred_dropped_total() {
 #[inline]
 pub fn set_market_data_track_worker_queue_depth(depth: usize) {
     MARKET_DATA_TRACK_WORKER_QUEUE_DEPTH.store(depth as u64, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_track_pending_pool_overflow_total() {
+    MARKET_DATA_TRACK_PENDING_POOL_OVERFLOW_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1132,6 +1132,9 @@ pub static MARKET_DATA_ARB_TRACK_WORKER_ENQUEUE_DROPPED_TOTAL: Lazy<AtomicU64> =
 pub static MARKET_DATA_TRACK_PENDING_POOL_OVERFLOW_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 /// Pool snapshot revision registry full / key not registered (fail-closed before command issue).
+pub static MARKET_DATA_TRACKER_DEMAND_CAP_REJECTED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 pub static MARKET_DATA_REVISION_REGISTRY_FULL_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
@@ -1382,6 +1385,11 @@ pub fn set_market_data_track_worker_queue_depth(depth: usize) {
 #[inline]
 pub fn inc_market_data_track_pending_pool_overflow_total() {
     MARKET_DATA_TRACK_PENDING_POOL_OVERFLOW_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_tracker_demand_cap_rejected_total() {
+    MARKET_DATA_TRACKER_DEMAND_CAP_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -382,6 +382,76 @@ pub static MARKET_DATA_GEYSER_SYNC_SKIPPED_RATE_LIMIT_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 /// Phase 2a: current explicit Geyser pubkey count in DesiredExplicitSet.
 pub static MARKET_DATA_GEYSER_EXPLICIT_SET_SIZE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// I-MD-7: deduplicated admitted explicit pubkey count (DesiredExplicitSet SSOT).
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMITTED_ACCOUNTS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// I-MD-7: oversubscription gauge; 0 after convergence.
+pub static MARKET_DATA_GEYSER_EXPLICIT_CAP_OVERFLOW: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// I-MD-8: requested pool groups by consumer (logical demand, not admitted).
+pub static MARKET_DATA_GEYSER_EXPLICIT_REQUESTED_POOLS_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_REQUESTED_POOLS_ARB: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_REQUESTED_POOLS_TRACKER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// I-MD-8: admitted pool groups by consumer.
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMITTED_POOLS_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMITTED_POOLS_ARB: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMITTED_POOLS_TRACKER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// I-MD-7: admission rejections {consumer, reason}.
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_CAP_WALLET: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_CAP_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_CAP_ARB: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_CAP_TRACKER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_PROTECTED_WALLET: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_PROTECTED_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_PROTECTED_ARB: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_PROTECTED_TRACKER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_INVALID_GROUP_WALLET: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_INVALID_GROUP_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_INVALID_GROUP_ARB: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_INVALID_GROUP_TRACKER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// I-MD-8: group evictions {consumer, reason}.
+pub static MARKET_DATA_GEYSER_EXPLICIT_EVICTED_HIGHER_PRIORITY_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_EVICTED_HIGHER_PRIORITY_ARB: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_EVICTED_HIGHER_PRIORITY_TRACKER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_EVICTED_SAME_PRIORITY_LRU_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_EVICTED_SAME_PRIORITY_LRU_ARB: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_EVICTED_SAME_PRIORITY_LRU_TRACKER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_EVICTED_CAP_SHRINK_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_EVICTED_CAP_SHRINK_ARB: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_EVICTED_CAP_SHRINK_TRACKER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_EVICTED_RESTORE_CONVERGE_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_EVICTED_RESTORE_CONVERGE_ARB: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_GEYSER_EXPLICIT_EVICTED_RESTORE_CONVERGE_TRACKER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// Phase 2a: pubkey count in one delta-only Geyser subscribe push.
 pub static MARKET_DATA_GEYSER_SUBSCRIBE_DELTA_PUBKEYS: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -783,6 +853,110 @@ pub fn set_market_data_explicit_set_snapshot_restore_duration_ms(ms: u64) {
 #[inline]
 pub fn market_data_geyser_explicit_set_size_value() -> u64 {
     MARKET_DATA_GEYSER_EXPLICIT_SET_SIZE.load(Ordering::Relaxed)
+}
+
+#[inline]
+pub fn set_market_data_geyser_explicit_admitted_accounts(n: usize) {
+    MARKET_DATA_GEYSER_EXPLICIT_ADMITTED_ACCOUNTS.store(n as u64, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn set_market_data_geyser_explicit_cap_overflow(n: usize) {
+    MARKET_DATA_GEYSER_EXPLICIT_CAP_OVERFLOW.store(n as u64, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn set_market_data_geyser_explicit_requested_pools(consumer: &str, n: usize) {
+    let v = n as u64;
+    match consumer {
+        "momentum" => {
+            MARKET_DATA_GEYSER_EXPLICIT_REQUESTED_POOLS_MOMENTUM.store(v, Ordering::Relaxed)
+        }
+        "arb" => MARKET_DATA_GEYSER_EXPLICIT_REQUESTED_POOLS_ARB.store(v, Ordering::Relaxed),
+        "tracker" => {
+            MARKET_DATA_GEYSER_EXPLICIT_REQUESTED_POOLS_TRACKER.store(v, Ordering::Relaxed)
+        }
+        _ => {}
+    }
+}
+
+#[inline]
+pub fn set_market_data_geyser_explicit_admitted_pools(consumer: &str, n: usize) {
+    let v = n as u64;
+    match consumer {
+        "momentum" => {
+            MARKET_DATA_GEYSER_EXPLICIT_ADMITTED_POOLS_MOMENTUM.store(v, Ordering::Relaxed)
+        }
+        "arb" => MARKET_DATA_GEYSER_EXPLICIT_ADMITTED_POOLS_ARB.store(v, Ordering::Relaxed),
+        "tracker" => MARKET_DATA_GEYSER_EXPLICIT_ADMITTED_POOLS_TRACKER.store(v, Ordering::Relaxed),
+        _ => {}
+    }
+}
+
+#[inline]
+pub fn inc_market_data_geyser_explicit_admission_rejected_total(consumer: &str, reason: &str) {
+    let counter = match (consumer, reason) {
+        ("wallet", "cap") => &*MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_CAP_WALLET,
+        ("momentum", "cap") => &*MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_CAP_MOMENTUM,
+        ("arb", "cap") => &*MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_CAP_ARB,
+        ("tracker", "cap") => &*MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_CAP_TRACKER,
+        ("wallet", "protected") => {
+            &*MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_PROTECTED_WALLET
+        }
+        ("momentum", "protected") => {
+            &*MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_PROTECTED_MOMENTUM
+        }
+        ("arb", "protected") => &*MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_PROTECTED_ARB,
+        ("tracker", "protected") => {
+            &*MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_PROTECTED_TRACKER
+        }
+        ("wallet", "invalid_group") => {
+            &*MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_INVALID_GROUP_WALLET
+        }
+        ("momentum", "invalid_group") => {
+            &*MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_INVALID_GROUP_MOMENTUM
+        }
+        ("arb", "invalid_group") => {
+            &*MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_INVALID_GROUP_ARB
+        }
+        ("tracker", "invalid_group") => {
+            &*MARKET_DATA_GEYSER_EXPLICIT_ADMISSION_REJECTED_INVALID_GROUP_TRACKER
+        }
+        _ => return,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_geyser_explicit_evicted_total(consumer: &str, reason: &str) {
+    let counter = match (consumer, reason) {
+        ("momentum", "higher_priority") => {
+            &*MARKET_DATA_GEYSER_EXPLICIT_EVICTED_HIGHER_PRIORITY_MOMENTUM
+        }
+        ("arb", "higher_priority") => &*MARKET_DATA_GEYSER_EXPLICIT_EVICTED_HIGHER_PRIORITY_ARB,
+        ("tracker", "higher_priority") => {
+            &*MARKET_DATA_GEYSER_EXPLICIT_EVICTED_HIGHER_PRIORITY_TRACKER
+        }
+        ("momentum", "same_priority_lru") => {
+            &*MARKET_DATA_GEYSER_EXPLICIT_EVICTED_SAME_PRIORITY_LRU_MOMENTUM
+        }
+        ("arb", "same_priority_lru") => &*MARKET_DATA_GEYSER_EXPLICIT_EVICTED_SAME_PRIORITY_LRU_ARB,
+        ("tracker", "same_priority_lru") => {
+            &*MARKET_DATA_GEYSER_EXPLICIT_EVICTED_SAME_PRIORITY_LRU_TRACKER
+        }
+        ("momentum", "cap_shrink") => &*MARKET_DATA_GEYSER_EXPLICIT_EVICTED_CAP_SHRINK_MOMENTUM,
+        ("arb", "cap_shrink") => &*MARKET_DATA_GEYSER_EXPLICIT_EVICTED_CAP_SHRINK_ARB,
+        ("tracker", "cap_shrink") => &*MARKET_DATA_GEYSER_EXPLICIT_EVICTED_CAP_SHRINK_TRACKER,
+        ("momentum", "restore_converge") => {
+            &*MARKET_DATA_GEYSER_EXPLICIT_EVICTED_RESTORE_CONVERGE_MOMENTUM
+        }
+        ("arb", "restore_converge") => &*MARKET_DATA_GEYSER_EXPLICIT_EVICTED_RESTORE_CONVERGE_ARB,
+        ("tracker", "restore_converge") => {
+            &*MARKET_DATA_GEYSER_EXPLICIT_EVICTED_RESTORE_CONVERGE_TRACKER
+        }
+        _ => return,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -6237,6 +6411,38 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_geyser_explicit_set_size",
         MARKET_DATA_GEYSER_EXPLICIT_SET_SIZE.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_geyser_explicit_admitted_accounts",
+        MARKET_DATA_GEYSER_EXPLICIT_ADMITTED_ACCOUNTS.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_geyser_explicit_cap_overflow",
+        MARKET_DATA_GEYSER_EXPLICIT_CAP_OVERFLOW.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_geyser_explicit_requested_pools{consumer=\"momentum\"}",
+        MARKET_DATA_GEYSER_EXPLICIT_REQUESTED_POOLS_MOMENTUM.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_geyser_explicit_requested_pools{consumer=\"arb\"}",
+        MARKET_DATA_GEYSER_EXPLICIT_REQUESTED_POOLS_ARB.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_geyser_explicit_requested_pools{consumer=\"tracker\"}",
+        MARKET_DATA_GEYSER_EXPLICIT_REQUESTED_POOLS_TRACKER.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_geyser_explicit_admitted_pools{consumer=\"momentum\"}",
+        MARKET_DATA_GEYSER_EXPLICIT_ADMITTED_POOLS_MOMENTUM.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_geyser_explicit_admitted_pools{consumer=\"arb\"}",
+        MARKET_DATA_GEYSER_EXPLICIT_ADMITTED_POOLS_ARB.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_geyser_explicit_admitted_pools{consumer=\"tracker\"}",
+        MARKET_DATA_GEYSER_EXPLICIT_ADMITTED_POOLS_TRACKER.load(Ordering::Relaxed)
     );
     line!(
         "market_data_geyser_subscribe_delta_pubkeys",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1131,6 +1131,9 @@ pub static MARKET_DATA_ARB_TRACK_WORKER_ENQUEUE_DROPPED_TOTAL: Lazy<AtomicU64> =
 /// Durable pending pool registration overflow (fail-closed; no silent eviction).
 pub static MARKET_DATA_TRACK_PENDING_POOL_OVERFLOW_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// Pool snapshot revision registry full / key not registered (fail-closed before command issue).
+pub static MARKET_DATA_REVISION_REGISTRY_FULL_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 /// PR169a: single-writer Geyser tracking actor queue depth (gauge).
 pub static MARKET_DATA_GEYSER_TRACKING_QUEUE_DEPTH: Lazy<AtomicU64> =
@@ -1379,6 +1382,16 @@ pub fn set_market_data_track_worker_queue_depth(depth: usize) {
 #[inline]
 pub fn inc_market_data_track_pending_pool_overflow_total() {
     MARKET_DATA_TRACK_PENDING_POOL_OVERFLOW_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_revision_registry_full_total() {
+    MARKET_DATA_REVISION_REGISTRY_FULL_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn market_data_track_pending_pool_overflow_value() -> u64 {
+    MARKET_DATA_TRACK_PENDING_POOL_OVERFLOW_TOTAL.load(Ordering::Relaxed)
 }
 
 #[inline]


### PR DESCRIPTION
## Summary
- make the track-worker DesiredExplicitSet the admission source of truth
- enforce atomic, priority-aware account-group admission with owner references
- converge restore, cap shrink, tracked maps, metrics, and Geyser snapshots to the admitted set

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test
- [ ] Impl CI including Eval (Level 5)