### PR TITLE
fix(market-data): Restore-Barrier vs budgetierter Geyser-Flush (Prod Crash-Loop)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3205,10 +3205,13 @@ impl MarketDataContext {
     }
 
     fn signal_restore_barrier(&self, ok: bool) {
-        let wallet_fits =
-            self.wallet_explicit_demand_pubkeys().len() <= self.config.read().max_tracked_accounts;
-        if ok && self.geyser_explicit_readiness_ok() && wallet_fits {
-            self.geyser_connect_barrier.mark_ready();
+        if ok {
+            let wallet_fits = self.wallet_explicit_demand_pubkeys().len()
+                <= self.config.read().max_tracked_accounts;
+            if self.geyser_explicit_readiness_ok() && wallet_fits {
+                self.geyser_connect_barrier.mark_ready();
+            }
+            // Incomplete restore slices stay PENDING until physical publish completes.
         } else {
             self.geyser_connect_barrier.mark_failed();
         }
@@ -3602,6 +3605,33 @@ impl MarketDataContext {
     }
 
     /// Phase 3 P3: restore explicit set from disk before first Geyser connect (I-MD-6).
+    fn geyser_restore_barrier_timeout(snapshot_pubkey_count: u64) -> Duration {
+        const MIN_SECS: u64 = 30;
+        let scaled = MIN_SECS.saturating_add(snapshot_pubkey_count / 2_000);
+        Duration::from_secs(scaled.max(MIN_SECS))
+    }
+
+    fn geyser_explicit_not_ready_bail_message(&self) -> String {
+        self.geyser_explicit_config_error
+            .read()
+            .clone()
+            .unwrap_or_else(|| {
+                if self.geyser_connect_barrier.is_failed() {
+                    "geyser explicit restore barrier failed".to_string()
+                } else {
+                    "geyser explicit admission not ready (unknown reason)".to_string()
+                }
+            })
+    }
+
+    fn geyser_barrier_wait_bail_message(&self, wait_err: &'static str) -> String {
+        if let Some(msg) = self.geyser_explicit_config_error.read().clone() {
+            format!("{wait_err}: {msg}")
+        } else {
+            wait_err.to_string()
+        }
+    }
+
     fn restore_explicit_set_from_snapshot_on_startup(
         ctx: &MarketDataContext,
         track_worker: &TrackWorkerSender,
@@ -3609,13 +3639,16 @@ impl MarketDataContext {
         let path = explicit_set_snapshot_path();
         let Some(snapshot) = load_explicit_set_snapshot(&path) else {
             let _ = track_worker_try_enqueue(track_worker, TrackWorkerCommand::ScheduleGeyserPush);
-            if ctx
+            if let Err(wait_err) = ctx
                 .geyser_connect_barrier
-                .wait_ready(Duration::from_secs(30))
-                .is_err()
+                .wait_ready(Self::geyser_restore_barrier_timeout(0))
             {
                 warn!("explicit Geyser startup barrier failed or timed out (no snapshot, fail-closed)");
                 ctx.geyser_explicit_ready.store(false, Ordering::Release);
+                if ctx.geyser_explicit_config_error.read().is_none() {
+                    *ctx.geyser_explicit_config_error.write() =
+                        Some(ctx.geyser_barrier_wait_bail_message(wait_err));
+                }
             }
             return;
         };
@@ -3633,13 +3666,16 @@ impl MarketDataContext {
             TrackWorkerCommand::RestoreExplicitSnapshot(snapshot),
         );
         let _ = track_worker_try_enqueue(track_worker, TrackWorkerCommand::ScheduleGeyserPush);
-        if ctx
+        if let Err(wait_err) = ctx
             .geyser_connect_barrier
-            .wait_ready(Duration::from_secs(30))
-            .is_err()
+            .wait_ready(Self::geyser_restore_barrier_timeout(pubkey_count))
         {
             warn!("explicit Geyser restore barrier failed or timed out (fail-closed)");
             ctx.geyser_explicit_ready.store(false, Ordering::Release);
+            if ctx.geyser_explicit_config_error.read().is_none() {
+                *ctx.geyser_explicit_config_error.write() =
+                    Some(ctx.geyser_barrier_wait_bail_message(wait_err));
+            }
         }
         set_market_data_explicit_set_snapshot_restore_pubkeys(pubkey_count);
         set_market_data_explicit_set_snapshot_restore_duration_ms(
@@ -8366,18 +8402,14 @@ async fn run_geyser_loop(
     if !ctx.geyser_explicit_readiness_ok() {
         anyhow::bail!(
             "Geyser explicit admission not ready: {}",
-            ctx.geyser_explicit_config_error
-                .read()
-                .clone()
-                .unwrap_or_else(|| "protected explicit overflow".into())
+            ctx.geyser_explicit_not_ready_bail_message()
         );
     }
-    if ctx
+    if let Err(wait_err) = ctx
         .geyser_connect_barrier
-        .wait_ready(Duration::from_secs(30))
-        .is_err()
+        .wait_ready(MarketDataContext::geyser_restore_barrier_timeout(0))
     {
-        anyhow::bail!("Geyser explicit restore/convergence barrier failed before connect");
+        anyhow::bail!("{}", ctx.geyser_barrier_wait_bail_message(wait_err));
     }
     // PR169c / Phase-2b: coalesce momentum NATS bursts before md-track-worker.
     let momentum_coalesce_tx =
@@ -16311,6 +16343,127 @@ mod pr_b_geyser_tracking_tests {
         assert_eq!(published, admitted);
         assert!(ctx.geyser_connect_barrier.is_ready());
         drop(tracked_mints_rx);
+    }
+
+    #[test]
+    fn restore_barrier_incomplete_sync_stays_pending_then_ready() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        {
+            let mut vaults = ctx.tracked_vaults.write();
+            for _ in 0..50_000 {
+                let stale = Pubkey::new_unique();
+                vaults.insert(
+                    stale,
+                    VaultInfo {
+                        pool_address: pool,
+                        dex: "test".into(),
+                        base_mint: Pubkey::new_unique(),
+                        quote_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                        is_base_vault: true,
+                        last_balance: std::sync::atomic::AtomicU64::new(0),
+                        last_used_at: Instant::now(),
+                        pinned: false,
+                        pin: None,
+                        active_id: None,
+                        bin_step: None,
+                        sibling_vault: None,
+                    },
+                );
+            }
+        }
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        converge_admission_from_ctx(ctx.as_ref(), &mut admission);
+        *ctx.geyser_prune_resume.lock() = GeyserPruneResume {
+            active: true,
+            map: GeyserPruneMap::Vaults,
+            pending: ctx.tracked_vaults.read().keys().copied().collect(),
+        };
+
+        let before = admitted_pubkey_set(&admission);
+        let incomplete =
+            !track_worker_execute_coalesced_push(&ctx, &mut admission, before, true, false, true);
+        assert!(
+            incomplete,
+            "budgeted continue slice must be incomplete for large prune backlog"
+        );
+        assert!(ctx.geyser_connect_barrier.is_pending());
+        assert!(!ctx.geyser_connect_barrier.is_failed());
+        assert!(!ctx.geyser_connect_barrier.is_ready());
+
+        while TrackWorkerContext::tracked_maps_need_prune(ctx.as_ref(), &admission) {
+            let before = admitted_pubkey_set(&admission);
+            track_worker_execute_coalesced_push(&ctx, &mut admission, before, true, false, true);
+        }
+        if !ctx.geyser_connect_barrier.is_ready() {
+            let before = admitted_pubkey_set(&admission);
+            assert!(track_worker_execute_coalesced_push(
+                &ctx,
+                &mut admission,
+                before,
+                false,
+                false,
+                true,
+            ));
+        }
+        assert!(ctx.geyser_connect_barrier.is_ready());
+    }
+
+    #[test]
+    fn restore_barrier_protected_overflow_marks_failed_with_message() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let admission = FixedCapAdmission::new(2);
+        ctx.on_admission_converge_result(&admission, AdmissionConvergeResult::ProtectedOverflow);
+        assert!(!ctx.geyser_explicit_ready.load(Ordering::Relaxed));
+        assert!(ctx.geyser_connect_barrier.is_failed());
+        let msg = ctx
+            .geyser_explicit_config_error
+            .read()
+            .clone()
+            .expect("protected overflow message");
+        assert!(msg.contains("wallet protected explicit demand"));
+    }
+
+    #[test]
+    fn geyser_explicit_not_ready_bail_message_avoids_default_overflow() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        ctx.geyser_explicit_ready.store(false, Ordering::Release);
+        assert_eq!(
+            ctx.geyser_explicit_not_ready_bail_message(),
+            "geyser explicit admission not ready (unknown reason)"
+        );
+        ctx.geyser_connect_barrier.mark_failed();
+        assert_eq!(
+            ctx.geyser_explicit_not_ready_bail_message(),
+            "geyser explicit restore barrier failed"
+        );
+        *ctx.geyser_explicit_config_error.write() =
+            Some("explicit admission cap unconverged".into());
+        assert_eq!(
+            ctx.geyser_explicit_not_ready_bail_message(),
+            "explicit admission cap unconverged"
+        );
+    }
+
+    #[test]
+    fn geyser_restore_barrier_timeout_scales_with_snapshot_size() {
+        assert_eq!(
+            MarketDataContext::geyser_restore_barrier_timeout(0),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            MarketDataContext::geyser_restore_barrier_timeout(96_000),
+            Duration::from_secs(78)
+        );
     }
 
     #[test]

--- a/src/market_data/track/barrier.rs
+++ b/src/market_data/track/barrier.rs
@@ -38,6 +38,14 @@ impl GeyserConnectBarrier {
         self.state.load(Ordering::Acquire) == BARRIER_READY
     }
 
+    pub fn is_failed(&self) -> bool {
+        self.state.load(Ordering::Acquire) == BARRIER_FAILED
+    }
+
+    pub fn is_pending(&self) -> bool {
+        self.state.load(Ordering::Acquire) == BARRIER_PENDING
+    }
+
     pub fn wait_ready(&self, timeout: Duration) -> Result<(), &'static str> {
         let deadline = Instant::now() + timeout;
         while Instant::now() < deadline {
@@ -68,9 +76,24 @@ mod tests {
         let b = GeyserConnectBarrier::new();
         b.mark_failed();
         assert!(!b.is_ready());
+        assert!(b.is_failed());
+        assert!(!b.is_pending());
         assert_eq!(
             b.wait_ready(Duration::from_millis(20)),
             Err("geyser_explicit_barrier_failed")
         );
+    }
+
+    #[test]
+    fn barrier_stays_pending_until_ready_or_failed() {
+        let b = GeyserConnectBarrier::new();
+        assert!(b.is_pending());
+        assert!(!b.is_ready());
+        assert!(!b.is_failed());
+        assert_eq!(
+            b.wait_ready(Duration::from_millis(20)),
+            Err("geyser_explicit_barrier_timeout")
+        );
+        assert!(b.is_pending());
     }
 }

--- a/src/market_data/track/geyser_sync.rs
+++ b/src/market_data/track/geyser_sync.rs
@@ -22,6 +22,8 @@ use std::time::{Duration, Instant};
 
 /// PR235: wall time budget for sync/evict slice after job batch (track-worker only).
 pub const MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS: u64 = 8;
+/// First restore publish may use a larger slice budget while `restore_barrier_pending`.
+pub const MARKET_DATA_MD_STATE_RESTORE_FLUSH_BUDGET_MS: u64 = 64;
 
 pub fn explicit_subscription_has_new_keys(
     before: &HashSet<Pubkey>,
@@ -106,8 +108,12 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
     if !delta.is_empty() {
         record_market_data_geyser_subscribe_delta_pubkeys(delta.len() as u64);
     }
-    let flush_deadline =
-        Instant::now() + Duration::from_millis(MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS);
+    let flush_budget_ms = if restore_barrier_pending && !continue_evict {
+        MARKET_DATA_MD_STATE_RESTORE_FLUSH_BUDGET_MS
+    } else {
+        MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS
+    };
+    let flush_deadline = Instant::now() + Duration::from_millis(flush_budget_ms);
     let sync_start = Instant::now();
     let sync_complete = if continue_evict {
         ctx.continue_geyser_evict_with_deadline(flush_deadline, admission)
@@ -128,9 +134,8 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
         }
         true
     } else {
-        if restore_barrier_pending {
-            ctx.signal_restore_barrier(false);
-        }
+        // Budgeted incomplete sync during restore: barrier stays PENDING until a later
+        // `ContinueGeyserEvict` slice completes physical publish (I-MD-6).
         false
     }
 }

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -301,7 +301,12 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
             }
             false
         }
