### PR TITLE
fix(arb): pair-complete track selection (Scope S1)

### DIFF
--- a/src/arbitrage/track_selection.rs
+++ b/src/arbitrage/track_selection.rs
@@ -103,6 +103,10 @@ pub struct TrackSelectionResult {
     /// Pools that would have been selected for a mint but were dropped by the global budget.
     pub budget_displaced: Vec<String>,
     pub selected_mints: usize,
+    /// Mints with ≥2 selected pools on ≥2 distinct DEXes (I-ARB-10b).
+    pub pair_complete_mints: usize,
+    /// Selected pools whose mint lacks a cross-DEX pair in the selected set (Soll: 0).
+    pub orphan_pools: usize,
     pub candidate_counts: TrackCandidateCounts,
 }
 
@@ -167,12 +171,50 @@ pub fn select_arb_track_pools(
     budget_displaced.sort();
     budget_displaced.dedup();
 
+    let (pair_complete_mints, orphan_pools) = compute_pair_completeness_stats(&selected, mints);
+
     TrackSelectionResult {
         selected_mints: selected_mints.len(),
+        pair_complete_mints,
+        orphan_pools,
         selected,
         budget_displaced,
         candidate_counts,
     }
+}
+
+/// Count pair-complete mints and orphan pools in the selected set (I-ARB-10b observability).
+pub fn compute_pair_completeness_stats(
+    selected: &[SelectedTrackPool],
+    mints: &[TrackMintInput],
+) -> (usize, usize) {
+    let pool_dex: HashMap<&str, &str> = mints
+        .iter()
+        .flat_map(|mint| {
+            mint.pools
+                .iter()
+                .map(|pool| (pool.pool_address.as_str(), pool.dex.as_str()))
+        })
+        .collect();
+
+    let mut by_mint: HashMap<&str, Vec<&str>> = HashMap::new();
+    for entry in selected {
+        if let Some(dex) = pool_dex.get(entry.pool.as_str()) {
+            by_mint.entry(entry.mint.as_str()).or_default().push(*dex);
+        }
+    }
+
+    let mut pair_complete_mints = 0usize;
+    let mut orphan_pools = 0usize;
+    for pools in by_mint.values() {
+        let distinct_dexes: HashSet<&str> = pools.iter().copied().collect();
+        if pools.len() >= 2 && distinct_dexes.len() >= 2 {
+            pair_complete_mints += 1;
+        } else {
+            orphan_pools += pools.len();
+        }
+    }
+    (pair_complete_mints, orphan_pools)
 }
 
 /// Map selection removals for pools no longer in the target set.
