### PR TITLE
refactor(market-data): add admission owner LRU metadata

### DIFF
--- a/src/market_data/track/explicit_admission.rs
+++ b/src/market_data/track/explicit_admission.rs
@@ -142,6 +142,21 @@ pub struct FixedCapAdmission {
     test_force_remove_planning_underflow: bool,
     #[cfg(test)]
     test_force_remove_planning_zero_refcount: bool,
+    #[cfg(test)]
+    test_force_stamp_plan_failure: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StampPlan {
+    owner_lru: BTreeMap<ExplicitOwner, u64>,
+    next_touch_stamp: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StampPlanError {
+    Overflow,
+    MissingOwnerStamp,
+    ForcedFailure,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -211,6 +226,8 @@ impl FixedCapAdmission {
             test_force_remove_planning_underflow: false,
             #[cfg(test)]
             test_force_remove_planning_zero_refcount: false,
+            #[cfg(test)]
+            test_force_stamp_plan_failure: false,
         }
     }
 
@@ -247,10 +264,20 @@ impl FixedCapAdmission {
         if self.ownership.owner_group(&owner).is_none() {
             return TouchResult::NotFound;
         }
-        if !self.owner_lru.contains_key(&owner) {
+        let Some(_pre_stamp) = self.owner_lru.get(&owner).copied() else {
+            self.fail_closed_remove_owner_stamp_mismatch(&owner);
             return TouchResult::InternalInvariantViolation;
-        }
-        self.stamp_owner(&owner);
+        };
+        let stamp_plan = match plan_stamp_assign(
+            &self.owner_lru,
+            self.next_touch_stamp,
+            &owner,
+            self.stamp_plan_force_failure(),
+        ) {
+            Ok(plan) => plan,
+            Err(_) => return TouchResult::InternalInvariantViolation,
+        };
+        self.apply_stamp_plan(&stamp_plan);
         TouchResult::Touched
     }
 
@@ -296,6 +323,11 @@ impl FixedCapAdmission {
     }
 
     #[cfg(test)]
+    pub fn set_test_force_stamp_plan_failure(&mut self, enabled: bool) {
+        self.test_force_stamp_plan_failure = enabled;
+    }
+
+    #[cfg(test)]
     pub fn set_test_next_touch_stamp(&mut self, stamp: u64) {
         self.next_touch_stamp = stamp;
     }
@@ -324,8 +356,21 @@ impl FixedCapAdmission {
     }
 
     #[cfg(test)]
+    pub fn test_next_touch_stamp(&self) -> u64 {
+        self.next_touch_stamp
+    }
+
+    #[cfg(test)]
     pub fn test_renormalize_lru_stamps(&mut self) {
-        self.renormalize_lru_stamps();
+        if let Ok(map) = renormalize_stamps_fallible(&self.owner_lru) {
+            let len = map.len();
+            if let Ok(base) = u64::try_from(len) {
+                if let Some(next) = base.checked_add(1) {
+                    self.owner_lru = map;
+                    self.next_touch_stamp = next;
+                }
+            }
+        }
     }
 
     /// Admit a new owner group when the owner is absent and projected physical pubkeys fit the cap.
@@ -362,6 +407,16 @@ impl FixedCapAdmission {
             InsertPlanOutcome::Ready(plan) => plan,
         };
 
+        let stamp_plan = match plan_stamp_assign(
+            &self.owner_lru,
+            self.next_touch_stamp,
+            &owner,
+            self.stamp_plan_force_failure(),
+        ) {
+            Ok(plan) => plan,
+            Err(_) => return FixedCapAdmissionResult::InternalInvariantViolation,
+        };
+
         let force_mismatch = {
             #[cfg(test)]
             {
@@ -389,7 +444,7 @@ impl FixedCapAdmission {
         }
 
         self.physical_len = plan.projected_final_len;
-        self.stamp_owner(&owner);
+        self.apply_stamp_plan(&stamp_plan);
         if plan.physical_added.is_empty() {
             FixedCapAdmissionResult::OwnerAddedNoNewPubkey
         } else {
@@ -438,7 +493,26 @@ impl FixedCapAdmission {
             ReplacePlanOutcome::Ready(plan) => plan,
         };
 
-        let pre_touch_stamp = self.owner_lru.get(&existing_owner).copied();
+        let pre_touch_stamp = match required_existing_stamp(&self.owner_lru, &existing_owner) {
+            Ok(stamp) => stamp,
+            Err(StampPlanError::MissingOwnerStamp) => {
+                self.fail_closed_remove_owner_stamp_mismatch(&existing_owner);
+                return FixedCapReplaceResult::InternalInvariantViolation {
+                    recovery: InvariantViolationRecovery::OwnerRemovedFailClosed,
+                };
+            }
+            Err(_) => return FixedCapReplaceResult::PlanningInvariantViolation,
+        };
+
+        let stamp_plan = match plan_stamp_assign(
+            &self.owner_lru,
+            self.next_touch_stamp,
+            &existing_owner,
+            self.stamp_plan_force_failure(),
+        ) {
+            Ok(plan) => plan,
+            Err(_) => return FixedCapReplaceResult::PlanningInvariantViolation,
+        };
 
         let force_commit_mismatch = {
             #[cfg(test)]
@@ -474,7 +548,7 @@ impl FixedCapAdmission {
         }
 
         self.physical_len = plan.projected_final_len;
-        self.stamp_owner(&existing_owner);
+        self.apply_stamp_plan(&stamp_plan);
         FixedCapReplaceResult::Replaced {
             physical_added: plan.physical_added,
             physical_removed: plan.physical_removed,
@@ -490,7 +564,14 @@ impl FixedCapAdmission {
         };
         let old_normalized = old_group.to_vec();
 
-        let pre_touch_stamp = self.owner_lru.get(&owner).copied();
+        let pre_touch_stamp = match required_existing_stamp(&self.owner_lru, &owner) {
+            Ok(stamp) => stamp,
+            Err(StampPlanError::MissingOwnerStamp) => {
+                self.fail_closed_remove_owner_stamp_mismatch(&owner);
+                return FixedCapRemoveResult::PlanningInvariantViolation;
+            }
+            Err(_) => return FixedCapRemoveResult::PlanningInvariantViolation,
+        };
 
         let plan = match self.plan_remove(&old_normalized) {
             RemovePlanOutcome::PlanningInvariantViolation => {
@@ -498,6 +579,8 @@ impl FixedCapAdmission {
             }
             RemovePlanOutcome::Ready(plan) => plan,
         };
+
+        let stamp_plan = plan_stamp_remove(&self.owner_lru, self.next_touch_stamp, &owner);
 
         let force_commit_mismatch = {
             #[cfg(test)]
@@ -525,7 +608,7 @@ impl FixedCapAdmission {
         }
 
         self.physical_len = plan.projected_final_len;
-        self.owner_lru.remove(&owner);
+        self.apply_stamp_plan(&stamp_plan);
         FixedCapRemoveResult::Removed {
             physical_removed: plan.physical_removed,
         }
@@ -730,7 +813,7 @@ impl FixedCapAdmission {
         &mut self,
         owner: &ExplicitOwner,
         plan: &ReplacePlan,
-        pre_touch_stamp: Option<u64>,
+        pre_touch_stamp: u64,
     ) -> FixedCapReplaceResult {
         let force_restore_mismatch = {
             #[cfg(test)]
@@ -768,14 +851,16 @@ impl FixedCapAdmission {
         };
 
         if restored {
-            self.physical_len = plan.pre_len;
-            self.restore_owner_touch_stamp(owner, pre_touch_stamp);
-            if self.ownership.owner_group(owner).is_none() {
-                self.reconcile_physical_len_cold();
+            self.owner_lru.insert(owner.clone(), pre_touch_stamp);
+            if self.owner_group(owner) == Some(restore_pubkeys.as_slice())
+                && self.last_touch(owner) == Some(pre_touch_stamp)
+            {
+                self.physical_len = plan.pre_len;
+                return FixedCapReplaceResult::InternalInvariantViolation {
+                    recovery: InvariantViolationRecovery::PreviousRestored,
+                };
             }
-            FixedCapReplaceResult::InternalInvariantViolation {
-                recovery: InvariantViolationRecovery::PreviousRestored,
-            }
+            self.fail_closed_remove_owner_after_replace(owner)
         } else {
             self.fail_closed_remove_owner_after_replace(owner)
         }
@@ -792,9 +877,7 @@ impl FixedCapAdmission {
             }
         }
         self.owner_lru.remove(owner);
-        self.reconcile_physical_len_cold();
-        debug_assert!(self.ownership.owner_group(owner).is_none());
-        debug_assert!(self.physical_len <= self.cap);
+        self.reconcile_cold();
         FixedCapReplaceResult::InternalInvariantViolation {
             recovery: InvariantViolationRecovery::OwnerRemovedFailClosed,
         }
@@ -804,7 +887,7 @@ impl FixedCapAdmission {
         &mut self,
         owner: &ExplicitOwner,
         plan: &RemovePlan,
-        pre_touch_stamp: Option<u64>,
+        pre_touch_stamp: u64,
     ) -> FixedCapRemoveResult {
         let force_restore_mismatch = {
             #[cfg(test)]
@@ -842,14 +925,16 @@ impl FixedCapAdmission {
         };
 
         if restored {
-            self.physical_len = plan.pre_len;
-            self.restore_owner_touch_stamp(owner, pre_touch_stamp);
-            if self.ownership.owner_group(owner).is_none() {
-                self.reconcile_physical_len_cold();
+            self.owner_lru.insert(owner.clone(), pre_touch_stamp);
+            if self.owner_group(owner) == Some(restore_pubkeys.as_slice())
+                && self.last_touch(owner) == Some(pre_touch_stamp)
+            {
+                self.physical_len = plan.pre_len;
+                return FixedCapRemoveResult::InternalInvariantViolation {
+                    recovery: FixedCapRemoveRecovery::PreviousRestored,
+                };
             }
-            FixedCapRemoveResult::InternalInvariantViolation {
-                recovery: FixedCapRemoveRecovery::PreviousRestored,
-            }
+            self.fail_closed_remove_owner_after_remove(owner)
         } else {
             self.fail_closed_remove_owner_after_remove(owner)
         }
@@ -862,72 +947,53 @@ impl FixedCapAdmission {
         let _ = self.ownership.remove_group(owner);
         if self.ownership.owner_group(owner).is_some() {
             self.owner_lru.remove(owner);
-            self.reconcile_physical_len_cold();
+            self.reconcile_cold();
             return FixedCapRemoveResult::InternalInvariantViolation {
                 recovery: FixedCapRemoveRecovery::RecoveryFailed,
             };
         }
         self.owner_lru.remove(owner);
-        self.reconcile_physical_len_cold();
-        debug_assert!(self.physical_len <= self.cap);
+        self.reconcile_cold();
         FixedCapRemoveResult::InternalInvariantViolation {
             recovery: FixedCapRemoveRecovery::OwnerRemovedFailClosed,
         }
     }
 
-    fn stamp_owner(&mut self, owner: &ExplicitOwner) {
-        let stamp = self.allocate_touch_stamp();
-        self.owner_lru.insert(owner.clone(), stamp);
-    }
-
-    fn restore_owner_touch_stamp(&mut self, owner: &ExplicitOwner, stamp: Option<u64>) {
-        match stamp {
-            Some(stamp) => {
-                self.owner_lru.insert(owner.clone(), stamp);
-            }
-            None => {
-                self.owner_lru.remove(owner);
+    fn fail_closed_remove_owner_stamp_mismatch(&mut self, owner: &ExplicitOwner) {
+        let _ = self.ownership.remove_group(owner);
+        while self.ownership.owner_group(owner).is_some() {
+            if self.ownership.remove_group(owner).is_none() {
+                break;
             }
         }
+        self.owner_lru.remove(owner);
+        self.reconcile_cold();
     }
 
-    fn allocate_touch_stamp(&mut self) -> u64 {
-        if self.next_touch_stamp == u64::MAX {
-            self.renormalize_lru_stamps();
-        }
-        let stamp = self.next_touch_stamp;
-        self.next_touch_stamp = self.next_touch_stamp.saturating_add(1);
-        stamp
+    fn apply_stamp_plan(&mut self, plan: &StampPlan) {
+        self.owner_lru = plan.owner_lru.clone();
+        self.next_touch_stamp = plan.next_touch_stamp;
     }
 
-    fn renormalize_lru_stamps(&mut self) {
-        if self.owner_lru.is_empty() {
-            self.next_touch_stamp = 1;
-            return;
+    fn stamp_plan_force_failure(&self) -> bool {
+        #[cfg(test)]
+        {
+            self.test_force_stamp_plan_failure
         }
-        let mut entries: Vec<(ExplicitOwner, u64)> = self
-            .owner_lru
-            .iter()
-            .map(|(owner, &stamp)| (owner.clone(), stamp))
-            .collect();
-        entries.sort_by(|(owner_a, stamp_a), (owner_b, stamp_b)| {
-            stamp_a.cmp(stamp_b).then_with(|| owner_a.cmp(owner_b))
-        });
-        self.owner_lru.clear();
-        for (idx, (owner, _)) in entries.into_iter().enumerate() {
-            self.owner_lru
-                .insert(owner, u64::try_from(idx).expect("owner count fits u64") + 1);
+        #[cfg(not(test))]
+        {
+            false
         }
-        self.next_touch_stamp = u64::try_from(self.owner_lru.len())
-            .expect("owner count fits u64")
-            .saturating_add(1);
     }
 
-    /// Cold fail-closed recovery: full scan of ownership to repair cached `physical_len`
-    /// and reconcile LRU metadata with ownership.
-    fn reconcile_physical_len_cold(&mut self) {
-        self.physical_len = self.ownership.len();
+    /// Cold fail-closed recovery: reconcile owner/stamp parity, then repair `physical_len`.
+    fn reconcile_cold(&mut self) {
         self.reconcile_lru_cold();
+        self.physical_len = self.ownership.len();
+    }
+
+    fn reconcile_physical_len_cold(&mut self) {
+        self.reconcile_cold();
     }
 
     fn reconcile_lru_cold(&mut self) {
@@ -958,6 +1024,86 @@ impl FixedCapAdmission {
                 }
             }
         }
+    }
+}
+
+fn required_existing_stamp(
+    owner_lru: &BTreeMap<ExplicitOwner, u64>,
+    owner: &ExplicitOwner,
+) -> Result<u64, StampPlanError> {
+    owner_lru
+        .get(owner)
+        .copied()
+        .ok_or(StampPlanError::MissingOwnerStamp)
+}
+
+fn renormalize_stamps_fallible(
+    owner_lru: &BTreeMap<ExplicitOwner, u64>,
+) -> Result<BTreeMap<ExplicitOwner, u64>, StampPlanError> {
+    if owner_lru.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let mut entries: Vec<(ExplicitOwner, u64)> = owner_lru
+        .iter()
+        .map(|(owner, &stamp)| (owner.clone(), stamp))
+        .collect();
+    entries.sort_by(|(owner_a, stamp_a), (owner_b, stamp_b)| {
+        stamp_a.cmp(stamp_b).then_with(|| owner_a.cmp(owner_b))
+    });
+    let mut renormalized = BTreeMap::new();
+    for (idx, (owner, _)) in entries.into_iter().enumerate() {
+        let rank = u64::try_from(idx).map_err(|_| StampPlanError::Overflow)?;
+        let stamp = rank.checked_add(1).ok_or(StampPlanError::Overflow)?;
+        renormalized.insert(owner, stamp);
+    }
+    Ok(renormalized)
+}
+
+fn prepare_stamp_base(
+    owner_lru: &BTreeMap<ExplicitOwner, u64>,
+    next_touch_stamp: u64,
+) -> Result<(BTreeMap<ExplicitOwner, u64>, u64), StampPlanError> {
+    if next_touch_stamp == u64::MAX {
+        let map = renormalize_stamps_fallible(owner_lru)?;
+        let len = map.len();
+        let base = u64::try_from(len).map_err(|_| StampPlanError::Overflow)?;
+        let assign = base.checked_add(1).ok_or(StampPlanError::Overflow)?;
+        Ok((map, assign))
+    } else {
+        Ok((owner_lru.clone(), next_touch_stamp))
+    }
+}
+
+fn plan_stamp_assign(
+    owner_lru: &BTreeMap<ExplicitOwner, u64>,
+    next_touch_stamp: u64,
+    owner: &ExplicitOwner,
+    force_failure: bool,
+) -> Result<StampPlan, StampPlanError> {
+    if force_failure {
+        return Err(StampPlanError::ForcedFailure);
+    }
+    let (mut map, assign_stamp) = prepare_stamp_base(owner_lru, next_touch_stamp)?;
+    let new_next = assign_stamp
+        .checked_add(1)
+        .ok_or(StampPlanError::Overflow)?;
+    map.insert(owner.clone(), assign_stamp);
+    Ok(StampPlan {
+        owner_lru: map,
+        next_touch_stamp: new_next,
+    })
+}
+
+fn plan_stamp_remove(
+    owner_lru: &BTreeMap<ExplicitOwner, u64>,
+    next_touch_stamp: u64,
+    owner: &ExplicitOwner,
+) -> StampPlan {
+    let mut map = owner_lru.clone();
+    map.remove(owner);
+    StampPlan {
+        owner_lru: map,
+        next_touch_stamp,
     }
 }
 
@@ -2484,11 +2630,12 @@ mod tests {
             .expect("LRU snapshot must build eviction planning snapshot");
     }
 
-    /// Independent LRU stamp model — never calls [`FixedCapAdmission`] LRU helpers directly.
+    /// Independent LRU stamp model — separate monotonic/event logic from production.
     #[derive(Debug, Clone)]
     struct RefLruModel {
         stamps: BTreeMap<ExplicitOwner, u64>,
         next_stamp: u64,
+        events: Vec<(ExplicitOwner, u64)>,
     }
 
     impl RefLruModel {
@@ -2496,71 +2643,71 @@ mod tests {
             Self {
                 stamps: BTreeMap::new(),
                 next_stamp: 1,
+                events: Vec::new(),
             }
         }
 
+        fn next_counter(&self) -> u64 {
+            self.next_stamp
+        }
+
         fn on_successful_insert(&mut self, owner: &ExplicitOwner) {
-            self.stamp_owner(owner);
+            self.assign_stamp(owner);
         }
 
         fn on_successful_replace(&mut self, owner: &ExplicitOwner) {
-            self.stamp_owner(owner);
+            self.assign_stamp(owner);
         }
 
         fn on_successful_remove(&mut self, owner: &ExplicitOwner) {
             self.stamps.remove(owner);
+            self.events.retain(|(o, _)| o != owner);
         }
 
         fn on_touch(&mut self, owner: &ExplicitOwner) {
-            self.stamp_owner(owner);
+            self.assign_stamp(owner);
         }
 
-        fn restore_stamp(&mut self, owner: &ExplicitOwner, stamp: Option<u64>) {
-            match stamp {
-                Some(stamp) => {
-                    self.stamps.insert(owner.clone(), stamp);
-                }
-                None => {
-                    self.stamps.remove(owner);
-                }
-            }
-        }
-
-        fn stamp_owner(&mut self, owner: &ExplicitOwner) {
-            let stamp = self.allocate_stamp();
+        fn restore_stamp(&mut self, owner: &ExplicitOwner, stamp: u64) {
             self.stamps.insert(owner.clone(), stamp);
+            self.events.retain(|(o, _)| o != owner);
+            self.events.push((owner.clone(), stamp));
         }
 
-        fn allocate_stamp(&mut self) -> u64 {
+        fn assign_stamp(&mut self, owner: &ExplicitOwner) {
             if self.next_stamp == u64::MAX {
-                self.renormalize();
+                self.compact_from_event_order();
             }
             let stamp = self.next_stamp;
-            self.next_stamp = self.next_stamp.checked_add(1).unwrap_or(u64::MAX);
-            stamp
+            self.next_stamp = self.next_stamp.saturating_add(1);
+            self.stamps.insert(owner.clone(), stamp);
+            self.events.push((owner.clone(), stamp));
         }
 
-        fn renormalize(&mut self) {
-            if self.stamps.is_empty() {
-                self.next_stamp = 1;
-                return;
-            }
-            let mut entries: Vec<(ExplicitOwner, u64)> = self
-                .stamps
+        fn compact_from_event_order(&mut self) {
+            let mut ordered: Vec<(ExplicitOwner, u64)> = self
+                .events
                 .iter()
-                .map(|(owner, &stamp)| (owner.clone(), stamp))
+                .map(|(owner, stamp)| (owner.clone(), *stamp))
                 .collect();
-            entries.sort_by(|(owner_a, stamp_a), (owner_b, stamp_b)| {
+            ordered.sort_by(|(owner_a, stamp_a), (owner_b, stamp_b)| {
                 stamp_a.cmp(stamp_b).then_with(|| owner_a.cmp(owner_b))
             });
             self.stamps.clear();
-            for (idx, (owner, _)) in entries.into_iter().enumerate() {
-                self.stamps
-                    .insert(owner, u64::try_from(idx).expect("owner count fits u64") + 1);
+            self.events.clear();
+            for (idx, (owner, _)) in ordered.into_iter().enumerate() {
+                if let Ok(rank) = u64::try_from(idx) {
+                    if let Some(stamp) = rank.checked_add(1) {
+                        self.stamps.insert(owner.clone(), stamp);
+                        self.events.push((owner, stamp));
+                    }
+                }
             }
-            self.next_stamp = u64::try_from(self.stamps.len())
-                .expect("owner count fits u64")
-                .saturating_add(1);
+            if let Ok(len) = u64::try_from(self.stamps.len()) {
+                if let Some(next) = len.checked_add(1) {
+                    self.next_stamp = next;
+                }
+            }
         }
 
         fn snapshot(&self) -> BTreeMap<ExplicitOwner, u64> {
@@ -2570,6 +2717,7 @@ mod tests {
 
     fn assert_lru_matches_model(admission: &FixedCapAdmission, model: &RefLruModel) {
         assert_eq!(admission.test_owner_stamps(), model.snapshot());
+        assert_eq!(admission.test_next_touch_stamp(), model.next_counter());
         assert_lru_matches_ownership(admission);
     }
 
@@ -2700,9 +2848,12 @@ mod tests {
     #[test]
     fn lru_reject_paths_consume_no_stamp() {
         let mut admission = FixedCapAdmission::new(2);
+        let mut model = RefLruModel::new();
         let owner = pool_owner(ExplicitConsumer::Momentum, 1);
         assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1)]));
+        model.on_successful_insert(&owner);
         let stamp_before = admission.last_touch(&owner).unwrap();
+        let counter_before = admission.test_next_touch_stamp();
 
         assert_eq!(
             admission.try_admit_new_group(owner.clone(), [pk(2)]),
@@ -2725,6 +2876,124 @@ mod tests {
         );
         assert_eq!(admission.last_touch(&owner).unwrap(), stamp_before);
         assert_eq!(admission.snapshot_lru_entries().len(), 1);
+        assert_eq!(admission.test_next_touch_stamp(), counter_before);
+
+        let other = pool_owner(ExplicitConsumer::Arb, 2);
+        assert_admitted(admission.try_admit_new_group(other.clone(), [pk(2)]));
+        model.on_successful_insert(&other);
+        assert_lru_matches_model(&admission, &model);
+
+        assert_eq!(admission.touch_group(owner.clone()), TouchResult::Touched);
+        model.on_touch(&owner);
+        assert_lru_matches_model(&admission, &model);
+    }
+
+    #[test]
+    fn lru_stamp_plan_failure_is_mutation_free() {
+        let mut admission = FixedCapAdmission::new(4);
+        let owner = pool_owner(ExplicitConsumer::Momentum, 1);
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1)]));
+        let before = capture_admission_snapshot(&admission);
+        let counter_before = admission.test_next_touch_stamp();
+        let stamps_before = admission.test_owner_stamps();
+
+        admission.set_test_force_stamp_plan_failure(true);
+        assert_eq!(
+            admission.try_admit_new_group(pool_owner(ExplicitConsumer::Arb, 2), [pk(2)]),
+            FixedCapAdmissionResult::InternalInvariantViolation
+        );
+        assert_eq!(
+            admission.try_replace_group(owner.clone(), [pk(2)]),
+            FixedCapReplaceResult::PlanningInvariantViolation
+        );
+        assert_eq!(
+            admission.touch_group(owner.clone()),
+            TouchResult::InternalInvariantViolation
+        );
+        admission.set_test_force_stamp_plan_failure(false);
+
+        assert_public_snapshots_equal(&capture_admission_snapshot(&admission), &before);
+        assert_eq!(admission.test_owner_stamps(), stamps_before);
+        assert_eq!(admission.test_next_touch_stamp(), counter_before);
+        assert_lru_matches_ownership(&admission);
+    }
+
+    #[test]
+    fn lru_missing_stamp_fail_closed_before_replace_remove_touch() {
+        let mut admission = FixedCapAdmission::new(4);
+        let owner = pool_owner(ExplicitConsumer::Momentum, 1);
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1), pk(2)]));
+        admission.owner_lru.remove(&owner);
+
+        assert_eq!(
+            admission.try_replace_group(owner.clone(), [pk(2), pk(3)]),
+            FixedCapReplaceResult::InternalInvariantViolation {
+                recovery: InvariantViolationRecovery::OwnerRemovedFailClosed,
+            }
+        );
+        assert!(admission.owner_group(&owner).is_none());
+        assert!(admission.last_touch(&owner).is_none());
+        assert_lru_matches_ownership(&admission);
+
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1)]));
+        admission.owner_lru.remove(&owner);
+        assert_eq!(
+            admission.remove_group(owner.clone()),
+            FixedCapRemoveResult::PlanningInvariantViolation
+        );
+        assert!(admission.owner_group(&owner).is_none());
+        assert_lru_matches_ownership(&admission);
+
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1)]));
+        admission.owner_lru.remove(&owner);
+        assert_eq!(
+            admission.touch_group(owner.clone()),
+            TouchResult::InternalInvariantViolation
+        );
+        assert!(admission.owner_group(&owner).is_none());
+        assert_lru_matches_ownership(&admission);
+    }
+
+    #[test]
+    fn lru_recovery_branches_build_eviction_snapshot() {
+        let mut admission = FixedCapAdmission::new(4);
+        let owner = pool_owner(ExplicitConsumer::Momentum, 1);
+        let other = pool_owner(ExplicitConsumer::Arb, 2);
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1), pk(2)]));
+        assert_admitted(admission.try_admit_new_group(other.clone(), [pk(3)]));
+
+        admission.set_test_force_commit_plan_mismatch(true);
+        assert_eq!(
+            admission.try_replace_group(owner.clone(), [pk(2), pk(4)]),
+            FixedCapReplaceResult::InternalInvariantViolation {
+                recovery: InvariantViolationRecovery::PreviousRestored,
+            }
+        );
+        assert_lru_matches_ownership(&admission);
+        admission.set_test_force_commit_plan_mismatch(false);
+
+        admission.set_test_force_commit_plan_mismatch(true);
+        admission.set_test_force_restore_plan_mismatch(true);
+        assert_eq!(
+            admission.try_replace_group(owner.clone(), [pk(2), pk(5)]),
+            FixedCapReplaceResult::InternalInvariantViolation {
+                recovery: InvariantViolationRecovery::OwnerRemovedFailClosed,
+            }
+        );
+        assert_lru_matches_ownership(&admission);
+        admission.set_test_force_commit_plan_mismatch(false);
+        admission.set_test_force_restore_plan_mismatch(false);
+
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1)]));
+        admission.set_test_force_commit_plan_mismatch(true);
+        assert_eq!(
+            admission.remove_group(owner.clone()),
+            FixedCapRemoveResult::InternalInvariantViolation {
+                recovery: FixedCapRemoveRecovery::PreviousRestored,
+            }
+        );
+        assert_lru_matches_ownership(&admission);
+        admission.set_test_force_commit_plan_mismatch(false);
     }
 
     #[test]
@@ -2743,9 +3012,10 @@ mod tests {
                 recovery: InvariantViolationRecovery::PreviousRestored,
             }
         );
-        model.restore_stamp(&owner, Some(old_stamp));
+        model.restore_stamp(&owner, old_stamp);
         assert_eq!(admission.last_touch(&owner).unwrap(), old_stamp);
         assert_lru_matches_model(&admission, &model);
+        assert_lru_matches_ownership(&admission);
     }
 
     #[test]
