### PR TITLE
fix(market-data): admit momentum and arb groups before tracked maps

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4489,8 +4489,8 @@ impl MarketDataContext {
                 warn!(pool = %a.pool, "MomentumActivePoolsUpdate.active: invalid pool");
                 continue;
             };
-            self.hot_pool_registry.pin_pool(mint_pk, pool_pk);
             if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Momentum) {
+                self.hot_pool_registry.pin_pool(mint_pk, pool_pk);
                 inc_market_data_momentum_admission_admitted_total();
                 if self.register_geyser_reserves_for_momentum_active_pool(pool_pk) {
                     batch_dirty = true;
@@ -4672,8 +4672,8 @@ impl MarketDataContext {
                 warn!(pool = %a.pool, "ArbTrackRequestsUpdate.active: invalid pool");
                 continue;
             };
-            self.hot_pool_registry.pin_arb_pool(pool_pk);
             if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Arb) {
+                self.hot_pool_registry.pin_arb_pool(pool_pk);
                 inc_market_data_arb_admission_admitted_total();
                 if self.register_geyser_reserves_for_arb_active_pool(pool_pk) {
                     batch_dirty = true;
@@ -14849,7 +14849,7 @@ mod pr_b_geyser_tracking_tests {
         );
         assert_eq!(ctx.tracked_vaults.read().len(), vaults_before);
         assert_eq!(ctx.tracked_mints.read().len(), mints_before);
-        assert!(ctx.hot_pool_registry.is_hot_pool(pool));
+        assert!(!ctx.hot_pool_registry.is_hot_pool(pool));
     }
 
     /// Phase 2c: trade handler must not reference arb reconcile enqueue helpers.

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4531,12 +4531,12 @@ impl MarketDataContext {
         mint: Pubkey,
         pool: Pubkey,
     ) -> bool {
-        self.release_pool_consumer_group(admission, pool, ExplicitConsumer::Momentum);
         self.hot_pool_registry.unpin_pool(mint, pool);
         let mut changed = false;
         // Pool-level reserve pins are shared: only demote vaults/bin arrays when no `(m, pool)`
         // row remains after this unpin (PR #147 follow-up).
         if !self.hot_pool_registry.pool_has_any_pin(pool) {
+            self.release_pool_consumer_group(admission, pool, ExplicitConsumer::Momentum);
             {
                 let mut vaults = self.tracked_vaults.write();
                 for v in vaults.values_mut() {

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4704,6 +4704,21 @@ impl MarketDataContext {
                         );
                     }
                 }
+            } else if self.live_pool_cache.get(&pool_pk).is_none() {
+                inc_market_data_arb_pin_geyser_register_deferred_total("live_pool_cache_miss");
+                let now = Instant::now();
+                if ARB_PIN_DEFERRED_LOG_THROTTLE
+                    .lock()
+                    .should_emit(ArbPinDeferredLogCategory::LivePoolCacheMiss as usize, now)
+                {
+                    warn!(
+                        run_id = %self.run_id,
+                        pool = %pool_pk,
+                        pin = "ArbMultiDex",
+                        reason = "live_pool_cache_miss",
+                        "Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)"
+                    );
+                }
             } else {
                 inc_market_data_arb_admission_rejected_total();
             }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -83,10 +83,11 @@ use ironcrab::market_data::track::{
     arb_coalesce_try_send, explicit_set_snapshot_path, explicit_subscription_has_new_keys,
     flush_explicit_set_snapshot, load_explicit_set_snapshot, momentum_coalesce_try_send,
     owner_group_snapshot_to_disk, pool_is_enrichment_member, restore_admission_from_owner_groups,
-    spawn_track_worker, track_worker_try_enqueue, AdmissionConvergeResult, AdmissionRestoreResult,
-    CapShrinkResult, ConsumerId, ExplicitAccountKind, ExplicitSetSnapshot, ExplicitSnapshotRow,
-    FixedCapAdmission, GeyserConnectBarrier, SnapshotConsumer, TrackPinReason, TrackWorkerCommand,
-    TrackWorkerContext, TrackWorkerSender, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
+    spawn_track_worker, track_worker_try_enqueue, try_admit_owner_group, AdmissionConvergeResult,
+    AdmissionRestoreResult, CapShrinkResult, ConsumerId, ExplicitAccountKind, ExplicitConsumer,
+    ExplicitOwner, ExplicitOwnerKey, ExplicitSetSnapshot, ExplicitSnapshotRow, FixedCapAdmission,
+    GeyserConnectBarrier, SnapshotConsumer, TrackPinReason, TrackWorkerCommand, TrackWorkerContext,
+    TrackWorkerSender, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -95,15 +96,17 @@ use ironcrab::metrics::{
     geyser_metrics_set_subscription_accounts, geyser_metrics_set_tracked_pinned_accounts,
     inc_market_data_account_high_priority_queue_depth,
     inc_market_data_account_low_priority_queue_depth, inc_market_data_account_worker_queue_depth,
+    inc_market_data_arb_admission_admitted_total, inc_market_data_arb_admission_rejected_total,
     inc_market_data_arb_pin_geyser_register_deferred_total,
     inc_market_data_balance_updated_from_cache_total, inc_market_data_geyser_sync_partial_total,
     inc_market_data_geyser_sync_skipped_rate_limit_total,
     inc_market_data_ingest_membership_snapshot_hits_total,
     inc_market_data_jsonl_enqueue_dropped_total,
     inc_market_data_md_state_evict_steps_budget_exhausted_total,
-    inc_market_data_md_state_evict_steps_total, inc_market_data_vault_high_priority_dispatch_total,
-    market_data_bump_geyser_head_slot, market_data_geyser_head_slot_value,
-    market_data_geyser_tracking_enqueue_dropped_value,
+    inc_market_data_md_state_evict_steps_total, inc_market_data_momentum_admission_admitted_total,
+    inc_market_data_momentum_admission_rejected_total,
+    inc_market_data_vault_high_priority_dispatch_total, market_data_bump_geyser_head_slot,
+    market_data_geyser_head_slot_value, market_data_geyser_tracking_enqueue_dropped_value,
     market_data_geyser_tracking_jobs_processed_value, market_data_md_state_bursts_completed_value,
     market_data_request_account_session_reconnect, market_data_request_tx_session_reconnect,
     market_data_tx_handler_processed_value, record_market_data_account_broadcast_lagged,
@@ -1770,6 +1773,43 @@ fn pool_mints_for_geyser_explicit_tracking(state: &CachedPoolState) -> Option<(P
     }
 }
 
+/// PR4a: cache-planned explicit pubkeys for one pool owner group (no tracked-map reads).
+fn planned_explicit_pubkeys_for_pool_from_cache(
+    pool: Pubkey,
+    state: &CachedPoolState,
+    enable_meteora_cpmm: bool,
+    enable_meteora_dlmm: bool,
+) -> Vec<Pubkey> {
+    use std::collections::BTreeSet;
+    let mut set = BTreeSet::new();
+    if let Some((base_vault, quote_vault)) =
+        expected_pool_vault_pubkeys_from_cache(state, enable_meteora_cpmm, enable_meteora_dlmm)
+    {
+        set.insert(base_vault);
+        set.insert(quote_vault);
+    }
+    if let CachedPoolState::RaydiumAmm(s) = state {
+        set.insert(s.coin_vault);
+        set.insert(s.pc_vault);
+    }
+    if enable_meteora_dlmm {
+        if let CachedPoolState::Meteora(s) = state {
+            let active_array_index = MeteoraDlmmSwapBuilder::bin_id_to_bin_array_index(s.active_id);
+            for offset in -3i64..=3i64 {
+                let index = active_array_index + offset;
+                if let Ok(pda) = MeteoraDlmmSwapBuilder::derive_bin_array_pda(&pool, index) {
+                    set.insert(pda);
+                }
+            }
+        }
+    }
+    if let Some((a, b)) = pool_mints_for_geyser_explicit_tracking(state) {
+        set.insert(a);
+        set.insert(b);
+    }
+    set.into_iter().collect()
+}
+
 /// CPMM pool cache rows: normalize base/quote mints and vault ATAs (SOL as quote when present).
 fn cpmm_token_mints_and_vaults_sol_normalized(
     token_0_mint: Pubkey,
@@ -1885,36 +1925,68 @@ impl TrackWorkerContext for MarketDataContext {
         self.config.read().max_tracked_accounts
     }
 
-    fn apply_momentum_active_pools_update(&self, update: &MomentumActivePoolsUpdate) -> bool {
-        self.apply_momentum_active_pools_update(update)
+    fn apply_momentum_active_pools_update(
+        &self,
+        admission: &mut FixedCapAdmission,
+        update: &MomentumActivePoolsUpdate,
+    ) -> bool {
+        self.apply_momentum_active_pools_update(admission, update)
     }
 
-    fn apply_momentum_snapshot_reconcile(&self, active: &[MomentumActivePoolEntry]) -> bool {
-        self.apply_momentum_snapshot_reconcile(active)
+    fn apply_momentum_snapshot_reconcile(
+        &self,
+        admission: &mut FixedCapAdmission,
+        active: &[MomentumActivePoolEntry],
+    ) -> bool {
+        self.apply_momentum_snapshot_reconcile(admission, active)
     }
 
-    fn apply_momentum_removed_entries(&self, chunk: &[MomentumRemovedPoolEntry]) -> bool {
-        self.apply_momentum_removed_entries(chunk)
+    fn apply_momentum_removed_entries(
+        &self,
+        admission: &mut FixedCapAdmission,
+        chunk: &[MomentumRemovedPoolEntry],
+    ) -> bool {
+        self.apply_momentum_removed_entries(admission, chunk)
     }
 
-    fn apply_momentum_active_entries(&self, chunk: &[MomentumActivePoolEntry]) -> bool {
-        self.apply_momentum_active_entries(chunk)
+    fn apply_momentum_active_entries(
+        &self,
+        admission: &mut FixedCapAdmission,
+        chunk: &[MomentumActivePoolEntry],
+    ) -> bool {
+        self.apply_momentum_active_entries(admission, chunk)
     }
 
-    fn apply_arb_track_requests_update(&self, update: &ArbTrackRequestsUpdate) -> bool {
-        self.apply_arb_track_requests_update(update)
+    fn apply_arb_track_requests_update(
+        &self,
+        admission: &mut FixedCapAdmission,
+        update: &ArbTrackRequestsUpdate,
+    ) -> bool {
+        self.apply_arb_track_requests_update(admission, update)
     }
 
-    fn apply_arb_snapshot_reconcile(&self, active: &[ArbTrackActiveEntry]) -> bool {
-        self.apply_arb_snapshot_reconcile(active)
+    fn apply_arb_snapshot_reconcile(
+        &self,
+        admission: &mut FixedCapAdmission,
+        active: &[ArbTrackActiveEntry],
+    ) -> bool {
+        self.apply_arb_snapshot_reconcile(admission, active)
     }
 
-    fn apply_arb_removed_entries(&self, chunk: &[ArbTrackRemovedEntry]) -> bool {
-        self.apply_arb_removed_entries(chunk)
+    fn apply_arb_removed_entries(
+        &self,
+        admission: &mut FixedCapAdmission,
+        chunk: &[ArbTrackRemovedEntry],
+    ) -> bool {
+        self.apply_arb_removed_entries(admission, chunk)
     }
 
-    fn apply_arb_active_entries(&self, chunk: &[ArbTrackActiveEntry]) -> bool {
-        self.apply_arb_active_entries(chunk)
+    fn apply_arb_active_entries(
+        &self,
+        admission: &mut FixedCapAdmission,
+        chunk: &[ArbTrackActiveEntry],
+    ) -> bool {
+        self.apply_arb_active_entries(admission, chunk)
     }
 
     fn track_mint_for_geyser_metadata(&self, mint: Pubkey, pin: Option<TrackPinReason>) -> bool {
@@ -2492,6 +2564,57 @@ impl MarketDataContext {
         self.hot_pool_registry.is_hot_pool(pool)
             || self.wallet_tracks_mint_for_geyser(&base_mint)
             || self.wallet_tracks_mint_for_geyser(&quote_mint)
+    }
+
+    fn pool_consumer_owner(pool: Pubkey, consumer: ExplicitConsumer) -> ExplicitOwner {
+        ExplicitOwner {
+            consumer,
+            owner_key: ExplicitOwnerKey::Pool(pool),
+        }
+    }
+
+    fn planned_pool_consumer_group_pubkeys(&self, pool: Pubkey) -> Vec<Pubkey> {
+        let Some(state) = self.live_pool_cache.get(&pool) else {
+            return Vec::new();
+        };
+        let (enable_meteora_cpmm, enable_meteora_dlmm) = {
+            let cfg = self.config.read();
+            (cfg.enable_meteora_cpmm, cfg.enable_meteora_dlmm)
+        };
+        planned_explicit_pubkeys_for_pool_from_cache(
+            pool,
+            &state,
+            enable_meteora_cpmm,
+            enable_meteora_dlmm,
+        )
+    }
+
+    /// PR4a: admit immutable pool owner group before tracked-map mutation.
+    fn try_admit_pool_consumer_group(
+        &self,
+        admission: &mut FixedCapAdmission,
+        pool: Pubkey,
+        consumer: ExplicitConsumer,
+    ) -> bool {
+        let pubkeys = self.planned_pool_consumer_group_pubkeys(pool);
+        if pubkeys.is_empty() {
+            return false;
+        }
+        try_admit_owner_group(
+            admission,
+            Self::pool_consumer_owner(pool, consumer),
+            pubkeys,
+        )
+    }
+
+    /// PR4a: drop pool owner group from admission before tracked-map demotion.
+    fn release_pool_consumer_group(
+        &self,
+        admission: &mut FixedCapAdmission,
+        pool: Pubkey,
+        consumer: ExplicitConsumer,
+    ) {
+        let _ = admission.remove_group(Self::pool_consumer_owner(pool, consumer));
     }
 
     fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
@@ -4275,14 +4398,18 @@ impl MarketDataContext {
     }
 
     /// PR-D / PR169b: apply momentum-bot active pool pin updates (actor-only writer; caller schedules sync).
-    fn apply_momentum_active_pools_update(&self, update: &MomentumActivePoolsUpdate) -> bool {
+    fn apply_momentum_active_pools_update(
+        &self,
+        admission: &mut FixedCapAdmission,
+        update: &MomentumActivePoolsUpdate,
+    ) -> bool {
         record_market_data_momentum_active_pool_messages_total();
         let mut batch_dirty = false;
         if update.full_active_snapshot {
-            batch_dirty |= self.apply_momentum_snapshot_reconcile(&update.active);
+            batch_dirty |= self.apply_momentum_snapshot_reconcile(admission, &update.active);
         }
-        batch_dirty |= self.apply_momentum_removed_entries(&update.removed);
-        batch_dirty |= self.apply_momentum_active_entries(&update.active);
+        batch_dirty |= self.apply_momentum_removed_entries(admission, &update.removed);
+        batch_dirty |= self.apply_momentum_active_entries(admission, &update.active);
         if !batch_dirty {
             self.refresh_geyser_pins_gauge();
         }
@@ -4291,7 +4418,11 @@ impl MarketDataContext {
     }
 
     /// PR169c: snapshot reconcile only (`full_active_snapshot` target set).
-    fn apply_momentum_snapshot_reconcile(&self, active: &[MomentumActivePoolEntry]) -> bool {
+    fn apply_momentum_snapshot_reconcile(
+        &self,
+        admission: &mut FixedCapAdmission,
+        active: &[MomentumActivePoolEntry],
+    ) -> bool {
         let mut target: HashSet<(Pubkey, Pubkey)> = HashSet::new();
         for a in active {
             let Ok(mint_pk) = Pubkey::from_str(a.mint.trim()) else {
@@ -4314,14 +4445,18 @@ impl MarketDataContext {
         let mut batch_dirty = false;
         let before = self.hot_pool_registry.snapshot_pairs();
         for (m, p) in before.difference(&target) {
-            if self.clear_momentum_geyser_reserves_for_active_entry(*m, *p) {
+            if self.clear_momentum_geyser_reserves_for_active_entry(admission, *m, *p) {
                 batch_dirty = true;
             }
         }
         batch_dirty
     }
 
-    fn apply_momentum_removed_entries(&self, removed: &[MomentumRemovedPoolEntry]) -> bool {
+    fn apply_momentum_removed_entries(
+        &self,
+        admission: &mut FixedCapAdmission,
+        removed: &[MomentumRemovedPoolEntry],
+    ) -> bool {
         let mut batch_dirty = false;
         for r in removed {
             let Ok(mint_pk) = Pubkey::from_str(r.mint.trim()) else {
@@ -4332,14 +4467,18 @@ impl MarketDataContext {
                 warn!(pool = %r.pool, "MomentumActivePoolsUpdate.removed: invalid pool");
                 continue;
             };
-            if self.clear_momentum_geyser_reserves_for_active_entry(mint_pk, pool_pk) {
+            if self.clear_momentum_geyser_reserves_for_active_entry(admission, mint_pk, pool_pk) {
                 batch_dirty = true;
             }
         }
         batch_dirty
     }
 
-    fn apply_momentum_active_entries(&self, active: &[MomentumActivePoolEntry]) -> bool {
+    fn apply_momentum_active_entries(
+        &self,
+        admission: &mut FixedCapAdmission,
+        active: &[MomentumActivePoolEntry],
+    ) -> bool {
         let mut batch_dirty = false;
         for a in active {
             let Ok(mint_pk) = Pubkey::from_str(a.mint.trim()) else {
@@ -4351,8 +4490,13 @@ impl MarketDataContext {
                 continue;
             };
             self.hot_pool_registry.pin_pool(mint_pk, pool_pk);
-            if self.register_geyser_reserves_for_momentum_active_pool(pool_pk) {
-                batch_dirty = true;
+            if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Momentum) {
+                inc_market_data_momentum_admission_admitted_total();
+                if self.register_geyser_reserves_for_momentum_active_pool(pool_pk) {
+                    batch_dirty = true;
+                }
+            } else {
+                inc_market_data_momentum_admission_rejected_total();
             }
             let _ = &a.pin_reason;
         }
@@ -4381,7 +4525,13 @@ impl MarketDataContext {
     }
 
     /// Clear `MomentumActive` pins for one `(mint, pool)` side; never demotes [`GeyserPinReason::Wallet`].
-    fn clear_momentum_geyser_reserves_for_active_entry(&self, mint: Pubkey, pool: Pubkey) -> bool {
+    fn clear_momentum_geyser_reserves_for_active_entry(
+        &self,
+        admission: &mut FixedCapAdmission,
+        mint: Pubkey,
+        pool: Pubkey,
+    ) -> bool {
+        self.release_pool_consumer_group(admission, pool, ExplicitConsumer::Momentum);
         self.hot_pool_registry.unpin_pool(mint, pool);
         let mut changed = false;
         // Pool-level reserve pins are shared: only demote vaults/bin arrays when no `(m, pool)`
@@ -4444,14 +4594,18 @@ impl MarketDataContext {
     }
 
     /// Phase 3: apply arb-strategy track_requests pin updates (md-track-worker only).
-    fn apply_arb_track_requests_update(&self, update: &ArbTrackRequestsUpdate) -> bool {
+    fn apply_arb_track_requests_update(
+        &self,
+        admission: &mut FixedCapAdmission,
+        update: &ArbTrackRequestsUpdate,
+    ) -> bool {
         record_market_data_arb_track_requests_messages_total();
         let mut batch_dirty = false;
         if update.reconcile {
-            batch_dirty |= self.apply_arb_snapshot_reconcile(&update.active);
+            batch_dirty |= self.apply_arb_snapshot_reconcile(admission, &update.active);
         }
-        batch_dirty |= self.apply_arb_removed_entries(&update.removed);
-        batch_dirty |= self.apply_arb_active_entries(&update.active);
+        batch_dirty |= self.apply_arb_removed_entries(admission, &update.removed);
+        batch_dirty |= self.apply_arb_active_entries(admission, &update.active);
         if !batch_dirty {
             self.refresh_geyser_pins_gauge();
         }
@@ -4459,7 +4613,11 @@ impl MarketDataContext {
         batch_dirty
     }
 
-    fn apply_arb_snapshot_reconcile(&self, active: &[ArbTrackActiveEntry]) -> bool {
+    fn apply_arb_snapshot_reconcile(
+        &self,
+        admission: &mut FixedCapAdmission,
+        active: &[ArbTrackActiveEntry],
+    ) -> bool {
         let mut target: HashSet<Pubkey> = HashSet::new();
         for a in active {
             let Ok(pool_pk) = Pubkey::from_str(a.pool.trim()) else {
@@ -4478,28 +4636,36 @@ impl MarketDataContext {
         let mut batch_dirty = false;
         let before = self.hot_pool_registry.snapshot_arb_pools();
         for pool in before.difference(&target) {
-            if self.clear_arb_geyser_reserves_for_pool(*pool) {
+            if self.clear_arb_geyser_reserves_for_pool(admission, *pool) {
                 batch_dirty = true;
             }
         }
         batch_dirty
     }
 
-    fn apply_arb_removed_entries(&self, removed: &[ArbTrackRemovedEntry]) -> bool {
+    fn apply_arb_removed_entries(
+        &self,
+        admission: &mut FixedCapAdmission,
+        removed: &[ArbTrackRemovedEntry],
+    ) -> bool {
         let mut batch_dirty = false;
         for r in removed {
             let Ok(pool_pk) = Pubkey::from_str(r.pool.trim()) else {
                 warn!(pool = %r.pool, "ArbTrackRequestsUpdate.removed: invalid pool");
                 continue;
             };
-            if self.clear_arb_geyser_reserves_for_pool(pool_pk) {
+            if self.clear_arb_geyser_reserves_for_pool(admission, pool_pk) {
                 batch_dirty = true;
             }
         }
         batch_dirty
     }
 
-    fn apply_arb_active_entries(&self, active: &[ArbTrackActiveEntry]) -> bool {
+    fn apply_arb_active_entries(
+        &self,
+        admission: &mut FixedCapAdmission,
+        active: &[ArbTrackActiveEntry],
+    ) -> bool {
         let mut batch_dirty = false;
         for a in active {
             let Ok(pool_pk) = Pubkey::from_str(a.pool.trim()) else {
@@ -4507,32 +4673,39 @@ impl MarketDataContext {
                 continue;
             };
             self.hot_pool_registry.pin_arb_pool(pool_pk);
-            if self.register_geyser_reserves_for_arb_active_pool(pool_pk) {
-                batch_dirty = true;
-            } else {
-                let category = if self.live_pool_cache.get(&pool_pk).is_none() {
-                    ArbPinDeferredLogCategory::LivePoolCacheMiss
+            if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Arb) {
+                inc_market_data_arb_admission_admitted_total();
+                if self.register_geyser_reserves_for_arb_active_pool(pool_pk) {
+                    batch_dirty = true;
                 } else {
-                    ArbPinDeferredLogCategory::VaultRegisterNoChange
-                };
-                let reason: &'static str = match category {
-                    ArbPinDeferredLogCategory::LivePoolCacheMiss => "live_pool_cache_miss",
-                    ArbPinDeferredLogCategory::VaultRegisterNoChange => "vault_register_no_change",
-                };
-                inc_market_data_arb_pin_geyser_register_deferred_total(reason);
-                let now = Instant::now();
-                if ARB_PIN_DEFERRED_LOG_THROTTLE
-                    .lock()
-                    .should_emit(category as usize, now)
-                {
-                    warn!(
-                        run_id = %self.run_id,
-                        pool = %pool_pk,
-                        pin = "ArbMultiDex",
-                        reason = reason,
-                        "Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)"
-                    );
+                    let category = if self.live_pool_cache.get(&pool_pk).is_none() {
+                        ArbPinDeferredLogCategory::LivePoolCacheMiss
+                    } else {
+                        ArbPinDeferredLogCategory::VaultRegisterNoChange
+                    };
+                    let reason: &'static str = match category {
+                        ArbPinDeferredLogCategory::LivePoolCacheMiss => "live_pool_cache_miss",
+                        ArbPinDeferredLogCategory::VaultRegisterNoChange => {
+                            "vault_register_no_change"
+                        }
+                    };
+                    inc_market_data_arb_pin_geyser_register_deferred_total(reason);
+                    let now = Instant::now();
+                    if ARB_PIN_DEFERRED_LOG_THROTTLE
+                        .lock()
+                        .should_emit(category as usize, now)
+                    {
+                        warn!(
+                            run_id = %self.run_id,
+                            pool = %pool_pk,
+                            pin = "ArbMultiDex",
+                            reason = reason,
+                            "Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)"
+                        );
+                    }
                 }
+            } else {
+                inc_market_data_arb_admission_rejected_total();
             }
             let _ = &a.reason;
         }
@@ -4556,7 +4729,12 @@ impl MarketDataContext {
     }
 
     /// Clear Arb consumer pins for one pool; never demotes [`GeyserPinReason::Wallet`] or Momentum.
-    fn clear_arb_geyser_reserves_for_pool(&self, pool: Pubkey) -> bool {
+    fn clear_arb_geyser_reserves_for_pool(
+        &self,
+        admission: &mut FixedCapAdmission,
+        pool: Pubkey,
+    ) -> bool {
+        self.release_pool_consumer_group(admission, pool, ExplicitConsumer::Arb);
         self.hot_pool_registry.unpin_arb_pool(pool);
         let mut changed = false;
         if !self.hot_pool_registry.pool_has_arb(pool)
@@ -10926,6 +11104,10 @@ mod pr_b_geyser_tracking_tests {
         spawn_inline_track_worker_sender(Arc::clone(ctx), 4096)
     }
 
+    fn test_admission_for(ctx: &MarketDataContext) -> FixedCapAdmission {
+        FixedCapAdmission::new(ctx.config.read().max_tracked_accounts)
+    }
+
     fn test_sidefx_host(
         ctx: &Arc<MarketDataContext>,
         md_state: MdStateSender,
@@ -11580,7 +11762,8 @@ mod pr_b_geyser_tracking_tests {
             removed: vec![],
             full_active_snapshot: false,
         };
-        ctx.apply_momentum_active_pools_update(&update);
+        let mut admission = test_admission_for(&ctx);
+        ctx.apply_momentum_active_pools_update(&mut admission, &update);
 
         let vs = ctx.tracked_vaults.read();
         assert_eq!(
@@ -11622,17 +11805,21 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
 
-        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
-            version: 1,
-            ts_unix_ms: 1,
-            active: vec![MomentumActivePoolEntry {
-                mint: base_mint.to_string(),
-                pool: pool.to_string(),
-                pin_reason: MomentumActivePinReason::Tracker,
-            }],
-            removed: vec![],
-            full_active_snapshot: false,
-        });
+        let mut admission = test_admission_for(&ctx);
+        ctx.apply_momentum_active_pools_update(
+            &mut admission,
+            &MomentumActivePoolsUpdate {
+                version: 1,
+                ts_unix_ms: 1,
+                active: vec![MomentumActivePoolEntry {
+                    mint: base_mint.to_string(),
+                    pool: pool.to_string(),
+                    pin_reason: MomentumActivePinReason::Tracker,
+                }],
+                removed: vec![],
+                full_active_snapshot: false,
+            },
+        );
 
         {
             let mut vs = ctx.tracked_vaults.write();
@@ -11642,17 +11829,20 @@ mod pr_b_geyser_tracking_tests {
             }
         }
 
-        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
-            version: 1,
-            ts_unix_ms: 2,
-            active: vec![],
-            removed: vec![MomentumRemovedPoolEntry {
-                mint: base_mint.to_string(),
-                pool: pool.to_string(),
-                reason: "closed".to_string(),
-            }],
-            full_active_snapshot: false,
-        });
+        ctx.apply_momentum_active_pools_update(
+            &mut admission,
+            &MomentumActivePoolsUpdate {
+                version: 1,
+                ts_unix_ms: 2,
+                active: vec![],
+                removed: vec![MomentumRemovedPoolEntry {
+                    mint: base_mint.to_string(),
+                    pool: pool.to_string(),
+                    reason: "closed".to_string(),
+                }],
+                full_active_snapshot: false,
+            },
+        );
 
         let vs = ctx.tracked_vaults.read();
         assert_eq!(vs.get(&coin_vault).and_then(|v| v.pin), None);
@@ -11694,36 +11884,43 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
 
-        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
-            version: 1,
-            ts_unix_ms: 1,
-            active: vec![
-                MomentumActivePoolEntry {
+        let mut admission = test_admission_for(&ctx);
+        ctx.apply_momentum_active_pools_update(
+            &mut admission,
+            &MomentumActivePoolsUpdate {
+                version: 1,
+                ts_unix_ms: 1,
+                active: vec![
+                    MomentumActivePoolEntry {
+                        mint: base_mint.to_string(),
+                        pool: pool.to_string(),
+                        pin_reason: MomentumActivePinReason::Tracker,
+                    },
+                    MomentumActivePoolEntry {
+                        mint: other_tracker_mint.to_string(),
+                        pool: pool.to_string(),
+                        pin_reason: MomentumActivePinReason::Tracker,
+                    },
+                ],
+                removed: vec![],
+                full_active_snapshot: false,
+            },
+        );
+
+        ctx.apply_momentum_active_pools_update(
+            &mut admission,
+            &MomentumActivePoolsUpdate {
+                version: 1,
+                ts_unix_ms: 2,
+                active: vec![],
+                removed: vec![MomentumRemovedPoolEntry {
                     mint: base_mint.to_string(),
                     pool: pool.to_string(),
-                    pin_reason: MomentumActivePinReason::Tracker,
-                },
-                MomentumActivePoolEntry {
-                    mint: other_tracker_mint.to_string(),
-                    pool: pool.to_string(),
-                    pin_reason: MomentumActivePinReason::Tracker,
-                },
-            ],
-            removed: vec![],
-            full_active_snapshot: false,
-        });
-
-        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
-            version: 1,
-            ts_unix_ms: 2,
-            active: vec![],
-            removed: vec![MomentumRemovedPoolEntry {
-                mint: base_mint.to_string(),
-                pool: pool.to_string(),
-                reason: "stale_discovery".to_string(),
-            }],
-            full_active_snapshot: false,
-        });
+                    reason: "stale_discovery".to_string(),
+                }],
+                full_active_snapshot: false,
+            },
+        );
 
         assert!(
             ctx.hot_pool_registry.is_pinned(other_tracker_mint, pool),
@@ -11774,24 +11971,28 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
 
-        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
-            version: 1,
-            ts_unix_ms: 1,
-            active: vec![
-                MomentumActivePoolEntry {
-                    mint: base_mint.to_string(),
-                    pool: pool_a.to_string(),
-                    pin_reason: MomentumActivePinReason::Tracker,
-                },
-                MomentumActivePoolEntry {
-                    mint: other_tracker_mint.to_string(),
-                    pool: pool_b.to_string(),
-                    pin_reason: MomentumActivePinReason::Tracker,
-                },
-            ],
-            removed: vec![],
-            full_active_snapshot: false,
-        });
+        let mut admission = test_admission_for(&ctx);
+        ctx.apply_momentum_active_pools_update(
+            &mut admission,
+            &MomentumActivePoolsUpdate {
+                version: 1,
+                ts_unix_ms: 1,
+                active: vec![
+                    MomentumActivePoolEntry {
+                        mint: base_mint.to_string(),
+                        pool: pool_a.to_string(),
+                        pin_reason: MomentumActivePinReason::Tracker,
+                    },
+                    MomentumActivePoolEntry {
+                        mint: other_tracker_mint.to_string(),
+                        pool: pool_b.to_string(),
+                        pin_reason: MomentumActivePinReason::Tracker,
+                    },
+                ],
+                removed: vec![],
+                full_active_snapshot: false,
+            },
+        );
 
         assert!(
             ctx.tracked_mints
@@ -11801,17 +12002,20 @@ mod pr_b_geyser_tracking_tests {
             "setup: WSOL leg tracked for pool_a"
         );
 
-        ctx.apply_momentum_active_pools_update(&MomentumActivePoolsUpdate {
-            version: 1,
-            ts_unix_ms: 2,
-            active: vec![],
-            removed: vec![MomentumRemovedPoolEntry {
-                mint: base_mint.to_string(),
-                pool: pool_a.to_string(),
-                reason: "closed".to_string(),
-            }],
-            full_active_snapshot: false,
-        });
+        ctx.apply_momentum_active_pools_update(
+            &mut admission,
+            &MomentumActivePoolsUpdate {
+                version: 1,
+                ts_unix_ms: 2,
+                active: vec![],
+                removed: vec![MomentumRemovedPoolEntry {
+                    mint: base_mint.to_string(),
+                    pool: pool_a.to_string(),
+                    reason: "closed".to_string(),
+                }],
+                full_active_snapshot: false,
+            },
+        );
 
         assert!(
             ctx.hot_pool_registry.is_pinned(other_tracker_mint, pool_b),
@@ -13195,11 +13399,13 @@ mod pr_b_geyser_tracking_tests {
             },
         ];
 
+        let mut admission_seq = test_admission_for(&ctx_seq);
         for u in &updates {
-            ctx_seq.apply_momentum_active_pools_update(u);
+            ctx_seq.apply_momentum_active_pools_update(&mut admission_seq, u);
         }
         let merged = merge_momentum_active_pools_updates(&updates).expect("merged");
-        ctx_merged.apply_momentum_active_pools_update(&merged);
+        let mut admission_merged = test_admission_for(&ctx_merged);
+        ctx_merged.apply_momentum_active_pools_update(&mut admission_merged, &merged);
 
         assert_eq!(pin_count(&ctx_seq), pin_count(&ctx_merged));
         assert_eq!(
@@ -14589,6 +14795,48 @@ mod pr_b_geyser_tracking_tests {
         );
     }
 
+    #[test]
+    fn pr4a_momentum_admission_reject_skips_tracked_map_mutation() {
+        use ironcrab::nats::{MomentumActivePinReason, MomentumActivePoolEntry};
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: mint,
+                token_1_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+
+        let vaults_before = ctx.tracked_vaults.read().len();
+        let mints_before = ctx.tracked_mints.read().len();
+        let mut admission = FixedCapAdmission::new(2);
+        ctx.apply_momentum_active_entries(
+            &mut admission,
+            &[MomentumActivePoolEntry {
+                mint: mint.to_string(),
+                pool: pool.to_string(),
+                pin_reason: MomentumActivePinReason::Tracker,
+            }],
+        );
+        assert_eq!(ctx.tracked_vaults.read().len(), vaults_before);
+        assert_eq!(ctx.tracked_mints.read().len(), mints_before);
+        assert!(ctx.hot_pool_registry.is_hot_pool(pool));
+    }
+
     /// Phase 2c: trade handler must not reference arb reconcile enqueue helpers.
     #[test]
     fn phase2c_trade_path_no_arb_reconcile_enqueue() {
@@ -15127,16 +15375,20 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
 
-        ctx.apply_arb_track_requests_update(&ArbTrackRequestsUpdate {
-            version: 1,
-            ts_unix_ms: 1,
-            active: vec![ArbTrackActiveEntry {
-                pool: pool.to_string(),
-                reason: ArbTrackActiveReason::Baseline,
-            }],
-            removed: vec![],
-            reconcile: false,
-        });
+        let mut admission = test_admission_for(&ctx);
+        ctx.apply_arb_track_requests_update(
+            &mut admission,
+            &ArbTrackRequestsUpdate {
+                version: 1,
+                ts_unix_ms: 1,
+                active: vec![ArbTrackActiveEntry {
+                    pool: pool.to_string(),
+                    reason: ArbTrackActiveReason::Baseline,
+                }],
+                removed: vec![],
+                reconcile: false,
+            },
+        );
 
         {
             let mut vs = ctx.tracked_vaults.write();
@@ -15146,16 +15398,19 @@ mod pr_b_geyser_tracking_tests {
             }
         }
 
-        ctx.apply_arb_track_requests_update(&ArbTrackRequestsUpdate {
-            version: 1,
-            ts_unix_ms: 2,
-            active: vec![],
-            removed: vec![ArbTrackRemovedEntry {
-                pool: pool.to_string(),
-                reason: ironcrab::nats::ArbTrackRemovedReason::Cooldown,
-            }],
-            reconcile: false,
-        });
+        ctx.apply_arb_track_requests_update(
+            &mut admission,
+            &ArbTrackRequestsUpdate {
+                version: 1,
+                ts_unix_ms: 2,
+                active: vec![],
+                removed: vec![ArbTrackRemovedEntry {
+                    pool: pool.to_string(),
+                    reason: ironcrab::nats::ArbTrackRemovedReason::Cooldown,
+                }],
+                reconcile: false,
+            },
+        );
 
         let vs = ctx.tracked_vaults.read();
         assert_eq!(vs.get(&coin_vault).and_then(|v| v.pin), None);

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -11187,10 +11187,10 @@ mod pr_b_geyser_tracking_tests {
         solana_sdk::pubkey!("pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA");
     use ironcrab::market_data::track::{
         converge_admission_from_ctx, converge_admission_from_groups,
-        merge_momentum_active_pools_updates,
-        spawn_inline_track_worker_sender, spawn_noop_track_worker_sender,
-        track_worker_execute_coalesced_push, track_worker_try_enqueue, FixedCapAdmission,
-        TrackWorkerCommand, MARKET_DATA_TRACK_WORKER_COALESCE_MS,
+        merge_momentum_active_pools_updates, spawn_inline_track_worker_sender,
+        spawn_noop_track_worker_sender, track_worker_execute_coalesced_push,
+        track_worker_try_enqueue, FixedCapAdmission, TrackWorkerCommand,
+        MARKET_DATA_TRACK_WORKER_COALESCE_MS,
     };
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc as std_mpsc;

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -80,14 +80,15 @@ use ironcrab::market_data::sidefx::{
     SidefxVaultMembershipView, SidefxWorkerHost, MARKET_DATA_MD_SIDEFX_QUEUE_CAP,
 };
 use ironcrab::market_data::track::{
-    arb_coalesce_try_send, explicit_set_snapshot_path, explicit_subscription_has_new_keys,
-    flush_explicit_set_snapshot, load_explicit_set_snapshot, momentum_coalesce_try_send,
-    owner_group_snapshot_to_disk, pool_is_enrichment_member, restore_admission_from_owner_groups,
-    spawn_track_worker, track_worker_try_enqueue, try_admit_owner_group, AdmissionConvergeResult,
-    AdmissionRestoreResult, CapShrinkResult, ConsumerId, ExplicitAccountKind, ExplicitConsumer,
-    ExplicitOwner, ExplicitOwnerKey, ExplicitSetSnapshot, ExplicitSnapshotRow, FixedCapAdmission,
-    GeyserConnectBarrier, SnapshotConsumer, TrackPinReason, TrackWorkerCommand, TrackWorkerContext,
-    TrackWorkerSender, EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
+    arb_coalesce_try_send, explicit_admitted_pool_sets_from_admission, explicit_set_snapshot_path,
+    explicit_subscription_has_new_keys, flush_explicit_set_snapshot, load_explicit_set_snapshot,
+    momentum_coalesce_try_send, owner_group_snapshot_to_disk, pool_is_enrichment_member,
+    restore_admission_from_owner_groups, spawn_track_worker, track_worker_try_enqueue,
+    try_admit_owner_group, AdmissionConvergeResult, AdmissionRestoreResult, CapShrinkResult,
+    ConsumerId, ExplicitAccountKind, ExplicitConsumer, ExplicitOwner, ExplicitOwnerKey,
+    ExplicitSetSnapshot, ExplicitSnapshotRow, FixedCapAdmission, GeyserConnectBarrier,
+    SnapshotConsumer, TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
+    EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
 };
 use ironcrab::metrics::{
     dec_market_data_account_high_priority_queue_depth,
@@ -2582,6 +2583,40 @@ impl MarketDataContext {
         self.explicit_admitted_arb_pools.write().remove(&pool);
     }
 
+    /// PR4a: keep bypass-gate pool sets aligned with [`FixedCapAdmission`] SSOT.
+    fn rebuild_explicit_admitted_pools_from_admission(&self, admission: &FixedCapAdmission) {
+        let (momentum, arb) = explicit_admitted_pool_sets_from_admission(admission);
+        *self.explicit_admitted_momentum_pools.write() = momentum;
+        *self.explicit_admitted_arb_pools.write() = arb;
+    }
+
+    fn sync_explicit_pool_admitted_from_admission(
+        &self,
+        admission: &FixedCapAdmission,
+        pool: Pubkey,
+        consumer: ExplicitConsumer,
+    ) {
+        let owner = Self::pool_consumer_owner(pool, consumer);
+        let admitted = admission.owner_group(&owner).is_some();
+        match consumer {
+            ExplicitConsumer::Momentum => {
+                if admitted {
+                    self.note_explicit_momentum_pool_admitted(pool);
+                } else {
+                    self.clear_explicit_momentum_pool_admitted(pool);
+                }
+            }
+            ExplicitConsumer::Arb => {
+                if admitted {
+                    self.note_explicit_arb_pool_admitted(pool);
+                } else {
+                    self.clear_explicit_arb_pool_admitted(pool);
+                }
+            }
+            ExplicitConsumer::Wallet | ExplicitConsumer::Tracker => {}
+        }
+    }
+
     /// PR-B: explicit vault/bin-array/mint Geyser filters — admitted pool groups or wallet only.
     fn admit_geyser_explicit_pool_assets(
         &self,
@@ -2644,6 +2679,11 @@ impl MarketDataContext {
         consumer: ExplicitConsumer,
     ) {
         let _ = admission.remove_group(Self::pool_consumer_owner(pool, consumer));
+        match consumer {
+            ExplicitConsumer::Momentum => self.clear_explicit_momentum_pool_admitted(pool),
+            ExplicitConsumer::Arb => self.clear_explicit_arb_pool_admitted(pool),
+            ExplicitConsumer::Wallet | ExplicitConsumer::Tracker => {}
+        }
     }
 
     fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
@@ -2885,6 +2925,7 @@ impl MarketDataContext {
         admission: &FixedCapAdmission,
         result: AdmissionConvergeResult,
     ) {
+        self.rebuild_explicit_admitted_pools_from_admission(admission);
         set_market_data_geyser_explicit_cap_overflow(
             if matches!(
                 result,
@@ -3053,6 +3094,7 @@ impl MarketDataContext {
         let result = restore_admission_from_owner_groups(admission, &groups);
         match result {
             AdmissionRestoreResult::Restored => {
+                self.rebuild_explicit_admitted_pools_from_admission(admission);
                 if self.admission_exceeds_configured_cap(admission) {
                     self.mark_explicit_admission_config_cap_desync(
                         admission,
@@ -3112,6 +3154,12 @@ impl MarketDataContext {
             };
         }
         let result = admission.try_shrink_cap(new_cap);
+        if matches!(
+            result,
+            CapShrinkResult::Converged { .. } | CapShrinkResult::NoOpAlreadyWithinCap { .. }
+        ) {
+            self.rebuild_explicit_admitted_pools_from_admission(admission);
+        }
         match result {
             CapShrinkResult::Converged { .. } | CapShrinkResult::NoOpAlreadyWithinCap { .. } => {
                 if self.admission_exceeds_configured_cap(admission) {
@@ -4520,7 +4568,6 @@ impl MarketDataContext {
             };
             self.hot_pool_registry.pin_pool(mint_pk, pool_pk);
             if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Momentum) {
-                self.note_explicit_momentum_pool_admitted(pool_pk);
                 inc_market_data_momentum_admission_admitted_total();
                 if self.register_geyser_reserves_for_momentum_active_pool(pool_pk) {
                     batch_dirty = true;
@@ -4528,6 +4575,11 @@ impl MarketDataContext {
             } else {
                 inc_market_data_momentum_admission_rejected_total();
             }
+            self.sync_explicit_pool_admitted_from_admission(
+                admission,
+                pool_pk,
+                ExplicitConsumer::Momentum,
+            );
             let _ = &a.pin_reason;
         }
         batch_dirty
@@ -4567,7 +4619,6 @@ impl MarketDataContext {
         // row remains after this unpin (PR #147 follow-up).
         if !self.hot_pool_registry.pool_has_any_pin(pool) {
             self.release_pool_consumer_group(admission, pool, ExplicitConsumer::Momentum);
-            self.clear_explicit_momentum_pool_admitted(pool);
             {
                 let mut vaults = self.tracked_vaults.write();
                 for v in vaults.values_mut() {
@@ -4705,7 +4756,6 @@ impl MarketDataContext {
             };
             self.hot_pool_registry.pin_arb_pool(pool_pk);
             if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Arb) {
-                self.note_explicit_arb_pool_admitted(pool_pk);
                 inc_market_data_arb_admission_admitted_total();
                 if self.register_geyser_reserves_for_arb_active_pool(pool_pk) {
                     batch_dirty = true;
@@ -4754,6 +4804,11 @@ impl MarketDataContext {
             } else {
                 inc_market_data_arb_admission_rejected_total();
             }
+            self.sync_explicit_pool_admitted_from_admission(
+                admission,
+                pool_pk,
+                ExplicitConsumer::Arb,
+            );
             let _ = &a.reason;
         }
         batch_dirty
@@ -4782,7 +4837,6 @@ impl MarketDataContext {
         pool: Pubkey,
     ) -> bool {
         self.release_pool_consumer_group(admission, pool, ExplicitConsumer::Arb);
-        self.clear_explicit_arb_pool_admitted(pool);
         self.hot_pool_registry.unpin_arb_pool(pool);
         let mut changed = false;
         if !self.hot_pool_registry.pool_has_arb(pool)
@@ -11132,7 +11186,8 @@ mod pr_b_geyser_tracking_tests {
     const PUMPFUN_AMM_PROGRAM_OWNER: Pubkey =
         solana_sdk::pubkey!("pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA");
     use ironcrab::market_data::track::{
-        converge_admission_from_ctx, merge_momentum_active_pools_updates,
+        converge_admission_from_ctx, converge_admission_from_groups,
+        merge_momentum_active_pools_updates,
         spawn_inline_track_worker_sender, spawn_noop_track_worker_sender,
         track_worker_execute_coalesced_push, track_worker_try_enqueue, FixedCapAdmission,
         TrackWorkerCommand, MARKET_DATA_TRACK_WORKER_COALESCE_MS,
@@ -14859,6 +14914,132 @@ mod pr_b_geyser_tracking_tests {
             vs.get(&coin).unwrap().pin,
             Some(GeyserPinReason::MomentumActive)
         );
+    }
+
+    #[test]
+    fn release_pool_consumer_group_clears_explicit_momentum_bypass_gate() {
+        use ironcrab::market_data::track::{
+            try_admit_owner_group, ExplicitConsumer, ExplicitOwner, ExplicitOwnerKey,
+        };
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: mint,
+                token_1_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+
+        let mut admission = FixedCapAdmission::new(100);
+        let owner = ExplicitOwner {
+            consumer: ExplicitConsumer::Momentum,
+            owner_key: ExplicitOwnerKey::Pool(pool),
+        };
+        assert!(try_admit_owner_group(&mut admission, owner, vec![coin, pc]));
+        ctx.note_explicit_momentum_pool_admitted(pool);
+        assert!(ctx.pool_has_explicit_momentum_admission(pool));
+
+        ctx.release_pool_consumer_group(&mut admission, pool, ExplicitConsumer::Momentum);
+        assert!(!ctx.pool_has_explicit_momentum_admission(pool));
+
+        ctx.hot_pool_registry.pin_pool(mint, pool);
+        MarketDataContext::register_geyser_reserves_after_trade(&ctx, pool);
+        let vs = ctx.tracked_vaults.read();
+        assert!(!vs.contains_key(&coin));
+        assert!(!vs.contains_key(&pc));
+    }
+
+    #[test]
+    fn converge_rebuild_clears_stale_explicit_momentum_pool() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let stale_pool = Pubkey::new_unique();
+        ctx.note_explicit_momentum_pool_admitted(stale_pool);
+        assert!(ctx.pool_has_explicit_momentum_admission(stale_pool));
+
+        let mut admission = FixedCapAdmission::new(100);
+        assert_eq!(
+            converge_admission_from_groups(&mut admission, &[]),
+            AdmissionConvergeResult::Converged
+        );
+        ctx.on_admission_converge_result(&admission, AdmissionConvergeResult::Converged);
+        assert!(!ctx.pool_has_explicit_momentum_admission(stale_pool));
+    }
+
+    #[test]
+    fn restore_explicit_admission_rebuilds_bypass_gate_pool_sets() {
+        use ironcrab::market_data::track::AdmissionRestoreResult;
+        use ironcrab::nats::{MomentumActivePinReason, MomentumActivePoolEntry};
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: mint,
+                token_1_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+
+        let mut snap_admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        ctx.apply_momentum_active_entries(
+            &mut snap_admission,
+            &[MomentumActivePoolEntry {
+                mint: mint.to_string(),
+                pool: pool.to_string(),
+                pin_reason: MomentumActivePinReason::Tracker,
+            }],
+        );
+        let snapshot = ctx.build_explicit_set_snapshot(&snap_admission);
+        assert!(ctx.pool_has_explicit_momentum_admission(pool));
+
+        let fresh = minimal_market_data_context_for_pr_d_tests(
+            QueuedJsonlWriter::spawn(
+                JsonlWriterConfig::new("market_events").with_log_dir(tmp.path()),
+                256,
+            )
+            .expect("jsonl2"),
+        );
+        assert!(!fresh.pool_has_explicit_momentum_admission(pool));
+
+        let mut admission = FixedCapAdmission::new(fresh.max_tracked_accounts());
+        let result = fresh.restore_explicit_admission_from_snapshot(&mut admission, &snapshot);
+        assert_eq!(result, AdmissionRestoreResult::Restored);
+        assert!(fresh.pool_has_explicit_momentum_admission(pool));
+        assert!(fresh.admit_geyser_explicit_pool_assets(
+            pool,
+            mint,
+            Pubkey::from_str(NATIVE_SOL_MINT).unwrap()
+        ));
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1016,6 +1016,10 @@ struct MarketDataContext {
 
     /// Momentum active hot pools (single writer: track-worker / md-state).
     hot_pool_registry: Arc<UnifiedHotPoolRegistry>,
+    /// PR4a: pools whose Momentum owner group passed `FixedCapAdmission` (bypass gate).
+    explicit_admitted_momentum_pools: parking_lot::RwLock<HashSet<Pubkey>>,
+    /// PR4a: pools whose Arb owner group passed `FixedCapAdmission` (bypass gate).
+    explicit_admitted_arb_pools: parking_lot::RwLock<HashSet<Pubkey>>,
 
     /// Known pump_amm pools (already seen first trade).
     /// We emit PoolCreated + DexPoolAccounts on FIRST trade, then just DexPoolAccounts on subsequent trades.
@@ -2554,14 +2558,39 @@ impl MarketDataContext {
         self.tracked_wallet_mint_decimals.read().contains_key(mint)
     }
 
-    /// PR-B: explicit vault/bin-array/mint Geyser filters — hot-set or wallet only.
+    fn pool_has_explicit_momentum_admission(&self, pool: Pubkey) -> bool {
+        self.explicit_admitted_momentum_pools.read().contains(&pool)
+    }
+
+    fn pool_has_explicit_arb_admission(&self, pool: Pubkey) -> bool {
+        self.explicit_admitted_arb_pools.read().contains(&pool)
+    }
+
+    fn note_explicit_momentum_pool_admitted(&self, pool: Pubkey) {
+        self.explicit_admitted_momentum_pools.write().insert(pool);
+    }
+
+    fn note_explicit_arb_pool_admitted(&self, pool: Pubkey) {
+        self.explicit_admitted_arb_pools.write().insert(pool);
+    }
+
+    fn clear_explicit_momentum_pool_admitted(&self, pool: Pubkey) {
+        self.explicit_admitted_momentum_pools.write().remove(&pool);
+    }
+
+    fn clear_explicit_arb_pool_admitted(&self, pool: Pubkey) {
+        self.explicit_admitted_arb_pools.write().remove(&pool);
+    }
+
+    /// PR-B: explicit vault/bin-array/mint Geyser filters — admitted pool groups or wallet only.
     fn admit_geyser_explicit_pool_assets(
         &self,
         pool: Pubkey,
         base_mint: Pubkey,
         quote_mint: Pubkey,
     ) -> bool {
-        self.hot_pool_registry.is_hot_pool(pool)
+        self.pool_has_explicit_momentum_admission(pool)
+            || self.pool_has_explicit_arb_admission(pool)
             || self.wallet_tracks_mint_for_geyser(&base_mint)
             || self.wallet_tracks_mint_for_geyser(&quote_mint)
     }
@@ -4489,8 +4518,9 @@ impl MarketDataContext {
                 warn!(pool = %a.pool, "MomentumActivePoolsUpdate.active: invalid pool");
                 continue;
             };
+            self.hot_pool_registry.pin_pool(mint_pk, pool_pk);
             if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Momentum) {
-                self.hot_pool_registry.pin_pool(mint_pk, pool_pk);
+                self.note_explicit_momentum_pool_admitted(pool_pk);
                 inc_market_data_momentum_admission_admitted_total();
                 if self.register_geyser_reserves_for_momentum_active_pool(pool_pk) {
                     batch_dirty = true;
@@ -4537,6 +4567,7 @@ impl MarketDataContext {
         // row remains after this unpin (PR #147 follow-up).
         if !self.hot_pool_registry.pool_has_any_pin(pool) {
             self.release_pool_consumer_group(admission, pool, ExplicitConsumer::Momentum);
+            self.clear_explicit_momentum_pool_admitted(pool);
             {
                 let mut vaults = self.tracked_vaults.write();
                 for v in vaults.values_mut() {
@@ -4672,8 +4703,9 @@ impl MarketDataContext {
                 warn!(pool = %a.pool, "ArbTrackRequestsUpdate.active: invalid pool");
                 continue;
             };
+            self.hot_pool_registry.pin_arb_pool(pool_pk);
             if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Arb) {
-                self.hot_pool_registry.pin_arb_pool(pool_pk);
+                self.note_explicit_arb_pool_admitted(pool_pk);
                 inc_market_data_arb_admission_admitted_total();
                 if self.register_geyser_reserves_for_arb_active_pool(pool_pk) {
                     batch_dirty = true;
@@ -4750,6 +4782,7 @@ impl MarketDataContext {
         pool: Pubkey,
     ) -> bool {
         self.release_pool_consumer_group(admission, pool, ExplicitConsumer::Arb);
+        self.clear_explicit_arb_pool_admitted(pool);
         self.hot_pool_registry.unpin_arb_pool(pool);
         let mut changed = false;
         if !self.hot_pool_registry.pool_has_arb(pool)
@@ -6883,6 +6916,8 @@ async fn main() -> Result<()> {
         tracked_mints: parking_lot::RwLock::new(std::collections::HashMap::new()),
         tracked_mints_tx,
         hot_pool_registry: Arc::new(UnifiedHotPoolRegistry::new()),
+        explicit_admitted_momentum_pools: parking_lot::RwLock::new(HashSet::new()),
+        explicit_admitted_arb_pools: parking_lot::RwLock::new(HashSet::new()),
         known_pump_amm_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
         known_trade_dex_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
         pumpfun_pool_discovery_mint_info_emitted: parking_lot::RwLock::new(
@@ -10507,6 +10542,8 @@ mod wallet_snapshot_stale_cleanup_tests {
             tracked_mints: parking_lot::RwLock::new(std::collections::HashMap::new()),
             tracked_mints_tx,
             hot_pool_registry: Arc::new(UnifiedHotPoolRegistry::new()),
+            explicit_admitted_momentum_pools: parking_lot::RwLock::new(HashSet::new()),
+            explicit_admitted_arb_pools: parking_lot::RwLock::new(HashSet::new()),
             known_pump_amm_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
             known_trade_dex_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
             pumpfun_pool_discovery_mint_info_emitted: parking_lot::RwLock::new(
@@ -10730,6 +10767,8 @@ mod wallet_tx_meta_balance_tests {
             tracked_mints: parking_lot::RwLock::new(std::collections::HashMap::new()),
             tracked_mints_tx,
             hot_pool_registry: Arc::new(UnifiedHotPoolRegistry::new()),
+            explicit_admitted_momentum_pools: parking_lot::RwLock::new(HashSet::new()),
+            explicit_admitted_arb_pools: parking_lot::RwLock::new(HashSet::new()),
             known_pump_amm_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
             known_trade_dex_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
             pumpfun_pool_discovery_mint_info_emitted: parking_lot::RwLock::new(
@@ -11610,6 +11649,8 @@ mod pr_b_geyser_tracking_tests {
             tracked_mints: parking_lot::RwLock::new(std::collections::HashMap::new()),
             tracked_mints_tx,
             hot_pool_registry: Arc::new(UnifiedHotPoolRegistry::new()),
+            explicit_admitted_momentum_pools: parking_lot::RwLock::new(HashSet::new()),
+            explicit_admitted_arb_pools: parking_lot::RwLock::new(HashSet::new()),
             known_pump_amm_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
             known_trade_dex_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
             pumpfun_pool_discovery_mint_info_emitted: parking_lot::RwLock::new(
@@ -11685,6 +11726,8 @@ mod pr_b_geyser_tracking_tests {
             tracked_mints: parking_lot::RwLock::new(std::collections::HashMap::new()),
             tracked_mints_tx,
             hot_pool_registry: Arc::new(UnifiedHotPoolRegistry::new()),
+            explicit_admitted_momentum_pools: parking_lot::RwLock::new(HashSet::new()),
+            explicit_admitted_arb_pools: parking_lot::RwLock::new(HashSet::new()),
             known_pump_amm_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
             known_trade_dex_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
             pumpfun_pool_discovery_mint_info_emitted: parking_lot::RwLock::new(
@@ -12473,6 +12516,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
 
+        ctx.hot_pool_registry.pin_pool(base_mint, pool);
         MarketDataContext::register_geyser_reserves_after_trade(&ctx, pool);
 
         let vs = ctx.tracked_vaults.read();
@@ -12505,6 +12549,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
         ctx.hot_pool_registry.pin_pool(base_mint, pool);
+        ctx.note_explicit_momentum_pool_admitted(pool);
 
         MarketDataContext::register_geyser_reserves_after_trade(&ctx, pool);
 
@@ -12561,6 +12606,8 @@ mod pr_b_geyser_tracking_tests {
         );
         ctx.hot_pool_registry.pin_pool(base_a, pool_a);
         ctx.hot_pool_registry.pin_pool(base_b, pool_b);
+        ctx.note_explicit_momentum_pool_admitted(pool_a);
+        ctx.note_explicit_momentum_pool_admitted(pool_b);
 
         let imm0 = MARKET_DATA_GEYSER_SYNC_IMMEDIATE_TOTAL.load(Ordering::Relaxed);
         let batch0 = MARKET_DATA_GEYSER_SYNC_BATCH_TOTAL.load(Ordering::Relaxed);
@@ -12617,6 +12664,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
         ctx.hot_pool_registry.pin_pool(base, pool);
+        ctx.note_explicit_momentum_pool_admitted(pool);
         assert!(MarketDataContext::register_geyser_reserves_after_trade(
             &ctx, pool
         ));
@@ -12664,6 +12712,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
         ctx.hot_pool_registry.pin_pool(base, pool);
+        ctx.note_explicit_momentum_pool_admitted(pool);
         assert!(MarketDataContext::register_geyser_reserves_after_trade(
             &ctx, pool
         ));
@@ -12709,6 +12758,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
         ctx.hot_pool_registry.pin_pool(base, pool);
+        ctx.note_explicit_momentum_pool_admitted(pool);
         let coin_vault = coin;
         assert!(MarketDataContext::register_geyser_reserves_after_trade(
             &ctx, pool
@@ -13118,6 +13168,7 @@ mod pr_b_geyser_tracking_tests {
             1,
         );
         ctx.hot_pool_registry.pin_pool(base_mint, pool);
+        ctx.note_explicit_momentum_pool_admitted(pool);
 
         let md_state = test_spawn_md_state(&ctx);
 
@@ -14849,7 +14900,8 @@ mod pr_b_geyser_tracking_tests {
         );
         assert_eq!(ctx.tracked_vaults.read().len(), vaults_before);
         assert_eq!(ctx.tracked_mints.read().len(), mints_before);
-        assert!(!ctx.hot_pool_registry.is_hot_pool(pool));
+        assert!(ctx.hot_pool_registry.is_hot_pool(pool));
+        assert!(!ctx.pool_has_explicit_momentum_admission(pool));
     }
 
     /// Phase 2c: trade handler must not reference arb reconcile enqueue helpers.

--- a/src/market_data/track/admission_wiring.rs
+++ b/src/market_data/track/admission_wiring.rs
@@ -99,6 +99,37 @@ fn owner_group_key(owner: &ExplicitOwner) -> (ExplicitConsumer, ExplicitOwnerKey
     (owner.consumer, owner.owner_key.clone())
 }
 
+/// Pool pubkey for pool-scoped owner groups (`ExplicitOwnerKey::Pool`).
+pub fn pool_pubkey_from_owner_group(group: &OwnerGroupSnapshot) -> Option<Pubkey> {
+    match group.owner_key {
+        ExplicitOwnerKey::Pool(pool) => Some(pool),
+        _ => None,
+    }
+}
+
+/// Derive bypass-gate pool sets from [`FixedCapAdmission`] owner groups (SSOT).
+pub fn explicit_admitted_pool_sets_from_admission(
+    admission: &FixedCapAdmission,
+) -> (HashSet<Pubkey>, HashSet<Pubkey>) {
+    let mut momentum = HashSet::new();
+    let mut arb = HashSet::new();
+    for group in admission.snapshot_owner_groups() {
+        let Some(pool) = pool_pubkey_from_owner_group(&group) else {
+            continue;
+        };
+        match group.consumer {
+            ExplicitConsumer::Momentum => {
+                momentum.insert(pool);
+            }
+            ExplicitConsumer::Arb => {
+                arb.insert(pool);
+            }
+            ExplicitConsumer::Wallet | ExplicitConsumer::Tracker => {}
+        }
+    }
+    (momentum, arb)
+}
+
 /// Admit or replace one immutable owner group (eviction when required).
 pub fn try_admit_owner_group(
     admission: &mut FixedCapAdmission,
@@ -453,5 +484,39 @@ mod tests {
             AdmissionConvergeResult::Converged
         );
         assert!(!admission.contains(&stale_pk));
+    }
+
+    #[test]
+    fn explicit_admitted_pool_sets_from_admission_maps_pool_owner_groups() {
+        let mut admission = FixedCapAdmission::new(100);
+        let mom_pool = Pubkey::new_unique();
+        let arb_pool = Pubkey::new_unique();
+        assert!(try_admit_owner_group(
+            &mut admission,
+            pool_owner(ExplicitConsumer::Momentum, mom_pool),
+            vec![Pubkey::new_unique()]
+        ));
+        assert!(try_admit_owner_group(
+            &mut admission,
+            pool_owner(ExplicitConsumer::Arb, arb_pool),
+            vec![Pubkey::new_unique()]
+        ));
+        let (momentum, arb) = explicit_admitted_pool_sets_from_admission(&admission);
+        assert_eq!(momentum, std::collections::HashSet::from([mom_pool]));
+        assert_eq!(arb, std::collections::HashSet::from([arb_pool]));
+    }
+
+    #[test]
+    fn explicit_admitted_pool_sets_omit_wallet_and_tracker_pool_groups() {
+        let mut admission = FixedCapAdmission::new(100);
+        let pool = Pubkey::new_unique();
+        assert!(try_admit_owner_group(
+            &mut admission,
+            pool_owner(ExplicitConsumer::Tracker, pool),
+            vec![Pubkey::new_unique()]
+        ));
+        let (momentum, arb) = explicit_admitted_pool_sets_from_admission(&admission);
+        assert!(momentum.is_empty());
+        assert!(arb.is_empty());
     }
 }

--- a/src/market_data/track/admission_wiring.rs
+++ b/src/market_data/track/admission_wiring.rs
@@ -99,7 +99,8 @@ fn owner_group_key(owner: &ExplicitOwner) -> (ExplicitConsumer, ExplicitOwnerKey
     (owner.consumer, owner.owner_key.clone())
 }
 
-fn admit_or_replace(
+/// Admit or replace one immutable owner group (eviction when required).
+pub fn try_admit_owner_group(
     admission: &mut FixedCapAdmission,
     owner: ExplicitOwner,
     pubkeys: Vec<Pubkey>,
@@ -179,7 +180,7 @@ pub fn converge_admission_from_groups(
     ordered.sort_by(|(a, _), (b, _)| a.cmp(b));
 
     for (owner, pubkeys) in ordered {
-        if !admit_or_replace(admission, owner, pubkeys) {
+        if !try_admit_owner_group(admission, owner, pubkeys) {
             if admission.wallet_demand_exceeds_cap(cap) {
                 return AdmissionConvergeResult::ProtectedOverflow;
             }
@@ -227,7 +228,7 @@ pub fn restore_admission_from_owner_groups(
             consumer: group.consumer,
             owner_key: group.owner_key.clone(),
         };
-        if !admit_or_replace(admission, owner, group.pubkeys.clone()) {
+        if !try_admit_owner_group(admission, owner, group.pubkeys.clone()) {
             if admission.wallet_demand_exceeds_cap(cap) {
                 return AdmissionRestoreResult::ProtectedOverflow;
             }
@@ -370,7 +371,7 @@ mod tests {
         assert!(!admission_exceeds_configured_cap(&admission, 10_000));
         assert!(admission_exceeds_configured_cap(&admission, 5_000));
         let owner = pool_owner(ExplicitConsumer::Momentum, Pubkey::new_unique());
-        assert!(admit_or_replace(
+        assert!(try_admit_owner_group(
             &mut admission,
             owner,
             vec![Pubkey::new_unique()]
@@ -418,7 +419,7 @@ mod tests {
         let tracker_pk = Pubkey::new_unique();
         let arb_pk = Pubkey::new_unique();
         let tracker_owner = pool_owner(ExplicitConsumer::Tracker, pool);
-        assert!(admit_or_replace(
+        assert!(try_admit_owner_group(
             &mut admission,
             tracker_owner.clone(),
             vec![tracker_pk]
@@ -441,7 +442,7 @@ mod tests {
         let mut admission = FixedCapAdmission::new(10);
         let stale_pool = Pubkey::new_unique();
         let stale_pk = Pubkey::new_unique();
-        assert!(admit_or_replace(
+        assert!(try_admit_owner_group(
             &mut admission,
             pool_owner(ExplicitConsumer::Momentum, stale_pool),
             vec![stale_pk]

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -14,9 +14,10 @@ pub mod worker_commands;
 
 pub use admission_wiring::{
     admission_exceeds_configured_cap, admitted_pubkey_set, apply_cap_shrink,
-    converge_admission_from_groups, merge_admission_tracker_owner_groups,
-    partition_admitted_pubkeys_for_geyser_channels, restore_admission_from_owner_groups,
-    rows_to_owner_groups, try_admit_owner_group, AdmissionConvergeResult, AdmissionRestoreResult,
+    converge_admission_from_groups, explicit_admitted_pool_sets_from_admission,
+    merge_admission_tracker_owner_groups, partition_admitted_pubkeys_for_geyser_channels,
+    pool_pubkey_from_owner_group, restore_admission_from_owner_groups, rows_to_owner_groups,
+    try_admit_owner_group, AdmissionConvergeResult, AdmissionRestoreResult,
 };
 pub use barrier::GeyserConnectBarrier;
 pub use coalesce::{

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -16,7 +16,7 @@ pub use admission_wiring::{
     admission_exceeds_configured_cap, admitted_pubkey_set, apply_cap_shrink,
     converge_admission_from_groups, merge_admission_tracker_owner_groups,
     partition_admitted_pubkeys_for_geyser_channels, restore_admission_from_owner_groups,
-    rows_to_owner_groups, AdmissionConvergeResult, AdmissionRestoreResult,
+    rows_to_owner_groups, try_admit_owner_group, AdmissionConvergeResult, AdmissionRestoreResult,
 };
 pub use barrier::GeyserConnectBarrier;
 pub use coalesce::{

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -47,14 +47,46 @@ pub const MARKET_DATA_ARB_APPLY_CHUNK_SIZE: usize = 16;
 pub trait TrackWorkerContext: Send + Sync {
     fn geyser_sync_batch_debounce_ms(&self) -> u64;
     fn max_tracked_accounts(&self) -> usize;
-    fn apply_momentum_active_pools_update(&self, update: &MomentumActivePoolsUpdate) -> bool;
-    fn apply_momentum_snapshot_reconcile(&self, active: &[MomentumActivePoolEntry]) -> bool;
-    fn apply_momentum_removed_entries(&self, chunk: &[MomentumRemovedPoolEntry]) -> bool;
-    fn apply_momentum_active_entries(&self, chunk: &[MomentumActivePoolEntry]) -> bool;
-    fn apply_arb_track_requests_update(&self, update: &ArbTrackRequestsUpdate) -> bool;
-    fn apply_arb_snapshot_reconcile(&self, active: &[ArbTrackActiveEntry]) -> bool;
-    fn apply_arb_removed_entries(&self, chunk: &[ArbTrackRemovedEntry]) -> bool;
-    fn apply_arb_active_entries(&self, chunk: &[ArbTrackActiveEntry]) -> bool;
+    fn apply_momentum_active_pools_update(
+        &self,
+        admission: &mut FixedCapAdmission,
+        update: &MomentumActivePoolsUpdate,
+    ) -> bool;
+    fn apply_momentum_snapshot_reconcile(
+        &self,
+        admission: &mut FixedCapAdmission,
+        active: &[MomentumActivePoolEntry],
+    ) -> bool;
+    fn apply_momentum_removed_entries(
+        &self,
+        admission: &mut FixedCapAdmission,
+        chunk: &[MomentumRemovedPoolEntry],
+    ) -> bool;
+    fn apply_momentum_active_entries(
+        &self,
+        admission: &mut FixedCapAdmission,
+        chunk: &[MomentumActivePoolEntry],
+    ) -> bool;
+    fn apply_arb_track_requests_update(
+        &self,
+        admission: &mut FixedCapAdmission,
+        update: &ArbTrackRequestsUpdate,
+    ) -> bool;
+    fn apply_arb_snapshot_reconcile(
+        &self,
+        admission: &mut FixedCapAdmission,
+        active: &[ArbTrackActiveEntry],
+    ) -> bool;
+    fn apply_arb_removed_entries(
+        &self,
+        admission: &mut FixedCapAdmission,
+        chunk: &[ArbTrackRemovedEntry],
+    ) -> bool;
+    fn apply_arb_active_entries(
+        &self,
+        admission: &mut FixedCapAdmission,
+        chunk: &[ArbTrackActiveEntry],
+    ) -> bool;
     fn track_mint_for_geyser_metadata(&self, mint: Pubkey, pin: Option<TrackPinReason>) -> bool;
     fn refresh_geyser_pins_gauge(&self);
     fn hot_pool_registry_pair_count(&self) -> usize;
@@ -163,24 +195,25 @@ fn track_worker_dec_queue_depth(
 /// Phase-2b: sync momentum apply on `md-track-worker` thread (no Tokio yield).
 pub fn apply_momentum_active_pools_on_track_worker<C: TrackWorkerContext>(
     ctx: &Arc<C>,
+    admission: &mut FixedCapAdmission,
     update: MomentumActivePoolsUpdate,
 ) -> bool {
     let item_count = update.active.len() + update.removed.len();
     if item_count <= MARKET_DATA_MOMENTUM_APPLY_CHUNK_THRESHOLD {
-        return ctx.apply_momentum_active_pools_update(&update);
+        return ctx.apply_momentum_active_pools_update(admission, &update);
     }
     record_market_data_momentum_active_pool_messages_total();
     let mut batch_dirty = false;
     if update.full_active_snapshot {
-        batch_dirty |= ctx.apply_momentum_snapshot_reconcile(&update.active);
+        batch_dirty |= ctx.apply_momentum_snapshot_reconcile(admission, &update.active);
         std::thread::yield_now();
     }
     for chunk in update.removed.chunks(MARKET_DATA_MOMENTUM_APPLY_CHUNK_SIZE) {
-        batch_dirty |= ctx.apply_momentum_removed_entries(chunk);
+        batch_dirty |= ctx.apply_momentum_removed_entries(admission, chunk);
         std::thread::yield_now();
     }
     for chunk in update.active.chunks(MARKET_DATA_MOMENTUM_APPLY_CHUNK_SIZE) {
-        batch_dirty |= ctx.apply_momentum_active_entries(chunk);
+        batch_dirty |= ctx.apply_momentum_active_entries(admission, chunk);
         std::thread::yield_now();
     }
     if !batch_dirty {
@@ -193,24 +226,25 @@ pub fn apply_momentum_active_pools_on_track_worker<C: TrackWorkerContext>(
 /// Phase 3: sync arb track apply on `md-track-worker` thread (no Tokio yield).
 pub fn apply_arb_track_requests_on_track_worker<C: TrackWorkerContext>(
     ctx: &Arc<C>,
+    admission: &mut FixedCapAdmission,
     update: ArbTrackRequestsUpdate,
 ) -> bool {
     let item_count = update.active.len() + update.removed.len();
     if item_count <= MARKET_DATA_ARB_APPLY_CHUNK_THRESHOLD {
-        return ctx.apply_arb_track_requests_update(&update);
+        return ctx.apply_arb_track_requests_update(admission, &update);
     }
     record_market_data_arb_track_requests_messages_total();
     let mut batch_dirty = false;
     if update.reconcile {
-        batch_dirty |= ctx.apply_arb_snapshot_reconcile(&update.active);
+        batch_dirty |= ctx.apply_arb_snapshot_reconcile(admission, &update.active);
         std::thread::yield_now();
     }
     for chunk in update.removed.chunks(MARKET_DATA_ARB_APPLY_CHUNK_SIZE) {
-        batch_dirty |= ctx.apply_arb_removed_entries(chunk);
+        batch_dirty |= ctx.apply_arb_removed_entries(admission, chunk);
         std::thread::yield_now();
     }
     for chunk in update.active.chunks(MARKET_DATA_ARB_APPLY_CHUNK_SIZE) {
-        batch_dirty |= ctx.apply_arb_active_entries(chunk);
+        batch_dirty |= ctx.apply_arb_active_entries(admission, chunk);
         std::thread::yield_now();
     }
     if !batch_dirty {
@@ -228,10 +262,10 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
 ) -> bool {
     match job {
         TrackWorkerCommand::ApplyMomentumActivePools(update) => {
-            apply_momentum_active_pools_on_track_worker(ctx, update)
+            apply_momentum_active_pools_on_track_worker(ctx, admission, update)
         }
         TrackWorkerCommand::ApplyArbTrackRequests(update) => {
-            apply_arb_track_requests_on_track_worker(ctx, update)
+            apply_arb_track_requests_on_track_worker(ctx, admission, update)
         }
         TrackWorkerCommand::ApplyWalletPin { mint } => {
             ctx.track_mint_for_geyser_metadata(mint, Some(TrackPinReason::Wallet))

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -970,6 +970,18 @@ pub static MARKET_DATA_MOMENTUM_TRACK_WORKER_ENQUEUE_DROPPED_TOTAL: Lazy<AtomicU
 /// Phase 3: arb track requests enqueue dropped on full track-worker queue.
 pub static MARKET_DATA_ARB_TRACK_WORKER_ENQUEUE_DROPPED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// PR4a: momentum pool groups admitted before tracked-map mutation.
+pub static MARKET_DATA_MOMENTUM_ADMISSION_ADMITTED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// PR4a: momentum pool groups rejected at admission (no tracked-map mutation).
+pub static MARKET_DATA_MOMENTUM_ADMISSION_REJECTED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// PR4a: arb pool groups admitted before tracked-map mutation.
+pub static MARKET_DATA_ARB_ADMISSION_ADMITTED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// PR4a: arb pool groups rejected at admission (no tracked-map mutation).
+pub static MARKET_DATA_ARB_ADMISSION_REJECTED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 /// Bounded track-worker protocol: pending slot depth (gauge).
 pub static MARKET_DATA_TRACK_PROTOCOL_PENDING_DEPTH: Lazy<AtomicU64> =
@@ -1234,6 +1246,26 @@ pub fn set_market_data_track_worker_queue_depth(depth: usize) {
 #[inline]
 pub fn inc_market_data_momentum_track_worker_enqueue_dropped_total() {
     MARKET_DATA_MOMENTUM_TRACK_WORKER_ENQUEUE_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_momentum_admission_admitted_total() {
+    MARKET_DATA_MOMENTUM_ADMISSION_ADMITTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_momentum_admission_rejected_total() {
+    MARKET_DATA_MOMENTUM_ADMISSION_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_arb_admission_admitted_total() {
+    MARKET_DATA_ARB_ADMISSION_ADMITTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_arb_admission_rejected_total() {
+    MARKET_DATA_ARB_ADMISSION_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -5910,6 +5942,22 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_momentum_track_worker_enqueue_dropped_total",
         MARKET_DATA_MOMENTUM_TRACK_WORKER_ENQUEUE_DROPPED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_momentum_admission_admitted_total",
+        MARKET_DATA_MOMENTUM_ADMISSION_ADMITTED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_momentum_admission_rejected_total",
+        MARKET_DATA_MOMENTUM_ADMISSION_REJECTED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_arb_admission_admitted_total",
+        MARKET_DATA_ARB_ADMISSION_ADMITTED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_arb_admission_rejected_total",
+        MARKET_DATA_ARB_ADMISSION_REJECTED_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_track_protocol_pending_depth",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR 4a: Momentum- und Arb-Track-Commands werden weiterhin bounded enqueued; der `md-track-worker` admittiert **komplette DEX-Account-Gruppen** via `FixedCapAdmission`, bevor `tracked_mints` / `tracked_vaults` / `tracked_bin_arrays` mutiert werden.

- **Admission-first**: `planned_explicit_pubkeys_for_pool_from_cache` plant Gruppen aus `LivePoolCache` (Vaults, DLMM-Bins, Mints); `try_admit_pool_consumer_group` ruft `try_admit_owner_group` auf.
- **Reject = keine Map-Mutation**: Bei Cap-Ablehnung bleiben `tracked_*` unverändert; Consumer-Demand landet weiter in `hot_pool_registry`.
- **Removal**: `release_pool_consumer_group` entfernt Owner-Gruppe aus Admission vor Map-Demotion.
- **Queue-full replay** (PR 2): unverändert — bounded pending protocol bleibt aktiv.
- **Metriken**: `market_data_momentum_admission_{admitted,rejected}_total`, `market_data_arb_admission_{admitted,rejected}_total`.

## STOP-CHECK (durchgeführt)

1. **I-7 Hot Path RPC**: Keine neuen RPC-Calls.
2. **Bestehendes Pattern**: `try_admit_owner_group` / `admit_or_replace` aus `admission_wiring` (wie Wallet/Converge-Pfad).
3. **Architektur-Grenzen**: Nur erlaubte Dateien im Track-Worker-Scope.
4. **I-9 Simulation-Gate**: Keine Trading-TX-Änderung.
5. **Level-5**: Keine Eval-Test-Lektüre.

## Tests

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (inkl. `pr4a_momentum_admission_reject_skips_tracked_map_mutation`)
- `cargo test --bin market-data` (159 passed)

## Scope

- PR 4b (Wallet/Tracker) und 4c (Legacy-Removal) bewusst ausgeschlossen.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3c83394-bca7-49bd-bd76-631013360950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3c83394-bca7-49bd-bd76-631013360950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