-        TrackWorkerCommand::ContinueGeyserEvict => false,
+        TrackWorkerCommand::ContinueGeyserEvict => {
+            if ctx.geyser_connect_barrier_pending() {
+                *restore_barrier_pending = true;
+            }
+            false
+        }
         TrackWorkerCommand::FlushExplicitSetSnapshot { done } => {
             try_write_explicit_set_snapshot_from_ctx(ctx.as_ref(), admission);
             let _ = done.send(());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Kontext (Prod nach Deploy `3ccd6af` / #307)

`market-data` Crash-Loop beim Startup:

```
Restoring explicit Geyser set from snapshot ... pubkeys=96073 owner_groups=67971
WARN explicit Geyser restore barrier failed or timed out (fail-closed)
Error: Geyser explicit admission not ready: protected explicit overflow
```

Ops-Mitigation: Snapshot-Backup + Cold-Start ohne Warm-Restore stabil.

## Root Cause

1. #307 budgetiert Sync auf **8 ms**; Restore von ~96k Keys braucht viele `ContinueGeyserEvict`-Slices.
2. Bei `sync_complete == false` + `restore_barrier_pending` rief `track_worker_execute_coalesced_push` `signal_restore_barrier(false)` → `mark_failed()` (**permanent**).
3. `ContinueGeyserEvict` konnte die Barrier danach nicht mehr auf READY setzen.
4. Startup-Bail maskierte Timeout/Barrier-Fail als „protected explicit overflow“.

## Fix

- **Incomplete während Restore:** Barrier bleibt `PENDING` (kein `mark_failed`); `ContinueGeyserEvict` kann über Slices zu READY konvergieren (I-MD-6).
- **`signal_restore_barrier(true)`:** markiert READY nur bei echter Readiness + Wallet-Fit; kein FAILED bei vorzeitigem `ok=true`.
- **Timeout:** `geyser_restore_barrier_timeout` — min 30s, skaliert mit `pubkey_count / 2000` (96k → 78s).
- **Bail-Messages:** `geyser_explicit_not_ready_bail_message` / `geyser_barrier_wait_bail_message` — kein Default-Overflow bei unbekanntem Grund.
- **Optional:** Erster Restore-Publish 64ms Flush-Budget (`MARKET_DATA_MD_STATE_RESTORE_FLUSH_BUDGET_MS`); Continue-Slices weiter 8ms.

## Invarianten

- I-MD-6: READY erst nach vollständigem physischem Publish; budgetiertes Incomplete ≠ fail-closed.
- I-MD-7/8: Echtes ProtectedOverflow/Unconverged/Wallet-over-cap weiterhin fail-closed.
- I-7 / I-4: Kein Hot-Path-RPC.

## Tests

- `restore_barrier_incomplete_sync_stays_pending_then_ready`
- `restore_barrier_protected_overflow_marks_failed_with_message`
- `geyser_explicit_not_ready_bail_message_avoids_default_overflow`
- `geyser_restore_barrier_timeout_scales_with_snapshot_size`
- Bestehende #307 Flush-/no-delta-Tests grün

## Verifikation

```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-301a286f-cb9e-4cda-923a-2be19f8260d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-301a286f-cb9e-4cda-923a-2be19f8260d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

