### PR TITLE
fix(market-data): coalesce tracker TrackMint flood (Scope H)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2831,6 +2831,7 @@ impl MarketDataContext {
         let _ = admission.remove_group(Self::tracker_mint_owner(mint));
         self.tracked_mints.write().remove(&mint);
         inc_market_data_wallet_admission_admitted_total();
+        self.refresh_tracked_membership_snapshot();
         true
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2245,6 +2245,10 @@ impl IngestHost for MarketDataContext {
         self.tracked_membership.load().vaults.contains(pubkey)
     }
 
+    fn ingest_membership_mint_contains(&self, pubkey: &Pubkey) -> bool {
+        self.tracked_membership.load().mints.contains(pubkey)
+    }
+
     fn ingest_membership_bin_array_contains(&self, pubkey: &Pubkey) -> bool {
         self.tracked_membership.load().bin_arrays.contains(pubkey)
     }
@@ -17366,6 +17370,53 @@ mod pr_b_geyser_tracking_tests {
         assert!(ctx.apply_track_mint(&mut admission, mint, None));
         assert!(ctx.tracked_mints.read().contains_key(&mint));
         assert!(ctx.apply_track_mint(&mut admission, mint, None));
+    }
+
+    /// Scope H: lock-free mint membership snapshot gates redundant TX TrackMint enqueue.
+    #[test]
+    fn scope_h_ingest_membership_mint_contains_after_track() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let mint = Pubkey::new_unique();
+        assert!(!ctx.ingest_membership_mint_contains(&mint));
+
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        assert!(ctx.apply_track_mint(&mut admission, mint, None));
+        ctx.refresh_tracked_membership_snapshot();
+        assert!(ctx.ingest_membership_mint_contains(&mint));
+    }
+
+    /// Scope H: batched TrackMints must not downgrade wallet pin to unpinned tracker.
+    #[test]
+    fn scope_h_track_mints_batch_preserves_wallet_pin() {
+        use ironcrab::market_data::track::{track_worker_process_command, TrackWorkerCommand};
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let mint = Pubkey::new_unique();
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        let mut restore_barrier_pending = false;
+
+        assert!(track_worker_process_command(
+            &ctx,
+            &mut admission,
+            &mut restore_barrier_pending,
+            TrackWorkerCommand::TrackMints {
+                entries: vec![(mint, None), (mint, Some(TrackPinReason::Wallet)),],
+            },
+        ));
+        let info = ctx
+            .tracked_mints
+            .read()
+            .get(&mint)
+            .cloned()
+            .expect("mint tracked");
+        assert!(info.pinned);
+        assert_eq!(info.pin, Some(GeyserPinReason::Wallet));
     }
 
     #[test]

--- a/src/market_data/ingest/account_filter.rs
+++ b/src/market_data/ingest/account_filter.rs
@@ -223,6 +223,10 @@ mod tests {
             false
         }
 
+        fn ingest_membership_mint_contains(&self, pubkey: &Pubkey) -> bool {
+            self.membership.contains(pubkey)
+        }
+
         fn ingest_membership_bin_array_contains(&self, _pubkey: &Pubkey) -> bool {
             false
         }

