### PR TITLE
chore(market-data): instrument account recv classify/enqueue (Scope J1)

### DIFF
--- a/docs/RUNBOOK_PROD.md
+++ b/docs/RUNBOOK_PROD.md
@@ -202,6 +202,11 @@ Alle Werte nutzen konsistent `RecordHeader.ts_unix_ms` bzw. Geyser-`Instant::now
 | Account-Publish-Queue (Gauge) | `market_data_account_publish_queue_depth` | Jobs in der dedizierten NATS-Publish-`mpsc` (JetStream + Core MarketEvent) |
 | Account-Early-Drop (Counter) | `market_data_account_early_drop_total` | Billiger Relevanz-Filter im Recv-Task (kein DEX-Parse) |
 | Account-Handler-Zeit (Histogram, µs) | `market_data_account_handler_duration_us_*` | Wall-Time pro Worker für `handle_geyser_account` (ohne Warteschlangen-Wartezeit) |
+| Account-Recv-Drain (Counter) | `market_data_account_recv_iterations_total` | Erfolgreiche Account-Broadcast-`recv`-Iterationen; Drain-Rate via `rate(market_data_account_recv_iterations_total[5m])` |
+| Account-Recv-Classify (Histogram, µs) | `market_data_account_recv_classify_duration_us_*` | Wall-Time `classify_account_geyser_update` im dedizierten Recv-Task |
+| Account-Recv-HIGH-Enqueue (Histogram, µs) | `market_data_account_recv_high_enqueue_duration_us_*` | Wall-Time `mpsc::send().await` auf den HIGH-Worker-Shard im Recv-Task |
+| Account-Recv-ENRICH-Ingress (Histogram, µs) | `market_data_account_recv_enrich_ingress_duration_us_*` | Wall-Time `account_enrich_ingress_try_send` im Recv-Task |
+| Account-Recv-Iteration (Histogram, µs) | `market_data_account_recv_iteration_duration_us_*` | Gesamtzeit pro Recv-Iteration (`recv` → Dispatch fertig) |
 | Drops | `market_data_tx_broadcast_lagged_total`, `market_data_account_broadcast_lagged_total` | Summe der übersprungenen Nachrichten bei `RecvError::Lagged` |
 | Ketten vs. Wall | `market_data_bonding_to_trade_slot_delta_slots` | Slot-Delta letztes `BondingCurveProgress` → nächstes Pump.fun-`Trade` (I-16: Geyser-Slots) |
 
@@ -276,6 +281,24 @@ market_data_account_broadcast_lagged_total
 histogram_quantile(0.50, sum(rate(market_data_tx_channel_lag_ms_bucket[5m])) by (le))
 histogram_quantile(0.50, sum(rate(market_data_geyser_to_publish_ms_trade_bucket[5m])) by (le))
 ```
