### PR TITLE
config: raise max_tracked_accounts default to 500_000

### DIFF
--- a/docs/CONFIG_SCHEMA.md
+++ b/docs/CONFIG_SCHEMA.md
@@ -285,13 +285,14 @@ Loaded from root TOML section `[market_data_geyser]` in `config.toml` (not the J
 
 | Key | Type | Default | Range | Description |
 |-----|------|---------|-------|-------------|
-| `max_tracked_accounts` | usize | 25000 | 1000-500000 | Max combined explicit Yellowstone accounts (mints + vaults + bin arrays + wallet list). LRU evicts unpinned rows when exceeded. |
+| `max_tracked_accounts` | usize | 500000 | 1000-500000 | Max combined explicit Yellowstone accounts (mints + vaults + bin arrays + wallet list). LRU evicts unpinned rows when exceeded. |
 | `geyser_full_reconnect_threshold` | usize | 10000 | 1000-500000 | When combined explicit accounts exceed this, `market-data` forces a full Geyser gRPC reconnect on subscription changes instead of many in-place subscribe updates. |
 
 ### Validation Rules
 - Boolean values must be `true` or `false`
 - `max_events_per_sec` must be between 1 and 1,000,000
 - `max_tracked_accounts` and `geyser_full_reconnect_threshold` must be between 1000 and 500000 (when set via control-plane JSON; TOML should use same bounds)
+- **Ops note (2026-07):** Prod default `500000` leaves ~300k headroom below historical self-hosted Yellowstone crash levels (~800k+ explicit accounts). Self-hosted Yellowstone has no `filters.account_max` plugin cap; admission is enforced in `market-data` only (I-MD-7).
 
 ---
 

--- a/my_config.server.toml
+++ b/my_config.server.toml
@@ -41,7 +41,7 @@ ws_headers = { "Sec-WebSocket-Protocol" = "jsonrpc" }
 
 # market-data: Yellowstone explicit account subscription caps (PR-B)
 [market_data_geyser]
-max_tracked_accounts = 25000
+max_tracked_accounts = 500000
 geyser_full_reconnect_threshold = 10000
 
 # --- Markets (sum must be 100) ---

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -15947,7 +15947,7 @@ mod pr_b_geyser_tracking_tests {
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
-        let mut admission = FixedCapAdmission::new(25_000);
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
         let before = ctx.snapshot_explicit_subscription_pubkeys();
         use ironcrab::metrics::MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL;
         let skip0 = MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL.load(Ordering::Relaxed);
@@ -15973,7 +15973,7 @@ mod pr_b_geyser_tracking_tests {
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
         let mint = Pubkey::new_unique();
         ctx.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::Wallet));
-        let mut admission = FixedCapAdmission::new(25_000);
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
         ironcrab::market_data::track::converge_admission_from_ctx(ctx.as_ref(), &mut admission);
         assert_eq!(admission.len(), 1);
         assert_eq!(
@@ -16192,7 +16192,7 @@ mod pr_b_geyser_tracking_tests {
             MARKET_DATA_TRACK_WORKER_COALESCE_MS + 200,
         ));
 
-        let mut admission = FixedCapAdmission::new(25_000);
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
         let keys = ctx.snapshot_explicit_subscription_pubkeys();
         use ironcrab::metrics::MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL;
         let skip0 = MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL.load(Ordering::Relaxed);
@@ -16521,7 +16521,7 @@ mod pr_b_geyser_tracking_tests {
         let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
 
         let mint = Pubkey::new_unique();
-        let mut admission = FixedCapAdmission::new(25_000);
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
         assert!(ctx.apply_wallet_pin(&mut admission, mint));
         assert!(ctx.tracked_mints.read().contains_key(&mint));
         assert!(admission.contains(&mint));

--- a/src/config.rs
+++ b/src/config.rs
@@ -225,7 +225,7 @@ pub struct MarketDataGeyserCfg {
 }
 
 fn default_max_tracked_accounts() -> usize {
-    25_000
+    500_000
 }
 
 fn default_geyser_full_reconnect_threshold() -> usize {

--- a/src/market_data/track/admission_wiring.rs
+++ b/src/market_data/track/admission_wiring.rs
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     fn converge_wallet_mint_row() {
-        let mut admission = FixedCapAdmission::new(25_000);
+        let mut admission = FixedCapAdmission::new(500_000);
         let mint = Pubkey::new_unique();
         let owner = explicit_owner_from_row(ConsumerId::Wallet, None, mint);
         assert_eq!(

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -790,7 +790,7 @@ mod tests {
         }
 
         fn max_tracked_accounts(&self) -> usize {
-            25_000
+            500_000
         }
 
         fn apply_momentum_active_pools_update(
@@ -980,8 +980,8 @@ mod tests {
             _new_cap: usize,
         ) -> CapShrinkResult {
             CapShrinkResult::NoOpAlreadyWithinCap {
-                old_cap: 25_000,
-                new_cap: 25_000,
+                old_cap: 500_000,
+                new_cap: 500_000,
             }
         }
 
@@ -1002,7 +1002,7 @@ mod tests {
             let mut store = protocol.lock().expect("lock");
             store.wrap_command(TrackWorkerCommand::ApplyWalletPin { mint })
         };
-        let mut admission = FixedCapAdmission::new(25_000);
+        let mut admission = FixedCapAdmission::new(500_000);
         let mut restore_barrier_pending = false;
 
         track_worker_apply_protocol_command(
@@ -1059,7 +1059,7 @@ mod tests {
             })
         };
         assert_eq!(cmd.stream, TrackCommandStream::Wallet);
-        let mut admission = FixedCapAdmission::new(25_000);
+        let mut admission = FixedCapAdmission::new(500_000);
         let mut restore_barrier_pending = false;
 
         track_worker_apply_protocol_command(
@@ -1098,7 +1098,7 @@ mod tests {
             }
 
             fn max_tracked_accounts(&self) -> usize {
-                25_000
+                500_000
             }
 
             fn apply_momentum_active_pools_update(
@@ -1282,8 +1282,8 @@ mod tests {
                 _new_cap: usize,
             ) -> CapShrinkResult {
                 CapShrinkResult::NoOpAlreadyWithinCap {
-                    old_cap: 25_000,
-                    new_cap: 25_000,
+                    old_cap: 500_000,
+                    new_cap: 500_000,
                 }
             }
 
@@ -1298,7 +1298,7 @@ mod tests {
         let ctx = Arc::new(TrackerIdempotentCtx);
         let protocol = Arc::new(Mutex::new(BoundedProtocolStore::default_caps()));
         let mint = Pubkey::new_unique();
-        let mut admission = FixedCapAdmission::new(25_000);
+        let mut admission = FixedCapAdmission::new(500_000);
         let mut restore_barrier_pending = false;
 
         for _ in 0..2 {
@@ -1344,7 +1344,7 @@ mod tests {
         }
 
         fn max_tracked_accounts(&self) -> usize {
-            25_000
+            500_000
         }
 
         fn apply_momentum_active_pools_update(
@@ -1529,8 +1529,8 @@ mod tests {
             _new_cap: usize,
         ) -> CapShrinkResult {
             CapShrinkResult::NoOpAlreadyWithinCap {
-                old_cap: 25_000,
-                new_cap: 25_000,
+                old_cap: 500_000,
+                new_cap: 500_000,
             }
         }
 
@@ -1547,7 +1547,7 @@ mod tests {
         let ctx = Arc::new(WithdrawSupersedesTrackerTestCtx::new());
         let protocol = Arc::new(Mutex::new(BoundedProtocolStore::default_caps()));
         let mint = Pubkey::new_unique();
-        let mut admission = FixedCapAdmission::new(25_000);
+        let mut admission = FixedCapAdmission::new(500_000);
         let mut restore_barrier_pending = false;
 
         let tracker_cmd = {
@@ -1605,7 +1605,7 @@ mod tests {
                 0
             }
             fn max_tracked_accounts(&self) -> usize {
-                25_000
+                500_000
             }
             fn apply_momentum_active_pools_update(
                 &self,
@@ -1752,8 +1752,8 @@ mod tests {
                 _new_cap: usize,
             ) -> super::super::explicit_admission::CapShrinkResult {
                 super::super::explicit_admission::CapShrinkResult::NoOpAlreadyWithinCap {
-                    old_cap: 25_000,
-                    new_cap: 25_000,
+                    old_cap: 500_000,
+                    new_cap: 500_000,
                 }
             }
             fn retry_deferred_hot_pool_reserve_registrations(
@@ -1769,7 +1769,7 @@ mod tests {
             retry_calls: AtomicUsize::new(0),
             last_synced: parking_lot::RwLock::new(HashSet::new()),
         });
-        let mut admission = FixedCapAdmission::new(25_000);
+        let mut admission = FixedCapAdmission::new(500_000);
         let mut active = Vec::new();
         for i in 0..48 {
             active.push(MomentumActivePoolEntry {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Raises the explicit Geyser account subscription cap from **25_000** to **500_000** per user approval after prod soak (Scopes A–D).

Prod showed the explicit set pinned at ~24 992 with track-worker thrash (`pending_evicted` 500k+). Self-hosted Yellowstone has no `filters.account_max` plugin limit; historical crashes occurred around **800k+** accounts, so **500k** leaves ~300k margin.

## Changes

- `default_max_tracked_accounts()` → `500_000` in `src/config.rs`
- `my_config.server.toml` → `max_tracked_accounts = 500000`
- `docs/CONFIG_SCHEMA.md` default + short ops note (range unchanged: 1000–500000)
- Test fixtures mirroring config default updated (`worker.rs`, `admission_wiring.rs`, `market_data.rs`)

## Not in scope

- No momentum pool budget / `prune_stale_discovery` changes
- No track-worker queue redesign
- No Yellowstone plugin config changes

## Invariants

- **I-MD-7**: Admission still enforced before mutation; cap ≤ `max_tracked_accounts`
- **I-7 / I-4**: No RPC or Hot Path changes
- `tracked_cuckoo_max_capacity` already follows `max_tracked_accounts` at runtime

## Verification

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (all passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58d5a706-275a-46cc-8d15-81724a33449c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58d5a706-275a-46cc-8d15-81724a33449c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

