### PR TITLE
refactor(market-data): add deterministic cap shrink

### DIFF
--- a/src/market_data/track/eviction_planner.rs
+++ b/src/market_data/track/eviction_planner.rs
@@ -557,6 +557,27 @@ pub enum VictimSelectionResult {
     InternalInvariantViolation,
 }
 
+/// Concrete victim plan for cap shrink (no incoming group).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapShrinkSelectionPlan {
+    pub victims: Vec<ExplicitOwner>,
+    pub physical_freed: Vec<Pubkey>,
+    pub projected_final_len: usize,
+    pub opened_through: EvictionTier,
+}
+
+/// Outcome of priority/LRU victim selection for cap shrink.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapShrinkSelectionResult {
+    /// `physical_len <= target_cap`; no victims required.
+    NoShrinkNeeded,
+    Planned(CapShrinkSelectionPlan),
+    RejectedProtected {
+        required_to_free: usize,
+    },
+    InternalInvariantViolation,
+}
+
 /// Test-only counters for selector hot loops (not clone/tautology metrics).
 #[cfg(test)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -682,6 +703,186 @@ fn run_victim_selection<S: SelectorStatsSink>(
     incoming_pubkeys.dedup();
     let incoming_set: BTreeSet<Pubkey> = incoming_pubkeys.iter().copied().collect();
 
