### PR TITLE
fix(md): Restore wait_ready timeout + flush budget for large snapshots (96k)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3605,9 +3605,11 @@ impl MarketDataContext {
     }
 
     /// Phase 3 P3: restore explicit set from disk before first Geyser connect (I-MD-6).
+    /// Wall-clock budget for `wait_ready` during explicit-set restore (I-MD-6).
+    /// Must cover large snapshots (~100k pubkeys) converging via budgeted Continue slices.
     fn geyser_restore_barrier_timeout(snapshot_pubkey_count: u64) -> Duration {
-        const MIN_SECS: u64 = 30;
-        let scaled = MIN_SECS.saturating_add(snapshot_pubkey_count / 2_000);
+        const MIN_SECS: u64 = 120;
+        let scaled = MIN_SECS.saturating_add(snapshot_pubkey_count / 400);
         Duration::from_secs(scaled.max(MIN_SECS))
     }
 
@@ -16354,7 +16356,7 @@ mod pr_b_geyser_tracking_tests {
         let pool = Pubkey::new_unique();
         {
             let mut vaults = ctx.tracked_vaults.write();
-            for _ in 0..50_000 {
+            for _ in 0..250_000 {
                 let stale = Pubkey::new_unique();
                 vaults.insert(
                     stale,
@@ -16458,12 +16460,14 @@ mod pr_b_geyser_tracking_tests {
     fn geyser_restore_barrier_timeout_scales_with_snapshot_size() {
         assert_eq!(
             MarketDataContext::geyser_restore_barrier_timeout(0),
-            Duration::from_secs(30)
+            Duration::from_secs(120)
         );
-        assert_eq!(
-            MarketDataContext::geyser_restore_barrier_timeout(96_000),
-            Duration::from_secs(78)
+        let timeout_96k = MarketDataContext::geyser_restore_barrier_timeout(96_000);
+        assert!(
+            timeout_96k >= Duration::from_secs(300),
+            "96k snapshot restore must have >=5min wait_ready budget, got {timeout_96k:?}"
         );
+        assert_eq!(timeout_96k, Duration::from_secs(360));
     }
 
     #[test]

--- a/src/market_data/track/geyser_sync.rs
+++ b/src/market_data/track/geyser_sync.rs
@@ -22,8 +22,9 @@ use std::time::{Duration, Instant};
 
 /// PR235: wall time budget for sync/evict slice after job batch (track-worker only).
 pub const MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS: u64 = 8;
-/// First restore publish may use a larger slice budget while `restore_barrier_pending`.
-pub const MARKET_DATA_MD_STATE_RESTORE_FLUSH_BUDGET_MS: u64 = 64;
+/// Restore slices (initial push and ContinueGeyserEvict) use a larger flush budget while
+/// `restore_barrier_pending` so large snapshots converge before `wait_ready` (I-MD-6).
+pub const MARKET_DATA_MD_STATE_RESTORE_FLUSH_BUDGET_MS: u64 = 250;
 
 pub fn explicit_subscription_has_new_keys(
     before: &HashSet<Pubkey>,
@@ -108,11 +109,7 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
     if !delta.is_empty() {
         record_market_data_geyser_subscribe_delta_pubkeys(delta.len() as u64);
     }
-    let flush_budget_ms = if restore_barrier_pending && !continue_evict {
-        MARKET_DATA_MD_STATE_RESTORE_FLUSH_BUDGET_MS
-    } else {
-        MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS
-    };
+    let flush_budget_ms = md_state_flush_budget_ms(restore_barrier_pending);
     let flush_deadline = Instant::now() + Duration::from_millis(flush_budget_ms);
     let sync_start = Instant::now();
     let sync_complete = if continue_evict {
@@ -140,6 +137,17 @@ pub fn track_worker_execute_coalesced_push<C: TrackWorkerContext>(
     }
 }
 
+/// Steady-state flush uses 8ms; restore barrier uses [`MARKET_DATA_MD_STATE_RESTORE_FLUSH_BUDGET_MS`]
+/// for every slice including `ContinueGeyserEvict`.
+#[inline]
+pub fn md_state_flush_budget_ms(restore_barrier_pending: bool) -> u64 {
+    if restore_barrier_pending {
+        MARKET_DATA_MD_STATE_RESTORE_FLUSH_BUDGET_MS
+    } else {
+        MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS
+    }
+}
+
 pub fn consumer_id_for_track_pin(
     pin: super::worker::TrackPinReason,
 ) -> super::desired_set::ConsumerId {
@@ -147,5 +155,27 @@ pub fn consumer_id_for_track_pin(
         super::worker::TrackPinReason::Wallet => super::desired_set::ConsumerId::Wallet,
         super::worker::TrackPinReason::MomentumActive => super::desired_set::ConsumerId::Momentum,
         super::worker::TrackPinReason::ArbMultiDex => super::desired_set::ConsumerId::Arb,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restore_flush_budget_applies_to_continue_slices() {
+        assert_eq!(
+            md_state_flush_budget_ms(true),
+            MARKET_DATA_MD_STATE_RESTORE_FLUSH_BUDGET_MS
+        );
+        assert_eq!(
+            md_state_flush_budget_ms(false),
+            MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS
+        );
+        assert_ne!(
+            md_state_flush_budget_ms(true),
+            MARKET_DATA_MD_STATE_FLUSH_BUDGET_MS,
+            "continue_evict slices under restore_barrier_pending must not use steady-state 8ms"
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (Prod 2026-07-19)

After deploy `2e53aa2` (#308), ~25k warm-restore works (~5.7s). **96k snapshot still crash-loops:**

```
Restoring explicit Geyser set from snapshot ... pubkeys=96073 owner_groups=67971
WARN explicit Geyser restore barrier failed or timed out (fail-closed)
Error: Geyser explicit admission not ready: geyser_explicit_barrier_timeout
```

- Timeout hit exactly `30 + 96073/2000 ≈ 78s` while CPU was busy (~1min CPU / 78s wall) — work continued via Continue slices but `wait_ready` expired.
- `#308` PENDING semantics are correct; root cause is too-aggressive timeout scaling and restore flush budget only on first push (continue slices stayed at 8ms).

Snapshot quarantined: `/var/lib/ironcrab/explicit_set.snapshot.bak-20260719-protected-overflow`

## Changes

1. **`geyser_restore_barrier_timeout`**: `MIN=120s`, scale `pubkey_count/400` → 96k ≈ **360s** (was 78s)
2. **Restore flush budget**: while `restore_barrier_pending`, **all** slices (including `ContinueGeyserEvict`) use `MARKET_DATA_MD_STATE_RESTORE_FLUSH_BUDGET_MS` (**250ms**, was 64ms first-slice-only)
3. Steady-state flush remains **8ms** outside restore
4. `#308` PENDING-on-incomplete semantics unchanged; ProtectedOverflow/Unconverged still fail-closed

## Tests

- `geyser_restore_barrier_timeout(0) == 120s`, `geyser_restore_barrier_timeout(96_000) == 360s` (≥300s)
- `md_state_flush_budget_ms(true)` ≠ 8ms (continue slices under restore)
- Existing #307/#308 tests green (incomplete→PENDING→READY, overflow fail-closed)

## STOP-CHECK

- I-7: no RPC changes
- Steady-state 8ms flush unchanged
- No admission/cap/snapshot-format changes

**No deploy** — ops can re-test quarantined 96k snapshot after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b4bad41-6f3a-4418-b940-9483d7ba2aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b4bad41-6f3a-4418-b940-9483d7ba2aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