@@ -2839,10 +3109,10 @@ mod tests {
                     }
                 }
                 2 => {
-                    if admission.owner_group(&owner).is_some() {
-                        if admission.touch_group(owner.clone()) == TouchResult::Touched {
-                            model.on_touch(&owner);
-                        }
+                    if admission.owner_group(&owner).is_some()
+                        && admission.touch_group(owner.clone()) == TouchResult::Touched
+                    {
+                        model.on_touch(&owner);
                     }
                 }
                 _ => {

--- a/src/market_data/track/explicit_admission.rs
+++ b/src/market_data/track/explicit_admission.rs
@@ -277,7 +277,7 @@ impl FixedCapAdmission {
             Ok(plan) => plan,
             Err(_) => return TouchResult::InternalInvariantViolation,
         };
-        self.apply_stamp_plan(&stamp_plan);
+        self.apply_stamp_plan(stamp_plan);
         TouchResult::Touched
     }
 
@@ -444,7 +444,7 @@ impl FixedCapAdmission {
         }
 
         self.physical_len = plan.projected_final_len;
-        self.apply_stamp_plan(&stamp_plan);
+        self.apply_stamp_plan(stamp_plan);
         if plan.physical_added.is_empty() {
             FixedCapAdmissionResult::OwnerAddedNoNewPubkey
         } else {
@@ -470,6 +470,16 @@ impl FixedCapAdmission {
         let Some(old_group) = self.ownership.owner_group(&existing_owner) else {
             return FixedCapReplaceResult::RejectedMissingOwner;
         };
+        let pre_touch_stamp = match required_existing_stamp(&self.owner_lru, &existing_owner) {
+            Ok(stamp) => stamp,
+            Err(StampPlanError::MissingOwnerStamp) => {
+                self.fail_closed_remove_owner_stamp_mismatch(&existing_owner);
+                return FixedCapReplaceResult::InternalInvariantViolation {
+                    recovery: InvariantViolationRecovery::OwnerRemovedFailClosed,
+                };
+            }
+            Err(_) => return FixedCapReplaceResult::PlanningInvariantViolation,
+        };
         let old_normalized = old_group.to_vec();
         if old_normalized == normalized {
             return FixedCapReplaceResult::Unchanged;
@@ -491,17 +501,6 @@ impl FixedCapAdmission {
                 return FixedCapReplaceResult::PlanningInvariantViolation;
             }
             ReplacePlanOutcome::Ready(plan) => plan,
-        };
-
-        let pre_touch_stamp = match required_existing_stamp(&self.owner_lru, &existing_owner) {
-            Ok(stamp) => stamp,
-            Err(StampPlanError::MissingOwnerStamp) => {
-                self.fail_closed_remove_owner_stamp_mismatch(&existing_owner);
-                return FixedCapReplaceResult::InternalInvariantViolation {
-                    recovery: InvariantViolationRecovery::OwnerRemovedFailClosed,
-                };
-            }
-            Err(_) => return FixedCapReplaceResult::PlanningInvariantViolation,
         };
 
         let stamp_plan = match plan_stamp_assign(
@@ -548,7 +547,7 @@ impl FixedCapAdmission {
         }
 
         self.physical_len = plan.projected_final_len;
-        self.apply_stamp_plan(&stamp_plan);
+        self.apply_stamp_plan(stamp_plan);
         FixedCapReplaceResult::Replaced {
             physical_added: plan.physical_added,
             physical_removed: plan.physical_removed,
@@ -568,7 +567,9 @@ impl FixedCapAdmission {
             Ok(stamp) => stamp,
             Err(StampPlanError::MissingOwnerStamp) => {
                 self.fail_closed_remove_owner_stamp_mismatch(&owner);
-                return FixedCapRemoveResult::PlanningInvariantViolation;
+                return FixedCapRemoveResult::InternalInvariantViolation {
+                    recovery: FixedCapRemoveRecovery::OwnerRemovedFailClosed,
+                };
             }
             Err(_) => return FixedCapRemoveResult::PlanningInvariantViolation,
         };
@@ -608,7 +609,7 @@ impl FixedCapAdmission {
         }
 
         self.physical_len = plan.projected_final_len;
-        self.apply_stamp_plan(&stamp_plan);
+        self.apply_stamp_plan(stamp_plan);
         FixedCapRemoveResult::Removed {
             physical_removed: plan.physical_removed,
         }
@@ -970,8 +971,8 @@ impl FixedCapAdmission {
         self.reconcile_cold();
     }
 
-    fn apply_stamp_plan(&mut self, plan: &StampPlan) {
-        self.owner_lru = plan.owner_lru.clone();
+    fn apply_stamp_plan(&mut self, plan: StampPlan) {
+        self.owner_lru = plan.owner_lru;
         self.next_touch_stamp = plan.next_touch_stamp;
     }
 
@@ -2630,12 +2631,11 @@ mod tests {
             .expect("LRU snapshot must build eviction planning snapshot");
     }
 
-    /// Independent LRU stamp model — separate monotonic/event logic from production.
+    /// Independent LRU stamp model — separate monotonic logic from production.
     #[derive(Debug, Clone)]
     struct RefLruModel {
         stamps: BTreeMap<ExplicitOwner, u64>,
         next_stamp: u64,
-        events: Vec<(ExplicitOwner, u64)>,
     }
 
     impl RefLruModel {
@@ -2643,7 +2643,6 @@ mod tests {
             Self {
                 stamps: BTreeMap::new(),
                 next_stamp: 1,
-                events: Vec::new(),
             }
         }
 
@@ -2661,7 +2660,6 @@ mod tests {
 
         fn on_successful_remove(&mut self, owner: &ExplicitOwner) {
             self.stamps.remove(owner);
-            self.events.retain(|(o, _)| o != owner);
         }
 
         fn on_touch(&mut self, owner: &ExplicitOwner) {
@@ -2670,23 +2668,21 @@ mod tests {
 
         fn restore_stamp(&mut self, owner: &ExplicitOwner, stamp: u64) {
             self.stamps.insert(owner.clone(), stamp);
-            self.events.retain(|(o, _)| o != owner);
-            self.events.push((owner.clone(), stamp));
+            self.next_stamp = self.next_stamp.max(stamp.saturating_add(1));
         }
 
         fn assign_stamp(&mut self, owner: &ExplicitOwner) {
             if self.next_stamp == u64::MAX {
-                self.compact_from_event_order();
+                self.compact_from_stamp_order();
             }
             let stamp = self.next_stamp;
             self.next_stamp = self.next_stamp.saturating_add(1);
             self.stamps.insert(owner.clone(), stamp);
-            self.events.push((owner.clone(), stamp));
         }
 
-        fn compact_from_event_order(&mut self) {
+        fn compact_from_stamp_order(&mut self) {
             let mut ordered: Vec<(ExplicitOwner, u64)> = self
-                .events
+                .stamps
                 .iter()
                 .map(|(owner, stamp)| (owner.clone(), *stamp))
                 .collect();
@@ -2694,24 +2690,36 @@ mod tests {
                 stamp_a.cmp(stamp_b).then_with(|| owner_a.cmp(owner_b))
             });
             self.stamps.clear();
-            self.events.clear();
             for (idx, (owner, _)) in ordered.into_iter().enumerate() {
                 if let Ok(rank) = u64::try_from(idx) {
                     if let Some(stamp) = rank.checked_add(1) {
-                        self.stamps.insert(owner.clone(), stamp);
-                        self.events.push((owner, stamp));
+                        self.stamps.insert(owner, stamp);
                     }
                 }
             }
-            if let Ok(len) = u64::try_from(self.stamps.len()) {
-                if let Some(next) = len.checked_add(1) {
-                    self.next_stamp = next;
-                }
-            }
+            self.next_stamp = self
+                .stamps
+                .values()
+                .copied()
+                .max()
+                .and_then(|max| max.checked_add(1))
+                .unwrap_or(1);
         }
 
         fn snapshot(&self) -> BTreeMap<ExplicitOwner, u64> {
             self.stamps.clone()
+        }
+
+        fn ordered_owner_stamps(&self) -> Vec<(u64, ExplicitOwner)> {
+            let mut ordered: Vec<(u64, ExplicitOwner)> = self
+                .stamps
+                .iter()
+                .map(|(owner, stamp)| (*stamp, owner.clone()))
+                .collect();
+            ordered.sort_by(|(stamp_a, owner_a), (stamp_b, owner_b)| {
+                stamp_a.cmp(stamp_b).then_with(|| owner_a.cmp(owner_b))
+            });
+            ordered
         }
     }
 
@@ -2919,6 +2927,43 @@ mod tests {
     }
 
     #[test]
+    fn lru_replace_missing_stamp_before_unchanged_fail_closed() {
+        let mut admission = FixedCapAdmission::new(4);
+        let owner = pool_owner(ExplicitConsumer::Momentum, 1);
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1), pk(2)]));
+        let stamp_before = admission.test_next_touch_stamp();
+        admission.owner_lru.remove(&owner);
+
+        assert_eq!(
+            admission.try_replace_group(owner.clone(), [pk(1), pk(2)]),
+            FixedCapReplaceResult::InternalInvariantViolation {
+                recovery: InvariantViolationRecovery::OwnerRemovedFailClosed,
+            }
+        );
+        assert!(admission.owner_group(&owner).is_none());
+        assert_eq!(admission.test_next_touch_stamp(), stamp_before);
+    }
+
+    #[test]
+    fn lru_replace_unchanged_with_valid_stamp_consumes_no_stamp() {
+        let mut admission = FixedCapAdmission::new(4);
+        let mut model = RefLruModel::new();
+        let owner = pool_owner(ExplicitConsumer::Momentum, 1);
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1), pk(2)]));
+        model.on_successful_insert(&owner);
+        let stamp = admission.last_touch(&owner).unwrap();
+        let counter = admission.test_next_touch_stamp();
+
+        assert_eq!(
+            admission.try_replace_group(owner.clone(), [pk(2), pk(1)]),
+            FixedCapReplaceResult::Unchanged
+        );
+        assert_eq!(admission.last_touch(&owner).unwrap(), stamp);
+        assert_eq!(admission.test_next_touch_stamp(), counter);
+        assert_lru_matches_model(&admission, &model);
+    }
+
+    #[test]
     fn lru_missing_stamp_fail_closed_before_replace_remove_touch() {
         let mut admission = FixedCapAdmission::new(4);
         let owner = pool_owner(ExplicitConsumer::Momentum, 1);
@@ -2939,9 +2984,14 @@ mod tests {
         admission.owner_lru.remove(&owner);
         assert_eq!(
             admission.remove_group(owner.clone()),
-            FixedCapRemoveResult::PlanningInvariantViolation
+            FixedCapRemoveResult::InternalInvariantViolation {
+                recovery: FixedCapRemoveRecovery::OwnerRemovedFailClosed,
+            }
         );
         assert!(admission.owner_group(&owner).is_none());
+        assert!(admission.last_touch(&owner).is_none());
+        assert_eq!(admission.len(), 0);
+        assert!(admission.snapshot_lru_entries().is_empty());
         assert_lru_matches_ownership(&admission);
 
         assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1)]));
