### PR TITLE
feat(arb): raise track baseline max pools to 2000 (Scope S2)

### DIFF
--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -122,7 +122,8 @@ const TOPIC_CONFIG_RELOAD: &str = "ironcrab.control.config.reload";
 /// Wire format version for `TOPIC_ARB_TRACK_REQUESTS`.
 const ARB_TRACK_REQUESTS_WIRE_VERSION: u32 = 1;
 /// Default cap for baseline reconcile `active[]` (configurable via `arb_track_baseline_max_pools`).
-const ARB_TRACK_BASELINE_MAX_POOLS_DEFAULT: usize = 500;
+/// Raised after pair-complete selection (S1): budget applies to complete pairs only; orphan gauge stays 0.
+const ARB_TRACK_BASELINE_MAX_POOLS_DEFAULT: usize = 2000;
 /// Default baseline reconcile interval (configurable via `arb_track_reconcile_interval_secs`).
 const ARB_TRACK_RECONCILE_INTERVAL_SECS_DEFAULT: u64 = 60;
 /// Max trade-signal pairs remembered per mint (bounded LRU by recency).
@@ -177,7 +178,7 @@ struct ArbConfig {
     intent_ttl_ms: u64,
     /// Enable 2-hop arbitrage (A→B on DEX1, B→A on DEX2). Default: true
     two_hop_enabled: bool,
-    /// Max pools in baseline reconcile snapshot. Default: 500.
+    /// Max pools in baseline reconcile snapshot. Default: 2000.
     arb_track_baseline_max_pools: usize,
     /// Baseline reconcile publish interval in seconds. Default: 60.
     arb_track_reconcile_interval_secs: u64,
@@ -10990,7 +10991,7 @@ mod two_hop_price_tests {
             last_activity_unix_ms: 2,
         };
         let config = TrackSelectionConfig {
-            max_pools: 500,
+            max_pools: ARB_TRACK_BASELINE_MAX_POOLS_DEFAULT,
             max_pools_per_mint: 3,
             probe_lamports: 10_000_000,
             freshness: QuoteFreshnessConfig::default(),

--- a/src/nats/arb_track_requests.rs
+++ b/src/nats/arb_track_requests.rs
@@ -254,11 +254,11 @@ mod tests {
     }
 
     #[test]
-    fn reconcile_baseline_500_stays_single_chunk() {
+    fn reconcile_baseline_2000_stays_single_chunk() {
         let update = ArbTrackRequestsUpdate {
             version: 1,
             ts_unix_ms: 1_700_000_000,
-            active: large_baseline_active(500),
+            active: large_baseline_active(2000),
             removed: Vec::new(),
             reconcile: true,
         };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Raises `ARB_TRACK_BASELINE_MAX_POOLS_DEFAULT` / default `arb_track_baseline_max_pools` from **500 → 2000** after S1 pair-complete selection is merged.

## Changes

- Default constant in `arb_strategy.rs` set to 2000
- Comment notes budget applies post pair-complete selection; orphan gauge should stay 0
- Related unit tests updated (selection test uses constant; NATS reconcile payload test renamed to 2000)

## Scope

- **S2 only** — no selection logic changes (S1 unchanged)
- `max_tracked_accounts` untouched

## STOP-CHECK

- I-7: no RPC changes
- I-ARB-10b: pair-complete selection untouched
- I-4e, I-MD-5: unaffected

## Verification

```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```

All passed locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cc7ae19-36d4-4dee-83ed-dc2a4e077e48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cc7ae19-36d4-4dee-83ed-dc2a4e077e48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

