### PR TITLE
feat(market-data): Scope D sidefx ENRICH throttle; preserve EXEC_HOT JetStream

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -77,7 +77,8 @@ use ironcrab::market_data::sidefx::{
     md_sidefx_process_vault_balance_tick as sidefx_process_vault_balance_tick,
     md_sidefx_try_enqueue as sidefx_try_enqueue, spawn_md_sidefx_worker as spawn_sidefx_worker,
     MarketEventCorePublishTrace, MdSidefxBurstScratch, MdSidefxCommand, MdSidefxSender,
-    SidefxVaultMembershipView, SidefxWorkerHost, MARKET_DATA_MD_SIDEFX_QUEUE_CAP,
+    SidefxUpdateClass, SidefxVaultMembershipView, SidefxWorkerHost,
+    MARKET_DATA_MD_SIDEFX_QUEUE_CAP,
 };
 use ironcrab::market_data::track::{
     arb_coalesce_try_send, explicit_admitted_pool_sets_from_admission, explicit_set_snapshot_path,
@@ -455,11 +456,26 @@ impl SidefxWorkerHost for MarketDataSidefxHost {
         if scratch.lru_touches_empty() {
             return;
         }
-        let (vaults, bin_arrays) = scratch.drain_lru_touches();
-        md_state_try_enqueue(
-            &self.md_state,
-            MdStateCommand::TouchTrackedLruBatch { vaults, bin_arrays },
-        );
+        let (exec_hot_vaults, enrich_vaults, exec_hot_bins, enrich_bins) =
+            scratch.drain_lru_touches();
+        if !exec_hot_vaults.is_empty() || !exec_hot_bins.is_empty() {
+            md_state_try_enqueue(
+                &self.md_state,
+                MdStateCommand::TouchTrackedLruBatch {
+                    vaults: exec_hot_vaults,
+                    bin_arrays: exec_hot_bins,
+                },
+            );
+        }
+        if !enrich_vaults.is_empty() || !enrich_bins.is_empty() {
+            md_state_try_enqueue(
+                &self.md_state,
+                MdStateCommand::TouchTrackedLruBatch {
+                    vaults: enrich_vaults,
+                    bin_arrays: enrich_bins,
+                },
+            );
+        }
     }
 
     fn live_pool_cache(&self) -> &LivePoolCache {
@@ -1667,8 +1683,8 @@ fn note_trade_pool_lru_touches_from_cache(
     if let Some((base_vault, quote_vault)) =
         expected_pool_vault_pubkeys_from_cache(&state, enable_meteora_cpmm, enable_meteora_dlmm)
     {
-        scratch.note_vault_touch(base_vault);
-        scratch.note_vault_touch(quote_vault);
+        scratch.note_vault_touch(base_vault, SidefxUpdateClass::ExecHot);
+        scratch.note_vault_touch(quote_vault, SidefxUpdateClass::ExecHot);
     }
     if enable_meteora_dlmm {
         if let CachedPoolState::Meteora(s) = &state {
@@ -1676,7 +1692,7 @@ fn note_trade_pool_lru_touches_from_cache(
             for offset in -3i64..=3i64 {
                 let index = active_array_index + offset;
                 if let Ok(pda) = MeteoraDlmmSwapBuilder::derive_bin_array_pda(&pool, index) {
-                    scratch.note_bin_array_touch(pda);
+                    scratch.note_bin_array_touch(pda, SidefxUpdateClass::ExecHot);
                 }
             }
         }
@@ -7542,6 +7558,7 @@ fn spawn_market_data_md_state_liveness_task(process_started: Instant) {
 struct AccountWorkItem {
     update: GeyserAccountUpdate,
     recv_at: Instant,
+    class: ironcrab::market_data::ingest::AccountUpdateClass,
 }
 
 /// Per-shard ENRICH latest-wins buffer before / alongside the LOW `mpsc`.
@@ -8056,6 +8073,7 @@ async fn handle_geyser_account(
     publish_tx: Option<&mpsc::Sender<AccountPathNatsJob>>,
     md_state: &MdStateSender,
     md_sidefx: &MdSidefxSender,
+    update_class: ironcrab::market_data::ingest::AccountUpdateClass,
 ) {
     handle_geyser_account_update(
         ctx.as_ref(),
@@ -8066,6 +8084,7 @@ async fn handle_geyser_account(
         publish_tx,
         md_state,
         md_sidefx,
+        update_class,
     )
     .await;
 }
@@ -8645,6 +8664,7 @@ async fn run_geyser_loop(
                     publish_tx_w.as_ref(),
                     &md_state_w,
                     &md_sidefx_w,
+                    work.class,
                 )
                 .await;
                 record_market_data_account_handler_duration_us(
@@ -8703,6 +8723,7 @@ async fn run_geyser_loop(
                             .send(AccountWorkItem {
                                 update: account_update,
                                 recv_at,
+                                class,
                             })
                             .await;
                         if send_res.is_ok() {
@@ -8720,6 +8741,7 @@ async fn run_geyser_loop(
                         let work = AccountWorkItem {
                             update: account_update,
                             recv_at,
+                            class,
                         };
                         let mut coalesce_shard = enrich_coalesce_recv[shard].lock().await;
                         let upsert = account_enrich_coalesce_upsert(&mut coalesce_shard, work);
@@ -11606,6 +11628,8 @@ mod momentum_nats_subject_tests {
 mod pr_b_geyser_tracking_tests {
     use super::*;
     use ironcrab::market_data::ingest::maybe_emit_dev_wallet_after_pool_mint_map;
+    use ironcrab::market_data::ingest::AccountUpdateClass;
+    use ironcrab::market_data::sidefx::SidefxUpdateClass;
     const RAYDIUM_CPMM_OWNER: Pubkey =
         solana_sdk::pubkey!("CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C");
     const PUMPFUN_PROGRAM_OWNER: Pubkey =
@@ -11737,6 +11761,7 @@ mod pr_b_geyser_tracking_tests {
             account_data: account_data.clone(),
             slot: 1,
             grpc_recv_at: Instant::now(),
+            update_class: SidefxUpdateClass::Enrich,
         };
         let mut scratch = MdSidefxBurstScratch::new();
         md_sidefx_process_live_pool_cache_account_update(&worker, &job, &mut scratch);
@@ -11754,6 +11779,7 @@ mod pr_b_geyser_tracking_tests {
                 account_data: account_data.clone(),
                 slot: 2,
                 grpc_recv_at: Instant::now(),
+                update_class: SidefxUpdateClass::ExecHot,
             },
             &mut scratch,
         );
@@ -11775,6 +11801,7 @@ mod pr_b_geyser_tracking_tests {
                 account_data,
                 slot: 3,
                 grpc_recv_at: Instant::now(),
+                update_class: SidefxUpdateClass::ExecHot,
             },
             &mut scratch2,
         );
@@ -11784,6 +11811,122 @@ mod pr_b_geyser_tracking_tests {
             0,
             "phase1: repeat hot upsert still must not enqueue md-state register from sidefx"
         );
+    }
+
+    /// Scope D: ENRICH account-parse sidefx skips redundant JetStream when vault feed is live.
+    #[test]
+    fn scope_d_enrich_sidefx_skips_redundant_pool_discovered_under_vault_feed() {
+        use ironcrab::metrics::MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let (md_state, _depth, _md_state_rx) = test_md_state_sender_no_worker();
+        let worker = test_sidefx_host(&ctx, md_state, test_noop_track_worker_sender());
+
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        let account_data = test_raydium_cpmm_account_data(base, quote, coin_vault, pc_vault);
+
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool(base, pool);
+        ctx.note_explicit_momentum_pool_admitted(pool);
+        assert!(MarketDataContext::register_geyser_reserves_after_trade(
+            &ctx, pool
+        ));
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        ironcrab::market_data::track::converge_admission_from_ctx(ctx.as_ref(), &mut admission);
+        ctx.prune_tracked_maps_to_admitted(&admission);
+        ctx.publish_admitted_explicit_physical(&admission);
+        *ctx.last_synced_explicit_pubkeys.write() =
+            admission.snapshot_pubkeys().into_iter().collect();
+        assert!(worker.pool_has_live_vault_geyser_feed(pool));
+
+        MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.store(0, Ordering::Relaxed);
+        let mk_job =
+            |slot: u64, class: SidefxUpdateClass| MdSidefxCommand::LivePoolCacheAccountUpdate {
+                run_id: "scope-d".into(),
+                pool_pubkey: pool,
+                owner: RAYDIUM_CPMM_OWNER,
+                account_data: account_data.clone(),
+                slot,
+                grpc_recv_at: Instant::now(),
+                update_class: class,
+            };
+
+        let mut scratch = MdSidefxBurstScratch::new();
+        md_sidefx_process_live_pool_cache_account_update(
+            &worker,
+            &mk_job(10, SidefxUpdateClass::Enrich),
+            &mut scratch,
+        );
+        let skipped_after_first =
+            MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed);
+
+        let mut scratch2 = MdSidefxBurstScratch::new();
+        md_sidefx_process_live_pool_cache_account_update(
+            &worker,
+            &mk_job(11, SidefxUpdateClass::Enrich),
+            &mut scratch2,
+        );
+        assert!(
+            MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed)
+                > skipped_after_first,
+            "second ENRICH upsert with unchanged reserves under vault feed must skip JetStream"
+        );
+
+        let skipped_before_exec_hot =
+            MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed);
+        let mut scratch3 = MdSidefxBurstScratch::new();
+        md_sidefx_process_live_pool_cache_account_update(
+            &worker,
+            &mk_job(12, SidefxUpdateClass::ExecHot),
+            &mut scratch3,
+        );
+        assert_eq!(
+            MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed),
+            skipped_before_exec_hot,
+            "EXEC_HOT must not increment ENRICH skip counter (I-MD-4)"
+        );
+    }
+
+    /// Scope D regression: arb-pinned pool uses EXEC_HOT class (dual-consumer, not momentum-only).
+    #[test]
+    fn scope_d_arb_hot_pool_sidefx_uses_exec_hot_class() {
+        use ironcrab::market_data::ingest::{classify_account_geyser_update, AccountUpdateClass};
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+        let update = GeyserAccountUpdate {
+            pubkey: pool,
+            slot: 7,
+            owner: RAYDIUM_CPMM_OWNER,
+            data: vec![],
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        };
+        let (class, _) = classify_account_geyser_update(&ctx, &update);
+        assert_eq!(class, AccountUpdateClass::ExecHot);
+        assert!(SidefxUpdateClass::from(class).is_exec_hot());
     }
 
     #[test]
@@ -11796,6 +11939,7 @@ mod pr_b_geyser_tracking_tests {
                 balance: i + 1,
                 slot: i + 1,
                 grpc_recv_at: Instant::now(),
+                update_class: SidefxUpdateClass::ExecHot,
             })
             .collect();
         let out = md_sidefx_coalesce_burst(jobs);
@@ -13497,7 +13641,7 @@ mod pr_b_geyser_tracking_tests {
         let (ltx, mut lrx) = mpsc::channel(8);
         let pool_h = Pubkey::new_unique();
         let pool_l = Pubkey::new_unique();
-        let mk = |p: Pubkey| AccountWorkItem {
+        let mk_high = |p: Pubkey| AccountWorkItem {
             update: GeyserAccountUpdate {
                 pubkey: p,
                 slot: 1,
@@ -13507,9 +13651,22 @@ mod pr_b_geyser_tracking_tests {
                 grpc_recv_at: Instant::now(),
             },
             recv_at: Instant::now(),
+            class: AccountUpdateClass::ExecHot,
         };
-        ltx.send(mk(pool_l)).await.unwrap();
-        htx.send(mk(pool_h)).await.unwrap();
+        let mk_low = |p: Pubkey| AccountWorkItem {
+            update: GeyserAccountUpdate {
+                pubkey: p,
+                slot: 1,
+                owner: PUMPFUN_PROGRAM_OWNER,
+                data: vec![],
+                lamports: 0,
+                grpc_recv_at: Instant::now(),
+            },
+            recv_at: Instant::now(),
+            class: AccountUpdateClass::Enrich,
+        };
+        ltx.send(mk_low(pool_l)).await.unwrap();
+        htx.send(mk_high(pool_h)).await.unwrap();
         drop(htx);
         drop(ltx);
         let w1 = account_worker_recv_next(&mut hrx, &mut lrx)
@@ -13551,6 +13708,7 @@ mod pr_b_geyser_tracking_tests {
                 grpc_recv_at: Instant::now(),
             },
             recv_at: Instant::now(),
+            class: AccountUpdateClass::Enrich,
         };
         for slot in 0..16 {
             ltx.send(mk(slot)).await.unwrap();
@@ -13591,6 +13749,7 @@ mod pr_b_geyser_tracking_tests {
                 grpc_recv_at: Instant::now(),
             },
             recv_at: Instant::now(),
+            class: AccountUpdateClass::Enrich,
         };
         assert!(matches!(
             account_enrich_coalesce_upsert(&mut shard, mk(1)),
@@ -13630,6 +13789,7 @@ mod pr_b_geyser_tracking_tests {
                     grpc_recv_at: Instant::now(),
                 },
                 recv_at: Instant::now(),
+                class: AccountUpdateClass::Enrich,
             },
         );
         assert_eq!(shard.unique_pending_pubkey_count(), 1);
@@ -13650,6 +13810,7 @@ mod pr_b_geyser_tracking_tests {
                 grpc_recv_at: Instant::now(),
             },
             recv_at: Instant::now(),
+            class: AccountUpdateClass::Enrich,
         };
         assert!(matches!(
             account_enrich_coalesce_upsert_with_cap(&mut shard, mk(7), CAP),
@@ -13690,6 +13851,7 @@ mod pr_b_geyser_tracking_tests {
                 grpc_recv_at: Instant::now(),
             },
             recv_at: Instant::now(),
+            class: AccountUpdateClass::Enrich,
         };
         assert!(matches!(
             account_enrich_coalesce_upsert_with_cap(&mut shard, work, CAP),
@@ -13706,6 +13868,7 @@ mod pr_b_geyser_tracking_tests {
                 grpc_recv_at: Instant::now(),
             },
             recv_at: Instant::now(),
+            class: AccountUpdateClass::Enrich,
         };
         full_tx.try_send(blocker).expect("prefill channel");
         assert_eq!(
@@ -13737,6 +13900,7 @@ mod pr_b_geyser_tracking_tests {
                 grpc_recv_at: Instant::now(),
             },
             recv_at: Instant::now(),
+            class: AccountUpdateClass::Enrich,
         };
         for slot in 0..3 {
             let pk = Pubkey::new_unique();
@@ -13795,6 +13959,7 @@ mod pr_b_geyser_tracking_tests {
                         grpc_recv_at: Instant::now(),
                     },
                     recv_at: Instant::now(),
+                    class: AccountUpdateClass::Enrich,
                 },
             );
             assert!(matches!(
@@ -14403,6 +14568,7 @@ mod pr_b_geyser_tracking_tests {
             None,
             &md_state,
             &md_sidefx,
+            AccountUpdateClass::ExecHot,
         )
         .await;
 
@@ -15559,6 +15725,7 @@ mod pr_b_geyser_tracking_tests {
                 pool_address: pool,
                 slot: 50,
                 grpc_recv_at: Instant::now(),
+                update_class: SidefxUpdateClass::ExecHot,
             },
             &mut scratch,
         );
@@ -15569,6 +15736,7 @@ mod pr_b_geyser_tracking_tests {
                 pool_address: pool,
                 slot: 99,
                 grpc_recv_at: Instant::now(),
+                update_class: SidefxUpdateClass::ExecHot,
             },
             &mut scratch,
         );
@@ -15680,6 +15848,7 @@ mod pr_b_geyser_tracking_tests {
                 balance: 10_000,
                 slot: 42,
                 grpc_recv_at: Instant::now(),
+                update_class: SidefxUpdateClass::ExecHot,
             },
             &mut scratch,
         );

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -11905,6 +11905,81 @@ mod pr_b_geyser_tracking_tests {
         );
     }
 
+    /// Bugbot: ENRICH JetStream skip must not skip MASTER readiness merge.
+    #[test]
+    fn scope_d_enrich_skips_publish_but_merges_readiness() {
+        use ironcrab::ipc::DexPoolReadiness;
+        use ironcrab::metrics::MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let (md_state, _depth, _md_state_rx) = test_md_state_sender_no_worker();
+        let worker = test_sidefx_host(&ctx, md_state, test_noop_track_worker_sender());
+
+        let pool = Pubkey::new_unique();
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+        let account_data = test_raydium_cpmm_account_data(base, quote, coin_vault, pc_vault);
+
+        // Seed MASTER cache from parse-shaped row (no vault balances in pool account bytes).
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: None,
+                reserve_1: None,
+            }),
+            1,
+        );
+        assert_eq!(ctx.live_pool_cache.raydium_cpmm_readiness(&pool), None);
+
+        ctx.hot_pool_registry.pin_pool(base, pool);
+        ctx.note_explicit_momentum_pool_admitted(pool);
+        assert!(MarketDataContext::register_geyser_reserves_after_trade(
+            &ctx, pool
+        ));
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        ironcrab::market_data::track::converge_admission_from_ctx(ctx.as_ref(), &mut admission);
+        ctx.prune_tracked_maps_to_admitted(&admission);
+        ctx.publish_admitted_explicit_physical(&admission);
+        *ctx.last_synced_explicit_pubkeys.write() =
+            admission.snapshot_pubkeys().into_iter().collect();
+        assert!(worker.pool_has_live_vault_geyser_feed(pool));
+
+        MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.store(0, Ordering::Relaxed);
+        let mut scratch = MdSidefxBurstScratch::new();
+        md_sidefx_process_live_pool_cache_account_update(
+            &worker,
+            &MdSidefxCommand::LivePoolCacheAccountUpdate {
+                run_id: "scope-d-readiness".into(),
+                pool_pubkey: pool,
+                owner: RAYDIUM_CPMM_OWNER,
+                account_data,
+                slot: 2,
+                grpc_recv_at: Instant::now(),
+                update_class: SidefxUpdateClass::Enrich,
+            },
+            &mut scratch,
+        );
+
+        assert!(
+            MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed) > 0,
+            "ENRICH must skip redundant JetStream under vault feed + unchanged layout/reserves"
+        );
+        assert_eq!(
+            ctx.live_pool_cache.raydium_cpmm_readiness(&pool),
+            Some(DexPoolReadiness::Observed),
+            "readiness merge must run even when JetStream publish is skipped"
+        );
+    }
+
     /// Scope D regression: arb-pinned pool uses EXEC_HOT class (dual-consumer, not momentum-only).
     #[test]
     fn scope_d_arb_hot_pool_sidefx_uses_exec_hot_class() {

--- a/src/market_data/ingest/account_handler.rs
+++ b/src/market_data/ingest/account_handler.rs
@@ -11,12 +11,14 @@ use super::account_parse::{
     WalletGeyserUpdateSource,
 };
 use crate::ipc::{BinData, MarketEvent, MarketEventKind, NATIVE_SOL_MINT};
+use crate::market_data::ingest::AccountUpdateClass;
 use crate::market_data::md_state::MdStateSender;
 use crate::market_data::publish::{
     account_path_enqueue_core_market_event, account_path_enqueue_jetstream, AccountPublishSender,
 };
 use crate::market_data::sidefx::{
-    md_sidefx_try_enqueue, MarketEventCorePublishTrace, MdSidefxCommand, MdSidefxSender,
+    md_sidefx_try_enqueue_classed, MarketEventCorePublishTrace, MdSidefxCommand, MdSidefxSender,
+    SidefxUpdateClass,
 };
 use crate::metrics::{
     record_market_data_tokio_progress, record_market_data_unparsed_account_dropped,
@@ -47,7 +49,9 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
     publish_tx: Option<&AccountPublishSender>,
     _md_state: &MdStateSender,
     md_sidefx: &MdSidefxSender,
+    update_class: AccountUpdateClass,
 ) {
+    let sidefx_class = SidefxUpdateClass::from(update_class);
     let account_geyser_recv_at = recv_at;
     account_count.fetch_add(1, Ordering::Relaxed);
     record_market_data_tokio_progress();
@@ -244,8 +248,9 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
             host.account_wallet_mint_decimals_insert(account_update.pubkey, decimals);
 
             // Phase-R-R4b: MASTER mint_decimals off account ingest (`md-sidefx`).
-            md_sidefx_try_enqueue(
+            md_sidefx_try_enqueue_classed(
                 md_sidefx,
+                SidefxUpdateClass::ExecHot,
                 MdSidefxCommand::LivePoolCacheMintDecimals {
                     mint: account_update.pubkey,
                     decimals,
@@ -317,14 +322,16 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
     {
         // Phase-R-R4: vault pairing + publish off hot path (`md-sidefx`; no `tracked_vaults` read here).
         if let Some(balance) = try_parse_token_account_balance(&account_update.data) {
-            md_sidefx_try_enqueue(
+            md_sidefx_try_enqueue_classed(
                 md_sidefx,
+                sidefx_class,
                 MdSidefxCommand::VaultBalanceTick {
                     run_id: run_id.to_string(),
                     vault_pubkey: account_update.pubkey,
                     balance,
                     slot: account_update.slot,
                     grpc_recv_at: account_update.grpc_recv_at,
+                    update_class: sidefx_class,
                 },
             );
             return;
@@ -338,10 +345,12 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
     if account_update.owner == dlmm_program {
         if let Some(bin_array_info) = host.account_membership_bin_array_info(&account_update.pubkey)
         {
-            md_sidefx_try_enqueue(
+            md_sidefx_try_enqueue_classed(
                 md_sidefx,
+                sidefx_class,
                 MdSidefxCommand::TouchBinArrayTick {
                     pda: account_update.pubkey,
+                    update_class: sidefx_class,
                 },
             );
             // Parse bin array to extract liquidity distribution
@@ -395,13 +404,15 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
                             .await;
                         }
                         if host.ingest_is_hot_pool(&bin_array_info.pool_address) {
-                            md_sidefx_try_enqueue(
+                            md_sidefx_try_enqueue_classed(
                                 md_sidefx,
+                                SidefxUpdateClass::ExecHot,
                                 MdSidefxCommand::DlmmPoolStatePublishSignal {
                                     run_id: run_id.to_string(),
                                     pool_address: bin_array_info.pool_address,
                                     slot: account_update.slot,
                                     grpc_recv_at: account_geyser_recv_at,
+                                    update_class: SidefxUpdateClass::ExecHot,
                                 },
                             );
                         }
@@ -421,8 +432,9 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
 
     // Phase-R-R4b: LivePoolCache populate + PoolCacheUpdate off account ingest (`md-sidefx`).
     if account_geyser_update_is_dex_pool_owner(&account_update.owner) {
-        md_sidefx_try_enqueue(
+        md_sidefx_try_enqueue_classed(
             md_sidefx,
+            sidefx_class,
             MdSidefxCommand::LivePoolCacheAccountUpdate {
                 run_id: run_id.to_string(),
                 pool_pubkey: account_update.pubkey,
@@ -430,6 +442,7 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
                 account_data: account_update.data.clone(),
                 slot: account_update.slot,
                 grpc_recv_at: account_geyser_recv_at,
+                update_class: sidefx_class,
             },
         );
         if account_geyser_update_is_sidefx_only_pool_owner(&account_update.owner) {
@@ -453,8 +466,9 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
         slot,
     }) = &parsed
     {
-        md_sidefx_try_enqueue(
+        md_sidefx_try_enqueue_classed(
             md_sidefx,
+            sidefx_class,
             MdSidefxCommand::BondingCurveDevWallet {
                 run_id: run_id.to_string(),
                 pool_address: *pool_address,

--- a/src/market_data/sidefx/handlers.rs
+++ b/src/market_data/sidefx/handlers.rs
@@ -5,8 +5,9 @@ use super::pool_publish::{
     cache_balance_fields_unchanged, cached_pool_has_fresh_reserve_basis,
     meteora_cpmm_onchain_mints_for_pool_cache_update, meteora_cpmm_vaults_for_pool_cache_update,
     meteora_dlmm_metadata_for_pool_cache_update, orca_metadata_for_pool_cache_update,
-    pool_cache_balance_fields_from_state, pump_amm_sell_layout_publish_state,
-    raydium_cpmm_readiness_for_pool_cache_update, raydium_cpmm_vaults_for_pool_cache_update,
+    pool_cache_balance_fields_from_state, pool_cache_state_layout_significant_change,
+    pump_amm_sell_layout_publish_state, raydium_cpmm_readiness_for_pool_cache_update,
+    raydium_cpmm_vaults_for_pool_cache_update,
 };
 use super::worker::{DlmmPoolStateSignal, MdSidefxBurstScratch, MdSidefxCommand};
 use crate::execution::live_pool_cache::{
@@ -23,6 +24,7 @@ use crate::metrics::{
     inc_market_data_devwallet_bonding_path_total, inc_market_data_devwallet_tx_published_total,
     inc_market_data_enrichment_balance_updated_total,
     inc_market_data_enrichment_pool_state_publish_total,
+    inc_market_data_md_sidefx_enrich_publish_skipped_total,
     inc_market_data_pool_state_publish_skipped_balance_unchanged_total,
     record_market_data_bonding_curve_grpc_to_devwallet_ms,
     record_market_data_pool_mint_map_to_devwallet_ms, MarketDataLatencySegment,
@@ -187,6 +189,33 @@ fn md_sidefx_publish_enrichment_from_cache_upsert(
     }
 }
 
+/// ENRICH-only: skip redundant JetStream `PoolCacheUpdate` when vault feed already covers reserves.
+/// EXEC_HOT always publishes (I-MD-4). Stale upsert early-return is handled before this gate.
+fn md_sidefx_should_publish_enrich_pool_cache_update(
+    host: &dyn SidefxWorkerHost,
+    pool_pubkey: &Pubkey,
+    prev_state: Option<&CachedPoolState>,
+    cached_state: &CachedPoolState,
+) -> bool {
+    let Some(prev) = prev_state else {
+        return true;
+    };
+    if pool_cache_state_layout_significant_change(prev, cached_state) {
+        return true;
+    }
+    if host.pool_has_live_vault_geyser_feed(*pool_pubkey)
+        && cache_balance_fields_unchanged(prev, cached_state)
+    {
+        inc_market_data_md_sidefx_enrich_publish_skipped_total();
+        return false;
+    }
+    if cache_balance_fields_unchanged(prev, cached_state) {
+        inc_market_data_md_sidefx_enrich_publish_skipped_total();
+        return false;
+    }
+    true
+}
+
 /// P2 SLO: count enrichment publishes only for EnrichmentRegistry members.
 fn md_sidefx_inc_enrichment_publish_metrics_if_member(
     host: &dyn SidefxWorkerHost,
@@ -296,6 +325,7 @@ pub fn md_sidefx_process_dlmm_pool_state_publish_signal(
         pool_address,
         slot,
         grpc_recv_at,
+        update_class: _,
     } = job
     else {
         return;
@@ -1153,6 +1183,7 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
         account_data,
         slot,
         grpc_recv_at,
+        update_class,
     } = job
     else {
         return;
@@ -1308,7 +1339,14 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
         };
 
         // Publish PoolCacheUpdate to JetStream (Single Source of Truth for pool state)
-        if host.nats_enabled() {
+        let should_publish_pool_cache = update_class.is_exec_hot()
+            || md_sidefx_should_publish_enrich_pool_cache_update(
+                host,
+                pool_pubkey,
+                prev_state.as_ref(),
+                &cached_state,
+            );
+        if should_publish_pool_cache && host.nats_enabled() {
             let mut pool_update = PoolCacheUpdate::new_pool_discovered(
                 "market-data",
                 host.build_version(),
@@ -1576,6 +1614,7 @@ pub fn md_sidefx_process_vault_balance_tick(
         balance,
         slot,
         grpc_recv_at,
+        update_class,
     } = job
     else {
         return;
@@ -1590,7 +1629,7 @@ pub fn md_sidefx_process_vault_balance_tick(
         inc_market_data_pool_state_publish_skipped_balance_unchanged_total();
         return;
     }
-    scratch.note_vault_touch(*vault_pubkey);
+    scratch.note_vault_touch(*vault_pubkey, *update_class);
 
     let (mut final_base, mut final_quote) = host
         .snapshot_vault_pair_balances(vault_pubkey, *balance)
@@ -1617,7 +1656,8 @@ pub fn md_sidefx_process_vault_balance_tick(
     host.live_pool_cache()
         .update_vault_balance(vault_pubkey, *balance, *slot);
 
-    if host.nats_enabled() {
+    let publish_jetstream = update_class.is_exec_hot();
+    if publish_jetstream && host.nats_enabled() {
         let mut balance_update = PoolCacheUpdate::new_balance_updated(
             "market-data",
             host.build_version(),
@@ -1725,6 +1765,8 @@ pub fn md_sidefx_process_vault_balance_tick(
             slot = slot,
             "MASTER CACHE: PoolCacheUpdate::BalanceUpdated enqueued for JetStream"
         );
+    } else if !update_class.is_exec_hot() {
+        inc_market_data_md_sidefx_enrich_publish_skipped_total();
     }
 
     let state_event = MarketEvent::new(
@@ -1749,7 +1791,7 @@ pub fn md_sidefx_process_vault_balance_tick(
 
     host.write_market_event_jsonl(&state_event);
 
-    if host.nats_enabled() {
+    if publish_jetstream && host.nats_enabled() {
         let pool_state_enqueued = host.enqueue_core_market_event(
             state_event,
             Some(MarketEventCorePublishTrace {
@@ -1772,10 +1814,10 @@ pub fn md_sidefx_process_touch_bin_array_tick(
     job: &MdSidefxCommand,
     scratch: &mut MdSidefxBurstScratch,
 ) {
-    let MdSidefxCommand::TouchBinArrayTick { pda } = job else {
+    let MdSidefxCommand::TouchBinArrayTick { pda, update_class } = job else {
         return;
     };
-    scratch.note_bin_array_touch(*pda);
+    scratch.note_bin_array_touch(*pda, *update_class);
 }
 
 pub fn md_sidefx_process_trade_pool_lru_touch(

--- a/src/market_data/sidefx/handlers.rs
+++ b/src/market_data/sidefx/handlers.rs
@@ -216,6 +216,49 @@ fn md_sidefx_should_publish_enrich_pool_cache_update(
     true
 }
 
+/// Refresh MASTER monotonic readiness maps after cache upsert (independent of ENRICH publish throttle).
+fn md_sidefx_merge_pool_readiness_from_cached_state(
+    host: &dyn SidefxWorkerHost,
+    pool_pubkey: &Pubkey,
+    cached_state: &CachedPoolState,
+) {
+    match cached_state {
+        CachedPoolState::PumpFun(_) => {
+            host.live_pool_cache()
+                .merge_pumpfun_bonding_readiness(*pool_pubkey, DexPoolReadiness::Partial);
+        }
+        CachedPoolState::PumpAmm(_) => {
+            host.live_pool_cache()
+                .merge_pump_amm_pool_accounts_readiness(*pool_pubkey, DexPoolReadiness::Partial);
+        }
+        CachedPoolState::RaydiumAmm(s) => {
+            let readiness = raydium_amm_readiness_for_pool_cache_update(s);
+            host.live_pool_cache()
+                .merge_raydium_amm_pool_readiness(*pool_pubkey, readiness);
+        }
+        CachedPoolState::RaydiumCpmm(s) => {
+            let readiness = raydium_cpmm_readiness_for_pool_cache_update(s);
+            host.live_pool_cache()
+                .merge_raydium_cpmm_pool_readiness(*pool_pubkey, readiness);
+        }
+        CachedPoolState::MeteoraCpmm(s) => {
+            let readiness = meteora_cpmm_readiness_for_pool_cache_update(s);
+            host.live_pool_cache()
+                .merge_meteora_cpmm_pool_readiness(*pool_pubkey, readiness);
+        }
+        CachedPoolState::Orca(s) => {
+            let readiness = orca_readiness_for_pool_cache_update(s);
+            host.live_pool_cache()
+                .merge_orca_pool_readiness(*pool_pubkey, readiness);
+        }
+        CachedPoolState::Meteora(s) => {
+            let readiness = meteora_dlmm_readiness_for_pool_cache_update(s);
+            host.live_pool_cache()
+                .merge_meteora_dlmm_pool_readiness(*pool_pubkey, readiness);
+        }
+    }
+}
+
 /// P2 SLO: count enrichment publishes only for EnrichmentRegistry members.
 fn md_sidefx_inc_enrichment_publish_metrics_if_member(
     host: &dyn SidefxWorkerHost,
@@ -1338,6 +1381,8 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
             }
         };
 
+        md_sidefx_merge_pool_readiness_from_cached_state(host, pool_pubkey, &cached_state);
+
         // Publish PoolCacheUpdate to JetStream (Single Source of Truth for pool state)
         let should_publish_pool_cache = update_class.is_exec_hot()
             || md_sidefx_should_publish_enrich_pool_cache_update(
@@ -1394,8 +1439,6 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
                     pool_update.metadata = Some(meta);
                     // Geyser-fed bonding curve: observation / partial only — not cold-path verified Ready.
                     pool_update.set_dex_readiness_in_metadata(DexPoolReadiness::Partial);
-                    host.live_pool_cache()
-                        .merge_pumpfun_bonding_readiness(*pool_pubkey, DexPoolReadiness::Partial);
 
                     // === BondingCurveProgress event for momentum-bot exit signal ===
                     // PumpFun initial real_token_reserves = 793_100_000_000_000
@@ -1487,11 +1530,6 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
                     }
                     // Geyser-fed accounts + reserves: stronger than observation-only, not Ready until verified trade/discovery.
                     pool_update.set_dex_readiness_in_metadata(DexPoolReadiness::Partial);
-                    host.live_pool_cache()
-                        .merge_pump_amm_pool_accounts_readiness(
-                            *pool_pubkey,
-                            DexPoolReadiness::Partial,
-                        );
                 }
                 CachedPoolState::RaydiumAmm(s) => {
                     // FIX-29: Always propagate market_id (from Geyser parse),
@@ -1512,8 +1550,6 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
                     }
                     let readiness = raydium_amm_readiness_for_pool_cache_update(s);
                     pool_update.set_dex_readiness_in_metadata(readiness);
-                    host.live_pool_cache()
-                        .merge_raydium_amm_pool_readiness(*pool_pubkey, readiness);
                 }
                 CachedPoolState::RaydiumCpmm(s) => {
                     let mut meta = std::collections::HashMap::new();
@@ -1524,8 +1560,6 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
                     pool_update.metadata = Some(meta);
                     let readiness = raydium_cpmm_readiness_for_pool_cache_update(s);
                     pool_update.set_dex_readiness_in_metadata(readiness);
-                    host.live_pool_cache()
-                        .merge_raydium_cpmm_pool_readiness(*pool_pubkey, readiness);
                 }
                 CachedPoolState::MeteoraCpmm(s) => {
                     let mut meta = std::collections::HashMap::new();
@@ -1540,22 +1574,16 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
                     pool_update.metadata = Some(meta);
                     let readiness = meteora_cpmm_readiness_for_pool_cache_update(s);
                     pool_update.set_dex_readiness_in_metadata(readiness);
-                    host.live_pool_cache()
-                        .merge_meteora_cpmm_pool_readiness(*pool_pubkey, readiness);
                 }
                 CachedPoolState::Orca(s) => {
                     pool_update.metadata = Some(orca_metadata_for_pool_cache_update(s));
                     let readiness = orca_readiness_for_pool_cache_update(s);
                     pool_update.set_dex_readiness_in_metadata(readiness);
-                    host.live_pool_cache()
-                        .merge_orca_pool_readiness(*pool_pubkey, readiness);
                 }
                 CachedPoolState::Meteora(s) => {
                     pool_update.metadata = Some(meteora_dlmm_metadata_for_pool_cache_update(s));
                     let readiness = meteora_dlmm_readiness_for_pool_cache_update(s);
                     pool_update.set_dex_readiness_in_metadata(readiness);
-                    host.live_pool_cache()
-                        .merge_meteora_dlmm_pool_readiness(*pool_pubkey, readiness);
                 }
             }
             // P3 #13: Propagate base_decimals and quote_decimals to SLAVE caches (all DEX types)

--- a/src/market_data/sidefx/handlers.rs
+++ b/src/market_data/sidefx/handlers.rs
@@ -1267,6 +1267,8 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
             return;
         }
 
+        md_sidefx_merge_pool_readiness_from_cached_state(host, pool_pubkey, &cached_state);
+
         if let CachedPoolState::Meteora(ref s) = cached_state {
             let meta_changed = match prev_meteora_meta {
                 None => host.is_hot_pool(pool_pubkey),
@@ -1380,8 +1382,6 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
                 }
             }
         };
-
-        md_sidefx_merge_pool_readiness_from_cached_state(host, pool_pubkey, &cached_state);
 
         // Publish PoolCacheUpdate to JetStream (Single Source of Truth for pool state)
         let should_publish_pool_cache = update_class.is_exec_hot()

--- a/src/market_data/sidefx/mod.rs
+++ b/src/market_data/sidefx/mod.rs
@@ -14,6 +14,7 @@ pub use handlers::{
 pub use host::{MarketEventCorePublishTrace, SidefxVaultMembershipView, SidefxWorkerHost};
 pub use worker::{
     md_sidefx_coalesce_burst, md_sidefx_coalesce_key, md_sidefx_flush_pending_md_state_jobs,
-    md_sidefx_try_enqueue, spawn_md_sidefx_worker, MdSidefxBurstScratch, MdSidefxCommand,
-    MdSidefxSender, MARKET_DATA_MD_SIDEFX_BURST_MAX, MARKET_DATA_MD_SIDEFX_QUEUE_CAP,
+    md_sidefx_job_update_class, md_sidefx_try_enqueue, md_sidefx_try_enqueue_classed,
+    spawn_md_sidefx_worker, MdSidefxBurstScratch, MdSidefxCommand, MdSidefxSender,
+    SidefxUpdateClass, MARKET_DATA_MD_SIDEFX_BURST_MAX, MARKET_DATA_MD_SIDEFX_QUEUE_CAP,
 };

--- a/src/market_data/sidefx/pool_publish.rs
+++ b/src/market_data/sidefx/pool_publish.rs
@@ -333,20 +333,66 @@ pub fn pool_cache_state_layout_significant_change(
         return true;
     }
     match (prev, new) {
+        (CachedPoolState::RaydiumAmm(p), CachedPoolState::RaydiumAmm(n)) => {
+            p.market_id != n.market_id
+                || p.serum_bids != n.serum_bids
+                || p.serum_asks != n.serum_asks
+                || p.serum_event_queue != n.serum_event_queue
+                || p.coin_vault != n.coin_vault
+                || p.pc_vault != n.pc_vault
+                || p.base_mint != n.base_mint
+                || p.quote_mint != n.quote_mint
+        }
+        (CachedPoolState::RaydiumCpmm(p), CachedPoolState::RaydiumCpmm(n)) => {
+            p.token_0_vault != n.token_0_vault
+                || p.token_1_vault != n.token_1_vault
+                || p.token_0_mint != n.token_0_mint
+                || p.token_1_mint != n.token_1_mint
+        }
+        (CachedPoolState::MeteoraCpmm(p), CachedPoolState::MeteoraCpmm(n)) => {
+            p.token_0_vault != n.token_0_vault
+                || p.token_1_vault != n.token_1_vault
+                || p.token_0_mint != n.token_0_mint
+                || p.token_1_mint != n.token_1_mint
+                || p.amm_config != n.amm_config
+                || p.observation_key != n.observation_key
+                || p.token_0_program != n.token_0_program
+                || p.token_1_program != n.token_1_program
+        }
         (CachedPoolState::Meteora(p), CachedPoolState::Meteora(n)) => {
-            p.active_id != n.active_id || p.bin_step != n.bin_step
+            p.active_id != n.active_id
+                || p.bin_step != n.bin_step
+                || p.reserve_x != n.reserve_x
+                || p.reserve_y != n.reserve_y
+                || p.token_x_mint != n.token_x_mint
+                || p.token_y_mint != n.token_y_mint
         }
         (CachedPoolState::PumpAmm(p), CachedPoolState::PumpAmm(n)) => {
             p.pool_accounts != n.pool_accounts
+                || p.creator != n.creator
+                || p.pool_base_token_account != n.pool_base_token_account
+                || p.pool_quote_token_account != n.pool_quote_token_account
+                || p.base_mint != n.base_mint
+                || p.quote_mint != n.quote_mint
         }
         (CachedPoolState::PumpFun(p), CachedPoolState::PumpFun(n)) => {
             p.complete != n.complete
                 || p.real_token_reserves != n.real_token_reserves
                 || p.real_sol_reserves != n.real_sol_reserves
                 || p.creator != n.creator
+                || p.associated_bonding_curve != n.associated_bonding_curve
+                || p.cashback_enabled != n.cashback_enabled
         }
         (CachedPoolState::Orca(p), CachedPoolState::Orca(n)) => {
-            p.tick_current_index != n.tick_current_index || p.sqrt_price != n.sqrt_price
+            p.tick_current_index != n.tick_current_index
+                || p.sqrt_price != n.sqrt_price
+                || p.token_vault_a != n.token_vault_a
+                || p.token_vault_b != n.token_vault_b
+                || p.token_mint_a != n.token_mint_a
+                || p.token_mint_b != n.token_mint_b
+                || p.tick_spacing != n.tick_spacing
+                || p.token_a_program != n.token_a_program
+                || p.token_b_program != n.token_b_program
         }
         _ => false,
     }

--- a/src/market_data/sidefx/pool_publish.rs
+++ b/src/market_data/sidefx/pool_publish.rs
@@ -324,6 +324,34 @@ pub fn cache_balance_fields_unchanged(prev: &CachedPoolState, new: &CachedPoolSt
     }
 }
 
+/// True when parsed pool layout metadata materially changed (ENRICH publish gate, Scope D).
+pub fn pool_cache_state_layout_significant_change(
+    prev: &CachedPoolState,
+    new: &CachedPoolState,
+) -> bool {
+    if std::mem::discriminant(prev) != std::mem::discriminant(new) {
+        return true;
+    }
+    match (prev, new) {
+        (CachedPoolState::Meteora(p), CachedPoolState::Meteora(n)) => {
+            p.active_id != n.active_id || p.bin_step != n.bin_step
+        }
+        (CachedPoolState::PumpAmm(p), CachedPoolState::PumpAmm(n)) => {
+            p.pool_accounts != n.pool_accounts
+        }
+        (CachedPoolState::PumpFun(p), CachedPoolState::PumpFun(n)) => {
+            p.complete != n.complete
+                || p.real_token_reserves != n.real_token_reserves
+                || p.real_sol_reserves != n.real_sol_reserves
+                || p.creator != n.creator
+        }
+        (CachedPoolState::Orca(p), CachedPoolState::Orca(n)) => {
+            p.tick_current_index != n.tick_current_index || p.sqrt_price != n.sqrt_price
+        }
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/market_data/sidefx/pool_publish.rs
+++ b/src/market_data/sidefx/pool_publish.rs
@@ -325,6 +325,9 @@ pub fn cache_balance_fields_unchanged(prev: &CachedPoolState, new: &CachedPoolSt
 }
 
 /// True when parsed pool layout metadata materially changed (ENRICH publish gate, Scope D).
+///
+/// Compares vault pubkeys, mints, Serum/DLMM/Orca layout fields — not reserve balances
+/// (those are gated separately via [`cache_balance_fields_unchanged`]).
 pub fn pool_cache_state_layout_significant_change(
     prev: &CachedPoolState,
     new: &CachedPoolState,
@@ -335,62 +338,67 @@ pub fn pool_cache_state_layout_significant_change(
     match (prev, new) {
         (CachedPoolState::RaydiumAmm(p), CachedPoolState::RaydiumAmm(n)) => {
             p.market_id != n.market_id
-                || p.serum_bids != n.serum_bids
-                || p.serum_asks != n.serum_asks
-                || p.serum_event_queue != n.serum_event_queue
                 || p.coin_vault != n.coin_vault
                 || p.pc_vault != n.pc_vault
                 || p.base_mint != n.base_mint
                 || p.quote_mint != n.quote_mint
+                || p.serum_bids != n.serum_bids
+                || p.serum_asks != n.serum_asks
+                || p.serum_event_queue != n.serum_event_queue
         }
         (CachedPoolState::RaydiumCpmm(p), CachedPoolState::RaydiumCpmm(n)) => {
-            p.token_0_vault != n.token_0_vault
-                || p.token_1_vault != n.token_1_vault
-                || p.token_0_mint != n.token_0_mint
+            p.token_0_mint != n.token_0_mint
                 || p.token_1_mint != n.token_1_mint
+                || p.token_0_vault != n.token_0_vault
+                || p.token_1_vault != n.token_1_vault
         }
         (CachedPoolState::MeteoraCpmm(p), CachedPoolState::MeteoraCpmm(n)) => {
-            p.token_0_vault != n.token_0_vault
-                || p.token_1_vault != n.token_1_vault
-                || p.token_0_mint != n.token_0_mint
+            p.token_0_mint != n.token_0_mint
                 || p.token_1_mint != n.token_1_mint
+                || p.token_0_vault != n.token_0_vault
+                || p.token_1_vault != n.token_1_vault
                 || p.amm_config != n.amm_config
                 || p.observation_key != n.observation_key
                 || p.token_0_program != n.token_0_program
                 || p.token_1_program != n.token_1_program
+                || p.status != n.status
         }
         (CachedPoolState::Meteora(p), CachedPoolState::Meteora(n)) => {
             p.active_id != n.active_id
                 || p.bin_step != n.bin_step
-                || p.reserve_x != n.reserve_x
-                || p.reserve_y != n.reserve_y
                 || p.token_x_mint != n.token_x_mint
                 || p.token_y_mint != n.token_y_mint
+                || p.reserve_x != n.reserve_x
+                || p.reserve_y != n.reserve_y
         }
         (CachedPoolState::PumpAmm(p), CachedPoolState::PumpAmm(n)) => {
             p.pool_accounts != n.pool_accounts
-                || p.creator != n.creator
                 || p.pool_base_token_account != n.pool_base_token_account
                 || p.pool_quote_token_account != n.pool_quote_token_account
                 || p.base_mint != n.base_mint
                 || p.quote_mint != n.quote_mint
+                || p.creator != n.creator
         }
         (CachedPoolState::PumpFun(p), CachedPoolState::PumpFun(n)) => {
             p.complete != n.complete
                 || p.real_token_reserves != n.real_token_reserves
                 || p.real_sol_reserves != n.real_sol_reserves
                 || p.creator != n.creator
+                || p.token_mint != n.token_mint
                 || p.associated_bonding_curve != n.associated_bonding_curve
                 || p.cashback_enabled != n.cashback_enabled
         }
         (CachedPoolState::Orca(p), CachedPoolState::Orca(n)) => {
             p.tick_current_index != n.tick_current_index
                 || p.sqrt_price != n.sqrt_price
-                || p.token_vault_a != n.token_vault_a
-                || p.token_vault_b != n.token_vault_b
                 || p.token_mint_a != n.token_mint_a
                 || p.token_mint_b != n.token_mint_b
+                || p.token_vault_a != n.token_vault_a
+                || p.token_vault_b != n.token_vault_b
                 || p.tick_spacing != n.tick_spacing
+                || p.fee_rate != n.fee_rate
+                || p.protocol_fee_rate != n.protocol_fee_rate
+                || p.liquidity != n.liquidity
                 || p.token_a_program != n.token_a_program
                 || p.token_b_program != n.token_b_program
         }
@@ -455,5 +463,108 @@ mod tests {
         });
         assert!(cache_balance_fields_unchanged(&a, &b));
         assert!(!cache_balance_fields_unchanged(&a, &c));
+    }
+
+    #[test]
+    fn layout_change_raydium_cpmm_vault_pubkey_is_significant() {
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let v0 = Pubkey::new_unique();
+        let v1 = Pubkey::new_unique();
+        let prev = CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+            token_0_mint: mint_a,
+            token_1_mint: mint_b,
+            token_0_vault: v0,
+            token_1_vault: v1,
+            reserve_0: Some(100),
+            reserve_1: Some(200),
+        });
+        let new_vault = CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+            token_0_mint: mint_a,
+            token_1_mint: mint_b,
+            token_0_vault: Pubkey::new_unique(),
+            token_1_vault: v1,
+            reserve_0: Some(100),
+            reserve_1: Some(200),
+        });
+        assert!(pool_cache_state_layout_significant_change(
+            &prev, &new_vault
+        ));
+        assert!(!pool_cache_state_layout_significant_change(&prev, &prev));
+    }
+
+    #[test]
+    fn layout_change_raydium_cpmm_reserve_only_is_not_significant() {
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let v0 = Pubkey::new_unique();
+        let v1 = Pubkey::new_unique();
+        let prev = CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+            token_0_mint: mint_a,
+            token_1_mint: mint_b,
+            token_0_vault: v0,
+            token_1_vault: v1,
+            reserve_0: Some(100),
+            reserve_1: Some(200),
+        });
+        let new_bal = CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+            token_0_mint: mint_a,
+            token_1_mint: mint_b,
+            token_0_vault: v0,
+            token_1_vault: v1,
+            reserve_0: Some(101),
+            reserve_1: Some(200),
+        });
+        assert!(!pool_cache_state_layout_significant_change(&prev, &new_bal));
+        assert!(!cache_balance_fields_unchanged(&prev, &new_bal));
+    }
+
+    #[test]
+    fn layout_change_raydium_amm_serum_accounts_is_significant() {
+        use crate::execution::live_pool_cache::RaydiumAmmState;
+
+        let base = |serum_bids: Option<Pubkey>| {
+            CachedPoolState::RaydiumAmm(RaydiumAmmState {
+                base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                coin_vault: Pubkey::new_unique(),
+                pc_vault: Pubkey::new_unique(),
+                base_decimals: 6,
+                quote_decimals: 9,
+                coin_reserve: Some(1),
+                pc_reserve: Some(2),
+                market_id: Pubkey::new_unique(),
+                serum_bids,
+                serum_asks: Some(Pubkey::new_unique()),
+                serum_event_queue: Some(Pubkey::new_unique()),
+            })
+        };
+        let prev = base(Some(Pubkey::new_unique()));
+        let with_new_bids = base(Some(Pubkey::new_unique()));
+        assert!(pool_cache_state_layout_significant_change(
+            &prev,
+            &with_new_bids
+        ));
+    }
+
+    #[test]
+    fn layout_change_meteora_dlmm_reserve_pubkeys_is_significant() {
+        use crate::execution::live_pool_cache::MeteoraState;
+
+        let mk = |reserve_x: Pubkey| {
+            CachedPoolState::Meteora(MeteoraState {
+                token_x_mint: Pubkey::new_unique(),
+                token_y_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                reserve_x,
+                reserve_y: Pubkey::new_unique(),
+                active_id: 1,
+                bin_step: 10,
+                reserve_x_balance: Some(1),
+                reserve_y_balance: Some(2),
+            })
+        };
+        let prev = mk(Pubkey::new_unique());
+        let next = mk(Pubkey::new_unique());
+        assert!(pool_cache_state_layout_significant_change(&prev, &next));
     }
 }

--- a/src/market_data/sidefx/worker.rs
+++ b/src/market_data/sidefx/worker.rs
@@ -2,8 +2,10 @@
 
 use super::handlers::md_sidefx_process_job;
 use super::host::SidefxWorkerHost;
+use crate::market_data::ingest::AccountUpdateClass;
 use crate::metrics::{
     inc_market_data_md_sidefx_enqueue_dropped_total,
+    inc_market_data_md_sidefx_enrich_enqueue_dropped_total,
     inc_market_data_md_sidefx_jobs_processed_total, set_market_data_md_sidefx_queue_depth,
 };
 use crate::solana::dex_parser::DexType;
@@ -14,6 +16,41 @@ use std::sync::mpsc as std_mpsc;
 use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::Instant;
+
+/// Sidefx job priority propagated from account ingest classification (Scope D).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SidefxUpdateClass {
+    ExecHot,
+    Enrich,
+}
+
+impl SidefxUpdateClass {
+    #[inline]
+    pub fn is_exec_hot(self) -> bool {
+        matches!(self, Self::ExecHot)
+    }
+
+    #[inline]
+    pub fn merge_priority(self, other: Self) -> Self {
+        if self.is_exec_hot() || other.is_exec_hot() {
+            Self::ExecHot
+        } else {
+            Self::Enrich
+        }
+    }
+}
+
+impl From<AccountUpdateClass> for SidefxUpdateClass {
+    fn from(class: AccountUpdateClass) -> Self {
+        match class {
+            AccountUpdateClass::ExecHot => Self::ExecHot,
+            AccountUpdateClass::Enrich | AccountUpdateClass::Drop => Self::Enrich,
+        }
+    }
+}
+
+/// Reserve headroom for EXEC_HOT when the sidefx queue is under pressure.
+const MARKET_DATA_MD_SIDEFX_ENRICH_HEADROOM: usize = 512;
 
 /// Phase-R-R4: bounded queue for deferred pool_mint_map / publish / live_pool_cache side-effects.
 pub const MARKET_DATA_MD_SIDEFX_QUEUE_CAP: usize = 4096;
@@ -93,15 +130,20 @@ pub enum MdSidefxCommand {
         balance: u64,
         slot: u64,
         grpc_recv_at: Instant,
+        update_class: SidefxUpdateClass,
     },
     /// DLMM bin-array LRU touch off account ingest (coalesced in md-sidefx burst).
-    TouchBinArrayTick { pda: Pubkey },
+    TouchBinArrayTick {
+        pda: Pubkey,
+        update_class: SidefxUpdateClass,
+    },
     /// P0: coalesced PoolStateUpdate for hot Meteora DLMM pools (bin/state signal, no vault delta).
     DlmmPoolStatePublishSignal {
         run_id: String,
         pool_address: Pubkey,
         slot: u64,
         grpc_recv_at: Instant,
+        update_class: SidefxUpdateClass,
     },
     /// PR237: trade-path vault/bin LRU touch via sidefx scratch (replaces md-state TouchPool).
     TradePoolLruTouch { pool: Pubkey },
@@ -113,6 +155,7 @@ pub enum MdSidefxCommand {
         account_data: Vec<u8>,
         slot: u64,
         grpc_recv_at: Instant,
+        update_class: SidefxUpdateClass,
     },
     /// Phase-R-R4b: mint decimals mirror into MASTER cache (TokenMintInfo path).
     LivePoolCacheMintDecimals { mint: Pubkey, decimals: u8 },
@@ -134,10 +177,12 @@ pub struct DlmmPoolStateSignal {
     pub grpc_recv_at: Instant,
 }
 
-/// Per-burst scratch: LRU touches coalesced before md-state enqueue.
+/// Per-burst scratch: LRU touches coalesced before md-state enqueue (class-split for Scope D).
 pub struct MdSidefxBurstScratch {
-    pending_vault_touches: HashSet<Pubkey>,
-    pending_bin_array_touches: HashSet<Pubkey>,
+    pending_exec_hot_vault_touches: HashSet<Pubkey>,
+    pending_enrich_vault_touches: HashSet<Pubkey>,
+    pending_exec_hot_bin_array_touches: HashSet<Pubkey>,
+    pending_enrich_bin_array_touches: HashSet<Pubkey>,
     pending_dlmm_pool_state_signals: HashMap<Pubkey, DlmmPoolStateSignal>,
 }
 
@@ -150,18 +195,30 @@ impl Default for MdSidefxBurstScratch {
 impl MdSidefxBurstScratch {
     pub fn new() -> Self {
         Self {
-            pending_vault_touches: HashSet::new(),
-            pending_bin_array_touches: HashSet::new(),
+            pending_exec_hot_vault_touches: HashSet::new(),
+            pending_enrich_vault_touches: HashSet::new(),
+            pending_exec_hot_bin_array_touches: HashSet::new(),
+            pending_enrich_bin_array_touches: HashSet::new(),
             pending_dlmm_pool_state_signals: HashMap::new(),
         }
     }
 
-    pub fn note_vault_touch(&mut self, vault: Pubkey) {
-        self.pending_vault_touches.insert(vault);
+    pub fn note_vault_touch(&mut self, vault: Pubkey, class: SidefxUpdateClass) {
+        if class.is_exec_hot() {
+            self.pending_exec_hot_vault_touches.insert(vault);
+            self.pending_enrich_vault_touches.remove(&vault);
+        } else {
+            self.pending_enrich_vault_touches.insert(vault);
+        }
     }
 
-    pub fn note_bin_array_touch(&mut self, pda: Pubkey) {
-        self.pending_bin_array_touches.insert(pda);
+    pub fn note_bin_array_touch(&mut self, pda: Pubkey, class: SidefxUpdateClass) {
+        if class.is_exec_hot() {
+            self.pending_exec_hot_bin_array_touches.insert(pda);
+            self.pending_enrich_bin_array_touches.remove(&pda);
+        } else {
+            self.pending_enrich_bin_array_touches.insert(pda);
+        }
     }
 
     pub fn note_dlmm_pool_state_signal(
@@ -191,17 +248,23 @@ impl MdSidefxBurstScratch {
     }
 
     pub fn pending_vault_touches_contains(&self, vault: &Pubkey) -> bool {
-        self.pending_vault_touches.contains(vault)
+        self.pending_exec_hot_vault_touches.contains(vault)
+            || self.pending_enrich_vault_touches.contains(vault)
     }
 
     pub fn lru_touches_empty(&self) -> bool {
-        self.pending_vault_touches.is_empty() && self.pending_bin_array_touches.is_empty()
+        self.pending_exec_hot_vault_touches.is_empty()
+            && self.pending_enrich_vault_touches.is_empty()
+            && self.pending_exec_hot_bin_array_touches.is_empty()
+            && self.pending_enrich_bin_array_touches.is_empty()
     }
 
-    pub fn drain_lru_touches(&mut self) -> (Vec<Pubkey>, Vec<Pubkey>) {
+    pub fn drain_lru_touches(&mut self) -> (Vec<Pubkey>, Vec<Pubkey>, Vec<Pubkey>, Vec<Pubkey>) {
         (
-            self.pending_vault_touches.drain().collect(),
-            self.pending_bin_array_touches.drain().collect(),
+            self.pending_exec_hot_vault_touches.drain().collect(),
+            self.pending_enrich_vault_touches.drain().collect(),
+            self.pending_exec_hot_bin_array_touches.drain().collect(),
+            self.pending_enrich_bin_array_touches.drain().collect(),
         )
     }
 }
@@ -212,6 +275,27 @@ pub fn md_sidefx_flush_pending_md_state_jobs(
 ) {
     super::handlers::md_sidefx_flush_pending_dlmm_pool_state_publishes(host, scratch);
     host.flush_lru_touches(scratch);
+}
+
+/// Read propagated ingest class from account-path sidefx commands (TX-path defaults to EXEC_HOT).
+pub fn md_sidefx_job_update_class(job: &MdSidefxCommand) -> SidefxUpdateClass {
+    match job {
+        MdSidefxCommand::LivePoolCacheAccountUpdate { update_class, .. } => *update_class,
+        MdSidefxCommand::VaultBalanceTick { update_class, .. } => *update_class,
+        MdSidefxCommand::TouchBinArrayTick { update_class, .. } => *update_class,
+        MdSidefxCommand::DlmmPoolStatePublishSignal { update_class, .. } => *update_class,
+        _ => SidefxUpdateClass::ExecHot,
+    }
+}
+
+fn md_sidefx_apply_update_class(job: &mut MdSidefxCommand, class: SidefxUpdateClass) {
+    match job {
+        MdSidefxCommand::LivePoolCacheAccountUpdate { update_class, .. } => *update_class = class,
+        MdSidefxCommand::VaultBalanceTick { update_class, .. } => *update_class = class,
+        MdSidefxCommand::TouchBinArrayTick { update_class, .. } => *update_class = class,
+        MdSidefxCommand::DlmmPoolStatePublishSignal { update_class, .. } => *update_class = class,
+        _ => {}
+    }
 }
 
 fn md_sidefx_dec_queue_depth(queue_depth: &AtomicUsize) {
@@ -230,15 +314,37 @@ fn md_sidefx_dec_queue_depth(queue_depth: &AtomicUsize) {
 }
 
 pub fn md_sidefx_try_enqueue(sender: &MdSidefxSender, job: MdSidefxCommand) {
-    if sender.queue_depth.load(Ordering::Relaxed) >= sender.queue_capacity {
-        inc_market_data_md_sidefx_enqueue_dropped_total();
+    let class = md_sidefx_job_update_class(&job);
+    md_sidefx_try_enqueue_classed(sender, class, job);
+}
+
+pub fn md_sidefx_try_enqueue_classed(
+    sender: &MdSidefxSender,
+    class: SidefxUpdateClass,
+    job: MdSidefxCommand,
+) {
+    let depth = sender.queue_depth.load(Ordering::Relaxed);
+    if depth >= sender.queue_capacity {
+        if class.is_exec_hot() {
+            inc_market_data_md_sidefx_enqueue_dropped_total();
+        } else {
+            inc_market_data_md_sidefx_enrich_enqueue_dropped_total();
+        }
+        return;
+    }
+    if !class.is_exec_hot()
+        && depth + MARKET_DATA_MD_SIDEFX_ENRICH_HEADROOM >= sender.queue_capacity
+    {
+        inc_market_data_md_sidefx_enrich_enqueue_dropped_total();
         return;
     }
     if sender.tx.try_send(job).is_ok() {
-        let depth = sender.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
-        set_market_data_md_sidefx_queue_depth(depth);
-    } else {
+        let new_depth = sender.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
+        set_market_data_md_sidefx_queue_depth(new_depth);
+    } else if class.is_exec_hot() {
         inc_market_data_md_sidefx_enqueue_dropped_total();
+    } else {
+        inc_market_data_md_sidefx_enrich_enqueue_dropped_total();
     }
 }
 
@@ -249,7 +355,7 @@ pub fn md_sidefx_coalesce_key(job: &MdSidefxCommand) -> Option<Pubkey> {
         MdSidefxCommand::PumpAmmCreatePoolObserved { pool_address, .. } => Some(*pool_address),
         MdSidefxCommand::LivePoolCacheAccountUpdate { pool_pubkey, .. } => Some(*pool_pubkey),
         MdSidefxCommand::VaultBalanceTick { vault_pubkey, .. } => Some(*vault_pubkey),
-        MdSidefxCommand::TouchBinArrayTick { pda } => Some(*pda),
+        MdSidefxCommand::TouchBinArrayTick { pda, .. } => Some(*pda),
         MdSidefxCommand::DlmmPoolStatePublishSignal { pool_address, .. } => Some(*pool_address),
         MdSidefxCommand::TradePoolLruTouch { pool } => Some(*pool),
         _ => None,
@@ -262,7 +368,10 @@ pub fn md_sidefx_coalesce_burst(jobs: Vec<MdSidefxCommand>) -> Vec<MdSidefxComma
     for job in jobs {
         if let Some(pool) = md_sidefx_coalesce_key(&job) {
             if let Some(&idx) = coalesced.get(&pool) {
+                let merged_class = md_sidefx_job_update_class(&out[idx])
+                    .merge_priority(md_sidefx_job_update_class(&job));
                 out[idx] = job;
+                md_sidefx_apply_update_class(&mut out[idx], merged_class);
             } else {
                 coalesced.insert(pool, out.len());
                 out.push(job);
@@ -272,6 +381,21 @@ pub fn md_sidefx_coalesce_burst(jobs: Vec<MdSidefxCommand>) -> Vec<MdSidefxComma
         }
     }
     out
+}
+
+fn md_sidefx_partition_by_class(
+    jobs: Vec<MdSidefxCommand>,
+) -> (Vec<MdSidefxCommand>, Vec<MdSidefxCommand>) {
+    let mut exec_hot = Vec::new();
+    let mut enrich = Vec::new();
+    for job in jobs {
+        if md_sidefx_job_update_class(&job).is_exec_hot() {
+            exec_hot.push(job);
+        } else {
+            enrich.push(job);
+        }
+    }
+    (exec_hot, enrich)
 }
 
 fn md_sidefx_worker_loop(
@@ -298,7 +422,12 @@ fn md_sidefx_worker_loop(
             }
         }
         let mut scratch = MdSidefxBurstScratch::new();
-        for job in md_sidefx_coalesce_burst(jobs) {
+        let coalesced = md_sidefx_coalesce_burst(jobs);
+        let (exec_hot_jobs, enrich_jobs) = md_sidefx_partition_by_class(coalesced);
+        for job in exec_hot_jobs {
+            md_sidefx_process_job(worker.as_ref(), &job, &mut scratch);
+        }
+        for job in enrich_jobs {
             md_sidefx_process_job(worker.as_ref(), &job, &mut scratch);
         }
         md_sidefx_flush_pending_md_state_jobs(worker.as_ref(), &mut scratch);
@@ -320,5 +449,91 @@ pub fn spawn_md_sidefx_worker(
         tx,
         queue_depth,
         queue_capacity,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RAYDIUM_CPMM_OWNER: Pubkey =
+        solana_sdk::pubkey!("CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C");
+
+    #[test]
+    fn md_sidefx_coalesce_preserves_exec_hot_class_over_enrich() {
+        let pool = Pubkey::new_unique();
+        let exec_hot = MdSidefxCommand::LivePoolCacheAccountUpdate {
+            run_id: "r".into(),
+            pool_pubkey: pool,
+            owner: RAYDIUM_CPMM_OWNER,
+            account_data: vec![1],
+            slot: 1,
+            grpc_recv_at: Instant::now(),
+            update_class: SidefxUpdateClass::ExecHot,
+        };
+        let enrich = MdSidefxCommand::LivePoolCacheAccountUpdate {
+            run_id: "r".into(),
+            pool_pubkey: pool,
+            owner: RAYDIUM_CPMM_OWNER,
+            account_data: vec![2],
+            slot: 2,
+            grpc_recv_at: Instant::now(),
+            update_class: SidefxUpdateClass::Enrich,
+        };
+        let out = md_sidefx_coalesce_burst(vec![enrich, exec_hot]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            md_sidefx_job_update_class(&out[0]),
+            SidefxUpdateClass::ExecHot
+        );
+        let MdSidefxCommand::LivePoolCacheAccountUpdate { account_data, .. } = &out[0] else {
+            panic!("expected LivePoolCacheAccountUpdate");
+        };
+        assert_eq!(account_data, &vec![1], "latest-wins data from last job in burst");
+    }
+
+    #[test]
+    fn md_sidefx_partition_processes_exec_hot_before_enrich() {
+        let pool_hot = Pubkey::new_unique();
+        let pool_enrich = Pubkey::new_unique();
+        let jobs = vec![
+            MdSidefxCommand::LivePoolCacheAccountUpdate {
+                run_id: "r".into(),
+                pool_pubkey: pool_enrich,
+                owner: RAYDIUM_CPMM_OWNER,
+                account_data: vec![],
+                slot: 1,
+                grpc_recv_at: Instant::now(),
+                update_class: SidefxUpdateClass::Enrich,
+            },
+            MdSidefxCommand::LivePoolCacheAccountUpdate {
+                run_id: "r".into(),
+                pool_pubkey: pool_hot,
+                owner: RAYDIUM_CPMM_OWNER,
+                account_data: vec![],
+                slot: 1,
+                grpc_recv_at: Instant::now(),
+                update_class: SidefxUpdateClass::ExecHot,
+            },
+        ];
+        let coalesced = md_sidefx_coalesce_burst(jobs);
+        let (exec_hot, enrich) = md_sidefx_partition_by_class(coalesced);
+        assert_eq!(exec_hot.len(), 1);
+        assert_eq!(enrich.len(), 1);
+        assert!(matches!(
+            exec_hot[0],
+            MdSidefxCommand::LivePoolCacheAccountUpdate { .. }
+        ));
+    }
+
+    #[test]
+    fn md_sidefx_burst_scratch_exec_hot_wins_vault_touch() {
+        let vault = Pubkey::new_unique();
+        let mut scratch = MdSidefxBurstScratch::new();
+        scratch.note_vault_touch(vault, SidefxUpdateClass::Enrich);
+        scratch.note_vault_touch(vault, SidefxUpdateClass::ExecHot);
+        let (hot_vaults, enrich_vaults, _, _) = scratch.drain_lru_touches();
+        assert_eq!(hot_vaults, vec![vault]);
+        assert!(enrich_vaults.is_empty());
     }
 }

--- a/src/market_data/sidefx/worker.rs
+++ b/src/market_data/sidefx/worker.rs
@@ -489,7 +489,11 @@ mod tests {
         let MdSidefxCommand::LivePoolCacheAccountUpdate { account_data, .. } = &out[0] else {
             panic!("expected LivePoolCacheAccountUpdate");
         };
-        assert_eq!(account_data, &vec![1], "latest-wins data from last job in burst");
+        assert_eq!(
+            account_data,
+            &vec![1],
+            "latest-wins data from last job in burst"
+        );
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1097,6 +1097,12 @@ pub static MARKET_DATA_MD_SIDEFX_QUEUE_DEPTH: Lazy<AtomicU64> = Lazy::new(|| Ato
 /// Phase-R-R4: `md-sidefx` queue full (`try_send` drop).
 pub static MARKET_DATA_MD_SIDEFX_ENQUEUE_DROPPED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// Scope D: ENRICH sidefx enqueue dropped (cap / headroom).
+pub static MARKET_DATA_MD_SIDEFX_ENRICH_ENQUEUE_DROPPED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Scope D: ENRICH JetStream publish skipped (redundant under vault feed / unchanged layout).
+pub static MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// Phase-R-R4: jobs processed by the `md-sidefx` worker.
 pub static MARKET_DATA_MD_SIDEFX_JOBS_PROCESSED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -1482,6 +1488,16 @@ pub fn set_market_data_md_sidefx_queue_depth(depth: usize) {
 #[inline]
 pub fn inc_market_data_md_sidefx_enqueue_dropped_total() {
     MARKET_DATA_MD_SIDEFX_ENQUEUE_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_md_sidefx_enrich_enqueue_dropped_total() {
+    MARKET_DATA_MD_SIDEFX_ENRICH_ENQUEUE_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_md_sidefx_enrich_publish_skipped_total() {
+    MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -6338,6 +6354,14 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_md_sidefx_enqueue_dropped_total",
         MARKET_DATA_MD_SIDEFX_ENQUEUE_DROPPED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_md_sidefx_enrich_enqueue_dropped_total",
+        MARKET_DATA_MD_SIDEFX_ENRICH_ENQUEUE_DROPPED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_md_sidefx_enrich_publish_skipped_total",
+        MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_md_sidefx_jobs_processed_total",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Scope D** from `plan_account_update_realtime_backlog_fix_20260716.md` (requires Scopes A–C on `architecture-rebuild`).

Account ingest already classifies updates (`ExecHot` / `Enrich`) and coalesces ENRICH worker enqueue. This PR extends that discipline into **md-sidefx** and downstream publish paths.

### Changes

1. **Class propagation** — `AccountUpdateClass` flows from account workers → `handle_geyser_account_update` → `SidefxUpdateClass` on `LivePoolCacheAccountUpdate`, `VaultBalanceTick`, `TouchBinArrayTick`, `DlmmPoolStatePublishSignal`.

2. **EXEC_HOT (I-MD-4)** — Hot pools (Momentum **or** Arb pins / vault / bin dispatch) always upsert MASTER cache and publish JetStream `PoolCacheUpdate` on account parse. No coalesce skip on EXEC_HOT.

3. **ENRICH throttle** — Sidefx burst coalesce is class-aware (ExecHot wins over Enrich on same pubkey). Worker processes EXEC_HOT jobs before ENRICH. ENRICH `new_pool_discovered` skipped when vault Geyser feed is live and reserves/layout unchanged; ENRICH vault ticks skip JetStream/Core publish (cache still updated). Cap-aware ENRICH enqueue drops with headroom for EXEC_HOT.

4. **md-state** — LRU vault/bin touches split by class; EXEC_HOT batch flushed before ENRICH batch (no new RegisterVault/Reconcile, no RPC).

5. **Metrics** — `market_data_md_sidefx_enrich_enqueue_dropped_total`, `market_data_md_sidefx_enrich_publish_skipped_total`.

### Dual-consumer

Arb-pinned pools classify as `ExecHot` (same as Momentum hot pools). No momentum-only publish shortcut.

### STOP-CHECK

- No Hot-Path RPC added
- No cap >25k changes
- RegisterVault/Coverage/Reconcile not reintroduced on account hot path
- Simulation gate untouched

### Verification

```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
cargo test --bin market-data scope_d_
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dca924b1-0b88-4df9-a1e7-ca1f0196cf1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dca924b1-0b88-4df9-a1e7-ca1f0196cf1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

