### PR TITLE
fix(market-data): make account recv await-free dispatch (Scope J2)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -101,6 +101,7 @@ use ironcrab::metrics::{
     inc_market_data_account_enrich_dispatch_contended_total,
     inc_market_data_account_enrich_enqueue_dropped_total,
     inc_market_data_account_enrich_ingress_queue_depth,
+    inc_market_data_account_high_enqueue_dropped_total,
     inc_market_data_account_high_priority_queue_depth,
     inc_market_data_account_low_priority_queue_depth,
     inc_market_data_account_recv_iterations_total, inc_market_data_account_updates_total,
@@ -8073,6 +8074,33 @@ enum AccountEnrichIngressSend {
     Closed,
 }
 
+/// Result of non-blocking EXEC_HOT HIGH enqueue from the broadcast recv task.
+#[derive(Debug, PartialEq, Eq)]
+enum AccountHighIngressSend {
+    Ok,
+    ContendedFull,
+    Closed,
+}
+
+/// Enqueue EXEC_HOT work into the per-shard HIGH channel without blocking the recv task.
+fn account_high_ingress_try_send(
+    high_tx: &mpsc::Sender<AccountWorkItem>,
+    work: AccountWorkItem,
+) -> AccountHighIngressSend {
+    match high_tx.try_send(work) {
+        Ok(()) => {
+            inc_market_data_account_worker_queue_depth();
+            inc_market_data_account_high_priority_queue_depth();
+            AccountHighIngressSend::Ok
+        }
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            inc_market_data_account_high_enqueue_dropped_total();
+            AccountHighIngressSend::ContendedFull
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => AccountHighIngressSend::Closed,
+    }
+}
+
 /// Enqueue ENRICH work into the per-shard ingress channel without touching the coalesce mutex.
 fn account_enrich_ingress_try_send(
     ingress_tx: &mpsc::Sender<AccountWorkItem>,
@@ -9114,30 +9142,31 @@ async fn run_geyser_loop(
                     );
                     if high {
                         let enqueue_start = Instant::now();
-                        let send_res = worker_high_recv[shard]
-                            .send(AccountWorkItem {
+                        match account_high_ingress_try_send(
+                            &worker_high_recv[shard],
+                            AccountWorkItem {
                                 update: account_update,
                                 recv_at,
                                 class,
-                            })
-                            .await;
+                            },
+                        ) {
+                            AccountHighIngressSend::Ok => {}
+                            AccountHighIngressSend::ContendedFull => {}
+                            AccountHighIngressSend::Closed => {
+                                error!(
+                                    shard = shard,
+                                    "account HIGH worker queue closed; stopping Geyser account stream"
+                                );
+                                let _ = geyser_account_stream_stopped_tx.send(true);
+                                break;
+                            }
+                        }
                         record_market_data_account_recv_high_enqueue_duration_us(
                             enqueue_start
                                 .elapsed()
                                 .as_micros()
                                 .min(u128::from(u64::MAX)) as u64,
                         );
-                        if send_res.is_ok() {
-                            inc_market_data_account_worker_queue_depth();
-                            inc_market_data_account_high_priority_queue_depth();
-                        } else {
-                            error!(
-                                shard = shard,
-                                "account HIGH worker queue closed; stopping Geyser account stream"
-                            );
-                            let _ = geyser_account_stream_stopped_tx.send(true);
-                            break;
-                        }
                     } else {
                         let work = AccountWorkItem {
                             update: account_update,
@@ -14337,6 +14366,39 @@ mod pr_b_geyser_tracking_tests {
         assert_eq!(
             account_enrich_ingress_try_send(&ingress_tx, mk(2)),
             AccountEnrichIngressSend::ContendedFull
+        );
+    }
+
+    #[test]
+    fn account_high_ingress_full_does_not_block_recv_path() {
+        use ironcrab::metrics::MARKET_DATA_ACCOUNT_HIGH_ENQUEUE_DROPPED_TOTAL;
+        use std::sync::atomic::Ordering;
+
+        MARKET_DATA_ACCOUNT_HIGH_ENQUEUE_DROPPED_TOTAL.store(0, Ordering::Relaxed);
+        let (high_tx, _high_rx) = mpsc::channel(1);
+        let mk = |slot: u64| AccountWorkItem {
+            update: GeyserAccountUpdate {
+                pubkey: Pubkey::new_unique(),
+                slot,
+                owner: PUMPFUN_PROGRAM_OWNER,
+                data: vec![],
+                lamports: 0,
+                grpc_recv_at: Instant::now(),
+            },
+            recv_at: Instant::now(),
+            class: AccountUpdateClass::ExecHot,
+        };
+        assert_eq!(
+            account_high_ingress_try_send(&high_tx, mk(1)),
+            AccountHighIngressSend::Ok
+        );
+        assert_eq!(
+            account_high_ingress_try_send(&high_tx, mk(2)),
+            AccountHighIngressSend::ContendedFull
+        );
+        assert_eq!(
+            MARKET_DATA_ACCOUNT_HIGH_ENQUEUE_DROPPED_TOTAL.load(Ordering::Relaxed),
+            1
         );
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1852,6 +1852,10 @@ pub static MARKET_DATA_ACCOUNT_ENRICH_INGRESS_QUEUE_DEPTH: Lazy<AtomicU64> =
 pub static MARKET_DATA_ACCOUNT_ENRICH_DISPATCH_CONTENDED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
+/// EXEC_HOT HIGH `try_send` dropped (channel full); recv did not block on worker backlog.
+pub static MARKET_DATA_ACCOUNT_HIGH_ENQUEUE_DROPPED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 /// Account ingest: jobs waiting in the dedicated NATS publish `mpsc` (JetStream + core publish).
 pub static MARKET_DATA_ACCOUNT_PUBLISH_QUEUE_DEPTH: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -2257,6 +2261,11 @@ pub fn dec_market_data_account_enrich_ingress_queue_depth() {
 #[inline]
 pub fn inc_market_data_account_enrich_dispatch_contended_total() {
     MARKET_DATA_ACCOUNT_ENRICH_DISPATCH_CONTENDED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_account_high_enqueue_dropped_total() {
+    MARKET_DATA_ACCOUNT_HIGH_ENQUEUE_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -7288,6 +7297,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_account_enrich_dispatch_contended_total",
         MARKET_DATA_ACCOUNT_ENRICH_DISPATCH_CONTENDED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_account_high_enqueue_dropped_total",
+        MARKET_DATA_ACCOUNT_HIGH_ENQUEUE_DROPPED_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_account_publish_queue_depth",


### PR DESCRIPTION
## Summary
- Scope J2: HIGH/EXEC_HOT enqueue uses try_send (no send().await in recv).
- Recv hot path awaits only broadcast.recv(); enrich ingress already non-blocking (Scope I).
- Metric: market_data_account_high_enqueue_dropped_total + unit test for full HIGH channel.

## Test plan
- [x] agent fmt/clippy/test
- [ ] CI + Eval L5
- [ ] Bugbot
- [ ] No deploy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Under worker backlog, EXEC_HOT updates can be silently dropped rather than blocking ingestion—latency improves but execution-critical account data may be missed until operators watch the new drop counter.
> 
> **Overview**
> **Scope J2** makes the Geyser account **recv** task await-free when dispatching **EXEC_HOT** work: HIGH-priority per-shard enqueue now uses `try_send` via `account_high_ingress_try_send`, matching the existing non-blocking ENRICH ingress pattern.
> 
> When a shard’s HIGH channel is full, the update is **dropped** (recv continues) instead of blocking on `send().await`. A new counter **`market_data_account_high_enqueue_dropped_total`** records those drops and is exposed in metrics output. Queue-depth increments move into the helper on successful enqueue; a closed channel still stops the account stream.
> 
> Adds a unit test that a full HIGH channel returns `ContendedFull` and increments the drop metric without blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0083f407a115e8bc50eca806952db0b644de5555. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->