### PR TITLE
PA-5.1: PositionAuthority KV feed + Momentum overlay lifecycle

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -2427,8 +2427,9 @@ struct ExecutionContext {
     lock_manager: LockManager,
     /// PA-2: passive PositionAuthority (metrics only; not used for gating or reservations).
     position_authority: Arc<ParkingMutex<PositionAuthority>>,
-    /// PA-5.1: cached JetStream KV store for PositionAuthority snapshots (I-24a).
-    position_authority_kv: tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
+    /// PA-5.1: FIFO queue for ordered PositionAuthority KV publishes (per reducer apply order).
+    position_authority_kv_tx:
+        Option<tokio::sync::mpsc::UnboundedSender<Vec<PositionAuthorityChange>>>,
     log_base: PathBuf, // P1: For state persistence
     decision_counter: std::sync::atomic::AtomicU64,
     execution_counter: std::sync::atomic::AtomicU64,
@@ -6388,40 +6389,32 @@ impl ExecutionContext {
     }
 
     fn apply_position_authority_from_execution_result(&self, exec: &ExecutionResult) {
-        let changes = self
-            .position_authority
-            .lock()
-            .apply_from_confirmed_execution_result(exec);
+        {
+            let mut pa = self.position_authority.lock();
+            let changes = pa.apply_from_confirmed_execution_result(exec);
+            self.enqueue_position_authority_kv_publish(&changes);
+        }
         self.refresh_position_authority_metrics();
-        self.spawn_publish_position_authority_changes(changes);
     }
 
     /// Wallet snapshot: same filter as `PositionEvent::try_from_market_event_kind` (ignores SOL/WSOL for authority open count).
     fn apply_position_authority_from_wallet_event_kind(&self, kind: &MarketEventKind) {
-        let changes = self
-            .position_authority
-            .lock()
-            .apply_from_wallet_market_event_kind(kind);
+        {
+            let mut pa = self.position_authority.lock();
+            let changes = pa.apply_from_wallet_market_event_kind(kind);
+            self.enqueue_position_authority_kv_publish(&changes);
+        }
         self.refresh_position_authority_metrics();
-        self.spawn_publish_position_authority_changes(changes);
     }
 
-    /// PA-5.1: fire-and-forget KV publish after reducer apply (non-blocking on hot path).
-    fn spawn_publish_position_authority_changes(&self, changes: Vec<PositionAuthorityChange>) {
+    /// PA-5.1: enqueue KV publish while holding reducer lock (preserves apply order).
+    fn enqueue_position_authority_kv_publish(&self, changes: &[PositionAuthorityChange]) {
         if changes.is_empty() {
             return;
         }
-        let Some(nats) = self.nats.as_ref() else {
-            return;
-        };
-        let nats = nats.clone_for_spawned_publish();
-        let kv_cell = self.position_authority_kv.clone();
-        tokio::spawn(async move {
-            if let Err(e) = publish_position_authority_changes_to_kv(&nats, &kv_cell, changes).await
-            {
-                warn!(error = %e, "PositionAuthority KV publish failed");
-            }
-        });
+        if let Some(tx) = &self.position_authority_kv_tx {
+            let _ = tx.send(changes.to_vec());
+        }
     }
 
     /// Apply a WalletBalanceSnapshot MarketEvent to LockManager + decimals cache.
@@ -6482,6 +6475,23 @@ impl ExecutionContext {
         POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE.store(lock_open as u64, Ordering::Relaxed);
         POSITION_AUTHORITY_DRIFT_LOCKMANAGER.store(drift, Ordering::Relaxed);
     }
+}
+
+/// PA-5.1: single worker preserves reducer apply order for PositionAuthority KV writes.
+fn spawn_position_authority_kv_publish_worker(
+    nats: NatsClient,
+    kv_cell: tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
+) -> tokio::sync::mpsc::UnboundedSender<Vec<PositionAuthorityChange>> {
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        while let Some(changes) = rx.recv().await {
+            if let Err(e) = publish_position_authority_changes_to_kv(&nats, &kv_cell, changes).await
+            {
+                warn!(error = %e, "PositionAuthority KV publish failed");
+            }
+        }
+    });
+    tx
 }
 
 /// PA-5.1: write PositionAuthority deltas to JetStream KV (`POSITION_AUTHORITY` bucket).
@@ -7955,6 +7965,14 @@ async fn main() -> Result<()> {
         parking_lot::RwLock<std::collections::HashMap<String, OrphanTxConfirmEntry>>,
     > = Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new()));
 
