### PR TITLE
fix(market-data): deadline-respecting Geyser explicit flush on track-worker

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3364,7 +3364,11 @@ impl MarketDataContext {
             }
 
             let batch_len = resume.pending.len().min(GEYSER_PRUNE_SLICE_MAX_REMOVALS);
-            let batch: Vec<Pubkey> = resume.pending.drain(..batch_len).collect();
+            let batch: Vec<Pubkey> = resume
+                .pending
+                .drain(..batch_len)
+                .filter(|pk| !admitted.contains(pk))
+                .collect();
             let map = resume.map;
             drop(resume);
             self.apply_prune_batch(map, &batch);

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3359,6 +3359,7 @@ impl MarketDataContext {
             let map = resume.map;
             drop(resume);
             self.apply_prune_batch(map, &batch);
+            self.refresh_tracked_membership_snapshot();
             resume = self.geyser_prune_resume.lock();
 
             if Instant::now() >= deadline
@@ -16204,6 +16205,112 @@ mod pr_b_geyser_tracking_tests {
             "expired deadline must return incomplete for ContinueGeyserEvict"
         );
         assert_eq!(ctx.tracked_vaults.read().len(), 2_000);
+    }
+
+    /// Bugbot PR307: budgeted prune must refresh membership snapshot after each batch,
+    /// including when sync returns incomplete (ContinueGeyserEvict).
+    #[test]
+    fn geyser_prune_incomplete_sync_refreshes_membership_snapshot() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        {
+            let mut vaults = ctx.tracked_vaults.write();
+            for _ in 0..1_024 {
+                let pk = Pubkey::new_unique();
+                vaults.insert(
+                    pk,
+                    VaultInfo {
+                        pool_address: pool,
+                        dex: "test".into(),
+                        base_mint: Pubkey::new_unique(),
+                        quote_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                        is_base_vault: true,
+                        last_balance: std::sync::atomic::AtomicU64::new(0),
+                        last_used_at: Instant::now(),
+                        pinned: false,
+                        pin: None,
+                        active_id: None,
+                        bin_step: None,
+                        sibling_vault: None,
+                    },
+                );
+            }
+        }
+        ctx.refresh_tracked_membership_snapshot();
+        assert_eq!(ctx.tracked_membership.load().vaults.len(), 1_024);
+
+        let admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        let deadline = Instant::now() + Duration::from_micros(500);
+        let complete = TrackWorkerContext::sync_geyser_tracked_accounts_batched_flush_with_deadline(
+            ctx.as_ref(),
+            deadline,
+            &admission,
+        );
+        let maps_len = ctx.tracked_vaults.read().len();
+        let snapshot_len = ctx.tracked_membership.load().vaults.len();
+        assert!(
+            !complete && maps_len < 1_024,
+            "expected partial prune with incomplete sync (complete={complete}, maps_len={maps_len})"
+        );
+        assert_eq!(
+            snapshot_len, maps_len,
+            "membership snapshot must track tracked_vaults after partial prune batch"
+        );
+        let maps_keys: HashSet<Pubkey> = ctx.tracked_vaults.read().keys().copied().collect();
+        assert_eq!(
+            ctx.tracked_membership.load().vaults,
+            maps_keys,
+            "membership snapshot keys must equal tracked_vaults after incomplete prune"
+        );
+    }
+
+    #[test]
+    fn geyser_prune_complete_sync_refreshes_membership_snapshot_without_extra_call() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        {
+            let mut vaults = ctx.tracked_vaults.write();
+            for _ in 0..600 {
+                let stale = Pubkey::new_unique();
+                vaults.insert(
+                    stale,
+                    VaultInfo {
+                        pool_address: pool,
+                        dex: "test".into(),
+                        base_mint: Pubkey::new_unique(),
+                        quote_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                        is_base_vault: true,
+                        last_balance: std::sync::atomic::AtomicU64::new(0),
+                        last_used_at: Instant::now(),
+                        pinned: false,
+                        pin: None,
+                        active_id: None,
+                        bin_step: None,
+                        sibling_vault: None,
+                    },
+                );
+            }
+        }
+        ctx.refresh_tracked_membership_snapshot();
+        assert_eq!(ctx.tracked_membership.load().vaults.len(), 600);
+
+        let admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        let deadline = Instant::now() + Duration::from_secs(5);
+        assert!(
+            TrackWorkerContext::sync_geyser_tracked_accounts_batched_flush_with_deadline(
+                ctx.as_ref(),
+                deadline,
+                &admission,
+            )
+        );
+        assert!(ctx.tracked_vaults.read().is_empty());
+        assert!(ctx.tracked_membership.load().vaults.is_empty());
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2121,6 +2121,15 @@ impl TrackWorkerContext for MarketDataContext {
         MarketDataContext::publish_admitted_explicit_physical(self, admission);
     }
 
+    fn tracked_maps_need_prune(&self, admission: &FixedCapAdmission) -> bool {
+        let admitted: HashSet<Pubkey> = admission.snapshot_pubkeys().into_iter().collect();
+        MarketDataContext::tracked_maps_need_prune(self, &admitted)
+    }
+
+    fn publish_admitted_explicit_physical_force(&self, admission: &FixedCapAdmission) {
+        MarketDataContext::publish_admitted_explicit_physical_force(self, admission);
+    }
+
     fn last_synced_explicit_pubkeys_write(
         &self,
     ) -> parking_lot::RwLockWriteGuard<'_, HashSet<Pubkey>> {