+    let Some((victims, physical_freed)) = execute_victim_selection(
+        snapshot,
+        &incoming_set,
+        required_to_free,
+        opened_through,
+        stats,
+    ) else {
+        return VictimSelectionResult::InternalInvariantViolation;
+    };
+
+    let projected_final_len = match snapshot
+        .physical_len()
+        .checked_add(incoming_physical_added)
+        .and_then(|v| v.checked_sub(physical_freed.len()))
+    {
+        Some(v) => v,
+        None => return VictimSelectionResult::InternalInvariantViolation,
+    };
+
+    VictimSelectionResult::Planned(VictimSelectionPlan {
+        victims,
+        physical_freed,
+        incoming_physical_added,
+        projected_final_len,
+        opened_through,
+    })
+}
+
+enum CapShrinkFeasibilityOutcome {
+    NoShrinkNeeded,
+    Feasible {
+        required_to_free: usize,
+        opened_through: EvictionTier,
+    },
+    RejectedProtected {
+        required_to_free: usize,
+    },
+    InternalInvariantViolation,
+}
+
+const CAP_SHRINK_ALLOWED_TIERS: &[EvictionTier] = &[
+    EvictionTier::Tracker,
+    EvictionTier::Arb,
+    EvictionTier::Momentum,
+];
+
+fn analyze_cap_shrink_feasibility(
+    snapshot: &EvictionPlanningSnapshot,
+    target_cap: usize,
+) -> CapShrinkFeasibilityOutcome {
+    let physical_len = snapshot.physical_len();
+    if physical_len <= target_cap {
+        return CapShrinkFeasibilityOutcome::NoShrinkNeeded;
+    }
+    let required_to_free = match physical_len.checked_sub(target_cap) {
+        Some(needed) => needed,
+        None => return CapShrinkFeasibilityOutcome::InternalInvariantViolation,
+    };
+
+    let mut evictable_owners_by_tier: BTreeMap<EvictionTier, BTreeSet<ExplicitOwner>> =
+        BTreeMap::new();
+    for record in snapshot.owners() {
+        let consumer = record.owner.consumer;
+        if consumer == ExplicitConsumer::Wallet {
+            continue;
+        }
+        for tier in CAP_SHRINK_ALLOWED_TIERS {
+            if EvictionTier::cumulative_consumers(*tier).contains(&consumer) {
+                evictable_owners_by_tier
+                    .entry(*tier)
+                    .or_default()
+                    .insert(record.owner.clone());
+            }
+        }
+    }
+
+    let empty_evictable_owners = BTreeSet::new();
+    let mut freeable_by_tier: BTreeMap<EvictionTier, Vec<Pubkey>> = BTreeMap::new();
+    for row in snapshot.pubkey_index() {
+        for tier in CAP_SHRINK_ALLOWED_TIERS {
+            let evictable = evictable_owners_by_tier
+                .get(tier)
+                .unwrap_or(&empty_evictable_owners);
+            if row.owners.iter().all(|owner| evictable.contains(owner)) {
+                freeable_by_tier.entry(*tier).or_default().push(row.pubkey);
+            }
+        }
+    }
+
+    for pubkeys in freeable_by_tier.values_mut() {
+        pubkeys.sort();
+        pubkeys.dedup();
+    }
+
+    let mut opened_through = None;
+    for tier in CAP_SHRINK_ALLOWED_TIERS {
+        let freeable = freeable_by_tier.get(tier).map(Vec::as_slice).unwrap_or(&[]);
+        if freeable.len() >= required_to_free {
+            opened_through = Some(*tier);
+            break;
+        }
+    }
+
+    match opened_through {
+        Some(tier) => CapShrinkFeasibilityOutcome::Feasible {
+            required_to_free,
+            opened_through: tier,
+        },
+        None => CapShrinkFeasibilityOutcome::RejectedProtected { required_to_free },
+    }
+}
+
+/// Side-effect-free victim selection for cap shrink — no incoming group.
+pub fn select_cap_shrink_victims(
+    snapshot: &EvictionPlanningSnapshot,
+    target_cap: usize,
+) -> CapShrinkSelectionResult {
+    select_cap_shrink_victims_inner(snapshot, target_cap, &mut NoopSelectorStats)
+}
+
+#[cfg(test)]
+pub fn select_cap_shrink_victims_with_stats(
+    snapshot: &EvictionPlanningSnapshot,
+    target_cap: usize,
+    stats: &mut SelectorStats,
+) -> CapShrinkSelectionResult {
+    select_cap_shrink_victims_inner(snapshot, target_cap, stats)
+}
+
+fn select_cap_shrink_victims_inner<S: SelectorStatsSink>(
+    snapshot: &EvictionPlanningSnapshot,
+    target_cap: usize,
+    stats: &mut S,
+) -> CapShrinkSelectionResult {
+    match analyze_cap_shrink_feasibility(snapshot, target_cap) {
+        CapShrinkFeasibilityOutcome::NoShrinkNeeded => CapShrinkSelectionResult::NoShrinkNeeded,
+        CapShrinkFeasibilityOutcome::InternalInvariantViolation => {
+            CapShrinkSelectionResult::InternalInvariantViolation
+        }
+        CapShrinkFeasibilityOutcome::RejectedProtected { required_to_free } => {
+            CapShrinkSelectionResult::RejectedProtected { required_to_free }
+        }
+        CapShrinkFeasibilityOutcome::Feasible {
+            required_to_free,
+            opened_through,
+        } => {
+            let incoming_set = BTreeSet::new();
+            let Some((victims, physical_freed)) = execute_victim_selection(
+                snapshot,
+                &incoming_set,
+                required_to_free,
+                opened_through,
+                stats,
+            ) else {
+                return CapShrinkSelectionResult::InternalInvariantViolation;
+            };
+
+            let projected_final_len =
+                match snapshot.physical_len().checked_sub(physical_freed.len()) {
+                    Some(v) => v,
+                    None => return CapShrinkSelectionResult::InternalInvariantViolation,
+                };
+
+            CapShrinkSelectionResult::Planned(CapShrinkSelectionPlan {
+                victims,
+                physical_freed,
+                projected_final_len,
+                opened_through,
+            })
+        }
+    }
+}
+
+fn execute_victim_selection<S: SelectorStatsSink>(
+    snapshot: &EvictionPlanningSnapshot,
+    incoming_set: &BTreeSet<Pubkey>,
+    required_to_free: usize,
+    opened_through: EvictionTier,
+    stats: &mut S,
+) -> Option<(Vec<ExplicitOwner>, Vec<Pubkey>)> {
     let cumulative = EvictionTier::cumulative_consumers(opened_through);
     let allowed_owners: BTreeSet<ExplicitOwner> = snapshot
         .owners()
@@ -718,7 +919,7 @@ fn run_victim_selection<S: SelectorStatsSink>(
         pubkey_index,
         owner_pubkey_indices,
         projected_refcounts,
-        incoming_set,
+        incoming_set: incoming_set.clone(),
         allowed_owners,
         selected: BTreeSet::new(),
         victims: Vec::new(),
@@ -745,12 +946,9 @@ fn run_victim_selection<S: SelectorStatsSink>(
 
         let packages = workspace.collect_joint_packages(stats);
 
-        let Some(best_package) = packages
+        let best_package = packages
             .into_iter()
-            .min_by(|a, b| compare_joint_packages(a, b, snapshot))
-        else {
-            return VictimSelectionResult::InternalInvariantViolation;
-        };
+            .min_by(|a, b| compare_joint_packages(a, b, snapshot))?;
 
         for owner in &candidates {
             if best_package.contains(owner) && !workspace.selected.contains(owner) {
@@ -760,22 +958,7 @@ fn run_victim_selection<S: SelectorStatsSink>(
     }
 
     let physical_freed: Vec<Pubkey> = workspace.freed_pubkeys.into_iter().collect();
-    let projected_final_len = match snapshot
-        .physical_len()
-        .checked_add(incoming_physical_added)
-        .and_then(|v| v.checked_sub(physical_freed.len()))
-    {
-        Some(v) => v,
-        None => return VictimSelectionResult::InternalInvariantViolation,
-    };
-
-    VictimSelectionResult::Planned(VictimSelectionPlan {
-        victims: workspace.victims,
-        physical_freed,
-        incoming_physical_added,
-        projected_final_len,
-        opened_through,
-    })
+    Some((workspace.victims, physical_freed))
 }
 
 struct SelectorWorkspace<'a> {
@@ -3018,5 +3201,125 @@ mod tests {
                 case.fixtures, case.incoming, case.keys, case.cap
             );
         }
+    }
+
+    fn assert_cap_shrink_planned(
+        result: &CapShrinkSelectionResult,
+        victims: &[ExplicitOwner],
+        physical_freed: &[Pubkey],
+        opened_through: EvictionTier,
+        projected_final_len: usize,
+    ) {
+        match result {
+            CapShrinkSelectionResult::Planned(plan) => {
+                assert_eq!(plan.victims.as_slice(), victims);
+                assert_eq!(plan.physical_freed.as_slice(), physical_freed);
+                assert_eq!(plan.opened_through, opened_through);
+                assert_eq!(plan.projected_final_len, projected_final_len);
+            }
+            other => panic!("expected planned cap shrink, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cap_shrink_selector_no_shrink_needed_when_within_cap() {
+        let tracker = pool_owner(ExplicitConsumer::Tracker, 1);
+        let fixtures = [(tracker, 1, vec![pk(1)])];
+        let snapshot = snapshot_from_fixtures(&fixtures);
+        assert_eq!(
+            select_cap_shrink_victims(&snapshot, 5),
+            CapShrinkSelectionResult::NoShrinkNeeded
+        );
+    }
+
+    #[test]
+    fn cap_shrink_selector_evicts_tracker_before_arb() {
+        let tracker = pool_owner(ExplicitConsumer::Tracker, 1);
+        let arb = pool_owner(ExplicitConsumer::Arb, 2);
+        let fixtures = [
+            (tracker.clone(), 10, vec![pk(1)]),
+            (arb.clone(), 20, vec![pk(2)]),
+        ];
+        let snapshot = snapshot_from_fixtures(&fixtures);
+        assert_cap_shrink_planned(
+            &select_cap_shrink_victims(&snapshot, 1),
+            &[tracker],
+            &[pk(1)],
+            EvictionTier::Tracker,
+            1,
+        );
+    }
+
+    #[test]
+    fn cap_shrink_selector_true_lru_within_tier() {
+        let t_old = pool_owner(ExplicitConsumer::Tracker, 1);
+        let t_new = pool_owner(ExplicitConsumer::Tracker, 2);
+        let fixtures = [
+            (t_old.clone(), 10, vec![pk(1)]),
+            (t_new.clone(), 20, vec![pk(2)]),
+        ];
+        let snapshot = snapshot_from_fixtures(&fixtures);
+        assert_cap_shrink_planned(
+            &select_cap_shrink_victims(&snapshot, 1),
+            &[t_old],
+            &[pk(1)],
+            EvictionTier::Tracker,
+            1,
+        );
+    }
+
+    #[test]
+    fn cap_shrink_selector_joint_shared_victims() {
+        let shared_a = pk(60);
+        let shared_b = pk(61);
+        let t1 = pool_owner(ExplicitConsumer::Tracker, 1);
+        let t2 = pool_owner(ExplicitConsumer::Tracker, 2);
+        let t3 = pool_owner(ExplicitConsumer::Tracker, 3);
+        let t4 = pool_owner(ExplicitConsumer::Tracker, 4);
+        let fixtures = [
+            (t1.clone(), 10, vec![shared_a]),
+            (t2.clone(), 20, vec![shared_a]),
+            (t3.clone(), 30, vec![shared_b]),
+            (t4.clone(), 40, vec![shared_b]),
+        ];
+        let snapshot = snapshot_from_fixtures(&fixtures);
+        assert_cap_shrink_planned(
+            &select_cap_shrink_victims(&snapshot, 1),
+            &[t1.clone(), t2.clone()],
+            &[shared_a],
+            EvictionTier::Tracker,
+            1,
+        );
+    }
+
+    #[test]
+    fn cap_shrink_selector_wallet_never_victim() {
+        let wallet = pool_owner(ExplicitConsumer::Wallet, 1);
+        let shared = pk(50);
+        let tracker = pool_owner(ExplicitConsumer::Tracker, 2);
+        let fixtures = [
+            (wallet.clone(), 1, vec![shared, pk(1)]),
+            (tracker.clone(), 10, vec![shared, pk(2)]),
+        ];
+        let snapshot = snapshot_from_fixtures(&fixtures);
+        match select_cap_shrink_victims(&snapshot, 2) {
+            CapShrinkSelectionResult::Planned(plan) => {
+                assert!(!plan.victims.contains(&wallet));
+            }
+            other => panic!("expected planned shrink, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cap_shrink_selector_protected_when_wallet_exceeds_target() {
+        let wallet = pool_owner(ExplicitConsumer::Wallet, 1);
+        let fixtures = [(wallet, 1, vec![pk(1), pk(2), pk(3)])];
+        let snapshot = snapshot_from_fixtures(&fixtures);
+        assert_eq!(
+            select_cap_shrink_victims(&snapshot, 2),
+            CapShrinkSelectionResult::RejectedProtected {
+                required_to_free: 1
+            }
+        );
     }
 }

--- a/src/market_data/track/explicit_admission.rs
+++ b/src/market_data/track/explicit_admission.rs
@@ -5916,7 +5916,7 @@ mod tests {
         }
     }
 
-    use super::super::eviction_planner::{select_cap_shrink_victims, CapShrinkSelectionResult};
+    use super::super::eviction_planner::select_cap_shrink_victims;
 
     fn assert_cap_shrink_converged(result: CapShrinkResult) -> (Vec<Pubkey>, Vec<ExplicitOwner>) {
         match result {

--- a/src/market_data/track/explicit_admission.rs
+++ b/src/market_data/track/explicit_admission.rs
@@ -1082,9 +1082,6 @@ impl FixedCapAdmission {
         if candidate.physical_len != plan.projected_final_len {
             return false;
         }
-        if candidate.physical_len != new_cap {
-            return false;
-        }
         if candidate.physical_len > new_cap {
             return false;
         }

--- a/src/market_data/track/explicit_admission.rs
+++ b/src/market_data/track/explicit_admission.rs
@@ -9,11 +9,13 @@
 //! may scan ownership only on exceptional invariant/rollback failure.
 
 use super::eviction_planner::{
-    select_eviction_victims, EvictionPlanningSnapshot, EvictionTier, OwnerLruEntry,
+    select_cap_shrink_victims, select_eviction_victims, CapShrinkSelectionPlan,
+    CapShrinkSelectionResult, EvictionPlanningSnapshot, EvictionTier, OwnerLruEntry,
     VictimSelectionPlan, VictimSelectionRequest, VictimSelectionResult,
 };
 use super::explicit_ownership::{
-    EmptyOwnerGroupError, ExplicitOwner, ExplicitOwnership, GroupChange, OwnerGroupSnapshot,
+    EmptyOwnerGroupError, ExplicitConsumer, ExplicitOwner, ExplicitOwnership, GroupChange,
+    OwnerGroupSnapshot,
 };
 use solana_sdk::pubkey::Pubkey;
 use std::collections::{BTreeMap, BTreeSet};
@@ -97,6 +99,35 @@ pub enum EvictingAdmissionResult {
         required_to_free: usize,
     },
     /// Empty incoming group.
+    RejectedInvalidInput,
+    /// Candidate build/validation or planner inconsistency; live state unchanged.
+    InternalInvariantViolation,
+}
+
+/// Result of a deterministic cap-shrink attempt (PR 1c3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapShrinkResult {
+    /// Cap lowered with eviction when `physical_len` exceeded the new cap.
+    Converged {
+        old_cap: usize,
+        new_cap: usize,
+        physical_removed: Vec<Pubkey>,
+        victims: Vec<ExplicitOwner>,
+        opened_through: EvictionTier,
+    },
+    /// `physical_len <= new_cap`; only the cap field changed.
+    NoOpAlreadyWithinCap { old_cap: usize, new_cap: usize },
+    /// Requested cap exceeds the current cap; no mutation.
+    RejectedCapIncrease {
+        old_cap: usize,
+        requested_cap: usize,
+    },
+    /// Protected wallet pubkeys alone exceed the requested cap; no mutation.
+    ProtectedOverflow {
+        wallet_physical: usize,
+        requested_cap: usize,
+    },
+    /// Invalid shrink input (e.g. `new_cap == 0` with positive physical length).
     RejectedInvalidInput,
     /// Candidate build/validation or planner inconsistency; live state unchanged.
     InternalInvariantViolation,
@@ -756,6 +787,320 @@ impl FixedCapAdmission {
         }
 
         mapped
+    }
+
+    /// Count deduplicated physically tracked pubkeys owned by wallet groups.
+    pub fn wallet_physical_len(&self) -> usize {
+        let mut wallet_pubkeys = BTreeSet::new();
+        for group in self.ownership.snapshot_owner_groups() {
+            if group.consumer == ExplicitConsumer::Wallet {
+                wallet_pubkeys.extend(group.pubkeys.iter().copied());
+            }
+        }
+        wallet_pubkeys.len()
+    }
+
+    /// Whether deduplicated wallet pubkeys alone exceed `cap`.
+    pub fn wallet_demand_exceeds_cap(&self, cap: usize) -> bool {
+        self.wallet_physical_len() > cap
+    }
+
+    /// Plan cap-shrink victims using only internal state (read-only).
+    pub fn plan_cap_shrink(&self, target_cap: usize) -> CapShrinkSelectionResult {
+        let snapshot = match EvictionPlanningSnapshot::from_ownership(
+            &self.ownership,
+            self.eviction_planning_lru_entries(),
+        ) {
+            Ok(snapshot) => snapshot,
+            Err(_) => return CapShrinkSelectionResult::InternalInvariantViolation,
+        };
+        select_cap_shrink_victims(&snapshot, target_cap)
+    }
+
+    /// Lower the hard cap, evicting victims when `physical_len` exceeds the new cap.
+    ///
+    /// Cap increases are rejected without mutation. When `physical_len <= new_cap`, only the cap
+    /// field is updated. The eviction path builds and validates a full candidate snapshot, then
+    /// commits via infallible swap.
+    pub fn try_shrink_cap(&mut self, new_cap: usize) -> CapShrinkResult {
+        let old_cap = self.cap;
+
+        if new_cap > old_cap {
+            return CapShrinkResult::RejectedCapIncrease {
+                old_cap,
+                requested_cap: new_cap,
+            };
+        }
+
+        if self.wallet_demand_exceeds_cap(new_cap) {
+            return CapShrinkResult::ProtectedOverflow {
+                wallet_physical: self.wallet_physical_len(),
+                requested_cap: new_cap,
+            };
+        }
+
+        if self.physical_len <= new_cap {
+            self.cap = new_cap;
+            return CapShrinkResult::NoOpAlreadyWithinCap { old_cap, new_cap };
+        }
+
+        let plan_result = self.plan_cap_shrink(new_cap);
+        let plan = match plan_result {
+            CapShrinkSelectionResult::Planned(plan) => plan,
+            CapShrinkSelectionResult::NoShrinkNeeded => {
+                self.cap = new_cap;
+                return CapShrinkResult::NoOpAlreadyWithinCap { old_cap, new_cap };
+            }
+            CapShrinkSelectionResult::RejectedProtected { required_to_free } => {
+                if self.wallet_demand_exceeds_cap(new_cap) {
+                    return CapShrinkResult::ProtectedOverflow {
+                        wallet_physical: self.wallet_physical_len(),
+                        requested_cap: new_cap,
+                    };
+                }
+                let _ = required_to_free;
+                return CapShrinkResult::InternalInvariantViolation;
+            }
+            CapShrinkSelectionResult::InternalInvariantViolation => {
+                return CapShrinkResult::InternalInvariantViolation;
+            }
+        };
+
+        let (candidate, stats_delta) = match self.build_shrink_candidate(&plan) {
+            Ok(state) => state,
+            Err(()) => return CapShrinkResult::InternalInvariantViolation,
+        };
+
+        if !self.validate_shrink_candidate(&candidate, &plan, new_cap) {
+            return CapShrinkResult::InternalInvariantViolation;
+        }
+
+        #[cfg(test)]
+        let post_stats = match self.planning_stats.after_eviction_delta(stats_delta) {
+            Some(stats) => stats,
+            None => return CapShrinkResult::InternalInvariantViolation,
+        };
+        #[cfg(not(test))]
+        let _stats_delta = stats_delta;
+
+        let result = CapShrinkResult::Converged {
+            old_cap,
+            new_cap,
+            physical_removed: plan.physical_freed.clone(),
+            victims: plan.victims.clone(),
+            opened_through: plan.opened_through,
+        };
+
+        self.ownership = candidate.ownership;
+        self.owner_lru = candidate.owner_lru;
+        self.next_touch_stamp = candidate.next_touch_stamp;
+        self.physical_len = candidate.physical_len;
+        self.cap = new_cap;
+        #[cfg(test)]
+        {
+            self.planning_stats = post_stats;
+        }
+
+        result
+    }
+
+    fn build_shrink_candidate(
+        &self,
+        plan: &CapShrinkSelectionPlan,
+    ) -> Result<(EvictingCandidateState, EvictingStatsDelta), ()> {
+        let victims: BTreeSet<ExplicitOwner> = plan.victims.iter().cloned().collect();
+
+        let mut candidate_ownership = ExplicitOwnership::new();
+        let mut group_edges = 0usize;
+        for group in self.ownership.snapshot_owner_groups() {
+            let owner = ExplicitOwner {
+                consumer: group.consumer,
+                owner_key: group.owner_key,
+            };
+            if victims.contains(&owner) {
+                continue;
+            }
+            #[cfg(test)]
+            if self.test_force_evicting_omit_survivor.as_ref() == Some(&owner) {
+                return Err(());
+            }
+            group_edges = group_edges.saturating_add(group.pubkeys.len());
+            candidate_ownership
+                .upsert_group(owner, group.pubkeys.clone())
+                .map_err(|EmptyOwnerGroupError| ())?;
+        }
+
+        #[cfg(test)]
+        if let Some((extra_owner, extra_pubkeys)) = &self.test_force_evicting_extra_candidate_owner
+        {
+            candidate_ownership
+                .upsert_group(extra_owner.clone(), extra_pubkeys.clone())
+                .map_err(|EmptyOwnerGroupError| ())?;
+            group_edges = group_edges.saturating_add(extra_pubkeys.len());
+        }
+
+        let mut candidate_lru = self.owner_lru.clone();
+        for victim in &plan.victims {
+            candidate_lru.remove(victim);
+        }
+
+        #[cfg(test)]
+        {
+            if let Some(owner) = &self.test_force_evicting_corrupt_survivor_stamp {
+                if let Some(stamp) = candidate_lru.get_mut(owner) {
+                    *stamp = stamp.saturating_add(1);
+                }
+            }
+        }
+
+        let next_touch_stamp = {
+            #[cfg(test)]
+            {
+                if self.test_force_evicting_corrupt_next_touch_stamp {
+                    candidate_lru.values().copied().min().unwrap_or(0)
+                } else {
+                    self.next_touch_stamp
+                }
+            }
+            #[cfg(not(test))]
+            {
+                self.next_touch_stamp
+            }
+        };
+
+        let physical_len = {
+            let base = candidate_ownership.len();
+            #[cfg(test)]
+            {
+                if self.test_force_evicting_corrupt_physical_len {
+                    base.saturating_add(1)
+                } else {
+                    base
+                }
+            }
+            #[cfg(not(test))]
+            {
+                base
+            }
+        };
+
+        let stats_delta = EvictingStatsDelta {
+            owner_group_lookups: 0,
+            refcount_lookups: 0,
+            candidate_builds: 1,
+            candidate_group_edges: u64::try_from(group_edges).map_err(|_| ())?,
+        };
+
+        Ok((
+            EvictingCandidateState {
+                ownership: candidate_ownership,
+                owner_lru: candidate_lru,
+                next_touch_stamp,
+                physical_len,
+            },
+            stats_delta,
+        ))
+    }
+
+    fn validate_shrink_candidate(
+        &self,
+        candidate: &EvictingCandidateState,
+        plan: &CapShrinkSelectionPlan,
+        new_cap: usize,
+    ) -> bool {
+        let victims: BTreeSet<ExplicitOwner> = plan.victims.iter().cloned().collect();
+
+        let expected_owners: BTreeSet<ExplicitOwner> = self
+            .ownership
+            .snapshot_owner_groups()
+            .into_iter()
+            .map(|group| ExplicitOwner {
+                consumer: group.consumer,
+                owner_key: group.owner_key,
+            })
+            .filter(|owner| !victims.contains(owner))
+            .collect();
+
+        let candidate_owners: BTreeSet<ExplicitOwner> = candidate
+            .ownership
+            .snapshot_owner_groups()
+            .into_iter()
+            .map(|group| ExplicitOwner {
+                consumer: group.consumer,
+                owner_key: group.owner_key,
+            })
+            .collect();
+        if candidate_owners != expected_owners {
+            return false;
+        }
+
+        for victim in &plan.victims {
+            if candidate.ownership.owner_group(victim).is_some() {
+                return false;
+            }
+            if candidate.owner_lru.contains_key(victim) {
+                return false;
+            }
+        }
+
+        for group in self.ownership.snapshot_owner_groups() {
+            let owner = ExplicitOwner {
+                consumer: group.consumer,
+                owner_key: group.owner_key,
+            };
+            if victims.contains(&owner) {
+                continue;
+            }
+            if self.ownership.owner_group(&owner) != candidate.ownership.owner_group(&owner) {
+                return false;
+            }
+            match (self.owner_lru.get(&owner), candidate.owner_lru.get(&owner)) {
+                (Some(live), Some(cand)) if live == cand => {}
+                _ => return false,
+            }
+        }
+
+        if candidate.next_touch_stamp != self.next_touch_stamp {
+            return false;
+        }
+
+        let live_keys: BTreeSet<Pubkey> = self.ownership.snapshot_pubkeys().into_iter().collect();
+        let candidate_keys: BTreeSet<Pubkey> =
+            candidate.ownership.snapshot_pubkeys().into_iter().collect();
+        let mut removed: Vec<Pubkey> = live_keys.difference(&candidate_keys).copied().collect();
+        removed.sort();
+        let mut expected_freed = plan.physical_freed.clone();
+        expected_freed.sort();
+        if removed != expected_freed {
+            return false;
+        }
+
+        if !candidate_keys.is_subset(&live_keys) {
+            return false;
+        }
+
+        if candidate.physical_len != plan.projected_final_len {
+            return false;
+        }
+        if candidate.physical_len != new_cap {
+            return false;
+        }
+        if candidate.physical_len > new_cap {
+            return false;
+        }
+        if candidate.physical_len != candidate.ownership.len() {
+            return false;
+        }
+
+        let lru_entries: Vec<OwnerLruEntry> = candidate
+            .owner_lru
+            .iter()
+            .map(|(owner, &last_touch)| OwnerLruEntry {
+                owner: owner.clone(),
+                last_touch,
+            })
+            .collect();
+        EvictionPlanningSnapshot::from_ownership(&candidate.ownership, lru_entries).is_ok()
     }
 
     fn build_evicting_candidate(
@@ -5565,6 +5910,438 @@ mod tests {
                         let _ = admission.remove_group(owner.clone());
                         let _ = model.remove_group(owner);
                         assert_evicting_model_matches_admission(&admission, &model);
+                    }
+                }
+            }
+        }
+    }
+
+    use super::super::eviction_planner::{select_cap_shrink_victims, CapShrinkSelectionResult};
+
+    fn assert_cap_shrink_converged(result: CapShrinkResult) -> (Vec<Pubkey>, Vec<ExplicitOwner>) {
+        match result {
+            CapShrinkResult::Converged {
+                physical_removed,
+                victims,
+                ..
+            } => (physical_removed, victims),
+            other => panic!("expected converged cap shrink, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cap_shrink_within_cap_only_updates_cap_field() {
+        let tracker = pool_owner(ExplicitConsumer::Tracker, 1);
+        let admission = admission_from_eviction_fixtures(5, &[(tracker, 1, vec![pk(1)])]);
+        let before = snapshot_admission_plan_state(&admission);
+        let mut admission = admission;
+        assert_eq!(
+            admission.try_shrink_cap(4),
+            CapShrinkResult::NoOpAlreadyWithinCap {
+                old_cap: 5,
+                new_cap: 4,
+            }
+        );
+        assert_eq!(admission.cap(), 4);
+        assert_eq!(admission.len(), 1);
+        let mut after = snapshot_admission_plan_state(&admission);
+        after.cap = 5;
+        assert_eq!(after, before);
+    }
+
+    #[test]
+    fn cap_shrink_evicts_tracker_before_arb_and_momentum() {
+        let tracker = pool_owner(ExplicitConsumer::Tracker, 1);
+        let arb = pool_owner(ExplicitConsumer::Arb, 2);
+        let momentum = pool_owner(ExplicitConsumer::Momentum, 3);
+        let mut admission = admission_from_eviction_fixtures(
+            4,
+            &[
+                (tracker.clone(), 10, vec![pk(1)]),
+                (arb.clone(), 20, vec![pk(2)]),
+                (momentum.clone(), 30, vec![pk(3)]),
+            ],
+        );
+        let (removed, victims) = assert_cap_shrink_converged(admission.try_shrink_cap(2));
+        assert_eq!(removed, vec![pk(1)]);
+        assert_eq!(victims, vec![tracker]);
+        assert_eq!(admission.cap(), 2);
+        assert_eq!(admission.len(), 2);
+    }
+
+    #[test]
+    fn cap_shrink_true_lru_within_tier() {
+        let t_old = pool_owner(ExplicitConsumer::Tracker, 1);
+        let t_new = pool_owner(ExplicitConsumer::Tracker, 2);
+        let mut admission = admission_from_eviction_fixtures(
+            3,
+            &[
+                (t_old.clone(), 10, vec![pk(1)]),
+                (t_new.clone(), 20, vec![pk(2)]),
+                (pool_owner(ExplicitConsumer::Arb, 3), 30, vec![pk(3)]),
+            ],
+        );
+        let (_, victims) = assert_cap_shrink_converged(admission.try_shrink_cap(2));
+        assert_eq!(victims, vec![t_old]);
+    }
+
+    #[test]
+    fn cap_shrink_joint_shared_victims() {
+        let shared_a = pk(60);
+        let shared_b = pk(61);
+        let t1 = pool_owner(ExplicitConsumer::Tracker, 1);
+        let t2 = pool_owner(ExplicitConsumer::Tracker, 2);
+        let t3 = pool_owner(ExplicitConsumer::Tracker, 3);
+        let t4 = pool_owner(ExplicitConsumer::Tracker, 4);
+        let mut admission = admission_from_eviction_fixtures(
+            3,
+            &[
+                (t1.clone(), 10, vec![shared_a]),
+                (t2.clone(), 20, vec![shared_a]),
+                (t3.clone(), 30, vec![shared_b]),
+                (t4.clone(), 40, vec![shared_b]),
+            ],
+        );
+        let (removed, victims) = assert_cap_shrink_converged(admission.try_shrink_cap(1));
+        assert_eq!(removed, vec![shared_a]);
+        assert_eq!(victims, vec![t1, t2]);
+    }
+
+    #[test]
+    fn cap_shrink_wallet_only_over_cap_protected_overflow_no_mutation() {
+        let wallet = pool_owner(ExplicitConsumer::Wallet, 1);
+        let mut admission =
+            admission_from_eviction_fixtures(5, &[(wallet, 1, vec![pk(1), pk(2), pk(3)])]);
+        let before = snapshot_admission_plan_state(&admission);
+        assert_eq!(
+            admission.try_shrink_cap(2),
+            CapShrinkResult::ProtectedOverflow {
+                wallet_physical: 3,
+                requested_cap: 2,
+            }
+        );
+        assert_admission_live_state_unchanged(&admission, &before);
+    }
+
+    #[test]
+    fn cap_shrink_rejected_cap_increase_without_mutation() {
+        let mut admission = admission_from_eviction_fixtures(
+            4,
+            &[(pool_owner(ExplicitConsumer::Tracker, 1), 1, vec![pk(1)])],
+        );
+        let before = snapshot_admission_plan_state(&admission);
+        assert_eq!(
+            admission.try_shrink_cap(6),
+            CapShrinkResult::RejectedCapIncrease {
+                old_cap: 4,
+                requested_cap: 6,
+            }
+        );
+        assert_admission_live_state_unchanged(&admission, &before);
+    }
+
+    #[test]
+    fn cap_shrink_exact_physical_removed_and_final_len_parity() {
+        let tracker = pool_owner(ExplicitConsumer::Tracker, 1);
+        let arb = pool_owner(ExplicitConsumer::Arb, 2);
+        let mut admission = admission_from_eviction_fixtures(
+            3,
+            &[
+                (tracker.clone(), 10, vec![pk(1)]),
+                (arb.clone(), 20, vec![pk(2)]),
+            ],
+        );
+        let result = admission.try_shrink_cap(1);
+        let (removed, _) = assert_cap_shrink_converged(result);
+        assert_eq!(admission.len(), 1);
+        assert_eq!(admission.cap(), 1);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(admission.snapshot_pubkeys(), vec![pk(2)]);
+    }
+
+    #[test]
+    fn cap_shrink_victim_stamps_removed_survivor_stamps_preserved() {
+        let t1 = pool_owner(ExplicitConsumer::Tracker, 1);
+        let t2 = pool_owner(ExplicitConsumer::Tracker, 2);
+        let mut admission = admission_from_eviction_fixtures(
+            3,
+            &[(t1.clone(), 10, vec![pk(1)]), (t2.clone(), 20, vec![pk(2)])],
+        );
+        let stamp_before = admission.last_touch(&t2).unwrap();
+        let next_before = admission.test_owner_stamps();
+        let _ = admission.try_shrink_cap(1);
+        assert!(admission.last_touch(&t1).is_none());
+        assert_eq!(admission.last_touch(&t2), Some(stamp_before));
+        assert_eq!(admission.test_owner_stamps().get(&t2), next_before.get(&t2));
+    }
+
+    #[test]
+    fn cap_shrink_wallet_never_victim() {
+        let wallet = pool_owner(ExplicitConsumer::Wallet, 1);
+        let shared = pk(50);
+        let tracker = pool_owner(ExplicitConsumer::Tracker, 2);
+        let mut admission = admission_from_eviction_fixtures(
+            4,
+            &[
+                (wallet.clone(), 1, vec![shared, pk(1)]),
+                (tracker.clone(), 10, vec![shared, pk(2)]),
+                (pool_owner(ExplicitConsumer::Arb, 3), 20, vec![pk(3)]),
+            ],
+        );
+        let (_, victims) = assert_cap_shrink_converged(admission.try_shrink_cap(2));
+        assert!(!victims.contains(&wallet));
+    }
+
+    #[test]
+    fn cap_shrink_candidate_fault_seams_never_commit() {
+        let tracker = pool_owner(ExplicitConsumer::Tracker, 1);
+        let arb = pool_owner(ExplicitConsumer::Arb, 2);
+        let fixtures = [
+            (tracker.clone(), 10, vec![pk(1)]),
+            (arb.clone(), 20, vec![pk(2)]),
+        ];
+
+        let mut omit = admission_from_eviction_fixtures(3, &fixtures);
+        omit.set_test_force_evicting_omit_survivor(Some(arb.clone()));
+        let before_omit = snapshot_admission_plan_state(&omit);
+        assert_eq!(
+            omit.try_shrink_cap(1),
+            CapShrinkResult::InternalInvariantViolation
+        );
+        assert_admission_live_state_unchanged(&omit, &before_omit);
+
+        let mut corrupt_len = admission_from_eviction_fixtures(3, &fixtures);
+        corrupt_len.set_test_force_evicting_corrupt_physical_len(true);
+        let before_len = snapshot_admission_plan_state(&corrupt_len);
+        assert_eq!(
+            corrupt_len.try_shrink_cap(1),
+            CapShrinkResult::InternalInvariantViolation
+        );
+        assert_admission_live_state_unchanged(&corrupt_len, &before_len);
+
+        let mut corrupt_stamp = admission_from_eviction_fixtures(3, &fixtures);
+        corrupt_stamp.set_test_force_evicting_corrupt_survivor_stamp(Some(arb.clone()));
+        let before_stamp = snapshot_admission_plan_state(&corrupt_stamp);
+        assert_eq!(
+            corrupt_stamp.try_shrink_cap(1),
+            CapShrinkResult::InternalInvariantViolation
+        );
+        assert_admission_live_state_unchanged(&corrupt_stamp, &before_stamp);
+    }
+
+    #[test]
+    fn cap_shrink_plan_facade_matches_direct_selector() {
+        let tracker = pool_owner(ExplicitConsumer::Tracker, 1);
+        let arb = pool_owner(ExplicitConsumer::Arb, 2);
+        let fixtures = [
+            (tracker.clone(), 10, vec![pk(1)]),
+            (arb.clone(), 20, vec![pk(2)]),
+        ];
+        let admission = admission_from_eviction_fixtures(3, &fixtures);
+        let snapshot = admission
+            .test_build_eviction_snapshot()
+            .expect("fixture admission must build eviction snapshot");
+        let expected = select_cap_shrink_victims(&snapshot, 1);
+        let before = snapshot_admission_plan_state(&admission);
+        let actual = admission.plan_cap_shrink(1);
+        assert_admission_plan_state_unchanged(&admission, &before);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn cap_shrink_repeated_deterministic_fixtures() {
+        let tracker = pool_owner(ExplicitConsumer::Tracker, 1);
+        let arb = pool_owner(ExplicitConsumer::Arb, 2);
+        let fixtures = [
+            (tracker.clone(), 10, vec![pk(1)]),
+            (arb.clone(), 20, vec![pk(2)]),
+        ];
+        let first = {
+            let mut admission = admission_from_eviction_fixtures(3, &fixtures);
+            admission.try_shrink_cap(1)
+        };
+        for _ in 0..5 {
+            let mut admission = admission_from_eviction_fixtures(3, &fixtures);
+            assert_eq!(admission.try_shrink_cap(1), first);
+        }
+    }
+
+    /// Independent cap-shrink oracle — never calls production planner/selector or [`FixedCapAdmission`].
+    struct RefCapShrinkOracle(RefEvictingOracle);
+
+    impl RefCapShrinkOracle {
+        fn from_state(
+            groups: &BTreeMap<ExplicitOwner, BTreeSet<Pubkey>>,
+            lru: &BTreeMap<ExplicitOwner, u64>,
+        ) -> Self {
+            Self(RefEvictingOracle::from_state(groups, lru))
+        }
+
+        fn wallet_physical_len(&self) -> usize {
+            let mut wallet_pubkeys = BTreeSet::new();
+            for (owner, (_, pubkeys)) in &self.0.owner_records {
+                if owner.consumer == ExplicitConsumer::Wallet {
+                    wallet_pubkeys.extend(pubkeys.iter().copied());
+                }
+            }
+            wallet_pubkeys.len()
+        }
+
+        fn predict_shrink(&self, target_cap: usize) -> CapShrinkResult {
+            if self.wallet_physical_len() > target_cap {
+                return CapShrinkResult::ProtectedOverflow {
+                    wallet_physical: self.wallet_physical_len(),
+                    requested_cap: target_cap,
+                };
+            }
+            if self.0.physical_len <= target_cap {
+                return CapShrinkResult::NoOpAlreadyWithinCap {
+                    old_cap: usize::MAX,
+                    new_cap: target_cap,
+                };
+            }
+            let incoming = BTreeSet::new();
+            let required = self.0.physical_len - target_cap;
+            let allowed_tiers = [
+                RefOraclePolicyTier::Tracker,
+                RefOraclePolicyTier::Arb,
+                RefOraclePolicyTier::Momentum,
+            ];
+            let mut opened = None;
+            for tier in allowed_tiers {
+                if self.0.pubkey_freeable_count_at_tier(tier, &incoming) >= required {
+                    opened = Some(tier);
+                    break;
+                }
+            }
+            let Some(opened_tier) = opened else {
+                return CapShrinkResult::InternalInvariantViolation;
+            };
+            let allowed = self.0.eligible_owners_at_tier(opened_tier);
+            let Some((victims, freed)) = self.0.procedural_selection(&allowed, &incoming, required)
+            else {
+                return CapShrinkResult::InternalInvariantViolation;
+            };
+            let mut physical_removed: Vec<Pubkey> = freed.into_iter().collect();
+            physical_removed.sort();
+            CapShrinkResult::Converged {
+                old_cap: usize::MAX,
+                new_cap: target_cap,
+                physical_removed,
+                victims,
+                opened_through: opened_tier.to_eviction_tier(),
+            }
+        }
+    }
+
+    fn assert_cap_shrink_model_matches_admission(
+        admission: &FixedCapAdmission,
+        groups: &BTreeMap<ExplicitOwner, BTreeSet<Pubkey>>,
+        lru: &BTreeMap<ExplicitOwner, u64>,
+    ) {
+        assert_eq!(admission_groups(admission), *groups);
+        assert_eq!(admission.test_owner_stamps(), *lru);
+        assert!(admission.len() <= admission.cap());
+    }
+
+    #[test]
+    fn cap_shrink_independent_model_matches_final_graph() {
+        let tracker = pool_owner(ExplicitConsumer::Tracker, 1);
+        let arb = pool_owner(ExplicitConsumer::Arb, 2);
+        let fixtures = [
+            (tracker.clone(), 10, vec![pk(1)]),
+            (arb.clone(), 20, vec![pk(2)]),
+        ];
+        let mut admission = admission_from_eviction_fixtures(3, &fixtures);
+        let oracle = RefCapShrinkOracle::from_state(
+            &admission_groups(&admission),
+            &admission.test_owner_stamps(),
+        );
+        let expected = oracle.predict_shrink(1);
+        let actual = admission.try_shrink_cap(1);
+        match (&actual, &expected) {
+            (
+                CapShrinkResult::Converged {
+                    physical_removed: a_removed,
+                    victims: a_victims,
+                    ..
+                },
+                CapShrinkResult::Converged {
+                    physical_removed: e_removed,
+                    victims: e_victims,
+                    ..
+                },
+            ) => {
+                assert_eq!(a_removed, e_removed);
+                assert_eq!(a_victims, e_victims);
+            }
+            (
+                CapShrinkResult::NoOpAlreadyWithinCap { .. },
+                CapShrinkResult::NoOpAlreadyWithinCap { .. },
+            ) => {}
+            _ => panic!("oracle mismatch: actual={actual:?} expected={expected:?}"),
+        }
+        assert_cap_shrink_model_matches_admission(
+            &admission,
+            &admission_groups(&admission),
+            &admission.test_owner_stamps(),
+        );
+    }
+
+    #[test]
+    fn cap_shrink_property_sequence_mixed_operations_with_hard_cap() {
+        let caps = [2usize, 3, 5];
+        let seeds = [5u8, 17, 31];
+
+        for initial_cap in caps {
+            for seed in seeds {
+                let mut admission = FixedCapAdmission::new(initial_cap);
+                let owners = [
+                    pool_owner(ExplicitConsumer::Tracker, seed),
+                    pool_owner(ExplicitConsumer::Arb, seed.wrapping_add(1)),
+                    pool_owner(ExplicitConsumer::Momentum, seed.wrapping_add(2)),
+                ];
+                let key_pool: Vec<Pubkey> = (0u8..6).map(|b| pk(b.wrapping_add(seed))).collect();
+
+                for (step, owner) in owners.iter().enumerate() {
+                    let keys: Vec<Pubkey> = key_pool
+                        .iter()
+                        .copied()
+                        .filter(|k| (k.to_bytes()[0] as usize + step) % 2 == 0)
+                        .take(1 + step % 2)
+                        .collect();
+                    if keys.is_empty() {
+                        continue;
+                    }
+                    let _ = admission.try_admit_new_group(owner.clone(), keys);
+                    assert!(admission.len() <= admission.cap());
+                }
+
+                let shrink_targets = [initial_cap.saturating_sub(1), 1usize.max(initial_cap / 2)];
+                for new_cap in shrink_targets {
+                    if new_cap > admission.cap() {
+                        continue;
+                    }
+                    let before = snapshot_admission_plan_state(&admission);
+                    let result = admission.try_shrink_cap(new_cap);
+                    match result {
+                        CapShrinkResult::RejectedCapIncrease { .. }
+                        | CapShrinkResult::ProtectedOverflow { .. }
+                        | CapShrinkResult::InternalInvariantViolation => {
+                            assert_admission_live_state_unchanged(&admission, &before);
+                        }
+                        CapShrinkResult::NoOpAlreadyWithinCap { .. }
+                        | CapShrinkResult::Converged { .. } => {
+                            assert_eq!(admission.cap(), new_cap);
+                            assert!(admission.len() <= admission.cap());
+                        }
+                        CapShrinkResult::RejectedInvalidInput => {}
+                    }
+                }
+
+                if let Some(owner) = owners.first() {
+                    if admission.owner_group(owner).is_some() {
+                        let _ = admission.touch_group(owner.clone());
                     }
                 }
             }

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -21,13 +21,14 @@ pub use enrichment::{
     is_enrichment_member_from_inputs, pool_is_enrichment_member, EnrichmentMembershipInputs,
 };
 pub use eviction_planner::{
-    select_eviction_victims, ConsumerProtectionRank, EvictionPlanningSnapshot, EvictionTier,
+    select_cap_shrink_victims, select_eviction_victims, CapShrinkSelectionPlan,
+    CapShrinkSelectionResult, ConsumerProtectionRank, EvictionPlanningSnapshot, EvictionTier,
     OwnerLruEntry, OwnerPlanningRecord, PubkeyOwnerIndex, SnapshotBuildError,
     TierFeasibilityRequest, TierFeasibilityResult, VictimSelectionPlan, VictimSelectionRequest,
     VictimSelectionResult,
 };
 pub use explicit_admission::{
-    AdmissionEvictionPlanResult, EvictingAdmissionResult, FixedCapAdmission,
+    AdmissionEvictionPlanResult, CapShrinkResult, EvictingAdmissionResult, FixedCapAdmission,
     FixedCapAdmissionResult, FixedCapRemoveRecovery, FixedCapRemoveResult, FixedCapReplaceResult,
     InvariantViolationRecovery, TouchResult,
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements PR 1c3 — deterministic cap shrink for `FixedCapAdmission`:

- **`try_shrink_cap(new_cap)`** — lowers hard cap with validated state-swap commit (same pattern as `try_admit_with_eviction`)
- **`wallet_demand_exceeds_cap` / `wallet_physical_len`** — deduplicated wallet pubkey demand check
- **`select_cap_shrink_victims`** — additive planner selector with identical tier/LRU semantics, no incoming group
- **`CapShrinkResult`** — `Converged`, `NoOpAlreadyWithinCap`, `RejectedCapIncrease`, `ProtectedOverflow`, `RejectedInvalidInput`, `InternalInvariantViolation`

## Behavior

| Condition | Result |
|-----------|--------|
| `new_cap > cap` | `RejectedCapIncrease` (no mutation) |
| wallet pubkeys alone > `new_cap` | `ProtectedOverflow` (fail-closed) |
| `physical_len <= new_cap` | cap field only → `NoOpAlreadyWithinCap` |
| `physical_len > new_cap` | evict victims (I-MD-8), swap commit → `Converged` |

## Scope

- 3 files only: `explicit_admission.rs`, `eviction_planner.rs`, `mod.rs`
- No runtime wiring, restore/reconcile, or existing result-type changes
- Reuses evicting candidate build/validation fault seams for shrink tests

## STOP-CHECK (performed)

1. **I-7 Hot Path RPC** — no RPC added; pure local state machine
2. **Existing pattern** — mirrors `try_admit_with_eviction` swap + `select_eviction_victims` planner
3. **Architecture boundaries** — only allowed files touched
4. **I-9 Simulation gate** — no TX/intent changes
5. **Level-5 separation** — no eval test reads

## Tests

- 12+ shrink scenarios (within-cap, tier priority, true LRU, joint victims, wallet overflow, cap increase, parity, stamps, fault seams, determinism, independent oracle, property sequences)
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` green locally

## Definition of Done

- [x] Max 3 allowed files
- [x] Shrink commit only via prevalidated state swap
- [x] Wallet overflow fail-closed
- [x] No runtime semantic change
- [ ] CI green (pending)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3752807-5adf-453e-9d38-490dcc3b5264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3752807-5adf-453e-9d38-490dcc3b5264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

