### PR TITLE
fix(market-data): tighten EXEC_HOT admission to hot-pool legs only (Scope F)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -845,6 +845,14 @@ impl UnifiedHotPoolRegistry {
             .collect()
     }
 
+    fn snapshot_hot_pool_pubkeys(&self) -> HashSet<Pubkey> {
+        let mut pools = self.snapshot_arb_pools();
+        for (_, pool) in self.snapshot_pairs() {
+            pools.insert(pool);
+        }
+        pools
+    }
+
     /// Pool is in the execution hot set (momentum active and/or arb track pin).
     fn is_hot_pool(&self, pool: Pubkey) -> bool {
         self.pool_has_momentum(pool) || self.pool_has_arb(pool)
@@ -1105,6 +1113,8 @@ struct MarketDataContext {
 
     /// PR237: ingest hot-path membership (no `tracked_*` read locks).
     tracked_membership: ArcSwap<TrackedMembershipSnapshot>,
+    /// Scope F: EXEC_HOT vault/bin pubkeys for hot-pool legs only (no full explicit-set flood).
+    exec_hot_membership: ArcSwap<ExecHotMembershipSnapshot>,
     /// PR237: pool → vault/bin pubkeys for O(legs) LRU touch (md-state writer only).
     pool_tracked_legs: parking_lot::RwLock<HashMap<Pubkey, PoolTrackedLegs>>,
 
@@ -1476,6 +1486,13 @@ struct TrackedMembershipSnapshot {
     bin_arrays: HashSet<Pubkey>,
     vault_by_pubkey: HashMap<Pubkey, SnapshotVaultView>,
     bin_array_by_pubkey: HashMap<Pubkey, SnapshotBinArrayView>,
+}
+
+/// Scope F: lock-free EXEC_HOT vault/bin view (hot-pool legs only, not full explicit membership).
+#[derive(Clone, Default)]
+struct ExecHotMembershipSnapshot {
+    vaults: HashSet<Pubkey>,
+    bin_arrays: HashSet<Pubkey>,
 }
 
 /// PR237: reverse index pool → tracked vault/bin pubkeys (md-state writer only).
@@ -2230,6 +2247,14 @@ impl IngestHost for MarketDataContext {
 
     fn ingest_membership_bin_array_contains(&self, pubkey: &Pubkey) -> bool {
         self.tracked_membership.load().bin_arrays.contains(pubkey)
+    }
+
+    fn ingest_exec_hot_vault_contains(&self, pubkey: &Pubkey) -> bool {
+        self.exec_hot_membership.load().vaults.contains(pubkey)
+    }
+
+    fn ingest_exec_hot_bin_array_contains(&self, pubkey: &Pubkey) -> bool {
+        self.exec_hot_membership.load().bin_arrays.contains(pubkey)
     }
 
     fn ingest_is_hot_pool(&self, pool: &Pubkey) -> bool {
@@ -3722,6 +3747,7 @@ impl MarketDataContext {
         set_market_data_momentum_active_pool_pins_gauge(self.hot_pool_registry.pair_count());
         set_market_data_arb_pinned_pools_gauge(arb);
         self.refresh_enrichment_registry_gauge();
+        self.refresh_exec_hot_membership_snapshot();
     }
 
     fn refresh_enrichment_registry_gauge(&self) {
@@ -3800,6 +3826,36 @@ impl MarketDataContext {
                 bin_array_by_pubkey,
             }));
         touch_market_data_tracked_membership_snapshot_refresh();
+        self.refresh_exec_hot_membership_snapshot();
+    }
+
+    /// Scope F: rebuild EXEC_HOT vault/bin snapshot from hot-pool registry + tracked legs.
+    fn refresh_exec_hot_membership_snapshot(&self) {
+        let hot_pools = self.hot_pool_registry.snapshot_hot_pool_pubkeys();
+        let mut vaults = HashSet::new();
+        let mut bin_arrays = HashSet::new();
+        {
+            let legs = self.pool_tracked_legs.read();
+            for pool in &hot_pools {
+                if let Some(entry) = legs.get(pool) {
+                    vaults.extend(entry.vaults.iter().copied());
+                    bin_arrays.extend(entry.bin_arrays.iter().copied());
+                }
+            }
+        }
+        let membership = self.tracked_membership.load();
+        for (pk, view) in membership.vault_by_pubkey.iter() {
+            if hot_pools.contains(&view.pool_address) {
+                vaults.insert(*pk);
+            }
+        }
+        for (pk, view) in membership.bin_array_by_pubkey.iter() {
+            if hot_pools.contains(&view.pool_address) {
+                bin_arrays.insert(*pk);
+            }
+        }
+        self.exec_hot_membership
+            .store(Arc::new(ExecHotMembershipSnapshot { vaults, bin_arrays }));
     }
 
     fn pool_tracked_legs_note_vault(&self, pool: Pubkey, vault: Pubkey) {
@@ -7397,6 +7453,7 @@ async fn main() -> Result<()> {
         tracked_bin_arrays: parking_lot::RwLock::new(std::collections::HashMap::new()),
         tracked_bin_arrays_tx,
         tracked_membership: ArcSwap::from_pointee(TrackedMembershipSnapshot::default()),
+        exec_hot_membership: ArcSwap::from_pointee(ExecHotMembershipSnapshot::default()),
         pool_tracked_legs: parking_lot::RwLock::new(HashMap::new()),
         live_pool_cache: Arc::new(LivePoolCache::new()),
         creator_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
@@ -11311,6 +11368,7 @@ mod wallet_snapshot_stale_cleanup_tests {
             tracked_bin_arrays: parking_lot::RwLock::new(std::collections::HashMap::new()),
             tracked_bin_arrays_tx,
             tracked_membership: ArcSwap::from_pointee(TrackedMembershipSnapshot::default()),
+            exec_hot_membership: ArcSwap::from_pointee(ExecHotMembershipSnapshot::default()),
             pool_tracked_legs: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: Arc::new(LivePoolCache::new()),
             creator_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
@@ -11536,6 +11594,7 @@ mod wallet_tx_meta_balance_tests {
             tracked_bin_arrays: parking_lot::RwLock::new(std::collections::HashMap::new()),
             tracked_bin_arrays_tx,
             tracked_membership: ArcSwap::from_pointee(TrackedMembershipSnapshot::default()),
+            exec_hot_membership: ArcSwap::from_pointee(ExecHotMembershipSnapshot::default()),
             pool_tracked_legs: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: Arc::new(LivePoolCache::new()),
             creator_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
@@ -12627,6 +12686,7 @@ mod pr_b_geyser_tracking_tests {
             tracked_bin_arrays: parking_lot::RwLock::new(std::collections::HashMap::new()),
             tracked_bin_arrays_tx,
             tracked_membership: ArcSwap::from_pointee(TrackedMembershipSnapshot::default()),
+            exec_hot_membership: ArcSwap::from_pointee(ExecHotMembershipSnapshot::default()),
             pool_tracked_legs: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: live_pool_cache.unwrap_or_else(|| Arc::new(LivePoolCache::new())),
             creator_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
@@ -12702,6 +12762,7 @@ mod pr_b_geyser_tracking_tests {
             tracked_bin_arrays: parking_lot::RwLock::new(std::collections::HashMap::new()),
             tracked_bin_arrays_tx,
             tracked_membership: ArcSwap::from_pointee(TrackedMembershipSnapshot::default()),
+            exec_hot_membership: ArcSwap::from_pointee(ExecHotMembershipSnapshot::default()),
             pool_tracked_legs: parking_lot::RwLock::new(HashMap::new()),
             live_pool_cache: Arc::new(LivePoolCache::new()),
             creator_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
@@ -13903,7 +13964,7 @@ mod pr_b_geyser_tracking_tests {
     }
 
     #[test]
-    fn account_geyser_dispatch_high_when_pool_mint_map_contains_pubkey() {
+    fn account_geyser_dispatch_not_high_when_pool_mint_map_only() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
@@ -13920,11 +13981,11 @@ mod pr_b_geyser_tracking_tests {
             lamports: 0,
             grpc_recv_at: Instant::now(),
         };
-        assert!(account_geyser_dispatch_priority_high(&ctx, &u));
+        assert!(!account_geyser_dispatch_priority_high(&ctx, &u));
     }
 
     #[test]
-    fn account_geyser_dispatch_high_when_tracked_vault_pubkey() {
+    fn account_geyser_dispatch_not_high_when_tracked_vault_without_hot_pool() {
         use ironcrab::metrics::MARKET_DATA_VAULT_HIGH_PRIORITY_DISPATCH_TOTAL;
 
         let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -13939,6 +14000,52 @@ mod pr_b_geyser_tracking_tests {
                 pool_address: Pubkey::new_unique(),
                 dex: "raydium_cpmm".to_string(),
                 base_mint: Pubkey::new_unique(),
+                quote_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                is_base_vault: true,
+                last_balance: std::sync::atomic::AtomicU64::new(0),
+                last_used_at: Instant::now(),
+                pinned: false,
+                pin: None,
+                active_id: None,
+                bin_step: None,
+                sibling_vault: None,
+            },
+        );
+        ctx.refresh_tracked_membership_snapshot();
+        let u = GeyserAccountUpdate {
+            pubkey: vault,
+            slot: 1,
+            owner: Pubkey::new_unique(),
+            data: vec![],
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        };
+        assert!(!account_geyser_dispatch_priority_high(&ctx, &u));
+        assert_eq!(
+            MARKET_DATA_VAULT_HIGH_PRIORITY_DISPATCH_TOTAL.load(Ordering::Relaxed),
+            before
+        );
+    }
+
+    #[test]
+    fn account_geyser_dispatch_high_when_tracked_vault_for_hot_pool() {
+        use ironcrab::metrics::MARKET_DATA_VAULT_HIGH_PRIORITY_DISPATCH_TOTAL;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let vault = Pubkey::new_unique();
+        let before = MARKET_DATA_VAULT_HIGH_PRIORITY_DISPATCH_TOTAL.load(Ordering::Relaxed);
+        ctx.hot_pool_registry.pin_pool(base_mint, pool);
+        ctx.tracked_vaults.write().insert(
+            vault,
+            VaultInfo {
+                pool_address: pool,
+                dex: "raydium_cpmm".to_string(),
+                base_mint,
                 quote_mint: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
                 is_base_vault: true,
                 last_balance: std::sync::atomic::AtomicU64::new(0),
@@ -15863,7 +15970,7 @@ mod pr_b_geyser_tracking_tests {
             grpc_recv_at: Instant::now(),
         };
         assert!(account_geyser_update_might_be_relevant(&ctx, &u));
-        assert!(account_geyser_dispatch_priority_high(&ctx, &u));
+        assert!(!account_geyser_dispatch_priority_high(&ctx, &u));
     }
 
     /// PR237: pool touch uses reverse index (O(legs)), not full-map scan.

--- a/src/market_data/ingest/account_filter.rs
+++ b/src/market_data/ingest/account_filter.rs
@@ -57,11 +57,8 @@ pub enum AccountGeyserRelevance {
 ///
 /// Maps to existing HIGH/LOW worker dispatch without changing queue semantics:
 /// - `Drop` — `account_geyser_update_relevance` early drop (no worker enqueue)
-/// - `ExecHot` — `account_geyser_dispatch_priority_high` (vault/bin/hot-pool pins incl. Arb)
-/// - `Enrich` — relevant but not EXEC_HOT (e.g. wallet token ATA without pin)
-///
-/// Known gap (Scope C): open-position pools without Momentum/Arb pin are often `Enrich`, not
-/// `ExecHot` — do not silently widen HIGH dispatch here; only metrics.
+/// - `ExecHot` — `account_geyser_dispatch_priority_high` (hot-pool vault/bin snapshot + Scope C wallet/bonding)
+/// - `Enrich` — relevant explicit membership / discovery without EXEC_HOT admission
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccountUpdateClass {
     ExecHot,
@@ -149,27 +146,24 @@ pub fn classify_account_geyser_update<H: IngestHost>(
     }
 }
 
-/// Strategic HIGH admission for account worker sharding (ACCOUNT-PATH-TX-PARITY-CREATOR).
+/// Strategic HIGH admission for account worker sharding (Scope F: hot-pool legs + Scope C wallet/bonding).
 pub fn account_geyser_dispatch_priority_high<H: IngestHost>(
     host: &H,
     u: &GeyserAccountUpdate,
 ) -> bool {
     let pool_pk = u.pubkey;
-    if host.ingest_membership_vault_contains(&pool_pk) {
+    if account_geyser_update_is_dex_pool_owner(&u.owner) && host.ingest_is_hot_pool(&pool_pk) {
+        return true;
+    }
+    if host.ingest_exec_hot_vault_contains(&pool_pk) {
         host.ingest_record_vault_high_priority_dispatch();
         return true;
     }
-    if host.ingest_membership_bin_array_contains(&pool_pk) {
+    if host.ingest_exec_hot_bin_array_contains(&pool_pk) {
         host.ingest_record_membership_snapshot_hit();
         return true;
     }
     if host.ingest_high_priority_bonding_curve_contains(&pool_pk) {
-        return true;
-    }
-    if host.ingest_pool_mint_map_contains(&pool_pk) {
-        return true;
-    }
-    if host.ingest_is_enrichment_member(&pool_pk) {
         return true;
     }
     if host.ingest_wallet_tracks_mint(&pool_pk) {
@@ -192,6 +186,8 @@ mod tests {
         membership: HashSet<Pubkey>,
         enrichment_members: HashSet<Pubkey>,
         hot_pools: HashSet<Pubkey>,
+        exec_hot_vaults: HashSet<Pubkey>,
+        exec_hot_bin_arrays: HashSet<Pubkey>,
         tracked_wallet_token_accounts: HashSet<Pubkey>,
         pumpfun_wallet_track: HashSet<Pubkey>,
     }
@@ -202,6 +198,8 @@ mod tests {
                 membership: HashSet::new(),
                 enrichment_members: HashSet::new(),
                 hot_pools: HashSet::new(),
+                exec_hot_vaults: HashSet::new(),
+                exec_hot_bin_arrays: HashSet::new(),
                 tracked_wallet_token_accounts: HashSet::new(),
                 pumpfun_wallet_track: HashSet::new(),
             }
@@ -227,6 +225,14 @@ mod tests {
 
         fn ingest_membership_bin_array_contains(&self, _pubkey: &Pubkey) -> bool {
             false
+        }
+
+        fn ingest_exec_hot_vault_contains(&self, pubkey: &Pubkey) -> bool {
+            self.exec_hot_vaults.contains(pubkey)
+        }
+
+        fn ingest_exec_hot_bin_array_contains(&self, pubkey: &Pubkey) -> bool {
+            self.exec_hot_bin_arrays.contains(pubkey)
         }
 
         fn ingest_is_hot_pool(&self, pool: &Pubkey) -> bool {
@@ -314,6 +320,52 @@ mod tests {
             AccountGeyserRelevance::Relevant
         );
         assert!(account_geyser_update_might_be_relevant(&host, &u));
+    }
+
+    #[test]
+    fn classify_account_geyser_update_enrich_membership_vault_without_hot_pool() {
+        let vault = Pubkey::new_unique();
+        let mut host = MockIngestHost::new();
+        host.membership.insert(vault);
+        let u = sample_update(vault, Pubkey::new_unique());
+        let (class, early_drop_reason) = classify_account_geyser_update(&host, &u);
+        assert_eq!(class, AccountUpdateClass::Enrich);
+        assert_eq!(early_drop_reason, None);
+    }
+
+    #[test]
+    fn classify_account_geyser_update_exec_hot_via_hot_pool_vault_snapshot() {
+        let vault = Pubkey::new_unique();
+        let mut host = MockIngestHost::new();
+        host.membership.insert(vault);
+        host.exec_hot_vaults.insert(vault);
+        let u = sample_update(vault, Pubkey::new_unique());
+        let (class, early_drop_reason) = classify_account_geyser_update(&host, &u);
+        assert_eq!(class, AccountUpdateClass::ExecHot);
+        assert_eq!(early_drop_reason, None);
+    }
+
+    #[test]
+    fn classify_account_geyser_update_exec_hot_via_hot_pool_bin_snapshot() {
+        let bin = Pubkey::new_unique();
+        let mut host = MockIngestHost::new();
+        host.membership.insert(bin);
+        host.exec_hot_bin_arrays.insert(bin);
+        let u = sample_update(bin, Pubkey::new_unique());
+        let (class, early_drop_reason) = classify_account_geyser_update(&host, &u);
+        assert_eq!(class, AccountUpdateClass::ExecHot);
+        assert_eq!(early_drop_reason, None);
+    }
+
+    #[test]
+    fn classify_account_geyser_update_enrich_enrichment_only_pool() {
+        let pool = Pubkey::new_unique();
+        let mut host = MockIngestHost::new();
+        host.enrichment_members.insert(pool);
+        let u = sample_update(pool, RAYDIUM_CPMM_OWNER);
+        let (class, early_drop_reason) = classify_account_geyser_update(&host, &u);
+        assert_eq!(class, AccountUpdateClass::Enrich);
+        assert_eq!(early_drop_reason, None);
     }
 
     #[test]

--- a/src/market_data/ingest/host.rs
+++ b/src/market_data/ingest/host.rs
@@ -16,6 +16,12 @@ pub trait IngestHost: Send + Sync {
 
     fn ingest_membership_bin_array_contains(&self, pubkey: &Pubkey) -> bool;
 
+    /// EXEC_HOT vault membership: vault pubkeys for hot-pool legs only (not full explicit set).
+    fn ingest_exec_hot_vault_contains(&self, pubkey: &Pubkey) -> bool;
+
+    /// EXEC_HOT bin-array membership: bin PDAs for hot-pool legs only.
+    fn ingest_exec_hot_bin_array_contains(&self, pubkey: &Pubkey) -> bool;
+
     fn ingest_is_hot_pool(&self, pool: &Pubkey) -> bool;
 
     /// P2 EnrichmentRegistry: pool_mint_map ∪ bonding-curve priority ∪ hot-pool pins.

--- a/src/market_data/ingest/mod.rs
+++ b/src/market_data/ingest/mod.rs
@@ -58,6 +58,14 @@ impl<T: IngestHost + ?Sized> IngestHost for Arc<T> {
         (**self).ingest_membership_bin_array_contains(pubkey)
     }
 
+    fn ingest_exec_hot_vault_contains(&self, pubkey: &solana_sdk::pubkey::Pubkey) -> bool {
+        (**self).ingest_exec_hot_vault_contains(pubkey)
+    }
+
+    fn ingest_exec_hot_bin_array_contains(&self, pubkey: &solana_sdk::pubkey::Pubkey) -> bool {
+        (**self).ingest_exec_hot_bin_array_contains(pubkey)
+    }
+
     fn ingest_is_hot_pool(&self, pool: &solana_sdk::pubkey::Pubkey) -> bool {
         (**self).ingest_is_hot_pool(pool)
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prod showed EXEC_HOT flooding the account ingest path (~8.3M `exec_hot` vs ~5.5k `enrich`, ~404s channel lag) because `account_geyser_dispatch_priority_high` treated **every** explicit-membership vault/bin as HIGH.

This PR implements **Scope F** from the account-realtime backlog plan (§3.1):

- New lock-free `ExecHotMembershipSnapshot` (`ArcSwap`) with vault/bin pubkeys **only** for pools in `hot_pool_registry` (Momentum + Arb pins)
- `account_geyser_dispatch_priority_high` rebuilt: HIGH only for hot-pool legs, hot pool accounts, high-priority bonding curves, and Scope C wallet/bonding tracks
- **Removed** as HIGH triggers: full membership vaults/bins, `pool_mint_map`, enrichment registry alone
- Explicit membership **relevance unchanged** — non-hot vaults stay `Relevant` → `Enrich`, not `Drop`

## Expected prod effect

- `exec_hot:enrich` ratio should drop from ~1500:1 toward hot-pool volume (~3k momentum + ~400 arb)
- `account_broadcast_queue_depth` and `exec_hot` channel lag should decrease after deploy (Scope E validation)

## Invariants

- I-7 / I-4b: no RPC; lock-free snapshot reads only in ingest hot path
- I-MD-1: TX path unchanged
- No cap changes, no deploy in this PR

## Tests

- Unit tests: membership vault without hot → `Enrich`; hot vault/bin → `ExecHot`; enrichment-only → `Enrich`
- Integration tests updated in `market_data.rs`
- `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` — all green locally
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5436864b-eb2a-4652-b602-d96ab32ca8b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5436864b-eb2a-4652-b602-d96ab32ca8b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

