### PR TITLE
fix(market-data): bounded wallet and tracker admission integration

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2765,11 +2765,19 @@ impl MarketDataContext {
     ) -> bool {
         match pin {
             None => {
-                if !try_admit_owner_group(admission, Self::tracker_mint_owner(mint), vec![mint]) {
-                    inc_market_data_tracker_admission_rejected_total();
-                    return false;
+                let skip_tracker_admit = self
+                    .tracked_mints
+                    .read()
+                    .get(&mint)
+                    .is_some_and(|info| info.pin.is_some());
+                if !skip_tracker_admit {
+                    if !try_admit_owner_group(admission, Self::tracker_mint_owner(mint), vec![mint])
+                    {
+                        inc_market_data_tracker_admission_rejected_total();
+                        return false;
+                    }
+                    inc_market_data_tracker_admission_admitted_total();
                 }
-                inc_market_data_tracker_admission_admitted_total();
                 self.track_mint_for_geyser_metadata(mint, None)
             }
             Some(TrackPinReason::Wallet) => self.apply_wallet_pin(admission, mint),

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -106,7 +106,11 @@ use ironcrab::metrics::{
     inc_market_data_md_state_evict_steps_budget_exhausted_total,
     inc_market_data_md_state_evict_steps_total, inc_market_data_momentum_admission_admitted_total,
     inc_market_data_momentum_admission_rejected_total,
-    inc_market_data_vault_high_priority_dispatch_total, market_data_bump_geyser_head_slot,
+    inc_market_data_tracker_admission_admitted_total,
+    inc_market_data_tracker_admission_rejected_total,
+    inc_market_data_vault_high_priority_dispatch_total,
+    inc_market_data_wallet_admission_admitted_total,
+    inc_market_data_wallet_admission_rejected_total, market_data_bump_geyser_head_slot,
     market_data_geyser_head_slot_value, market_data_geyser_tracking_enqueue_dropped_value,
     market_data_geyser_tracking_jobs_processed_value, market_data_md_state_bursts_completed_value,
     market_data_request_account_session_reconnect, market_data_request_tx_session_reconnect,
@@ -1909,7 +1913,8 @@ fn consumer_id_for_geyser_pin(pin: Option<GeyserPinReason>) -> ConsumerId {
     match pin {
         Some(GeyserPinReason::Wallet) => ConsumerId::Wallet,
         Some(GeyserPinReason::MomentumActive) => ConsumerId::Momentum,
-        Some(GeyserPinReason::ArbMultiDex) | None => ConsumerId::Arb,
+        Some(GeyserPinReason::ArbMultiDex) => ConsumerId::Arb,
+        None => ConsumerId::Tracker,
     }
 }
 
@@ -1994,8 +1999,21 @@ impl TrackWorkerContext for MarketDataContext {
         self.apply_arb_active_entries(admission, chunk)
     }
 
-    fn track_mint_for_geyser_metadata(&self, mint: Pubkey, pin: Option<TrackPinReason>) -> bool {
-        self.track_mint_for_geyser_metadata(mint, track_pin_to_geyser_pin(pin))
+    fn apply_wallet_pin(&self, admission: &mut FixedCapAdmission, mint: Pubkey) -> bool {
+        self.apply_wallet_pin(admission, mint)
+    }
+
+    fn withdraw_wallet_pin(&self, admission: &mut FixedCapAdmission, mint: Pubkey) -> bool {
+        self.withdraw_wallet_pin(admission, mint)
+    }
+
+    fn apply_track_mint(
+        &self,
+        admission: &mut FixedCapAdmission,
+        mint: Pubkey,
+        pin: Option<TrackPinReason>,
+    ) -> bool {
+        self.apply_track_mint(admission, mint, pin)
     }
 
     fn refresh_geyser_pins_gauge(&self) {
@@ -2651,6 +2669,113 @@ impl MarketDataContext {
             enable_meteora_cpmm,
             enable_meteora_dlmm,
         )
+    }
+
+    /// PR4b: wallet owner-group pubkeys for admission (accounts + wallet-pinned mints).
+    fn wallet_owner_group_pubkeys(&self, pending_mint: Option<Pubkey>) -> Vec<Pubkey> {
+        let mut set = self.wallet_explicit_demand_pubkeys();
+        for (pk, m) in self.tracked_mints.read().iter() {
+            if m.pin == Some(GeyserPinReason::Wallet) {
+                set.insert(*pk);
+            }
+        }
+        if let Some(mint) = pending_mint {
+            set.insert(mint);
+        }
+        let mut pubkeys: Vec<Pubkey> = set.into_iter().collect();
+        pubkeys.sort();
+        pubkeys
+    }
+
+    fn wallet_owner_group() -> ExplicitOwner {
+        ExplicitOwner {
+            consumer: ExplicitConsumer::Wallet,
+            owner_key: ExplicitOwnerKey::Wallet,
+        }
+    }
+
+    fn tracker_mint_owner(mint: Pubkey) -> ExplicitOwner {
+        ExplicitOwner {
+            consumer: ExplicitConsumer::Tracker,
+            owner_key: ExplicitOwnerKey::Mint(mint),
+        }
+    }
+
+    /// PR4b: admit wallet protected owner group before tracked-map mutation.
+    fn try_admit_wallet_owner_group(
+        &self,
+        admission: &mut FixedCapAdmission,
+        pending_mint: Option<Pubkey>,
+    ) -> bool {
+        let pubkeys = self.wallet_owner_group_pubkeys(pending_mint);
+        if pubkeys.is_empty() {
+            let _ = admission.remove_group(Self::wallet_owner_group());
+            return true;
+        }
+        if pubkeys.len() > admission.cap() {
+            return false;
+        }
+        try_admit_owner_group(admission, Self::wallet_owner_group(), pubkeys)
+    }
+
+    /// PR4b: wallet mint pin — admission gate then tracked-map mutation.
+    fn apply_wallet_pin(&self, admission: &mut FixedCapAdmission, mint: Pubkey) -> bool {
+        if !self.try_admit_wallet_owner_group(admission, Some(mint)) {
+            inc_market_data_wallet_admission_rejected_total();
+            return false;
+        }
+        inc_market_data_wallet_admission_admitted_total();
+        self.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::Wallet))
+    }
+
+    /// PR4b: explicit wallet-pin withdrawal — admission refresh then map removal.
+    fn withdraw_wallet_pin(&self, admission: &mut FixedCapAdmission, mint: Pubkey) -> bool {
+        let removed = {
+            let mut mints = self.tracked_mints.write();
+            if mints
+                .get(&mint)
+                .is_some_and(|info| info.pin == Some(GeyserPinReason::Wallet))
+            {
+                mints.remove(&mint);
+                true
+            } else {
+                false
+            }
+        };
+        if removed {
+            let _ = admission.remove_group(Self::tracker_mint_owner(mint));
+        }
+        if !self.try_admit_wallet_owner_group(admission, None) {
+            inc_market_data_wallet_admission_rejected_total();
+            return removed;
+        }
+        if removed {
+            inc_market_data_wallet_admission_admitted_total();
+        }
+        removed
+    }
+
+    /// PR4b: tracker (`pin == None`) or promoted pin mint apply with admission gate where required.
+    fn apply_track_mint(
+        &self,
+        admission: &mut FixedCapAdmission,
+        mint: Pubkey,
+        pin: Option<TrackPinReason>,
+    ) -> bool {
+        match pin {
+            None => {
+                if !try_admit_owner_group(admission, Self::tracker_mint_owner(mint), vec![mint]) {
+                    inc_market_data_tracker_admission_rejected_total();
+                    return false;
+                }
+                inc_market_data_tracker_admission_admitted_total();
+                self.track_mint_for_geyser_metadata(mint, None)
+            }
+            Some(TrackPinReason::Wallet) => self.apply_wallet_pin(admission, mint),
+            Some(other) => {
+                self.track_mint_for_geyser_metadata(mint, track_pin_to_geyser_pin(Some(other)))
+            }
+        }
     }
 
     /// PR4a: admit immutable pool owner group before tracked-map mutation.
@@ -11687,10 +11812,20 @@ mod pr_b_geyser_tracking_tests {
     fn minimal_market_data_context_for_pr_d_tests(
         jsonl_writer: QueuedJsonlWriter,
     ) -> Arc<MarketDataContext> {
+        minimal_market_data_context_for_pr_d_tests_with_wallet(jsonl_writer, None, &[])
+    }
+
+    fn minimal_market_data_context_for_pr_d_tests_with_wallet(
+        jsonl_writer: QueuedJsonlWriter,
+        tracked_wallet: Option<TrackedWallet>,
+        extra_wallet_token_accounts: &[Pubkey],
+    ) -> Arc<MarketDataContext> {
         let (tracked_mints_tx, _tracked_mints_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_bin_arrays_tx, _tracked_bin_arrays_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_wallet_tx, _tracked_wallet_rx) = watch::channel(Vec::<Pubkey>::new());
+        let mut wallet_token_accounts = std::collections::HashSet::new();
+        wallet_token_accounts.extend(extra_wallet_token_accounts.iter().copied());
         Arc::new(MarketDataContext {
             run_id: "run-prd-test".to_string(),
             config: parking_lot::RwLock::new(MarketDataConfig::default()),
@@ -11723,11 +11858,9 @@ mod pr_b_geyser_tracking_tests {
             pool_creator_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
             high_priority_bonding_curves: parking_lot::RwLock::new(HashSet::new()),
             raydium_serum_fetched: parking_lot::RwLock::new(std::collections::HashSet::new()),
-            tracked_wallet: None,
+            tracked_wallet,
             tracked_wallet_tx,
-            tracked_wallet_token_accounts: parking_lot::RwLock::new(
-                std::collections::HashSet::new(),
-            ),
+            tracked_wallet_token_accounts: parking_lot::RwLock::new(wallet_token_accounts),
             tracked_wallet_mint_decimals: parking_lot::RwLock::new(std::collections::HashMap::new()),
             execution_results_deduper: parking_lot::Mutex::new(ExecutionResultDeduper::default()),
             last_emitted_curve_progress: parking_lot::RwLock::new(std::collections::HashMap::new()),
@@ -15083,6 +15216,76 @@ mod pr_b_geyser_tracking_tests {
         assert_eq!(ctx.tracked_mints.read().len(), mints_before);
         assert!(ctx.hot_pool_registry.is_hot_pool(pool));
         assert!(!ctx.pool_has_explicit_momentum_admission(pool));
+    }
+
+    #[test]
+    fn pr4b_tracker_admission_reject_skips_tracked_map_mutation() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let mint = Pubkey::new_unique();
+        let mints_before = ctx.tracked_mints.read().len();
+        let mut admission = FixedCapAdmission::new(2);
+        let w1 = Pubkey::new_unique();
+        let w2 = Pubkey::new_unique();
+        assert!(try_admit_owner_group(
+            &mut admission,
+            ExplicitOwner {
+                consumer: ExplicitConsumer::Wallet,
+                owner_key: ExplicitOwnerKey::Wallet,
+            },
+            vec![w1, w2],
+        ));
+        assert!(!ctx.apply_track_mint(&mut admission, mint, None));
+        assert_eq!(ctx.tracked_mints.read().len(), mints_before);
+        assert!(!ctx.tracked_mints.read().contains_key(&mint));
+    }
+
+    #[test]
+    fn pr4b_wallet_admission_reject_skips_tracked_map_mutation() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let wallet = Pubkey::new_unique();
+        let tracked = TrackedWallet::new(wallet);
+        let extra_ata = Pubkey::new_unique();
+        let ctx = minimal_market_data_context_for_pr_d_tests_with_wallet(
+            jsonl,
+            Some(tracked),
+            &[extra_ata],
+        );
+        ctx.config.write().max_tracked_accounts = 2;
+
+        let mint = Pubkey::new_unique();
+        let mints_before = ctx.tracked_mints.read().len();
+        let mut admission = FixedCapAdmission::new(2);
+        assert!(!ctx.apply_wallet_pin(&mut admission, mint));
+        assert_eq!(ctx.tracked_mints.read().len(), mints_before);
+        assert!(!ctx.tracked_mints.read().contains_key(&mint));
+    }
+
+    #[test]
+    fn pr4b_withdraw_wallet_pin_demotes_mint_and_refreshes_admission() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let mint = Pubkey::new_unique();
+        let mut admission = FixedCapAdmission::new(25_000);
+        assert!(ctx.apply_wallet_pin(&mut admission, mint));
+        assert!(ctx.tracked_mints.read().contains_key(&mint));
+        assert!(admission.contains(&mint));
+        assert!(ctx.withdraw_wallet_pin(&mut admission, mint));
+        assert!(!ctx.tracked_mints.read().contains_key(&mint));
+        assert!(!admission.contains(&mint));
+    }
+
+    #[test]
+    fn pr4b_consumer_id_for_unpinned_mint_is_tracker() {
+        assert_eq!(consumer_id_for_geyser_pin(None), ConsumerId::Tracker);
     }
 
     /// Phase 2c: trade handler must not reference arb reconcile enqueue helpers.

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2742,7 +2742,7 @@ impl MarketDataContext {
             .get(&mint)
             .is_some_and(|info| info.pin == Some(GeyserPinReason::Wallet));
         if !should_remove {
-            return false;
+            return true;
         }
         if !self.try_admit_wallet_owner_group(admission, None, Some(mint)) {
             inc_market_data_wallet_admission_rejected_total();

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1918,11 +1918,12 @@ fn consumer_id_for_geyser_pin(pin: Option<GeyserPinReason>) -> ConsumerId {
     }
 }
 
-fn snapshot_consumer_to_geyser_pin(consumer: SnapshotConsumer) -> GeyserPinReason {
+fn snapshot_consumer_to_geyser_pin(consumer: SnapshotConsumer) -> Option<GeyserPinReason> {
     match consumer {
-        SnapshotConsumer::Wallet => GeyserPinReason::Wallet,
-        SnapshotConsumer::Momentum => GeyserPinReason::MomentumActive,
-        SnapshotConsumer::Arb | SnapshotConsumer::Tracker => GeyserPinReason::ArbMultiDex,
+        SnapshotConsumer::Wallet => Some(GeyserPinReason::Wallet),
+        SnapshotConsumer::Momentum => Some(GeyserPinReason::MomentumActive),
+        SnapshotConsumer::Arb => Some(GeyserPinReason::ArbMultiDex),
+        SnapshotConsumer::Tracker => None,
     }
 }
 
@@ -2909,7 +2910,7 @@ impl MarketDataContext {
             let pool = row.pool.as_deref().and_then(|s| Pubkey::from_str(s).ok());
             match row.kind {
                 ExplicitAccountKind::Mint => {
-                    let _ = self.track_mint_for_geyser_metadata(pk, Some(pin));
+                    let _ = self.track_mint_for_geyser_metadata(pk, pin);
                     if self.tracked_mints.read().contains_key(&pk) {
                         restored += 1;
                     }
@@ -2932,8 +2933,8 @@ impl MarketDataContext {
                                 is_base_vault: true,
                                 last_balance: std::sync::atomic::AtomicU64::new(0),
                                 last_used_at: now,
-                                pinned: true,
-                                pin: Some(pin),
+                                pinned: pin.is_some(),
+                                pin,
                                 active_id: None,
                                 bin_step: None,
                                 sibling_vault: None,
@@ -2947,9 +2948,11 @@ impl MarketDataContext {
                         Entry::Occupied(mut e) => {
                             let v = e.get_mut();
                             v.last_used_at = now;
-                            if Self::geyser_pin_may_promote(v.pin, pin) {
-                                v.pinned = true;
-                                v.pin = Some(pin);
+                            if let Some(target) = pin {
+                                if Self::geyser_pin_may_promote(v.pin, target) {
+                                    v.pinned = true;
+                                    v.pin = Some(target);
+                                }
                             }
                             restored += 1;
                         }
@@ -2966,8 +2969,8 @@ impl MarketDataContext {
                                 bin_array_index: 0,
                                 bin_step: 0,
                                 last_used_at: now,
-                                pinned: true,
-                                pin: Some(pin),
+                                pinned: pin.is_some(),
+                                pin,
                             });
                             drop(bins);
                             if pool_addr != Pubkey::default() {
@@ -2978,9 +2981,11 @@ impl MarketDataContext {
                         Entry::Occupied(mut e) => {
                             let b = e.get_mut();
                             b.last_used_at = now;
-                            if Self::geyser_pin_may_promote(b.pin, pin) {
-                                b.pinned = true;
-                                b.pin = Some(pin);
+                            if let Some(target) = pin {
+                                if Self::geyser_pin_may_promote(b.pin, target) {
+                                    b.pinned = true;
+                                    b.pin = Some(target);
+                                }
                             }
                             restored += 1;
                         }
@@ -15293,6 +15298,41 @@ mod pr_b_geyser_tracking_tests {
     #[test]
     fn pr4b_consumer_id_for_unpinned_mint_is_tracker() {
         assert_eq!(consumer_id_for_geyser_pin(None), ConsumerId::Tracker);
+    }
+
+    /// PR4b: tracker snapshot rows restore as unpinned mints, not arb-pinned.
+    #[test]
+    fn pr4b_tracker_snapshot_mint_restores_unpinned() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let mint = Pubkey::new_unique();
+        ctx.track_mint_for_geyser_metadata(mint, None);
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        converge_admission_from_ctx(ctx.as_ref(), &mut admission);
+        let snapshot = ctx.build_explicit_set_snapshot(&admission);
+        let row = snapshot
+            .rows
+            .iter()
+            .find(|r| r.pubkey == mint.to_string())
+            .expect("tracker mint row");
+        assert_eq!(row.consumer, SnapshotConsumer::Tracker);
+
+        let fresh = minimal_market_data_context_for_pr_d_tests(
+            QueuedJsonlWriter::spawn(
+                JsonlWriterConfig::new("market_events").with_log_dir(tmp.path()),
+                256,
+            )
+            .expect("jsonl2"),
+        );
+        let restored = fresh.apply_explicit_set_snapshot_impl(&snapshot);
+        assert!(restored > 0);
+        let tracked = fresh.tracked_mints.read();
+        let info = tracked.get(&mint).expect("restored tracker mint");
+        assert_eq!(info.pin, None);
+        assert!(!info.pinned);
     }
 
     /// Phase 2c: trade handler must not reference arb reconcile enqueue helpers.

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -338,6 +338,9 @@ mod eval_grep_md_state_command {
         TrackWalletMint {
             mint: Pubkey,
         },
+        WithdrawWalletMint {
+            mint: Pubkey,
+        },
         ScheduleGeyserSyncAfterConfigChange,
         FlushGeyserSyncDebounced,
         ContinueGeyserEvict,
@@ -9012,6 +9015,20 @@ async fn run_geyser_loop(
                                                 tracked_wallet.last_wsol_balance.store(0, Ordering::Relaxed);
                                             }
 
+                                            let should_withdraw_wallet_pin = ctx
+                                                .tracked_mints
+                                                .read()
+                                                .get(&mint)
+                                                .is_some_and(|info| {
+                                                    info.pin == Some(GeyserPinReason::Wallet)
+                                                });
+                                            if should_withdraw_wallet_pin {
+                                                md_state_try_enqueue(
+                                                    &md_state,
+                                                    MdStateCommand::WithdrawWalletMint { mint },
+                                                );
+                                            }
+
                                             let mut set = ctx.tracked_wallet_token_accounts.write();
                                             if set.remove(&ata) {
                                                 let mut accounts: Vec<Pubkey> = Vec::new();
@@ -15329,6 +15346,26 @@ mod pr_b_geyser_tracking_tests {
         let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
         assert!(ctx.apply_wallet_pin(&mut admission, mint));
         assert!(ctx.apply_wallet_pin(&mut admission, mint));
+    }
+
+    #[tokio::test]
+    async fn pr4b_withdraw_wallet_mint_actor_enqueues_protocol_withdraw() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let md_state = test_spawn_md_state(&ctx);
+
+        let mint = Pubkey::new_unique();
+        assert!(ctx.apply_wallet_pin(
+            &mut FixedCapAdmission::new(ctx.max_tracked_accounts()),
+            mint
+        ));
+
+        md_state_try_enqueue(&md_state, MdStateCommand::WithdrawWalletMint { mint });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert!(!ctx.tracked_mints.read().contains_key(&mint));
     }
 
     /// PR4b: tracker snapshot rows restore as unpinned mints, not arb-pinned.

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2732,7 +2732,9 @@ impl MarketDataContext {
         }
         let _ = admission.remove_group(Self::tracker_mint_owner(mint));
         inc_market_data_wallet_admission_admitted_total();
-        self.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::Wallet))
+        let _ = self.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::Wallet));
+        // Idempotent wallet pin / LRU refresh must not fail protocol replay (I-MD-5).
+        true
     }
 
     /// PR4b: explicit wallet-pin withdrawal — admission refresh then map removal.
@@ -2777,7 +2779,9 @@ impl MarketDataContext {
                     }
                     inc_market_data_tracker_admission_admitted_total();
                 }
-                self.track_mint_for_geyser_metadata(mint, None)
+                let _ = self.track_mint_for_geyser_metadata(mint, None);
+                // Unpinned tracker LRU refresh / already-tracked mint is idempotent success.
+                true
             }
             Some(TrackPinReason::Wallet) => self.apply_wallet_pin(admission, mint),
             Some(other) => {
@@ -15298,6 +15302,33 @@ mod pr_b_geyser_tracking_tests {
     #[test]
     fn pr4b_consumer_id_for_unpinned_mint_is_tracker() {
         assert_eq!(consumer_id_for_geyser_pin(None), ConsumerId::Tracker);
+    }
+
+    #[test]
+    fn pr4b_repeated_track_mint_unpinned_is_idempotent_success() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let mint = Pubkey::new_unique();
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        assert!(ctx.apply_track_mint(&mut admission, mint, None));
+        assert!(ctx.tracked_mints.read().contains_key(&mint));
+        assert!(ctx.apply_track_mint(&mut admission, mint, None));
+    }
+
+    #[test]
+    fn pr4b_repeated_wallet_pin_is_idempotent_success() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let mint = Pubkey::new_unique();
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        assert!(ctx.apply_wallet_pin(&mut admission, mint));
+        assert!(ctx.apply_wallet_pin(&mut admission, mint));
     }
 
     /// PR4b: tracker snapshot rows restore as unpinned mints, not arb-pinned.

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2724,6 +2724,7 @@ impl MarketDataContext {
             inc_market_data_wallet_admission_rejected_total();
             return false;
         }
+        let _ = admission.remove_group(Self::tracker_mint_owner(mint));
         inc_market_data_wallet_admission_admitted_total();
         self.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::Wallet))
     }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -56,8 +56,8 @@ use ironcrab::market_data::jsonl::{
     spawn_market_data_jsonl_writer, write_market_event_jsonl, JsonlHost,
 };
 use ironcrab::market_data::md_state::{
-    md_state_try_enqueue, spawn_md_state_worker, MdStateCommand, MdStateContext, MdStateSender,
-    MARKET_DATA_GEYSER_TRACKING_QUEUE_CAP,
+    md_state_try_enqueue, md_state_try_enqueue_withdraw_wallet_mint, spawn_md_state_worker,
+    MdStateCommand, MdStateContext, MdStateSender, MARKET_DATA_GEYSER_TRACKING_QUEUE_CAP,
 };
 use ironcrab::market_data::publish::{
     account_path_enqueue_core_market_event as publish_enqueue_core_market_event,
@@ -5877,6 +5877,14 @@ fn execution_result_sell_closes_wallet_position(exec: &ExecutionResult) -> bool 
     )
 }
 
+/// PR4b: keep wallet ATA tracked until wallet-pin withdraw is successfully enqueued.
+fn wallet_sell_close_should_untrack_ata(
+    should_withdraw_wallet_pin: bool,
+    withdraw_enqueued: bool,
+) -> bool {
+    !should_withdraw_wallet_pin || withdraw_enqueued
+}
+
 /// Mixed-deploy / foreign producers may omit Scope 48 fields. Preserve legacy behavior: assume
 /// full close so zero snapshot + untrack still runs for old sell-all tooling, etc.
 /// **Never** backfill `execution-engine` results — that process must emit explicit metadata.
@@ -9022,28 +9030,42 @@ async fn run_geyser_loop(
                                                 .is_some_and(|info| {
                                                     info.pin == Some(GeyserPinReason::Wallet)
                                                 });
-                                            if should_withdraw_wallet_pin {
-                                                md_state_try_enqueue(
-                                                    &md_state,
-                                                    MdStateCommand::WithdrawWalletMint { mint },
+                                            let withdraw_enqueued = if should_withdraw_wallet_pin {
+                                                md_state_try_enqueue_withdraw_wallet_mint(
+                                                    &md_state, mint,
+                                                )
+                                            } else {
+                                                true
+                                            };
+                                            if should_withdraw_wallet_pin && !withdraw_enqueued {
+                                                warn!(
+                                                    mint = %mint_str,
+                                                    ata = %ata,
+                                                    "WithdrawWalletMint enqueue dropped after retries; keeping ATA tracked until withdraw succeeds"
                                                 );
                                             }
 
-                                            let mut set = ctx.tracked_wallet_token_accounts.write();
-                                            if set.remove(&ata) {
-                                                let mut accounts: Vec<Pubkey> = Vec::new();
-                                                accounts.push(tracked_wallet.wallet);
-                                                accounts.push(tracked_wallet.wsol_ata);
-                                                accounts.extend(set.iter().copied());
-                                                accounts.sort();
-                                                accounts.dedup();
-                                                let _ = ctx.tracked_wallet_tx.send(accounts);
-                                                info!(
-                                                    mint = %mint_str,
-                                                    ata = %ata,
-                                                    remaining_tracked = set.len(),
-                                                    "Untracked ATA after confirmed SELL"
-                                                );
+                                            if wallet_sell_close_should_untrack_ata(
+                                                should_withdraw_wallet_pin,
+                                                withdraw_enqueued,
+                                            ) {
+                                                let mut set =
+                                                    ctx.tracked_wallet_token_accounts.write();
+                                                if set.remove(&ata) {
+                                                    let mut accounts: Vec<Pubkey> = Vec::new();
+                                                    accounts.push(tracked_wallet.wallet);
+                                                    accounts.push(tracked_wallet.wsol_ata);
+                                                    accounts.extend(set.iter().copied());
+                                                    accounts.sort();
+                                                    accounts.dedup();
+                                                    let _ = ctx.tracked_wallet_tx.send(accounts);
+                                                    info!(
+                                                        mint = %mint_str,
+                                                        ata = %ata,
+                                                        remaining_tracked = set.len(),
+                                                        "Untracked ATA after confirmed SELL"
+                                                    );
+                                                }
                                             }
                                         } else if is_confirmed_sell {
                                             info!(
@@ -15346,6 +15368,23 @@ mod pr_b_geyser_tracking_tests {
         let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
         assert!(ctx.apply_wallet_pin(&mut admission, mint));
         assert!(ctx.apply_wallet_pin(&mut admission, mint));
+    }
+
+    #[test]
+    fn pr4b_sell_close_skips_ata_untrack_when_withdraw_enqueue_drops() {
+        assert!(!wallet_sell_close_should_untrack_ata(true, false));
+        assert!(wallet_sell_close_should_untrack_ata(true, true));
+        assert!(wallet_sell_close_should_untrack_ata(false, false));
+    }
+
+    #[test]
+    fn pr4b_withdraw_wallet_mint_enqueue_fails_when_md_state_queue_saturated() {
+        let (md_state, _, _) = test_md_state_sender_no_worker();
+        fill_md_state_queue(&md_state);
+        assert!(!md_state_try_enqueue_withdraw_wallet_mint(
+            &md_state,
+            Pubkey::new_unique()
+        ));
     }
 
     #[tokio::test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2672,10 +2672,14 @@ impl MarketDataContext {
     }
 
     /// PR4b: wallet owner-group pubkeys for admission (accounts + wallet-pinned mints).
-    fn wallet_owner_group_pubkeys(&self, pending_mint: Option<Pubkey>) -> Vec<Pubkey> {
+    fn wallet_owner_group_pubkeys(
+        &self,
+        pending_mint: Option<Pubkey>,
+        exclude_mint: Option<Pubkey>,
+    ) -> Vec<Pubkey> {
         let mut set = self.wallet_explicit_demand_pubkeys();
         for (pk, m) in self.tracked_mints.read().iter() {
-            if m.pin == Some(GeyserPinReason::Wallet) {
+            if m.pin == Some(GeyserPinReason::Wallet) && exclude_mint != Some(*pk) {
                 set.insert(*pk);
             }
         }
@@ -2706,8 +2710,9 @@ impl MarketDataContext {
         &self,
         admission: &mut FixedCapAdmission,
         pending_mint: Option<Pubkey>,
+        exclude_mint: Option<Pubkey>,
     ) -> bool {
-        let pubkeys = self.wallet_owner_group_pubkeys(pending_mint);
+        let pubkeys = self.wallet_owner_group_pubkeys(pending_mint, exclude_mint);
         if pubkeys.is_empty() {
             let _ = admission.remove_group(Self::wallet_owner_group());
             return true;
@@ -2720,7 +2725,7 @@ impl MarketDataContext {
 
     /// PR4b: wallet mint pin — admission gate then tracked-map mutation.
     fn apply_wallet_pin(&self, admission: &mut FixedCapAdmission, mint: Pubkey) -> bool {
-        if !self.try_admit_wallet_owner_group(admission, Some(mint)) {
+        if !self.try_admit_wallet_owner_group(admission, Some(mint), None) {
             inc_market_data_wallet_admission_rejected_total();
             return false;
         }
@@ -2731,29 +2736,22 @@ impl MarketDataContext {
 
     /// PR4b: explicit wallet-pin withdrawal — admission refresh then map removal.
     fn withdraw_wallet_pin(&self, admission: &mut FixedCapAdmission, mint: Pubkey) -> bool {
-        let removed = {
-            let mut mints = self.tracked_mints.write();
-            if mints
-                .get(&mint)
-                .is_some_and(|info| info.pin == Some(GeyserPinReason::Wallet))
-            {
-                mints.remove(&mint);
-                true
-            } else {
-                false
-            }
-        };
-        if removed {
-            let _ = admission.remove_group(Self::tracker_mint_owner(mint));
+        let should_remove = self
+            .tracked_mints
+            .read()
+            .get(&mint)
+            .is_some_and(|info| info.pin == Some(GeyserPinReason::Wallet));
+        if !should_remove {
+            return false;
         }
-        if !self.try_admit_wallet_owner_group(admission, None) {
+        if !self.try_admit_wallet_owner_group(admission, None, Some(mint)) {
             inc_market_data_wallet_admission_rejected_total();
-            return removed;
+            return false;
         }
-        if removed {
-            inc_market_data_wallet_admission_admitted_total();
-        }
-        removed
+        let _ = admission.remove_group(Self::tracker_mint_owner(mint));
+        self.tracked_mints.write().remove(&mint);
+        inc_market_data_wallet_admission_admitted_total();
+        true
     }
 
     /// PR4b: tracker (`pin == None`) or promoted pin mint apply with admission gate where required.

--- a/src/market_data/md_state/command.rs
+++ b/src/market_data/md_state/command.rs
@@ -11,6 +11,8 @@ pub enum MdStateCommand {
     },
     /// PR169b: wallet bootstrap / execution-results mint pin (no immediate sync).
     TrackWalletMint { mint: Pubkey },
+    /// PR4b: wallet position close — withdraw wallet pin before map demotion.
+    WithdrawWalletMint { mint: Pubkey },
     /// PR169b: `max_tracked_accounts` cap change — debounced flush/eviction only.
     ScheduleGeyserSyncAfterConfigChange,
     /// PR233: debounced explicit Geyser sync flush — executed only on `md-state` thread.

--- a/src/market_data/md_state/mod.rs
+++ b/src/market_data/md_state/mod.rs
@@ -5,7 +5,9 @@ pub mod worker;
 pub use command::MdStateCommand;
 pub use host::MdStateContext;
 pub use worker::{
-    md_state_coalesce_jobs, md_state_process_job, md_state_try_enqueue, spawn_md_state_worker,
-    MdStateSender, MARKET_DATA_GEYSER_TRACKING_QUEUE_CAP, MARKET_DATA_MD_STATE_BURST_MAX,
-    MARKET_DATA_MD_STATE_JOB_BUDGET_MS, MARKET_DATA_MD_STATE_MIN_JOBS_PER_BURST,
+    md_state_coalesce_jobs, md_state_process_job, md_state_try_enqueue,
+    md_state_try_enqueue_withdraw_wallet_mint, spawn_md_state_worker, MdStateSender,
+    MARKET_DATA_GEYSER_TRACKING_QUEUE_CAP, MARKET_DATA_MD_STATE_BURST_MAX,
+    MARKET_DATA_MD_STATE_CRITICAL_ENQUEUE_ATTEMPTS, MARKET_DATA_MD_STATE_JOB_BUDGET_MS,
+    MARKET_DATA_MD_STATE_MIN_JOBS_PER_BURST,
 };

--- a/src/market_data/md_state/worker.rs
+++ b/src/market_data/md_state/worker.rs
@@ -14,6 +14,7 @@ use crate::metrics::{
     set_market_data_md_state_burst_in_progress, set_market_data_md_state_deferred_jobs_len,
     set_market_data_md_state_queue_depth,
 };
+use solana_sdk::pubkey::Pubkey;
 use std::collections::{HashSet, VecDeque};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc as std_mpsc;
@@ -29,6 +30,8 @@ pub const MARKET_DATA_MD_STATE_BURST_MAX: usize = 256;
 pub const MARKET_DATA_MD_STATE_JOB_BUDGET_MS: u64 = 16;
 /// PR235: minimum jobs completed per burst before time-budget defer (avoids re-defer loops).
 pub const MARKET_DATA_MD_STATE_MIN_JOBS_PER_BURST: usize = 32;
+/// Bounded retries for critical md-state enqueues that must not be silently dropped (PR4b).
+pub const MARKET_DATA_MD_STATE_CRITICAL_ENQUEUE_ATTEMPTS: usize = 32;
 
 /// Bounded enqueue handle for the `md-state` OS thread (non-Tokio).
 #[derive(Clone)]
@@ -171,6 +174,19 @@ pub fn md_state_try_enqueue(sender: &MdStateSender, job: MdStateCommand) -> bool
         inc_market_data_geyser_tracking_enqueue_dropped_total();
         false
     }
+}
+
+/// PR4b: enqueue wallet-pin withdraw with bounded yield-retry (I-MD-8 demand must not be lost).
+pub fn md_state_try_enqueue_withdraw_wallet_mint(sender: &MdStateSender, mint: Pubkey) -> bool {
+    for attempt in 0..MARKET_DATA_MD_STATE_CRITICAL_ENQUEUE_ATTEMPTS {
+        if md_state_try_enqueue(sender, MdStateCommand::WithdrawWalletMint { mint }) {
+            return true;
+        }
+        if attempt + 1 < MARKET_DATA_MD_STATE_CRITICAL_ENQUEUE_ATTEMPTS {
+            std::thread::yield_now();
+        }
+    }
+    false
 }
 
 fn md_state_worker_loop<C: MdStateContext + 'static>(

--- a/src/market_data/md_state/worker.rs
+++ b/src/market_data/md_state/worker.rs
@@ -111,6 +111,10 @@ pub fn md_state_process_job<C: MdStateContext>(
             track_worker_try_enqueue(track_worker, TrackWorkerCommand::ApplyWalletPin { mint });
             false
         }
+        MdStateCommand::WithdrawWalletMint { mint } => {
+            track_worker_try_enqueue(track_worker, TrackWorkerCommand::WithdrawWalletPin { mint });
+            false
+        }
         MdStateCommand::ScheduleGeyserSyncAfterConfigChange => {
             track_worker_try_enqueue(
                 track_worker,

--- a/src/market_data/track/admission_wiring.rs
+++ b/src/market_data/track/admission_wiring.rs
@@ -32,6 +32,7 @@ pub fn consumer_id_to_explicit(consumer: ConsumerId) -> ExplicitConsumer {
         ConsumerId::Wallet => ExplicitConsumer::Wallet,
         ConsumerId::Momentum => ExplicitConsumer::Momentum,
         ConsumerId::Arb => ExplicitConsumer::Arb,
+        ConsumerId::Tracker => ExplicitConsumer::Tracker,
     }
 }
 
@@ -69,8 +70,8 @@ pub fn rows_to_owner_groups(
         .collect()
 }
 
-/// Until PR 4b emits live Tracker demand via ctx rows, preserve Tracker-labelled owner
-/// groups already in admission (e.g. cold restore) as authoritative demand during converge.
+/// Preserve Tracker-labelled owner groups already in admission (e.g. cold restore) when ctx
+/// rows omit them transiently during converge.
 pub fn merge_admission_tracker_owner_groups(
     admission: &FixedCapAdmission,
     authoritative: &mut Vec<(ExplicitOwner, Vec<Pubkey>)>,

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -9,6 +9,8 @@ pub enum ConsumerId {
     Wallet,
     Momentum,
     Arb,
+    /// Unpinned mint / recent-trade LRU demand (I-MD-5: lowest protection).
+    Tracker,
 }
 
 /// Pin priority for cap eviction — lower ordinal = higher protection (Plan §3.4).
@@ -192,6 +194,7 @@ pub fn pin_priority_from_consumer(consumer: ConsumerId) -> PinPriority {
         ConsumerId::Wallet => PinPriority::Wallet,
         ConsumerId::Momentum => PinPriority::Momentum,
         ConsumerId::Arb => PinPriority::Arb,
+        ConsumerId::Tracker => PinPriority::Tracker,
     }
 }
 

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -99,7 +99,7 @@ impl BoundedProtocolStore {
         set_market_data_track_protocol_pending_depth(self.pending.len());
     }
 
-    /// Stage command in bounded pending when the worker queue is full (I-MD-5).
+    /// Stage command for later replay (queue full or transient wallet/tracker admission reject).
     pub fn stage_on_queue_full(&mut self, cmd: ImmutableTrackCommand) -> StageResult {
         inc_market_data_track_protocol_replay_triggers_total();
         if self.pending.len() < self.pending_cap {

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -1,8 +1,8 @@
 //! Bounded pending / inflight / revision store for track-worker queue-full replay.
 
 use super::worker_commands::{
-    stream_for_command, ImmutableTrackCommand, RevisionAssigner, TrackCommandStream,
-    TrackWorkerCommand,
+    demand_mint_for_command, stream_for_command, stream_uses_per_mint_revision,
+    ImmutableTrackCommand, RevisionAssigner, TrackCommandStream, TrackWorkerCommand,
 };
 use crate::metrics::{
     inc_market_data_track_protocol_pending_evicted_total,
@@ -10,6 +10,8 @@ use crate::metrics::{
     inc_market_data_track_protocol_superseded_revisions_total,
     set_market_data_track_protocol_inflight_depth, set_market_data_track_protocol_pending_depth,
 };
+use solana_sdk::pubkey::Pubkey;
+use std::collections::HashMap;
 
 /// Bounded cap for pending slots when the worker queue is full (I-MD-5).
 pub const MARKET_DATA_TRACK_PENDING_CAP: usize = 512;
@@ -25,7 +27,7 @@ pub enum StageResult {
     Lost,
 }
 
-/// Bounded store: pending slots, inflight accounting, last-applied revision per stream.
+/// Bounded store: pending slots, inflight accounting, last-applied revision per stream/mint.
 #[derive(Debug)]
 pub struct BoundedProtocolStore {
     pending: Vec<ImmutableTrackCommand>,
@@ -35,6 +37,8 @@ pub struct BoundedProtocolStore {
     inflight_cap: usize,
     revision: RevisionAssigner,
     last_applied: [u64; TrackCommandStream::COUNT],
+    last_applied_wallet_mint: HashMap<Pubkey, u64>,
+    last_applied_tracker_mint: HashMap<Pubkey, u64>,
 }
 
 impl BoundedProtocolStore {
@@ -46,6 +50,8 @@ impl BoundedProtocolStore {
             inflight_cap,
             revision: RevisionAssigner::default(),
             last_applied: [0; TrackCommandStream::COUNT],
+            last_applied_wallet_mint: HashMap::new(),
+            last_applied_tracker_mint: HashMap::new(),
         }
     }
 
@@ -66,19 +72,61 @@ impl BoundedProtocolStore {
         self.inflight
     }
 
-    /// Wrap a legacy command with the next monotone revision for its stream.
+    /// Wrap a legacy command with the next monotone revision for its stream (per-mint for wallet/tracker).
     pub fn wrap_command(&mut self, payload: TrackWorkerCommand) -> ImmutableTrackCommand {
         let stream = stream_for_command(&payload);
-        let revision = self.revision.next_revision(stream);
+        let demand_mint = demand_mint_for_command(&payload);
+        let revision = self.revision.next_revision(stream, demand_mint);
         ImmutableTrackCommand::new(stream, revision, payload)
     }
 
-    /// True when `revision` is strictly newer than the last applied revision for `stream`.
-    pub fn is_applicable(&self, stream: TrackCommandStream, revision: u64) -> bool {
+    fn last_applied_for_cmd(&self, cmd: &ImmutableTrackCommand) -> u64 {
+        if stream_uses_per_mint_revision(cmd.stream) {
+            let mint = demand_mint_for_command(&cmd.payload)
+                .expect("wallet/tracker command requires demand mint");
+            let map = match cmd.stream {
+                TrackCommandStream::Wallet => &self.last_applied_wallet_mint,
+                TrackCommandStream::Tracker => &self.last_applied_tracker_mint,
+                _ => unreachable!(),
+            };
+            *map.get(&mint).unwrap_or(&0)
+        } else {
+            self.last_applied[cmd.stream.index()]
+        }
+    }
+
+    /// True when `cmd.revision` is strictly newer than the last applied revision for its demand key.
+    pub fn is_applicable(&self, cmd: &ImmutableTrackCommand) -> bool {
+        cmd.revision > self.last_applied_for_cmd(cmd)
+    }
+
+    pub fn mark_applied(&mut self, cmd: &ImmutableTrackCommand) {
+        if stream_uses_per_mint_revision(cmd.stream) {
+            let mint = demand_mint_for_command(&cmd.payload)
+                .expect("wallet/tracker command requires demand mint");
+            let map = match cmd.stream {
+                TrackCommandStream::Wallet => &mut self.last_applied_wallet_mint,
+                TrackCommandStream::Tracker => &mut self.last_applied_tracker_mint,
+                _ => unreachable!(),
+            };
+            let entry = map.entry(mint).or_insert(0);
+            if cmd.revision > *entry {
+                *entry = cmd.revision;
+            }
+            return;
+        }
+        let idx = cmd.stream.index();
+        if cmd.revision > self.last_applied[idx] {
+            self.last_applied[idx] = cmd.revision;
+        }
+    }
+
+    /// Backward-compatible helper for global-stream tests.
+    pub fn is_applicable_stream(&self, stream: TrackCommandStream, revision: u64) -> bool {
         revision > self.last_applied[stream.index()]
     }
 
-    pub fn mark_applied(&mut self, stream: TrackCommandStream, revision: u64) {
+    pub fn mark_applied_stream(&mut self, stream: TrackCommandStream, revision: u64) {
         let idx = stream.index();
         if revision > self.last_applied[idx] {
             self.last_applied[idx] = revision;
@@ -138,7 +186,7 @@ impl BoundedProtocolStore {
                 .collect();
             stream_cmds.sort_by_key(|cmd| cmd.revision);
             for cmd in stream_cmds {
-                if self.is_applicable(cmd.stream, cmd.revision) {
+                if self.is_applicable(&cmd) {
                     applicable.push(cmd);
                 } else {
                     inc_market_data_track_protocol_superseded_revisions_total();
@@ -184,7 +232,7 @@ mod tests {
         store.stage_on_queue_full(c2.clone());
         let mut applied = Vec::new();
         for cmd in store.take_applicable_pending_sorted() {
-            store.mark_applied(cmd.stream, cmd.revision);
+            store.mark_applied(&cmd);
             applied.push(cmd.revision);
         }
         assert_eq!(applied, vec![1, 2]);
@@ -196,13 +244,13 @@ mod tests {
         let mut store = BoundedProtocolStore::new(8, 64);
         let c1 = store.wrap_command(momentum_cmd(1));
         let c2 = store.wrap_command(momentum_cmd(2));
-        store.mark_applied(TrackCommandStream::Momentum, 2);
+        store.mark_applied_stream(TrackCommandStream::Momentum, 2);
         store.stage_on_queue_full(c1);
         store.stage_on_queue_full(c2);
         let mut applied = Vec::new();
         for cmd in store.take_applicable_pending_sorted() {
-            if store.is_applicable(cmd.stream, cmd.revision) {
-                store.mark_applied(cmd.stream, cmd.revision);
+            if store.is_applicable(&cmd) {
+                store.mark_applied(&cmd);
                 applied.push(cmd.revision);
             }
         }
@@ -221,7 +269,7 @@ mod tests {
         store.stage_on_queue_full(c2);
         let mut applied = Vec::new();
         for cmd in store.take_applicable_pending_sorted() {
-            store.mark_applied(cmd.stream, cmd.revision);
+            store.mark_applied(&cmd);
             applied.push(cmd.revision);
         }
         assert_eq!(applied, vec![1, 2, 3]);
@@ -259,12 +307,33 @@ mod tests {
         let pin_old = store.wrap_command(TrackWorkerCommand::ApplyWalletPin { mint });
         store.stage_on_queue_full(pin_old.clone());
         let withdraw = store.wrap_command(TrackWorkerCommand::WithdrawWalletPin { mint });
-        store.mark_applied(withdraw.stream, withdraw.revision);
-        assert!(!store.is_applicable(pin_old.stream, pin_old.revision));
+        store.mark_applied(&withdraw);
+        assert!(!store.is_applicable(&pin_old));
         let applicable = store.take_applicable_pending_sorted();
         assert!(
             applicable.is_empty(),
             "stale wallet pin must not replay after newer withdraw advances watermark"
+        );
+    }
+
+    #[test]
+    fn wallet_later_mint_does_not_supersede_pending_pin_for_other_mint() {
+        let mut store = BoundedProtocolStore::new(8, 64);
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::new_unique();
+        let pin_a = store.wrap_command(TrackWorkerCommand::ApplyWalletPin { mint: mint_a });
+        store.stage_on_queue_full(pin_a.clone());
+        let pin_b = store.wrap_command(TrackWorkerCommand::ApplyWalletPin { mint: mint_b });
+        store.mark_applied(&pin_b);
+        assert!(
+            store.is_applicable(&pin_a),
+            "pending wallet pin for mint A must remain applicable after mint B advances"
+        );
+        let applicable = store.take_applicable_pending_sorted();
+        assert_eq!(applicable.len(), 1);
+        assert_eq!(
+            demand_mint_for_command(&applicable[0].payload),
+            Some(mint_a)
         );
     }
 

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -133,6 +133,37 @@ impl BoundedProtocolStore {
         }
     }
 
+    /// Wallet pin/withdraw supersedes unpinned tracker demand for the same mint (cross-stream).
+    pub fn supersede_tracker_demand_for_mint(&mut self, mint: Pubkey) {
+        let mut watermark = *self.last_applied_tracker_mint.get(&mint).unwrap_or(&0);
+        watermark = watermark.max(
+            self.revision
+                .last_issued_revision_for_mint(TrackCommandStream::Tracker, mint),
+        );
+        for cmd in &self.pending {
+            if cmd.stream == TrackCommandStream::Tracker
+                && demand_mint_for_command(&cmd.payload) == Some(mint)
+            {
+                watermark = watermark.max(cmd.revision);
+            }
+        }
+        if watermark > 0 {
+            let entry = self.last_applied_tracker_mint.entry(mint).or_insert(0);
+            if watermark > *entry {
+                *entry = watermark;
+            }
+        }
+    }
+
+    /// Mark wallet demand applied and supersede stale tracker protocol demand for the mint.
+    pub fn mark_applied_wallet_demand(&mut self, cmd: &ImmutableTrackCommand) {
+        debug_assert_eq!(cmd.stream, TrackCommandStream::Wallet);
+        self.mark_applied(cmd);
+        if let Some(mint) = demand_mint_for_command(&cmd.payload) {
+            self.supersede_tracker_demand_for_mint(mint);
+        }
+    }
+
     pub fn begin_inflight(&mut self) {
         self.inflight = self.inflight.saturating_add(1);
         set_market_data_track_protocol_inflight_depth(self.inflight);
@@ -335,6 +366,37 @@ mod tests {
             demand_mint_for_command(&applicable[0].payload),
             Some(mint_a)
         );
+    }
+
+    #[test]
+    fn wallet_withdraw_supersedes_pending_tracker_demand_for_same_mint() {
+        let mut store = BoundedProtocolStore::new(8, 64);
+        let mint = Pubkey::new_unique();
+        let tracker = store.wrap_command(TrackWorkerCommand::TrackMint { mint, pin: None });
+        store.stage_on_queue_full(tracker.clone());
+        let withdraw = store.wrap_command(TrackWorkerCommand::WithdrawWalletPin { mint });
+        store.mark_applied_wallet_demand(&withdraw);
+        assert!(
+            !store.is_applicable(&tracker),
+            "wallet withdraw must supersede pending tracker demand for same mint"
+        );
+        let applicable = store.take_applicable_pending_sorted();
+        assert!(
+            applicable.is_empty(),
+            "superseded tracker demand must not replay after wallet withdraw"
+        );
+    }
+
+    #[test]
+    fn wallet_pin_supersedes_pending_tracker_demand_for_same_mint() {
+        let mut store = BoundedProtocolStore::new(8, 64);
+        let mint = Pubkey::new_unique();
+        let tracker = store.wrap_command(TrackWorkerCommand::TrackMint { mint, pin: None });
+        store.stage_on_queue_full(tracker.clone());
+        let pin = store.wrap_command(TrackWorkerCommand::ApplyWalletPin { mint });
+        store.mark_applied_wallet_demand(&pin);
+        assert!(!store.is_applicable(&tracker));
+        assert!(store.take_applicable_pending_sorted().is_empty());
     }
 
     #[test]

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -232,6 +232,7 @@ impl BoundedProtocolStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use super::super::worker_commands::TrackPinReason;
     use crate::nats::MomentumActivePoolsUpdate;
     use solana_sdk::pubkey::Pubkey;
 
@@ -397,6 +398,36 @@ mod tests {
         store.mark_applied_wallet_demand(&pin);
         assert!(!store.is_applicable(&tracker));
         assert!(store.take_applicable_pending_sorted().is_empty());
+    }
+
+    #[test]
+    fn wallet_track_mint_uses_wallet_stream_per_mint_revision() {
+        let mut store = BoundedProtocolStore::new(8, 64);
+        let mint = Pubkey::new_unique();
+        let cmd = store.wrap_command(TrackWorkerCommand::TrackMint {
+            mint,
+            pin: Some(TrackPinReason::Wallet),
+        });
+        assert_eq!(cmd.stream, TrackCommandStream::Wallet);
+        assert_eq!(cmd.revision, 1);
+        let cmd2 = store.wrap_command(TrackWorkerCommand::TrackMint {
+            mint,
+            pin: Some(TrackPinReason::Wallet),
+        });
+        assert_eq!(cmd2.revision, 2);
+    }
+
+    #[test]
+    fn wallet_track_mint_reject_re_stages_pending() {
+        let mut store = BoundedProtocolStore::new(8, 64);
+        let mint = Pubkey::new_unique();
+        let cmd = store.wrap_command(TrackWorkerCommand::TrackMint {
+            mint,
+            pin: Some(TrackPinReason::Wallet),
+        });
+        assert_eq!(store.stage_on_queue_full(cmd.clone()), StageResult::Staged);
+        assert_eq!(store.pending_len(), 1);
+        assert!(store.is_applicable(&cmd));
     }
 
     #[test]

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -249,18 +249,34 @@ mod tests {
             store.stage_on_queue_full(cmd);
         }
         assert!(store.pending_len() <= MARKET_DATA_TRACK_PENDING_CAP);
-        assert_eq!(TrackCommandStream::COUNT, 3);
+        assert_eq!(TrackCommandStream::COUNT, 5);
     }
 
     #[test]
-    fn control_stream_separate_revision_sequence() {
+    fn wallet_withdraw_supersedes_older_pending_pin() {
         let mut store = BoundedProtocolStore::new(8, 64);
-        let m = store.wrap_command(momentum_cmd(1));
         let mint = Pubkey::new_unique();
-        let c = store.wrap_command(TrackWorkerCommand::TrackMint { mint, pin: None });
-        assert_eq!(m.stream, TrackCommandStream::Momentum);
-        assert_eq!(c.stream, TrackCommandStream::Control);
-        assert_eq!(m.revision, 1);
-        assert_eq!(c.revision, 1);
+        let pin_old = store.wrap_command(TrackWorkerCommand::ApplyWalletPin { mint });
+        store.stage_on_queue_full(pin_old.clone());
+        let withdraw = store.wrap_command(TrackWorkerCommand::WithdrawWalletPin { mint });
+        store.mark_applied(withdraw.stream, withdraw.revision);
+        assert!(!store.is_applicable(pin_old.stream, pin_old.revision));
+        let applicable = store.take_applicable_pending_sorted();
+        assert!(
+            applicable.is_empty(),
+            "stale wallet pin must not replay after newer withdraw advances watermark"
+        );
+    }
+
+    #[test]
+    fn tracker_stream_separate_from_control() {
+        let mut store = BoundedProtocolStore::new(8, 64);
+        let mint = Pubkey::new_unique();
+        let tracker = store.wrap_command(TrackWorkerCommand::TrackMint { mint, pin: None });
+        let control = store.wrap_command(TrackWorkerCommand::ScheduleGeyserPush);
+        assert_eq!(tracker.stream, TrackCommandStream::Tracker);
+        assert_eq!(control.stream, TrackCommandStream::Control);
+        assert_eq!(tracker.revision, 1);
+        assert_eq!(control.revision, 1);
     }
 }

--- a/src/market_data/track/pending.rs
+++ b/src/market_data/track/pending.rs
@@ -231,8 +231,8 @@ impl BoundedProtocolStore {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::worker_commands::TrackPinReason;
+    use super::*;
     use crate::nats::MomentumActivePoolsUpdate;
     use solana_sdk::pubkey::Pubkey;
 

--- a/src/market_data/track/snapshot.rs
+++ b/src/market_data/track/snapshot.rs
@@ -34,6 +34,7 @@ impl From<ConsumerId> for SnapshotConsumer {
             ConsumerId::Wallet => SnapshotConsumer::Wallet,
             ConsumerId::Momentum => SnapshotConsumer::Momentum,
             ConsumerId::Arb => SnapshotConsumer::Arb,
+            ConsumerId::Tracker => SnapshotConsumer::Tracker,
         }
     }
 }

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -9,7 +9,7 @@ use super::snapshot::{
     MARKET_DATA_EXPLICIT_SET_SNAPSHOT_INTERVAL_SECS,
 };
 use super::worker_commands::ImmutableTrackCommand;
-pub use super::worker_commands::{TrackPinReason, TrackWorkerCommand};
+pub use super::worker_commands::{TrackCommandStream, TrackPinReason, TrackWorkerCommand};
 use crate::metrics::{
     inc_market_data_explicit_set_snapshot_write_errors_total,
     inc_market_data_explicit_set_snapshot_write_total,
@@ -304,6 +304,20 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
     }
 }
 
+/// Wallet/Tracker demand commands only advance the monotone revision when the handler
+/// succeeds so transient admission rejects remain replayable (I-MD-5).
+fn track_protocol_should_advance_revision(
+    stream: TrackCommandStream,
+    handler_succeeded: bool,
+) -> bool {
+    match stream {
+        TrackCommandStream::Wallet | TrackCommandStream::Tracker => handler_succeeded,
+        TrackCommandStream::Momentum | TrackCommandStream::Arb | TrackCommandStream::Control => {
+            true
+        }
+    }
+}
+
 fn track_worker_apply_protocol_command<C: TrackWorkerContext>(
     ctx: &Arc<C>,
     protocol: &Arc<Mutex<BoundedProtocolStore>>,
@@ -319,9 +333,12 @@ fn track_worker_apply_protocol_command<C: TrackWorkerContext>(
         inc_market_data_track_protocol_superseded_revisions_total();
         return;
     }
-    let _ = track_worker_process_command(ctx, admission, restore_barrier_pending, cmd.payload);
-    let mut store = protocol.lock().expect("track protocol store lock");
-    store.mark_applied(cmd.stream, cmd.revision);
+    let handler_succeeded =
+        track_worker_process_command(ctx, admission, restore_barrier_pending, cmd.payload);
+    if track_protocol_should_advance_revision(cmd.stream, handler_succeeded) {
+        let mut store = protocol.lock().expect("track protocol store lock");
+        store.mark_applied(cmd.stream, cmd.revision);
+    }
 }
 
 fn track_worker_prepare_command_delivery<C: TrackWorkerContext>(
@@ -700,6 +717,296 @@ mod tests {
             applicable.is_empty(),
             "older pending push must be superseded after newer push advances watermark"
         );
+    }
+
+    #[test]
+    fn wallet_stream_revision_held_on_handler_failure() {
+        let mut store = BoundedProtocolStore::default_caps();
+        let mint = Pubkey::new_unique();
+        let cmd = store.wrap_command(TrackWorkerCommand::ApplyWalletPin { mint });
+        assert_eq!(cmd.stream, TrackCommandStream::Wallet);
+        assert!(!track_protocol_should_advance_revision(cmd.stream, false));
+        assert!(store.is_applicable(cmd.stream, cmd.revision));
+        assert!(track_protocol_should_advance_revision(cmd.stream, true));
+        store.mark_applied(cmd.stream, cmd.revision);
+        assert!(!store.is_applicable(cmd.stream, cmd.revision));
+    }
+
+    #[test]
+    fn tracker_stream_revision_held_on_handler_failure() {
+        let mut store = BoundedProtocolStore::default_caps();
+        let mint = Pubkey::new_unique();
+        let cmd = store.wrap_command(TrackWorkerCommand::TrackMint { mint, pin: None });
+        assert_eq!(cmd.stream, TrackCommandStream::Tracker);
+        assert!(!track_protocol_should_advance_revision(cmd.stream, false));
+        assert!(store.is_applicable(cmd.stream, cmd.revision));
+    }
+
+    struct WalletReplayTestCtx {
+        fail_wallet_pin_once: std::sync::atomic::AtomicBool,
+        pinned: parking_lot::Mutex<Vec<Pubkey>>,
+    }
+
+    impl WalletReplayTestCtx {
+        fn fail_once() -> Self {
+            Self {
+                fail_wallet_pin_once: std::sync::atomic::AtomicBool::new(true),
+                pinned: parking_lot::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl TrackWorkerContext for WalletReplayTestCtx {
+        fn geyser_sync_batch_debounce_ms(&self) -> u64 {
+            0
+        }
+
+        fn max_tracked_accounts(&self) -> usize {
+            25_000
+        }
+
+        fn apply_momentum_active_pools_update(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _update: &MomentumActivePoolsUpdate,
+        ) -> bool {
+            false
+        }
+
+        fn apply_momentum_snapshot_reconcile(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _active: &[MomentumActivePoolEntry],
+        ) -> bool {
+            false
+        }
+
+        fn apply_momentum_removed_entries(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _chunk: &[MomentumRemovedPoolEntry],
+        ) -> bool {
+            false
+        }
+
+        fn apply_momentum_active_entries(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _chunk: &[MomentumActivePoolEntry],
+        ) -> bool {
+            false
+        }
+
+        fn apply_arb_track_requests_update(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _update: &ArbTrackRequestsUpdate,
+        ) -> bool {
+            false
+        }
+
+        fn apply_arb_snapshot_reconcile(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _active: &[ArbTrackActiveEntry],
+        ) -> bool {
+            false
+        }
+
+        fn apply_arb_removed_entries(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _chunk: &[ArbTrackRemovedEntry],
+        ) -> bool {
+            false
+        }
+
+        fn apply_arb_active_entries(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _chunk: &[ArbTrackActiveEntry],
+        ) -> bool {
+            false
+        }
+
+        fn apply_wallet_pin(&self, _admission: &mut FixedCapAdmission, mint: Pubkey) -> bool {
+            if self
+                .fail_wallet_pin_once
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                return false;
+            }
+            self.pinned.lock().push(mint);
+            true
+        }
+
+        fn withdraw_wallet_pin(&self, _admission: &mut FixedCapAdmission, _mint: Pubkey) -> bool {
+            true
+        }
+
+        fn apply_track_mint(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _mint: Pubkey,
+            _pin: Option<TrackPinReason>,
+        ) -> bool {
+            true
+        }
+
+        fn refresh_geyser_pins_gauge(&self) {}
+
+        fn hot_pool_registry_pair_count(&self) -> usize {
+            0
+        }
+
+        fn hot_pool_registry_arb_pool_count(&self) -> usize {
+            0
+        }
+
+        fn refresh_hot_pool_registry_gauges(&self) {}
+
+        fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
+            HashSet::new()
+        }
+
+        fn pending_geyser_evict(&self) -> bool {
+            false
+        }
+
+        fn sync_geyser_tracked_accounts_batched_flush_with_deadline(
+            &self,
+            _deadline: Instant,
+            _admission: &FixedCapAdmission,
+        ) -> bool {
+            true
+        }
+
+        fn continue_geyser_evict_with_deadline(
+            &self,
+            _deadline: Instant,
+            _admission: &FixedCapAdmission,
+        ) -> bool {
+            true
+        }
+
+        fn release_geyser_sync_flush_slot(&self) {}
+
+        fn refresh_tracked_membership_snapshot(&self) {}
+
+        fn explicit_pubkey_rows_for_desired_set(
+            &self,
+        ) -> Vec<(Pubkey, crate::market_data::track::ConsumerId, Option<Pubkey>)> {
+            Vec::new()
+        }
+
+        fn build_explicit_set_snapshot(
+            &self,
+            _admission: &FixedCapAdmission,
+        ) -> super::ExplicitSetSnapshot {
+            super::ExplicitSetSnapshot::new(None)
+        }
+
+        fn apply_explicit_set_snapshot(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _snapshot: &super::ExplicitSetSnapshot,
+        ) -> AdmissionRestoreResult {
+            AdmissionRestoreResult::Restored
+        }
+
+        fn apply_explicit_set_snapshot_legacy(
+            &self,
+            _snapshot: &super::ExplicitSetSnapshot,
+        ) -> usize {
+            0
+        }
+
+        fn on_admission_converge_result(
+            &self,
+            _admission: &FixedCapAdmission,
+            _result: AdmissionConvergeResult,
+        ) {
+        }
+
+        fn prune_tracked_maps_to_admitted(&self, _admission: &FixedCapAdmission) {}
+
+        fn publish_admitted_explicit_physical(&self, _admission: &FixedCapAdmission) {}
+
+        fn last_synced_explicit_pubkeys_write(
+            &self,
+        ) -> parking_lot::RwLockWriteGuard<'_, HashSet<Pubkey>> {
+            static KEYS: std::sync::LazyLock<parking_lot::RwLock<HashSet<Pubkey>>> =
+                std::sync::LazyLock::new(|| parking_lot::RwLock::new(HashSet::new()));
+            KEYS.write()
+        }
+
+        fn clear_pending_geyser_evict(&self) {}
+
+        fn geyser_explicit_readiness_ok(&self) -> bool {
+            true
+        }
+
+        fn geyser_connect_barrier_pending(&self) -> bool {
+            false
+        }
+
+        fn signal_restore_barrier(&self, _ok: bool) {}
+
+        fn apply_explicit_cap_shrink(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _new_cap: usize,
+        ) -> CapShrinkResult {
+            CapShrinkResult::NoOpAlreadyWithinCap {
+                old_cap: 25_000,
+                new_cap: 25_000,
+            }
+        }
+    }
+
+    #[test]
+    fn wallet_pin_replays_via_protocol_after_transient_reject() {
+        let ctx = Arc::new(WalletReplayTestCtx::fail_once());
+        let protocol = Arc::new(Mutex::new(BoundedProtocolStore::default_caps()));
+        let mint = Pubkey::new_unique();
+        let cmd = {
+            let mut store = protocol.lock().expect("lock");
+            store.wrap_command(TrackWorkerCommand::ApplyWalletPin { mint })
+        };
+        let mut admission = FixedCapAdmission::new(25_000);
+        let mut restore_barrier_pending = false;
+
+        track_worker_apply_protocol_command(
+            &ctx,
+            &protocol,
+            &mut admission,
+            &mut restore_barrier_pending,
+            cmd.clone(),
+        );
+        {
+            let store = protocol.lock().expect("lock");
+            assert!(
+                store.is_applicable(cmd.stream, cmd.revision),
+                "failed wallet pin must not advance revision"
+            );
+        }
+        assert!(ctx.pinned.lock().is_empty());
+
+        track_worker_apply_protocol_command(
+            &ctx,
+            &protocol,
+            &mut admission,
+            &mut restore_barrier_pending,
+            cmd.clone(),
+        );
+        {
+            let store = protocol.lock().expect("lock");
+            assert!(
+                !store.is_applicable(cmd.stream, cmd.revision),
+                "successful wallet pin must advance revision"
+            );
+        }
+        assert_eq!(ctx.pinned.lock().as_slice(), &[mint]);
     }
 
     #[test]

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -1046,6 +1046,250 @@ mod tests {
     }
 
     #[test]
+    fn repeated_tracker_mint_advances_revision_without_pending_growth() {
+        struct TrackerIdempotentCtx;
+
+        impl TrackWorkerContext for TrackerIdempotentCtx {
+            fn geyser_sync_batch_debounce_ms(&self) -> u64 {
+                0
+            }
+
+            fn max_tracked_accounts(&self) -> usize {
+                25_000
+            }
+
+            fn apply_momentum_active_pools_update(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _update: &MomentumActivePoolsUpdate,
+            ) -> bool {
+                false
+            }
+
+            fn apply_momentum_snapshot_reconcile(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _active: &[MomentumActivePoolEntry],
+            ) -> bool {
+                false
+            }
+
+            fn apply_momentum_removed_entries(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _chunk: &[MomentumRemovedPoolEntry],
+            ) -> bool {
+                false
+            }
+
+            fn apply_momentum_active_entries(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _chunk: &[MomentumActivePoolEntry],
+            ) -> bool {
+                false
+            }
+
+            fn apply_arb_track_requests_update(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _update: &ArbTrackRequestsUpdate,
+            ) -> bool {
+                false
+            }
+
+            fn apply_arb_snapshot_reconcile(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _active: &[ArbTrackActiveEntry],
+            ) -> bool {
+                false
+            }
+
+            fn apply_arb_removed_entries(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _chunk: &[ArbTrackRemovedEntry],
+            ) -> bool {
+                false
+            }
+
+            fn apply_arb_active_entries(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _chunk: &[ArbTrackActiveEntry],
+            ) -> bool {
+                false
+            }
+
+            fn apply_wallet_pin(&self, _admission: &mut FixedCapAdmission, _mint: Pubkey) -> bool {
+                true
+            }
+
+            fn withdraw_wallet_pin(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _mint: Pubkey,
+            ) -> bool {
+                true
+            }
+
+            fn apply_track_mint(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _mint: Pubkey,
+                _pin: Option<TrackPinReason>,
+            ) -> bool {
+                true
+            }
+
+            fn refresh_geyser_pins_gauge(&self) {}
+
+            fn hot_pool_registry_pair_count(&self) -> usize {
+                0
+            }
+
+            fn hot_pool_registry_arb_pool_count(&self) -> usize {
+                0
+            }
+
+            fn refresh_hot_pool_registry_gauges(&self) {}
+
+            fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
+                HashSet::new()
+            }
+
+            fn pending_geyser_evict(&self) -> bool {
+                false
+            }
+
+            fn sync_geyser_tracked_accounts_batched_flush_with_deadline(
+                &self,
+                _deadline: Instant,
+                _admission: &FixedCapAdmission,
+            ) -> bool {
+                true
+            }
+
+            fn continue_geyser_evict_with_deadline(
+                &self,
+                _deadline: Instant,
+                _admission: &FixedCapAdmission,
+            ) -> bool {
+                true
+            }
+
+            fn release_geyser_sync_flush_slot(&self) {}
+
+            fn refresh_tracked_membership_snapshot(&self) {}
+
+            fn explicit_pubkey_rows_for_desired_set(
+                &self,
+            ) -> Vec<(
+                Pubkey,
+                crate::market_data::track::ConsumerId,
+                Option<Pubkey>,
+            )> {
+                Vec::new()
+            }
+
+            fn build_explicit_set_snapshot(
+                &self,
+                _admission: &FixedCapAdmission,
+            ) -> super::ExplicitSetSnapshot {
+                super::ExplicitSetSnapshot::new(None)
+            }
+
+            fn apply_explicit_set_snapshot(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _snapshot: &super::ExplicitSetSnapshot,
+            ) -> AdmissionRestoreResult {
+                AdmissionRestoreResult::Restored
+            }
+
+            fn apply_explicit_set_snapshot_legacy(
+                &self,
+                _snapshot: &super::ExplicitSetSnapshot,
+            ) -> usize {
+                0
+            }
+
+            fn on_admission_converge_result(
+                &self,
+                _admission: &FixedCapAdmission,
+                _result: AdmissionConvergeResult,
+            ) {
+            }
+
+            fn prune_tracked_maps_to_admitted(&self, _admission: &FixedCapAdmission) {}
+
+            fn publish_admitted_explicit_physical(&self, _admission: &FixedCapAdmission) {}
+
+            fn last_synced_explicit_pubkeys_write(
+                &self,
+            ) -> parking_lot::RwLockWriteGuard<'_, HashSet<Pubkey>> {
+                static KEYS: std::sync::LazyLock<parking_lot::RwLock<HashSet<Pubkey>>> =
+                    std::sync::LazyLock::new(|| parking_lot::RwLock::new(HashSet::new()));
+                KEYS.write()
+            }
+
+            fn clear_pending_geyser_evict(&self) {}
+
+            fn geyser_explicit_readiness_ok(&self) -> bool {
+                true
+            }
+
+            fn geyser_connect_barrier_pending(&self) -> bool {
+                false
+            }
+
+            fn signal_restore_barrier(&self, _ok: bool) {}
+
+            fn apply_explicit_cap_shrink(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _new_cap: usize,
+            ) -> CapShrinkResult {
+                CapShrinkResult::NoOpAlreadyWithinCap {
+                    old_cap: 25_000,
+                    new_cap: 25_000,
+                }
+            }
+        }
+
+        let ctx = Arc::new(TrackerIdempotentCtx);
+        let protocol = Arc::new(Mutex::new(BoundedProtocolStore::default_caps()));
+        let mint = Pubkey::new_unique();
+        let mut admission = FixedCapAdmission::new(25_000);
+        let mut restore_barrier_pending = false;
+
+        for _ in 0..2 {
+            let cmd = {
+                let mut store = protocol.lock().expect("lock");
+                store.wrap_command(TrackWorkerCommand::TrackMint { mint, pin: None })
+            };
+            track_worker_apply_protocol_command(
+                &ctx,
+                &protocol,
+                &mut admission,
+                &mut restore_barrier_pending,
+                cmd.clone(),
+            );
+            let store = protocol.lock().expect("lock");
+            assert_eq!(
+                store.pending_len(),
+                0,
+                "idempotent tracker mint must not re-stage pending"
+            );
+            assert!(
+                !store.is_applicable(cmd.stream, cmd.revision),
+                "each tracker mint command must advance revision"
+            );
+        }
+    }
+
+    #[test]
     fn control_push_evict_variants_advance_revision() {
         let mut store = BoundedProtocolStore::default_caps();
         for payload in [

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -318,6 +318,14 @@ fn track_protocol_should_advance_revision(
     }
 }
 
+fn track_protocol_stage_for_replay(
+    protocol: &Arc<Mutex<BoundedProtocolStore>>,
+    cmd: ImmutableTrackCommand,
+) {
+    let mut store = protocol.lock().expect("track protocol store lock");
+    let _ = store.stage_on_queue_full(cmd);
+}
+
 fn track_worker_apply_protocol_command<C: TrackWorkerContext>(
     ctx: &Arc<C>,
     protocol: &Arc<Mutex<BoundedProtocolStore>>,
@@ -333,11 +341,27 @@ fn track_worker_apply_protocol_command<C: TrackWorkerContext>(
         inc_market_data_track_protocol_superseded_revisions_total();
         return;
     }
+    let stream = cmd.stream;
+    let revision = cmd.revision;
+    let restage_on_failure = matches!(
+        stream,
+        TrackCommandStream::Wallet | TrackCommandStream::Tracker
+    );
+    let payload_for_restage = if restage_on_failure {
+        Some(cmd.payload.clone())
+    } else {
+        None
+    };
     let handler_succeeded =
         track_worker_process_command(ctx, admission, restore_barrier_pending, cmd.payload);
-    if track_protocol_should_advance_revision(cmd.stream, handler_succeeded) {
+    if track_protocol_should_advance_revision(stream, handler_succeeded) {
         let mut store = protocol.lock().expect("track protocol store lock");
-        store.mark_applied(cmd.stream, cmd.revision);
+        store.mark_applied(stream, revision);
+    } else if restage_on_failure {
+        track_protocol_stage_for_replay(
+            protocol,
+            ImmutableTrackCommand::new(stream, revision, payload_for_restage.expect("restage")),
+        );
     }
 }
 
@@ -993,15 +1017,23 @@ mod tests {
                 store.is_applicable(cmd.stream, cmd.revision),
                 "failed wallet pin must not advance revision"
             );
+            assert_eq!(
+                store.pending_len(),
+                1,
+                "failed wallet pin must be re-staged into bounded pending"
+            );
         }
         assert!(ctx.pinned.lock().is_empty());
 
-        track_worker_apply_protocol_command(
+        track_worker_drain_pending_replay(
             &ctx,
             &protocol,
             &mut admission,
             &mut restore_barrier_pending,
-            cmd.clone(),
+            &mut None,
+            &mut None,
+            &mut false,
+            &mut false,
         );
         {
             let store = protocol.lock().expect("lock");

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -895,7 +895,11 @@ mod tests {
 
         fn explicit_pubkey_rows_for_desired_set(
             &self,
-        ) -> Vec<(Pubkey, crate::market_data::track::ConsumerId, Option<Pubkey>)> {
+        ) -> Vec<(
+            Pubkey,
+            crate::market_data::track::ConsumerId,
+            Option<Pubkey>,
+        )> {
             Vec::new()
         }
 

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -353,7 +353,17 @@ fn track_worker_apply_protocol_command<C: TrackWorkerContext>(
     let protocol_cmd = ImmutableTrackCommand::new(stream, revision, payload_backup);
     if track_protocol_should_advance_revision(stream, handler_succeeded) {
         let mut store = protocol.lock().expect("track protocol store lock");
-        store.mark_applied(&protocol_cmd);
+        if stream == TrackCommandStream::Wallet
+            && matches!(
+                protocol_cmd.payload,
+                TrackWorkerCommand::ApplyWalletPin { .. }
+                    | TrackWorkerCommand::WithdrawWalletPin { .. }
+            )
+        {
+            store.mark_applied_wallet_demand(&protocol_cmd);
+        } else {
+            store.mark_applied(&protocol_cmd);
+        }
     } else if restage_on_failure {
         track_protocol_stage_for_replay(protocol, protocol_cmd);
     }
@@ -1280,6 +1290,277 @@ mod tests {
                 !store.is_applicable(&cmd),
                 "each tracker mint command must advance revision"
             );
+        }
+    }
+
+    struct WithdrawSupersedesTrackerTestCtx {
+        tracked: parking_lot::Mutex<std::collections::HashSet<Pubkey>>,
+    }
+
+    impl WithdrawSupersedesTrackerTestCtx {
+        fn new() -> Self {
+            Self {
+                tracked: parking_lot::Mutex::new(std::collections::HashSet::new()),
+            }
+        }
+    }
+
+    impl TrackWorkerContext for WithdrawSupersedesTrackerTestCtx {
+        fn geyser_sync_batch_debounce_ms(&self) -> u64 {
+            0
+        }
+
+        fn max_tracked_accounts(&self) -> usize {
+            25_000
+        }
+
+        fn apply_momentum_active_pools_update(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _update: &MomentumActivePoolsUpdate,
+        ) -> bool {
+            false
+        }
+
+        fn apply_momentum_snapshot_reconcile(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _active: &[MomentumActivePoolEntry],
+        ) -> bool {
+            false
+        }
+
+        fn apply_momentum_removed_entries(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _chunk: &[MomentumRemovedPoolEntry],
+        ) -> bool {
+            false
+        }
+
+        fn apply_momentum_active_entries(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _chunk: &[MomentumActivePoolEntry],
+        ) -> bool {
+            false
+        }
+
+        fn apply_arb_track_requests_update(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _update: &ArbTrackRequestsUpdate,
+        ) -> bool {
+            false
+        }
+
+        fn apply_arb_snapshot_reconcile(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _active: &[ArbTrackActiveEntry],
+        ) -> bool {
+            false
+        }
+
+        fn apply_arb_removed_entries(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _chunk: &[ArbTrackRemovedEntry],
+        ) -> bool {
+            false
+        }
+
+        fn apply_arb_active_entries(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _chunk: &[ArbTrackActiveEntry],
+        ) -> bool {
+            false
+        }
+
+        fn apply_wallet_pin(&self, _admission: &mut FixedCapAdmission, mint: Pubkey) -> bool {
+            self.tracked.lock().insert(mint);
+            true
+        }
+
+        fn withdraw_wallet_pin(&self, _admission: &mut FixedCapAdmission, mint: Pubkey) -> bool {
+            self.tracked.lock().remove(&mint);
+            true
+        }
+
+        fn apply_track_mint(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            mint: Pubkey,
+            pin: Option<TrackPinReason>,
+        ) -> bool {
+            if pin.is_none() {
+                self.tracked.lock().insert(mint);
+            }
+            true
+        }
+
+        fn refresh_geyser_pins_gauge(&self) {}
+
+        fn hot_pool_registry_pair_count(&self) -> usize {
+            0
+        }
+
+        fn hot_pool_registry_arb_pool_count(&self) -> usize {
+            0
+        }
+
+        fn refresh_hot_pool_registry_gauges(&self) {}
+
+        fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
+            HashSet::new()
+        }
+
+        fn pending_geyser_evict(&self) -> bool {
+            false
+        }
+
+        fn sync_geyser_tracked_accounts_batched_flush_with_deadline(
+            &self,
+            _deadline: Instant,
+            _admission: &FixedCapAdmission,
+        ) -> bool {
+            true
+        }
+
+        fn continue_geyser_evict_with_deadline(
+            &self,
+            _deadline: Instant,
+            _admission: &FixedCapAdmission,
+        ) -> bool {
+            true
+        }
+
+        fn release_geyser_sync_flush_slot(&self) {}
+
+        fn refresh_tracked_membership_snapshot(&self) {}
+
+        fn explicit_pubkey_rows_for_desired_set(
+            &self,
+        ) -> Vec<(
+            Pubkey,
+            crate::market_data::track::ConsumerId,
+            Option<Pubkey>,
+        )> {
+            Vec::new()
+        }
+
+        fn build_explicit_set_snapshot(
+            &self,
+            _admission: &FixedCapAdmission,
+        ) -> super::ExplicitSetSnapshot {
+            super::ExplicitSetSnapshot::new(None)
+        }
+
+        fn apply_explicit_set_snapshot(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _snapshot: &super::ExplicitSetSnapshot,
+        ) -> AdmissionRestoreResult {
+            AdmissionRestoreResult::Restored
+        }
+
+        fn apply_explicit_set_snapshot_legacy(
+            &self,
+            _snapshot: &super::ExplicitSetSnapshot,
+        ) -> usize {
+            0
+        }
+
+        fn on_admission_converge_result(
+            &self,
+            _admission: &FixedCapAdmission,
+            _result: AdmissionConvergeResult,
+        ) {
+        }
+
+        fn prune_tracked_maps_to_admitted(&self, _admission: &FixedCapAdmission) {}
+
+        fn publish_admitted_explicit_physical(&self, _admission: &FixedCapAdmission) {}
+
+        fn last_synced_explicit_pubkeys_write(
+            &self,
+        ) -> parking_lot::RwLockWriteGuard<'_, HashSet<Pubkey>> {
+            static KEYS: std::sync::LazyLock<parking_lot::RwLock<HashSet<Pubkey>>> =
+                std::sync::LazyLock::new(|| parking_lot::RwLock::new(HashSet::new()));
+            KEYS.write()
+        }
+
+        fn clear_pending_geyser_evict(&self) {}
+
+        fn geyser_explicit_readiness_ok(&self) -> bool {
+            true
+        }
+
+        fn geyser_connect_barrier_pending(&self) -> bool {
+            false
+        }
+
+        fn signal_restore_barrier(&self, _ok: bool) {}
+
+        fn apply_explicit_cap_shrink(
+            &self,
+            _admission: &mut FixedCapAdmission,
+            _new_cap: usize,
+        ) -> CapShrinkResult {
+            CapShrinkResult::NoOpAlreadyWithinCap {
+                old_cap: 25_000,
+                new_cap: 25_000,
+            }
+        }
+    }
+
+    #[test]
+    fn wallet_withdraw_supersedes_staged_tracker_replay() {
+        let ctx = Arc::new(WithdrawSupersedesTrackerTestCtx::new());
+        let protocol = Arc::new(Mutex::new(BoundedProtocolStore::default_caps()));
+        let mint = Pubkey::new_unique();
+        let mut admission = FixedCapAdmission::new(25_000);
+        let mut restore_barrier_pending = false;
+
+        let tracker_cmd = {
+            let mut store = protocol.lock().expect("lock");
+            let cmd = store.wrap_command(TrackWorkerCommand::TrackMint { mint, pin: None });
+            store.stage_on_queue_full(cmd.clone());
+            cmd
+        };
+        ctx.tracked.lock().insert(mint);
+
+        let withdraw_cmd = {
+            let mut store = protocol.lock().expect("lock");
+            store.wrap_command(TrackWorkerCommand::WithdrawWalletPin { mint })
+        };
+        track_worker_apply_protocol_command(
+            &ctx,
+            &protocol,
+            &mut admission,
+            &mut restore_barrier_pending,
+            withdraw_cmd,
+        );
+        assert!(!ctx.tracked.lock().contains(&mint));
+
+        track_worker_drain_pending_replay(
+            &ctx,
+            &protocol,
+            &mut admission,
+            &mut restore_barrier_pending,
+            &mut None,
+            &mut None,
+            &mut false,
+            &mut false,
+        );
+        assert!(
+            !ctx.tracked.lock().contains(&mint),
+            "superseded tracker replay must not re-admit mint after wallet withdraw"
+        );
+        {
+            let store = protocol.lock().expect("lock");
+            assert!(!store.is_applicable(&tracker_cmd));
         }
     }
 

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -87,7 +87,14 @@ pub trait TrackWorkerContext: Send + Sync {
         admission: &mut FixedCapAdmission,
         chunk: &[ArbTrackActiveEntry],
     ) -> bool;
-    fn track_mint_for_geyser_metadata(&self, mint: Pubkey, pin: Option<TrackPinReason>) -> bool;
+    fn apply_wallet_pin(&self, admission: &mut FixedCapAdmission, mint: Pubkey) -> bool;
+    fn withdraw_wallet_pin(&self, admission: &mut FixedCapAdmission, mint: Pubkey) -> bool;
+    fn apply_track_mint(
+        &self,
+        admission: &mut FixedCapAdmission,
+        mint: Pubkey,
+        pin: Option<TrackPinReason>,
+    ) -> bool;
     fn refresh_geyser_pins_gauge(&self);
     fn hot_pool_registry_pair_count(&self) -> usize;
     fn hot_pool_registry_arb_pool_count(&self) -> usize;
@@ -267,12 +274,9 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
         TrackWorkerCommand::ApplyArbTrackRequests(update) => {
             apply_arb_track_requests_on_track_worker(ctx, admission, update)
         }
-        TrackWorkerCommand::ApplyWalletPin { mint } => {
-            ctx.track_mint_for_geyser_metadata(mint, Some(TrackPinReason::Wallet))
-        }
-        TrackWorkerCommand::TrackMint { mint, pin } => {
-            ctx.track_mint_for_geyser_metadata(mint, pin)
-        }
+        TrackWorkerCommand::ApplyWalletPin { mint } => ctx.apply_wallet_pin(admission, mint),
+        TrackWorkerCommand::WithdrawWalletPin { mint } => ctx.withdraw_wallet_pin(admission, mint),
+        TrackWorkerCommand::TrackMint { mint, pin } => ctx.apply_track_mint(admission, mint, pin),
         TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange => {
             let new_cap = ctx.max_tracked_accounts();
             let _ = ctx.apply_explicit_cap_shrink(admission, new_cap);

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -353,13 +353,7 @@ fn track_worker_apply_protocol_command<C: TrackWorkerContext>(
     let protocol_cmd = ImmutableTrackCommand::new(stream, revision, payload_backup);
     if track_protocol_should_advance_revision(stream, handler_succeeded) {
         let mut store = protocol.lock().expect("track protocol store lock");
-        if stream == TrackCommandStream::Wallet
-            && matches!(
-                protocol_cmd.payload,
-                TrackWorkerCommand::ApplyWalletPin { .. }
-                    | TrackWorkerCommand::WithdrawWalletPin { .. }
-            )
-        {
+        if stream == TrackCommandStream::Wallet {
             store.mark_applied_wallet_demand(&protocol_cmd);
         } else {
             store.mark_applied(&protocol_cmd);
@@ -874,10 +868,13 @@ mod tests {
 
         fn apply_track_mint(
             &self,
-            _admission: &mut FixedCapAdmission,
-            _mint: Pubkey,
-            _pin: Option<TrackPinReason>,
+            admission: &mut FixedCapAdmission,
+            mint: Pubkey,
+            pin: Option<TrackPinReason>,
         ) -> bool {
+            if pin == Some(TrackPinReason::Wallet) {
+                return self.apply_wallet_pin(admission, mint);
+            }
             true
         }
 
@@ -1046,6 +1043,48 @@ mod tests {
                 "successful wallet pin must advance revision"
             );
         }
+        assert_eq!(ctx.pinned.lock().as_slice(), &[mint]);
+    }
+
+    #[test]
+    fn wallet_track_mint_replays_after_transient_reject() {
+        let ctx = Arc::new(WalletReplayTestCtx::fail_once());
+        let protocol = Arc::new(Mutex::new(BoundedProtocolStore::default_caps()));
+        let mint = Pubkey::new_unique();
+        let cmd = {
+            let mut store = protocol.lock().expect("lock");
+            store.wrap_command(TrackWorkerCommand::TrackMint {
+                mint,
+                pin: Some(TrackPinReason::Wallet),
+            })
+        };
+        assert_eq!(cmd.stream, TrackCommandStream::Wallet);
+        let mut admission = FixedCapAdmission::new(25_000);
+        let mut restore_barrier_pending = false;
+
+        track_worker_apply_protocol_command(
+            &ctx,
+            &protocol,
+            &mut admission,
+            &mut restore_barrier_pending,
+            cmd.clone(),
+        );
+        {
+            let store = protocol.lock().expect("lock");
+            assert!(store.is_applicable(&cmd));
+            assert_eq!(store.pending_len(), 1);
+        }
+
+        track_worker_drain_pending_replay(
+            &ctx,
+            &protocol,
+            &mut admission,
+            &mut restore_barrier_pending,
+            &mut None,
+            &mut None,
+            &mut false,
+            &mut false,
+        );
         assert_eq!(ctx.pinned.lock().as_slice(), &[mint]);
     }
 

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -335,7 +335,7 @@ fn track_worker_apply_protocol_command<C: TrackWorkerContext>(
 ) {
     let applicable = {
         let store = protocol.lock().expect("track protocol store lock");
-        store.is_applicable(cmd.stream, cmd.revision)
+        store.is_applicable(&cmd)
     };
     if !applicable {
         inc_market_data_track_protocol_superseded_revisions_total();
@@ -347,21 +347,15 @@ fn track_worker_apply_protocol_command<C: TrackWorkerContext>(
         stream,
         TrackCommandStream::Wallet | TrackCommandStream::Tracker
     );
-    let payload_for_restage = if restage_on_failure {
-        Some(cmd.payload.clone())
-    } else {
-        None
-    };
+    let payload_backup = cmd.payload.clone();
     let handler_succeeded =
         track_worker_process_command(ctx, admission, restore_barrier_pending, cmd.payload);
+    let protocol_cmd = ImmutableTrackCommand::new(stream, revision, payload_backup);
     if track_protocol_should_advance_revision(stream, handler_succeeded) {
         let mut store = protocol.lock().expect("track protocol store lock");
-        store.mark_applied(stream, revision);
+        store.mark_applied(&protocol_cmd);
     } else if restage_on_failure {
-        track_protocol_stage_for_replay(
-            protocol,
-            ImmutableTrackCommand::new(stream, revision, payload_for_restage.expect("restage")),
-        );
+        track_protocol_stage_for_replay(protocol, protocol_cmd);
     }
 }
 
@@ -400,7 +394,7 @@ fn track_worker_receive_protocol_command<C: TrackWorkerContext>(
 ) {
     let applicable = {
         let store = protocol.lock().expect("track protocol store lock");
-        store.is_applicable(cmd.stream, cmd.revision)
+        store.is_applicable(&cmd)
     };
     if applicable {
         track_worker_prepare_command_delivery(
@@ -433,7 +427,7 @@ fn track_worker_drain_pending_replay<C: TrackWorkerContext>(
     for cmd in pending_cmds {
         let applicable = {
             let store = protocol.lock().expect("track protocol store lock");
-            store.is_applicable(cmd.stream, cmd.revision)
+            store.is_applicable(&cmd)
         };
         if applicable {
             track_worker_prepare_command_delivery(
@@ -719,13 +713,13 @@ mod tests {
                     full_active_snapshot: false,
                 },
             ));
-            store.mark_applied(TrackCommandStream::Momentum, c.revision);
+            store.mark_applied(&c);
             c
         };
         assert!(sender.tx.try_send(cmd.clone()).is_ok());
         // inline apply path not running; verify applicability directly
         let store = sender.protocol.lock().expect("lock");
-        assert!(!store.is_applicable(cmd.stream, cmd.revision));
+        assert!(!store.is_applicable(&cmd));
     }
 
     #[test]
@@ -734,8 +728,8 @@ mod tests {
         let push_old = store.wrap_command(TrackWorkerCommand::ScheduleGeyserPush);
         store.stage_on_queue_full(push_old.clone());
         let push_new = store.wrap_command(TrackWorkerCommand::ScheduleGeyserPush);
-        store.mark_applied(push_new.stream, push_new.revision);
-        assert!(!store.is_applicable(push_old.stream, push_old.revision));
+        store.mark_applied(&push_new);
+        assert!(!store.is_applicable(&push_old));
         let applicable = store.take_applicable_pending_sorted();
         assert!(
             applicable.is_empty(),
@@ -750,10 +744,10 @@ mod tests {
         let cmd = store.wrap_command(TrackWorkerCommand::ApplyWalletPin { mint });
         assert_eq!(cmd.stream, TrackCommandStream::Wallet);
         assert!(!track_protocol_should_advance_revision(cmd.stream, false));
-        assert!(store.is_applicable(cmd.stream, cmd.revision));
+        assert!(store.is_applicable(&cmd));
         assert!(track_protocol_should_advance_revision(cmd.stream, true));
-        store.mark_applied(cmd.stream, cmd.revision);
-        assert!(!store.is_applicable(cmd.stream, cmd.revision));
+        store.mark_applied(&cmd);
+        assert!(!store.is_applicable(&cmd));
     }
 
     #[test]
@@ -763,7 +757,7 @@ mod tests {
         let cmd = store.wrap_command(TrackWorkerCommand::TrackMint { mint, pin: None });
         assert_eq!(cmd.stream, TrackCommandStream::Tracker);
         assert!(!track_protocol_should_advance_revision(cmd.stream, false));
-        assert!(store.is_applicable(cmd.stream, cmd.revision));
+        assert!(store.is_applicable(&cmd));
     }
 
     struct WalletReplayTestCtx {
@@ -1014,7 +1008,7 @@ mod tests {
         {
             let store = protocol.lock().expect("lock");
             assert!(
-                store.is_applicable(cmd.stream, cmd.revision),
+                store.is_applicable(&cmd),
                 "failed wallet pin must not advance revision"
             );
             assert_eq!(
@@ -1038,7 +1032,7 @@ mod tests {
         {
             let store = protocol.lock().expect("lock");
             assert!(
-                !store.is_applicable(cmd.stream, cmd.revision),
+                !store.is_applicable(&cmd),
                 "successful wallet pin must advance revision"
             );
         }
@@ -1283,7 +1277,7 @@ mod tests {
                 "idempotent tracker mint must not re-stage pending"
             );
             assert!(
-                !store.is_applicable(cmd.stream, cmd.revision),
+                !store.is_applicable(&cmd),
                 "each tracker mint command must advance revision"
             );
         }
@@ -1298,9 +1292,9 @@ mod tests {
             TrackWorkerCommand::ContinueGeyserEvict,
         ] {
             let cmd = store.wrap_command(payload);
-            store.mark_applied(cmd.stream, cmd.revision);
+            store.mark_applied(&cmd);
             assert!(
-                !store.is_applicable(cmd.stream, cmd.revision),
+                !store.is_applicable(&cmd),
                 "applied revision must not remain applicable"
             );
         }

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -148,6 +148,16 @@ impl RevisionAssigner {
         self.next[idx] = rev;
         rev
     }
+
+    /// Highest revision already assigned for a per-mint wallet/tracker stream (0 if none).
+    pub fn last_issued_revision_for_mint(&self, stream: TrackCommandStream, mint: Pubkey) -> u64 {
+        let map = match stream {
+            TrackCommandStream::Wallet => &self.wallet_mint_next,
+            TrackCommandStream::Tracker => &self.tracker_mint_next,
+            _ => return 0,
+        };
+        *map.get(&mint).unwrap_or(&0)
+    }
 }
 
 #[cfg(test)]

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -87,6 +87,10 @@ pub fn stream_for_command(cmd: &TrackWorkerCommand) -> TrackCommandStream {
         TrackWorkerCommand::ApplyArbTrackRequests(_) => TrackCommandStream::Arb,
         TrackWorkerCommand::ApplyWalletPin { .. }
         | TrackWorkerCommand::WithdrawWalletPin { .. } => TrackCommandStream::Wallet,
+        TrackWorkerCommand::TrackMint {
+            pin: Some(TrackPinReason::Wallet),
+            ..
+        } => TrackCommandStream::Wallet,
         TrackWorkerCommand::TrackMint { pin: None, .. } => TrackCommandStream::Tracker,
         TrackWorkerCommand::TrackMint { .. }
         | TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange
@@ -103,7 +107,10 @@ pub fn demand_mint_for_command(cmd: &TrackWorkerCommand) -> Option<Pubkey> {
     match cmd {
         TrackWorkerCommand::ApplyWalletPin { mint }
         | TrackWorkerCommand::WithdrawWalletPin { mint } => Some(*mint),
-        TrackWorkerCommand::TrackMint { mint, pin: None } => Some(*mint),
+        TrackWorkerCommand::TrackMint {
+            mint,
+            pin: None | Some(TrackPinReason::Wallet),
+        } => Some(*mint),
         _ => None,
     }
 }
@@ -194,6 +201,13 @@ mod tests {
             ),
             (
                 TrackWorkerCommand::ApplyWalletPin { mint },
+                TrackCommandStream::Wallet,
+            ),
+            (
+                TrackWorkerCommand::TrackMint {
+                    mint,
+                    pin: Some(TrackPinReason::Wallet),
+                },
                 TrackCommandStream::Wallet,
             ),
             (

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -3,6 +3,7 @@
 use super::snapshot::ExplicitSetSnapshot;
 use crate::nats::{ArbTrackRequestsUpdate, MomentumActivePoolsUpdate};
 use solana_sdk::pubkey::Pubkey;
+use std::collections::HashMap;
 
 /// Pin reason for explicit Geyser tracking (maps to [`super::ConsumerId`] in rebuild).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,14 +98,51 @@ pub fn stream_for_command(cmd: &TrackWorkerCommand) -> TrackCommandStream {
     }
 }
 
-/// Monotone revision counter per stream (starts at 1).
+/// Per-mint demand key for wallet/tracker streams (supersession scoped per mint).
+pub fn demand_mint_for_command(cmd: &TrackWorkerCommand) -> Option<Pubkey> {
+    match cmd {
+        TrackWorkerCommand::ApplyWalletPin { mint }
+        | TrackWorkerCommand::WithdrawWalletPin { mint } => Some(*mint),
+        TrackWorkerCommand::TrackMint { mint, pin: None } => Some(*mint),
+        _ => None,
+    }
+}
+
+#[inline]
+pub fn stream_uses_per_mint_revision(stream: TrackCommandStream) -> bool {
+    matches!(
+        stream,
+        TrackCommandStream::Wallet | TrackCommandStream::Tracker
+    )
+}
+
+/// Monotone revision counter per stream (starts at 1); wallet/tracker use per-mint counters.
 #[derive(Debug, Clone, Default)]
 pub struct RevisionAssigner {
     next: [u64; TrackCommandStream::COUNT],
+    wallet_mint_next: HashMap<Pubkey, u64>,
+    tracker_mint_next: HashMap<Pubkey, u64>,
 }
 
 impl RevisionAssigner {
-    pub fn next_revision(&mut self, stream: TrackCommandStream) -> u64 {
+    pub fn next_revision(
+        &mut self,
+        stream: TrackCommandStream,
+        demand_mint: Option<Pubkey>,
+    ) -> u64 {
+        if stream_uses_per_mint_revision(stream) {
+            let mint = demand_mint.expect("wallet/tracker revision requires demand mint");
+            let map = match stream {
+                TrackCommandStream::Wallet => &mut self.wallet_mint_next,
+                TrackCommandStream::Tracker => &mut self.tracker_mint_next,
+                _ => unreachable!(),
+            };
+            let rev = map
+                .entry(mint)
+                .and_modify(|r| *r = r.saturating_add(1))
+                .or_insert(1);
+            return *rev;
+        }
         let idx = stream.index();
         let rev = self.next[idx].saturating_add(1);
         self.next[idx] = rev;
@@ -164,12 +202,29 @@ mod tests {
     #[test]
     fn revision_assigner_is_monotone_per_stream() {
         let mut assigner = RevisionAssigner::default();
-        let r1 = assigner.next_revision(TrackCommandStream::Momentum);
-        let r2 = assigner.next_revision(TrackCommandStream::Momentum);
-        let a1 = assigner.next_revision(TrackCommandStream::Arb);
+        let r1 = assigner.next_revision(TrackCommandStream::Momentum, None);
+        let r2 = assigner.next_revision(TrackCommandStream::Momentum, None);
+        let a1 = assigner.next_revision(TrackCommandStream::Arb, None);
         assert!(r2 > r1);
         assert_eq!(a1, 1);
         assert_eq!(r1, 1);
         assert_eq!(r2, 2);
+    }
+
+    #[test]
+    fn revision_assigner_wallet_tracker_is_per_mint() {
+        let mut assigner = RevisionAssigner::default();
+        let m1 = Pubkey::new_unique();
+        let m2 = Pubkey::new_unique();
+        let w1a = assigner.next_revision(TrackCommandStream::Wallet, Some(m1));
+        let w2a = assigner.next_revision(TrackCommandStream::Wallet, Some(m2));
+        let w1b = assigner.next_revision(TrackCommandStream::Wallet, Some(m1));
+        let t1a = assigner.next_revision(TrackCommandStream::Tracker, Some(m1));
+        let t2a = assigner.next_revision(TrackCommandStream::Tracker, Some(m2));
+        assert_eq!(w1a, 1);
+        assert_eq!(w2a, 1);
+        assert_eq!(w1b, 2);
+        assert_eq!(t1a, 1);
+        assert_eq!(t2a, 1);
     }
 }

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -20,6 +20,10 @@ pub enum TrackWorkerCommand {
     ApplyWalletPin {
         mint: Pubkey,
     },
+    /// PR4b: explicit wallet-pin withdrawal before tracked-map demotion (I-MD-8).
+    WithdrawWalletPin {
+        mint: Pubkey,
+    },
     TrackMint {
         mint: Pubkey,
         pin: Option<TrackPinReason>,
@@ -43,11 +47,13 @@ pub enum TrackWorkerCommand {
 pub enum TrackCommandStream {
     Momentum = 0,
     Arb = 1,
-    Control = 2,
+    Wallet = 2,
+    Tracker = 3,
+    Control = 4,
 }
 
 impl TrackCommandStream {
-    pub const COUNT: usize = 3;
+    pub const COUNT: usize = 5;
 
     #[inline]
     pub fn index(self) -> usize {
@@ -79,7 +85,9 @@ pub fn stream_for_command(cmd: &TrackWorkerCommand) -> TrackCommandStream {
         TrackWorkerCommand::ApplyMomentumActivePools(_) => TrackCommandStream::Momentum,
         TrackWorkerCommand::ApplyArbTrackRequests(_) => TrackCommandStream::Arb,
         TrackWorkerCommand::ApplyWalletPin { .. }
-        | TrackWorkerCommand::TrackMint { .. }
+        | TrackWorkerCommand::WithdrawWalletPin { .. } => TrackCommandStream::Wallet,
+        TrackWorkerCommand::TrackMint { pin: None, .. } => TrackCommandStream::Tracker,
+        TrackWorkerCommand::TrackMint { .. }
         | TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange
         | TrackWorkerCommand::ScheduleGeyserPush
         | TrackWorkerCommand::ScheduleGeyserPushDebounced
@@ -134,6 +142,17 @@ mod tests {
             ),
             (
                 TrackWorkerCommand::TrackMint { mint, pin: None },
+                TrackCommandStream::Tracker,
+            ),
+            (
+                TrackWorkerCommand::ApplyWalletPin { mint },
+                TrackCommandStream::Wallet,
+            ),
+            (
+                TrackWorkerCommand::TrackMint {
+                    mint,
+                    pin: Some(TrackPinReason::MomentumActive),
+                },
                 TrackCommandStream::Control,
             ),
         ];

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -982,6 +982,18 @@ pub static MARKET_DATA_ARB_ADMISSION_ADMITTED_TOTAL: Lazy<AtomicU64> =
 /// PR4a: arb pool groups rejected at admission (no tracked-map mutation).
 pub static MARKET_DATA_ARB_ADMISSION_REJECTED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// PR4b: wallet owner groups admitted before tracked-map mutation.
+pub static MARKET_DATA_WALLET_ADMISSION_ADMITTED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// PR4b: wallet owner groups rejected at admission (no tracked-map mutation).
+pub static MARKET_DATA_WALLET_ADMISSION_REJECTED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// PR4b: tracker mint groups admitted before tracked-map mutation.
+pub static MARKET_DATA_TRACKER_ADMISSION_ADMITTED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// PR4b: tracker mint groups rejected at admission (no tracked-map mutation).
+pub static MARKET_DATA_TRACKER_ADMISSION_REJECTED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 /// Bounded track-worker protocol: pending slot depth (gauge).
 pub static MARKET_DATA_TRACK_PROTOCOL_PENDING_DEPTH: Lazy<AtomicU64> =
@@ -1266,6 +1278,26 @@ pub fn inc_market_data_arb_admission_admitted_total() {
 #[inline]
 pub fn inc_market_data_arb_admission_rejected_total() {
     MARKET_DATA_ARB_ADMISSION_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_wallet_admission_admitted_total() {
+    MARKET_DATA_WALLET_ADMISSION_ADMITTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_wallet_admission_rejected_total() {
+    MARKET_DATA_WALLET_ADMISSION_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_tracker_admission_admitted_total() {
+    MARKET_DATA_TRACKER_ADMISSION_ADMITTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_tracker_admission_rejected_total() {
+    MARKET_DATA_TRACKER_ADMISSION_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -5958,6 +5990,22 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_arb_admission_rejected_total",
         MARKET_DATA_ARB_ADMISSION_REJECTED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_wallet_admission_admitted_total",
+        MARKET_DATA_WALLET_ADMISSION_ADMITTED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_wallet_admission_rejected_total",
+        MARKET_DATA_WALLET_ADMISSION_REJECTED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_tracker_admission_admitted_total",
+        MARKET_DATA_TRACKER_ADMISSION_ADMITTED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_tracker_admission_rejected_total",
+        MARKET_DATA_TRACKER_ADMISSION_REJECTED_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_track_protocol_pending_depth",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR 4b — bounded Wallet-/Tracker-Integration auf Basis von PR 4a (#294).

- **Wallet**: `ApplyWalletPin` admittiert die geschützte Wallet-Owner-Group (`ExplicitConsumer::Wallet`) **vor** `tracked_mints`-Mutation; bei Cap-Überlauf fail-closed (I-MD-8), keine Map-Änderung.
- **Withdrawal**: Neues `WithdrawWalletPin` entfernt Mint aus Map und refresht/leert die Wallet-Owner-Group in Admission.
- **Tracker**: `pin == None` → `ConsumerId::Tracker` (niedrigste Priorität, I-MD-5); `TrackMint { pin: None }` admittiert Tracker-Owner-Group vor LRU-Insert.
- **Bounded Protocol**: Eigene `TrackCommandStream::{Wallet, Tracker}`-Revisionssequenzen — stale Wallet-Pin replay wird nach neuerem Withdraw superseded; pending bleibt bounded (PR #292).
- **Metriken**: `market_data_wallet_admission_{admitted,rejected}_total`, `market_data_tracker_admission_{admitted,rejected}_total`.

## Invarianten-Check

| Invariante | Status |
|---|---|
| I-MD-8 Wallet > Momentum > Arb > Tracker; Wallet nie Victim; wallet-only over-cap fail-closed | ✓ `try_admit_wallet_owner_group` prüft `pubkeys.len() > cap` |
| I-MD-7 Admission vor tracked_* Mutation | ✓ `apply_wallet_pin` / `apply_track_mint(None)` gate vor Map |
| I-MD-5 Tracker niedrigste Priorität; pin==None → Tracker | ✓ `consumer_id_for_geyser_pin(None)` |
| I-7 Kein Hot-Path RPC | ✓ keine RPC-Änderungen |
| I-9 Simulation-Gate | ✓ unverändert |

## Tests

- `pr4b_tracker_admission_reject_skips_tracked_map_mutation`
- `pr4b_wallet_admission_reject_skips_tracked_map_mutation`
- `pr4b_withdraw_wallet_pin_demotes_mint_and_refreshes_admission`
- `pr4b_consumer_id_for_unpinned_mint_is_tracker`
- `pending`: wallet withdraw supersede, tracker stream isolation

## Verification

```
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo test
```

## STOP-CHECK durchgeführt

1. Hot Path RPC: keine neuen RPC-Calls
2. Bestehendes Pattern: `try_admit_owner_group` wie PR 4a Momentum/Arb
3. Architektur-Grenzen: nur erlaubte Dateien
4. Simulation-Gate: unverändert
5. Repo-Isolation: keine Eval-Tests gelesen

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-237fb222-b4e8-4f70-b3a8-1b5c64cc13f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-237fb222-b4e8-4f70-b3a8-1b5c64cc13f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