@@ -3162,6 +3212,7 @@ mod tests {
     #[test]
     fn lru_near_max_renormalization_preserves_stamp_owner_order() {
         let mut admission = FixedCapAdmission::new(16);
+        let mut model = RefLruModel::new();
         let owners: Vec<ExplicitOwner> = (0u8..4)
             .map(|seed| pool_owner(ExplicitConsumer::Momentum, seed))
             .collect();
@@ -3169,46 +3220,42 @@ mod tests {
             assert_admitted(
                 admission.try_admit_new_group(owner.clone(), [pk(owner_key_hash_seed(owner))]),
             );
+            model.on_successful_insert(owner);
         }
         admission.set_test_next_touch_stamp(u64::MAX - 1);
         admission.set_test_owner_stamp(owners[0].clone(), u64::MAX - 2);
         admission.set_test_owner_stamp(owners[1].clone(), u64::MAX - 2);
         admission.set_test_owner_stamp(owners[2].clone(), u64::MAX - 1);
         admission.set_test_owner_stamp(owners[3].clone(), u64::MAX - 1);
+        model.stamps = admission.test_owner_stamps();
+        model.next_stamp = admission.test_next_touch_stamp();
 
-        let mut before_sorted: Vec<(u64, ExplicitOwner)> = admission
-            .test_owner_stamps()
-            .into_iter()
-            .map(|(owner, stamp)| (stamp, owner))
-            .collect();
-        before_sorted.sort_by(|(stamp_a, owner_a), (stamp_b, owner_b)| {
-            stamp_a.cmp(stamp_b).then_with(|| owner_a.cmp(owner_b))
-        });
+        let before_sorted = model.ordered_owner_stamps();
 
         admission.test_renormalize_lru_stamps();
+        model.compact_from_stamp_order();
 
-        let mut after_sorted: Vec<(u64, ExplicitOwner)> = admission
-            .test_owner_stamps()
-            .into_iter()
-            .map(|(owner, stamp)| (stamp, owner))
-            .collect();
-        after_sorted.sort_by(|(stamp_a, owner_a), (stamp_b, owner_b)| {
-            stamp_a.cmp(stamp_b).then_with(|| owner_a.cmp(owner_b))
-        });
-
-        let before_owners: Vec<ExplicitOwner> = before_sorted.into_iter().map(|(_, o)| o).collect();
-        let after_owners: Vec<ExplicitOwner> = after_sorted.into_iter().map(|(_, o)| o).collect();
+        let after_sorted = model.ordered_owner_stamps();
+        let before_owners: Vec<ExplicitOwner> =
+            before_sorted.into_iter().map(|(_, owner)| owner).collect();
+        let after_owners: Vec<ExplicitOwner> =
+            after_sorted.into_iter().map(|(_, owner)| owner).collect();
         assert_eq!(before_owners, after_owners);
-        let mut compact_stamps: Vec<u64> =
-            admission.test_owner_stamps().values().copied().collect();
-        compact_stamps.sort();
-        assert_eq!(compact_stamps, vec![1, 2, 3, 4]);
-        admission.set_test_next_touch_stamp(5);
+        assert_lru_matches_model(&admission, &model);
+
         assert_eq!(
             admission.touch_group(owners[0].clone()),
             TouchResult::Touched
         );
-        assert_eq!(admission.last_touch(&owners[0]).unwrap(), 5);
+        model.on_touch(&owners[0]);
+        assert_lru_matches_model(&admission, &model);
+
+        assert_eq!(
+            admission.touch_group(owners[2].clone()),
+            TouchResult::Touched
+        );
+        model.on_touch(&owners[2]);
+        assert_lru_matches_model(&admission, &model);
     }
 
     #[test]

--- a/src/market_data/track/explicit_admission.rs
+++ b/src/market_data/track/explicit_admission.rs
@@ -7,10 +7,12 @@
 //! Normal planning is O(group_size). [`FixedCapAdmission::reconcile_physical_len_cold`]
 //! may scan ownership only on exceptional invariant/rollback failure.
 
+use super::eviction_planner::OwnerLruEntry;
 use super::explicit_ownership::{
     EmptyOwnerGroupError, ExplicitOwner, ExplicitOwnership, GroupChange, OwnerGroupSnapshot,
 };
 use solana_sdk::pubkey::Pubkey;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Recovery path after an internal invariant violation during replacement rollback.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,6 +67,17 @@ pub enum FixedCapRemoveResult {
     InternalInvariantViolation { recovery: FixedCapRemoveRecovery },
 }
 
+/// Result of an explicit owner-group LRU touch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TouchResult {
+    /// Owner present; stamp advanced.
+    Touched,
+    /// Owner absent; fully mutation-free.
+    NotFound,
+    /// Ownership/LRU owner sets diverged during internal recovery.
+    InternalInvariantViolation,
+}
+
 /// Result of a fixed-cap owner-group replacement attempt.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FixedCapReplaceResult {