--- a/src/market_data/ingest/host.rs
+++ b/src/market_data/ingest/host.rs
@@ -14,6 +14,9 @@ pub trait IngestHost: Send + Sync {
 
     fn ingest_membership_vault_contains(&self, pubkey: &Pubkey) -> bool;
 
+    /// Lock-free tracked-mint membership (tracker TrackMint idempotency gate, I-4b).
+    fn ingest_membership_mint_contains(&self, pubkey: &Pubkey) -> bool;
+
     fn ingest_membership_bin_array_contains(&self, pubkey: &Pubkey) -> bool;
 
     /// EXEC_HOT vault membership: vault pubkeys for hot-pool legs only (not full explicit set).

--- a/src/market_data/ingest/mod.rs
+++ b/src/market_data/ingest/mod.rs
@@ -54,6 +54,10 @@ impl<T: IngestHost + ?Sized> IngestHost for Arc<T> {
         (**self).ingest_membership_vault_contains(pubkey)
     }
 
+    fn ingest_membership_mint_contains(&self, pubkey: &solana_sdk::pubkey::Pubkey) -> bool {
+        (**self).ingest_membership_mint_contains(pubkey)
+    }
+
     fn ingest_membership_bin_array_contains(&self, pubkey: &solana_sdk::pubkey::Pubkey) -> bool {
         (**self).ingest_membership_bin_array_contains(pubkey)
     }

--- a/src/market_data/ingest/tx_handler.rs
+++ b/src/market_data/ingest/tx_handler.rs
@@ -6,8 +6,8 @@ use super::tx_parse::{
     maybe_emit_dev_wallet_after_pool_mint_map, process_wallet_balance_snapshots_from_tx_meta,
     resolve_pumpfun_creator_tx_path, tx_publish_segment, unparsed_tx_drop_reason,
 };
-use crate::market_data::ingest::host::IngestHost;
 use crate::ipc::{IntentTier, MarketEvent, MarketEventKind, PriorityFeePercentiles};
+use crate::market_data::ingest::host::IngestHost;
 use crate::market_data::md_state::{md_state_try_enqueue, MdStateCommand, MdStateSender};
 use crate::market_data::publish::{
     account_path_enqueue_core_market_event, account_path_enqueue_priority_fee_sample,

--- a/src/market_data/ingest/tx_handler.rs
+++ b/src/market_data/ingest/tx_handler.rs
@@ -6,6 +6,7 @@ use super::tx_parse::{
     maybe_emit_dev_wallet_after_pool_mint_map, process_wallet_balance_snapshots_from_tx_meta,
     resolve_pumpfun_creator_tx_path, tx_publish_segment, unparsed_tx_drop_reason,
 };
+use crate::market_data::ingest::host::IngestHost;
 use crate::ipc::{IntentTier, MarketEvent, MarketEventKind, PriorityFeePercentiles};
 use crate::market_data::md_state::{md_state_try_enqueue, MdStateCommand, MdStateSender};
 use crate::market_data::publish::{
@@ -17,8 +18,9 @@ use crate::market_data::sidefx::{
     MdSidefxCommand, MdSidefxSender,
 };
 use crate::metrics::{
-    market_data_bump_geyser_head_slot, record_market_data_tx_channel_lag_ms,
-    record_market_data_tx_handler_processed, record_market_data_unparsed_tx_dropped,
+    inc_market_data_track_mint_skipped_already_tracked_total, market_data_bump_geyser_head_slot,
+    record_market_data_tx_channel_lag_ms, record_market_data_tx_handler_processed,
+    record_market_data_unparsed_tx_dropped,
 };
 use crate::nats::TOPIC_PRIORITY_FEE_SAMPLES;
 use crate::solana::dex_parser::{
@@ -116,7 +118,11 @@ pub async fn handle_geyser_transaction_update<H: TxIngestHost>(
             ParsedDexEvent::BondingCurveUpdate { .. } => None,
         };
         if let Some((mint, dex_opt)) = mint_and_dex {
-            md_state_try_enqueue(md_state, MdStateCommand::TrackMint { mint, pin: None });
+            if IngestHost::ingest_membership_mint_contains(host, &mint) {
+                inc_market_data_track_mint_skipped_already_tracked_total();
+            } else {
+                md_state_try_enqueue(md_state, MdStateCommand::TrackMint { mint, pin: None });
+            }
             debug!(
                 mint = %mint,
                 dex = ?dex_opt,

--- a/src/market_data/md_state/command.rs
+++ b/src/market_data/md_state/command.rs
@@ -9,6 +9,10 @@ pub enum MdStateCommand {
         mint: Pubkey,
         pin: Option<TrackPinReason>,
     },
+    /// Scope H: burst-coalesced tracker/wallet TrackMint demand (deduped by mint).
+    TrackMints {
+        entries: Vec<(Pubkey, Option<TrackPinReason>)>,
+    },
     /// PR169b: wallet bootstrap / execution-results mint pin (no immediate sync).
     TrackWalletMint { mint: Pubkey },
     /// PR4b: wallet position close — withdraw wallet pin before map demotion.

--- a/src/market_data/md_state/worker.rs
+++ b/src/market_data/md_state/worker.rs
@@ -3,19 +3,21 @@
 use super::command::MdStateCommand;
 use super::host::MdStateContext;
 use crate::market_data::track::{
-    explicit_subscription_has_new_keys, track_worker_try_enqueue, TrackWorkerCommand,
-    TrackWorkerSender,
+    explicit_subscription_has_new_keys, merge_track_mint_pin, track_worker_try_enqueue,
+    TrackPinReason, TrackWorkerCommand, TrackWorkerSender,
 };
 use crate::metrics::{
     inc_market_data_geyser_sync_skipped_no_delta_total,
     inc_market_data_geyser_tracking_enqueue_dropped_total,
     inc_market_data_geyser_tracking_jobs_processed_total,
-    inc_market_data_md_state_bursts_completed_total, set_market_data_geyser_tracking_queue_depth,
-    set_market_data_md_state_burst_in_progress, set_market_data_md_state_deferred_jobs_len,
-    set_market_data_md_state_queue_depth,
+    inc_market_data_md_state_bursts_completed_total,
+    inc_market_data_md_state_track_mint_coalesce_batches_out,
+    inc_market_data_md_state_track_mint_coalesce_messages_in,
+    set_market_data_geyser_tracking_queue_depth, set_market_data_md_state_burst_in_progress,
+    set_market_data_md_state_deferred_jobs_len, set_market_data_md_state_queue_depth,
 };
 use solana_sdk::pubkey::Pubkey;
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc as std_mpsc;
 use std::sync::Arc;
@@ -64,6 +66,8 @@ pub fn md_state_coalesce_jobs(jobs: Vec<MdStateCommand>) -> Vec<MdStateCommand> 
     let mut lru_bin_arrays = HashSet::new();
     let mut pending_flush = false;
     let mut pending_evict_continue = false;
+    let mut track_mints: HashMap<Pubkey, Option<TrackPinReason>> = HashMap::new();
+    let mut track_mint_messages_in = 0u64;
     for job in jobs {
         match job {
             MdStateCommand::FlushGeyserSyncDebounced => {
@@ -82,7 +86,32 @@ pub fn md_state_coalesce_jobs(jobs: Vec<MdStateCommand>) -> Vec<MdStateCommand> 
                 lru_vaults.extend(vaults);
                 lru_bin_arrays.extend(bin_arrays);
             }
+            MdStateCommand::TrackMint { mint, pin } => {
+                track_mint_messages_in += 1;
+                track_mints
+                    .entry(mint)
+                    .and_modify(|existing| *existing = merge_track_mint_pin(*existing, pin))
+                    .or_insert(pin);
+            }
+            MdStateCommand::TrackMints { entries } => {
+                track_mint_messages_in += entries.len() as u64;
+                for (mint, pin) in entries {
+                    track_mints
+                        .entry(mint)
+                        .and_modify(|existing| *existing = merge_track_mint_pin(*existing, pin))
+                        .or_insert(pin);
+                }
+            }
             other => out.push(other),
+        }
+    }
+    if track_mint_messages_in > 0 {
+        inc_market_data_md_state_track_mint_coalesce_messages_in(track_mint_messages_in);
+        if !track_mints.is_empty() {
+            inc_market_data_md_state_track_mint_coalesce_batches_out();
+            out.push(MdStateCommand::TrackMints {
+                entries: track_mints.into_iter().collect(),
+            });
         }
     }
     if !lru_vaults.is_empty() || !lru_bin_arrays.is_empty() {
@@ -108,6 +137,18 @@ pub fn md_state_process_job<C: MdStateContext>(
     match job {
         MdStateCommand::TrackMint { mint, pin } => {
             track_worker_try_enqueue(track_worker, TrackWorkerCommand::TrackMint { mint, pin });
+            false
+        }
+        MdStateCommand::TrackMints { entries } => {
+            if entries.is_empty() {
+                return false;
+            }
+            if entries.len() == 1 {
+                let (mint, pin) = entries[0];
+                track_worker_try_enqueue(track_worker, TrackWorkerCommand::TrackMint { mint, pin });
+            } else {
+                track_worker_try_enqueue(track_worker, TrackWorkerCommand::TrackMints { entries });
+            }
             false
         }
         MdStateCommand::TrackWalletMint { mint } => {
@@ -303,4 +344,47 @@ pub fn spawn_md_state_worker<C: MdStateContext + 'static>(
         })
         .expect("spawn md-state thread");
     md_state_sender
+}
+
+#[cfg(test)]
+mod tests {
+    use super::md_state_coalesce_jobs;
+    use crate::market_data::md_state::MdStateCommand;
+    use crate::market_data::track::TrackPinReason;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn scope_h_coalesce_dedupes_repeated_track_mint() {
+        let mint = Pubkey::new_unique();
+        let jobs: Vec<_> = (0..100)
+            .map(|_| MdStateCommand::TrackMint { mint, pin: None })
+            .collect();
+        let out = md_state_coalesce_jobs(jobs);
+        assert_eq!(out.len(), 1);
+        let MdStateCommand::TrackMints { entries } = &out[0] else {
+            panic!("expected TrackMints batch");
+        };
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0], (mint, None));
+    }
+
+    #[test]
+    fn scope_h_coalesce_track_mint_wallet_pin_wins() {
+        let mint = Pubkey::new_unique();
+        let jobs = vec![
+            MdStateCommand::TrackMint { mint, pin: None },
+            MdStateCommand::TrackMint {
+                mint,
+                pin: Some(TrackPinReason::Wallet),
+            },
+            MdStateCommand::TrackMint { mint, pin: None },
+        ];
+        let out = md_state_coalesce_jobs(jobs);
+        assert_eq!(out.len(), 1);
+        let MdStateCommand::TrackMints { entries } = &out[0] else {
+            panic!("expected TrackMints batch");
+        };
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0], (mint, Some(TrackPinReason::Wallet)));
+    }
 }

--- a/src/market_data/md_state/worker.rs
+++ b/src/market_data/md_state/worker.rs
@@ -129,6 +129,49 @@ pub fn md_state_coalesce_jobs(jobs: Vec<MdStateCommand>) -> Vec<MdStateCommand> 
     out
 }
 
+/// Split wallet/strategy pins out before tracker batch enqueue (I-MD-5 wallet demand preserved).
+fn enqueue_track_mints_to_worker(
+    track_worker: &TrackWorkerSender,
+    entries: Vec<(Pubkey, Option<TrackPinReason>)>,
+) {
+    if entries.is_empty() {
+        return;
+    }
+    let mut tracker_entries = Vec::with_capacity(entries.len());
+    for (mint, pin) in entries {
+        match pin {
+            Some(TrackPinReason::Wallet) => {
+                track_worker_try_enqueue(track_worker, TrackWorkerCommand::ApplyWalletPin { mint });
+            }
+            None => tracker_entries.push((mint, pin)),
+            Some(other) => {
+                track_worker_try_enqueue(
+                    track_worker,
+                    TrackWorkerCommand::TrackMint {
+                        mint,
+                        pin: Some(other),
+                    },
+                );
+            }
+        }
+    }
+    match tracker_entries.len() {
+        0 => {}
+        1 => {
+            let (mint, pin) = tracker_entries[0];
+            track_worker_try_enqueue(track_worker, TrackWorkerCommand::TrackMint { mint, pin });
+        }
+        _ => {
+            track_worker_try_enqueue(
+                track_worker,
+                TrackWorkerCommand::TrackMints {
+                    entries: tracker_entries,
+                },
+            );
+        }
+    }
+}
+
 pub fn md_state_process_job<C: MdStateContext>(
     ctx: &Arc<C>,
     job: MdStateCommand,
@@ -140,15 +183,7 @@ pub fn md_state_process_job<C: MdStateContext>(
             false
         }
         MdStateCommand::TrackMints { entries } => {
-            if entries.is_empty() {
-                return false;
-            }
-            if entries.len() == 1 {
-                let (mint, pin) = entries[0];
-                track_worker_try_enqueue(track_worker, TrackWorkerCommand::TrackMint { mint, pin });
-            } else {
-                track_worker_try_enqueue(track_worker, TrackWorkerCommand::TrackMints { entries });
-            }
+            enqueue_track_mints_to_worker(track_worker, entries);
             false
         }
         MdStateCommand::TrackWalletMint { mint } => {

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -74,5 +74,6 @@ pub use worker::{
     MARKET_DATA_TRACK_WORKER_QUEUE_CAP,
 };
 pub use worker_commands::{
-    stream_for_command, ImmutableTrackCommand, RevisionAssigner, TrackCommandStream,
+    merge_track_mint_pin, stream_for_command, ImmutableTrackCommand, RevisionAssigner,
+    TrackCommandStream,
 };

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -307,11 +307,11 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
         TrackWorkerCommand::WithdrawWalletPin { mint } => ctx.withdraw_wallet_pin(admission, mint),
         TrackWorkerCommand::TrackMint { mint, pin } => ctx.apply_track_mint(admission, mint, pin),
         TrackWorkerCommand::TrackMints { entries } => {
-            let mut batch_dirty = false;
+            let mut all_ok = true;
             for (mint, pin) in entries {
-                batch_dirty |= ctx.apply_track_mint(admission, mint, pin);
+                all_ok &= ctx.apply_track_mint(admission, mint, pin);
             }
-            batch_dirty
+            all_ok
         }
         TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange => {
             let new_cap = ctx.max_tracked_accounts();
@@ -361,6 +361,12 @@ fn track_protocol_should_advance_revision(
     }
 }
 
+/// Coalesced TrackMints batches use Control revision but must replay like tracker demand.
+#[inline]
+fn track_mints_batch_requires_replay_on_failure(payload: &TrackWorkerCommand) -> bool {
+    matches!(payload, TrackWorkerCommand::TrackMints { .. })
+}
+
 fn track_protocol_stage_for_replay(
     protocol: &Arc<Mutex<BoundedProtocolStore>>,
     cmd: ImmutableTrackCommand,
@@ -386,15 +392,20 @@ fn track_worker_apply_protocol_command<C: TrackWorkerContext>(
     }
     let stream = cmd.stream;
     let revision = cmd.revision;
+    let payload_backup = cmd.payload.clone();
     let restage_on_failure = matches!(
         stream,
         TrackCommandStream::Wallet | TrackCommandStream::Tracker
-    );
-    let payload_backup = cmd.payload.clone();
+    ) || track_mints_batch_requires_replay_on_failure(&payload_backup);
     let handler_succeeded =
         track_worker_process_command(ctx, admission, restore_barrier_pending, cmd.payload);
     let protocol_cmd = ImmutableTrackCommand::new(stream, revision, payload_backup);
-    if track_protocol_should_advance_revision(stream, handler_succeeded) {
+    let should_advance = if track_mints_batch_requires_replay_on_failure(&protocol_cmd.payload) {
+        handler_succeeded
+    } else {
+        track_protocol_should_advance_revision(stream, handler_succeeded)
+    };
+    if should_advance {
         let mut store = protocol.lock().expect("track protocol store lock");
         if stream == TrackCommandStream::Wallet {
             store.mark_applied_wallet_demand(&protocol_cmd);

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -306,6 +306,13 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
         TrackWorkerCommand::ApplyWalletPin { mint } => ctx.apply_wallet_pin(admission, mint),
         TrackWorkerCommand::WithdrawWalletPin { mint } => ctx.withdraw_wallet_pin(admission, mint),
         TrackWorkerCommand::TrackMint { mint, pin } => ctx.apply_track_mint(admission, mint, pin),
+        TrackWorkerCommand::TrackMints { entries } => {
+            let mut batch_dirty = false;
+            for (mint, pin) in entries {
+                batch_dirty |= ctx.apply_track_mint(admission, mint, pin);
+            }
+            batch_dirty
+        }
         TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange => {
             let new_cap = ctx.max_tracked_accounts();
             let _ = ctx.apply_explicit_cap_shrink(admission, new_cap);

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -86,6 +86,22 @@ impl ImmutableTrackCommand {
     }
 }
 
+/// Protocol stream for a coalesced TrackMints batch (after wallet pins are split out).
+pub fn track_mints_batch_stream(
+    entries: &[(Pubkey, Option<TrackPinReason>)],
+) -> TrackCommandStream {
+    match entries.len() {
+        0 => TrackCommandStream::Control,
+        1 => stream_for_command(&TrackWorkerCommand::TrackMint {
+            mint: entries[0].0,
+            pin: entries[0].1,
+        }),
+        // Multi-mint unpinned tracker batches use Control revision (per-mint keys need demand_mint).
+        _ if entries.iter().all(|(_, pin)| pin.is_none()) => TrackCommandStream::Control,
+        _ => TrackCommandStream::Control,
+    }
+}
+
 /// Map a legacy command to its protocol stream.
 pub fn stream_for_command(cmd: &TrackWorkerCommand) -> TrackCommandStream {
     match cmd {
@@ -98,8 +114,8 @@ pub fn stream_for_command(cmd: &TrackWorkerCommand) -> TrackCommandStream {
             ..
         } => TrackCommandStream::Wallet,
         TrackWorkerCommand::TrackMint { pin: None, .. } => TrackCommandStream::Tracker,
-        TrackWorkerCommand::TrackMints { .. }
-        | TrackWorkerCommand::TrackMint { .. }
+        TrackWorkerCommand::TrackMints { entries } => track_mints_batch_stream(entries),
+        TrackWorkerCommand::TrackMint { .. }
         | TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange
         | TrackWorkerCommand::ScheduleGeyserPush
         | TrackWorkerCommand::ScheduleGeyserPushDebounced
@@ -359,11 +375,23 @@ mod tests {
     }
 
     #[test]
-    fn stream_mapping_track_mints_is_control() {
+    fn stream_mapping_track_mints_single_unpinned_is_tracker() {
         let mint = Pubkey::new_unique();
         assert_eq!(
             stream_for_command(&TrackWorkerCommand::TrackMints {
                 entries: vec![(mint, None)],
+            }),
+            TrackCommandStream::Tracker
+        );
+    }
+
+    #[test]
+    fn stream_mapping_track_mints_multi_unpinned_is_control() {
+        let m1 = Pubkey::new_unique();
+        let m2 = Pubkey::new_unique();
+        assert_eq!(
+            stream_for_command(&TrackWorkerCommand::TrackMints {
+                entries: vec![(m1, None), (m2, None)],
             }),
             TrackCommandStream::Control
         );

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -29,6 +29,10 @@ pub enum TrackWorkerCommand {
         mint: Pubkey,
         pin: Option<TrackPinReason>,
     },
+    /// Scope H: burst-coalesced tracker/wallet TrackMint demand (deduped by mint, single Geyser schedule).
+    TrackMints {
+        entries: Vec<(Pubkey, Option<TrackPinReason>)>,
+    },
     ScheduleGeyserSyncAfterConfigChange,
     /// Coalesced explicit Geyser push (md-state burst / trade path).
     ScheduleGeyserPush,
@@ -94,7 +98,8 @@ pub fn stream_for_command(cmd: &TrackWorkerCommand) -> TrackCommandStream {
             ..
         } => TrackCommandStream::Wallet,
         TrackWorkerCommand::TrackMint { pin: None, .. } => TrackCommandStream::Tracker,
-        TrackWorkerCommand::TrackMint { .. }
+        TrackWorkerCommand::TrackMints { .. }
+        | TrackWorkerCommand::TrackMint { .. }
         | TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange
         | TrackWorkerCommand::ScheduleGeyserPush
         | TrackWorkerCommand::ScheduleGeyserPushDebounced
@@ -134,6 +139,30 @@ impl TrackCommandKind {
     }
 }
 
+/// Relative strength for TrackMint pin merge (higher wins on coalesce).
+#[inline]
+pub fn track_mint_pin_strength(pin: Option<TrackPinReason>) -> u8 {
+    match pin {
+        Some(TrackPinReason::Wallet) => 3,
+        Some(TrackPinReason::MomentumActive) => 2,
+        Some(TrackPinReason::ArbMultiDex) => 1,
+        None => 0,
+    }
+}
+
+/// Merge two TrackMint pins; stronger pin wins (Wallet > strategy pins > unpinned tracker).
+#[inline]
+pub fn merge_track_mint_pin(
+    existing: Option<TrackPinReason>,
+    incoming: Option<TrackPinReason>,
+) -> Option<TrackPinReason> {
+    if track_mint_pin_strength(incoming) >= track_mint_pin_strength(existing) {
+        incoming
+    } else {
+        existing
+    }
+}
+
 /// Relative strength for idempotent Geyser sync intents (higher wins on merge).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SyncIntentStrength {
@@ -154,6 +183,7 @@ pub fn track_command_kind(cmd: &TrackWorkerCommand) -> TrackCommandKind {
             ..
         } => TrackCommandKind::Wallet,
         TrackWorkerCommand::TrackMint { pin: None, .. } => TrackCommandKind::Tracker,
+        TrackWorkerCommand::TrackMints { .. } => TrackCommandKind::Tracker,
         TrackWorkerCommand::ScheduleGeyserSyncAfterConfigChange
         | TrackWorkerCommand::ScheduleGeyserPush
         | TrackWorkerCommand::ScheduleGeyserPushDebounced => TrackCommandKind::Sync,
@@ -313,6 +343,30 @@ mod tests {
         for (cmd, expected) in streams {
             assert_eq!(stream_for_command(&cmd), expected);
         }
+    }
+
+    #[test]
+    fn merge_track_mint_pin_prefers_wallet_over_unpinned() {
+        use super::merge_track_mint_pin;
+        assert_eq!(
+            merge_track_mint_pin(None, Some(TrackPinReason::Wallet)),
+            Some(TrackPinReason::Wallet)
+        );
+        assert_eq!(
+            merge_track_mint_pin(Some(TrackPinReason::Wallet), None),
+            Some(TrackPinReason::Wallet)
+        );
+    }
+
+    #[test]
+    fn stream_mapping_track_mints_is_control() {
+        let mint = Pubkey::new_unique();
+        assert_eq!(
+            stream_for_command(&TrackWorkerCommand::TrackMints {
+                entries: vec![(mint, None)],
+            }),
+            TrackCommandStream::Control
+        );
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1025,8 +1025,17 @@ pub static MARKET_DATA_TRACK_PROTOCOL_STAGE_BY_KIND_TOTAL: Lazy<[AtomicU64; 7]> 
 /// Scope G: enqueue deduped because equivalent intent already queued or pending.
 pub static MARKET_DATA_TRACK_WORKER_ENQUEUE_DEDUPED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
-/// Scope G: pending supersede/coalesce avoided a new slot (no eviction).
+/// Scope H: pending supersede/coalesce avoided a new slot (no eviction).
 pub static MARKET_DATA_TRACK_PROTOCOL_PENDING_COALESCED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Scope H: TX ingest skipped TrackMint because mint is already in tracked-membership snapshot.
+pub static MARKET_DATA_TRACK_MINT_SKIPPED_ALREADY_TRACKED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Scope H: TrackMint messages absorbed by md-state burst coalesce (before dedupe).
+pub static MARKET_DATA_MD_STATE_TRACK_MINT_COALESCE_MESSAGES_IN_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Scope H: TrackMints batches emitted by md-state burst coalesce.
+pub static MARKET_DATA_MD_STATE_TRACK_MINT_COALESCE_BATCHES_OUT_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
 /// PR169a: single-writer Geyser tracking actor queue depth (gauge).
@@ -1381,6 +1390,21 @@ pub fn inc_market_data_track_worker_enqueue_deduped_total() {
 #[inline]
 pub fn inc_market_data_track_protocol_pending_coalesced_total() {
     MARKET_DATA_TRACK_PROTOCOL_PENDING_COALESCED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_track_mint_skipped_already_tracked_total() {
+    MARKET_DATA_TRACK_MINT_SKIPPED_ALREADY_TRACKED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_md_state_track_mint_coalesce_messages_in(n: u64) {
+    MARKET_DATA_MD_STATE_TRACK_MINT_COALESCE_MESSAGES_IN_TOTAL.fetch_add(n, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_md_state_track_mint_coalesce_batches_out() {
+    MARKET_DATA_MD_STATE_TRACK_MINT_COALESCE_BATCHES_OUT_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -6328,6 +6352,18 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_track_protocol_pending_coalesced_total",
         MARKET_DATA_TRACK_PROTOCOL_PENDING_COALESCED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_track_mint_skipped_already_tracked_total",
+        MARKET_DATA_TRACK_MINT_SKIPPED_ALREADY_TRACKED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_md_state_track_mint_coalesce_messages_in_total",
+        MARKET_DATA_MD_STATE_TRACK_MINT_COALESCE_MESSAGES_IN_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_md_state_track_mint_coalesce_batches_out_total",
+        MARKET_DATA_MD_STATE_TRACK_MINT_COALESCE_BATCHES_OUT_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_geyser_tracking_queue_depth",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Kontext (Prod Scope G, ~20min Soak)

| Metrik | Wert |
|--------|------|
| Queue 5m Ø / Max | ~4.8–5.1k / **8192** |
| `pending_evicted` | **0** (Scope G OK) |
| Enqueue by kind | **tracker ~100k**, momentum ~1.6k, arb ~687 |
| EXEC_HOT Lag 5m | ~21–61 ms (nicht der Blocker) |

**Root cause:** Jeder TX-Trade/PoolCreated/LiquidityRemoved enqueued 1:1 `TrackMint { pin: None }` ohne Idempotenz gegen bereits getrackte Mints. `md_state_coalesce_jobs` coalescte Touch/Flush, aber nicht TrackMint.

## Änderungen

### 1) TX-Enqueue-Idempotenz (I-4b)
- Neues `IngestHost::ingest_membership_mint_contains` (lock-free `tracked_membership` Snapshot)
- `tx_handler`: skip `TrackMint` wenn Mint bereits im Snapshot → `track_mint_skipped_already_tracked_total`
- Wallet-Pfad (`TrackWalletMint`) unverändert

### 2) md-state Burst-Coalesce
- `TrackMint` im Burst → dedupe by mint (`merge_track_mint_pin`: Wallet > strategy > None)
- Ein `MdStateCommand::TrackMints` Batch pro Burst statt N Einzelcommands
- Metriken: `md_state_track_mint_coalesce_messages_in_total` / `batches_out_total`

### 3) Track-Worker Batch-Apply (Option A)
- `TrackWorkerCommand::TrackMints { entries }` — ein Apply-Loop, ein Dirty/Geyser-Schedule
- Einzelmint bleibt als `TrackMint` wenn Batch nur 1 Eintrag

## Tests
- `scope_h_coalesce_dedupes_repeated_track_mint` (100× → 1)
- `scope_h_coalesce_track_mint_wallet_pin_wins`
- `scope_h_ingest_membership_mint_contains_after_track`
- `scope_h_track_mints_batch_preserves_wallet_pin`

## Erwartete Prod-Proxies (nach Deploy)
- tracker enqueue rate ↓ (skip + coalesce)
- queue p90 ≪ 8192
- `pending_evicted` bleibt ~0

## STOP-CHECK
- Kein RPC / kein RwLock-Read auf `tracked_mints` im TX-Pfad
- I-MD-5: neue untracked Mints weiterhin enqueued; skip nur already-tracked
- I-MD-1: TX-Publish unverändert (Nebenwirkung Tracking only)

**Kein Deploy** — Supervisor nach Freigabe.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8640675-c14b-4ad7-8cd9-3156f65200bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8640675-c14b-4ad7-8cd9-3156f65200bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