@@ -654,6 +696,150 @@ mod tests {
     const MINT: &str = "TokenMint11111111111111111111111111111111";
     const RESERVE_BASE: u64 = 1_000_000_000_000;
     const RESERVE_QUOTE: u64 = 1_000_000_000;
+
+    #[test]
+    fn cross_dex_quotable_pair_both_selected() {
+        let fresh_vault = vault(RESERVE_BASE, RESERVE_QUOTE);
+        let mint = mint_input(
+            MINT,
+            vec![
+                pool_input(
+                    "orca",
+                    "orca_quote",
+                    MINT,
+                    true,
+                    true,
+                    Some(fresh_vault),
+                    10,
+                ),
+                pool_input(
+                    "pump_amm",
+                    "pump_quote",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
+                    9,
+                ),
+            ],
+            10,
+            None,
+        );
+        let result = select_arb_track_pools(&[mint], &default_config(500));
+        assert_eq!(result.selected.len(), 2);
+        assert_eq!(result.pair_complete_mints, 1);
+        assert_eq!(result.orphan_pools, 0);
+        let pools: HashSet<_> = result.selected.iter().map(|p| p.pool.as_str()).collect();
+        assert!(pools.contains("orca_quote"));
+        assert!(pools.contains("pump_quote"));
+    }
+
+    #[test]
+    fn multi_dex_mint_rejected_when_filters_leave_lt_2_candidates() {
+        let mint = mint_input(
+            MINT,
+            vec![
+                pool_input(
+                    "orca",
+                    "orca_ok",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                    10,
+                ),
+                pool_input("pump_amm", "pump_unknown", MINT, false, false, None, 9),
+                pool_input("raydium", "ray_unknown", MINT, false, false, None, 8),
+            ],
+            10,
+            None,
+        );
+        let result = select_arb_track_pools(&[mint], &default_config(500));
+        assert!(result.selected.is_empty());
+        assert_eq!(result.pair_complete_mints, 0);
+        assert_eq!(result.orphan_pools, 0);
+    }
+
+    #[test]
+    fn budget_prefers_fewer_complete_mints_over_orphan_fill() {
+        let make_mint = |idx: u64| {
+            mint_input(
+                &format!("Mint{idx:04}"),
+                vec![
+                    pool_input(
+                        "orca",
+                        &format!("orca_{idx}"),
+                        MINT,
+                        true,
+                        true,
+                        Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                        idx,
+                    ),
+                    pool_input(
+                        "pump_amm",
+                        &format!("pump_{idx}"),
+                        MINT,
+                        true,
+                        true,
+                        Some(vault(RESERVE_BASE, RESERVE_QUOTE * 2)),
+                        idx,
+                    ),
+                ],
+                idx,
+                None,
+            )
+        };
+        let mints: Vec<_> = (0..5).map(make_mint).collect();
+        let result = select_arb_track_pools(&mints, &default_config(4));
+        assert_eq!(result.selected.len(), 4);
+        assert_eq!(result.orphan_pools, 0);
+        assert_eq!(result.pair_complete_mints, 2);
+        assert_eq!(result.selected_mints, 2);
+    }
+
+    #[test]
+    fn pair_complete_stats_detect_orphans() {
+        let selected = vec![
+            SelectedTrackPool {
+                mint: "m1".to_string(),
+                pool: "solo".to_string(),
+                readiness: TrackPoolReadiness::QuoteReady,
+                active_reason: ArbTrackActiveReason::MultiDex,
+            },
+            SelectedTrackPool {
+                mint: "m2".to_string(),
+                pool: "a".to_string(),
+                readiness: TrackPoolReadiness::QuoteReady,
+                active_reason: ArbTrackActiveReason::MultiDex,
+            },
+            SelectedTrackPool {
+                mint: "m2".to_string(),
+                pool: "b".to_string(),
+                readiness: TrackPoolReadiness::QuoteReady,
+                active_reason: ArbTrackActiveReason::MultiDex,
+            },
+        ];
+        let mints = vec![
+            TrackMintInput {
+                mint: "m1".to_string(),
+                pools: vec![pool_input("orca", "solo", MINT, true, true, None, 1)],
+                trade_signal_pools: None,
+                last_activity_unix_ms: 1,
+            },
+            TrackMintInput {
+                mint: "m2".to_string(),
+                pools: vec![
+                    pool_input("orca", "a", MINT, true, true, None, 2),
+                    pool_input("pump_amm", "b", MINT, true, true, None, 2),
+                ],
+                trade_signal_pools: None,
+                last_activity_unix_ms: 2,
+            },
+        ];
+        let (pair_complete, orphans) = compute_pair_completeness_stats(&selected, &mints);
+        assert_eq!(pair_complete, 1);
+        assert_eq!(orphans, 1);
+    }
 
     #[test]
     fn single_dex_mint_selects_nothing() {

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -6084,6 +6084,8 @@ impl ArbContext {
         set_arb_track_selection_metrics(
             result.selected.len(),
             result.selected_mints,
+            result.pair_complete_mints,
+            result.orphan_pools,
             &result.candidate_counts,
         );
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3750,6 +3750,9 @@ pub static ARB_TWO_HOP_V2_SELL_QUOTE_NONE_DETAIL_MINT_DIRECTION_INVALID: Lazy<At
 pub static ARB_PROACTIVE_TRACK_PUBLISH_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TRACK_SELECTED_POOLS_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TRACK_SELECTED_MINTS_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_SELECTED_PAIR_COMPLETE_MINTS_GAUGE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TRACK_SELECTED_ORPHAN_POOLS_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TRACK_CANDIDATE_POOLS_EXECUTABLE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TRACK_CANDIDATE_POOLS_QUOTE_READY: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TRACK_CANDIDATE_POOLS_WARMABLE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -4420,10 +4423,15 @@ pub fn record_arb_proactive_track_publish_total() {
 pub fn set_arb_track_selection_metrics(
     selected_pools: usize,
     selected_mints: usize,
+    pair_complete_mints: usize,
+    orphan_pools: usize,
     candidate_counts: &crate::arbitrage::TrackCandidateCounts,
 ) {
     ARB_TRACK_SELECTED_POOLS_GAUGE.store(selected_pools as u64, Ordering::Relaxed);
     ARB_TRACK_SELECTED_MINTS_GAUGE.store(selected_mints as u64, Ordering::Relaxed);
+    ARB_TRACK_SELECTED_PAIR_COMPLETE_MINTS_GAUGE
+        .store(pair_complete_mints as u64, Ordering::Relaxed);
+    ARB_TRACK_SELECTED_ORPHAN_POOLS_GAUGE.store(orphan_pools as u64, Ordering::Relaxed);
     ARB_TRACK_CANDIDATE_POOLS_EXECUTABLE.store(candidate_counts.executable, Ordering::Relaxed);
     ARB_TRACK_CANDIDATE_POOLS_QUOTE_READY.store(candidate_counts.quote_ready, Ordering::Relaxed);
     ARB_TRACK_CANDIDATE_POOLS_WARMABLE.store(candidate_counts.warmable, Ordering::Relaxed);
@@ -8307,6 +8315,14 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "arb_track_selected_mints",
         ARB_TRACK_SELECTED_MINTS_GAUGE.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_track_selected_pair_complete_mints",
+        ARB_TRACK_SELECTED_PAIR_COMPLETE_MINTS_GAUGE.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_track_selected_orphan_pools",
+        ARB_TRACK_SELECTED_ORPHAN_POOLS_GAUGE.load(Ordering::Relaxed)
     );
     out.push_str("arb_track_candidate_pools_total{readiness=\"executable\"} ");
     out.push_str(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes Scope S1 observability and test coverage for **I-ARB-10b pair-complete track selection**.

The core selection logic (`select_arb_track_pools` in `track_selection.rs`) was already in place from prior bounded-selection work: mints are only admitted as atomic cross-DEX bundles via `select_round_trip_pools` / pinable-pair heuristics, and both proactive + reconcile paths call the same helper.

This PR adds the missing production metrics and handoff test cases.

## Changes

- **`TrackSelectionResult`**: new fields `pair_complete_mints` and `orphan_pools`
- **`compute_pair_completeness_stats`**: integrity helper (≥2 pools on ≥2 DEXes per mint)
- **Metrics**: `arb_track_selected_pair_complete_mints` and `arb_track_selected_orphan_pools` gauges (orphan Soll: 0)
- **Tests**: cross-DEX quotable pair, filter rejection, budget prefers complete mints, orphan detection

## STOP-CHECK

- I-7: no RPC added (selection remains Geyser/cache-only)
- I-9 / I-12: unchanged
- `arb_track_baseline_max_pools` default unchanged (S2 out of scope)

## Verification

```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63c531e1-6ef8-400e-bb4a-55725484267a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63c531e1-6ef8-400e-bb4a-55725484267a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