@@ -117,6 +130,8 @@ pub struct FixedCapAdmission {
     cap: usize,
     physical_len: usize,
     ownership: ExplicitOwnership,
+    owner_lru: BTreeMap<ExplicitOwner, u64>,
+    next_touch_stamp: u64,
     #[cfg(test)]
     planning_stats: PlanningStats,
     #[cfg(test)]
@@ -184,6 +199,8 @@ impl FixedCapAdmission {
             cap,
             physical_len: 0,
             ownership: ExplicitOwnership::new(),
+            owner_lru: BTreeMap::new(),
+            next_touch_stamp: 1,
             #[cfg(test)]
             planning_stats: PlanningStats::default(),
             #[cfg(test)]
@@ -225,6 +242,34 @@ impl FixedCapAdmission {
         self.ownership.owner_refcount(pubkey)
     }
 
+    /// Advance the LRU stamp for an existing owner group.
+    pub fn touch_group(&mut self, owner: ExplicitOwner) -> TouchResult {
+        if self.ownership.owner_group(&owner).is_none() {
+            return TouchResult::NotFound;
+        }
+        if !self.owner_lru.contains_key(&owner) {
+            return TouchResult::InternalInvariantViolation;
+        }
+        self.stamp_owner(&owner);
+        TouchResult::Touched
+    }
+
+    /// One LRU row per current owner, sorted deterministically by owner.
+    pub fn snapshot_lru_entries(&self) -> Vec<OwnerLruEntry> {
+        self.owner_lru
+            .iter()
+            .map(|(owner, &last_touch)| OwnerLruEntry {
+                owner: owner.clone(),
+                last_touch,
+            })
+            .collect()
+    }
+
+    /// Current LRU stamp for an owner, if present.
+    pub fn last_touch(&self, owner: &ExplicitOwner) -> Option<u64> {
+        self.owner_lru.get(owner).copied()
+    }
+
     #[cfg(test)]
     pub fn planning_stats(&self) -> &PlanningStats {
         &self.planning_stats
@@ -248,6 +293,39 @@ impl FixedCapAdmission {
     #[cfg(test)]
     pub fn set_test_force_remove_planning_zero_refcount(&mut self, enabled: bool) {
         self.test_force_remove_planning_zero_refcount = enabled;
+    }
+
+    #[cfg(test)]
+    pub fn set_test_next_touch_stamp(&mut self, stamp: u64) {
+        self.next_touch_stamp = stamp;
+    }
+
+    #[cfg(test)]
+    pub fn set_test_owner_stamp(&mut self, owner: ExplicitOwner, stamp: u64) {
+        self.owner_lru.insert(owner, stamp);
+    }
+
+    #[cfg(test)]
+    pub fn test_owner_stamps(&self) -> BTreeMap<ExplicitOwner, u64> {
+        self.owner_lru.clone()
+    }
+
+    #[cfg(test)]
+    pub fn test_build_eviction_snapshot(
+        &self,
+    ) -> Result<
+        super::eviction_planner::EvictionPlanningSnapshot,
+        super::eviction_planner::SnapshotBuildError,
+    > {
+        super::eviction_planner::EvictionPlanningSnapshot::from_ownership(
+            &self.ownership,
+            self.snapshot_lru_entries(),
+        )
+    }
+
+    #[cfg(test)]
+    pub fn test_renormalize_lru_stamps(&mut self) {
+        self.renormalize_lru_stamps();
     }
 
     /// Admit a new owner group when the owner is absent and projected physical pubkeys fit the cap.
@@ -311,6 +389,7 @@ impl FixedCapAdmission {
         }
 
         self.physical_len = plan.projected_final_len;
+        self.stamp_owner(&owner);
         if plan.physical_added.is_empty() {
             FixedCapAdmissionResult::OwnerAddedNoNewPubkey
         } else {
@@ -359,6 +438,8 @@ impl FixedCapAdmission {
             ReplacePlanOutcome::Ready(plan) => plan,
         };
 
+        let pre_touch_stamp = self.owner_lru.get(&existing_owner).copied();
+
         let force_commit_mismatch = {
             #[cfg(test)]
             {
@@ -389,10 +470,11 @@ impl FixedCapAdmission {
             &expected_physical_added,
             &expected_physical_removed,
         ) {
-            return self.rollback_failed_replace(&existing_owner, &plan);
+            return self.rollback_failed_replace(&existing_owner, &plan, pre_touch_stamp);
         }
 
         self.physical_len = plan.projected_final_len;
+        self.stamp_owner(&existing_owner);
         FixedCapReplaceResult::Replaced {
             physical_added: plan.physical_added,
             physical_removed: plan.physical_removed,
@@ -407,6 +489,8 @@ impl FixedCapAdmission {
             return FixedCapRemoveResult::NotFound;
         };
         let old_normalized = old_group.to_vec();
+
+        let pre_touch_stamp = self.owner_lru.get(&owner).copied();
 
         let plan = match self.plan_remove(&old_normalized) {
             RemovePlanOutcome::PlanningInvariantViolation => {
@@ -437,10 +521,11 @@ impl FixedCapAdmission {
             &expected_physical_removed,
             &self.ownership,
         ) {
-            return self.rollback_failed_remove(&owner, &plan);
+            return self.rollback_failed_remove(&owner, &plan, pre_touch_stamp);
         }
 
         self.physical_len = plan.projected_final_len;
+        self.owner_lru.remove(&owner);
         FixedCapRemoveResult::Removed {
             physical_removed: plan.physical_removed,
         }
@@ -645,6 +730,7 @@ impl FixedCapAdmission {
         &mut self,
         owner: &ExplicitOwner,
         plan: &ReplacePlan,
+        pre_touch_stamp: Option<u64>,
     ) -> FixedCapReplaceResult {
         let force_restore_mismatch = {
             #[cfg(test)]
@@ -683,6 +769,7 @@ impl FixedCapAdmission {
 
         if restored {
             self.physical_len = plan.pre_len;
+            self.restore_owner_touch_stamp(owner, pre_touch_stamp);
             if self.ownership.owner_group(owner).is_none() {
                 self.reconcile_physical_len_cold();
             }
@@ -704,6 +791,7 @@ impl FixedCapAdmission {
                 break;
             }
         }
+        self.owner_lru.remove(owner);
         self.reconcile_physical_len_cold();
         debug_assert!(self.ownership.owner_group(owner).is_none());
         debug_assert!(self.physical_len <= self.cap);
@@ -716,6 +804,7 @@ impl FixedCapAdmission {
         &mut self,
         owner: &ExplicitOwner,
         plan: &RemovePlan,
+        pre_touch_stamp: Option<u64>,
     ) -> FixedCapRemoveResult {
         let force_restore_mismatch = {
             #[cfg(test)]
@@ -754,6 +843,7 @@ impl FixedCapAdmission {
 
         if restored {
             self.physical_len = plan.pre_len;
+            self.restore_owner_touch_stamp(owner, pre_touch_stamp);
             if self.ownership.owner_group(owner).is_none() {
                 self.reconcile_physical_len_cold();
             }
@@ -771,11 +861,13 @@ impl FixedCapAdmission {
     ) -> FixedCapRemoveResult {
         let _ = self.ownership.remove_group(owner);
         if self.ownership.owner_group(owner).is_some() {
+            self.owner_lru.remove(owner);
             self.reconcile_physical_len_cold();
             return FixedCapRemoveResult::InternalInvariantViolation {
                 recovery: FixedCapRemoveRecovery::RecoveryFailed,
             };
         }
+        self.owner_lru.remove(owner);
         self.reconcile_physical_len_cold();
         debug_assert!(self.physical_len <= self.cap);
         FixedCapRemoveResult::InternalInvariantViolation {
@@ -783,9 +875,89 @@ impl FixedCapAdmission {
         }
     }
 
-    /// Cold fail-closed recovery: full scan of ownership to repair cached `physical_len`.
+    fn stamp_owner(&mut self, owner: &ExplicitOwner) {
+        let stamp = self.allocate_touch_stamp();
+        self.owner_lru.insert(owner.clone(), stamp);
+    }
+
+    fn restore_owner_touch_stamp(&mut self, owner: &ExplicitOwner, stamp: Option<u64>) {
+        match stamp {
+            Some(stamp) => {
+                self.owner_lru.insert(owner.clone(), stamp);
+            }
+            None => {
+                self.owner_lru.remove(owner);
+            }
+        }
+    }
+
+    fn allocate_touch_stamp(&mut self) -> u64 {
+        if self.next_touch_stamp == u64::MAX {
+            self.renormalize_lru_stamps();
+        }
+        let stamp = self.next_touch_stamp;
+        self.next_touch_stamp = self.next_touch_stamp.saturating_add(1);
+        stamp
+    }
+
+    fn renormalize_lru_stamps(&mut self) {
+        if self.owner_lru.is_empty() {
+            self.next_touch_stamp = 1;
+            return;
+        }
+        let mut entries: Vec<(ExplicitOwner, u64)> = self
+            .owner_lru
+            .iter()
+            .map(|(owner, &stamp)| (owner.clone(), stamp))
+            .collect();
+        entries.sort_by(|(owner_a, stamp_a), (owner_b, stamp_b)| {
+            stamp_a.cmp(stamp_b).then_with(|| owner_a.cmp(owner_b))
+        });
+        self.owner_lru.clear();
+        for (idx, (owner, _)) in entries.into_iter().enumerate() {
+            self.owner_lru
+                .insert(owner, u64::try_from(idx).expect("owner count fits u64") + 1);
+        }
+        self.next_touch_stamp = u64::try_from(self.owner_lru.len())
+            .expect("owner count fits u64")
+            .saturating_add(1);
+    }
+
+    /// Cold fail-closed recovery: full scan of ownership to repair cached `physical_len`
+    /// and reconcile LRU metadata with ownership.
     fn reconcile_physical_len_cold(&mut self) {
         self.physical_len = self.ownership.len();
+        self.reconcile_lru_cold();
+    }
+
+    fn reconcile_lru_cold(&mut self) {
+        let ownership_owners: BTreeSet<ExplicitOwner> = self
+            .ownership
+            .snapshot_owner_groups()
+            .into_iter()
+            .map(|group| ExplicitOwner {
+                consumer: group.consumer,
+                owner_key: group.owner_key,
+            })
+            .collect();
+
+        self.owner_lru
+            .retain(|owner, _| ownership_owners.contains(owner));
+
+        let owners_missing_stamp: Vec<ExplicitOwner> = ownership_owners
+            .iter()
+            .filter(|owner| !self.owner_lru.contains_key(owner))
+            .cloned()
+            .collect();
+
+        for owner in owners_missing_stamp {
+            let _ = self.ownership.remove_group(&owner);
+            while self.ownership.owner_group(&owner).is_some() {
+                if self.ownership.remove_group(&owner).is_none() {
+                    break;
+                }
+            }
+        }
     }
 }
 
@@ -2289,6 +2461,519 @@ mod tests {
             FixedCapAdmissionResult::Inserted { .. }
             | FixedCapAdmissionResult::OwnerAddedNoNewPubkey => {}
             other => panic!("expected successful admission, got {other:?}"),
+        }
+    }
+
+    fn assert_lru_matches_ownership(admission: &FixedCapAdmission) {
+        let owners: BTreeSet<ExplicitOwner> = admission
+            .snapshot_owner_groups()
+            .into_iter()
+            .map(|group| ExplicitOwner {
+                consumer: group.consumer,
+                owner_key: group.owner_key,
+            })
+            .collect();
+        let lru_owners: BTreeSet<ExplicitOwner> = admission
+            .snapshot_lru_entries()
+            .into_iter()
+            .map(|entry| entry.owner)
+            .collect();
+        assert_eq!(lru_owners, owners);
+        admission
+            .test_build_eviction_snapshot()
+            .expect("LRU snapshot must build eviction planning snapshot");
+    }
+
+    /// Independent LRU stamp model — never calls [`FixedCapAdmission`] LRU helpers directly.
+    #[derive(Debug, Clone)]
+    struct RefLruModel {
+        stamps: BTreeMap<ExplicitOwner, u64>,
+        next_stamp: u64,
+    }
+
+    impl RefLruModel {
+        fn new() -> Self {
+            Self {
+                stamps: BTreeMap::new(),
+                next_stamp: 1,
+            }
+        }
+
+        fn on_successful_insert(&mut self, owner: &ExplicitOwner) {
+            self.stamp_owner(owner);
+        }
+
+        fn on_successful_replace(&mut self, owner: &ExplicitOwner) {
+            self.stamp_owner(owner);
+        }
+
+        fn on_successful_remove(&mut self, owner: &ExplicitOwner) {
+            self.stamps.remove(owner);
+        }
+
+        fn on_touch(&mut self, owner: &ExplicitOwner) {
+            self.stamp_owner(owner);
+        }
+
+        fn restore_stamp(&mut self, owner: &ExplicitOwner, stamp: Option<u64>) {
+            match stamp {
+                Some(stamp) => {
+                    self.stamps.insert(owner.clone(), stamp);
+                }
+                None => {
+                    self.stamps.remove(owner);
+                }
+            }
+        }
+
+        fn stamp_owner(&mut self, owner: &ExplicitOwner) {
+            let stamp = self.allocate_stamp();
+            self.stamps.insert(owner.clone(), stamp);
+        }
+
+        fn allocate_stamp(&mut self) -> u64 {
+            if self.next_stamp == u64::MAX {
+                self.renormalize();
+            }
+            let stamp = self.next_stamp;
+            self.next_stamp = self.next_stamp.checked_add(1).unwrap_or(u64::MAX);
+            stamp
+        }
+
+        fn renormalize(&mut self) {
+            if self.stamps.is_empty() {
+                self.next_stamp = 1;
+                return;
+            }
+            let mut entries: Vec<(ExplicitOwner, u64)> = self
+                .stamps
+                .iter()
+                .map(|(owner, &stamp)| (owner.clone(), stamp))
+                .collect();
+            entries.sort_by(|(owner_a, stamp_a), (owner_b, stamp_b)| {
+                stamp_a.cmp(stamp_b).then_with(|| owner_a.cmp(owner_b))
+            });
+            self.stamps.clear();
+            for (idx, (owner, _)) in entries.into_iter().enumerate() {
+                self.stamps
+                    .insert(owner, u64::try_from(idx).expect("owner count fits u64") + 1);
+            }
+            self.next_stamp = u64::try_from(self.stamps.len())
+                .expect("owner count fits u64")
+                .saturating_add(1);
+        }
+
+        fn snapshot(&self) -> BTreeMap<ExplicitOwner, u64> {
+            self.stamps.clone()
+        }
+    }
+
+    fn assert_lru_matches_model(admission: &FixedCapAdmission, model: &RefLruModel) {
+        assert_eq!(admission.test_owner_stamps(), model.snapshot());
+        assert_lru_matches_ownership(admission);
+    }
+
+    // --- LRU metadata tests (PR 1c2a) ---
+
+    #[test]
+    fn lru_inserts_receive_monotone_stamps() {
+        let mut admission = FixedCapAdmission::new(8);
+        let mut model = RefLruModel::new();
+        let owners = [
+            pool_owner(ExplicitConsumer::Momentum, 1),
+            pool_owner(ExplicitConsumer::Arb, 2),
+            pool_owner(ExplicitConsumer::Tracker, 3),
+        ];
+
+        let mut prev = 0u64;
+        for owner in &owners {
+            assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1)]));
+            model.on_successful_insert(owner);
+            let stamp = admission.last_touch(owner).unwrap();
+            assert!(stamp > prev);
+            prev = stamp;
+            assert_lru_matches_model(&admission, &model);
+        }
+    }
+
+    #[test]
+    fn lru_shared_owner_groups_remain_separate_owners() {
+        let mut admission = FixedCapAdmission::new(4);
+        let mut model = RefLruModel::new();
+        let shared = pk(1);
+        let first = pool_owner(ExplicitConsumer::Momentum, 1);
+        let second = pool_owner(ExplicitConsumer::Arb, 2);
+        assert_admitted(admission.try_admit_new_group(first.clone(), [shared]));
+        model.on_successful_insert(&first);
+        assert_admitted(admission.try_admit_new_group(second.clone(), [shared]));
+        model.on_successful_insert(&second);
+
+        let stamp_a = admission.last_touch(&first).unwrap();
+        let stamp_b = admission.last_touch(&second).unwrap();
+        assert_ne!(stamp_a, stamp_b);
+        assert_eq!(admission.snapshot_lru_entries().len(), 2);
+        assert_lru_matches_model(&admission, &model);
+    }
+
+    #[test]
+    fn lru_replace_touches_unchanged_does_not() {
+        let mut admission = FixedCapAdmission::new(4);
+        let mut model = RefLruModel::new();
+        let owner = pool_owner(ExplicitConsumer::Momentum, 1);
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1), pk(2)]));
+        model.on_successful_insert(&owner);
+        let before = admission.last_touch(&owner).unwrap();
+
+        assert_eq!(
+            admission.try_replace_group(owner.clone(), [pk(2), pk(3)]),
+            FixedCapReplaceResult::Replaced {
+                physical_added: vec![pk(3)],
+                physical_removed: vec![pk(1)],
+            }
+        );
+        model.on_successful_replace(&owner);
+        assert!(admission.last_touch(&owner).unwrap() > before);
+
+        let after_replace = admission.last_touch(&owner).unwrap();
+        assert_eq!(
+            admission.try_replace_group(owner.clone(), [pk(2), pk(3)]),
+            FixedCapReplaceResult::Unchanged
+        );
+        assert_eq!(admission.last_touch(&owner).unwrap(), after_replace);
+        assert_lru_matches_model(&admission, &model);
+    }
+
+    #[test]
+    fn lru_explicit_touch_changes_only_target_owner() {
+        let mut admission = FixedCapAdmission::new(4);
+        let mut model = RefLruModel::new();
+        let owner_a = pool_owner(ExplicitConsumer::Momentum, 1);
+        let owner_b = pool_owner(ExplicitConsumer::Arb, 2);
+        assert_admitted(admission.try_admit_new_group(owner_a.clone(), [pk(1)]));
+        model.on_successful_insert(&owner_a);
+        assert_admitted(admission.try_admit_new_group(owner_b.clone(), [pk(2)]));
+        model.on_successful_insert(&owner_b);
+        let stamp_b_before = admission.last_touch(&owner_b).unwrap();
+
+        assert_eq!(admission.touch_group(owner_a.clone()), TouchResult::Touched);
+        model.on_touch(&owner_a);
+        assert!(admission.last_touch(&owner_a).unwrap() > stamp_b_before);
+        assert_eq!(admission.last_touch(&owner_b).unwrap(), stamp_b_before);
+        assert_lru_matches_model(&admission, &model);
+    }
+
+    #[test]
+    fn lru_unknown_touch_is_full_no_op() {
+        let mut admission = FixedCapAdmission::new(4);
+        let mut model = RefLruModel::new();
+        let owner = pool_owner(ExplicitConsumer::Momentum, 1);
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1)]));
+        model.on_successful_insert(&owner);
+        let before = capture_admission_snapshot(&admission);
+        let lru_before = admission.snapshot_lru_entries();
+
+        assert_eq!(
+            admission.touch_group(pool_owner(ExplicitConsumer::Arb, 9)),
+            TouchResult::NotFound
+        );
+        assert_public_snapshots_equal(&capture_admission_snapshot(&admission), &before);
+        assert_eq!(admission.snapshot_lru_entries(), lru_before);
+        assert_lru_matches_model(&admission, &model);
+    }
+
+    #[test]
+    fn lru_remove_deletes_stamp() {
+        let mut admission = FixedCapAdmission::new(4);
+        let mut model = RefLruModel::new();
+        let owner = pool_owner(ExplicitConsumer::Momentum, 1);
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1)]));
+        model.on_successful_insert(&owner);
+        assert!(admission.last_touch(&owner).is_some());
+
+        assert_matches_remove(admission.remove_group(owner.clone()));
+        model.on_successful_remove(&owner);
+        assert!(admission.last_touch(&owner).is_none());
+        assert!(admission.snapshot_lru_entries().is_empty());
+        assert_lru_matches_model(&admission, &model);
+    }
+
+    #[test]
+    fn lru_reject_paths_consume_no_stamp() {
+        let mut admission = FixedCapAdmission::new(2);
+        let owner = pool_owner(ExplicitConsumer::Momentum, 1);
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1)]));
+        let stamp_before = admission.last_touch(&owner).unwrap();
+
+        assert_eq!(
+            admission.try_admit_new_group(owner.clone(), [pk(2)]),
+            FixedCapAdmissionResult::RejectedExistingOwner
+        );
+        assert_eq!(
+            admission.try_replace_group(owner.clone(), []),
+            FixedCapReplaceResult::RejectedInvalidGroup
+        );
+        assert_eq!(
+            admission.try_replace_group(pool_owner(ExplicitConsumer::Arb, 9), [pk(1)]),
+            FixedCapReplaceResult::RejectedMissingOwner
+        );
+        assert_eq!(
+            admission.try_replace_group(owner.clone(), [pk(1), pk(2), pk(3)]),
+            FixedCapReplaceResult::RejectedCap {
+                required_unique: 2,
+                available_unique: 1,
+            }
+        );
+        assert_eq!(admission.last_touch(&owner).unwrap(), stamp_before);
+        assert_eq!(admission.snapshot_lru_entries().len(), 1);
+    }
+
+    #[test]
+    fn lru_replace_previous_restored_restores_old_stamp() {
+        let mut admission = FixedCapAdmission::new(4);
+        let mut model = RefLruModel::new();
+        let owner = pool_owner(ExplicitConsumer::Momentum, 1);
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1), pk(2)]));
+        model.on_successful_insert(&owner);
+        let old_stamp = admission.last_touch(&owner).unwrap();
+
+        admission.set_test_force_commit_plan_mismatch(true);
+        assert_eq!(
+            admission.try_replace_group(owner.clone(), [pk(2), pk(3)]),
+            FixedCapReplaceResult::InternalInvariantViolation {
+                recovery: InvariantViolationRecovery::PreviousRestored,
+            }
+        );
+        model.restore_stamp(&owner, Some(old_stamp));
+        assert_eq!(admission.last_touch(&owner).unwrap(), old_stamp);
+        assert_lru_matches_model(&admission, &model);
+    }
+
+    #[test]
+    fn lru_fail_closed_removes_stamp() {
+        let mut admission = FixedCapAdmission::new(4);
+        let mut model = RefLruModel::new();
+        let owner = pool_owner(ExplicitConsumer::Momentum, 1);
+        let other = pool_owner(ExplicitConsumer::Arb, 2);
+        assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1), pk(2)]));
+        model.on_successful_insert(&owner);
+        assert_admitted(admission.try_admit_new_group(other.clone(), [pk(3)]));
+        model.on_successful_insert(&other);
+
+        admission.set_test_force_commit_plan_mismatch(true);
+        admission.set_test_force_restore_plan_mismatch(true);
+        assert_eq!(
+            admission.try_replace_group(owner.clone(), [pk(2), pk(4)]),
+            FixedCapReplaceResult::InternalInvariantViolation {
+                recovery: InvariantViolationRecovery::OwnerRemovedFailClosed,
+            }
+        );
+        model.on_successful_remove(&owner);
+        assert!(admission.last_touch(&owner).is_none());
+        assert_lru_matches_model(&admission, &model);
+
+        admission.set_test_force_commit_plan_mismatch(true);
+        admission.set_test_force_restore_plan_mismatch(true);
+        let remove_owner = other.clone();
+        assert_eq!(
+            admission.remove_group(remove_owner.clone()),
+            FixedCapRemoveResult::InternalInvariantViolation {
+                recovery: FixedCapRemoveRecovery::OwnerRemovedFailClosed,
+            }
+        );
+        model.on_successful_remove(&remove_owner);
+        assert!(admission.last_touch(&remove_owner).is_none());
+        assert_lru_matches_model(&admission, &model);
+    }
+
+    #[test]
+    fn lru_snapshot_parity_after_long_sequences() {
+        let mut admission = FixedCapAdmission::new(6);
+        let mut model = RefLruModel::new();
+        let owners = [
+            pool_owner(ExplicitConsumer::Momentum, 1),
+            pool_owner(ExplicitConsumer::Arb, 2),
+            pool_owner(ExplicitConsumer::Tracker, 3),
+        ];
+        let key_pool: Vec<Pubkey> = (1u8..=8).map(pk).collect();
+
+        for (step, owner) in owners.iter().enumerate() {
+            let keys: Vec<Pubkey> = key_pool
+                .iter()
+                .copied()
+                .filter(|k| (k.to_bytes()[0] as usize + step) % 2 == 0)
+                .take(2)
+                .collect();
+            assert_admitted(admission.try_admit_new_group(owner.clone(), keys));
+            model.on_successful_insert(owner);
+            assert_lru_matches_model(&admission, &model);
+        }
+
+        for step in 0..24 {
+            let owner = owners[step % owners.len()].clone();
+            match step % 4 {
+                0 => {
+                    if admission.owner_group(&owner).is_none() {
+                        continue;
+                    }
+                    let keys: Vec<Pubkey> = key_pool
+                        .iter()
+                        .copied()
+                        .filter(|k| (k.to_bytes()[0] as usize + step) % 3 != 0)
+                        .take(1 + step % 3)
+                        .collect();
+                    if keys.is_empty() {
+                        continue;
+                    }
+                    let result = admission.try_replace_group(owner.clone(), keys);
+                    if matches!(result, FixedCapReplaceResult::Replaced { .. }) {
+                        model.on_successful_replace(&owner);
+                    }
+                }
+                1 => {
+                    if admission.owner_group(&owner).is_none() {
+                        continue;
+                    }
+                    let result = admission.remove_group(owner.clone());
+                    if matches!(result, FixedCapRemoveResult::Removed { .. }) {
+                        model.on_successful_remove(&owner);
+                    }
+                }
+                2 => {
+                    if admission.owner_group(&owner).is_some() {
+                        if admission.touch_group(owner.clone()) == TouchResult::Touched {
+                            model.on_touch(&owner);
+                        }
+                    }
+                }
+                _ => {
+                    if admission.owner_group(&owner).is_some() {
+                        continue;
+                    }
+                    let keys: Vec<Pubkey> = key_pool
+                        .iter()
+                        .copied()
+                        .filter(|k| (k.to_bytes()[0] as usize + step) % 4 == 0)
+                        .take(1)
+                        .collect();
+                    if keys.is_empty() {
+                        continue;
+                    }
+                    let result = admission.try_admit_new_group(owner.clone(), keys);
+                    if matches!(
+                        result,
+                        FixedCapAdmissionResult::Inserted { .. }
+                            | FixedCapAdmissionResult::OwnerAddedNoNewPubkey
+                    ) {
+                        model.on_successful_insert(&owner);
+                    }
+                }
+            }
+            assert_lru_matches_model(&admission, &model);
+        }
+    }
+
+    #[test]
+    fn lru_snapshot_sorted_by_owner() {
+        let mut admission = FixedCapAdmission::new(8);
+        let owners = [
+            pool_owner(ExplicitConsumer::Tracker, 3),
+            pool_owner(ExplicitConsumer::Momentum, 1),
+            pool_owner(ExplicitConsumer::Arb, 2),
+        ];
+        for owner in &owners {
+            assert_admitted(admission.try_admit_new_group(owner.clone(), [pk(1)]));
+        }
+        let snapshot = admission.snapshot_lru_entries();
+        let mut sorted = snapshot.clone();
+        sorted.sort_by(|a, b| a.owner.cmp(&b.owner));
+        assert_eq!(snapshot, sorted);
+    }
+
+    #[test]
+    fn lru_near_max_renormalization_preserves_stamp_owner_order() {
+        let mut admission = FixedCapAdmission::new(16);
+        let owners: Vec<ExplicitOwner> = (0u8..4)
+            .map(|seed| pool_owner(ExplicitConsumer::Momentum, seed))
+            .collect();
+        for owner in &owners {
+            assert_admitted(
+                admission.try_admit_new_group(owner.clone(), [pk(owner_key_hash_seed(owner))]),
+            );
+        }
+        admission.set_test_next_touch_stamp(u64::MAX - 1);
+        admission.set_test_owner_stamp(owners[0].clone(), u64::MAX - 2);
+        admission.set_test_owner_stamp(owners[1].clone(), u64::MAX - 2);
+        admission.set_test_owner_stamp(owners[2].clone(), u64::MAX - 1);
+        admission.set_test_owner_stamp(owners[3].clone(), u64::MAX - 1);
+
+        let mut before_sorted: Vec<(u64, ExplicitOwner)> = admission
+            .test_owner_stamps()
+            .into_iter()
+            .map(|(owner, stamp)| (stamp, owner))
+            .collect();
+        before_sorted.sort_by(|(stamp_a, owner_a), (stamp_b, owner_b)| {
+            stamp_a.cmp(stamp_b).then_with(|| owner_a.cmp(owner_b))
+        });
+
+        admission.test_renormalize_lru_stamps();
+
+        let mut after_sorted: Vec<(u64, ExplicitOwner)> = admission
+            .test_owner_stamps()
+            .into_iter()
+            .map(|(owner, stamp)| (stamp, owner))
+            .collect();
+        after_sorted.sort_by(|(stamp_a, owner_a), (stamp_b, owner_b)| {
+            stamp_a.cmp(stamp_b).then_with(|| owner_a.cmp(owner_b))
+        });
+
+        let before_owners: Vec<ExplicitOwner> = before_sorted.into_iter().map(|(_, o)| o).collect();
+        let after_owners: Vec<ExplicitOwner> = after_sorted.into_iter().map(|(_, o)| o).collect();
+        assert_eq!(before_owners, after_owners);
+        let mut compact_stamps: Vec<u64> =
+            admission.test_owner_stamps().values().copied().collect();
+        compact_stamps.sort();
+        assert_eq!(compact_stamps, vec![1, 2, 3, 4]);
+        admission.set_test_next_touch_stamp(5);
+        assert_eq!(
+            admission.touch_group(owners[0].clone()),
+            TouchResult::Touched
+        );
+        assert_eq!(admission.last_touch(&owners[0]).unwrap(), 5);
+    }
+
+    #[test]
+    fn lru_touches_remain_monotone_after_renormalization() {
+        let mut admission = FixedCapAdmission::new(8);
+        let owner_a = pool_owner(ExplicitConsumer::Momentum, 1);
+        let owner_b = pool_owner(ExplicitConsumer::Arb, 2);
+        assert_admitted(admission.try_admit_new_group(owner_a.clone(), [pk(1)]));
+        assert_admitted(admission.try_admit_new_group(owner_b.clone(), [pk(2)]));
+        admission.set_test_next_touch_stamp(u64::MAX);
+        admission.set_test_owner_stamp(owner_a.clone(), u64::MAX - 1);
+        admission.set_test_owner_stamp(owner_b.clone(), u64::MAX);
+
+        assert_eq!(admission.touch_group(owner_a.clone()), TouchResult::Touched);
+        let first = admission.last_touch(&owner_a).unwrap();
+        assert_eq!(admission.touch_group(owner_b.clone()), TouchResult::Touched);
+        let second = admission.last_touch(&owner_b).unwrap();
+        assert!(second > first);
+        assert_eq!(admission.touch_group(owner_a.clone()), TouchResult::Touched);
+        let third = admission.last_touch(&owner_a).unwrap();
+        assert!(third > second);
+    }
+
+    fn owner_key_hash_seed(owner: &ExplicitOwner) -> u8 {
+        match &owner.owner_key {
+            ExplicitOwnerKey::Wallet => 0,
+            ExplicitOwnerKey::Pool(pk) | ExplicitOwnerKey::Mint(pk) => pk.to_bytes()[0],
+            ExplicitOwnerKey::Generic(id) => (*id & 0xFF) as u8,
+        }
+    }
+
+    fn assert_matches_remove(result: FixedCapRemoveResult) {
+        match result {
+            FixedCapRemoveResult::Removed { .. } => {}
+            other => panic!("expected successful removal, got {other:?}"),
         }
     }
 }