+
+**Account-Recv-Engpass-Diagnose (Scope J1, nach Deploy):** Wenn `market_data_account_broadcast_queue_depth` am Cap klebt und `market_data_account_channel_lag_ms` hoch ist, trennen die Recv-Segment-Histogramme **Classify** vs. **HIGH-await** vs. **ENRICH-Ingress**. Drain-Rate: `rate(market_data_account_recv_iterations_total[5m])` (sollte in der Größenordnung der Geyser-Account-Rate liegen; deutlich darunter = Recv-Sättigung).
+
+```promql
+# Drain-Rate (Iterationen/s)
+rate(market_data_account_recv_iterations_total[5m])
+# Engpass-Segmentierung (p95, µs)
+histogram_quantile(0.95, sum(rate(market_data_account_recv_classify_duration_us_bucket[5m])) by (le))
+histogram_quantile(0.95, sum(rate(market_data_account_recv_high_enqueue_duration_us_bucket[5m])) by (le))
+histogram_quantile(0.95, sum(rate(market_data_account_recv_enrich_ingress_duration_us_bucket[5m])) by (le))
+histogram_quantile(0.95, sum(rate(market_data_account_recv_iteration_duration_us_bucket[5m])) by (le))
+# Kontext (unverändert)
+market_data_account_broadcast_queue_depth
+rate(market_data_account_broadcast_lagged_total[5m])
+histogram_quantile(0.95, sum(rate(market_data_account_channel_lag_ms_bucket[5m])) by (le))
+```
+
+**Interpretation für J2-Entscheidung:** Hohes `recv_high_enqueue_duration_us` bei niedrigem `recv_classify_duration_us` und niedrigem `recv_enrich_ingress_duration_us` → Recv blockiert auf HIGH-`send().await` (Kandidat J2 try_send). Hohes `recv_classify_duration_us` bei niedrigen Enqueue-Zeiten → Classify/Registry-Hotspot. Hohes `recv_iteration_duration_us` ohne dominantes Segment → mehrere kleine Anteile oder Scheduling-Jitter; `iteration` vs. Summe der Segmente vergleichen.
 
 | Segment | Metrik (Präfix je nach Export) | Kurzinterpretation |
 |--------|--------------------------------|---------------------|

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -102,7 +102,8 @@ use ironcrab::metrics::{
     inc_market_data_account_enrich_enqueue_dropped_total,
     inc_market_data_account_enrich_ingress_queue_depth,
     inc_market_data_account_high_priority_queue_depth,
-    inc_market_data_account_low_priority_queue_depth, inc_market_data_account_updates_total,
+    inc_market_data_account_low_priority_queue_depth,
+    inc_market_data_account_recv_iterations_total, inc_market_data_account_updates_total,
     inc_market_data_account_worker_queue_depth, inc_market_data_arb_admission_admitted_total,
     inc_market_data_arb_admission_rejected_total,
     inc_market_data_arb_pin_geyser_register_deferred_total,
@@ -124,6 +125,10 @@ use ironcrab::metrics::{
     market_data_tx_handler_processed_value, record_market_data_account_broadcast_lagged,
     record_market_data_account_channel_lag_ms, record_market_data_account_channel_lag_ms_for_class,
     record_market_data_account_early_drop, record_market_data_account_handler_duration_us,
+    record_market_data_account_recv_classify_duration_us,
+    record_market_data_account_recv_enrich_ingress_duration_us,
+    record_market_data_account_recv_high_enqueue_duration_us,
+    record_market_data_account_recv_iteration_duration_us,
     record_market_data_arb_track_requests_messages_total,
     record_market_data_geyser_merge_coalesced_total, record_market_data_geyser_sync_batch_total,
     record_market_data_global_ingest_stall, record_market_data_md_state_stall,
@@ -9064,20 +9069,35 @@ async fn run_geyser_loop(
         loop {
             match account_rx_geyser.recv().await {
                 Ok(account_update) => {
+                    let iteration_start = Instant::now();
                     let recv_at = Instant::now();
+                    inc_market_data_account_recv_iterations_total();
                     record_market_data_account_channel_lag_ms(account_update.grpc_recv_at, recv_at);
                     set_market_data_account_broadcast_queue_depth(account_rx_geyser.len());
                     market_data_bump_geyser_head_slot(account_update.slot);
 
+                    let classify_start = Instant::now();
                     let (class, early_drop_reason) =
                         ironcrab::market_data::ingest::classify_account_geyser_update(
                             &ctx_geyser_acc,
                             &account_update,
                         );
+                    record_market_data_account_recv_classify_duration_us(
+                        classify_start
+                            .elapsed()
+                            .as_micros()
+                            .min(u128::from(u64::MAX)) as u64,
+                    );
                     inc_market_data_account_updates_total(class.as_prometheus_label());
 
                     if let Some(reason) = early_drop_reason {
                         record_market_data_account_early_drop(reason);
+                        record_market_data_account_recv_iteration_duration_us(
+                            iteration_start
+                                .elapsed()
+                                .as_micros()
+                                .min(u128::from(u64::MAX)) as u64,
+                        );
                         continue;
                     }
 
@@ -9093,6 +9113,7 @@ async fn run_geyser_loop(
                         ironcrab::market_data::ingest::AccountUpdateClass::ExecHot
                     );
                     if high {
+                        let enqueue_start = Instant::now();
                         let send_res = worker_high_recv[shard]
                             .send(AccountWorkItem {
                                 update: account_update,
@@ -9100,6 +9121,12 @@ async fn run_geyser_loop(
                                 class,
                             })
                             .await;
+                        record_market_data_account_recv_high_enqueue_duration_us(
+                            enqueue_start
+                                .elapsed()
+                                .as_micros()
+                                .min(u128::from(u64::MAX)) as u64,
+                        );
                         if send_res.is_ok() {
                             inc_market_data_account_worker_queue_depth();
                             inc_market_data_account_high_priority_queue_depth();
@@ -9117,6 +9144,7 @@ async fn run_geyser_loop(
                             recv_at,
                             class,
                         };
+                        let ingress_start = Instant::now();
                         match account_enrich_ingress_try_send(&enrich_ingress_recv[shard], work) {
                             AccountEnrichIngressSend::Ok => {}
                             AccountEnrichIngressSend::ContendedFull => {}
@@ -9129,7 +9157,19 @@ async fn run_geyser_loop(
                                 break;
                             }
                         }
+                        record_market_data_account_recv_enrich_ingress_duration_us(
+                            ingress_start
+                                .elapsed()
+                                .as_micros()
+                                .min(u128::from(u64::MAX)) as u64,
+                        );
                     }
+                    record_market_data_account_recv_iteration_duration_us(
+                        iteration_start
+                            .elapsed()
+                            .as_micros()
+                            .min(u128::from(u64::MAX)) as u64,
+                    );
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                     record_market_data_account_broadcast_lagged(n);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1935,6 +1935,81 @@ static MARKET_DATA_ACCOUNT_HANDLER_DURATION_US_SUM: Lazy<AtomicU64> =
 static MARKET_DATA_ACCOUNT_HANDLER_DURATION_US_COUNT: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
+/// Successful account broadcast `recv` iterations (drain rate via `rate(...)`).
+pub static MARKET_DATA_ACCOUNT_RECV_ITERATIONS_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Wall microseconds for `classify_account_geyser_update` in the account recv task.
+const MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_BUCKETS: &[u64] = &[
+    1, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 25_000, 50_000, 100_000, 250_000,
+    500_000,
+];
+
+static MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Wall microseconds for HIGH-path `mpsc::send().await` in the account recv task.
+const MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_BUCKETS: &[u64] = &[
+    50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 25_000, 50_000, 100_000, 250_000, 500_000,
+    1_000_000, 2_000_000,
+];
+
+static MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Wall microseconds for ENRICH-path `account_enrich_ingress_try_send` in the account recv task.
+const MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_BUCKETS: &[u64] = &[
+    1, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 25_000, 50_000, 100_000,
+];
+
+static MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Wall microseconds per account recv loop iteration (`recv` → dispatch done).
+const MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_BUCKETS: &[u64] = &[
+    50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 25_000, 50_000, 100_000, 250_000, 500_000,
+    1_000_000, 2_000_000,
+];
+
+static MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> =
+    Lazy::new(|| {
+        MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_BUCKETS
+            .iter()
+            .map(|_| AtomicU64::new(0))
+            .collect()
+    });
+static MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_SUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_COUNT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 /// Monotonic tick bumped on Geyser account/tx ingest (Tokio liveness vs OS-thread watchdog).
 pub static MARKET_DATA_INGEST_PROGRESS_TICK: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
@@ -2299,6 +2374,64 @@ pub fn record_market_data_account_handler_duration_us(us: u64) {
         &MARKET_DATA_ACCOUNT_HANDLER_DURATION_US_BUCKET_COUNTS,
         &MARKET_DATA_ACCOUNT_HANDLER_DURATION_US_SUM,
         &MARKET_DATA_ACCOUNT_HANDLER_DURATION_US_COUNT,
+        us,
+        u64::MAX,
+    );
+}
+
+/// Successful account broadcast recv iteration (one `Ok(account_update)` handled).
+#[inline]
+pub fn inc_market_data_account_recv_iterations_total() {
+    MARKET_DATA_ACCOUNT_RECV_ITERATIONS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Classify wall time in the account recv task, microseconds.
+#[inline]
+pub fn record_market_data_account_recv_classify_duration_us(us: u64) {
+    record_histogram_u64_into(
+        MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_BUCKETS,
+        &MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_BUCKET_COUNTS,
+        &MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_SUM,
+        &MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_COUNT,
+        us,
+        u64::MAX,
+    );
+}
+
+/// HIGH-path worker enqueue wall time in the account recv task, microseconds.
+#[inline]
+pub fn record_market_data_account_recv_high_enqueue_duration_us(us: u64) {
+    record_histogram_u64_into(
+        MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_BUCKETS,
+        &MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_BUCKET_COUNTS,
+        &MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_SUM,
+        &MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_COUNT,
+        us,
+        u64::MAX,
+    );
+}
+
+/// ENRICH ingress try-send wall time in the account recv task, microseconds.
+#[inline]
+pub fn record_market_data_account_recv_enrich_ingress_duration_us(us: u64) {
+    record_histogram_u64_into(
+        MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_BUCKETS,
+        &MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_BUCKET_COUNTS,
+        &MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_SUM,
+        &MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_COUNT,
+        us,
+        u64::MAX,
+    );
+}
+
+/// Total recv-loop iteration wall time (`recv` → dispatch done), microseconds.
+#[inline]
+pub fn record_market_data_account_recv_iteration_duration_us(us: u64) {
+    record_histogram_u64_into(
+        MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_BUCKETS,
+        &MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_BUCKET_COUNTS,
+        &MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_SUM,
+        &MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_COUNT,
         us,
         u64::MAX,
     );
@@ -7233,6 +7366,42 @@ async fn metrics_response() -> Response<Body> {
         &MARKET_DATA_ACCOUNT_HANDLER_DURATION_US_SUM,
         &MARKET_DATA_ACCOUNT_HANDLER_DURATION_US_COUNT,
     );
+    line!(
+        "market_data_account_recv_iterations_total",
+        MARKET_DATA_ACCOUNT_RECV_ITERATIONS_TOTAL.load(Ordering::Relaxed)
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_account_recv_classify_duration_us",
+        MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_BUCKETS,
+        &MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_BUCKET_COUNTS,
+        &MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_SUM,
+        &MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_account_recv_high_enqueue_duration_us",
+        MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_BUCKETS,
+        &MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_BUCKET_COUNTS,
+        &MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_SUM,
+        &MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_account_recv_enrich_ingress_duration_us",
+        MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_BUCKETS,
+        &MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_BUCKET_COUNTS,
+        &MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_SUM,
+        &MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_COUNT,
+    );
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "market_data_account_recv_iteration_duration_us",
+        MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_BUCKETS,
+        &MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_BUCKET_COUNTS,
+        &MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_SUM,
+        &MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_COUNT,
+    );
 
     // --- momentum-bot service ---
     line!(
@@ -9721,5 +9890,52 @@ mod arb_two_hop_v2_sell_quote_none_detail_metrics_tests {
                 "missing sell_quote_none detail label {label}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod market_data_account_recv_metrics_tests {
+    use super::*;
+
+    #[test]
+    fn recv_record_functions_increment_histogram_counts() {
+        let classify_before =
+            MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_COUNT.load(Ordering::Relaxed);
+        record_market_data_account_recv_classify_duration_us(42);
+        assert_eq!(
+            MARKET_DATA_ACCOUNT_RECV_CLASSIFY_DURATION_US_COUNT.load(Ordering::Relaxed),
+            classify_before + 1
+        );
+
+        let high_before =
+            MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_COUNT.load(Ordering::Relaxed);
+        record_market_data_account_recv_high_enqueue_duration_us(100);
+        assert_eq!(
+            MARKET_DATA_ACCOUNT_RECV_HIGH_ENQUEUE_DURATION_US_COUNT.load(Ordering::Relaxed),
+            high_before + 1
+        );
+
+        let enrich_before =
+            MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_COUNT.load(Ordering::Relaxed);
+        record_market_data_account_recv_enrich_ingress_duration_us(5);
+        assert_eq!(
+            MARKET_DATA_ACCOUNT_RECV_ENRICH_INGRESS_DURATION_US_COUNT.load(Ordering::Relaxed),
+            enrich_before + 1
+        );
+
+        let iter_before =
+            MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_COUNT.load(Ordering::Relaxed);
+        record_market_data_account_recv_iteration_duration_us(250);
+        assert_eq!(
+            MARKET_DATA_ACCOUNT_RECV_ITERATION_DURATION_US_COUNT.load(Ordering::Relaxed),
+            iter_before + 1
+        );
+
+        let recv_iters_before = MARKET_DATA_ACCOUNT_RECV_ITERATIONS_TOTAL.load(Ordering::Relaxed);
+        inc_market_data_account_recv_iterations_total();
+        assert_eq!(
+            MARKET_DATA_ACCOUNT_RECV_ITERATIONS_TOTAL.load(Ordering::Relaxed),
+            recv_iters_before + 1
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Scope J1: instrument account broadcast recv path (classify / HIGH enqueue / enrich ingress / iteration) without behavior change.
- Metrics: `market_data_account_recv_iterations_total` + duration histograms (us).
- RUNBOOK: Account-Recv Engpass-Diagnose PromQL for J2 decisions.

## Test plan
- [x] cargo fmt / clippy / test (agent)
- [ ] GitHub CI + Eval L5
- [ ] Bugbot before merge
- [ ] No deploy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Instrumentation and runbook only; no changes to account routing, queues, or trading logic beyond timing calls on the existing hot path.
> 
> **Overview**
> Adds **Scope J1** observability on the dedicated Geyser account broadcast recv loop so prod can see whether backlog is classify, HIGH `send().await`, or enrich ingress—without changing dispatch behavior.
> 
> The recv task now increments **`market_data_account_recv_iterations_total`** and records microsecond histograms for **classify**, **HIGH enqueue**, **enrich ingress**, and **full iteration** (including early-drop paths). Metrics are wired through `src/metrics.rs` (Prometheus export) with unit tests on the record helpers.
> 
> **`docs/RUNBOOK_PROD.md`** documents the new signals, PromQL for drain rate and p95 segment breakdown, and interpretation rules aimed at a future **J2** fix (e.g. try_send on HIGH when enqueue dominates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34b8d1c905057bf6ebba240fcce9b58116609a1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->