+    let position_authority_kv = tokio::sync::OnceCell::new();
+    let position_authority_kv_tx = nats.as_ref().map(|n| {
+        spawn_position_authority_kv_publish_worker(
+            n.clone_for_spawned_publish(),
+            position_authority_kv.clone(),
+        )
+    });
+
     let mut ctx = ExecutionContext {
         run_id: run_id.clone(),
         rpc_url: args.rpc_url.clone(),
@@ -7975,7 +7993,7 @@ async fn main() -> Result<()> {
         burn_writer,
         lock_manager,
         position_authority: Arc::new(ParkingMutex::new(PositionAuthority::new())),
-        position_authority_kv: tokio::sync::OnceCell::new(),
+        position_authority_kv_tx,
         log_base: log_base.clone(),
         decision_counter: std::sync::atomic::AtomicU64::new(initial_decision_counter),
         execution_counter: std::sync::atomic::AtomicU64::new(initial_execution_counter),
@@ -9315,7 +9333,7 @@ async fn build_replay_context(
         burn_writer,
         lock_manager,
         position_authority: Arc::new(ParkingMutex::new(PositionAuthority::new())),
-        position_authority_kv: tokio::sync::OnceCell::new(),
+        position_authority_kv_tx: None,
         log_base: log_dir,
         decision_counter: std::sync::atomic::AtomicU64::new(0),
         execution_counter: std::sync::atomic::AtomicU64::new(0),

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -70,7 +70,7 @@ use ironcrab::ipc::{
     FairnessPolicy, FeePolicy, FillStatus, FillUnavailableReason, IntentOrigin, IntentTier,
     KillSwitchContext, MarketEvent, MarketEventKind, PoolCacheUpdate, PriorityFeePercentiles,
     RecordHeader, RejectReason, SimulationResult, TradeExecutionConstraints, TradeIntent,
-    TradeResources, TradeSide, TradingRegime,
+    TradeResources, TradeSide, TradingRegime, POSITION_AUTHORITY_KV_BUCKET,
 };
 use ironcrab::ipc::{ControlRequest, ControlRequestKind, ControlResponse, ControlResponseStatus};
 use ironcrab::metrics::{
@@ -116,7 +116,9 @@ use ironcrab::nats::{
     TOPIC_PRIORITY_FEE_SAMPLES, TOPIC_TRADE_INTENTS, TRADE_INTENTS_STREAM_NAME,
     WALLET_SNAPSHOT_STREAM_NAME, WALLET_TX_CONFIRM_STREAM_NAME,
 };
-use ironcrab::position_authority::{position_authority_drift_lockmanager, PositionAuthority};
+use ironcrab::position_authority::{
+    position_authority_drift_lockmanager, PositionAuthority, PositionAuthorityChange,
+};
 use ironcrab::solana::cross_dex_handler::CrossDexHandler;
 use ironcrab::solana::dex::meteora_dlmm::MeteoraDlmm;
 use ironcrab::solana::dex::orca::Orca;
@@ -2425,6 +2427,8 @@ struct ExecutionContext {
     lock_manager: LockManager,
     /// PA-2: passive PositionAuthority (metrics only; not used for gating or reservations).
     position_authority: Arc<ParkingMutex<PositionAuthority>>,
+    /// PA-5.1: cached JetStream KV store for PositionAuthority snapshots (I-24a).
+    position_authority_kv: tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
     log_base: PathBuf, // P1: For state persistence
     decision_counter: std::sync::atomic::AtomicU64,
     execution_counter: std::sync::atomic::AtomicU64,
@@ -6384,18 +6388,40 @@ impl ExecutionContext {
     }
 
     fn apply_position_authority_from_execution_result(&self, exec: &ExecutionResult) {
-        self.position_authority
+        let changes = self
+            .position_authority
             .lock()
             .apply_from_confirmed_execution_result(exec);
         self.refresh_position_authority_metrics();
+        self.spawn_publish_position_authority_changes(changes);
     }
 
     /// Wallet snapshot: same filter as `PositionEvent::try_from_market_event_kind` (ignores SOL/WSOL for authority open count).
     fn apply_position_authority_from_wallet_event_kind(&self, kind: &MarketEventKind) {
-        self.position_authority
+        let changes = self
+            .position_authority
             .lock()
             .apply_from_wallet_market_event_kind(kind);
         self.refresh_position_authority_metrics();
+        self.spawn_publish_position_authority_changes(changes);
+    }
+
+    /// PA-5.1: fire-and-forget KV publish after reducer apply (non-blocking on hot path).
+    fn spawn_publish_position_authority_changes(&self, changes: Vec<PositionAuthorityChange>) {
+        if changes.is_empty() {
+            return;
+        }
+        let Some(nats) = self.nats.as_ref() else {
+            return;
+        };
+        let nats = nats.clone_for_spawned_publish();
+        let kv_cell = self.position_authority_kv.clone();
+        tokio::spawn(async move {
+            if let Err(e) = publish_position_authority_changes_to_kv(&nats, &kv_cell, changes).await
+            {
+                warn!(error = %e, "PositionAuthority KV publish failed");
+            }
+        });
     }
 
     /// Apply a WalletBalanceSnapshot MarketEvent to LockManager + decimals cache.
@@ -6456,6 +6482,40 @@ impl ExecutionContext {
         POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE.store(lock_open as u64, Ordering::Relaxed);
         POSITION_AUTHORITY_DRIFT_LOCKMANAGER.store(drift, Ordering::Relaxed);
     }
+}
+
+/// PA-5.1: write PositionAuthority deltas to JetStream KV (`POSITION_AUTHORITY` bucket).
+async fn publish_position_authority_changes_to_kv(
+    nats: &NatsClient,
+    kv_cell: &tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
+    changes: Vec<PositionAuthorityChange>,
+) -> anyhow::Result<()> {
+    if changes.is_empty() {
+        return Ok(());
+    }
+    let store = if let Some(store) = kv_cell.get() {
+        store.clone()
+    } else {
+        let store = nats
+            .get_or_create_kv_bucket(POSITION_AUTHORITY_KV_BUCKET)
+            .await?;
+        let _ = kv_cell.set(store.clone());
+        store
+    };
+    for change in changes {
+        match change {
+            PositionAuthorityChange::Put(snapshot) => {
+                let mint = snapshot.mint.clone();
+                nats.kv_put(&store, &mint, &snapshot).await?;
+            }
+            PositionAuthorityChange::Tombstone { mint } => {
+                if let Err(e) = nats.kv_delete(&store, &mint).await {
+                    debug!(mint = %mint, error = %e, "PositionAuthority KV tombstone delete (may not exist)");
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 #[allow(dead_code)]
@@ -7915,6 +7975,7 @@ async fn main() -> Result<()> {
         burn_writer,
         lock_manager,
         position_authority: Arc::new(ParkingMutex::new(PositionAuthority::new())),
+        position_authority_kv: tokio::sync::OnceCell::new(),
         log_base: log_base.clone(),
         decision_counter: std::sync::atomic::AtomicU64::new(initial_decision_counter),
         execution_counter: std::sync::atomic::AtomicU64::new(initial_execution_counter),
@@ -9254,6 +9315,7 @@ async fn build_replay_context(
         burn_writer,
         lock_manager,
         position_authority: Arc::new(ParkingMutex::new(PositionAuthority::new())),
+        position_authority_kv: tokio::sync::OnceCell::new(),
         log_base: log_dir,
         decision_counter: std::sync::atomic::AtomicU64::new(0),
         execution_counter: std::sync::atomic::AtomicU64::new(0),

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -68,9 +68,10 @@ use ironcrab::ipc::{
     CheckResult, ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, DecisionOutcome,
     DecisionRecord, DexPoolReadiness, ExecutionResult, ExecutionStatus, ExplicitAmount,
     FairnessPolicy, FeePolicy, FillStatus, FillUnavailableReason, IntentOrigin, IntentTier,
-    KillSwitchContext, MarketEvent, MarketEventKind, PoolCacheUpdate, PriorityFeePercentiles,
-    RecordHeader, RejectReason, SimulationResult, TradeExecutionConstraints, TradeIntent,
-    TradeResources, TradeSide, TradingRegime, POSITION_AUTHORITY_KV_BUCKET,
+    KillSwitchContext, MarketEvent, MarketEventKind, PoolCacheUpdate, PositionAuthoritySnapshot,
+    PriorityFeePercentiles, RecordHeader, RejectReason, SimulationResult,
+    TradeExecutionConstraints, TradeIntent, TradeResources, TradeSide, TradingRegime,
+    POSITION_AUTHORITY_KV_BUCKET,
 };
 use ironcrab::ipc::{ControlRequest, ControlRequestKind, ControlResponse, ControlResponseStatus};
 use ironcrab::metrics::{
@@ -6528,6 +6529,57 @@ async fn publish_position_authority_changes_to_kv(
     Ok(())
 }
 
+/// PA-5.1: after EE restart, seed in-process PositionAuthority from wallet bootstrap and
+/// tombstone JetStream KV keys that no longer exist in the authority model.
+async fn reconcile_position_authority_kv_after_restart(
+    nats: &NatsClient,
+    position_authority: &ParkingMutex<PositionAuthority>,
+    kv_cell: &tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
+    wallet_snapshot_kinds: &[MarketEventKind],
+) -> anyhow::Result<()> {
+    let (changes, tracked) = {
+        let mut pa = position_authority.lock();
+        let mut changes = Vec::new();
+        for kind in wallet_snapshot_kinds {
+            changes.extend(pa.apply_from_wallet_market_event_kind(kind));
+        }
+        let tracked: std::collections::HashSet<String> = pa.tracked_mints().into_iter().collect();
+        (changes, tracked)
+    };
+
+    let mut changes = changes;
+
+    let store = if let Some(store) = kv_cell.get() {
+        store.clone()
+    } else {
+        let store = nats
+            .get_or_create_kv_bucket(POSITION_AUTHORITY_KV_BUCKET)
+            .await?;
+        let _ = kv_cell.set(store.clone());
+        store
+    };
+
+    let kv_entries = nats
+        .kv_get_all::<PositionAuthoritySnapshot>(&store)
+        .await
+        .unwrap_or_default();
+    for mint in kv_entries.keys() {
+        if !tracked.contains(mint) {
+            changes.push(PositionAuthorityChange::Tombstone { mint: mint.clone() });
+        }
+    }
+
+    if !changes.is_empty() {
+        publish_position_authority_changes_to_kv(nats, kv_cell, changes).await?;
+        info!(
+            wallet_snapshots = wallet_snapshot_kinds.len(),
+            kv_keys = kv_entries.len(),
+            "PositionAuthority KV reconciled after execution-engine restart"
+        );
+    }
+    Ok(())
+}
+
 #[allow(dead_code)]
 fn token_program_for_mint_owner(owner: &Pubkey) -> Option<Pubkey> {
     let spl_token_program = Pubkey::new_from_array(spl_token::id().to_bytes());
@@ -6669,7 +6721,7 @@ async fn bootstrap_token_balances_from_wallet_snapshot(
     nats_client: &NatsClient,
     wallet: &Pubkey,
     lock_manager: &LockManager,
-) -> Result<usize> {
+) -> Result<(usize, Vec<MarketEventKind>)> {
     use async_nats::jetstream;
     use futures::StreamExt;
 
@@ -6682,7 +6734,7 @@ async fn bootstrap_token_balances_from_wallet_snapshot(
                 stream = WALLET_SNAPSHOT_STREAM_NAME,
                 "Wallet snapshot stream not found (market-data may not be running)"
             );
-            return Ok(0);
+            return Ok((0, Vec::new()));
         }
     };
 
@@ -6695,6 +6747,7 @@ async fn bootstrap_token_balances_from_wallet_snapshot(
     let mut observed = 0usize;
     let mut bootstrap_sol: Option<u64> = None;
     let mut bootstrap_wsol: Option<u64> = None;
+    let mut wallet_snapshot_kinds = Vec::new();
 
     loop {
         let mut messages = consumer.fetch().max_messages(batch_size).messages().await?;
@@ -6734,6 +6787,7 @@ async fn bootstrap_token_balances_from_wallet_snapshot(
                     // Regular token balance (skip SOL_MINT which equals WSOL_MINT
                     // but could appear from old JetStream entries)
                     lock_manager.set_available_token_balance(mint.clone(), *balance_raw);
+                    wallet_snapshot_kinds.push(event.kind.clone());
                 }
             }
 
@@ -6774,7 +6828,7 @@ async fn bootstrap_token_balances_from_wallet_snapshot(
         );
     }
 
-    Ok(observed)
+    Ok((observed, wallet_snapshot_kinds))
 }
 
 /// Create the durable live wallet snapshot consumer for the main loop.
@@ -7867,22 +7921,20 @@ async fn main() -> Result<()> {
     // The live consumer is created immediately after bootstrap (reused in the main loop)
     // so snapshots published during the long startup phase are not missed (DeliverPolicy::New).
     let mut wallet_snapshot_bootstrap_observed = 0usize;
+    let mut wallet_snapshot_kinds: Vec<MarketEventKind> = Vec::new();
     let wallet_snapshot_bootstrap_consumer = if let (Some(ref nats_client), Some(wallet)) =
         (&nats, wallet_pubkey)
     {
-        wallet_snapshot_bootstrap_observed = match bootstrap_token_balances_from_wallet_snapshot(
-            nats_client,
-            &wallet,
-            &lock_manager,
-        )
-        .await
-        {
-            Ok(observed) => observed,
-            Err(e) => {
-                warn!(error = %e, "Wallet snapshot bootstrap: failed to seed token balances");
-                0
-            }
-        };
+        (wallet_snapshot_bootstrap_observed, wallet_snapshot_kinds) =
+            match bootstrap_token_balances_from_wallet_snapshot(nats_client, &wallet, &lock_manager)
+                .await
+            {
+                Ok(pair) => pair,
+                Err(e) => {
+                    warn!(error = %e, "Wallet snapshot bootstrap: failed to seed token balances");
+                    (0, Vec::new())
+                }
+            };
         // "Available WSOL" metric: always actual WSOL (0 when no ATA), never native SOL fallback.
         let wsol = lock_manager.available_wsol();
         AVAILABLE_SOL_LAMPORTS.store(wsol, Ordering::Relaxed);
@@ -8036,6 +8088,23 @@ async fn main() -> Result<()> {
         replay_mode: false,
         pump_amm_hot_path_refresh_last: Arc::new(ParkingMutex::new(HashMap::new())),
     };
+
+    if let Some(ref nats_client) = ctx.nats {
+        if let Err(e) = reconcile_position_authority_kv_after_restart(
+            nats_client,
+            &ctx.position_authority,
+            &position_authority_kv,
+            &wallet_snapshot_kinds,
+        )
+        .await
+        {
+            warn!(
+                error = %e,
+                "PositionAuthority KV startup reconcile failed (Momentum may see stale KV until next update)"
+            );
+        }
+        ctx.refresh_position_authority_metrics();
+    }
 
     // Sync kill switch to global metric so control plane /status can display correct state after restarts
     KILL_SWITCH_ACTIVE.store(initial_kill_switch_active, Ordering::Relaxed);

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -6529,6 +6529,16 @@ async fn publish_position_authority_changes_to_kv(
     Ok(())
 }
 
+/// PA-5.1: tombstone sweep only when bootstrap included `WalletSnapshotComplete`
+/// (partial balance snapshots alone are not a complete wallet picture).
+fn wallet_bootstrap_allows_pa_kv_tombstone_sweep(
+    wallet_snapshot_kinds: &[MarketEventKind],
+) -> bool {
+    wallet_snapshot_kinds
+        .iter()
+        .any(|k| matches!(k, MarketEventKind::WalletSnapshotComplete { .. }))
+}
+
 /// PA-5.1: after EE restart, seed in-process PositionAuthority from wallet bootstrap and
 /// tombstone JetStream KV keys that no longer exist in the authority model.
 async fn reconcile_position_authority_kv_after_restart(
@@ -6559,24 +6569,40 @@ async fn reconcile_position_authority_kv_after_restart(
         store
     };
 
-    let kv_entries = nats
-        .kv_get_all::<PositionAuthoritySnapshot>(&store)
-        .await
-        .unwrap_or_default();
-    for mint in kv_entries.keys() {
-        if !tracked.contains(mint) {
-            changes.push(PositionAuthorityChange::Tombstone { mint: mint.clone() });
-        }
-    }
+    let allow_tombstone_sweep =
+        wallet_bootstrap_allows_pa_kv_tombstone_sweep(wallet_snapshot_kinds);
 
-    if !changes.is_empty() {
-        publish_position_authority_changes_to_kv(nats, kv_cell, changes).await?;
-        info!(
+    if allow_tombstone_sweep {
+        let kv_entries = nats
+            .kv_get_all::<PositionAuthoritySnapshot>(&store)
+            .await
+            .unwrap_or_default();
+        for mint in kv_entries.keys() {
+            if !tracked.contains(mint) {
+                changes.push(PositionAuthorityChange::Tombstone { mint: mint.clone() });
+            }
+        }
+        if !changes.is_empty() {
+            publish_position_authority_changes_to_kv(nats, kv_cell, changes).await?;
+            info!(
+                wallet_snapshots = wallet_snapshot_kinds.len(),
+                kv_keys = kv_entries.len(),
+                tracked_mints = tracked.len(),
+                "PositionAuthority KV reconciled after execution-engine restart (tombstone sweep)"
+            );
+        }
+    } else {
+        if !changes.is_empty() {
+            publish_position_authority_changes_to_kv(nats, kv_cell, changes).await?;
+        }
+        warn!(
             wallet_snapshots = wallet_snapshot_kinds.len(),
-            kv_keys = kv_entries.len(),
-            "PositionAuthority KV reconciled after execution-engine restart"
+            has_snapshot_complete = false,
+            tracked_mints = tracked.len(),
+            "PositionAuthority KV reconcile: tombstone sweep skipped (wallet bootstrap missing WalletSnapshotComplete or empty)"
         );
     }
+
     Ok(())
 }
 
@@ -6789,6 +6815,9 @@ async fn bootstrap_token_balances_from_wallet_snapshot(
                     lock_manager.set_available_token_balance(mint.clone(), *balance_raw);
                     wallet_snapshot_kinds.push(event.kind.clone());
                 }
+            } else if matches!(event.kind, MarketEventKind::WalletSnapshotComplete { .. }) {
+                observed += 1;
+                wallet_snapshot_kinds.push(event.kind.clone());
             }
 
             let _ = msg.ack().await;
@@ -13770,9 +13799,9 @@ mod execution_engine_tests {
         try_pump_amm_hot_path_refresh_publish, wait_for_meteora_dlmm_slave_after_recovery,
         wait_for_pump_amm_pool_hint_ready_for_tx_plan_builder,
         wait_for_pump_amm_slave_after_recovery, wait_for_pumpfun_bonding_cache_refresh,
-        ComputedIntentFills, DiscoveryRequestOutcome, ExecutionConfig,
-        PumpAmmHotPathRefreshDecision, RouteCandidate, PUMP_AMM_HOT_PATH_REFRESH_COOLDOWN,
-        WSOL_MINT,
+        wallet_bootstrap_allows_pa_kv_tombstone_sweep, ComputedIntentFills,
+        DiscoveryRequestOutcome, ExecutionConfig, PumpAmmHotPathRefreshDecision, RouteCandidate,
+        PUMP_AMM_HOT_PATH_REFRESH_COOLDOWN, WSOL_MINT,
     };
     use ironcrab::execution::live_pool_cache::{
         CachedPoolState, LivePoolCache, MeteoraState, PumpAmmState, PumpFunState,
@@ -13783,8 +13812,8 @@ mod execution_engine_tests {
     use ironcrab::ipc::{
         CheckResult, ControlResponse, ControlResponseStatus, DecisionOutcome, DecisionRecord,
         DexPoolReadiness, ExecutionResult, ExecutionStatus, ExplicitAmount, FillStatus,
-        IntentOrigin, IntentTier, PoolCacheUpdate, TradeIntent, TradeResources, TradeSide,
-        TradingRegime,
+        IntentOrigin, IntentTier, MarketEventKind, PoolCacheUpdate, TradeIntent, TradeResources,
+        TradeSide, TradingRegime,
     };
     use ironcrab::solana::address_lookup_table::LoadedAlt;
     use ironcrab::solana::dex::pumpfun::PumpFunDex;
@@ -13828,6 +13857,33 @@ mod execution_engine_tests {
 
         assert_eq!(unsigned.message, signed.message);
         assert!(matches!(unsigned.message, VersionedMessage::Legacy(_)));
+    }
+
+    #[test]
+    fn wallet_bootstrap_tombstone_sweep_requires_snapshot_complete() {
+        let balance_only = vec![MarketEventKind::WalletBalanceSnapshot {
+            mint: "mintA".to_string(),
+            balance_raw: 1,
+            decimals: 6,
+            token_program: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string(),
+        }];
+        assert!(
+            !wallet_bootstrap_allows_pa_kv_tombstone_sweep(&balance_only),
+            "partial balance snapshots must not authorize tombstone sweep"
+        );
+        assert!(
+            !wallet_bootstrap_allows_pa_kv_tombstone_sweep(&[]),
+            "empty bootstrap must not authorize tombstone sweep"
+        );
+        let with_complete = vec![MarketEventKind::WalletSnapshotComplete {
+            wallet: "wallet".to_string(),
+            mints_in_wallet: vec!["mintA".to_string()],
+            is_periodic: true,
+        }];
+        assert!(
+            wallet_bootstrap_allows_pa_kv_tombstone_sweep(&with_complete),
+            "WalletSnapshotComplete authorizes tombstone sweep"
+        );
     }
 
     #[test]

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -43,8 +43,9 @@ use ironcrab::execution::tokens_per_sol;
 use ironcrab::ipc::{
     ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, ControlRequest, ControlRequestKind,
     ExecutionResult, ExecutionStatus, ExplicitAmount, IntentOrigin, IntentTier, MarketEvent,
-    MarketEventKind, TradeExecutionConstraints, TradeIntent, TradeResources, TradeSide,
-    TradingRegime, NATIVE_SOL_MINT,
+    MarketEventKind, PositionAuthoritySnapshot, PositionAuthorityStatus, TradeExecutionConstraints,
+    TradeIntent, TradeResources, TradeSide, TradingRegime, NATIVE_SOL_MINT,
+    POSITION_AUTHORITY_KV_BUCKET,
 };
 use ironcrab::metrics::{
     momentum_event_ts_latency_delta_ms, record_momentum_active_pools_messages_total,
@@ -53,11 +54,12 @@ use ironcrab::metrics::{
     record_momentum_core_market_events_received_kind, record_momentum_ingest_to_process_us,
     record_momentum_market_events_last_applied_slot,
     record_momentum_market_events_subscription_max_dequeued_slot,
-    record_momentum_nats_batch_prepare_us, record_momentum_signal_eval_us,
-    record_momentum_tracker_rejected, record_momentum_tracker_trades_recorded,
-    record_momentum_trades_received_no_tracker, serve_metrics,
-    set_momentum_bot_process_start_unix_sec,
-    set_momentum_market_events_ingest_max_wall_lag_ms_last_batch, set_readiness_nats_connected,
+    record_momentum_nats_batch_prepare_us, record_momentum_overlay_closed_by_authority_total,
+    record_momentum_signal_eval_us, record_momentum_tracker_rejected,
+    record_momentum_tracker_trades_recorded, record_momentum_trades_received_no_tracker,
+    serve_metrics, set_momentum_bot_process_start_unix_sec,
+    set_momentum_market_events_ingest_max_wall_lag_ms_last_batch,
+    set_position_authority_drift_momentum, set_readiness_nats_connected,
     try_record_momentum_event_to_ingest_ms, try_record_momentum_event_to_intent_publish_ms,
     try_record_momentum_intent_header_to_publish_ms,
     try_record_momentum_jetstream_poolcache_event_to_ingest_ms,
@@ -79,6 +81,7 @@ use ironcrab::nats::{
     TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS, TOPIC_MOMENTUM_ACTIVE_POOLS,
     TOPIC_MOMENTUM_MARKET_EVENTS, TOPIC_TRADE_INTENTS, WALLET_SNAPSHOT_STREAM_NAME,
 };
+use ironcrab::position_authority::position_authority_drift_momentum;
 use ironcrab::solana::dex_parser::SOL_MINT_PUBKEY;
 use ironcrab::storage::{JsonlWriterConfig, QueuedJsonlWriter};
 use tokio::sync::mpsc;
@@ -3260,6 +3263,10 @@ struct MomentumContext {
     open_position_pool_recovery_last_sent: parking_lot::RwLock<HashMap<String, Instant>>,
     /// JetStream KV Store for position persistence (initialized lazily)
     position_kv: tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
+    /// PA-5.1: JetStream KV for readonly PositionAuthority snapshots (I-24a).
+    position_authority_kv: tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
+    /// PA-5.1: readonly cache of execution-engine PositionAuthority (mint → snapshot).
+    authority_by_mint: parking_lot::RwLock<HashMap<String, PositionAuthoritySnapshot>>,
     /// Mints with non-zero wallet balance that could not be reconciled at bootstrap
     /// because no pool was known yet. Checked when new pools are registered.
     orphaned_mints: parking_lot::RwLock<HashMap<String, (u64, u8)>>,
@@ -5839,6 +5846,153 @@ impl MomentumContext {
         });
     }
 
+    /// PA-5.1: close overlay when PositionAuthority signals closed / absent / zero balance.
+    fn close_position_by_authority(self: &Arc<Self>, mint: &str, reason: &str) {
+        if !self.positions.read().contains_key(mint) {
+            return;
+        }
+        info!(
+            mint = %mint,
+            reason = %reason,
+            "PositionAuthority closed overlay (ghost cleanup)"
+        );
+        record_momentum_overlay_closed_by_authority_total();
+        self.close_position(mint);
+    }
+
+    fn authority_signals_closed(snap: Option<&PositionAuthoritySnapshot>) -> bool {
+        match snap {
+            None => true,
+            Some(s) => s.balance_raw == 0 || s.status == PositionAuthorityStatus::Closed,
+        }
+    }
+
+    /// Apply a PositionAuthority KV update and enforce overlay-close rule.
+    fn apply_authority_snapshot_update(
+        self: &Arc<Self>,
+        mint: &str,
+        snap: Option<PositionAuthoritySnapshot>,
+    ) {
+        {
+            let mut cache = self.authority_by_mint.write();
+            match snap {
+                Some(s) => {
+                    cache.insert(mint.to_string(), s);
+                }
+                None => {
+                    cache.remove(mint);
+                }
+            }
+        }
+        self.refresh_position_authority_drift_metrics();
+        let closed = {
+            let cache = self.authority_by_mint.read();
+            Self::authority_signals_closed(cache.get(mint))
+        };
+        if closed && self.positions.read().contains_key(mint) {
+            self.close_position_by_authority(mint, "authority_closed_or_tombstoned");
+        }
+    }
+
+    fn refresh_position_authority_drift_metrics(&self) {
+        let authority_open = self
+            .authority_by_mint
+            .read()
+            .values()
+            .filter(|s| s.balance_raw > 0 && s.status != PositionAuthorityStatus::Closed)
+            .count();
+        let overlay_count = self.positions.read().len();
+        set_position_authority_drift_momentum(position_authority_drift_momentum(
+            authority_open,
+            overlay_count,
+        ));
+    }
+
+    async fn get_position_authority_kv(&self) -> Option<&async_nats::jetstream::kv::Store> {
+        let nats = self.nats.as_ref()?;
+        if let Some(store) = self.position_authority_kv.get() {
+            return Some(store);
+        }
+        match nats
+            .get_or_create_kv_bucket(POSITION_AUTHORITY_KV_BUCKET)
+            .await
+        {
+            Ok(store) => {
+                let _ = self.position_authority_kv.set(store);
+                self.position_authority_kv.get()
+            }
+            Err(e) => {
+                error!(error = %e, "Failed to create PositionAuthority KV bucket");
+                None
+            }
+        }
+    }
+
+    /// Bootstrap + live watch on `POSITION_AUTHORITY` KV (readonly, no RPC).
+    async fn bootstrap_and_watch_position_authority_kv(self: &Arc<Self>) {
+        let Some(nats) = self.nats.as_ref() else {
+            return;
+        };
+        let Some(store) = self.get_position_authority_kv().await else {
+            return;
+        };
+
+        match nats.kv_get_all::<PositionAuthoritySnapshot>(store).await {
+            Ok(entries) => {
+                info!(
+                    count = entries.len(),
+                    "Bootstrapped PositionAuthority snapshots from JetStream KV"
+                );
+                for (mint, snap) in entries {
+                    self.apply_authority_snapshot_update(&mint, Some(snap));
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to bootstrap PositionAuthority KV");
+            }
+        }
+
+        let ctx = Arc::clone(self);
+        let store = store.clone();
+        tokio::spawn(async move {
+            use futures::StreamExt;
+            let mut watch = match store.watch_all().await {
+                Ok(w) => w,
+                Err(e) => {
+                    error!(error = %e, "PositionAuthority KV watch failed to start");
+                    return;
+                }
+            };
+            info!("PositionAuthority KV watch started");
+            while let Some(entry_res) = watch.next().await {
+                match entry_res {
+                    Ok(entry) => {
+                        let mint = entry.key;
+                        if entry.operation == async_nats::jetstream::kv::Operation::Delete
+                            || entry.value.is_empty()
+                        {
+                            ctx.apply_authority_snapshot_update(&mint, None);
+                            continue;
+                        }
+                        match serde_json::from_slice::<PositionAuthoritySnapshot>(&entry.value) {
+                            Ok(snap) => {
+                                ctx.apply_authority_snapshot_update(&mint, Some(snap));
+                            }
+                            Err(e) => {
+                                warn!(mint = %mint, error = %e, "Invalid PositionAuthority KV payload");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "PositionAuthority KV watch error");
+                        break;
+                    }
+                }
+            }
+            warn!("PositionAuthority KV watch ended");
+        });
+    }
+
     // =========================================================================
     // JetStream KV Position Persistence
     // =========================================================================
@@ -7090,8 +7244,26 @@ impl MomentumContext {
         );
     }
 
-    /// Phase 4 P2: confirmed `PositionTracker.token_amount` is SSOT for exit sizing; snapshot is hint.
+    /// Phase 4 P2 + PA-5.1: confirmed overlay SSOT; Authority caps exit when published.
     fn resolve_exit_token_amount_raw(&self, mint: &str, hint_amount: u64) -> u64 {
+        let authority_snap = self.authority_by_mint.read().get(mint).cloned();
+        if let Some(ref auth) = authority_snap {
+            if Self::authority_signals_closed(Some(auth)) {
+                return 0;
+            }
+            let overlay = self
+                .positions
+                .read()
+                .get(mint)
+                .map(|p| p.token_amount)
+                .filter(|t| *t > 0)
+                .unwrap_or(hint_amount);
+            if overlay > 0 {
+                return overlay.min(auth.balance_raw);
+            }
+            return auth.balance_raw.min(hint_amount);
+        }
+
         let overlay = self
             .positions
             .read()
@@ -7127,6 +7299,13 @@ impl MomentumContext {
         }
     }
 
+    fn execution_result_removes_pending(status: ExecutionStatus) -> bool {
+        matches!(
+            status,
+            ExecutionStatus::Confirmed | ExecutionStatus::Failed | ExecutionStatus::Timeout
+        )
+    }
+
     fn try_apply_reserve_hint_as_position_price(
         pos: &mut PositionTracker,
         hint: &CachedPoolReservePriceHint,
@@ -7158,9 +7337,14 @@ impl MomentumContext {
     /// Handle execution result from execution-engine
     fn handle_execution_result(self: &Arc<Self>, result: &ExecutionResult) {
         // Find the pending intent by id (source is not authoritative).
+        // PA-5.1: `Sent` must not remove pending — confirm path needs it for close_position.
         let pending_opt = {
             let mut pending = self.pending_intents.write();
-            pending.remove(&result.intent_id)
+            if Self::execution_result_removes_pending(result.status) {
+                pending.remove(&result.intent_id)
+            } else {
+                pending.get(&result.intent_id).cloned()
+            }
         };
 
         let Some(pending) = pending_opt else {
@@ -9852,6 +10036,8 @@ async fn main() -> Result<()> {
         live_pool_cache,
         open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
         position_kv: tokio::sync::OnceCell::new(),
+        position_authority_kv: tokio::sync::OnceCell::new(),
+        authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
         orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
         orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
             ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -9885,6 +10071,9 @@ async fn main() -> Result<()> {
     }
 
     startup_wallet_ghost_reconciliation(&ctx).await;
+
+    // PA-5.1: readonly PositionAuthority from JetStream KV (bootstrap + watch).
+    ctx.bootstrap_and_watch_position_authority_kv().await;
 
     // Open positions: request authoritative pool rows from market-data (bounded, deduped; no RPC here).
     ctx.schedule_open_position_pool_recoveries("startup").await;
@@ -12076,6 +12265,8 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -13934,6 +14125,8 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -14003,6 +14196,8 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -16362,6 +16557,8 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -16453,6 +16650,8 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -16538,6 +16737,8 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -16708,6 +16909,8 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -16823,6 +17026,8 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -16923,6 +17128,8 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -17000,6 +17207,8 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -17069,6 +17278,8 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -18076,6 +18287,8 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -18226,6 +18439,8 @@ mod tests {
             live_pool_cache: LivePoolCache::new(),
             open_position_pool_recovery_last_sent: parking_lot::RwLock::new(HashMap::new()),
             position_kv: tokio::sync::OnceCell::new(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_by_mint: parking_lot::RwLock::new(HashMap::new()),
             orphaned_mints: parking_lot::RwLock::new(HashMap::new()),
             orphaned_recovered_intent_ids: parking_lot::RwLock::new(BoundedIntentIdCache::new(
                 ORPHANED_RECOVERED_INTENT_IDS_CAP,
@@ -19412,6 +19627,136 @@ mod tests {
         );
     }
 
+    /// PA-5.1: `ExecutionStatus::Sent` must not remove pending (confirm needs it for close).
+    #[test]
+    fn pa51_sent_execution_result_keeps_pending() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+
+        let intent_id = "sell-sent-pending";
+        let mint = "SentPendingMintttttttttttttttttttttttttttttt";
+        ctx.pending_intents.write().insert(
+            intent_id.to_string(),
+            PendingIntent {
+                mint: mint.to_string(),
+                pool: "pool".to_string(),
+                dex: "raydium".to_string(),
+                side: TradeSide::Sell,
+                entry_kind: None,
+                sol_amount: 0,
+                token_amount: 1_000,
+                created_at: Instant::now(),
+            },
+        );
+
+        let result = ExecutionResult {
+            header: RecordHeader::new("test", BUILD_VERSION, "run-test"),
+            execution_id: "ex-sent".to_string(),
+            decision_id: "dec-sent".to_string(),
+            intent_id: intent_id.to_string(),
+            source: "momentum-bot".to_string(),
+            token_mint: Some(mint.to_string()),
+            signature: Some("sig".to_string()),
+            bundle_id: None,
+            status: ExecutionStatus::Sent,
+            fill_in: None,
+            fill_out: None,
+            fill_status: None,
+            fill_unavailable_reason: None,
+            confirmed_slot: None,
+            block_time_unix_ms: None,
+            fees: None,
+            pnl: None,
+            wallet_sol_delta_lamports: None,
+            error_message: None,
+            error_code: None,
+            latency_ms: None,
+            metadata: std::collections::HashMap::new(),
+        };
+
+        Arc::clone(&ctx).handle_execution_result(&result);
+        assert!(
+            ctx.pending_intents.read().contains_key(intent_id),
+            "Sent must not remove pending intent"
+        );
+    }
+
+    /// PA-5.1: Authority tombstone/closed closes momentum overlay.
+    #[tokio::test]
+    async fn pa51_authority_closed_closes_overlay() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+
+        let mint = "AuthCloseMinttttttttttttttttttttttttttttttt";
+        ctx.open_position(OpenPositionParams {
+            mint,
+            pool: "pool",
+            dex: "raydium",
+            entry_price: 1.0,
+            token_decimals: 6,
+            token_amount: 500,
+            sol_invested: 1_000_000,
+            token_program: None,
+            creator: None,
+            entry_confirmed_slot: 1,
+            initial_bonding: None,
+        });
+
+        Arc::clone(&ctx).apply_authority_snapshot_update(
+            mint,
+            Some(PositionAuthoritySnapshot {
+                mint: mint.to_string(),
+                balance_raw: 0,
+                decimals: 6,
+                status: PositionAuthorityStatus::Closed,
+                last_update_source: ironcrab::ipc::PositionAuthorityUpdateSource::Execution,
+                sold_raw_total: None,
+            }),
+        );
+        assert!(
+            !ctx.positions.read().contains_key(mint),
+            "overlay must close when authority is closed"
+        );
+    }
+
+    /// PA-5.1: exit sizing uses min(overlay, authority.balance_raw).
+    #[tokio::test]
+    async fn pa51_exit_amount_min_authority_balance() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+
+        let mint = "AuthExitMintttttttttttttttttttttttttttttttt";
+        ctx.open_position(OpenPositionParams {
+            mint,
+            pool: "pool",
+            dex: "raydium",
+            entry_price: 1.0,
+            token_decimals: 6,
+            token_amount: 1_000,
+            sol_invested: 1_000_000,
+            token_program: None,
+            creator: None,
+            entry_confirmed_slot: 1,
+            initial_bonding: None,
+        });
+        ctx.authority_by_mint.write().insert(
+            mint.to_string(),
+            PositionAuthoritySnapshot {
+                mint: mint.to_string(),
+                balance_raw: 400,
+                decimals: 6,
+                status: PositionAuthorityStatus::Open,
+                last_update_source: ironcrab::ipc::PositionAuthorityUpdateSource::WalletSnapshot,
+                sold_raw_total: None,
+            },
+        );
+
+        assert_eq!(ctx.resolve_exit_token_amount_raw(mint, 1_000), 400);
+    }
+
     fn orphan_buy_execution_result(
         intent_id: &str,
         mint: &str,
@@ -19695,8 +20040,16 @@ async fn generate_and_publish_exit_intent(
     // bootstrap, and any `check_for_exits()`-driven scan where one event is not tied to each exit.
     source_event_ts_unix_ms: Option<u64>,
 ) -> Result<()> {
-    // Authoritative sell size: overlay + optional JetStream wallet snapshot (Scope 57 / PA-5 interim).
+    // Authoritative sell size: overlay + PositionAuthority when published (PA-5.1).
     let token_amount = ctx.resolve_exit_token_amount_raw(mint, token_amount);
+    if token_amount == 0 {
+        debug!(
+            mint = %mint,
+            exit_type = %exit_type,
+            "Exit suppressed: PositionAuthority closed or zero balance"
+        );
+        return Ok(());
+    }
 
     // Phase 3: Slippage escalation — when prior sells failed with 6002, increase tolerance
     let max_slippage = {

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -5873,6 +5873,27 @@ impl MomentumContext {
         mint: &str,
         snap: Option<PositionAuthoritySnapshot>,
     ) {
+        const GHOST_CLEANUP_GRACE_SECS: u64 = 90;
+
+        let closed = Self::authority_signals_closed(snap.as_ref());
+        if closed && self.positions.read().contains_key(mint) {
+            let hold_secs = self
+                .positions
+                .read()
+                .get(mint)
+                .map(|p| p.entry_time.elapsed().as_secs())
+                .unwrap_or(u64::MAX);
+            if hold_secs < GHOST_CLEANUP_GRACE_SECS {
+                warn!(
+                    mint = %mint,
+                    hold_secs,
+                    grace_secs = GHOST_CLEANUP_GRACE_SECS,
+                    "Authority close skipped: overlay too fresh (grace period)"
+                );
+                return;
+            }
+        }
+
         {
             let mut cache = self.authority_by_mint.write();
             match snap {
@@ -5885,10 +5906,6 @@ impl MomentumContext {
             }
         }
         self.refresh_position_authority_drift_metrics();
-        let closed = {
-            let cache = self.authority_by_mint.read();
-            Self::authority_signals_closed(cache.get(mint))
-        };
         if closed && self.positions.read().contains_key(mint) {
             self.close_position_by_authority(mint, "authority_closed_or_tombstoned");
         }
@@ -19726,6 +19743,11 @@ mod tests {
             entry_confirmed_slot: 1,
             initial_bonding: None,
         });
+        ctx.positions
+            .write()
+            .get_mut(mint)
+            .expect("position")
+            .set_entry_time_ago(std::time::Duration::from_secs(91));
 
         Arc::clone(&ctx).apply_authority_snapshot_update(
             mint,

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -5867,6 +5867,22 @@ impl MomentumContext {
         }
     }
 
+    /// Overlay token amount when authority close is deferred by the 90s grace period.
+    fn overlay_exit_amount_during_authority_grace(&self, mint: &str) -> Option<u64> {
+        const GHOST_CLEANUP_GRACE_SECS: u64 = 90;
+        let positions = self.positions.read();
+        let pos = positions.get(mint)?;
+        if pos.entry_time.elapsed().as_secs() >= GHOST_CLEANUP_GRACE_SECS {
+            return None;
+        }
+        let amount = pos.token_amount;
+        if amount > 0 {
+            Some(amount)
+        } else {
+            None
+        }
+    }
+
     /// Apply a PositionAuthority KV update and enforce overlay-close rule.
     fn apply_authority_snapshot_update(
         self: &Arc<Self>,
@@ -7288,6 +7304,10 @@ impl MomentumContext {
         let authority_snap = self.authority_by_mint.read().get(mint).cloned();
         if let Some(ref auth) = authority_snap {
             if Self::authority_signals_closed(Some(auth)) {
+                // Grace: defer overlay close but do not block exits on a fresh position.
+                if let Some(overlay_grace) = self.overlay_exit_amount_during_authority_grace(mint) {
+                    return overlay_grace;
+                }
                 return 0;
             }
             let overlay = self
@@ -19799,6 +19819,50 @@ mod tests {
         );
 
         assert_eq!(ctx.resolve_exit_token_amount_raw(mint, 1_000), 400);
+    }
+
+    /// PA-5.1 bugfix: authority closed during 90s grace must not suppress exits.
+    #[tokio::test]
+    async fn pa51_authority_closed_grace_allows_exit_amount() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+
+        let mint = "AuthGraceMintttttttttttttttttttttttttttttttt";
+        ctx.open_position(OpenPositionParams {
+            mint,
+            pool: "pool",
+            dex: "raydium",
+            entry_price: 1.0,
+            token_decimals: 6,
+            token_amount: 800,
+            sol_invested: 1_000_000,
+            token_program: None,
+            creator: None,
+            entry_confirmed_slot: 1,
+            initial_bonding: None,
+        });
+        ctx.authority_by_mint.write().insert(
+            mint.to_string(),
+            PositionAuthoritySnapshot {
+                mint: mint.to_string(),
+                balance_raw: 0,
+                decimals: 6,
+                status: PositionAuthorityStatus::Closed,
+                last_update_source: ironcrab::ipc::PositionAuthorityUpdateSource::Execution,
+                sold_raw_total: None,
+            },
+        );
+
+        assert_eq!(
+            ctx.resolve_exit_token_amount_raw(mint, 800),
+            800,
+            "fresh overlay must still exit during authority-close grace"
+        );
+        assert!(
+            ctx.positions.read().contains_key(mint),
+            "overlay must remain open during grace"
+        );
     }
 
     fn orphan_buy_execution_result(

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -5956,40 +5956,63 @@ impl MomentumContext {
         let store = store.clone();
         tokio::spawn(async move {
             use futures::StreamExt;
-            let mut watch = match store.watch_all().await {
-                Ok(w) => w,
-                Err(e) => {
-                    error!(error = %e, "PositionAuthority KV watch failed to start");
-                    return;
-                }
-            };
-            info!("PositionAuthority KV watch started");
-            while let Some(entry_res) = watch.next().await {
-                match entry_res {
-                    Ok(entry) => {
-                        let mint = entry.key;
-                        if entry.operation == async_nats::jetstream::kv::Operation::Delete
-                            || entry.value.is_empty()
-                        {
-                            ctx.apply_authority_snapshot_update(&mint, None);
-                            continue;
-                        }
-                        match serde_json::from_slice::<PositionAuthoritySnapshot>(&entry.value) {
-                            Ok(snap) => {
-                                ctx.apply_authority_snapshot_update(&mint, Some(snap));
-                            }
-                            Err(e) => {
-                                warn!(mint = %mint, error = %e, "Invalid PositionAuthority KV payload");
-                            }
-                        }
-                    }
+            use std::time::Duration;
+
+            const WATCH_BACKOFF_INITIAL_MS: u64 = 500;
+            const WATCH_BACKOFF_MAX_MS: u64 = 30_000;
+            let mut backoff_ms = WATCH_BACKOFF_INITIAL_MS;
+
+            loop {
+                let mut watch = match store.watch_all().await {
+                    Ok(w) => w,
                     Err(e) => {
-                        warn!(error = %e, "PositionAuthority KV watch error");
-                        break;
+                        error!(
+                            error = %e,
+                            backoff_ms,
+                            "PositionAuthority KV watch failed to start"
+                        );
+                        tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                        backoff_ms = (backoff_ms * 2).min(WATCH_BACKOFF_MAX_MS);
+                        continue;
+                    }
+                };
+                info!("PositionAuthority KV watch started");
+                backoff_ms = WATCH_BACKOFF_INITIAL_MS;
+
+                while let Some(entry_res) = watch.next().await {
+                    match entry_res {
+                        Ok(entry) => {
+                            let mint = entry.key;
+                            if entry.operation == async_nats::jetstream::kv::Operation::Delete
+                                || entry.value.is_empty()
+                            {
+                                ctx.apply_authority_snapshot_update(&mint, None);
+                                continue;
+                            }
+                            match serde_json::from_slice::<PositionAuthoritySnapshot>(&entry.value)
+                            {
+                                Ok(snap) => {
+                                    ctx.apply_authority_snapshot_update(&mint, Some(snap));
+                                }
+                                Err(e) => {
+                                    warn!(mint = %mint, error = %e, "Invalid PositionAuthority KV payload");
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                error = %e,
+                                backoff_ms,
+                                "PositionAuthority KV watch error"
+                            );
+                            break;
+                        }
                     }
                 }
+                warn!(backoff_ms, "PositionAuthority KV watch ended, reconnecting");
+                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                backoff_ms = (backoff_ms * 2).min(WATCH_BACKOFF_MAX_MS);
             }
-            warn!("PositionAuthority KV watch ended");
         });
     }
 

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -5876,6 +5876,20 @@ impl MomentumContext {
         const GHOST_CLEANUP_GRACE_SECS: u64 = 90;
 
         let closed = Self::authority_signals_closed(snap.as_ref());
+
+        {
+            let mut cache = self.authority_by_mint.write();
+            match snap {
+                Some(s) => {
+                    cache.insert(mint.to_string(), s);
+                }
+                None => {
+                    cache.remove(mint);
+                }
+            }
+        }
+        self.refresh_position_authority_drift_metrics();
+
         if closed && self.positions.read().contains_key(mint) {
             let hold_secs = self
                 .positions
@@ -5892,21 +5906,6 @@ impl MomentumContext {
                 );
                 return;
             }
-        }
-
-        {
-            let mut cache = self.authority_by_mint.write();
-            match snap {
-                Some(s) => {
-                    cache.insert(mint.to_string(), s);
-                }
-                None => {
-                    cache.remove(mint);
-                }
-            }
-        }
-        self.refresh_position_authority_drift_metrics();
-        if closed && self.positions.read().contains_key(mint) {
             self.close_position_by_authority(mint, "authority_closed_or_tombstoned");
         }
     }

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -23,6 +23,10 @@ pub const SCHEMA_VERSION: u32 = 1;
 /// Native SOL mint address
 pub const NATIVE_SOL_MINT: &str = "So11111111111111111111111111111111111111112";
 
+/// JetStream KV bucket for PositionAuthority snapshots (PA-5.1, I-24a).
+/// Key = mint (base58), value = [`PositionAuthoritySnapshot`] JSON.
+pub const POSITION_AUTHORITY_KV_BUCKET: &str = "POSITION_AUTHORITY";
+
 /// Default quote mint for backward compatibility (SOL)
 fn default_sol_mint() -> String {
     NATIVE_SOL_MINT.to_string()
@@ -1784,6 +1788,37 @@ impl DecisionRecord {
         self.input_snapshots.insert(key, value);
         self
     }
+}
+
+// ============================================================================
+// PositionAuthority snapshot (PA-5.1 JetStream KV, I-24a)
+// ============================================================================
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PositionAuthorityStatus {
+    Open,
+    Closed,
+    ReconcileNeeded,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PositionAuthorityUpdateSource {
+    Execution,
+    WalletSnapshot,
+}
+
+/// Compact per-mint PositionAuthority view published by execution-engine.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PositionAuthoritySnapshot {
+    pub mint: String,
+    pub balance_raw: u64,
+    pub decimals: u8,
+    pub status: PositionAuthorityStatus,
+    pub last_update_source: PositionAuthorityUpdateSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sold_raw_total: Option<u64>,
 }
 
 // ============================================================================

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2436,6 +2436,9 @@ pub static MOMENTUM_ORPHAN_SCALE_IN_RECOVERY_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static MOMENTUM_EXIT_AMOUNT_OVERLAY_ONLY_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// PA-5.1: overlay closed because PositionAuthority signaled closed/absent/zero.
+pub static MOMENTUM_OVERLAY_CLOSED_BY_AUTHORITY_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 pub static MOMENTUM_SCALE_IN_GATE_BLOCKED_MISSING_PROBE_STATE: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -2458,6 +2461,16 @@ pub fn record_momentum_orphan_scale_in_recovery_total() {
 #[inline]
 pub fn record_momentum_exit_amount_overlay_only_total() {
     MOMENTUM_EXIT_AMOUNT_OVERLAY_ONLY_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_momentum_overlay_closed_by_authority_total() {
+    MOMENTUM_OVERLAY_CLOSED_BY_AUTHORITY_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn set_position_authority_drift_momentum(drift: i64) {
+    POSITION_AUTHORITY_DRIFT_MOMENTUM.store(drift, Ordering::Relaxed);
 }
 
 /// Per-mint signed divergence: `position.token_amount_raw - wallet_snapshot.balance_raw`.
@@ -5222,6 +5235,8 @@ pub static POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 /// `authority_open - lockmanager_open` (signed; Prometheus scalar).
 pub static POSITION_AUTHORITY_DRIFT_LOCKMANAGER: Lazy<AtomicI64> = Lazy::new(|| AtomicI64::new(0));
+/// PA-5.1: `authority_open - momentum_overlay_count` (signed; Prometheus scalar).
+pub static POSITION_AUTHORITY_DRIFT_MOMENTUM: Lazy<AtomicI64> = Lazy::new(|| AtomicI64::new(0));
 pub static CONCURRENT_INTENTS_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// Pending TradeIntents in `intent_rx` between JetStream enqueue and dispatcher recv.
 pub static EXECUTION_INTENT_RX_QUEUE_DEPTH: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -6990,6 +7005,10 @@ async fn metrics_response() -> Response<Body> {
         MOMENTUM_EXIT_AMOUNT_OVERLAY_ONLY_TOTAL.load(Ordering::Relaxed)
     );
     line!(
+        "momentum_overlay_closed_by_authority_total",
+        MOMENTUM_OVERLAY_CLOSED_BY_AUTHORITY_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
         "momentum_wallet_balance_divergence_total",
         MOMENTUM_WALLET_BALANCE_DIVERGENCE_TOTAL.load(Ordering::Relaxed)
     );
@@ -8517,6 +8536,10 @@ async fn metrics_response() -> Response<Body> {
     out.push_str(&format!(
         "position_authority_drift_lockmanager {}\n",
         POSITION_AUTHORITY_DRIFT_LOCKMANAGER.load(Ordering::Relaxed)
+    ));
+    out.push_str(&format!(
+        "position_authority_drift_momentum {}\n",
+        POSITION_AUTHORITY_DRIFT_MOMENTUM.load(Ordering::Relaxed)
     ));
     line!(
         "concurrent_intents",

--- a/src/position_authority/mod.rs
+++ b/src/position_authority/mod.rs
@@ -1,10 +1,10 @@
-//! Read-only **PositionAuthority** (PA-1): pure event reducer for durable position SOT migration.
-//!
-//! Not connected to NATS, execution, or Momentum. See [`state::PositionAuthority`].
+//! Read-only **PositionAuthority** reducer + JetStream snapshot types (PA-1 / PA-5.1).
+//! EE publishes KV snapshots; Momentum consumes readonly.
 
 mod state;
 
 pub use state::{
-    is_sol_or_wsol_mint, position_authority_drift_lockmanager, PositionAuthority, PositionEvent,
-    PositionState, PositionStatus, UpdateSource,
+    is_sol_or_wsol_mint, position_authority_drift_lockmanager, position_authority_drift_momentum,
+    PositionAuthority, PositionAuthorityChange, PositionEvent, PositionState, PositionStatus,
+    UpdateSource,
 };

--- a/src/position_authority/state.rs
+++ b/src/position_authority/state.rs
@@ -434,7 +434,7 @@ impl PositionAuthority {
                     sold_raw_total: 0,
                     status: PositionStatus::ReconcileNeeded,
                     last_update_source: UpdateSource::WalletSnapshot,
-                    last_execution_unix_secs: None,
+                    last_execution_unix_secs: Some(unix_secs_now()),
                 });
             }
         }
@@ -471,6 +471,11 @@ impl PositionAuthority {
 
     pub fn get(&self, mint: &str) -> Option<&PositionState> {
         self.by_mint.get(mint)
+    }
+
+    /// Mint keys currently tracked in the in-process authority model.
+    pub fn tracked_mints(&self) -> Vec<String> {
+        self.by_mint.keys().cloned().collect()
     }
 
     /// Count of mints with a non-zero balance in this model.
@@ -577,6 +582,32 @@ mod tests {
         assert_eq!(a.open_positions_count(), 1);
         assert!(a.get(&ghost).is_none());
         assert!(a.get(&m).is_some());
+        assert_eq!(changes.len(), 1);
+        assert_eq!(
+            changes[0],
+            PositionAuthorityChange::Tombstone {
+                mint: ghost.clone()
+            }
+        );
+    }
+
+    #[test]
+    fn wallet_snapshot_complete_closes_wallet_only_ghost() {
+        let m = mint();
+        let ghost = "WalletOnlyGhostMintttttttttttttttttttttttttttt".to_string();
+        let mut a = PositionAuthority::new();
+        a.apply(&buy(&m, 400, 6));
+        a.apply(&snap(&ghost, 200, 6));
+        assert_eq!(a.open_positions_count(), 2);
+        a.test_backdate_last_execution(&ghost, GHOST_CLEANUP_GRACE_SECS + 1);
+
+        let changes = a.apply(&PositionEvent::WalletSnapshotComplete {
+            wallet: "wallet".to_string(),
+            mints_in_wallet: vec![m.clone()],
+            is_periodic: true,
+        });
+        assert_eq!(a.open_positions_count(), 1);
+        assert!(a.get(&ghost).is_none());
         assert_eq!(changes.len(), 1);
         assert_eq!(
             changes[0],

--- a/src/position_authority/state.rs
+++ b/src/position_authority/state.rs
@@ -5,6 +5,7 @@
 
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashSet};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::ipc::schema::{
     ExecutionResult, ExecutionStatus, MarketEventKind, PositionAuthoritySnapshot,
@@ -32,6 +33,18 @@ pub struct PositionState {
     pub sold_raw_total: u64,
     pub status: PositionStatus,
     pub last_update_source: UpdateSource,
+    /// Wall-clock secs of last execution-confirmed BUY/SELL (ghost-cleanup grace).
+    pub last_execution_unix_secs: Option<u64>,
+}
+
+/// Skip ghost cleanup for positions with a recent execution update (stale wallet lists).
+const GHOST_CLEANUP_GRACE_SECS: u64 = 90;
+
+fn unix_secs_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 /// High-level position lifecycle for PA-1.
@@ -319,12 +332,14 @@ impl PositionAuthority {
                 sold_raw_total: 0,
                 status: PositionStatus::Closed,
                 last_update_source: UpdateSource::Execution,
+                last_execution_unix_secs: None,
             });
         e.decimals = decimals;
         e.token_program = token_program.to_string();
         if let Some(a) = ata {
             e.ata = Some(a.clone());
         }
+        e.last_execution_unix_secs = Some(unix_secs_now());
         e.buy_fills.push(fill_raw);
         e.balance_raw = e.balance_raw.saturating_add(fill_raw);
         e.status = if e.balance_raw == 0 {
@@ -356,9 +371,11 @@ impl PositionAuthority {
                 sold_raw_total: 0,
                 status: PositionStatus::Closed,
                 last_update_source: UpdateSource::Execution,
+                last_execution_unix_secs: None,
             });
         e.decimals = decimals;
         e.token_program = token_program.to_string();
+        e.last_execution_unix_secs = Some(unix_secs_now());
         e.sold_raw_total = e.sold_raw_total.saturating_add(sold_raw);
         let new_bal = e.balance_raw.saturating_sub(sold_raw);
         if sold_raw > e.balance_raw {
@@ -417,6 +434,7 @@ impl PositionAuthority {
                     sold_raw_total: 0,
                     status: PositionStatus::ReconcileNeeded,
                     last_update_source: UpdateSource::WalletSnapshot,
+                    last_execution_unix_secs: None,
                 });
             }
         }
@@ -429,6 +447,7 @@ impl PositionAuthority {
         mints_in_wallet: &[String],
     ) -> Vec<PositionAuthorityChange> {
         let wallet_set: HashSet<&str> = mints_in_wallet.iter().map(|s| s.as_str()).collect();
+        let now_secs = unix_secs_now();
         let ghosts: Vec<String> = self
             .by_mint
             .iter()
@@ -436,6 +455,9 @@ impl PositionAuthority {
                 p.balance_raw > 0
                     && !is_sol_or_wsol_mint(mint)
                     && !wallet_set.contains(mint.as_str())
+                    && p.last_execution_unix_secs
+                        .map(|t| now_secs.saturating_sub(t) >= GHOST_CLEANUP_GRACE_SECS)
+                        .unwrap_or(true)
             })
             .map(|(mint, _)| mint.clone())
             .collect();
@@ -462,6 +484,16 @@ impl PositionAuthority {
             .values()
             .filter(|p| p.balance_raw > 0 && p.status == PositionStatus::ReconcileNeeded)
             .count()
+    }
+}
+
+#[cfg(test)]
+impl PositionAuthority {
+    fn test_backdate_last_execution(&mut self, mint: &str, secs_ago: u64) {
+        let now = unix_secs_now();
+        if let Some(p) = self.by_mint.get_mut(mint) {
+            p.last_execution_unix_secs = Some(now.saturating_sub(secs_ago));
+        }
     }
 }
 
@@ -508,6 +540,25 @@ mod tests {
     }
 
     #[test]
+    fn wallet_snapshot_complete_skips_fresh_execution_ghost() {
+        let m = mint();
+        let ghost = "FreshGhostMintttttttttttttttttttttttttttttt".to_string();
+        let mut a = PositionAuthority::new();
+        a.apply(&buy(&m, 400, 6));
+        a.apply(&buy(&ghost, 200, 6));
+        assert_eq!(a.open_positions_count(), 2);
+
+        let changes = a.apply(&PositionEvent::WalletSnapshotComplete {
+            wallet: "wallet".to_string(),
+            mints_in_wallet: vec![m.clone()],
+            is_periodic: true,
+        });
+        assert_eq!(a.open_positions_count(), 2);
+        assert!(a.get(&ghost).is_some());
+        assert!(changes.is_empty());
+    }
+
+    #[test]
     fn wallet_snapshot_complete_closes_ghost_not_in_wallet() {
         let m = mint();
         let ghost = "GhostMinttttttttttttttttttttttttttttttttttt".to_string();
@@ -515,6 +566,8 @@ mod tests {
         a.apply(&buy(&m, 400, 6));
         a.apply(&buy(&ghost, 200, 6));
         assert_eq!(a.open_positions_count(), 2);
+        // Ghost mint must be older than grace period (matches momentum-bot WalletSnapshotComplete).
+        a.test_backdate_last_execution(&ghost, GHOST_CLEANUP_GRACE_SECS + 1);
 
         let changes = a.apply(&PositionEvent::WalletSnapshotComplete {
             wallet: "wallet".to_string(),

--- a/src/position_authority/state.rs
+++ b/src/position_authority/state.rs
@@ -4,9 +4,12 @@
 //! `position-manager` / JetStream consumption.
 
 use std::collections::btree_map::Entry;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
-use crate::ipc::schema::{ExecutionResult, ExecutionStatus, MarketEventKind, NATIVE_SOL_MINT};
+use crate::ipc::schema::{
+    ExecutionResult, ExecutionStatus, MarketEventKind, PositionAuthoritySnapshot,
+    PositionAuthorityStatus, PositionAuthorityUpdateSource, NATIVE_SOL_MINT,
+};
 
 // ---------------------------------------------------------------------------
 // Public domain types
@@ -172,11 +175,51 @@ pub fn is_sol_or_wsol_mint(mint: &str) -> bool {
     mint == "NATIVE_SOL" || mint == NATIVE_SOL_MINT
 }
 
+/// `authority open count` minus `momentum overlay count` (PA-5.1 drift metric).
+#[inline]
+pub fn position_authority_drift_momentum(authority_open: usize, momentum_overlay: usize) -> i64 {
+    authority_open as i64 - momentum_overlay as i64
+}
+
 /// `authority open count` minus `lock manager open count` (same notion as
 /// `LockManager::count_non_zero_token_balances` in execution-engine).
 #[inline]
 pub fn position_authority_drift_lockmanager(authority_open: usize, lockmanager_open: usize) -> i64 {
     authority_open as i64 - lockmanager_open as i64
+}
+
+/// KV publish delta after a reducer apply (PA-5.1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PositionAuthorityChange {
+    /// Upsert snapshot for mint.
+    Put(PositionAuthoritySnapshot),
+    /// Remove key from KV (mint absent from in-process authority).
+    Tombstone { mint: String },
+}
+
+impl PositionState {
+    /// Serialize to JetStream KV snapshot (PA-5.1).
+    pub fn to_snapshot(&self) -> PositionAuthoritySnapshot {
+        PositionAuthoritySnapshot {
+            mint: self.mint.clone(),
+            balance_raw: self.balance_raw,
+            decimals: self.decimals,
+            status: match self.status {
+                PositionStatus::Open => PositionAuthorityStatus::Open,
+                PositionStatus::Closed => PositionAuthorityStatus::Closed,
+                PositionStatus::ReconcileNeeded => PositionAuthorityStatus::ReconcileNeeded,
+            },
+            last_update_source: match self.last_update_source {
+                UpdateSource::Execution => PositionAuthorityUpdateSource::Execution,
+                UpdateSource::WalletSnapshot => PositionAuthorityUpdateSource::WalletSnapshot,
+            },
+            sold_raw_total: if self.sold_raw_total > 0 {
+                Some(self.sold_raw_total)
+            } else {
+                None
+            },
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -195,20 +238,30 @@ impl PositionAuthority {
     }
 
     /// PA-2: same mapping as execution-engine (confirmed-only; WSOL/SOL execution rows ignored).
-    pub fn apply_from_confirmed_execution_result(&mut self, result: &ExecutionResult) {
+    pub fn apply_from_confirmed_execution_result(
+        &mut self,
+        result: &ExecutionResult,
+    ) -> Vec<PositionAuthorityChange> {
         if let Some(ev) = PositionEvent::try_from_execution_result(result) {
-            self.apply(&ev);
+            self.apply(&ev)
+        } else {
+            Vec::new()
         }
     }
 
     /// PA-2: `MarketEventKind` → same filter as `try_from_market_event_kind` (skips SOL/WSOL for snapshots).
-    pub fn apply_from_wallet_market_event_kind(&mut self, kind: &MarketEventKind) {
+    pub fn apply_from_wallet_market_event_kind(
+        &mut self,
+        kind: &MarketEventKind,
+    ) -> Vec<PositionAuthorityChange> {
         if let Some(ev) = PositionEvent::try_from_market_event_kind(kind) {
-            self.apply(&ev);
+            self.apply(&ev)
+        } else {
+            Vec::new()
         }
     }
 
-    pub fn apply(&mut self, event: &PositionEvent) {
+    pub fn apply(&mut self, event: &PositionEvent) -> Vec<PositionAuthorityChange> {
         match event {
             PositionEvent::BuyConfirmed {
                 mint,
@@ -216,26 +269,32 @@ impl PositionAuthority {
                 decimals,
                 token_program,
                 ata,
-            } => {
-                self.apply_buy(mint, *fill_raw, *decimals, token_program, ata.as_ref());
-            }
+            } => self.apply_buy(mint, *fill_raw, *decimals, token_program, ata.as_ref()),
             PositionEvent::SellConfirmed {
                 mint,
                 sold_raw,
                 decimals,
                 token_program,
-            } => {
-                self.apply_sell(mint, *sold_raw, *decimals, token_program);
-            }
+            } => self.apply_sell(mint, *sold_raw, *decimals, token_program),
             PositionEvent::WalletBalanceSnapshot {
                 mint,
                 balance_raw,
                 decimals,
                 token_program,
-            } => {
-                self.apply_wallet_snapshot(mint, *balance_raw, *decimals, token_program);
+            } => self.apply_wallet_snapshot(mint, *balance_raw, *decimals, token_program),
+            PositionEvent::WalletSnapshotComplete {
+                mints_in_wallet, ..
+            } => self.apply_wallet_snapshot_complete(mints_in_wallet),
+        }
+    }
+
+    fn change_for_mint(&self, mint: &str) -> PositionAuthorityChange {
+        if let Some(state) = self.by_mint.get(mint) {
+            PositionAuthorityChange::Put(state.to_snapshot())
+        } else {
+            PositionAuthorityChange::Tombstone {
+                mint: mint.to_string(),
             }
-            PositionEvent::WalletSnapshotComplete { .. } => {}
         }
     }
 
@@ -246,7 +305,7 @@ impl PositionAuthority {
         decimals: u8,
         token_program: &str,
         ata: Option<&String>,
-    ) {
+    ) -> Vec<PositionAuthorityChange> {
         let e = self
             .by_mint
             .entry(mint.to_string())
@@ -274,9 +333,16 @@ impl PositionAuthority {
             PositionStatus::Open
         };
         e.last_update_source = UpdateSource::Execution;
+        vec![self.change_for_mint(mint)]
     }
 
-    fn apply_sell(&mut self, mint: &str, sold_raw: u64, decimals: u8, token_program: &str) {
+    fn apply_sell(
+        &mut self,
+        mint: &str,
+        sold_raw: u64,
+        decimals: u8,
+        token_program: &str,
+    ) -> Vec<PositionAuthorityChange> {
         let e = self
             .by_mint
             .entry(mint.to_string())
@@ -307,6 +373,7 @@ impl PositionAuthority {
             };
         }
         e.last_update_source = UpdateSource::Execution;
+        vec![self.change_for_mint(mint)]
     }
 
     fn apply_wallet_snapshot(
@@ -315,10 +382,12 @@ impl PositionAuthority {
         balance_raw: u64,
         decimals: u8,
         token_program: &str,
-    ) {
+    ) -> Vec<PositionAuthorityChange> {
         if balance_raw == 0 {
             self.by_mint.remove(mint);
-            return;
+            return vec![PositionAuthorityChange::Tombstone {
+                mint: mint.to_string(),
+            }];
         }
 
         match self.by_mint.entry(mint.to_string()) {
@@ -351,6 +420,31 @@ impl PositionAuthority {
                 });
             }
         }
+        vec![self.change_for_mint(mint)]
+    }
+
+    /// PA-5.1: close ghost mints not present in wallet after `WalletSnapshotComplete`.
+    fn apply_wallet_snapshot_complete(
+        &mut self,
+        mints_in_wallet: &[String],
+    ) -> Vec<PositionAuthorityChange> {
+        let wallet_set: HashSet<&str> = mints_in_wallet.iter().map(|s| s.as_str()).collect();
+        let ghosts: Vec<String> = self
+            .by_mint
+            .iter()
+            .filter(|(mint, p)| {
+                p.balance_raw > 0
+                    && !is_sol_or_wsol_mint(mint)
+                    && !wallet_set.contains(mint.as_str())
+            })
+            .map(|(mint, _)| mint.clone())
+            .collect();
+        let mut changes = Vec::with_capacity(ghosts.len());
+        for mint in ghosts {
+            self.by_mint.remove(&mint);
+            changes.push(PositionAuthorityChange::Tombstone { mint });
+        }
+        changes
     }
 
     pub fn get(&self, mint: &str) -> Option<&PositionState> {
@@ -411,6 +505,32 @@ mod tests {
             decimals: dec,
             token_program: default_spl_token_program(),
         }
+    }
+
+    #[test]
+    fn wallet_snapshot_complete_closes_ghost_not_in_wallet() {
+        let m = mint();
+        let ghost = "GhostMinttttttttttttttttttttttttttttttttttt".to_string();
+        let mut a = PositionAuthority::new();
+        a.apply(&buy(&m, 400, 6));
+        a.apply(&buy(&ghost, 200, 6));
+        assert_eq!(a.open_positions_count(), 2);
+
+        let changes = a.apply(&PositionEvent::WalletSnapshotComplete {
+            wallet: "wallet".to_string(),
+            mints_in_wallet: vec![m.clone()],
+            is_periodic: true,
+        });
+        assert_eq!(a.open_positions_count(), 1);
+        assert!(a.get(&ghost).is_none());
+        assert!(a.get(&m).is_some());
+        assert_eq!(changes.len(), 1);
+        assert_eq!(
+            changes[0],
+            PositionAuthorityChange::Tombstone {
+                mint: ghost.clone()
+            }
+        );
     }
 
     #[test]

--- a/src/position_authority/state.rs
+++ b/src/position_authority/state.rs
@@ -457,7 +457,7 @@ impl PositionAuthority {
                     && !wallet_set.contains(mint.as_str())
                     && p.last_execution_unix_secs
                         .map(|t| now_secs.saturating_sub(t) >= GHOST_CLEANUP_GRACE_SECS)
-                        .unwrap_or(true)
+                        .unwrap_or(false)
             })
             .map(|(mint, _)| mint.clone())
             .collect();

--- a/src/position_authority/state.rs
+++ b/src/position_authority/state.rs
@@ -434,7 +434,7 @@ impl PositionAuthority {
                     sold_raw_total: 0,
                     status: PositionStatus::ReconcileNeeded,
                     last_update_source: UpdateSource::WalletSnapshot,
-                    last_execution_unix_secs: Some(unix_secs_now()),
+                    last_execution_unix_secs: None,
                 });
             }
         }
@@ -455,9 +455,7 @@ impl PositionAuthority {
                 p.balance_raw > 0
                     && !is_sol_or_wsol_mint(mint)
                     && !wallet_set.contains(mint.as_str())
-                    && p.last_execution_unix_secs
-                        .map(|t| now_secs.saturating_sub(t) >= GHOST_CLEANUP_GRACE_SECS)
-                        .unwrap_or(false)
+                    && Self::ghost_eligible_after_snapshot_complete(p, now_secs)
             })
             .map(|(mint, _)| mint.clone())
             .collect();
@@ -467,6 +465,14 @@ impl PositionAuthority {
             changes.push(PositionAuthorityChange::Tombstone { mint });
         }
         changes
+    }
+
+    /// Execution-confirmed rows get 90s grace vs stale Complete lists; wallet-only rows do not.
+    fn ghost_eligible_after_snapshot_complete(p: &PositionState, now_secs: u64) -> bool {
+        match p.last_execution_unix_secs {
+            Some(t) => now_secs.saturating_sub(t) >= GHOST_CLEANUP_GRACE_SECS,
+            None => true,
+        }
     }
 
     pub fn get(&self, mint: &str) -> Option<&PositionState> {
@@ -592,14 +598,17 @@ mod tests {
     }
 
     #[test]
-    fn wallet_snapshot_complete_closes_wallet_only_ghost() {
+    fn wallet_snapshot_complete_closes_wallet_only_ghost_immediately() {
         let m = mint();
         let ghost = "WalletOnlyGhostMintttttttttttttttttttttttttttt".to_string();
         let mut a = PositionAuthority::new();
         a.apply(&buy(&m, 400, 6));
         a.apply(&snap(&ghost, 200, 6));
         assert_eq!(a.open_positions_count(), 2);
-        a.test_backdate_last_execution(&ghost, GHOST_CLEANUP_GRACE_SECS + 1);
+        assert!(
+            a.get(&ghost).unwrap().last_execution_unix_secs.is_none(),
+            "wallet-only vacant insert must not set execution timestamp"
+        );
 
         let changes = a.apply(&PositionEvent::WalletSnapshotComplete {
             wallet: "wallet".to_string(),
@@ -672,6 +681,10 @@ mod tests {
         assert_eq!(p.balance_raw, 250);
         assert_eq!(p.status, PositionStatus::ReconcileNeeded);
         assert_eq!(p.last_update_source, UpdateSource::WalletSnapshot);
+        assert!(
+            p.last_execution_unix_secs.is_none(),
+            "wallet-only recovery must not set execution timestamp"
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements PA-5.1: PositionAuthority becomes the readonly positions truth for Momentum overlay lifecycle (no new binary).

### A) EE: Authority PositionView publish (I-24a)
- After each PA update (confirmed `ExecutionResult`, `WalletBalanceSnapshot`, `WalletSnapshotComplete`), EE publishes compact snapshots to JetStream KV bucket `POSITION_AUTHORITY` (key = mint).
- Tombstones via KV delete when mint is removed from PA.
- Publish is fire-and-forget (`tokio::spawn`) — does not block hot path.

### B) PA Reducer: `WalletSnapshotComplete` ghost cleanup
- Mints with `balance_raw > 0` not in `mints_in_wallet` (excluding SOL/WSOL) are removed → tombstone publish.
- Unit test: BUY open → SnapshotComplete without mint → mint gone.

### C) Momentum: readonly Authority view + overlay close
- Bootstrap + `watch_all` on `POSITION_AUTHORITY` KV.
- Close rule: overlay + authority Closed/absent/zero → `close_position` + metric `momentum_overlay_closed_by_authority_total`.
- Exit amount: `min(overlay, authority.balance_raw)` when authority present; no exit when closed/0; overlay-only fallback + existing warn metric.
- Drift metric: `position_authority_drift_momentum`.

### D) Pending/Sent lifecycle
- `ExecutionStatus::Sent` no longer removes `pending_intents`; only terminal statuses (`Confirmed` / `Failed` / `Timeout`).

## STOP-CHECK (performed)
1. **I-7 Hot Path RPC**: No new RPC; authority data from JetStream KV cache only.
2. **Existing pattern**: KV bucket/watch mirrors `POSITIONS` pattern; PA apply returns change deltas like other modules' explicit publish hooks.
3. **Architecture boundaries**: Scope-limited to allowed files; no key-loading/signing changes.
4. **I-9 Simulation gate**: Exit suppression only reduces amount / skips intent; no sim bypass.
5. **Repo isolation**: No eval test reads.

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test -p ironcrab --bin execution-engine`
- `cargo test -p ironcrab --bin momentum-bot`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86d974aa-88e5-4dab-8739-dfb55ab377eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86d974aa-88e5-4dab-8739-dfb55ab377eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