@@ -3388,6 +3397,16 @@ impl MarketDataContext {
         if !self.explicit_physical_publish_needed(admission) {
             return;
         }
+        self.send_admitted_explicit_physical(admission);
+    }
+
+    fn publish_admitted_explicit_physical_force(&self, admission: &FixedCapAdmission) {
+        self.send_admitted_explicit_physical(admission);
+        *self.last_synced_explicit_pubkeys.write() =
+            admission.snapshot_pubkeys().into_iter().collect();
+    }
+
+    fn send_admitted_explicit_physical(&self, admission: &FixedCapAdmission) {
         if self.admission_exceeds_configured_cap(admission) {
             self.mark_explicit_admission_config_cap_desync(
                 admission,
@@ -11829,7 +11848,7 @@ mod pr_b_geyser_tracking_tests {
     const PUMPFUN_AMM_PROGRAM_OWNER: Pubkey =
         solana_sdk::pubkey!("pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA");
     use ironcrab::market_data::track::{
-        converge_admission_from_ctx, converge_admission_from_groups,
+        admitted_pubkey_set, converge_admission_from_ctx, converge_admission_from_groups,
         merge_momentum_active_pools_updates, spawn_inline_track_worker_sender,
         spawn_noop_track_worker_sender, track_worker_execute_coalesced_push,
         track_worker_try_enqueue, FixedCapAdmission, TrackWorkerCommand, TrackWorkerContext,
@@ -16162,6 +16181,127 @@ mod pr_b_geyser_tracking_tests {
             mints_after.is_empty(),
             "no-delta skip must not republish explicit watch channels"
         );
+    }
+
+    #[test]
+    fn tracked_maps_need_prune_detects_extraneous_tracked_vault() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let stale = Pubkey::new_unique();
+        ctx.tracked_vaults.write().insert(
+            stale,
+            VaultInfo {
+                pool_address: pool,
+                dex: "test".into(),
+                base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                is_base_vault: true,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: Instant::now(),
+                pinned: false,
+                pin: None,
+                active_id: None,
+                bin_step: None,
+                sibling_vault: None,
+            },
+        );
+        let admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        assert!(TrackWorkerContext::tracked_maps_need_prune(
+            ctx.as_ref(),
+            &admission
+        ));
+    }
+
+    #[test]
+    fn geyser_push_no_delta_with_extraneous_tracked_keys_runs_prune_not_skip() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let mut admission = FixedCapAdmission::new(2);
+        {
+            let mut tracked = ctx.tracked_vaults.write();
+            for _ in 0..3 {
+                let pool = Pubkey::new_unique();
+                let vault = Pubkey::new_unique();
+                tracked.insert(
+                    vault,
+                    VaultInfo {
+                        pool_address: pool,
+                        dex: "test".into(),
+                        base_mint: Pubkey::new_unique(),
+                        quote_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                        is_base_vault: true,
+                        last_balance: std::sync::atomic::AtomicU64::new(0),
+                        last_used_at: Instant::now(),
+                        pinned: false,
+                        pin: None,
+                        active_id: None,
+                        bin_step: None,
+                        sibling_vault: None,
+                    },
+                );
+            }
+        }
+        let converge = converge_admission_from_ctx(ctx.as_ref(), &mut admission);
+        assert!(
+            matches!(converge, AdmissionConvergeResult::Converged),
+            "cap=2 must converge with eviction for 3 tracked vaults"
+        );
+        assert_eq!(admission.len(), 2);
+        assert_eq!(ctx.tracked_vaults.read().len(), 3);
+        assert!(TrackWorkerContext::tracked_maps_need_prune(
+            ctx.as_ref(),
+            &admission
+        ));
+        let before = admitted_pubkey_set(&admission);
+        use ironcrab::metrics::MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL;
+        let skip0 = MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL.load(Ordering::Relaxed);
+        assert!(track_worker_execute_coalesced_push(
+            &ctx,
+            &mut admission,
+            before,
+            false,
+            false,
+            false,
+        ));
+        assert_eq!(
+            MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL.load(Ordering::Relaxed),
+            skip0,
+            "no-delta with extraneous tracked keys must not increment skipped_no_delta"
+        );
+        assert_eq!(ctx.tracked_vaults.read().len(), 2);
+    }
+
+    #[test]
+    fn geyser_push_restore_barrier_no_delta_force_publishes_watch_channels() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let (ctx, tracked_mints_rx, _, _, _) =
+            minimal_market_data_context_and_merge_receivers_for_pr161(jsonl);
+        let mint = Pubkey::new_unique();
+        ctx.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::Wallet));
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        converge_admission_from_ctx(ctx.as_ref(), &mut admission);
+        let admitted: HashSet<Pubkey> = admission.snapshot_pubkeys().into_iter().collect();
+        *ctx.last_synced_explicit_pubkeys.write() = admitted.clone();
+        assert!(tracked_mints_rx.borrow().is_empty());
+        assert!(track_worker_execute_coalesced_push(
+            &ctx,
+            &mut admission,
+            admitted.clone(),
+            false,
+            false,
+            true,
+        ));
+        let published: HashSet<Pubkey> = tracked_mints_rx.borrow().iter().copied().collect();
+        assert_eq!(published, admitted);
+        assert!(ctx.geyser_connect_barrier.is_ready());
+        drop(tracked_mints_rx);
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3331,21 +3331,24 @@ impl MarketDataContext {
         deadline: Instant,
         admission: &FixedCapAdmission,
     ) -> bool {
-        let admitted: HashSet<Pubkey> = admission.snapshot_pubkeys().into_iter().collect();
         let mut resume = self.geyser_prune_resume.lock();
-
-        if !resume.active {
-            if !self.tracked_maps_need_prune(&admitted) {
-                return true;
-            }
-            resume.active = true;
-            resume.map = GeyserPruneMap::Mints;
-            resume.pending.clear();
-        }
 
         loop {
             if Instant::now() >= deadline {
                 return false;
+            }
+
+            let admitted: HashSet<Pubkey> = admission.snapshot_pubkeys().into_iter().collect();
+
+            if !resume.active {
+                if !self.tracked_maps_need_prune(&admitted) {
+                    return true;
+                }
+                resume.active = true;
+                resume.map = GeyserPruneMap::Mints;
+                resume.pending.clear();
+            } else {
+                resume.pending.retain(|pk| !admitted.contains(pk));
             }
 
             if resume.pending.is_empty() {
@@ -3371,8 +3374,10 @@ impl MarketDataContext {
                 .collect();
             let map = resume.map;
             drop(resume);
-            self.apply_prune_batch(map, &batch);
-            self.refresh_tracked_membership_snapshot();
+            if !batch.is_empty() {
+                self.apply_prune_batch(map, &batch);
+                self.refresh_tracked_membership_snapshot();
+            }
             resume = self.geyser_prune_resume.lock();
 
             if Instant::now() >= deadline
@@ -16408,6 +16413,51 @@ mod pr_b_geyser_tracking_tests {
             ctx.tracked_membership.load().vaults,
             maps_keys,
             "membership snapshot keys must equal tracked_vaults after incomplete prune"
+        );
+    }
+
+    #[test]
+    fn geyser_prune_resume_pending_does_not_remove_re_admitted_key() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let vault = Pubkey::new_unique();
+        ctx.tracked_vaults.write().insert(
+            vault,
+            VaultInfo {
+                pool_address: pool,
+                dex: "test".into(),
+                base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                is_base_vault: true,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: Instant::now(),
+                pinned: false,
+                pin: None,
+                active_id: None,
+                bin_step: None,
+                sibling_vault: None,
+            },
+        );
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        converge_admission_from_ctx(ctx.as_ref(), &mut admission);
+        assert!(admission.snapshot_pubkeys().contains(&vault));
+        *ctx.geyser_prune_resume.lock() = GeyserPruneResume {
+            active: true,
+            map: GeyserPruneMap::Vaults,
+            pending: vec![vault],
+        };
+        let deadline = Instant::now() + Duration::from_secs(5);
+        assert!(TrackWorkerContext::continue_geyser_evict_with_deadline(
+            ctx.as_ref(),
+            deadline,
+            &admission,
+        ));
+        assert!(
+            ctx.tracked_vaults.read().contains_key(&vault),
+            "re-admitted vault queued for prune must not be removed on continue slice"
         );
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1193,6 +1193,44 @@ struct MarketDataContext {
     /// PR3: explicit admission readiness (wallet-over-cap fail-closed).
     geyser_explicit_ready: AtomicBool,
     geyser_explicit_config_error: parking_lot::RwLock<Option<String>>,
+    /// Resume cursor for budgeted prune across `ContinueGeyserEvict` slices.
+    geyser_prune_resume: parking_lot::Mutex<GeyserPruneResume>,
+}
+
+/// Max removals per budget slice when pruning tracked maps to admitted set.
+const GEYSER_PRUNE_SLICE_MAX_REMOVALS: usize = 512;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GeyserPruneMap {
+    Mints,
+    Vaults,
+    Bins,
+    Wallets,
+    Done,
+}
+
+impl GeyserPruneMap {
+    fn next(self) -> Self {
+        match self {
+            Self::Mints => Self::Vaults,
+            Self::Vaults => Self::Bins,
+            Self::Bins => Self::Wallets,
+            Self::Wallets | Self::Done => Self::Done,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct GeyserPruneResume {
+    active: bool,
+    map: GeyserPruneMap,
+    pending: Vec<Pubkey>,
+}
+
+impl Default for GeyserPruneMap {
+    fn default() -> Self {
+        Self::Mints
+    }
 }
 
 #[derive(Debug, Default)]
@@ -2038,7 +2076,7 @@ impl TrackWorkerContext for MarketDataContext {
         deadline: Instant,
         admission: &FixedCapAdmission,
     ) -> bool {
-        let _ = deadline;
+        self.clear_geyser_prune_resume();
         self.sync_geyser_tracked_accounts_from_admission_with_deadline(deadline, admission)
     }
 
@@ -3171,42 +3209,184 @@ impl MarketDataContext {
         self.geyser_explicit_ready.load(Ordering::Relaxed)
     }
 
-    fn prune_tracked_maps_to_admitted(&self, admission: &FixedCapAdmission) {
-        let admitted: HashSet<Pubkey> = admission.snapshot_pubkeys().into_iter().collect();
+    fn clear_geyser_prune_resume(&self) {
+        *self.geyser_prune_resume.lock() = GeyserPruneResume::default();
+    }
+
+    fn tracked_maps_need_prune(&self, admitted: &HashSet<Pubkey>) -> bool {
+        if self
+            .tracked_mints
+            .read()
+            .keys()
+            .any(|pk| !admitted.contains(pk))
         {
-            let mut mints = self.tracked_mints.write();
-            mints.retain(|pk, _| admitted.contains(pk));
+            return true;
         }
+        if self
+            .tracked_vaults
+            .read()
+            .keys()
+            .any(|pk| !admitted.contains(pk))
         {
-            let mut vaults = self.tracked_vaults.write();
-            let removed: Vec<(Pubkey, Pubkey)> = vaults
-                .iter()
-                .filter(|(pk, _)| !admitted.contains(pk))
-                .map(|(pk, v)| (*pk, v.pool_address))
-                .collect();
-            for (pk, pool) in removed {
-                vaults.remove(&pk);
-                self.pool_tracked_legs_remove_vault(pool, pk);
-            }
+            return true;
         }
+        if self
+            .tracked_bin_arrays
+            .read()
+            .keys()
+            .any(|pk| !admitted.contains(pk))
         {
-            let mut bins = self.tracked_bin_arrays.write();
-            let removed: Vec<(Pubkey, Pubkey)> = bins
-                .iter()
-                .filter(|(pk, _)| !admitted.contains(pk))
-                .map(|(pk, b)| (*pk, b.pool_address))
-                .collect();
-            for (pk, pool) in removed {
-                bins.remove(&pk);
-                self.pool_tracked_legs_remove_bin(pool, pk);
-            }
+            return true;
         }
         self.tracked_wallet_token_accounts
-            .write()
-            .retain(|pk| admitted.contains(pk));
+            .read()
+            .iter()
+            .any(|pk| !admitted.contains(pk))
+    }
+
+    fn collect_extraneous_keys_for_prune_map(
+        &self,
+        admitted: &HashSet<Pubkey>,
+        map: GeyserPruneMap,
+    ) -> Vec<Pubkey> {
+        match map {
+            GeyserPruneMap::Mints => self
+                .tracked_mints
+                .read()
+                .keys()
+                .filter(|pk| !admitted.contains(*pk))
+                .copied()
+                .collect(),
+            GeyserPruneMap::Vaults => self
+                .tracked_vaults
+                .read()
+                .keys()
+                .filter(|pk| !admitted.contains(*pk))
+                .copied()
+                .collect(),
+            GeyserPruneMap::Bins => self
+                .tracked_bin_arrays
+                .read()
+                .keys()
+                .filter(|pk| !admitted.contains(*pk))
+                .copied()
+                .collect(),
+            GeyserPruneMap::Wallets => self
+                .tracked_wallet_token_accounts
+                .read()
+                .iter()
+                .filter(|pk| !admitted.contains(*pk))
+                .copied()
+                .collect(),
+            GeyserPruneMap::Done => Vec::new(),
+        }
+    }
+
+    fn apply_prune_batch(&self, map: GeyserPruneMap, batch: &[Pubkey]) {
+        match map {
+            GeyserPruneMap::Mints => {
+                let mut mints = self.tracked_mints.write();
+                for pk in batch {
+                    mints.remove(pk);
+                }
+            }
+            GeyserPruneMap::Vaults => {
+                let mut vaults = self.tracked_vaults.write();
+                for pk in batch {
+                    if let Some(info) = vaults.remove(pk) {
+                        self.pool_tracked_legs_remove_vault(info.pool_address, *pk);
+                    }
+                }
+            }
+            GeyserPruneMap::Bins => {
+                let mut bins = self.tracked_bin_arrays.write();
+                for pk in batch {
+                    if let Some(info) = bins.remove(pk) {
+                        self.pool_tracked_legs_remove_bin(info.pool_address, *pk);
+                    }
+                }
+            }
+            GeyserPruneMap::Wallets => {
+                let mut wallets = self.tracked_wallet_token_accounts.write();
+                for pk in batch {
+                    wallets.remove(pk);
+                }
+            }
+            GeyserPruneMap::Done => {}
+        }
+    }
+
+    /// Budgeted prune: returns `true` when tracked maps match admitted set.
+    fn prune_tracked_maps_to_admitted_with_deadline(
+        &self,
+        deadline: Instant,
+        admission: &FixedCapAdmission,
+    ) -> bool {
+        let admitted: HashSet<Pubkey> = admission.snapshot_pubkeys().into_iter().collect();
+        let mut resume = self.geyser_prune_resume.lock();
+
+        if !resume.active {
+            if !self.tracked_maps_need_prune(&admitted) {
+                return true;
+            }
+            resume.active = true;
+            resume.map = GeyserPruneMap::Mints;
+            resume.pending.clear();
+        }
+
+        loop {
+            if Instant::now() >= deadline {
+                return false;
+            }
+
+            if resume.pending.is_empty() {
+                while resume.map != GeyserPruneMap::Done {
+                    resume.pending =
+                        self.collect_extraneous_keys_for_prune_map(&admitted, resume.map);
+                    if !resume.pending.is_empty() {
+                        break;
+                    }
+                    resume.map = resume.map.next();
+                }
+                if resume.pending.is_empty() {
+                    resume.active = false;
+                    return true;
+                }
+            }
+
+            let batch_len = resume.pending.len().min(GEYSER_PRUNE_SLICE_MAX_REMOVALS);
+            let batch: Vec<Pubkey> = resume.pending.drain(..batch_len).collect();
+            let map = resume.map;
+            drop(resume);
+            self.apply_prune_batch(map, &batch);
+            resume = self.geyser_prune_resume.lock();
+
+            if Instant::now() >= deadline
+                && (!resume.pending.is_empty() || resume.map != GeyserPruneMap::Done)
+            {
+                return false;
+            }
+            if resume.pending.is_empty() {
+                resume.map = resume.map.next();
+            }
+        }
+    }
+
+    fn prune_tracked_maps_to_admitted(&self, admission: &FixedCapAdmission) {
+        let deadline = Instant::now() + Duration::from_secs(300);
+        let _ = self.prune_tracked_maps_to_admitted_with_deadline(deadline, admission);
+        self.clear_geyser_prune_resume();
+    }
+
+    fn explicit_physical_publish_needed(&self, admission: &FixedCapAdmission) -> bool {
+        let admitted: HashSet<Pubkey> = admission.snapshot_pubkeys().into_iter().collect();
+        admitted != *self.last_synced_explicit_pubkeys.read()
     }
 
     fn publish_admitted_explicit_physical(&self, admission: &FixedCapAdmission) {
+        if !self.explicit_physical_publish_needed(admission) {
+            return;
+        }
         if self.admission_exceeds_configured_cap(admission) {
             self.mark_explicit_admission_config_cap_desync(
                 admission,
@@ -3372,15 +3552,23 @@ impl MarketDataContext {
 
     fn sync_geyser_tracked_accounts_from_admission_with_deadline(
         &self,
-        _deadline: Instant,
+        deadline: Instant,
         admission: &FixedCapAdmission,
     ) -> bool {
         set_market_data_geyser_sync_pending(0);
         record_market_data_geyser_sync_batch_total();
-        self.prune_tracked_maps_to_admitted(admission);
-        self.publish_admitted_explicit_physical(admission);
+        if !self.prune_tracked_maps_to_admitted_with_deadline(deadline, admission) {
+            return false;
+        }
+        if self.explicit_physical_publish_needed(admission) {
+            if Instant::now() >= deadline {
+                return false;
+            }
+            self.publish_admitted_explicit_physical(admission);
+        }
         *self.last_synced_explicit_pubkeys.write() =
             admission.snapshot_pubkeys().into_iter().collect();
+        self.clear_geyser_prune_resume();
         true
     }
 
@@ -7173,6 +7361,7 @@ async fn main() -> Result<()> {
         geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         geyser_explicit_ready: AtomicBool::new(true),
         geyser_explicit_config_error: parking_lot::RwLock::new(None),
+        geyser_prune_resume: parking_lot::Mutex::new(GeyserPruneResume::default()),
     });
 
     // === Main Loop: Geyser subscription or simulation ===
@@ -11092,6 +11281,7 @@ mod wallet_snapshot_stale_cleanup_tests {
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
+            geyser_prune_resume: parking_lot::Mutex::new(GeyserPruneResume::default()),
         }
     }
 
@@ -11316,6 +11506,7 @@ mod wallet_tx_meta_balance_tests {
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
+            geyser_prune_resume: parking_lot::Mutex::new(GeyserPruneResume::default()),
         })
     }
 
@@ -11640,7 +11831,7 @@ mod pr_b_geyser_tracking_tests {
         converge_admission_from_ctx, converge_admission_from_groups,
         merge_momentum_active_pools_updates, spawn_inline_track_worker_sender,
         spawn_noop_track_worker_sender, track_worker_execute_coalesced_push,
-        track_worker_try_enqueue, FixedCapAdmission, TrackWorkerCommand,
+        track_worker_try_enqueue, FixedCapAdmission, TrackWorkerCommand, TrackWorkerContext,
         MARKET_DATA_TRACK_WORKER_COALESCE_MS,
     };
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -12404,6 +12595,7 @@ mod pr_b_geyser_tracking_tests {
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
+            geyser_prune_resume: parking_lot::Mutex::new(GeyserPruneResume::default()),
         })
     }
 
@@ -12480,6 +12672,7 @@ mod pr_b_geyser_tracking_tests {
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
+            geyser_prune_resume: parking_lot::Mutex::new(GeyserPruneResume::default()),
         });
         (
             ctx,
@@ -15963,6 +16156,81 @@ mod pr_b_geyser_tracking_tests {
             MARKET_DATA_GEYSER_SYNC_SKIPPED_NO_DELTA_TOTAL.load(Ordering::Relaxed) > skip0,
             "empty delta must increment skipped_no_delta metric"
         );
+        let mints_after = ctx.tracked_mints_tx.borrow().clone();
+        assert!(
+            mints_after.is_empty(),
+            "no-delta skip must not republish explicit watch channels"
+        );
+    }
+
+    #[test]
+    fn geyser_sync_flush_deadline_incomplete_when_prune_exceeds_budget() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        {
+            let mut vaults = ctx.tracked_vaults.write();
+            for _ in 0..2_000 {
+                let stale = Pubkey::new_unique();
+                vaults.insert(
+                    stale,
+                    VaultInfo {
+                        pool_address: pool,
+                        dex: "test".into(),
+                        base_mint: Pubkey::new_unique(),
+                        quote_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                        is_base_vault: true,
+                        last_balance: std::sync::atomic::AtomicU64::new(0),
+                        last_used_at: Instant::now(),
+                        pinned: false,
+                        pin: None,
+                        active_id: None,
+                        bin_step: None,
+                        sibling_vault: None,
+                    },
+                );
+            }
+        }
+        let admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        let expired = Instant::now();
+        assert!(
+            !TrackWorkerContext::sync_geyser_tracked_accounts_batched_flush_with_deadline(
+                ctx.as_ref(),
+                expired,
+                &admission,
+            ),
+            "expired deadline must return incomplete for ContinueGeyserEvict"
+        );
+        assert_eq!(ctx.tracked_vaults.read().len(), 2_000);
+    }
+
+    #[test]
+    fn geyser_sync_flush_published_set_matches_admitted_i_md_7() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let (ctx, tracked_mints_rx, _, _, _) =
+            minimal_market_data_context_and_merge_receivers_for_pr161(jsonl);
+        let mint = Pubkey::new_unique();
+        ctx.track_mint_for_geyser_metadata(mint, Some(GeyserPinReason::Wallet));
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        converge_admission_from_ctx(ctx.as_ref(), &mut admission);
+        assert_eq!(admission.len(), 1);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        assert!(
+            TrackWorkerContext::sync_geyser_tracked_accounts_batched_flush_with_deadline(
+                ctx.as_ref(),
+                deadline,
+                &admission,
+            )
+        );
+        let admitted: HashSet<Pubkey> = admission.snapshot_pubkeys().into_iter().collect();
+        assert_eq!(*ctx.last_synced_explicit_pubkeys.read(), admitted);
+        let published_mints: HashSet<Pubkey> = tracked_mints_rx.borrow().iter().copied().collect();
+        assert_eq!(published_mints, admitted);
+        drop(tracked_mints_rx);
     }
 
     #[test]

--- a/src/market_data/track/geyser_sync.rs
+++ b/src/market_data/track/geyser_sync.rs
@@ -91,13 +91,35 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
     if delta.is_empty() && !continue_evict {
         inc_market_data_geyser_sync_skipped_no_delta_total();
         set_market_data_geyser_sync_pending(0);
+        let flush_deadline =
+            Instant::now() + Duration::from_millis(MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS);
+        let sync_start = Instant::now();
+        let sync_complete =
+            ctx.sync_geyser_tracked_accounts_batched_flush_with_deadline(flush_deadline, admission);
+        record_market_data_md_state_sync_flush_duration_us(
+            sync_start.elapsed().as_micros().min(u128::from(u64::MAX)) as u64,
+        );
+        ctx.refresh_tracked_membership_snapshot();
+        if restore_barrier_pending && sync_complete {
+            // Restored tracked maps may match the prior explicit pubkey set; force channel
+            // republish so Geyser subscribers observe post-restore physical membership.
+            *ctx.last_synced_explicit_pubkeys_write() = HashSet::new();
+            ctx.publish_admitted_explicit_physical(admission);
+            *ctx.last_synced_explicit_pubkeys_write() = admitted.clone();
+        }
         if release_flush_slot {
             ctx.release_geyser_sync_flush_slot();
         }
-        if restore_barrier_pending {
-            ctx.signal_restore_barrier(true);
+        if sync_complete {
+            if restore_barrier_pending {
+                ctx.signal_restore_barrier(true);
+            }
+            return true;
         }
-        return true;
+        if restore_barrier_pending {
+            ctx.signal_restore_barrier(false);
+        }
+        return false;
     }
     if !delta.is_empty() {
         record_market_data_geyser_subscribe_delta_pubkeys(delta.len() as u64);

--- a/src/market_data/track/geyser_sync.rs
+++ b/src/market_data/track/geyser_sync.rs
@@ -52,7 +52,6 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
     release_flush_slot: bool,
     restore_barrier_pending: bool,
 ) -> bool {
-    let flush_start = Instant::now();
     let converge = converge_admission_from_ctx(ctx.as_ref(), admission);
     let admitted = admitted_pubkey_set(admission);
     set_market_data_geyser_explicit_admitted_accounts(admitted.len());
@@ -88,14 +87,10 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
         return false;
     }
 
-    ctx.prune_tracked_maps_to_admitted(admission);
-    let after_keys = admitted;
-    let delta = symmetric_diff(&before_keys, &after_keys);
+    let delta = symmetric_diff(&before_keys, &admitted);
     if delta.is_empty() && !continue_evict {
         inc_market_data_geyser_sync_skipped_no_delta_total();
         set_market_data_geyser_sync_pending(0);
-        ctx.publish_admitted_explicit_physical(admission);
-        *ctx.last_synced_explicit_pubkeys_write() = after_keys;
         if release_flush_slot {
             ctx.release_geyser_sync_flush_slot();
         }
@@ -109,32 +104,31 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
     }
     let flush_deadline =
         Instant::now() + Duration::from_millis(MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS);
+    let sync_start = Instant::now();
     let sync_complete = if continue_evict {
         ctx.continue_geyser_evict_with_deadline(flush_deadline, admission)
     } else {
         ctx.sync_geyser_tracked_accounts_batched_flush_with_deadline(flush_deadline, admission)
     };
+    record_market_data_md_state_sync_flush_duration_us(
+        sync_start.elapsed().as_micros().min(u128::from(u64::MAX)) as u64,
+    );
     set_market_data_geyser_sync_pending(0);
     if release_flush_slot {
         ctx.release_geyser_sync_flush_slot();
     }
-    record_market_data_md_state_sync_flush_duration_us(
-        flush_start.elapsed().as_micros().min(u128::from(u64::MAX)) as u64,
-    );
-    ctx.prune_tracked_maps_to_admitted(admission);
-    ctx.publish_admitted_explicit_physical(admission);
-    ctx.refresh_tracked_membership_snapshot();
-    *ctx.last_synced_explicit_pubkeys_write() = admitted_pubkey_set(admission);
-    if !sync_complete {
+    if sync_complete {
+        ctx.refresh_tracked_membership_snapshot();
+        if restore_barrier_pending {
+            ctx.signal_restore_barrier(true);
+        }
+        true
+    } else {
         if restore_barrier_pending {
             ctx.signal_restore_barrier(false);
         }
-        return false;
+        false
     }
-    if restore_barrier_pending {
-        ctx.signal_restore_barrier(true);
-    }
-    true
 }
 
 pub fn consumer_id_for_track_pin(

--- a/src/market_data/track/geyser_sync.rs
+++ b/src/market_data/track/geyser_sync.rs
@@ -88,38 +88,20 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
     }
 
     let delta = symmetric_diff(&before_keys, &admitted);
-    if delta.is_empty() && !continue_evict {
-        inc_market_data_geyser_sync_skipped_no_delta_total();
-        set_market_data_geyser_sync_pending(0);
-        let flush_deadline =
-            Instant::now() + Duration::from_millis(MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS);
-        let sync_start = Instant::now();
-        let sync_complete =
-            ctx.sync_geyser_tracked_accounts_batched_flush_with_deadline(flush_deadline, admission);
-        record_market_data_md_state_sync_flush_duration_us(
-            sync_start.elapsed().as_micros().min(u128::from(u64::MAX)) as u64,
-        );
-        ctx.refresh_tracked_membership_snapshot();
-        if restore_barrier_pending && sync_complete {
-            // Restored tracked maps may match the prior explicit pubkey set; force channel
-            // republish so Geyser subscribers observe post-restore physical membership.
-            *ctx.last_synced_explicit_pubkeys_write() = HashSet::new();
-            ctx.publish_admitted_explicit_physical(admission);
-            *ctx.last_synced_explicit_pubkeys_write() = admitted.clone();
+    let maps_need_prune = ctx.tracked_maps_need_prune(admission);
+    if delta.is_empty() && !continue_evict && !maps_need_prune {
+        if !restore_barrier_pending {
+            inc_market_data_geyser_sync_skipped_no_delta_total();
         }
+        set_market_data_geyser_sync_pending(0);
         if release_flush_slot {
             ctx.release_geyser_sync_flush_slot();
         }
-        if sync_complete {
-            if restore_barrier_pending {
-                ctx.signal_restore_barrier(true);
-            }
-            return true;
-        }
         if restore_barrier_pending {
-            ctx.signal_restore_barrier(false);
+            ctx.publish_admitted_explicit_physical_force(admission);
+            ctx.signal_restore_barrier(true);
         }
-        return false;
+        return true;
     }
     if !delta.is_empty() {
         record_market_data_geyser_subscribe_delta_pubkeys(delta.len() as u64);

--- a/src/market_data/track/geyser_sync.rs
+++ b/src/market_data/track/geyser_sync.rs
@@ -114,11 +114,11 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
         sync_start.elapsed().as_micros().min(u128::from(u64::MAX)) as u64,
     );
     set_market_data_geyser_sync_pending(0);
+    ctx.refresh_tracked_membership_snapshot();
     if release_flush_slot {
         ctx.release_geyser_sync_flush_slot();
     }
     if sync_complete {
-        ctx.refresh_tracked_membership_snapshot();
         if restore_barrier_pending {
             ctx.signal_restore_barrier(true);
         }

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -128,6 +128,10 @@ pub trait TrackWorkerContext: Send + Sync {
     );
     fn prune_tracked_maps_to_admitted(&self, admission: &FixedCapAdmission);
     fn publish_admitted_explicit_physical(&self, admission: &FixedCapAdmission);
+    /// True when `tracked_*` maps contain pubkeys not present in admitted set.
+    fn tracked_maps_need_prune(&self, admission: &FixedCapAdmission) -> bool;
+    /// Publish physical explicit set even when admission matches `last_synced` (restore barrier).
+    fn publish_admitted_explicit_physical_force(&self, admission: &FixedCapAdmission);
     fn last_synced_explicit_pubkeys_write(
         &self,
     ) -> parking_lot::RwLockWriteGuard<'_, HashSet<Pubkey>>;
@@ -956,6 +960,12 @@ mod tests {
 
         fn publish_admitted_explicit_physical(&self, _admission: &FixedCapAdmission) {}
 
+        fn tracked_maps_need_prune(&self, _admission: &FixedCapAdmission) -> bool {
+            false
+        }
+
+        fn publish_admitted_explicit_physical_force(&self, _admission: &FixedCapAdmission) {}
+
         fn last_synced_explicit_pubkeys_write(
             &self,
         ) -> parking_lot::RwLockWriteGuard<'_, HashSet<Pubkey>> {
@@ -1258,6 +1268,12 @@ mod tests {
 
             fn publish_admitted_explicit_physical(&self, _admission: &FixedCapAdmission) {}
 
+            fn tracked_maps_need_prune(&self, _admission: &FixedCapAdmission) -> bool {
+                false
+            }
+
+            fn publish_admitted_explicit_physical_force(&self, _admission: &FixedCapAdmission) {}
+
             fn last_synced_explicit_pubkeys_write(
                 &self,
             ) -> parking_lot::RwLockWriteGuard<'_, HashSet<Pubkey>> {
@@ -1505,6 +1521,12 @@ mod tests {
 
         fn publish_admitted_explicit_physical(&self, _admission: &FixedCapAdmission) {}
 
+        fn tracked_maps_need_prune(&self, _admission: &FixedCapAdmission) -> bool {
+            false
+        }
+
+        fn publish_admitted_explicit_physical_force(&self, _admission: &FixedCapAdmission) {}
+
         fn last_synced_explicit_pubkeys_write(
             &self,
         ) -> parking_lot::RwLockWriteGuard<'_, HashSet<Pubkey>> {
@@ -1734,6 +1756,10 @@ mod tests {
             }
             fn prune_tracked_maps_to_admitted(&self, _admission: &FixedCapAdmission) {}
             fn publish_admitted_explicit_physical(&self, _admission: &FixedCapAdmission) {}
+            fn tracked_maps_need_prune(&self, _admission: &FixedCapAdmission) -> bool {
+                false
+            }
+            fn publish_admitted_explicit_physical_force(&self, _admission: &FixedCapAdmission) {}
             fn last_synced_explicit_pubkeys_write(
                 &self,
             ) -> parking_lot::RwLockWriteGuard<'_, HashSet<Pubkey>> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause (Prod `f251dcd`)

`market_data_md_state_sync_flush_duration_us` avg ~15–34s/flush at ~75k explicit accounts (cap 500k). Track-worker flush path ignored the 8ms budget:

1. **`sync_geyser_tracked_accounts_from_admission_with_deadline`** ignored `_deadline` and always ran full `prune_tracked_maps_to_admitted` + `publish_admitted_explicit_physical` (~75k merge/sort + 4× watch send).
2. **`track_worker_execute_coalesced_push`** republished on **no-delta** skip path and ran prune+publish **again** after sync (double work).

EXEC_HOT channel lag was dominated by flush/lock starvation on `md-track-worker`, not queue backlog.

## Fix

### `track_worker_execute_coalesced_push` (`geyser_sync.rs`)
- **No-delta + !continue_evict**: increment `geyser_sync_skipped_no_delta_total`, return — no prune, no publish, no sync.
- **Delta/continue path**: single sync call; no post-sync double prune/publish.
- `md_state_sync_flush_duration_us` measures sync/publish wall time only (not `converge_admission_from_ctx`).

### `sync_geyser_tracked_accounts_from_admission_with_deadline` (`market_data.rs`)
- **Budgeted prune**: slices of `GEYSER_PRUNE_SLICE_MAX_REMOVALS` (512) with `GeyserPruneResume` cursor; returns `false` on deadline → `ContinueGeyserEvict`.
- **Skip prune** when tracked maps have no extraneous keys.
- **Publish only** when `admitted != last_synced_explicit_pubkeys`.
- Fresh batched flush clears resume cursor; continue-evict resumes.

## Tests
- `geyser_sync_flush_deadline_incomplete_when_prune_exceeds_budget` — expired deadline + 2k stale vaults → incomplete (Continue path).
- `phase2a_geyser_push_skipped_when_delta_empty` — extended: no watch-channel republish on skip.
- `geyser_sync_flush_published_set_matches_admitted_i_md_7` — admitted == last_synced == published mints (I-MD-7).

## STOP-CHECK
- I-7: no new RPC.
- I-4b: sole writer unchanged.
- I-MD-7: cap/admission semantics untouched.
- I-MD-4: flush no longer blocks EXEC_HOT via multi-second full republish on no-delta.

## Verification
```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```
All green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-070a4d60-f30f-413a-888b-2ec40dd60fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-070a4d60-f30f-413a-888b-2ec40dd60fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

