### PR TITLE
feat(market-data): Scope C open-position pools pin to EXEC_HOT

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -314,6 +314,27 @@ fn is_regular_momentum_hot_path_sell(intent: &TradeIntent) -> bool {
     true
 }
 
+/// Scope C: EE open-position pool pin — momentum-sourced confirmed BUY only; skip SOL/WSOL and Arb legs.
+#[inline]
+fn should_publish_open_position_pool_pin_after_confirmed_buy(intent: &TradeIntent) -> bool {
+    if intent.side != TradeSide::Buy {
+        return false;
+    }
+    // Dual-consumer: Arb / manual / sell-all must not publish Momentum Position pins.
+    if intent.source != "momentum-bot" {
+        return false;
+    }
+    let mint = intent.resources.output_mint.as_str();
+    if mint.is_empty() || ironcrab::position_authority::is_sol_or_wsol_mint(mint) {
+        return false;
+    }
+    intent
+        .resources
+        .pools
+        .first()
+        .is_some_and(|pool| !pool.is_empty())
+}
+
 /// I-24e (P184m): Liquidation / stale-SLAVE PumpSwap discovery must not reuse cache-first MD path.
 #[inline]
 fn pump_amm_liquidation_discovery_force_refresh() -> bool {
@@ -6405,16 +6426,13 @@ impl ExecutionContext {
         intent: &TradeIntent,
         exec: &ExecutionResult,
     ) {
-        if exec.status != ExecutionStatus::Confirmed || intent.side != TradeSide::Buy {
+        if exec.status != ExecutionStatus::Confirmed
+            || !should_publish_open_position_pool_pin_after_confirmed_buy(intent)
+        {
             return;
         }
-        let Some(pool) = intent.resources.pools.first().filter(|p| !p.is_empty()) else {
-            return;
-        };
+        let pool = intent.resources.pools.first().expect("checked in filter");
         let mint = intent.resources.output_mint.as_str();
-        if mint.is_empty() {
-            return;
-        }
         let Some(nats) = self.nats.as_ref() else {
             return;
         };
@@ -13840,9 +13858,10 @@ mod execution_engine_tests {
         pump_amm_liquidation_quote_timeout_str, pump_amm_pool_market_hint_merge,
         pump_amm_slave_recovery_snapshot, record_pump_amm_hot_path_refresh_after_success,
         scale_in_max_open_positions_skip_details, scope48_confirmed_sell_close_decision,
-        sim_failure_reject_reason, simulation_result_on_rpc_timeout,
-        sort_route_candidates_by_amount_out, take_next_multi_pool_buildable_fallback_route,
-        try_pump_amm_hot_path_refresh_publish, wait_for_meteora_dlmm_slave_after_recovery,
+        should_publish_open_position_pool_pin_after_confirmed_buy, sim_failure_reject_reason,
+        simulation_result_on_rpc_timeout, sort_route_candidates_by_amount_out,
+        take_next_multi_pool_buildable_fallback_route, try_pump_amm_hot_path_refresh_publish,
+        wait_for_meteora_dlmm_slave_after_recovery,
         wait_for_pump_amm_pool_hint_ready_for_tx_plan_builder,
         wait_for_pump_amm_slave_after_recovery, wait_for_pumpfun_bonding_cache_refresh,
         wallet_bootstrap_allows_pa_kv_tombstone_sweep, ComputedIntentFills,
@@ -14522,6 +14541,59 @@ mod execution_engine_tests {
             .metadata
             .insert("sell_all".to_string(), "true".to_string());
         assert!(!is_regular_momentum_hot_path_sell(&intent));
+    }
+
+    #[test]
+    fn open_position_pool_pin_filters_arb_sol_and_requires_momentum_buy() {
+        let token_mint = "Mint111111111111111111111111111111111111111".to_string();
+        let pool = "Pool123".to_string();
+        let mut intent = TradeIntent::new(
+            "momentum-bot",
+            "v0.1.0",
+            "run-1",
+            "id-buy".to_string(),
+            "momentum-bot",
+            IntentTier::Tier1,
+            IntentOrigin::StrategyA,
+            ExplicitAmount::new(1_000_000, 6),
+            TradeResources {
+                input_mint: ironcrab::ipc::NATIVE_SOL_MINT.to_string(),
+                output_mint: token_mint.clone(),
+                pools: vec![pool.clone()],
+                accounts: vec![],
+                token_program: None,
+            },
+            0,
+            200,
+            TradeSide::Buy,
+            TradingRegime::Early,
+        );
+        assert!(should_publish_open_position_pool_pin_after_confirmed_buy(
+            &intent
+        ));
+
+        intent.source = "arb-strategy".to_string();
+        assert!(!should_publish_open_position_pool_pin_after_confirmed_buy(
+            &intent
+        ));
+
+        intent.source = "momentum-bot".to_string();
+        intent.resources.output_mint = ironcrab::ipc::NATIVE_SOL_MINT.to_string();
+        assert!(!should_publish_open_position_pool_pin_after_confirmed_buy(
+            &intent
+        ));
+
+        intent.resources.output_mint = token_mint;
+        intent.side = TradeSide::Sell;
+        assert!(!should_publish_open_position_pool_pin_after_confirmed_buy(
+            &intent
+        ));
+
+        intent.side = TradeSide::Buy;
+        intent.resources.pools.clear();
+        assert!(!should_publish_open_position_pool_pin_after_confirmed_buy(
+            &intent
+        ));
     }
 
     #[test]

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -111,11 +111,12 @@ use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
     ensure_trade_intents_stream, pool_cache_live_consumer_config_execution_engine,
     wallet_snapshot_consumer_config, wallet_snapshot_live_consumer_config_execution_engine,
-    wallet_tx_confirm_live_consumer_config_execution_engine, NatsClient, NatsConfig,
-    CONFIG_STREAM_NAME, STREAM_NAME, TOPIC_CONTROL_REQUESTS, TOPIC_CONTROL_RESPONSES,
-    TOPIC_DECISION_RECORDS, TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS,
-    TOPIC_PRIORITY_FEE_SAMPLES, TOPIC_TRADE_INTENTS, TRADE_INTENTS_STREAM_NAME,
-    WALLET_SNAPSHOT_STREAM_NAME, WALLET_TX_CONFIRM_STREAM_NAME,
+    wallet_tx_confirm_live_consumer_config_execution_engine, MomentumActivePinReason,
+    MomentumActivePoolEntry, MomentumActivePoolsUpdate, NatsClient, NatsConfig, CONFIG_STREAM_NAME,
+    MOMENTUM_ACTIVE_POOLS_WIRE_VERSION, STREAM_NAME, TOPIC_CONTROL_REQUESTS,
+    TOPIC_CONTROL_RESPONSES, TOPIC_DECISION_RECORDS, TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS,
+    TOPIC_MOMENTUM_ACTIVE_POOLS, TOPIC_PRIORITY_FEE_SAMPLES, TOPIC_TRADE_INTENTS,
+    TRADE_INTENTS_STREAM_NAME, WALLET_SNAPSHOT_STREAM_NAME, WALLET_TX_CONFIRM_STREAM_NAME,
 };
 use ironcrab::position_authority::{
     position_authority_drift_lockmanager, PositionAuthority, PositionAuthorityChange,
@@ -6398,6 +6399,47 @@ impl ExecutionContext {
         self.refresh_position_authority_metrics();
     }
 
+    /// Scope C: EE-only / authority BUY confirms publish Position pin when routed pool is known.
+    async fn publish_open_position_pool_pin_after_confirmed_buy(
+        &self,
+        intent: &TradeIntent,
+        exec: &ExecutionResult,
+    ) {
+        if exec.status != ExecutionStatus::Confirmed || intent.side != TradeSide::Buy {
+            return;
+        }
+        let Some(pool) = intent.resources.pools.first().filter(|p| !p.is_empty()) else {
+            return;
+        };
+        let mint = intent.resources.output_mint.as_str();
+        if mint.is_empty() {
+            return;
+        }
+        let Some(nats) = self.nats.as_ref() else {
+            return;
+        };
+        let update = MomentumActivePoolsUpdate {
+            version: MOMENTUM_ACTIVE_POOLS_WIRE_VERSION,
+            ts_unix_ms: wall_clock_unix_ms_now(),
+            active: vec![MomentumActivePoolEntry {
+                mint: mint.to_string(),
+                pool: pool.clone(),
+                pin_reason: MomentumActivePinReason::Position,
+            }],
+            removed: vec![],
+            full_active_snapshot: false,
+        };
+        if let Err(e) = nats.publish(TOPIC_MOMENTUM_ACTIVE_POOLS, &update).await {
+            warn!(
+                error = %e,
+                intent_id = %intent.intent_id,
+                mint = %mint,
+                pool = %pool,
+                "Failed to publish open-position pool pin for confirmed BUY"
+            );
+        }
+    }
+
     /// Wallet snapshot: same filter as `PositionEvent::try_from_market_event_kind` (ignores SOL/WSOL for authority open count).
     fn apply_position_authority_from_wallet_event_kind(&self, kind: &MarketEventKind) {
         {
@@ -12308,6 +12350,10 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
             }
             if exec.status == ExecutionStatus::Confirmed {
                 ctx.apply_position_authority_from_execution_result(&exec);
+                if intent.side == TradeSide::Buy {
+                    ctx.publish_open_position_pool_pin_after_confirmed_buy(&intent, &exec)
+                        .await;
+                }
             }
         }
     }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2566,35 +2566,41 @@ impl MarketDataContext {
         *self.explicit_admitted_arb_pools.write() = arb;
     }
 
+    fn sync_explicit_momentum_pool_admitted_from_admission(
+        &self,
+        admission: &FixedCapAdmission,
+        pool: Pubkey,
+    ) {
+        let momentum_admitted = admission
+            .owner_group(&Self::pool_consumer_owner(pool, ExplicitConsumer::Momentum))
+            .is_some();
+        let position_admitted = admission
+            .owner_group(&Self::pool_consumer_owner(
+                pool,
+                ExplicitConsumer::MomentumPosition,
+            ))
+            .is_some();
+        if momentum_admitted || position_admitted {
+            self.note_explicit_momentum_pool_admitted(pool);
+        } else {
+            self.clear_explicit_momentum_pool_admitted(pool);
+        }
+    }
+
     fn sync_explicit_pool_admitted_from_admission(
         &self,
         admission: &FixedCapAdmission,
         pool: Pubkey,
         consumer: ExplicitConsumer,
     ) {
-        let owner = Self::pool_consumer_owner(pool, consumer);
-        let admitted = admission.owner_group(&owner).is_some();
         match consumer {
             ExplicitConsumer::Momentum | ExplicitConsumer::MomentumPosition => {
-                if admitted {
-                    self.note_explicit_momentum_pool_admitted(pool);
-                } else {
-                    let other = if consumer == ExplicitConsumer::Momentum {
-                        ExplicitConsumer::MomentumPosition
-                    } else {
-                        ExplicitConsumer::Momentum
-                    };
-                    let other_admitted = admission
-                        .owner_group(&Self::pool_consumer_owner(pool, other))
-                        .is_some();
-                    if other_admitted {
-                        self.note_explicit_momentum_pool_admitted(pool);
-                    } else {
-                        self.clear_explicit_momentum_pool_admitted(pool);
-                    }
-                }
+                self.sync_explicit_momentum_pool_admitted_from_admission(admission, pool);
             }
             ExplicitConsumer::Arb => {
+                let admitted = admission
+                    .owner_group(&Self::pool_consumer_owner(pool, consumer))
+                    .is_some();
                 if admitted {
                     self.note_explicit_arb_pool_admitted(pool);
                 } else {
@@ -2787,7 +2793,7 @@ impl MarketDataContext {
         let _ = admission.remove_group(Self::pool_consumer_owner(pool, consumer));
         match consumer {
             ExplicitConsumer::Momentum | ExplicitConsumer::MomentumPosition => {
-                self.clear_explicit_momentum_pool_admitted(pool)
+                self.sync_explicit_momentum_pool_admitted_from_admission(admission, pool);
             }
             ExplicitConsumer::Arb => self.clear_explicit_arb_pool_admitted(pool),
             ExplicitConsumer::Wallet | ExplicitConsumer::Tracker => {}
@@ -4623,6 +4629,17 @@ impl MarketDataContext {
             } else {
                 ExplicitConsumer::Momentum
             };
+            let superseded_consumer = if is_position {
+                ExplicitConsumer::Momentum
+            } else {
+                ExplicitConsumer::MomentumPosition
+            };
+            if admission
+                .owner_group(&Self::pool_consumer_owner(pool_pk, superseded_consumer))
+                .is_some()
+            {
+                self.release_pool_consumer_group(admission, pool_pk, superseded_consumer);
+            }
             if self.try_admit_pool_consumer_group(admission, pool_pk, momentum_consumer) {
                 inc_market_data_momentum_admission_admitted_total();
                 let registered = self.register_geyser_reserves_for_momentum_active_pool(pool_pk);
@@ -12594,6 +12611,7 @@ mod pr_b_geyser_tracking_tests {
     /// Scope C: Tracker downgrade clears position-subset membership while momentum pin remains.
     #[test]
     fn scope_c_tracker_downgrade_clears_position_pin_subset() {
+        use ironcrab::market_data::track::{ExplicitConsumer, ExplicitOwner, ExplicitOwnerKey};
         use ironcrab::nats::{MomentumActivePinReason, MomentumActivePoolEntry};
 
         let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -12650,6 +12668,75 @@ mod pr_b_geyser_tracking_tests {
             !ctx.hot_pool_registry.is_position_pin(base_mint, pool),
             "position subset must clear on tracker downgrade"
         );
+        let momentum_owner = ExplicitOwner {
+            consumer: ExplicitConsumer::Momentum,
+            owner_key: ExplicitOwnerKey::Pool(pool),
+        };
+        let position_owner = ExplicitOwner {
+            consumer: ExplicitConsumer::MomentumPosition,
+            owner_key: ExplicitOwnerKey::Pool(pool),
+        };
+        assert!(
+            admission.owner_group(&position_owner).is_none(),
+            "tracker downgrade must release MomentumPosition admission owner"
+        );
+        assert!(
+            admission.owner_group(&momentum_owner).is_some(),
+            "tracker downgrade must admit Momentum consumer group"
+        );
+        assert!(ctx.pool_has_explicit_momentum_admission(pool));
+    }
+
+    /// Scope C: releasing one momentum consumer must not clear bypass while sibling remains.
+    #[test]
+    fn release_pool_consumer_group_keeps_bypass_while_sibling_momentum_consumer_admitted() {
+        use ironcrab::market_data::track::{
+            try_admit_owner_group, ExplicitConsumer, ExplicitOwner, ExplicitOwnerKey,
+        };
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+        let position_owner = ExplicitOwner {
+            consumer: ExplicitConsumer::MomentumPosition,
+            owner_key: ExplicitOwnerKey::Pool(pool),
+        };
+        let momentum_owner = ExplicitOwner {
+            consumer: ExplicitConsumer::Momentum,
+            owner_key: ExplicitOwnerKey::Pool(pool),
+        };
+
+        let mut admission = FixedCapAdmission::new(100);
+        assert!(try_admit_owner_group(
+            &mut admission,
+            position_owner.clone(),
+            vec![coin, pc],
+        ));
+        assert!(try_admit_owner_group(
+            &mut admission,
+            momentum_owner.clone(),
+            vec![coin, pc],
+        ));
+        ctx.note_explicit_momentum_pool_admitted(pool);
+        assert!(ctx.pool_has_explicit_momentum_admission(pool));
+
+        ctx.release_pool_consumer_group(&mut admission, pool, ExplicitConsumer::MomentumPosition);
+        assert!(
+            admission.owner_group(&momentum_owner).is_some(),
+            "Momentum owner must remain after releasing MomentumPosition"
+        );
+        assert!(
+            ctx.pool_has_explicit_momentum_admission(pool),
+            "bypass gate must stay while sibling Momentum consumer remains"
+        );
+
+        ctx.release_pool_consumer_group(&mut admission, pool, ExplicitConsumer::Momentum);
+        assert!(!ctx.pool_has_explicit_momentum_admission(pool));
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -106,6 +106,8 @@ use ironcrab::metrics::{
     inc_market_data_ingest_membership_snapshot_hits_total,
     inc_market_data_jsonl_enqueue_dropped_total, inc_market_data_momentum_admission_admitted_total,
     inc_market_data_momentum_admission_rejected_total,
+    inc_market_data_open_position_pin_applied_total,
+    inc_market_data_open_position_pin_deferred_cache_miss_total,
     inc_market_data_tracker_admission_admitted_total,
     inc_market_data_tracker_admission_rejected_total,
     inc_market_data_vault_high_priority_dispatch_total,
@@ -143,11 +145,11 @@ use ironcrab::nats::{
     ensure_pool_cache_stream, ensure_wallet_snapshot_stream, ensure_wallet_tx_confirm_stream,
     execution_results_consumer_config, pool_subject, wallet_snapshot_consumer_config,
     wallet_snapshot_subject, wallet_tx_confirm_subject, ArbTrackActiveEntry, ArbTrackRemovedEntry,
-    ArbTrackRequestsUpdate, MomentumActivePoolEntry, MomentumActivePoolsUpdate,
-    MomentumRemovedPoolEntry, NatsClient, NatsConfig, CONFIG_STREAM_NAME,
-    EXECUTION_RESULTS_STREAM_NAME, TOPIC_ARB_TRACK_REQUESTS, TOPIC_CONTROL_REQUESTS,
-    TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS, TOPIC_MOMENTUM_ACTIVE_POOLS,
-    WALLET_SNAPSHOT_STREAM_NAME,
+    ArbTrackRequestsUpdate, MomentumActivePinReason, MomentumActivePoolEntry,
+    MomentumActivePoolsUpdate, MomentumRemovedPoolEntry, NatsClient, NatsConfig,
+    CONFIG_STREAM_NAME, EXECUTION_RESULTS_STREAM_NAME, TOPIC_ARB_TRACK_REQUESTS,
+    TOPIC_CONTROL_REQUESTS, TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS,
+    TOPIC_MOMENTUM_ACTIVE_POOLS, WALLET_SNAPSHOT_STREAM_NAME,
 };
 use ironcrab::position_authority::is_sol_or_wsol_mint;
 use ironcrab::solana::dex::meteora_swap_builder::MeteoraDlmmSwapBuilder;
@@ -732,6 +734,8 @@ impl Default for MintTrackInfo {
 #[derive(Debug)]
 struct UnifiedHotPoolRegistry {
     momentum_pairs: parking_lot::RwLock<std::collections::HashSet<(Pubkey, Pubkey)>>,
+    /// Scope C: subset of `momentum_pairs` opened via Position pin (exit hot-path).
+    momentum_position_pairs: parking_lot::RwLock<std::collections::HashSet<(Pubkey, Pubkey)>>,
     arb_pools: parking_lot::RwLock<std::collections::HashSet<Pubkey>>,
 }
 
@@ -740,16 +744,36 @@ impl UnifiedHotPoolRegistry {
     fn new() -> Self {
         Self {
             momentum_pairs: parking_lot::RwLock::new(std::collections::HashSet::new()),
+            momentum_position_pairs: parking_lot::RwLock::new(std::collections::HashSet::new()),
             arb_pools: parking_lot::RwLock::new(std::collections::HashSet::new()),
         }
     }
 
     fn pin_pool(&self, mint: Pubkey, pool: Pubkey) {
+        self.pin_pool_with_reason(mint, pool, false);
+    }
+
+    fn pin_pool_with_reason(&self, mint: Pubkey, pool: Pubkey, is_position: bool) {
         self.momentum_pairs.write().insert((mint, pool));
+        if is_position {
+            self.momentum_position_pairs.write().insert((mint, pool));
+        }
+    }
+
+    fn is_position_pin(&self, mint: Pubkey, pool: Pubkey) -> bool {
+        self.momentum_position_pairs.read().contains(&(mint, pool))
+    }
+
+    fn is_position_pin_for_pool(&self, pool: Pubkey) -> bool {
+        self.momentum_position_pairs
+            .read()
+            .iter()
+            .any(|(_, p)| *p == pool)
     }
 
     fn unpin_pool(&self, mint: Pubkey, pool: Pubkey) {
         self.momentum_pairs.write().remove(&(mint, pool));
+        self.momentum_position_pairs.write().remove(&(mint, pool));
     }
 
     fn pin_arb_pool(&self, pool: Pubkey) {
@@ -1135,6 +1159,8 @@ struct MarketDataContext {
     last_arb_snapshot_target: parking_lot::RwLock<Option<HashSet<Pubkey>>>,
     /// Last `active_id` used when registering DLMM bin-array window per pool (Fix B).
     dlmm_registered_active_id: parking_lot::RwLock<HashMap<Pubkey, i32>>,
+    /// Scope C: hot pools awaiting LivePoolCache layout for vault/bin Geyser registration.
+    deferred_hot_pool_reserve_pins: parking_lot::RwLock<HashMap<Pubkey, GeyserPinReason>>,
     /// PR3: startup restore / first physical publish barrier before Geyser connect.
     geyser_connect_barrier: Arc<GeyserConnectBarrier>,
     /// PR3: explicit admission readiness (wallet-over-cap fail-closed).
@@ -2036,6 +2062,13 @@ impl TrackWorkerContext for MarketDataContext {
         new_cap: usize,
     ) -> CapShrinkResult {
         MarketDataContext::apply_explicit_cap_shrink(self, admission, new_cap)
+    }
+
+    fn retry_deferred_hot_pool_reserve_registrations(
+        &self,
+        admission: &mut FixedCapAdmission,
+    ) -> bool {
+        MarketDataContext::retry_deferred_hot_pool_reserve_registrations(self, admission)
     }
 }
 
@@ -4062,24 +4095,24 @@ impl MarketDataContext {
         if !self.hot_pool_registry.is_hot_pool(pool) {
             return false;
         }
-        let Some(cached_state) = self.live_pool_cache.get(&pool) else {
+        if self.live_pool_cache.get(&pool).is_none() {
             return false;
+        }
+        let pin = if self.hot_pool_registry.pool_has_arb(pool) {
+            GeyserPinReason::ArbMultiDex
+        } else {
+            GeyserPinReason::MomentumActive
         };
-        let (enable_meteora_cpmm, enable_meteora_dlmm) = {
-            let cfg = self.config.read();
-            (cfg.enable_meteora_cpmm, cfg.enable_meteora_dlmm)
-        };
-        let now = Instant::now();
         let before_keys = self.snapshot_explicit_demand_pubkeys();
-        let _vaults_changed = self.register_four_dex_pool_vaults_from_cached_state(
-            pool,
-            &cached_state,
-            now,
-            enable_meteora_cpmm,
-            enable_meteora_dlmm,
-            true,
-        );
-        explicit_subscription_has_new_keys(&before_keys, &self.snapshot_explicit_demand_pubkeys())
+        let changed = self.register_geyser_reserves_impl(pool, pin);
+        if changed {
+            self.clear_deferred_hot_pool_reserve_registration(pool);
+        }
+        changed
+            || explicit_subscription_has_new_keys(
+                &before_keys,
+                &self.snapshot_explicit_demand_pubkeys(),
+            )
     }
 
     /// PR-D / Phase 3: explicit vault/bin subscriptions when cache has layout.
@@ -4103,6 +4136,83 @@ impl MarketDataContext {
 
     fn register_geyser_reserves_for_arb_active_pool(&self, pool: Pubkey) -> bool {
         self.register_geyser_reserves_for_active_pool(pool, GeyserPinReason::ArbMultiDex)
+    }
+
+    fn note_deferred_hot_pool_reserve_registration(&self, pool: Pubkey, pin: GeyserPinReason) {
+        if !self.hot_pool_registry.is_hot_pool(pool) {
+            return;
+        }
+        self.deferred_hot_pool_reserve_pins
+            .write()
+            .insert(pool, pin);
+    }
+
+    fn clear_deferred_hot_pool_reserve_registration(&self, pool: Pubkey) {
+        self.deferred_hot_pool_reserve_pins.write().remove(&pool);
+    }
+
+    /// Bounded retry when LivePoolCache gains layout for a pinned hot pool (no RPC).
+    fn retry_deferred_hot_pool_reserve_registrations(
+        &self,
+        admission: &mut FixedCapAdmission,
+    ) -> bool {
+        let pending: Vec<(Pubkey, GeyserPinReason)> = self
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .iter()
+            .map(|(pool, pin)| (*pool, *pin))
+            .collect();
+        if pending.is_empty() {
+            return false;
+        }
+        let mut batch_dirty = false;
+        for (pool, pin) in pending {
+            if !self.hot_pool_registry.is_hot_pool(pool) {
+                self.clear_deferred_hot_pool_reserve_registration(pool);
+                continue;
+            }
+            if self.live_pool_cache.get(&pool).is_none() {
+                continue;
+            }
+            let consumer = match pin {
+                GeyserPinReason::ArbMultiDex => ExplicitConsumer::Arb,
+                GeyserPinReason::MomentumActive | GeyserPinReason::Wallet => {
+                    ExplicitConsumer::Momentum
+                }
+            };
+            let _ = self.try_admit_pool_consumer_group(admission, pool, consumer);
+            if self.register_geyser_reserves_for_active_pool(pool, pin) {
+                self.clear_deferred_hot_pool_reserve_registration(pool);
+                if self.hot_pool_registry.is_position_pin_for_pool(pool) {
+                    inc_market_data_open_position_pin_applied_total();
+                }
+                batch_dirty = true;
+            }
+            self.sync_explicit_pool_admitted_from_admission(admission, pool, consumer);
+        }
+        batch_dirty
+    }
+
+    fn record_momentum_active_pool_reserve_registration_outcome(
+        &self,
+        pool: Pubkey,
+        pin: GeyserPinReason,
+        is_position: bool,
+        registered: bool,
+    ) {
+        if registered {
+            self.clear_deferred_hot_pool_reserve_registration(pool);
+            if is_position {
+                inc_market_data_open_position_pin_applied_total();
+            }
+            return;
+        }
+        if self.live_pool_cache.get(&pool).is_none() {
+            self.note_deferred_hot_pool_reserve_registration(pool, pin);
+            if is_position {
+                inc_market_data_open_position_pin_deferred_cache_miss_total();
+            }
+        }
     }
 
     fn register_meteora_dlmm_bin_arrays(
@@ -4284,6 +4394,7 @@ impl MarketDataContext {
         }
         batch_dirty |= self.apply_momentum_removed_entries(admission, &update.removed);
         batch_dirty |= self.apply_momentum_active_entries(admission, &update.active);
+        batch_dirty |= self.retry_deferred_hot_pool_reserve_registrations(admission);
         if !batch_dirty {
             self.refresh_geyser_pins_gauge();
         }
@@ -4363,21 +4474,44 @@ impl MarketDataContext {
                 warn!(pool = %a.pool, "MomentumActivePoolsUpdate.active: invalid pool");
                 continue;
             };
-            self.hot_pool_registry.pin_pool(mint_pk, pool_pk);
+            let is_position = a.pin_reason == MomentumActivePinReason::Position;
+            self.hot_pool_registry
+                .pin_pool_with_reason(mint_pk, pool_pk, is_position);
             if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Momentum) {
                 inc_market_data_momentum_admission_admitted_total();
-                if self.register_geyser_reserves_for_momentum_active_pool(pool_pk) {
+                let registered = self.register_geyser_reserves_for_momentum_active_pool(pool_pk);
+                self.record_momentum_active_pool_reserve_registration_outcome(
+                    pool_pk,
+                    GeyserPinReason::MomentumActive,
+                    is_position,
+                    registered,
+                );
+                if registered {
                     batch_dirty = true;
+                } else if self.live_pool_cache.get(&pool_pk).is_none() {
+                    debug!(
+                        run_id = %self.run_id,
+                        pool = %pool_pk,
+                        pin_reason = ?a.pin_reason,
+                        "Momentum active pool pin: LivePoolCache miss — registry row kept; reserve registration deferred"
+                    );
                 }
             } else {
                 inc_market_data_momentum_admission_rejected_total();
+                if self.live_pool_cache.get(&pool_pk).is_none() {
+                    self.record_momentum_active_pool_reserve_registration_outcome(
+                        pool_pk,
+                        GeyserPinReason::MomentumActive,
+                        is_position,
+                        false,
+                    );
+                }
             }
             self.sync_explicit_pool_admitted_from_admission(
                 admission,
                 pool_pk,
                 ExplicitConsumer::Momentum,
             );
-            let _ = &a.pin_reason;
         }
         batch_dirty
     }
@@ -6814,6 +6948,7 @@ async fn main() -> Result<()> {
         last_momentum_snapshot_target: parking_lot::RwLock::new(None),
         last_arb_snapshot_target: parking_lot::RwLock::new(None),
         dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+        deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
         geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         geyser_explicit_ready: AtomicBool::new(true),
         geyser_explicit_config_error: parking_lot::RwLock::new(None),
@@ -8677,6 +8812,12 @@ async fn run_geyser_loop(
             // Keep /ready fresh even if Geyser/NATS are quiet.
             _ = activity_interval.tick() => {
                 ironcrab::metrics::record_activity();
+                if !ctx.deferred_hot_pool_reserve_pins.read().is_empty() {
+                    let _ = track_worker_try_enqueue(
+                        &track_worker,
+                        TrackWorkerCommand::RetryDeferredHotPoolReserves,
+                    );
+                }
 
                 // Refresh readiness from current runtime state (not startup-latch)
                 let nats_connected = ctx.nats.as_ref().is_some_and(|n| n.is_connected());
@@ -10720,6 +10861,7 @@ mod wallet_snapshot_stale_cleanup_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
@@ -10943,6 +11085,7 @@ mod wallet_tx_meta_balance_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
@@ -11832,6 +11975,7 @@ mod pr_b_geyser_tracking_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
@@ -11907,6 +12051,7 @@ mod pr_b_geyser_tracking_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
@@ -11968,6 +12113,130 @@ mod pr_b_geyser_tracking_tests {
         );
         assert_eq!(
             vs.get(&pc_vault).and_then(|v| v.pin),
+            Some(GeyserPinReason::MomentumActive)
+        );
+    }
+
+    /// Scope C: Position pin → hot pool + vault membership → EXEC_HOT classification.
+    #[test]
+    fn scope_c_position_pin_classifies_exec_hot() {
+        use ironcrab::market_data::ingest::{classify_account_geyser_update, AccountUpdateClass};
+        use ironcrab::nats::{MomentumActivePinReason, MomentumActivePoolEntry};
+        use ironcrab::solana::geyser_listener::GeyserAccountUpdate;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            1,
+        );
+
+        let mut admission = test_admission_for(&ctx);
+        ctx.apply_momentum_active_pools_update(
+            &mut admission,
+            &MomentumActivePoolsUpdate {
+                version: 1,
+                ts_unix_ms: 1,
+                active: vec![MomentumActivePoolEntry {
+                    mint: base_mint.to_string(),
+                    pool: pool.to_string(),
+                    pin_reason: MomentumActivePinReason::Position,
+                }],
+                removed: vec![],
+                full_active_snapshot: false,
+            },
+        );
+
+        assert!(ctx.hot_pool_registry.is_hot_pool(pool));
+        assert!(ctx.hot_pool_registry.is_position_pin(base_mint, pool));
+        ctx.refresh_tracked_membership_snapshot();
+        let update = GeyserAccountUpdate {
+            pubkey: coin_vault,
+            slot: 9,
+            owner: Pubkey::new_unique(),
+            data: vec![1; 8],
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        };
+        let (class, _) = classify_account_geyser_update(&ctx, &update);
+        assert_eq!(class, AccountUpdateClass::ExecHot);
+    }
+
+    /// Scope C: cache miss keeps pin; retry registers vaults when cache fills (no RPC).
+    #[test]
+    fn scope_c_position_pin_cache_miss_retries_when_cache_filled() {
+        use ironcrab::nats::{MomentumActivePinReason, MomentumActivePoolEntry};
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+
+        let mut admission = test_admission_for(&ctx);
+        ctx.apply_momentum_active_pools_update(
+            &mut admission,
+            &MomentumActivePoolsUpdate {
+                version: 1,
+                ts_unix_ms: 1,
+                active: vec![MomentumActivePoolEntry {
+                    mint: base_mint.to_string(),
+                    pool: pool.to_string(),
+                    pin_reason: MomentumActivePinReason::Position,
+                }],
+                removed: vec![],
+                full_active_snapshot: false,
+            },
+        );
+
+        assert!(ctx.hot_pool_registry.is_hot_pool(pool));
+        assert!(ctx
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(&pool));
+        assert!(ctx.tracked_vaults.read().is_empty());
+
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            2,
+        );
+        assert!(ctx.retry_deferred_hot_pool_reserve_registrations(&mut admission));
+        assert!(!ctx
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(&pool));
+        let vs = ctx.tracked_vaults.read();
+        assert_eq!(
+            vs.get(&coin_vault).and_then(|v| v.pin),
             Some(GeyserPinReason::MomentumActive)
         );
     }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -821,6 +821,14 @@ impl UnifiedHotPoolRegistry {
         self.momentum_pairs.read().clone()
     }
 
+    fn snapshot_position_pool_pubkeys(&self) -> HashSet<Pubkey> {
+        self.momentum_position_pairs
+            .read()
+            .iter()
+            .map(|(_, pool)| *pool)
+            .collect()
+    }
+
     /// Pool is in the execution hot set (momentum active and/or arb track pin).
     fn is_hot_pool(&self, pool: Pubkey) -> bool {
         self.pool_has_momentum(pool) || self.pool_has_arb(pool)
@@ -1883,7 +1891,9 @@ fn momentum_explicit_consumer_for_pool(ctx: &MarketDataContext, pool: Pubkey) ->
 fn snapshot_consumer_to_geyser_pin(consumer: SnapshotConsumer) -> Option<GeyserPinReason> {
     match consumer {
         SnapshotConsumer::Wallet => Some(GeyserPinReason::Wallet),
-        SnapshotConsumer::Momentum => Some(GeyserPinReason::MomentumActive),
+        SnapshotConsumer::MomentumPosition | SnapshotConsumer::Momentum => {
+            Some(GeyserPinReason::MomentumActive)
+        }
         SnapshotConsumer::Arb => Some(GeyserPinReason::ArbMultiDex),
         SnapshotConsumer::Tracker => None,
     }
@@ -2831,7 +2841,7 @@ impl MarketDataContext {
         for (pk, v) in self.tracked_vaults.read().iter() {
             rows.push(ExplicitSnapshotRow {
                 pubkey: pk.to_string(),
-                consumer: consumer_id_for_geyser_pin(v.pin).into(),
+                consumer: consumer_id_for_pool_explicit_row(self, v.pool_address, v.pin).into(),
                 pool: Some(v.pool_address.to_string()),
                 kind: ExplicitAccountKind::Vault,
             });
@@ -2839,7 +2849,7 @@ impl MarketDataContext {
         for (pk, b) in self.tracked_bin_arrays.read().iter() {
             rows.push(ExplicitSnapshotRow {
                 pubkey: pk.to_string(),
-                consumer: consumer_id_for_geyser_pin(b.pin).into(),
+                consumer: consumer_id_for_pool_explicit_row(self, b.pool_address, b.pin).into(),
                 pool: Some(b.pool_address.to_string()),
                 kind: ExplicitAccountKind::BinArray,
             });
@@ -2878,7 +2888,16 @@ impl MarketDataContext {
             if let Ok(pool) = Pubkey::from_str(pool_str) {
                 if let Some(mint_str) = self.pool_mint_map.read().get(pool_str) {
                     if let Ok(mint) = Pubkey::from_str(mint_str) {
-                        self.hot_pool_registry.pin_pool(mint, pool);
+                        let is_position = snapshot
+                            .momentum_position_pools
+                            .iter()
+                            .any(|p| p == pool_str);
+                        if is_position {
+                            self.hot_pool_registry
+                                .pin_pool_with_reason(mint, pool, true);
+                        } else {
+                            self.hot_pool_registry.pin_pool(mint, pool);
+                        }
                     }
                 }
             }
@@ -2907,6 +2926,18 @@ impl MarketDataContext {
                 }
                 ExplicitAccountKind::Vault => {
                     let pool_addr = pool.unwrap_or_default();
+                    if row.consumer == SnapshotConsumer::MomentumPosition
+                        && pool_addr != Pubkey::default()
+                    {
+                        if let Some(mint_str) =
+                            self.pool_mint_map.read().get(&pool_addr.to_string())
+                        {
+                            if let Ok(mint) = Pubkey::from_str(mint_str) {
+                                self.hot_pool_registry
+                                    .pin_pool_with_reason(mint, pool_addr, true);
+                            }
+                        }
+                    }
                     let mut vaults = self.tracked_vaults.write();
                     use std::collections::hash_map::Entry;
                     match vaults.entry(pk) {
@@ -3205,6 +3236,12 @@ impl MarketDataContext {
             .map(|(_, pool)| pool.to_string())
             .collect::<std::collections::HashSet<_>>()
             .into_iter()
+            .collect();
+        snapshot.momentum_position_pools = self
+            .hot_pool_registry
+            .snapshot_position_pool_pubkeys()
+            .into_iter()
+            .map(|p| p.to_string())
             .collect();
         snapshot.arb_pools = self
             .hot_pool_registry
@@ -16234,6 +16271,70 @@ mod pr_b_geyser_tracking_tests {
         let info = tracked.get(&mint).expect("restored tracker mint");
         assert_eq!(info.pin, None);
         assert!(!info.pinned);
+    }
+
+    /// Scope C / Bugbot: position pools survive snapshot restore with MomentumPosition consumer + pin subset.
+    #[test]
+    fn scope_c_position_pool_snapshot_restore_preserves_position_pin() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        ctx.pool_mint_map
+            .write()
+            .insert(pool.to_string(), base_mint.to_string());
+        ctx.hot_pool_registry
+            .pin_pool_with_reason(base_mint, pool, true);
+        {
+            let mut vaults = ctx.tracked_vaults.write();
+            let mut vaults_changed = false;
+            ctx.register_tracked_vault_pair_lru(
+                &mut vaults,
+                &mut vaults_changed,
+                TrackedVaultPairInsert {
+                    pool,
+                    now: Instant::now(),
+                    dex: "raydium_cpmm",
+                    base_mint,
+                    quote_mint: quote,
+                    base_vault: coin_vault,
+                    quote_vault: pc_vault,
+                    active_id: None,
+                    bin_step: None,
+                },
+            );
+            vaults.get_mut(&coin_vault).expect("coin").pin = Some(GeyserPinReason::MomentumActive);
+            vaults.get_mut(&pc_vault).expect("pc").pin = Some(GeyserPinReason::MomentumActive);
+        }
+
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        converge_admission_from_ctx(ctx.as_ref(), &mut admission);
+        let snapshot = ctx.build_explicit_set_snapshot(&admission);
+        let vault_row = snapshot
+            .rows
+            .iter()
+            .find(|r| r.pubkey == coin_vault.to_string())
+            .expect("position vault row");
+        assert_eq!(vault_row.consumer, SnapshotConsumer::MomentumPosition);
+        assert!(snapshot.momentum_position_pools.contains(&pool.to_string()));
+
+        let fresh = minimal_market_data_context_for_pr_d_tests(
+            QueuedJsonlWriter::spawn(
+                JsonlWriterConfig::new("market_events").with_log_dir(tmp.path()),
+                256,
+            )
+            .expect("jsonl2"),
+        );
+        let restored = fresh.restore_tracked_maps_from_snapshot_rows(&snapshot);
+        assert!(restored > 0);
+        assert!(fresh.hot_pool_registry.is_position_pin_for_pool(pool));
+        assert!(fresh.hot_pool_registry.is_position_pin(base_mint, pool));
     }
 
     /// Phase 2c: trade handler must not reference arb reconcile enqueue helpers.

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4090,6 +4090,31 @@ impl MarketDataContext {
         vaults_changed
     }
 
+    /// True when expected vault rows for a hot pool are already registered with sibling links.
+    fn pool_vaults_fully_tracked_for_hot_pool(&self, pool: Pubkey) -> bool {
+        let Some(state) = self.live_pool_cache.get(&pool) else {
+            return false;
+        };
+        let (enable_meteora_cpmm, enable_meteora_dlmm) = {
+            let cfg = self.config.read();
+            (cfg.enable_meteora_cpmm, cfg.enable_meteora_dlmm)
+        };
+        let Some((base_vault, quote_vault)) = expected_pool_vault_pubkeys_from_cache(
+            &state,
+            enable_meteora_cpmm,
+            enable_meteora_dlmm,
+        ) else {
+            return true;
+        };
+        let vaults = self.tracked_vaults.read();
+        vaults
+            .get(&base_vault)
+            .is_some_and(|v| v.pool_address == pool && v.sibling_vault == Some(quote_vault))
+            && vaults
+                .get(&quote_vault)
+                .is_some_and(|v| v.pool_address == pool && v.sibling_vault == Some(base_vault))
+    }
+
     /// PR169a: register vault ATAs from MASTER cache after account-path pool upsert (hot pools only).
     #[cfg_attr(not(test), allow(dead_code))]
     fn register_pool_vaults_from_account(&self, pool: Pubkey) -> bool {
@@ -4097,7 +4122,13 @@ impl MarketDataContext {
         if !self.hot_pool_registry.is_hot_pool(pool) {
             return false;
         }
-        if self.live_pool_cache.get(&pool).is_none() {
+        let Some(state) = self.live_pool_cache.get(&pool) else {
+            return false;
+        };
+        let Some((base_mint, quote_mint)) = pool_mints_for_geyser_explicit_tracking(&state) else {
+            return false;
+        };
+        if !self.admit_geyser_explicit_pool_assets(pool, base_mint, quote_mint) {
             return false;
         }
         let pin = if self.hot_pool_registry.pool_has_arb(pool) {
@@ -4107,7 +4138,7 @@ impl MarketDataContext {
         };
         let before_keys = self.snapshot_explicit_demand_pubkeys();
         let changed = self.register_geyser_reserves_impl(pool, pin);
-        if changed {
+        if changed || self.pool_vaults_fully_tracked_for_hot_pool(pool) {
             self.clear_deferred_hot_pool_reserve_registration(pool);
         }
         changed
@@ -4183,12 +4214,16 @@ impl MarketDataContext {
                 }
             };
             let _ = self.try_admit_pool_consumer_group(admission, pool, consumer);
-            if self.register_geyser_reserves_for_active_pool(pool, pin) {
+            let changed = self.register_geyser_reserves_for_active_pool(pool, pin);
+            let reserves_satisfied = changed || self.pool_vaults_fully_tracked_for_hot_pool(pool);
+            if reserves_satisfied {
                 self.clear_deferred_hot_pool_reserve_registration(pool);
                 if self.hot_pool_registry.is_position_pin_for_pool(pool) {
                     inc_market_data_open_position_pin_applied_total();
                 }
-                batch_dirty = true;
+                if changed {
+                    batch_dirty = true;
+                }
             }
             self.sync_explicit_pool_admitted_from_admission(admission, pool, consumer);
         }
@@ -4213,6 +4248,11 @@ impl MarketDataContext {
             self.note_deferred_hot_pool_reserve_registration(pool, pin);
             if is_position {
                 inc_market_data_open_position_pin_deferred_cache_miss_total();
+            }
+        } else if self.pool_vaults_fully_tracked_for_hot_pool(pool) {
+            self.clear_deferred_hot_pool_reserve_registration(pool);
+            if is_position {
+                inc_market_data_open_position_pin_applied_total();
             }
         }
     }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4345,7 +4345,9 @@ impl MarketDataContext {
                     momentum_explicit_consumer_for_pool(self, pool)
                 }
             };
-            let _ = self.try_admit_pool_consumer_group(admission, pool, consumer);
+            if !self.try_admit_pool_consumer_group(admission, pool, consumer) {
+                continue;
+            }
             let changed = self.register_geyser_reserves_for_active_pool(pool, pin);
             let reserves_satisfied = changed || self.hot_pool_reserve_registration_satisfied(pool);
             if reserves_satisfied {
@@ -4671,13 +4673,13 @@ impl MarketDataContext {
             } else {
                 ExplicitConsumer::MomentumPosition
             };
-            if admission
+            let superseded_present = admission
                 .owner_group(&Self::pool_consumer_owner(pool_pk, superseded_consumer))
-                .is_some()
-            {
-                self.release_pool_consumer_group(admission, pool_pk, superseded_consumer);
-            }
+                .is_some();
             if self.try_admit_pool_consumer_group(admission, pool_pk, momentum_consumer) {
+                if superseded_present {
+                    self.release_pool_consumer_group(admission, pool_pk, superseded_consumer);
+                }
                 inc_market_data_momentum_admission_admitted_total();
                 let registered = self.register_geyser_reserves_for_momentum_active_pool(pool_pk);
                 self.record_momentum_active_pool_reserve_registration_outcome(
@@ -12112,13 +12114,14 @@ mod pr_b_geyser_tracking_tests {
     fn minimal_market_data_context_for_pr_d_tests(
         jsonl_writer: QueuedJsonlWriter,
     ) -> Arc<MarketDataContext> {
-        minimal_market_data_context_for_pr_d_tests_with_wallet(jsonl_writer, None, &[])
+        minimal_market_data_context_for_pr_d_tests_with_wallet(jsonl_writer, None, &[], None)
     }
 
     fn minimal_market_data_context_for_pr_d_tests_with_wallet(
         jsonl_writer: QueuedJsonlWriter,
         tracked_wallet: Option<TrackedWallet>,
         extra_wallet_token_accounts: &[Pubkey],
+        live_pool_cache: Option<Arc<LivePoolCache>>,
     ) -> Arc<MarketDataContext> {
         let (tracked_mints_tx, _tracked_mints_rx) = watch::channel(Vec::<Pubkey>::new());
         let (tracked_vaults_tx, _tracked_vaults_rx) = watch::channel(Vec::<Pubkey>::new());
@@ -12152,7 +12155,7 @@ mod pr_b_geyser_tracking_tests {
             tracked_bin_arrays_tx,
             tracked_membership: ArcSwap::from_pointee(TrackedMembershipSnapshot::default()),
             pool_tracked_legs: parking_lot::RwLock::new(HashMap::new()),
-            live_pool_cache: Arc::new(LivePoolCache::new()),
+            live_pool_cache: live_pool_cache.unwrap_or_else(|| Arc::new(LivePoolCache::new())),
             creator_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
             pool_mint_map: parking_lot::RwLock::new(std::collections::HashMap::new()),
             pool_creator_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
@@ -12722,6 +12725,119 @@ mod pr_b_geyser_tracking_tests {
             "tracker downgrade must admit Momentum consumer group"
         );
         assert!(ctx.pool_has_explicit_momentum_admission(pool));
+    }
+
+    /// Scope C: Tracker→Position upgrade must admit Position before releasing Momentum; on admit failure keep Momentum.
+    #[test]
+    fn scope_c_tracker_to_position_upgrade_keeps_momentum_on_admit_failure() {
+        use ironcrab::market_data::track::{
+            try_admit_owner_group, ExplicitConsumer, ExplicitOwner, ExplicitOwnerKey,
+        };
+        use ironcrab::nats::{MomentumActivePinReason, MomentumActivePoolEntry};
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        let momentum_owner = ExplicitOwner {
+            consumer: ExplicitConsumer::Momentum,
+            owner_key: ExplicitOwnerKey::Pool(pool),
+        };
+        let position_owner = ExplicitOwner {
+            consumer: ExplicitConsumer::MomentumPosition,
+            owner_key: ExplicitOwnerKey::Pool(pool),
+        };
+
+        let mut admission = test_admission_for(&ctx);
+        assert!(try_admit_owner_group(
+            &mut admission,
+            momentum_owner.clone(),
+            vec![coin_vault, pc_vault, base_mint, quote],
+        ));
+        ctx.hot_pool_registry.pin_pool(base_mint, pool);
+
+        // No LivePoolCache layout: Position admit must fail while Momentum stays admitted.
+        ctx.apply_momentum_active_entries(
+            &mut admission,
+            &[MomentumActivePoolEntry {
+                mint: base_mint.to_string(),
+                pool: pool.to_string(),
+                pin_reason: MomentumActivePinReason::Position,
+            }],
+        );
+        assert!(
+            admission.owner_group(&momentum_owner).is_some(),
+            "failed Position admit must not release existing Momentum consumer"
+        );
+        assert!(
+            admission.owner_group(&position_owner).is_none(),
+            "Position admit should fail when cache layout is unavailable"
+        );
+    }
+
+    /// Scope C: deferred retry must not clear deferred when pool consumer admit fails.
+    #[test]
+    fn scope_c_deferred_retry_keeps_deferred_on_admit_failure() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        let state = CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+            token_0_mint: base_mint,
+            token_1_mint: quote,
+            token_0_vault: coin_vault,
+            token_1_vault: pc_vault,
+            reserve_0: Some(1_000_000),
+            reserve_1: Some(2_000_000),
+        });
+
+        ctx.live_pool_cache.upsert(pool, state.clone(), 1);
+        ctx.hot_pool_registry
+            .pin_pool_with_reason(base_mint, pool, true);
+        {
+            let mut vaults = ctx.tracked_vaults.write();
+            let mut vaults_changed = false;
+            ctx.register_tracked_vault_pair_lru(
+                &mut vaults,
+                &mut vaults_changed,
+                TrackedVaultPairInsert {
+                    pool,
+                    now: Instant::now(),
+                    dex: "raydium_cpmm",
+                    base_mint,
+                    quote_mint: quote,
+                    base_vault: coin_vault,
+                    quote_vault: pc_vault,
+                    active_id: None,
+                    bin_step: None,
+                },
+            );
+        }
+        assert!(ctx.pool_vaults_fully_tracked_for_cache(pool, &state));
+        ctx.deferred_hot_pool_reserve_pins
+            .write()
+            .insert(pool, GeyserPinReason::MomentumActive);
+
+        let mut admission = FixedCapAdmission::new(0);
+        ctx.retry_deferred_hot_pool_reserve_registrations(&mut admission);
+        assert!(
+            ctx.deferred_hot_pool_reserve_pins
+                .read()
+                .contains_key(&pool),
+            "deferred pin must remain when admit fails despite satisfied reserves"
+        );
     }
 
     /// Scope C: releasing one momentum consumer must not clear bypass while sibling remains.
@@ -16141,6 +16257,7 @@ mod pr_b_geyser_tracking_tests {
             jsonl,
             Some(tracked),
             &[extra_ata],
+            None,
         );
         ctx.config.write().max_tracked_accounts = 2;
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -757,6 +757,8 @@ impl UnifiedHotPoolRegistry {
         self.momentum_pairs.write().insert((mint, pool));
         if is_position {
             self.momentum_position_pairs.write().insert((mint, pool));
+        } else {
+            self.momentum_position_pairs.write().remove(&(mint, pool));
         }
     }
 
@@ -12238,6 +12240,67 @@ mod pr_b_geyser_tracking_tests {
         assert_eq!(
             vs.get(&coin_vault).and_then(|v| v.pin),
             Some(GeyserPinReason::MomentumActive)
+        );
+    }
+
+    /// Scope C: Tracker downgrade clears position-subset membership while momentum pin remains.
+    #[test]
+    fn scope_c_tracker_downgrade_clears_position_pin_subset() {
+        use ironcrab::nats::{MomentumActivePinReason, MomentumActivePoolEntry};
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            1,
+        );
+
+        let mut admission = test_admission_for(&ctx);
+        let position_then_tracker = |pin_reason| MomentumActivePoolsUpdate {
+            version: 1,
+            ts_unix_ms: 1,
+            active: vec![MomentumActivePoolEntry {
+                mint: base_mint.to_string(),
+                pool: pool.to_string(),
+                pin_reason,
+            }],
+            removed: vec![],
+            full_active_snapshot: false,
+        };
+
+        ctx.apply_momentum_active_pools_update(
+            &mut admission,
+            &position_then_tracker(MomentumActivePinReason::Position),
+        );
+        assert!(ctx.hot_pool_registry.is_position_pin(base_mint, pool));
+
+        ctx.apply_momentum_active_pools_update(
+            &mut admission,
+            &position_then_tracker(MomentumActivePinReason::Tracker),
+        );
+        assert!(
+            ctx.hot_pool_registry.is_hot_pool(pool),
+            "momentum pair pin must remain for tracker"
+        );
+        assert!(
+            !ctx.hot_pool_registry.is_position_pin(base_mint, pool),
+            "position subset must clear on tracker downgrade"
         );
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1860,6 +1860,26 @@ fn consumer_id_for_geyser_pin(pin: Option<GeyserPinReason>) -> ConsumerId {
     }
 }
 
+fn consumer_id_for_pool_explicit_row(
+    ctx: &MarketDataContext,
+    pool: Pubkey,
+    pin: Option<GeyserPinReason>,
+) -> ConsumerId {
+    if ctx.hot_pool_registry.is_position_pin_for_pool(pool) {
+        ConsumerId::MomentumPosition
+    } else {
+        consumer_id_for_geyser_pin(pin)
+    }
+}
+
+fn momentum_explicit_consumer_for_pool(ctx: &MarketDataContext, pool: Pubkey) -> ExplicitConsumer {
+    if ctx.hot_pool_registry.is_position_pin_for_pool(pool) {
+        ExplicitConsumer::MomentumPosition
+    } else {
+        ExplicitConsumer::Momentum
+    }
+}
+
 fn snapshot_consumer_to_geyser_pin(consumer: SnapshotConsumer) -> Option<GeyserPinReason> {
     match consumer {
         SnapshotConsumer::Wallet => Some(GeyserPinReason::Wallet),
@@ -2555,11 +2575,23 @@ impl MarketDataContext {
         let owner = Self::pool_consumer_owner(pool, consumer);
         let admitted = admission.owner_group(&owner).is_some();
         match consumer {
-            ExplicitConsumer::Momentum => {
+            ExplicitConsumer::Momentum | ExplicitConsumer::MomentumPosition => {
                 if admitted {
                     self.note_explicit_momentum_pool_admitted(pool);
                 } else {
-                    self.clear_explicit_momentum_pool_admitted(pool);
+                    let other = if consumer == ExplicitConsumer::Momentum {
+                        ExplicitConsumer::MomentumPosition
+                    } else {
+                        ExplicitConsumer::Momentum
+                    };
+                    let other_admitted = admission
+                        .owner_group(&Self::pool_consumer_owner(pool, other))
+                        .is_some();
+                    if other_admitted {
+                        self.note_explicit_momentum_pool_admitted(pool);
+                    } else {
+                        self.clear_explicit_momentum_pool_admitted(pool);
+                    }
                 }
             }
             ExplicitConsumer::Arb => {
@@ -2754,7 +2786,9 @@ impl MarketDataContext {
     ) {
         let _ = admission.remove_group(Self::pool_consumer_owner(pool, consumer));
         match consumer {
-            ExplicitConsumer::Momentum => self.clear_explicit_momentum_pool_admitted(pool),
+            ExplicitConsumer::Momentum | ExplicitConsumer::MomentumPosition => {
+                self.clear_explicit_momentum_pool_admitted(pool)
+            }
             ExplicitConsumer::Arb => self.clear_explicit_arb_pool_admitted(pool),
             ExplicitConsumer::Wallet | ExplicitConsumer::Tracker => {}
         }
@@ -2950,10 +2984,18 @@ impl MarketDataContext {
             rows.push((*pk, consumer_id_for_geyser_pin(m.pin), None));
         }
         for (pk, v) in self.tracked_vaults.read().iter() {
-            rows.push((*pk, consumer_id_for_geyser_pin(v.pin), Some(v.pool_address)));
+            rows.push((
+                *pk,
+                consumer_id_for_pool_explicit_row(self, v.pool_address, v.pin),
+                Some(v.pool_address),
+            ));
         }
         for (pk, b) in self.tracked_bin_arrays.read().iter() {
-            rows.push((*pk, consumer_id_for_geyser_pin(b.pin), Some(b.pool_address)));
+            rows.push((
+                *pk,
+                consumer_id_for_pool_explicit_row(self, b.pool_address, b.pin),
+                Some(b.pool_address),
+            ));
         }
         if let Some(w) = &self.tracked_wallet {
             rows.push((w.wallet, ConsumerId::Wallet, None));
@@ -4257,7 +4299,7 @@ impl MarketDataContext {
             let consumer = match pin {
                 GeyserPinReason::ArbMultiDex => ExplicitConsumer::Arb,
                 GeyserPinReason::MomentumActive | GeyserPinReason::Wallet => {
-                    ExplicitConsumer::Momentum
+                    momentum_explicit_consumer_for_pool(self, pool)
                 }
             };
             let _ = self.try_admit_pool_consumer_group(admission, pool, consumer);
@@ -4296,9 +4338,13 @@ impl MarketDataContext {
             if is_position {
                 inc_market_data_open_position_pin_deferred_cache_miss_total();
             }
-        } else {
-            self.maybe_clear_deferred_hot_pool_reserve_if_satisfied(pool);
+            return;
         }
+        if self.hot_pool_reserve_registration_satisfied(pool) {
+            self.maybe_clear_deferred_hot_pool_reserve_if_satisfied(pool);
+            return;
+        }
+        self.note_deferred_hot_pool_reserve_registration(pool, pin);
     }
 
     fn register_meteora_dlmm_bin_arrays(
@@ -4562,13 +4608,22 @@ impl MarketDataContext {
             };
             let is_position = a.pin_reason == MomentumActivePinReason::Position;
             let explicit_entry = ExplicitEntry {
-                consumers: HashSet::from([ConsumerId::Momentum]),
+                consumers: HashSet::from([if is_position {
+                    ConsumerId::MomentumPosition
+                } else {
+                    ConsumerId::Momentum
+                }]),
                 pool: Some(pool_pk),
                 pin_priority: pin_priority_for_momentum_active_pin(a.pin_reason),
             };
             self.hot_pool_registry
                 .pin_pool_with_reason(mint_pk, pool_pk, is_position);
-            if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Momentum) {
+            let momentum_consumer = if is_position {
+                ExplicitConsumer::MomentumPosition
+            } else {
+                ExplicitConsumer::Momentum
+            };
+            if self.try_admit_pool_consumer_group(admission, pool_pk, momentum_consumer) {
                 inc_market_data_momentum_admission_admitted_total();
                 let registered = self.register_geyser_reserves_for_momentum_active_pool(pool_pk);
                 self.record_momentum_active_pool_reserve_registration_outcome(
@@ -4589,40 +4644,21 @@ impl MarketDataContext {
                 }
             } else {
                 inc_market_data_momentum_admission_rejected_total();
-                let registered = if self.live_pool_cache.get(&pool_pk).is_none() {
-                    false
-                } else if is_position {
-                    self.register_geyser_reserves_for_momentum_active_pool(pool_pk)
-                } else {
-                    self.hot_pool_reserve_registration_satisfied(pool_pk)
-                };
                 self.record_momentum_active_pool_reserve_registration_outcome(
                     pool_pk,
                     GeyserPinReason::MomentumActive,
                     is_position,
-                    registered,
+                    false,
                 );
-                if is_position && registered {
-                    batch_dirty = true;
-                }
             }
-            self.sync_explicit_pool_admitted_from_admission(
-                admission,
-                pool_pk,
-                ExplicitConsumer::Momentum,
-            );
+            self.sync_explicit_pool_admitted_from_admission(admission, pool_pk, momentum_consumer);
             if explicit_entry.pin_priority <= PinPriority::MomentumPosition
                 && admission
-                    .owner_group(&Self::pool_consumer_owner(
-                        pool_pk,
-                        ExplicitConsumer::Momentum,
-                    ))
+                    .owner_group(&Self::pool_consumer_owner(pool_pk, momentum_consumer))
                     .is_some()
             {
-                let _ = admission.touch_group(Self::pool_consumer_owner(
-                    pool_pk,
-                    ExplicitConsumer::Momentum,
-                ));
+                let _ =
+                    admission.touch_group(Self::pool_consumer_owner(pool_pk, momentum_consumer));
             }
         }
         batch_dirty
@@ -4661,6 +4697,7 @@ impl MarketDataContext {
         // Pool-level reserve pins are shared: only demote vaults/bin arrays when no `(m, pool)`
         // row remains after this unpin (PR #147 follow-up).
         if !self.hot_pool_registry.pool_has_any_pin(pool) {
+            self.release_pool_consumer_group(admission, pool, ExplicitConsumer::MomentumPosition);
             self.release_pool_consumer_group(admission, pool, ExplicitConsumer::Momentum);
             {
                 let mut vaults = self.tracked_vaults.write();
@@ -12411,6 +12448,109 @@ mod pr_b_geyser_tracking_tests {
             .contains_key(&pool));
         assert_eq!(ctx.tracked_vaults.read().len(), 2);
         assert!(!ctx.retry_deferred_hot_pool_reserve_registrations(&mut admission));
+    }
+
+    /// Scope C: admission reject with cache hit still defers reserve registration for retry.
+    #[test]
+    fn scope_c_admission_reject_cache_hit_defers_reserve_registration() {
+        use ironcrab::nats::{MomentumActivePinReason, MomentumActivePoolEntry};
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            1,
+        );
+
+        let mut admission = FixedCapAdmission::new(0);
+        ctx.apply_momentum_active_entries(
+            &mut admission,
+            &[MomentumActivePoolEntry {
+                mint: base_mint.to_string(),
+                pool: pool.to_string(),
+                pin_reason: MomentumActivePinReason::Position,
+            }],
+        );
+
+        assert!(ctx.hot_pool_registry.is_hot_pool(pool));
+        assert!(ctx
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(&pool));
+        assert!(ctx.tracked_vaults.read().is_empty());
+    }
+
+    /// Scope C: position pool vault rows use MomentumPosition consumer for desired-set admission.
+    #[test]
+    fn scope_c_position_pool_explicit_rows_use_momentum_position_consumer() {
+        use ironcrab::market_data::track::ConsumerId;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: Some(1),
+                reserve_1: Some(1),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry
+            .pin_pool_with_reason(base_mint, pool, true);
+        {
+            let mut vaults = ctx.tracked_vaults.write();
+            let mut vaults_changed = false;
+            ctx.register_tracked_vault_pair_lru(
+                &mut vaults,
+                &mut vaults_changed,
+                TrackedVaultPairInsert {
+                    pool,
+                    now: Instant::now(),
+                    dex: "raydium_cpmm",
+                    base_mint,
+                    quote_mint: quote,
+                    base_vault: coin_vault,
+                    quote_vault: pc_vault,
+                    active_id: None,
+                    bin_step: None,
+                },
+            );
+        }
+
+        let rows = ctx.explicit_pubkey_rows_for_desired_set();
+        assert!(rows.iter().any(|(pk, consumer, pool_opt)| {
+            *pk == coin_vault
+                && *consumer == ConsumerId::MomentumPosition
+                && *pool_opt == Some(pool)
+        }));
     }
 
     /// PR169a regression: account-path vault register requires explicit admission (no cap hole).

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -82,12 +82,13 @@ use ironcrab::market_data::sidefx::{
 use ironcrab::market_data::track::{
     arb_coalesce_try_send, explicit_admitted_pool_sets_from_admission, explicit_set_snapshot_path,
     explicit_subscription_has_new_keys, flush_explicit_set_snapshot, load_explicit_set_snapshot,
-    momentum_coalesce_try_send, owner_group_snapshot_to_disk, pool_is_enrichment_member,
-    restore_admission_from_owner_groups, spawn_track_worker, track_worker_try_enqueue,
-    try_admit_owner_group, AdmissionConvergeResult, AdmissionRestoreResult, CapShrinkResult,
-    ConsumerId, ExplicitAccountKind, ExplicitConsumer, ExplicitOwner, ExplicitOwnerKey,
-    ExplicitSetSnapshot, ExplicitSnapshotRow, FixedCapAdmission, GeyserConnectBarrier,
-    SnapshotConsumer, TrackPinReason, TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
+    momentum_coalesce_try_send, owner_group_snapshot_to_disk, pin_priority_for_momentum_active_pin,
+    pool_is_enrichment_member, restore_admission_from_owner_groups, spawn_track_worker,
+    track_worker_try_enqueue, try_admit_owner_group, AdmissionConvergeResult,
+    AdmissionRestoreResult, CapShrinkResult, ConsumerId, ExplicitAccountKind, ExplicitConsumer,
+    ExplicitEntry, ExplicitOwner, ExplicitOwnerKey, ExplicitSetSnapshot, ExplicitSnapshotRow,
+    FixedCapAdmission, GeyserConnectBarrier, PinPriority, SnapshotConsumer, TrackPinReason,
+    TrackWorkerCommand, TrackWorkerContext, TrackWorkerSender,
     EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP,
 };
 use ironcrab::metrics::{
@@ -4560,6 +4561,11 @@ impl MarketDataContext {
                 continue;
             };
             let is_position = a.pin_reason == MomentumActivePinReason::Position;
+            let explicit_entry = ExplicitEntry {
+                consumers: HashSet::from([ConsumerId::Momentum]),
+                pool: Some(pool_pk),
+                pin_priority: pin_priority_for_momentum_active_pin(a.pin_reason),
+            };
             self.hot_pool_registry
                 .pin_pool_with_reason(mint_pk, pool_pk, is_position);
             if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Momentum) {
@@ -4583,13 +4589,21 @@ impl MarketDataContext {
                 }
             } else {
                 inc_market_data_momentum_admission_rejected_total();
-                if self.live_pool_cache.get(&pool_pk).is_none() {
-                    self.record_momentum_active_pool_reserve_registration_outcome(
-                        pool_pk,
-                        GeyserPinReason::MomentumActive,
-                        is_position,
-                        false,
-                    );
+                let registered = if self.live_pool_cache.get(&pool_pk).is_none() {
+                    false
+                } else if is_position {
+                    self.register_geyser_reserves_for_momentum_active_pool(pool_pk)
+                } else {
+                    self.hot_pool_reserve_registration_satisfied(pool_pk)
+                };
+                self.record_momentum_active_pool_reserve_registration_outcome(
+                    pool_pk,
+                    GeyserPinReason::MomentumActive,
+                    is_position,
+                    registered,
+                );
+                if is_position && registered {
+                    batch_dirty = true;
                 }
             }
             self.sync_explicit_pool_admitted_from_admission(
@@ -4597,6 +4611,19 @@ impl MarketDataContext {
                 pool_pk,
                 ExplicitConsumer::Momentum,
             );
+            if explicit_entry.pin_priority <= PinPriority::MomentumPosition
+                && admission
+                    .owner_group(&Self::pool_consumer_owner(
+                        pool_pk,
+                        ExplicitConsumer::Momentum,
+                    ))
+                    .is_some()
+            {
+                let _ = admission.touch_group(Self::pool_consumer_owner(
+                    pool_pk,
+                    ExplicitConsumer::Momentum,
+                ));
+            }
         }
         batch_dirty
     }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1599,33 +1599,6 @@ fn expected_pool_vault_pubkeys_from_cache(
     }
 }
 
-/// True when expected vault rows for a hot pool are already registered with sibling links.
-#[cfg(test)]
-fn pool_vaults_fully_tracked_for_cache(
-    ctx: &MarketDataContext,
-    pool: Pubkey,
-    cached_state: &CachedPoolState,
-) -> bool {
-    let (enable_meteora_cpmm, enable_meteora_dlmm) = {
-        let cfg = ctx.config.read();
-        (cfg.enable_meteora_cpmm, cfg.enable_meteora_dlmm)
-    };
-    let Some((base_vault, quote_vault)) = expected_pool_vault_pubkeys_from_cache(
-        cached_state,
-        enable_meteora_cpmm,
-        enable_meteora_dlmm,
-    ) else {
-        return true;
-    };
-    let vaults = ctx.tracked_vaults.read();
-    vaults
-        .get(&base_vault)
-        .is_some_and(|v| v.pool_address == pool && v.sibling_vault == Some(quote_vault))
-        && vaults
-            .get(&quote_vault)
-            .is_some_and(|v| v.pool_address == pool && v.sibling_vault == Some(base_vault))
-}
-
 /// True when a hot-pool cache upsert still needs vault registration (missing vault rows).
 #[cfg(test)]
 fn pool_needs_tracking_refresh_after_cache_upsert(
@@ -1636,11 +1609,34 @@ fn pool_needs_tracking_refresh_after_cache_upsert(
     if !ctx.hot_pool_registry.is_hot_pool(pool) {
         return false;
     }
-    if pool_vaults_fully_tracked_for_cache(ctx, pool, cached_state) {
+    if ctx.pool_vaults_fully_tracked_for_cache(pool, cached_state) {
         ironcrab::metrics::inc_market_data_md_state_register_skipped_idempotent_total();
         return false;
     }
     true
+}
+
+/// True when expected vault rows for a pool are already registered with sibling links.
+fn pool_vaults_fully_tracked_for_cache_inner(
+    tracked_vaults: &std::collections::HashMap<Pubkey, VaultInfo>,
+    pool: Pubkey,
+    cached_state: &CachedPoolState,
+    enable_meteora_cpmm: bool,
+    enable_meteora_dlmm: bool,
+) -> bool {
+    let Some((base_vault, quote_vault)) = expected_pool_vault_pubkeys_from_cache(
+        cached_state,
+        enable_meteora_cpmm,
+        enable_meteora_dlmm,
+    ) else {
+        return true;
+    };
+    tracked_vaults
+        .get(&base_vault)
+        .is_some_and(|v| v.pool_address == pool && v.sibling_vault == Some(quote_vault))
+        && tracked_vaults
+            .get(&quote_vault)
+            .is_some_and(|v| v.pool_address == pool && v.sibling_vault == Some(base_vault))
 }
 
 /// PR237: cache-first vault/bin pubkeys for trade-path LRU touch (no full-map scan).
@@ -4090,31 +4086,6 @@ impl MarketDataContext {
         vaults_changed
     }
 
-    /// True when expected vault rows for a hot pool are already registered with sibling links.
-    fn pool_vaults_fully_tracked_for_hot_pool(&self, pool: Pubkey) -> bool {
-        let Some(state) = self.live_pool_cache.get(&pool) else {
-            return false;
-        };
-        let (enable_meteora_cpmm, enable_meteora_dlmm) = {
-            let cfg = self.config.read();
-            (cfg.enable_meteora_cpmm, cfg.enable_meteora_dlmm)
-        };
-        let Some((base_vault, quote_vault)) = expected_pool_vault_pubkeys_from_cache(
-            &state,
-            enable_meteora_cpmm,
-            enable_meteora_dlmm,
-        ) else {
-            return true;
-        };
-        let vaults = self.tracked_vaults.read();
-        vaults
-            .get(&base_vault)
-            .is_some_and(|v| v.pool_address == pool && v.sibling_vault == Some(quote_vault))
-            && vaults
-                .get(&quote_vault)
-                .is_some_and(|v| v.pool_address == pool && v.sibling_vault == Some(base_vault))
-    }
-
     /// PR169a: register vault ATAs from MASTER cache after account-path pool upsert (hot pools only).
     #[cfg_attr(not(test), allow(dead_code))]
     fn register_pool_vaults_from_account(&self, pool: Pubkey) -> bool {
@@ -4122,26 +4093,27 @@ impl MarketDataContext {
         if !self.hot_pool_registry.is_hot_pool(pool) {
             return false;
         }
-        let Some(state) = self.live_pool_cache.get(&pool) else {
+        let Some(cached_state) = self.live_pool_cache.get(&pool) else {
             return false;
         };
-        let Some((base_mint, quote_mint)) = pool_mints_for_geyser_explicit_tracking(&state) else {
-            return false;
+        let (enable_meteora_cpmm, enable_meteora_dlmm) = {
+            let cfg = self.config.read();
+            (cfg.enable_meteora_cpmm, cfg.enable_meteora_dlmm)
         };
-        if !self.admit_geyser_explicit_pool_assets(pool, base_mint, quote_mint) {
-            return false;
-        }
-        let pin = if self.hot_pool_registry.pool_has_arb(pool) {
-            GeyserPinReason::ArbMultiDex
-        } else {
-            GeyserPinReason::MomentumActive
-        };
+        let now = Instant::now();
         let before_keys = self.snapshot_explicit_demand_pubkeys();
-        let changed = self.register_geyser_reserves_impl(pool, pin);
-        if changed || self.pool_vaults_fully_tracked_for_hot_pool(pool) {
+        let vaults_changed = self.register_four_dex_pool_vaults_from_cached_state(
+            pool,
+            &cached_state,
+            now,
+            enable_meteora_cpmm,
+            enable_meteora_dlmm,
+            true,
+        );
+        if vaults_changed || self.hot_pool_reserve_registration_satisfied(pool) {
             self.clear_deferred_hot_pool_reserve_registration(pool);
         }
-        changed
+        vaults_changed
             || explicit_subscription_has_new_keys(
                 &before_keys,
                 &self.snapshot_explicit_demand_pubkeys(),
@@ -4171,6 +4143,61 @@ impl MarketDataContext {
         self.register_geyser_reserves_for_active_pool(pool, GeyserPinReason::ArbMultiDex)
     }
 
+    fn pool_vaults_fully_tracked_for_cache(
+        &self,
+        pool: Pubkey,
+        cached_state: &CachedPoolState,
+    ) -> bool {
+        let (enable_meteora_cpmm, enable_meteora_dlmm) = {
+            let cfg = self.config.read();
+            (cfg.enable_meteora_cpmm, cfg.enable_meteora_dlmm)
+        };
+        pool_vaults_fully_tracked_for_cache_inner(
+            &self.tracked_vaults.read(),
+            pool,
+            cached_state,
+            enable_meteora_cpmm,
+            enable_meteora_dlmm,
+        )
+    }
+
+    fn pool_geyser_bins_fully_tracked_for_cache(
+        &self,
+        pool: Pubkey,
+        cached_state: &CachedPoolState,
+    ) -> bool {
+        if !self.config.read().enable_meteora_dlmm {
+            return true;
+        }
+        let CachedPoolState::Meteora(s) = cached_state else {
+            return true;
+        };
+        let active_array_index = MeteoraDlmmSwapBuilder::bin_id_to_bin_array_index(s.active_id);
+        let bins = self.tracked_bin_arrays.read();
+        for offset in -3i64..=3i64 {
+            let index = active_array_index + offset;
+            let Ok(pda) = MeteoraDlmmSwapBuilder::derive_bin_array_pda(&pool, index) else {
+                continue;
+            };
+            if !bins.contains_key(&pda) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// True when cache has layout and expected vault/bin rows are already tracked (registration no-op).
+    fn hot_pool_reserve_registration_satisfied(&self, pool: Pubkey) -> bool {
+        if !self.hot_pool_registry.is_hot_pool(pool) {
+            return true;
+        }
+        let Some(state) = self.live_pool_cache.get(&pool) else {
+            return false;
+        };
+        self.pool_vaults_fully_tracked_for_cache(pool, &state)
+            && self.pool_geyser_bins_fully_tracked_for_cache(pool, &state)
+    }
+
     fn note_deferred_hot_pool_reserve_registration(&self, pool: Pubkey, pin: GeyserPinReason) {
         if !self.hot_pool_registry.is_hot_pool(pool) {
             return;
@@ -4182,6 +4209,25 @@ impl MarketDataContext {
 
     fn clear_deferred_hot_pool_reserve_registration(&self, pool: Pubkey) {
         self.deferred_hot_pool_reserve_pins.write().remove(&pool);
+    }
+
+    /// Drop deferred retry when cache layout exists and vault/bin rows need no further work.
+    fn maybe_clear_deferred_hot_pool_reserve_if_satisfied(&self, pool: Pubkey) -> bool {
+        if !self
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(&pool)
+        {
+            return false;
+        }
+        if !self.hot_pool_reserve_registration_satisfied(pool) {
+            return false;
+        }
+        self.clear_deferred_hot_pool_reserve_registration(pool);
+        if self.hot_pool_registry.is_position_pin_for_pool(pool) {
+            inc_market_data_open_position_pin_applied_total();
+        }
+        true
     }
 
     /// Bounded retry when LivePoolCache gains layout for a pinned hot pool (no RPC).
@@ -4215,7 +4261,7 @@ impl MarketDataContext {
             };
             let _ = self.try_admit_pool_consumer_group(admission, pool, consumer);
             let changed = self.register_geyser_reserves_for_active_pool(pool, pin);
-            let reserves_satisfied = changed || self.pool_vaults_fully_tracked_for_hot_pool(pool);
+            let reserves_satisfied = changed || self.hot_pool_reserve_registration_satisfied(pool);
             if reserves_satisfied {
                 self.clear_deferred_hot_pool_reserve_registration(pool);
                 if self.hot_pool_registry.is_position_pin_for_pool(pool) {
@@ -4249,11 +4295,8 @@ impl MarketDataContext {
             if is_position {
                 inc_market_data_open_position_pin_deferred_cache_miss_total();
             }
-        } else if self.pool_vaults_fully_tracked_for_hot_pool(pool) {
-            self.clear_deferred_hot_pool_reserve_registration(pool);
-            if is_position {
-                inc_market_data_open_position_pin_applied_total();
-            }
+        } else {
+            self.maybe_clear_deferred_hot_pool_reserve_if_satisfied(pool);
         }
     }
 
@@ -12281,6 +12324,104 @@ mod pr_b_geyser_tracking_tests {
             vs.get(&coin_vault).and_then(|v| v.pin),
             Some(GeyserPinReason::MomentumActive)
         );
+    }
+
+    /// Scope C: deferred pin cleared when vaults already tracked (registration no-op).
+    #[test]
+    fn scope_c_deferred_pin_cleared_when_vaults_already_tracked() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        let state = CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+            token_0_mint: base_mint,
+            token_1_mint: quote,
+            token_0_vault: coin_vault,
+            token_1_vault: pc_vault,
+            reserve_0: Some(1_000_000),
+            reserve_1: Some(2_000_000),
+        });
+
+        ctx.live_pool_cache.upsert(pool, state.clone(), 1);
+        ctx.hot_pool_registry
+            .pin_pool_with_reason(base_mint, pool, true);
+        {
+            let mut vaults = ctx.tracked_vaults.write();
+            let mut vaults_changed = false;
+            ctx.register_tracked_vault_pair_lru(
+                &mut vaults,
+                &mut vaults_changed,
+                TrackedVaultPairInsert {
+                    pool,
+                    now: Instant::now(),
+                    dex: "raydium_cpmm",
+                    base_mint,
+                    quote_mint: quote,
+                    base_vault: coin_vault,
+                    quote_vault: pc_vault,
+                    active_id: None,
+                    bin_step: None,
+                },
+            );
+        }
+        assert!(ctx.pool_vaults_fully_tracked_for_cache(pool, &state));
+
+        ctx.deferred_hot_pool_reserve_pins
+            .write()
+            .insert(pool, GeyserPinReason::MomentumActive);
+
+        let mut admission = test_admission_for(&ctx);
+        ctx.retry_deferred_hot_pool_reserve_registrations(&mut admission);
+        assert!(!ctx
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(&pool));
+        assert_eq!(ctx.tracked_vaults.read().len(), 2);
+        assert!(!ctx.retry_deferred_hot_pool_reserve_registrations(&mut admission));
+    }
+
+    /// PR169a regression: account-path vault register requires explicit admission (no cap hole).
+    #[test]
+    fn register_pool_vaults_from_account_requires_explicit_admission() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool(base_mint, pool);
+        assert!(!ctx.pool_has_explicit_momentum_admission(pool));
+
+        assert!(!ctx.register_pool_vaults_from_account(pool));
+        assert!(ctx.tracked_vaults.read().is_empty());
+
+        ctx.note_explicit_momentum_pool_admitted(pool);
+        assert!(ctx.register_pool_vaults_from_account(pool));
+        let vs = ctx.tracked_vaults.read();
+        assert!(vs.contains_key(&coin_vault));
+        assert!(vs.contains_key(&pc_vault));
     }
 
     /// Scope C: Tracker downgrade clears position-subset membership while momentum pin remains.

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -4344,6 +4344,11 @@ impl MomentumContext {
                         balance_raw,
                         "Orphaned mint reconciled into position (pool discovered via trade)"
                     );
+                    self.queue_momentum_active_pool_active(
+                        mint,
+                        &reconciled.pool,
+                        MomentumActivePinReason::Position,
+                    );
                 }
             }
         }
@@ -12375,6 +12380,26 @@ mod tests {
 
     fn empty_test_context(jsonl_writer: QueuedJsonlWriter) -> Arc<MomentumContext> {
         empty_test_context_with_config(jsonl_writer, MomentumConfig::default())
+    }
+
+    /// FIX-37: orphan reconcile via trade auto-register must queue Position active-pool pin.
+    #[test]
+    fn fix37_orphan_trade_reconcile_queues_position_active_pool_pin() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+
+        ctx.orphaned_mints
+            .write()
+            .insert("mint".to_string(), (1_000_000, 6));
+        ctx.update_pool_trade_data("mint", "pool", "raydium", 1_000_000_000, 1_000_000, 1);
+
+        assert!(ctx.positions.read().contains_key("mint"));
+        let q = ctx.momentum_active_pool_publish_queue.lock();
+        assert_eq!(q.active.len(), 1);
+        assert_eq!(q.active[0].mint, "mint");
+        assert_eq!(q.active[0].pool, "pool");
+        assert_eq!(q.active[0].pin_reason, MomentumActivePinReason::Position);
     }
 
     #[tokio::test]

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -4268,6 +4268,11 @@ impl MomentumContext {
                     hold_secs,
                     "🧭 Orphaned mint reconciled into position (pool now known)"
                 );
+                self.queue_momentum_active_pool_active(
+                    mint,
+                    &reconciled.pool,
+                    MomentumActivePinReason::Position,
+                );
             }
         }
     }
@@ -21131,6 +21136,12 @@ async fn process_market_event(
                         "🧭 Wallet snapshot reconciled into position (timed exit will apply)"
                     );
                     ctx.save_position_to_kv(mint, &reconciled).await;
+                    ctx.queue_momentum_active_pool_active(
+                        mint,
+                        &reconciled.pool,
+                        MomentumActivePinReason::Position,
+                    );
+                    ctx.flush_momentum_active_pool_publish_queue();
                     return Ok(true);
                 } else {
                     // Wallet has tokens but no pool known yet. Store as orphaned so

--- a/src/market_data/track/admission_wiring.rs
+++ b/src/market_data/track/admission_wiring.rs
@@ -30,6 +30,7 @@ pub enum AdmissionRestoreResult {
 pub fn consumer_id_to_explicit(consumer: ConsumerId) -> ExplicitConsumer {
     match consumer {
         ConsumerId::Wallet => ExplicitConsumer::Wallet,
+        ConsumerId::MomentumPosition => ExplicitConsumer::MomentumPosition,
         ConsumerId::Momentum => ExplicitConsumer::Momentum,
         ConsumerId::Arb => ExplicitConsumer::Arb,
         ConsumerId::Tracker => ExplicitConsumer::Tracker,
@@ -119,7 +120,7 @@ pub fn explicit_admitted_pool_sets_from_admission(
             continue;
         };
         match group.consumer {
-            ExplicitConsumer::Momentum => {
+            ExplicitConsumer::Momentum | ExplicitConsumer::MomentumPosition => {
                 momentum.insert(pool);
             }
             ExplicitConsumer::Arb => {

--- a/src/market_data/track/coalesce.rs
+++ b/src/market_data/track/coalesce.rs
@@ -13,8 +13,8 @@ use crate::metrics::{
     inc_market_data_momentum_track_worker_enqueue_dropped_total,
 };
 use crate::nats::{
-    ArbTrackActiveEntry, ArbTrackRemovedEntry, ArbTrackRequestsUpdate, MomentumActivePoolEntry,
-    MomentumActivePoolsUpdate, MomentumRemovedPoolEntry,
+    ArbTrackActiveEntry, ArbTrackRemovedEntry, ArbTrackRequestsUpdate, MomentumActivePinReason,
+    MomentumActivePoolEntry, MomentumActivePoolsUpdate, MomentumRemovedPoolEntry,
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -28,6 +28,20 @@ pub const MARKET_DATA_MOMENTUM_COALESCE_CHANNEL_CAP: usize = 512;
 pub const MARKET_DATA_ARB_COALESCE_CHANNEL_CAP: usize = 512;
 
 type MomentumPoolKey = (String, String);
+
+/// When coalescing bursts, Position pins must not be downgraded to Tracker for the same `(mint, pool)`.
+fn merge_momentum_active_pin_reason(
+    existing: MomentumActivePinReason,
+    incoming: MomentumActivePinReason,
+) -> MomentumActivePinReason {
+    if existing == MomentumActivePinReason::Position
+        || incoming == MomentumActivePinReason::Position
+    {
+        MomentumActivePinReason::Position
+    } else {
+        MomentumActivePinReason::Tracker
+    }
+}
 
 /// PR169c: merge a burst of momentum updates into one payload equivalent to sequential applies.
 pub fn merge_momentum_active_pools_updates(
@@ -67,7 +81,21 @@ pub fn merge_momentum_active_pools_updates(
             for a in &update.active {
                 let key = (a.mint.clone(), a.pool.clone());
                 removed_map.remove(&key);
-                active_map.insert(key, a.clone());
+                match active_map.get(&key) {
+                    Some(existing) => {
+                        let merged = MomentumActivePoolEntry {
+                            pin_reason: merge_momentum_active_pin_reason(
+                                existing.pin_reason,
+                                a.pin_reason,
+                            ),
+                            ..a.clone()
+                        };
+                        active_map.insert(key, merged);
+                    }
+                    None => {
+                        active_map.insert(key, a.clone());
+                    }
+                }
             }
         } else {
             for r in &update.removed {
@@ -78,7 +106,21 @@ pub fn merge_momentum_active_pools_updates(
             for a in &update.active {
                 let key = (a.mint.clone(), a.pool.clone());
                 removed_map.remove(&key);
-                active_map.insert(key, a.clone());
+                match active_map.get(&key) {
+                    Some(existing) => {
+                        let merged = MomentumActivePoolEntry {
+                            pin_reason: merge_momentum_active_pin_reason(
+                                existing.pin_reason,
+                                a.pin_reason,
+                            ),
+                            ..a.clone()
+                        };
+                        active_map.insert(key, merged);
+                    }
+                    None => {
+                        active_map.insert(key, a.clone());
+                    }
+                }
             }
         }
     }
@@ -241,4 +283,43 @@ pub fn spawn_arb_tracking_coalescer<C: TrackWorkerContext + 'static>(
         }
     });
     coalesce_tx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_momentum_active_pools_prefers_position_over_tracker() {
+        let merged = merge_momentum_active_pools_updates(&[
+            MomentumActivePoolsUpdate {
+                version: 1,
+                ts_unix_ms: 1,
+                active: vec![MomentumActivePoolEntry {
+                    mint: "m".into(),
+                    pool: "p".into(),
+                    pin_reason: MomentumActivePinReason::Tracker,
+                }],
+                removed: vec![],
+                full_active_snapshot: false,
+            },
+            MomentumActivePoolsUpdate {
+                version: 1,
+                ts_unix_ms: 2,
+                active: vec![MomentumActivePoolEntry {
+                    mint: "m".into(),
+                    pool: "p".into(),
+                    pin_reason: MomentumActivePinReason::Position,
+                }],
+                removed: vec![],
+                full_active_snapshot: false,
+            },
+        ])
+        .expect("merged");
+        assert_eq!(merged.active.len(), 1);
+        assert_eq!(
+            merged.active[0].pin_reason,
+            MomentumActivePinReason::Position
+        );
+    }
 }

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -10,6 +10,8 @@ use std::collections::HashSet;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ConsumerId {
     Wallet,
+    /// Open-position pool pin (Scope C): eviction protection above [`Self::Momentum`].
+    MomentumPosition,
     Momentum,
     Arb,
     /// Unpinned mint / recent-trade LRU demand (I-MD-5: lowest protection).
@@ -37,6 +39,7 @@ pub struct ExplicitEntry {
 pub fn pin_priority_from_consumer(consumer: ConsumerId) -> PinPriority {
     match consumer {
         ConsumerId::Wallet => PinPriority::Wallet,
+        ConsumerId::MomentumPosition => PinPriority::MomentumPosition,
         ConsumerId::Momentum => PinPriority::Momentum,
         ConsumerId::Arb => PinPriority::Arb,
         ConsumerId::Tracker => PinPriority::Tracker,
@@ -61,6 +64,20 @@ pub fn symmetric_diff(a: &HashSet<Pubkey>, b: &HashSet<Pubkey>) -> HashSet<Pubke
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pin_priority_for_momentum_active_pin_orders_position_above_tracker() {
+        use crate::nats::MomentumActivePinReason;
+
+        assert!(
+            pin_priority_for_momentum_active_pin(MomentumActivePinReason::Position)
+                < pin_priority_for_momentum_active_pin(MomentumActivePinReason::Tracker)
+        );
+        assert_eq!(
+            pin_priority_for_momentum_active_pin(MomentumActivePinReason::Position),
+            PinPriority::MomentumPosition
+        );
+    }
 
     #[test]
     fn symmetric_diff_detects_add_and_remove() {

--- a/src/market_data/track/desired_set.rs
+++ b/src/market_data/track/desired_set.rs
@@ -20,9 +20,11 @@ pub enum ConsumerId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PinPriority {
     Wallet = 0,
-    Momentum = 1,
-    Arb = 2,
-    Tracker = 3,
+    /// Open-position pool pin (Scope C): protected at least at momentum-active tier.
+    MomentumPosition = 1,
+    Momentum = 2,
+    Arb = 3,
+    Tracker = 4,
 }
 
 #[derive(Debug, Clone)]
@@ -38,6 +40,16 @@ pub fn pin_priority_from_consumer(consumer: ConsumerId) -> PinPriority {
         ConsumerId::Momentum => PinPriority::Momentum,
         ConsumerId::Arb => PinPriority::Arb,
         ConsumerId::Tracker => PinPriority::Tracker,
+    }
+}
+
+/// Scope C: position pins must not lose eviction protection to tracker noise.
+pub fn pin_priority_for_momentum_active_pin(
+    pin_reason: crate::nats::MomentumActivePinReason,
+) -> PinPriority {
+    match pin_reason {
+        crate::nats::MomentumActivePinReason::Position => PinPriority::MomentumPosition,
+        crate::nats::MomentumActivePinReason::Tracker => PinPriority::Momentum,
     }
 }
 

--- a/src/market_data/track/eviction_planner.rs
+++ b/src/market_data/track/eviction_planner.rs
@@ -90,17 +90,19 @@ impl ConsumerProtectionRank {
     pub fn of(consumer: ExplicitConsumer) -> Self {
         Self(match consumer {
             ExplicitConsumer::Wallet => 0,
-            ExplicitConsumer::Momentum => 1,
-            ExplicitConsumer::Arb => 2,
-            ExplicitConsumer::Tracker => 3,
+            ExplicitConsumer::MomentumPosition => 1,
+            ExplicitConsumer::Momentum => 2,
+            ExplicitConsumer::Arb => 3,
+            ExplicitConsumer::Tracker => 4,
         })
     }
 
     pub fn consumer(self) -> ExplicitConsumer {
         match self.0 {
             0 => ExplicitConsumer::Wallet,
-            1 => ExplicitConsumer::Momentum,
-            2 => ExplicitConsumer::Arb,
+            1 => ExplicitConsumer::MomentumPosition,
+            2 => ExplicitConsumer::Momentum,
+            3 => ExplicitConsumer::Arb,
             _ => ExplicitConsumer::Tracker,
         }
     }
@@ -115,6 +117,7 @@ pub enum EvictionTier {
     Tracker,
     Arb,
     Momentum,
+    MomentumPosition,
 }
 
 impl EvictionTier {
@@ -127,6 +130,12 @@ impl EvictionTier {
                 ExplicitConsumer::Arb,
                 ExplicitConsumer::Momentum,
             ],
+            Self::MomentumPosition => &[
+                ExplicitConsumer::Tracker,
+                ExplicitConsumer::Arb,
+                ExplicitConsumer::Momentum,
+                ExplicitConsumer::MomentumPosition,
+            ],
         }
     }
 
@@ -134,9 +143,13 @@ impl EvictionTier {
         match consumer {
             ExplicitConsumer::Tracker => &[Self::Tracker],
             ExplicitConsumer::Arb => &[Self::Tracker, Self::Arb],
-            ExplicitConsumer::Momentum | ExplicitConsumer::Wallet => {
-                &[Self::Tracker, Self::Arb, Self::Momentum]
-            }
+            ExplicitConsumer::Momentum => &[Self::Tracker, Self::Arb, Self::Momentum],
+            ExplicitConsumer::MomentumPosition | ExplicitConsumer::Wallet => &[
+                Self::Tracker,
+                Self::Arb,
+                Self::Momentum,
+                Self::MomentumPosition,
+            ],
         }
     }
 }
@@ -626,6 +639,7 @@ fn consumer_eviction_priority(consumer: ExplicitConsumer) -> u8 {
         ExplicitConsumer::Tracker => 0,
         ExplicitConsumer::Arb => 1,
         ExplicitConsumer::Momentum => 2,
+        ExplicitConsumer::MomentumPosition => 3,
         ExplicitConsumer::Wallet => u8::MAX,
     }
 }
@@ -747,6 +761,7 @@ const CAP_SHRINK_ALLOWED_TIERS: &[EvictionTier] = &[
     EvictionTier::Tracker,
     EvictionTier::Arb,
     EvictionTier::Momentum,
+    EvictionTier::MomentumPosition,
 ];
 
 fn analyze_cap_shrink_feasibility(
@@ -1551,6 +1566,7 @@ mod tests {
         Tracker,
         Arb,
         Momentum,
+        MomentumPosition,
     }
 
     impl OracleTier {
@@ -1559,6 +1575,7 @@ mod tests {
                 Self::Tracker => EvictionTier::Tracker,
                 Self::Arb => EvictionTier::Arb,
                 Self::Momentum => EvictionTier::Momentum,
+                Self::MomentumPosition => EvictionTier::MomentumPosition,
             }
         }
     }
@@ -1567,9 +1584,15 @@ mod tests {
         match incoming {
             ExplicitConsumer::Tracker => &[OracleTier::Tracker],
             ExplicitConsumer::Arb => &[OracleTier::Tracker, OracleTier::Arb],
-            ExplicitConsumer::Momentum | ExplicitConsumer::Wallet => {
+            ExplicitConsumer::Momentum => {
                 &[OracleTier::Tracker, OracleTier::Arb, OracleTier::Momentum]
             }
+            ExplicitConsumer::MomentumPosition | ExplicitConsumer::Wallet => &[
+                OracleTier::Tracker,
+                OracleTier::Arb,
+                OracleTier::Momentum,
+                OracleTier::MomentumPosition,
+            ],
         }
     }
 
@@ -1577,8 +1600,16 @@ mod tests {
         match owner.consumer {
             ExplicitConsumer::Wallet => false,
             ExplicitConsumer::Tracker => true,
-            ExplicitConsumer::Arb => matches!(tier, OracleTier::Arb | OracleTier::Momentum),
-            ExplicitConsumer::Momentum => tier == OracleTier::Momentum,
+            ExplicitConsumer::Arb => {
+                matches!(
+                    tier,
+                    OracleTier::Arb | OracleTier::Momentum | OracleTier::MomentumPosition
+                )
+            }
+            ExplicitConsumer::Momentum => {
+                matches!(tier, OracleTier::Momentum | OracleTier::MomentumPosition)
+            }
+            ExplicitConsumer::MomentumPosition => tier == OracleTier::MomentumPosition,
         }
     }
 
@@ -1598,7 +1629,12 @@ mod tests {
 
             let mut evictable_owners_by_tier: BTreeMap<OracleTier, BTreeSet<ExplicitOwner>> =
                 BTreeMap::new();
-            for tier in [OracleTier::Tracker, OracleTier::Arb, OracleTier::Momentum] {
+            for tier in [
+                OracleTier::Tracker,
+                OracleTier::Arb,
+                OracleTier::Momentum,
+                OracleTier::MomentumPosition,
+            ] {
                 for owner in &all_owners {
                     if oracle_owner_in_cumulative_tier(owner, tier) {
                         evictable_owners_by_tier
@@ -2655,6 +2691,7 @@ mod tests {
         Tracker,
         Arb,
         Momentum,
+        MomentumPosition,
     }
 
     impl PolicyTier {
@@ -2663,6 +2700,7 @@ mod tests {
                 Self::Tracker => EvictionTier::Tracker,
                 Self::Arb => EvictionTier::Arb,
                 Self::Momentum => EvictionTier::Momentum,
+                Self::MomentumPosition => EvictionTier::MomentumPosition,
             }
         }
 
@@ -2670,9 +2708,13 @@ mod tests {
             match consumer {
                 ExplicitConsumer::Tracker => &[Self::Tracker],
                 ExplicitConsumer::Arb => &[Self::Tracker, Self::Arb],
-                ExplicitConsumer::Momentum | ExplicitConsumer::Wallet => {
-                    &[Self::Tracker, Self::Arb, Self::Momentum]
-                }
+                ExplicitConsumer::Momentum => &[Self::Tracker, Self::Arb, Self::Momentum],
+                ExplicitConsumer::MomentumPosition | ExplicitConsumer::Wallet => &[
+                    Self::Tracker,
+                    Self::Arb,
+                    Self::Momentum,
+                    Self::MomentumPosition,
+                ],
             }
         }
 
@@ -2684,6 +2726,12 @@ mod tests {
                     ExplicitConsumer::Tracker,
                     ExplicitConsumer::Arb,
                     ExplicitConsumer::Momentum,
+                ],
+                Self::MomentumPosition => &[
+                    ExplicitConsumer::Tracker,
+                    ExplicitConsumer::Arb,
+                    ExplicitConsumer::Momentum,
+                    ExplicitConsumer::MomentumPosition,
                 ],
             }
         }
@@ -2702,6 +2750,7 @@ mod tests {
                 ExplicitConsumer::Tracker => 0,
                 ExplicitConsumer::Arb => 1,
                 ExplicitConsumer::Momentum => 2,
+                ExplicitConsumer::MomentumPosition => 3,
                 ExplicitConsumer::Wallet => u8::MAX,
             }
         }

--- a/src/market_data/track/explicit_admission.rs
+++ b/src/market_data/track/explicit_admission.rs
@@ -4738,6 +4738,7 @@ mod tests {
         Tracker,
         Arb,
         Momentum,
+        MomentumPosition,
     }
 
     impl RefOraclePolicyTier {
@@ -4746,6 +4747,7 @@ mod tests {
                 Self::Tracker => EvictionTier::Tracker,
                 Self::Arb => EvictionTier::Arb,
                 Self::Momentum => EvictionTier::Momentum,
+                Self::MomentumPosition => EvictionTier::MomentumPosition,
             }
         }
 
@@ -4753,9 +4755,13 @@ mod tests {
             match consumer {
                 ExplicitConsumer::Tracker => &[Self::Tracker],
                 ExplicitConsumer::Arb => &[Self::Tracker, Self::Arb],
-                ExplicitConsumer::Momentum | ExplicitConsumer::Wallet => {
-                    &[Self::Tracker, Self::Arb, Self::Momentum]
-                }
+                ExplicitConsumer::Momentum => &[Self::Tracker, Self::Arb, Self::Momentum],
+                ExplicitConsumer::MomentumPosition | ExplicitConsumer::Wallet => &[
+                    Self::Tracker,
+                    Self::Arb,
+                    Self::Momentum,
+                    Self::MomentumPosition,
+                ],
             }
         }
 
@@ -4767,6 +4773,12 @@ mod tests {
                     ExplicitConsumer::Tracker,
                     ExplicitConsumer::Arb,
                     ExplicitConsumer::Momentum,
+                ],
+                Self::MomentumPosition => &[
+                    ExplicitConsumer::Tracker,
+                    ExplicitConsumer::Arb,
+                    ExplicitConsumer::Momentum,
+                    ExplicitConsumer::MomentumPosition,
                 ],
             }
         }
@@ -4786,6 +4798,7 @@ mod tests {
                 ExplicitConsumer::Tracker => 0,
                 ExplicitConsumer::Arb => 1,
                 ExplicitConsumer::Momentum => 2,
+                ExplicitConsumer::MomentumPosition => 3,
                 ExplicitConsumer::Wallet => u8::MAX,
             }
         }

--- a/src/market_data/track/explicit_ownership.rs
+++ b/src/market_data/track/explicit_ownership.rs
@@ -9,6 +9,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ExplicitConsumer {
     Wallet,
+    /// Open-position pool pin (Scope C): higher eviction protection than [`Self::Momentum`].
+    MomentumPosition,
     Momentum,
     Arb,
     Tracker,

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -26,7 +26,8 @@ pub use coalesce::{
     MARKET_DATA_ARB_COALESCE_CHANNEL_CAP, MARKET_DATA_MOMENTUM_COALESCE_CHANNEL_CAP,
 };
 pub use desired_set::{
-    pin_priority_from_consumer, symmetric_diff, ConsumerId, ExplicitEntry, PinPriority,
+    pin_priority_for_momentum_active_pin, pin_priority_from_consumer, symmetric_diff, ConsumerId,
+    ExplicitEntry, PinPriority,
 };
 pub use enrichment::{
     is_enrichment_member_from_inputs, pool_is_enrichment_member, EnrichmentMembershipInputs,

--- a/src/market_data/track/snapshot.rs
+++ b/src/market_data/track/snapshot.rs
@@ -9,10 +9,12 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// On-disk snapshot format version (v2 adds complete owner groups).
-pub const EXPLICIT_SET_SNAPSHOT_VERSION: u32 = 2;
+/// On-disk snapshot format version (v3 adds `MomentumPosition` consumer + position pool list).
+pub const EXPLICIT_SET_SNAPSHOT_VERSION: u32 = 3;
 /// Legacy v1 snapshots remain readable for restore.
 pub const EXPLICIT_SET_SNAPSHOT_VERSION_V1: u32 = 1;
+/// v2 adds complete owner groups (MomentumPosition still collapsed to Momentum).
+pub const EXPLICIT_SET_SNAPSHOT_VERSION_V2: u32 = 2;
 /// Default production snapshot path (I-MD-6).
 pub const EXPLICIT_SET_SNAPSHOT_DEFAULT_PATH: &str = "/var/lib/ironcrab/explicit_set.snapshot";
 /// Periodic snapshot write interval (5 min).
@@ -23,6 +25,7 @@ pub const EXPLICIT_SET_SNAPSHOT_POOL_MINT_MAP_CAP: usize = 50_000;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SnapshotConsumer {
     Wallet,
+    MomentumPosition,
     Momentum,
     Arb,
     Tracker,
@@ -32,7 +35,8 @@ impl From<ConsumerId> for SnapshotConsumer {
     fn from(c: ConsumerId) -> Self {
         match c {
             ConsumerId::Wallet => SnapshotConsumer::Wallet,
-            ConsumerId::MomentumPosition | ConsumerId::Momentum => SnapshotConsumer::Momentum,
+            ConsumerId::MomentumPosition => SnapshotConsumer::MomentumPosition,
+            ConsumerId::Momentum => SnapshotConsumer::Momentum,
             ConsumerId::Arb => SnapshotConsumer::Arb,
             ConsumerId::Tracker => SnapshotConsumer::Tracker,
         }
@@ -43,9 +47,8 @@ impl From<ExplicitConsumer> for SnapshotConsumer {
     fn from(c: ExplicitConsumer) -> Self {
         match c {
             ExplicitConsumer::Wallet => SnapshotConsumer::Wallet,
-            ExplicitConsumer::MomentumPosition | ExplicitConsumer::Momentum => {
-                SnapshotConsumer::Momentum
-            }
+            ExplicitConsumer::MomentumPosition => SnapshotConsumer::MomentumPosition,
+            ExplicitConsumer::Momentum => SnapshotConsumer::Momentum,
             ExplicitConsumer::Arb => SnapshotConsumer::Arb,
             ExplicitConsumer::Tracker => SnapshotConsumer::Tracker,
         }
@@ -91,6 +94,8 @@ pub struct ExplicitSetSnapshot {
     pub owner_groups: Vec<SnapshotOwnerGroup>,
     pub pool_mint_map: Vec<(String, String)>,
     pub momentum_pools: Vec<String>,
+    #[serde(default)]
+    pub momentum_position_pools: Vec<String>,
     pub arb_pools: Vec<String>,
 }
 
@@ -104,12 +109,14 @@ impl ExplicitSetSnapshot {
             owner_groups: Vec::new(),
             pool_mint_map: Vec::new(),
             momentum_pools: Vec::new(),
+            momentum_position_pools: Vec::new(),
             arb_pools: Vec::new(),
         }
     }
 
     pub fn is_compatible(&self) -> bool {
         self.version == EXPLICIT_SET_SNAPSHOT_VERSION_V1
+            || self.version == EXPLICIT_SET_SNAPSHOT_VERSION_V2
             || self.version == EXPLICIT_SET_SNAPSHOT_VERSION
     }
 
@@ -179,6 +186,7 @@ pub fn snapshot_owner_key_to_domain(key: &SnapshotOwnerKey) -> Option<ExplicitOw
 fn snapshot_consumer_to_domain(c: SnapshotConsumer) -> ExplicitConsumer {
     match c {
         SnapshotConsumer::Wallet => ExplicitConsumer::Wallet,
+        SnapshotConsumer::MomentumPosition => ExplicitConsumer::MomentumPosition,
         SnapshotConsumer::Momentum => ExplicitConsumer::Momentum,
         SnapshotConsumer::Arb => ExplicitConsumer::Arb,
         SnapshotConsumer::Tracker => ExplicitConsumer::Tracker,
@@ -220,6 +228,7 @@ pub fn rows_to_owner_group_snapshots(rows: &[ExplicitSnapshotRow]) -> Vec<OwnerG
         };
         let consumer = match row.consumer {
             SnapshotConsumer::Wallet => ExplicitConsumer::Wallet,
+            SnapshotConsumer::MomentumPosition => ExplicitConsumer::MomentumPosition,
             SnapshotConsumer::Momentum => ExplicitConsumer::Momentum,
             SnapshotConsumer::Arb => ExplicitConsumer::Arb,
             SnapshotConsumer::Tracker => ExplicitConsumer::Tracker,
@@ -307,6 +316,31 @@ mod tests {
         assert_eq!(loaded, snap);
         assert!(loaded.is_compatible());
         assert_eq!(loaded.to_owner_group_snapshots().len(), 1);
+    }
+
+    #[test]
+    fn explicit_set_snapshot_v3_momentum_position_roundtrip_json() {
+        let mut snap = ExplicitSetSnapshot::new(Some("run-v3".to_string()));
+        let pool = Pubkey::new_unique();
+        snap.owner_groups.push(SnapshotOwnerGroup {
+            consumer: SnapshotConsumer::MomentumPosition,
+            owner: SnapshotOwnerKey {
+                kind: "pool".to_string(),
+                pubkey: Some(pool.to_string()),
+            },
+            pubkeys: vec![Pubkey::new_unique().to_string()],
+        });
+        snap.momentum_position_pools.push(pool.to_string());
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("explicit_set.snapshot");
+        write_explicit_set_snapshot(&path, &snap).expect("write");
+        let loaded = load_explicit_set_snapshot(&path).expect("load");
+        assert_eq!(loaded.version, EXPLICIT_SET_SNAPSHOT_VERSION);
+        assert_eq!(loaded.momentum_position_pools, snap.momentum_position_pools);
+        let groups = loaded.to_owner_group_snapshots();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].consumer, ExplicitConsumer::MomentumPosition);
     }
 
     #[test]

--- a/src/market_data/track/snapshot.rs
+++ b/src/market_data/track/snapshot.rs
@@ -32,7 +32,7 @@ impl From<ConsumerId> for SnapshotConsumer {
     fn from(c: ConsumerId) -> Self {
         match c {
             ConsumerId::Wallet => SnapshotConsumer::Wallet,
-            ConsumerId::Momentum => SnapshotConsumer::Momentum,
+            ConsumerId::MomentumPosition | ConsumerId::Momentum => SnapshotConsumer::Momentum,
             ConsumerId::Arb => SnapshotConsumer::Arb,
             ConsumerId::Tracker => SnapshotConsumer::Tracker,
         }
@@ -43,7 +43,9 @@ impl From<ExplicitConsumer> for SnapshotConsumer {
     fn from(c: ExplicitConsumer) -> Self {
         match c {
             ExplicitConsumer::Wallet => SnapshotConsumer::Wallet,
-            ExplicitConsumer::Momentum => SnapshotConsumer::Momentum,
+            ExplicitConsumer::MomentumPosition | ExplicitConsumer::Momentum => {
+                SnapshotConsumer::Momentum
+            }
             ExplicitConsumer::Arb => SnapshotConsumer::Arb,
             ExplicitConsumer::Tracker => SnapshotConsumer::Tracker,
         }

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -139,6 +139,11 @@ pub trait TrackWorkerContext: Send + Sync {
         admission: &mut FixedCapAdmission,
         new_cap: usize,
     ) -> CapShrinkResult;
+    /// Scope C: retry vault/bin registration for hot pools deferred on LivePoolCache miss.
+    fn retry_deferred_hot_pool_reserve_registrations(
+        &self,
+        admission: &mut FixedCapAdmission,
+    ) -> bool;
 }
 
 #[derive(Clone)]
@@ -296,6 +301,9 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
             try_write_explicit_set_snapshot_from_ctx(ctx.as_ref(), admission);
             let _ = done.send(());
             false
+        }
+        TrackWorkerCommand::RetryDeferredHotPoolReserves => {
+            ctx.retry_deferred_hot_pool_reserve_registrations(admission)
         }
     }
 }
@@ -531,6 +539,7 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
             pending_release_flush_slot = false;
             restore_barrier_pending = false;
             coalesce_deadline = None;
+            let _ = ctx.retry_deferred_hot_pool_reserve_registrations(&mut admission);
             let push_ok = track_worker_execute_coalesced_push(
                 &ctx,
                 &mut admission,
@@ -974,6 +983,13 @@ mod tests {
                 new_cap: 25_000,
             }
         }
+
+        fn retry_deferred_hot_pool_reserve_registrations(
+            &self,
+            _admission: &mut FixedCapAdmission,
+        ) -> bool {
+            false
+        }
     }
 
     #[test]
@@ -1269,6 +1285,13 @@ mod tests {
                     new_cap: 25_000,
                 }
             }
+
+            fn retry_deferred_hot_pool_reserve_registrations(
+                &self,
+                _admission: &mut FixedCapAdmission,
+            ) -> bool {
+                false
+            }
         }
 
         let ctx = Arc::new(TrackerIdempotentCtx);
@@ -1508,6 +1531,13 @@ mod tests {
                 old_cap: 25_000,
                 new_cap: 25_000,
             }
+        }
+
+        fn retry_deferred_hot_pool_reserve_registrations(
+            &self,
+            _admission: &mut FixedCapAdmission,
+        ) -> bool {
+            false
         }
     }
 

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -1592,6 +1592,208 @@ mod tests {
     }
 
     #[test]
+    fn chunked_momentum_apply_retries_deferred_hot_pool_reserves() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct ChunkedRetryCtx {
+            retry_calls: AtomicUsize,
+            last_synced: parking_lot::RwLock<HashSet<Pubkey>>,
+        }
+
+        impl TrackWorkerContext for ChunkedRetryCtx {
+            fn geyser_sync_batch_debounce_ms(&self) -> u64 {
+                0
+            }
+            fn max_tracked_accounts(&self) -> usize {
+                25_000
+            }
+            fn apply_momentum_active_pools_update(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _update: &MomentumActivePoolsUpdate,
+            ) -> bool {
+                false
+            }
+            fn apply_momentum_snapshot_reconcile(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _active: &[MomentumActivePoolEntry],
+            ) -> bool {
+                false
+            }
+            fn apply_momentum_removed_entries(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _removed: &[MomentumRemovedPoolEntry],
+            ) -> bool {
+                false
+            }
+            fn apply_momentum_active_entries(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _active: &[MomentumActivePoolEntry],
+            ) -> bool {
+                false
+            }
+            fn apply_arb_track_requests_update(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _update: &ArbTrackRequestsUpdate,
+            ) -> bool {
+                false
+            }
+            fn apply_arb_snapshot_reconcile(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _active: &[ArbTrackActiveEntry],
+            ) -> bool {
+                false
+            }
+            fn apply_arb_removed_entries(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _removed: &[ArbTrackRemovedEntry],
+            ) -> bool {
+                false
+            }
+            fn apply_arb_active_entries(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _active: &[ArbTrackActiveEntry],
+            ) -> bool {
+                false
+            }
+            fn apply_wallet_pin(&self, _admission: &mut FixedCapAdmission, _mint: Pubkey) -> bool {
+                false
+            }
+            fn withdraw_wallet_pin(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _mint: Pubkey,
+            ) -> bool {
+                false
+            }
+            fn apply_track_mint(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _mint: Pubkey,
+                _pin: Option<TrackPinReason>,
+            ) -> bool {
+                false
+            }
+            fn refresh_geyser_pins_gauge(&self) {}
+            fn hot_pool_registry_pair_count(&self) -> usize {
+                0
+            }
+            fn hot_pool_registry_arb_pool_count(&self) -> usize {
+                0
+            }
+            fn refresh_hot_pool_registry_gauges(&self) {}
+            fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
+                HashSet::new()
+            }
+            fn sync_geyser_tracked_accounts_batched_flush_with_deadline(
+                &self,
+                _deadline: Instant,
+                _admission: &FixedCapAdmission,
+            ) -> bool {
+                true
+            }
+            fn continue_geyser_evict_with_deadline(
+                &self,
+                _deadline: Instant,
+                _admission: &FixedCapAdmission,
+            ) -> bool {
+                true
+            }
+            fn release_geyser_sync_flush_slot(&self) {}
+            fn refresh_tracked_membership_snapshot(&self) {}
+            fn explicit_pubkey_rows_for_desired_set(
+                &self,
+            ) -> Vec<(Pubkey, super::super::ConsumerId, Option<Pubkey>)> {
+                Vec::new()
+            }
+            fn build_explicit_set_snapshot(
+                &self,
+                _admission: &FixedCapAdmission,
+            ) -> super::super::snapshot::ExplicitSetSnapshot {
+                super::super::snapshot::ExplicitSetSnapshot::new(None)
+            }
+            fn apply_explicit_set_snapshot(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _snapshot: &super::super::snapshot::ExplicitSetSnapshot,
+            ) -> super::super::admission_wiring::AdmissionRestoreResult {
+                super::super::admission_wiring::AdmissionRestoreResult::Restored
+            }
+            fn on_admission_converge_result(
+                &self,
+                _admission: &FixedCapAdmission,
+                _result: super::super::admission_wiring::AdmissionConvergeResult,
+            ) {
+            }
+            fn prune_tracked_maps_to_admitted(&self, _admission: &FixedCapAdmission) {}
+            fn publish_admitted_explicit_physical(&self, _admission: &FixedCapAdmission) {}
+            fn last_synced_explicit_pubkeys_write(
+                &self,
+            ) -> parking_lot::RwLockWriteGuard<'_, HashSet<Pubkey>> {
+                self.last_synced.write()
+            }
+            fn geyser_explicit_readiness_ok(&self) -> bool {
+                true
+            }
+            fn geyser_connect_barrier_pending(&self) -> bool {
+                false
+            }
+            fn signal_restore_barrier(&self, _ok: bool) {}
+            fn apply_explicit_cap_shrink(
+                &self,
+                _admission: &mut FixedCapAdmission,
+                _new_cap: usize,
+            ) -> super::super::explicit_admission::CapShrinkResult {
+                super::super::explicit_admission::CapShrinkResult::NoOpAlreadyWithinCap {
+                    old_cap: 25_000,
+                    new_cap: 25_000,
+                }
+            }
+            fn retry_deferred_hot_pool_reserve_registrations(
+                &self,
+                _admission: &mut FixedCapAdmission,
+            ) -> bool {
+                self.retry_calls.fetch_add(1, Ordering::Relaxed);
+                false
+            }
+        }
+
+        let ctx = Arc::new(ChunkedRetryCtx {
+            retry_calls: AtomicUsize::new(0),
+            last_synced: parking_lot::RwLock::new(HashSet::new()),
+        });
+        let mut admission = FixedCapAdmission::new(25_000);
+        let mut active = Vec::new();
+        for i in 0..48 {
+            active.push(MomentumActivePoolEntry {
+                mint: Pubkey::new_unique().to_string(),
+                pool: Pubkey::new_unique().to_string(),
+                pin_reason: crate::nats::MomentumActivePinReason::Tracker,
+            });
+            let _ = i;
+        }
+        apply_momentum_active_pools_on_track_worker(
+            &ctx,
+            &mut admission,
+            MomentumActivePoolsUpdate {
+                version: 1,
+                ts_unix_ms: 1,
+                active,
+                removed: vec![],
+                full_active_snapshot: false,
+            },
+        );
+        assert_eq!(ctx.retry_calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
     fn control_push_evict_variants_advance_revision() {
         let mut store = BoundedProtocolStore::default_caps();
         for payload in [

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -225,6 +225,7 @@ pub fn apply_momentum_active_pools_on_track_worker<C: TrackWorkerContext>(
         batch_dirty |= ctx.apply_momentum_active_entries(admission, chunk);
         std::thread::yield_now();
     }
+    batch_dirty |= ctx.retry_deferred_hot_pool_reserve_registrations(admission);
     if !batch_dirty {
         ctx.refresh_geyser_pins_gauge();
     }

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -41,6 +41,8 @@ pub enum TrackWorkerCommand {
     FlushExplicitSetSnapshot {
         done: std::sync::mpsc::Sender<()>,
     },
+    /// Scope C: retry deferred hot-pool vault/bin registration after LivePoolCache fill.
+    RetryDeferredHotPoolReserves,
 }
 
 /// Consumer/stream identity for monotone revision assignment.
@@ -98,6 +100,7 @@ pub fn stream_for_command(cmd: &TrackWorkerCommand) -> TrackCommandStream {
         | TrackWorkerCommand::ScheduleGeyserPushDebounced
         | TrackWorkerCommand::RestoreExplicitSnapshot(_)
         | TrackWorkerCommand::ContinueGeyserEvict
+        | TrackWorkerCommand::RetryDeferredHotPoolReserves
         | TrackWorkerCommand::FlushExplicitSetSnapshot { .. } => TrackCommandStream::Control,
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -976,6 +976,12 @@ pub static MARKET_DATA_MOMENTUM_ADMISSION_ADMITTED_TOTAL: Lazy<AtomicU64> =
 /// PR4a: momentum pool groups rejected at admission (no tracked-map mutation).
 pub static MARKET_DATA_MOMENTUM_ADMISSION_REJECTED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// Scope C: open-position pool pins applied (vault/bin registration succeeded).
+pub static MARKET_DATA_OPEN_POSITION_PIN_APPLIED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Scope C: open-position pool pins deferred (LivePoolCache miss; registry row kept).
+pub static MARKET_DATA_OPEN_POSITION_PIN_DEFERRED_CACHE_MISS_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// PR4a: arb pool groups admitted before tracked-map mutation.
 pub static MARKET_DATA_ARB_ADMISSION_ADMITTED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -1268,6 +1274,16 @@ pub fn inc_market_data_momentum_admission_admitted_total() {
 #[inline]
 pub fn inc_market_data_momentum_admission_rejected_total() {
     MARKET_DATA_MOMENTUM_ADMISSION_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_open_position_pin_applied_total() {
+    MARKET_DATA_OPEN_POSITION_PIN_APPLIED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_open_position_pin_deferred_cache_miss_total() {
+    MARKET_DATA_OPEN_POSITION_PIN_DEFERRED_CACHE_MISS_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -6182,6 +6198,14 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_momentum_admission_rejected_total",
         MARKET_DATA_MOMENTUM_ADMISSION_REJECTED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_open_position_pin_applied_total",
+        MARKET_DATA_OPEN_POSITION_PIN_APPLIED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_open_position_pin_deferred_cache_miss_total",
+        MARKET_DATA_OPEN_POSITION_PIN_DEFERRED_CACHE_MISS_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_arb_admission_admitted_total",

--- a/src/nats/momentum_active_pools.rs
+++ b/src/nats/momentum_active_pools.rs
@@ -4,6 +4,9 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Wire version for [`MomentumActivePoolsUpdate`] (stable across producers).
+pub const MOMENTUM_ACTIVE_POOLS_WIRE_VERSION: u32 = 1;
+
 /// Wire payload for `ironcrab.v1.momentum.active_pools` ([`crate::nats::topics::TOPIC_MOMENTUM_ACTIVE_POOLS`]).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MomentumActivePoolsUpdate {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Scope C — Open-Position Pools → EXEC_HOT

Plan: `plan_account_update_realtime_backlog_fix_20260716.md` (Scope C)

**Voraussetzung:** Scope A/B (AccountUpdateClass + ENRICH latest-wins coalesce)

### Problem
Nach Confirm BUY fehlten frische Vault/Bin-Updates für den Positions-Pool, wenn dieser Pool nicht im EXEC_HOT-Set lag (hot_pool + vault membership).

### Lösung (minimal, dual-consumer-safe)
- **MD:** `pin_reason == Position` wird ausgewertet; Position-Pairs im `hot_pool_registry`; bei LivePoolCache-Miss bleibt Registry-Row erhalten + bounded Retry (track-worker `RetryDeferredHotPoolReserves`, Activity-Tick)
- **Coalesce:** Position ≥ Tracker für gleiches `(mint, pool)`
- **Momentum:** Position-Pin bei Orphan-Reconcile + Wallet-Snapshot-Reconcile (bisherige Gaps)
- **EE:** Nach confirmed BUY → `TOPIC_MOMENTUM_ACTIVE_POOLS` mit Position-Pin wenn `intent.resources.pools[0]` gesetzt (kein spekulatives Pinning)
- **Metriken:** `market_data_open_position_pin_applied_total`, `market_data_open_position_pin_deferred_cache_miss_total`

### Invarianten
- Kein Hot-Path-RPC
- Dual-Consumer: Arb-Pins unverändert, kein Momentum-only Account-Fast-Lane
- Kein Cap >25k, kein Exit-Policy-Umbau

### Out of Scope
- Falsche Pool-Bindung / WalletSnapshot-Orphans „heilen“ (TRUMP dust)
- Scope D (sidefx/md-state budget rewrite)

### Tests
- `scope_c_position_pin_classifies_exec_hot`
- `scope_c_position_pin_cache_miss_retries_when_cache_filled`
- `merge_momentum_active_pools_prefers_position_over_tracker`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f56130a9-100f-4dc5-a3fe-c28c11075b5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f56130a9-100f-4dc5-a3fe-c28c11075b5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