--- a/src/market_data/track/explicit_admission.rs
+++ b/src/market_data/track/explicit_admission.rs
@@ -947,8 +947,7 @@ impl FixedCapAdmission {
     ) -> FixedCapRemoveResult {
         let _ = self.ownership.remove_group(owner);
         if self.ownership.owner_group(owner).is_some() {
-            self.owner_lru.remove(owner);
-            self.reconcile_cold();
+            self.physical_len = self.ownership.len();
             return FixedCapRemoveResult::InternalInvariantViolation {
                 recovery: FixedCapRemoveRecovery::RecoveryFailed,
             };

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -28,7 +28,7 @@ pub use eviction_planner::{
 };
 pub use explicit_admission::{
     FixedCapAdmission, FixedCapAdmissionResult, FixedCapRemoveRecovery, FixedCapRemoveResult,
-    FixedCapReplaceResult, InvariantViolationRecovery,
+    FixedCapReplaceResult, InvariantViolationRecovery, TouchResult,
 };
 pub use explicit_ownership::{
     EmptyOwnerGroupError, ExplicitConsumer, ExplicitOwner, ExplicitOwnerKey, ExplicitOwnership,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR 1c2a: Adds deterministic internal owner-LRU stamps and full lifecycle to `FixedCapAdmission`. No eviction, cap mutation, or planner execution.

### Additive API
- `touch_group(owner) -> TouchResult::{Touched, NotFound, InternalInvariantViolation}`
- `snapshot_lru_entries() -> Vec<OwnerLruEntry>` (sorted by owner)
- `last_touch(owner) -> Option<u64>`

### Lifecycle
- Successful insert/replace/touch assign monotonic stamps
- Successful remove deletes stamp
- Reject/invalid/missing paths are no-ops for LRU state
- Recovery `PreviousRestored` restores prior stamp; `OwnerRemovedFailClosed` removes stamp
- `u64::MAX` counter overflow triggers deterministic renormalization preserving `(last_touch, owner)` order

### Files
- `src/market_data/track/explicit_admission.rs` — LRU state + 15 tests
- `src/market_data/track/mod.rs` — re-export `TouchResult`

### STOP-CHECK
- I-7: No RPC/hot-path changes (pure local state machine)
- I-9/I-12: No trading TX or decision-record changes
- Scope limited to allowed files; `explicit_ownership.rs` / `eviction_planner.rs` untouched

### Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test explicit_admission` (50 tests)
- `cargo test eviction_planner` (42 tests)
- `cargo test` (full suite green)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d947075d-d63a-46d0-8beb-085f57b75978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d947075d-d63a-46d0-8beb-085f57b75978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

