### PR TITLE
feat(market-data): Scope A account update class metrics (EXEC_HOT|ENRICH|DROP)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -95,8 +95,9 @@ use ironcrab::metrics::{
     dec_market_data_account_low_priority_queue_depth, dec_market_data_account_worker_queue_depth,
     geyser_account_listener_account_updates_value, geyser_metrics_set_subscription_accounts,
     geyser_metrics_set_tracked_pinned_accounts, inc_market_data_account_high_priority_queue_depth,
-    inc_market_data_account_low_priority_queue_depth, inc_market_data_account_worker_queue_depth,
-    inc_market_data_arb_admission_admitted_total, inc_market_data_arb_admission_rejected_total,
+    inc_market_data_account_low_priority_queue_depth, inc_market_data_account_updates_total,
+    inc_market_data_account_worker_queue_depth, inc_market_data_arb_admission_admitted_total,
+    inc_market_data_arb_admission_rejected_total,
     inc_market_data_arb_pin_geyser_register_deferred_total,
     inc_market_data_balance_updated_from_cache_total,
     inc_market_data_geyser_sync_skipped_rate_limit_total,
@@ -112,8 +113,8 @@ use ironcrab::metrics::{
     market_data_geyser_tracking_jobs_processed_value, market_data_md_state_bursts_completed_value,
     market_data_request_account_session_reconnect, market_data_request_tx_session_reconnect,
     market_data_tx_handler_processed_value, record_market_data_account_broadcast_lagged,
-    record_market_data_account_channel_lag_ms, record_market_data_account_early_drop,
-    record_market_data_account_handler_duration_us,
+    record_market_data_account_channel_lag_ms, record_market_data_account_channel_lag_ms_for_class,
+    record_market_data_account_early_drop, record_market_data_account_handler_duration_us,
     record_market_data_arb_track_requests_messages_total,
     record_market_data_geyser_merge_coalesced_total, record_market_data_geyser_sync_batch_total,
     record_market_data_global_ingest_stall, record_market_data_md_state_stall,
@@ -312,6 +313,7 @@ fn account_geyser_update_relevance(
 }
 
 /// Eval grep: account dispatch priority in `ingest/account_filter.rs` (tracked_membership snapshot).
+#[allow(dead_code)]
 fn account_geyser_dispatch_priority_high(ctx: &MarketDataContext, u: &GeyserAccountUpdate) -> bool {
     // I-4b eval grep: tracked_membership / tracked_membership_contains_pubkey snapshot (ingest/account_filter.rs).
     ironcrab::market_data::ingest::account_geyser_dispatch_priority_high(ctx, u)
@@ -8101,19 +8103,33 @@ async fn run_geyser_loop(
                     set_market_data_account_broadcast_queue_depth(account_rx_geyser.len());
                     market_data_bump_geyser_head_slot(account_update.slot);
 
-                    match account_geyser_update_relevance(&ctx_geyser_acc, &account_update) {
-                        ironcrab::market_data::ingest::AccountGeyserRelevance::Relevant => {}
-                        ironcrab::market_data::ingest::AccountGeyserRelevance::EarlyDrop(
+                    let class = ironcrab::market_data::ingest::classify_account_geyser_update(
+                        &ctx_geyser_acc,
+                        &account_update,
+                    );
+                    inc_market_data_account_updates_total(class.as_prometheus_label());
+
+                    if class == ironcrab::market_data::ingest::AccountUpdateClass::Drop {
+                        if let ironcrab::market_data::ingest::AccountGeyserRelevance::EarlyDrop(
                             reason,
-                        ) => {
+                        ) = account_geyser_update_relevance(&ctx_geyser_acc, &account_update)
+                        {
                             record_market_data_account_early_drop(reason);
-                            continue;
                         }
+                        continue;
                     }
 
+                    record_market_data_account_channel_lag_ms_for_class(
+                        class.as_prometheus_label(),
+                        account_update.grpc_recv_at,
+                        recv_at,
+                    );
+
                     let shard = market_data_account_worker_shard(&account_update.pubkey);
-                    let high =
-                        account_geyser_dispatch_priority_high(&ctx_geyser_acc, &account_update);
+                    let high = matches!(
+                        class,
+                        ironcrab::market_data::ingest::AccountUpdateClass::ExecHot
+                    );
                     let send_res = if high {
                         worker_high_recv[shard]
                             .send(AccountWorkItem {

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -8111,10 +8111,8 @@ async fn run_geyser_loop(
                         );
                     inc_market_data_account_updates_total(class.as_prometheus_label());
 
-                    if class == ironcrab::market_data::ingest::AccountUpdateClass::Drop {
-                        if let Some(reason) = early_drop_reason {
-                            record_market_data_account_early_drop(reason);
-                        }
+                    if let Some(reason) = early_drop_reason {
+                        record_market_data_account_early_drop(reason);
                         continue;
                     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -305,6 +305,7 @@ fn account_geyser_update_might_be_relevant(
 }
 
 /// Eval grep: account relevance filter with early-drop reason in `ingest/account_filter.rs`.
+#[allow(dead_code)]
 fn account_geyser_update_relevance(
     ctx: &MarketDataContext,
     u: &GeyserAccountUpdate,
@@ -8103,17 +8104,15 @@ async fn run_geyser_loop(
                     set_market_data_account_broadcast_queue_depth(account_rx_geyser.len());
                     market_data_bump_geyser_head_slot(account_update.slot);
 
-                    let class = ironcrab::market_data::ingest::classify_account_geyser_update(
-                        &ctx_geyser_acc,
-                        &account_update,
-                    );
+                    let (class, early_drop_reason) =
+                        ironcrab::market_data::ingest::classify_account_geyser_update(
+                            &ctx_geyser_acc,
+                            &account_update,
+                        );
                     inc_market_data_account_updates_total(class.as_prometheus_label());
 
                     if class == ironcrab::market_data::ingest::AccountUpdateClass::Drop {
-                        if let ironcrab::market_data::ingest::AccountGeyserRelevance::EarlyDrop(
-                            reason,
-                        ) = account_geyser_update_relevance(&ctx_geyser_acc, &account_update)
-                        {
+                        if let Some(reason) = early_drop_reason {
                             record_market_data_account_early_drop(reason);
                         }
                         continue;

--- a/src/market_data/ingest/account_filter.rs
+++ b/src/market_data/ingest/account_filter.rs
@@ -129,18 +129,22 @@ pub fn account_geyser_update_might_be_relevant<H: IngestHost>(
 }
 
 /// Classify a Geyser account update for lag/throughput metrics (reuses relevance + HIGH logic).
+///
+/// Returns `(class, early_drop_reason)` from a single relevance evaluation so recv-loop
+/// metrics cannot diverge from enqueue decisions when ingest membership changes concurrently.
 pub fn classify_account_geyser_update<H: IngestHost>(
     host: &H,
     u: &GeyserAccountUpdate,
-) -> AccountUpdateClass {
+) -> (AccountUpdateClass, Option<MarketDataAccountEarlyDropReason>) {
     match account_geyser_update_relevance(host, u) {
-        AccountGeyserRelevance::EarlyDrop(_) => AccountUpdateClass::Drop,
+        AccountGeyserRelevance::EarlyDrop(reason) => (AccountUpdateClass::Drop, Some(reason)),
         AccountGeyserRelevance::Relevant => {
-            if account_geyser_dispatch_priority_high(host, u) {
+            let class = if account_geyser_dispatch_priority_high(host, u) {
                 AccountUpdateClass::ExecHot
             } else {
                 AccountUpdateClass::Enrich
-            }
+            };
+            (class, None)
         }
     }
 }
@@ -319,7 +323,7 @@ mod tests {
         host.hot_pools.insert(pool);
         let u = sample_update(pool, RAYDIUM_CPMM_OWNER);
         assert_eq!(
-            classify_account_geyser_update(&host, &u),
+            classify_account_geyser_update(&host, &u).0,
             AccountUpdateClass::ExecHot
         );
     }
@@ -331,7 +335,7 @@ mod tests {
         host.hot_pools.insert(pool);
         let u = sample_update(pool, ORCA_WHIRLPOOL_OWNER);
         assert_eq!(
-            classify_account_geyser_update(&host, &u),
+            classify_account_geyser_update(&host, &u).0,
             AccountUpdateClass::ExecHot
         );
     }
@@ -343,7 +347,7 @@ mod tests {
         host.membership.insert(mint);
         let u = sample_update(mint, Pubkey::new_unique());
         assert_eq!(
-            classify_account_geyser_update(&host, &u),
+            classify_account_geyser_update(&host, &u).0,
             AccountUpdateClass::Enrich
         );
     }
@@ -353,9 +357,11 @@ mod tests {
         let host = MockIngestHost::new();
         let pool = Pubkey::new_unique();
         let u = sample_update(pool, RAYDIUM_CPMM_OWNER);
+        let (class, reason) = classify_account_geyser_update(&host, &u);
+        assert_eq!(class, AccountUpdateClass::Drop);
         assert_eq!(
-            classify_account_geyser_update(&host, &u),
-            AccountUpdateClass::Drop
+            reason,
+            Some(MarketDataAccountEarlyDropReason::DexPoolNotEnrichment)
         );
     }
 }

--- a/src/market_data/ingest/account_filter.rs
+++ b/src/market_data/ingest/account_filter.rs
@@ -322,10 +322,9 @@ mod tests {
         let mut host = MockIngestHost::new();
         host.hot_pools.insert(pool);
         let u = sample_update(pool, RAYDIUM_CPMM_OWNER);
-        assert_eq!(
-            classify_account_geyser_update(&host, &u).0,
-            AccountUpdateClass::ExecHot
-        );
+        let (class, early_drop_reason) = classify_account_geyser_update(&host, &u);
+        assert_eq!(class, AccountUpdateClass::ExecHot);
+        assert_eq!(early_drop_reason, None);
     }
 
     #[test]
@@ -334,10 +333,9 @@ mod tests {
         let mut host = MockIngestHost::new();
         host.hot_pools.insert(pool);
         let u = sample_update(pool, ORCA_WHIRLPOOL_OWNER);
-        assert_eq!(
-            classify_account_geyser_update(&host, &u).0,
-            AccountUpdateClass::ExecHot
-        );
+        let (class, early_drop_reason) = classify_account_geyser_update(&host, &u);
+        assert_eq!(class, AccountUpdateClass::ExecHot);
+        assert_eq!(early_drop_reason, None);
     }
 
     #[test]
@@ -346,10 +344,9 @@ mod tests {
         let mut host = MockIngestHost::new();
         host.membership.insert(mint);
         let u = sample_update(mint, Pubkey::new_unique());
-        assert_eq!(
-            classify_account_geyser_update(&host, &u).0,
-            AccountUpdateClass::Enrich
-        );
+        let (class, early_drop_reason) = classify_account_geyser_update(&host, &u);
+        assert_eq!(class, AccountUpdateClass::Enrich);
+        assert_eq!(early_drop_reason, None);
     }
 
     #[test]
@@ -357,10 +354,10 @@ mod tests {
         let host = MockIngestHost::new();
         let pool = Pubkey::new_unique();
         let u = sample_update(pool, RAYDIUM_CPMM_OWNER);
-        let (class, reason) = classify_account_geyser_update(&host, &u);
+        let (class, early_drop_reason) = classify_account_geyser_update(&host, &u);
         assert_eq!(class, AccountUpdateClass::Drop);
         assert_eq!(
-            reason,
+            early_drop_reason,
             Some(MarketDataAccountEarlyDropReason::DexPoolNotEnrichment)
         );
     }

--- a/src/market_data/ingest/account_filter.rs
+++ b/src/market_data/ingest/account_filter.rs
@@ -53,6 +53,33 @@ pub enum AccountGeyserRelevance {
     EarlyDrop(MarketDataAccountEarlyDropReason),
 }
 
+/// Observability class for each Geyser account update at market-data recv (Scope A).
+///
+/// Maps to existing HIGH/LOW worker dispatch without changing queue semantics:
+/// - `Drop` — `account_geyser_update_relevance` early drop (no worker enqueue)
+/// - `ExecHot` — `account_geyser_dispatch_priority_high` (vault/bin/hot-pool pins incl. Arb)
+/// - `Enrich` — relevant but not EXEC_HOT (e.g. wallet token ATA without pin)
+///
+/// Known gap (Scope C): open-position pools without Momentum/Arb pin are often `Enrich`, not
+/// `ExecHot` — do not silently widen HIGH dispatch here; only metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccountUpdateClass {
+    ExecHot,
+    Enrich,
+    Drop,
+}
+
+impl AccountUpdateClass {
+    #[inline]
+    pub fn as_prometheus_label(self) -> &'static str {
+        match self {
+            Self::ExecHot => "exec_hot",
+            Self::Enrich => "enrich",
+            Self::Drop => "drop",
+        }
+    }
+}
+
 /// Cheap filter before DEX parse / heavy locks: drop clearly irrelevant account updates.
 /// Conservative: any DEX program owner we parse in `parse_pool_account` / `parse_account_update` stays in.
 pub fn account_geyser_update_relevance<H: IngestHost>(
@@ -101,6 +128,23 @@ pub fn account_geyser_update_might_be_relevant<H: IngestHost>(
     )
 }
 
+/// Classify a Geyser account update for lag/throughput metrics (reuses relevance + HIGH logic).
+pub fn classify_account_geyser_update<H: IngestHost>(
+    host: &H,
+    u: &GeyserAccountUpdate,
+) -> AccountUpdateClass {
+    match account_geyser_update_relevance(host, u) {
+        AccountGeyserRelevance::EarlyDrop(_) => AccountUpdateClass::Drop,
+        AccountGeyserRelevance::Relevant => {
+            if account_geyser_dispatch_priority_high(host, u) {
+                AccountUpdateClass::ExecHot
+            } else {
+                AccountUpdateClass::Enrich
+            }
+        }
+    }
+}
+
 /// Strategic HIGH admission for account worker sharding (ACCOUNT-PATH-TX-PARITY-CREATOR).
 pub fn account_geyser_dispatch_priority_high<H: IngestHost>(
     host: &H,
@@ -143,7 +187,21 @@ mod tests {
     struct MockIngestHost {
         membership: HashSet<Pubkey>,
         enrichment_members: HashSet<Pubkey>,
+        hot_pools: HashSet<Pubkey>,
+        tracked_wallet_token_accounts: HashSet<Pubkey>,
         pumpfun_wallet_track: HashSet<Pubkey>,
+    }
+
+    impl MockIngestHost {
+        fn new() -> Self {
+            Self {
+                membership: HashSet::new(),
+                enrichment_members: HashSet::new(),
+                hot_pools: HashSet::new(),
+                tracked_wallet_token_accounts: HashSet::new(),
+                pumpfun_wallet_track: HashSet::new(),
+            }
+        }
     }
 
     impl IngestHost for MockIngestHost {
@@ -151,8 +209,8 @@ mod tests {
             None
         }
 
-        fn ingest_tracked_wallet_token_account_contains(&self, _pubkey: &Pubkey) -> bool {
-            false
+        fn ingest_tracked_wallet_token_account_contains(&self, pubkey: &Pubkey) -> bool {
+            self.tracked_wallet_token_accounts.contains(pubkey)
         }
 
         fn ingest_membership_contains(&self, pubkey: &Pubkey) -> bool {
@@ -167,12 +225,12 @@ mod tests {
             false
         }
 
-        fn ingest_is_hot_pool(&self, _pool: &Pubkey) -> bool {
-            false
+        fn ingest_is_hot_pool(&self, pool: &Pubkey) -> bool {
+            self.hot_pools.contains(pool)
         }
 
         fn ingest_is_enrichment_member(&self, pool: &Pubkey) -> bool {
-            self.enrichment_members.contains(pool)
+            self.enrichment_members.contains(pool) || self.hot_pools.contains(pool)
         }
 
         fn ingest_pool_mint_map_contains(&self, pool: &Pubkey) -> bool {
@@ -215,11 +273,7 @@ mod tests {
 
     #[test]
     fn account_geyser_update_relevance_non_enrichment_dex_pool() {
-        let host = MockIngestHost {
-            membership: HashSet::new(),
-            enrichment_members: HashSet::new(),
-            pumpfun_wallet_track: HashSet::new(),
-        };
+        let host = MockIngestHost::new();
         let pool = Pubkey::new_unique();
         let u = sample_update(pool, RAYDIUM_CPMM_OWNER);
         assert_eq!(
@@ -233,11 +287,7 @@ mod tests {
 
     #[test]
     fn account_geyser_update_relevance_random_non_dex_pubkey() {
-        let host = MockIngestHost {
-            membership: HashSet::new(),
-            enrichment_members: HashSet::new(),
-            pumpfun_wallet_track: HashSet::new(),
-        };
+        let host = MockIngestHost::new();
         let pubkey = Pubkey::new_unique();
         let u = sample_update(pubkey, Pubkey::new_unique());
         assert_eq!(
@@ -252,16 +302,60 @@ mod tests {
     #[test]
     fn account_geyser_update_relevance_membership_explicit_vault_no_early_drop() {
         let vault = Pubkey::new_unique();
-        let host = MockIngestHost {
-            membership: HashSet::from([vault]),
-            enrichment_members: HashSet::new(),
-            pumpfun_wallet_track: HashSet::new(),
-        };
+        let mut host = MockIngestHost::new();
+        host.membership.insert(vault);
         let u = sample_update(vault, Pubkey::new_unique());
         assert_eq!(
             account_geyser_update_relevance(&host, &u),
             AccountGeyserRelevance::Relevant
         );
         assert!(account_geyser_update_might_be_relevant(&host, &u));
+    }
+
+    #[test]
+    fn classify_account_geyser_update_exec_hot_via_hot_pool_pin() {
+        let pool = Pubkey::new_unique();
+        let mut host = MockIngestHost::new();
+        host.hot_pools.insert(pool);
+        let u = sample_update(pool, RAYDIUM_CPMM_OWNER);
+        assert_eq!(
+            classify_account_geyser_update(&host, &u),
+            AccountUpdateClass::ExecHot
+        );
+    }
+
+    #[test]
+    fn classify_account_geyser_update_exec_hot_via_arb_hot_pool_equivalent() {
+        let pool = Pubkey::new_unique();
+        let mut host = MockIngestHost::new();
+        host.hot_pools.insert(pool);
+        let u = sample_update(pool, ORCA_WHIRLPOOL_OWNER);
+        assert_eq!(
+            classify_account_geyser_update(&host, &u),
+            AccountUpdateClass::ExecHot
+        );
+    }
+
+    #[test]
+    fn classify_account_geyser_update_enrich_membership_mint_without_high_dispatch() {
+        let mint = Pubkey::new_unique();
+        let mut host = MockIngestHost::new();
+        host.membership.insert(mint);
+        let u = sample_update(mint, Pubkey::new_unique());
+        assert_eq!(
+            classify_account_geyser_update(&host, &u),
+            AccountUpdateClass::Enrich
+        );
+    }
+
+    #[test]
+    fn classify_account_geyser_update_drop_non_enrichment_dex_pool() {
+        let host = MockIngestHost::new();
+        let pool = Pubkey::new_unique();
+        let u = sample_update(pool, RAYDIUM_CPMM_OWNER);
+        assert_eq!(
+            classify_account_geyser_update(&host, &u),
+            AccountUpdateClass::Drop
+        );
     }
 }

--- a/src/market_data/ingest/mod.rs
+++ b/src/market_data/ingest/mod.rs
@@ -11,7 +11,7 @@ pub mod tx_parse;
 pub use account_filter::{
     account_geyser_dispatch_priority_high, account_geyser_update_is_dex_pool_owner,
     account_geyser_update_might_be_relevant, account_geyser_update_relevance,
-    AccountGeyserRelevance,
+    classify_account_geyser_update, AccountGeyserRelevance, AccountUpdateClass,
 };
 pub use account_handler::handle_geyser_account_update;
 pub use account_host::{AccountBinArrayView, AccountIngestHost, AccountTrackedWalletView};

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1646,6 +1646,38 @@ static MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = 
 static MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 static MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
+static MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+static MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_ENRICH_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_ENRICH_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_ENRICH_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Account ingest class counter `market_data_account_updates_total{class=...}`.
+pub static MARKET_DATA_ACCOUNT_UPDATES_TOTAL_EXEC_HOT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_ACCOUNT_UPDATES_TOTAL_ENRICH: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_ACCOUNT_UPDATES_TOTAL_DROP: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 /// Pump.fun: wall ms from Geyser `grpc_recv_at` on the TX update to `DevWalletIdentified` publish (TX fast-path after `pool_mint_map` insert).
 static MARKET_DATA_POOL_MINT_MAP_TO_DEVWALLET_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
     Lazy::new(|| {
@@ -1899,6 +1931,50 @@ pub fn record_market_data_account_channel_lag_ms(grpc_recv_at: Instant, recv_at:
         ms,
         MARKET_DATA_LATENCY_MS_SUM_CAP,
     );
+}
+
+/// Per-class account channel lag (`class="exec_hot"` | `class="enrich"`).
+#[inline]
+pub fn record_market_data_account_channel_lag_ms_for_class(
+    class: &str,
+    grpc_recv_at: Instant,
+    recv_at: Instant,
+) {
+    let ms = recv_at
+        .saturating_duration_since(grpc_recv_at)
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64;
+    match class {
+        "exec_hot" => record_histogram_u64_into(
+            MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+            &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_BUCKET_COUNTS,
+            &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_SUM,
+            &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_COUNT,
+            ms,
+            MARKET_DATA_LATENCY_MS_SUM_CAP,
+        ),
+        "enrich" => record_histogram_u64_into(
+            MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+            &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_ENRICH_BUCKET_COUNTS,
+            &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_ENRICH_SUM,
+            &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_ENRICH_COUNT,
+            ms,
+            MARKET_DATA_LATENCY_MS_SUM_CAP,
+        ),
+        _ => {}
+    }
+}
+
+/// Increment `market_data_account_updates_total{class=...}`.
+#[inline]
+pub fn inc_market_data_account_updates_total(class: &str) {
+    let counter = match class {
+        "exec_hot" => &*MARKET_DATA_ACCOUNT_UPDATES_TOTAL_EXEC_HOT,
+        "enrich" => &*MARKET_DATA_ACCOUNT_UPDATES_TOTAL_ENRICH,
+        "drop" => &*MARKET_DATA_ACCOUNT_UPDATES_TOTAL_DROP,
+        _ => return,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Pump.fun trade publish: chain slots since last bonding-curve progress publish for the same pool key.
@@ -5892,6 +5968,32 @@ fn append_momentum_latency_histogram_prometheus(
     out.push_str(&format!("{}_count {}\n", metric, c));
 }
 
+fn append_account_channel_lag_ms_labeled_histogram(
+    out: &mut String,
+    class: &str,
+    bucket_counts: &[AtomicU64],
+    sum: &AtomicU64,
+    count: &AtomicU64,
+) {
+    let c = count.load(Ordering::Relaxed);
+    let s = sum.load(Ordering::Relaxed);
+    for (i, b) in MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS.iter().enumerate() {
+        let v = bucket_counts[i].load(Ordering::Relaxed);
+        out.push_str(&format!(
+            "market_data_account_channel_lag_ms_bucket{{class=\"{class}\",le=\"{b}\"}} {v}\n"
+        ));
+    }
+    out.push_str(&format!(
+        "market_data_account_channel_lag_ms_bucket{{class=\"{class}\",le=\"+Inf\"}} {c}\n"
+    ));
+    out.push_str(&format!(
+        "market_data_account_channel_lag_ms_sum{{class=\"{class}\"}} {s}\n"
+    ));
+    out.push_str(&format!(
+        "market_data_account_channel_lag_ms_count{{class=\"{class}\"}} {c}\n"
+    ));
+}
+
 /// Append `_bucket{le=...}`, `_sum`, `_count` lines (same layout as `tx_slot_to_send_ms`).
 #[allow(clippy::too_many_arguments)]
 fn append_labeled_duration_seconds_histogram(
@@ -6781,6 +6883,20 @@ async fn metrics_response() -> Response<Body> {
         &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_SUM,
         &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_COUNT,
     );
+    append_account_channel_lag_ms_labeled_histogram(
+        &mut out,
+        "exec_hot",
+        &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_BUCKET_COUNTS,
+        &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_SUM,
+        &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_COUNT,
+    );
+    append_account_channel_lag_ms_labeled_histogram(
+        &mut out,
+        "enrich",
+        &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_ENRICH_BUCKET_COUNTS,
+        &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_ENRICH_SUM,
+        &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_ENRICH_COUNT,
+    );
     append_momentum_latency_histogram_prometheus(
         &mut out,
         "market_data_pool_mint_map_to_devwallet_ms",
@@ -6881,6 +6997,27 @@ async fn metrics_response() -> Response<Body> {
     out.push_str("market_data_account_early_drop_total{reason=\"dex_pool_not_enrichment\"} ");
     out.push_str(
         &MARKET_DATA_ACCOUNT_EARLY_DROP_DEX_POOL_NOT_ENRICHMENT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("market_data_account_updates_total{class=\"exec_hot\"} ");
+    out.push_str(
+        &MARKET_DATA_ACCOUNT_UPDATES_TOTAL_EXEC_HOT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("market_data_account_updates_total{class=\"enrich\"} ");
+    out.push_str(
+        &MARKET_DATA_ACCOUNT_UPDATES_TOTAL_ENRICH
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("market_data_account_updates_total{class=\"drop\"} ");
+    out.push_str(
+        &MARKET_DATA_ACCOUNT_UPDATES_TOTAL_DROP
             .load(Ordering::Relaxed)
             .to_string(),
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scope A from `plan_account_update_realtime_backlog_fix_20260716.md`: observability only — classify each Geyser account update at market-data recv and export per-class metrics. **No** queue/scheduling/coalesce changes (Scope B).

### Changes

- **`AccountUpdateClass`** (`ExecHot` | `Enrich` | `Drop`) + `classify_account_geyser_update()` in `account_filter.rs`, reusing existing `account_geyser_update_relevance` + `account_geyser_dispatch_priority_high` logic (Arb pins remain EXEC_HOT-capable via `ingest_is_enrichment_member` / hot pool).
- **Recv loop** (`market_data.rs`): classify + record metrics; HIGH/LOW enqueue derived from class (`ExecHot` → high shard) — bit-equivalent to prior `dispatch_priority_high` call.
- **Prometheus metrics**:
  - `market_data_account_updates_total{class="exec_hot"|"enrich"|"drop"}`
  - `market_data_account_channel_lag_ms{class="exec_hot"|"enrich"}` (labeled histogram)
  - Unlabeled `market_data_account_channel_lag_ms` and `market_data_account_early_drop_total` unchanged.
- **Unit tests** for EXEC_HOT (hot-pool / Arb-equivalent), ENRICH, DROP.

### Scope C note (documented in code)

Open-position pools without Momentum/Arb pin are often `Enrich`, not `ExecHot` — intentionally not widened in this PR.

### STOP-CHECK

- I-7: no new RPC
- I-9: no simulation-path changes
- Queue caps / worker count / `account_worker_recv_next` unchanged

### Verification

```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad1de05e-5d44-4602-9f8b-32cef57a6e94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad1de05e-5d44-4602-9f8b-32cef57a6e94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

