### PR TITLE
fix(market-data): split account broadcast recv for EXEC_HOT vs ENRICH (Scope L1)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -20,6 +20,7 @@
 use anyhow::Result;
 use arc_swap::ArcSwap;
 use clap::Parser;
+use dashmap::DashMap;
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 use std::collections::hash_map::DefaultHasher;
@@ -8107,7 +8108,15 @@ enum AccountBroadcastRecvOutcome {
     StopStream,
 }
 
+/// Per-update routing state for split EXEC_HOT / ENRICH broadcast recv (Scope L1).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AccountBroadcastRouteState {
+    PendingEnrichPath,
+    Done,
+}
+
 /// Handle one `Ok(account_update)` from the account broadcast channel (Scope L1 split recv).
+#[allow(clippy::too_many_arguments)]
 fn handle_account_broadcast_recv_ok(
     path: AccountBroadcastRecvPath,
     ctx: &MarketDataContext,
@@ -8115,6 +8124,7 @@ fn handle_account_broadcast_recv_ok(
     recv_at: Instant,
     worker_high: &[mpsc::Sender<AccountWorkItem>],
     enrich_ingress: &[mpsc::Sender<AccountWorkItem>],
+    route_states: &DashMap<(Pubkey, u64), AccountBroadcastRouteState>,
     stream_stopped: &watch::Sender<bool>,
 ) -> AccountBroadcastRecvOutcome {
     let iteration_start = Instant::now();
@@ -8142,6 +8152,7 @@ fn handle_account_broadcast_recv_ok(
     if let Some(reason) = early_drop_reason {
         if matches!(path, AccountBroadcastRecvPath::ExecHot) {
             record_market_data_account_early_drop(reason);
+            inc_market_data_account_updates_total(class.as_prometheus_label());
             record_market_data_account_recv_iteration_duration_us(
                 iteration_start
                     .elapsed()
@@ -8152,25 +8163,42 @@ fn handle_account_broadcast_recv_ok(
         return AccountBroadcastRecvOutcome::Continue;
     }
 
+    let route_key = (account_update.pubkey, account_update.slot);
+
     match path {
-        AccountBroadcastRecvPath::ExecHot => {
-            if !matches!(
-                class,
-                ironcrab::market_data::ingest::AccountUpdateClass::ExecHot
-            ) {
+        AccountBroadcastRecvPath::ExecHot => match class {
+            ironcrab::market_data::ingest::AccountUpdateClass::ExecHot => {
                 if matches!(
-                    class,
-                    ironcrab::market_data::ingest::AccountUpdateClass::Drop
+                    route_states.get(&route_key).map(|entry| *entry),
+                    Some(AccountBroadcastRouteState::Done)
                 ) {
-                    inc_market_data_account_updates_total(class.as_prometheus_label());
+                    return AccountBroadcastRecvOutcome::Continue;
                 }
+            }
+            ironcrab::market_data::ingest::AccountUpdateClass::Enrich => {
+                if route_states.contains_key(&route_key) {
+                    return AccountBroadcastRecvOutcome::Continue;
+                }
+                route_states.insert(route_key, AccountBroadcastRouteState::PendingEnrichPath);
                 return AccountBroadcastRecvOutcome::Continue;
             }
-        }
+            ironcrab::market_data::ingest::AccountUpdateClass::Drop => {
+                inc_market_data_account_updates_total(class.as_prometheus_label());
+                return AccountBroadcastRecvOutcome::Continue;
+            }
+        },
         AccountBroadcastRecvPath::Enrich => {
+            if matches!(
+                route_states.get(&route_key).map(|entry| *entry),
+                Some(AccountBroadcastRouteState::Done)
+            ) {
+                return AccountBroadcastRecvOutcome::Continue;
+            }
+            route_states.remove(&route_key);
             if !matches!(
                 class,
                 ironcrab::market_data::ingest::AccountUpdateClass::Enrich
+                    | ironcrab::market_data::ingest::AccountUpdateClass::ExecHot
             ) {
                 return AccountBroadcastRecvOutcome::Continue;
             }
@@ -8185,11 +8213,11 @@ fn handle_account_broadcast_recv_ok(
     );
     inc_market_data_account_updates_total(class.as_prometheus_label());
 
-    match path {
-        AccountBroadcastRecvPath::ExecHot => {
+    let enqueue_outcome = match class {
+        ironcrab::market_data::ingest::AccountUpdateClass::ExecHot => {
             let shard = market_data_account_exec_hot_shard(&account_update.pubkey);
             let enqueue_start = Instant::now();
-            match account_high_ingress_try_send(
+            let outcome = match account_high_ingress_try_send(
                 &worker_high[shard],
                 AccountWorkItem {
                     update: account_update,
@@ -8197,8 +8225,8 @@ fn handle_account_broadcast_recv_ok(
                     class,
                 },
             ) {
-                AccountHighIngressSend::Ok => {}
-                AccountHighIngressSend::ContendedFull => {}
+                AccountHighIngressSend::Ok => AccountBroadcastRecvOutcome::Continue,
+                AccountHighIngressSend::ContendedFull => AccountBroadcastRecvOutcome::Continue,
                 AccountHighIngressSend::Closed => {
                     error!(
                         shard = shard,
@@ -8206,17 +8234,18 @@ fn handle_account_broadcast_recv_ok(
                         "account HIGH worker queue closed; stopping Geyser account stream"
                     );
                     let _ = stream_stopped.send(true);
-                    return AccountBroadcastRecvOutcome::StopStream;
+                    AccountBroadcastRecvOutcome::StopStream
                 }
-            }
+            };
             record_market_data_account_recv_high_enqueue_duration_us(
                 enqueue_start
                     .elapsed()
                     .as_micros()
                     .min(u128::from(u64::MAX)) as u64,
             );
+            outcome
         }
-        AccountBroadcastRecvPath::Enrich => {
+        ironcrab::market_data::ingest::AccountUpdateClass::Enrich => {
             let shard = market_data_account_enrich_shard(&account_update.pubkey);
             let work = AccountWorkItem {
                 update: account_update,
@@ -8224,9 +8253,9 @@ fn handle_account_broadcast_recv_ok(
                 class,
             };
             let ingress_start = Instant::now();
-            match account_enrich_ingress_try_send(&enrich_ingress[shard], work) {
-                AccountEnrichIngressSend::Ok => {}
-                AccountEnrichIngressSend::ContendedFull => {}
+            let outcome = match account_enrich_ingress_try_send(&enrich_ingress[shard], work) {
+                AccountEnrichIngressSend::Ok => AccountBroadcastRecvOutcome::Continue,
+                AccountEnrichIngressSend::ContendedFull => AccountBroadcastRecvOutcome::Continue,
                 AccountEnrichIngressSend::Closed => {
                     error!(
                         shard = shard,
@@ -8234,16 +8263,23 @@ fn handle_account_broadcast_recv_ok(
                         "account ENRICH ingress channel closed; stopping Geyser account stream"
                     );
                     let _ = stream_stopped.send(true);
-                    return AccountBroadcastRecvOutcome::StopStream;
+                    AccountBroadcastRecvOutcome::StopStream
                 }
-            }
+            };
             record_market_data_account_recv_enrich_ingress_duration_us(
                 ingress_start
                     .elapsed()
                     .as_micros()
                     .min(u128::from(u64::MAX)) as u64,
             );
+            outcome
         }
+        ironcrab::market_data::ingest::AccountUpdateClass::Drop => {
+            unreachable!("drop updates are handled by early_drop_reason")
+        }
+    };
+    if matches!(enqueue_outcome, AccountBroadcastRecvOutcome::Continue) {
+        route_states.insert(route_key, AccountBroadcastRouteState::Done);
     }
 
     record_market_data_account_recv_iteration_duration_us(
@@ -8252,7 +8288,7 @@ fn handle_account_broadcast_recv_ok(
             .as_micros()
             .min(u128::from(u64::MAX)) as u64,
     );
-    AccountBroadcastRecvOutcome::Continue
+    enqueue_outcome
 }
 
 /// Enqueue EXEC_HOT work into the per-shard HIGH channel without blocking the recv task.
@@ -9328,9 +9364,12 @@ async fn run_geyser_loop(
 
     let worker_high_recv = Arc::clone(&worker_high_dispatch);
     let enrich_ingress_recv = Arc::clone(&enrich_ingress_dispatch);
+    let account_broadcast_route_states =
+        Arc::new(DashMap::<(Pubkey, u64), AccountBroadcastRouteState>::new());
     let ctx_exec_hot_recv = Arc::clone(&ctx_geyser_acc);
     let worker_high_exec_hot = Arc::clone(&worker_high_recv);
     let enrich_ingress_exec_hot = Arc::clone(&enrich_ingress_recv);
+    let route_states_exec_hot = Arc::clone(&account_broadcast_route_states);
     let geyser_account_stream_stopped_exec_hot = geyser_account_stream_stopped_tx.clone();
     tokio::spawn(async move {
         loop {
@@ -9351,6 +9390,7 @@ async fn run_geyser_loop(
                             recv_at,
                             worker_high_exec_hot.as_ref(),
                             enrich_ingress_exec_hot.as_ref(),
+                            route_states_exec_hot.as_ref(),
                             &geyser_account_stream_stopped_exec_hot,
                         ),
                         AccountBroadcastRecvOutcome::StopStream
@@ -9376,6 +9416,7 @@ async fn run_geyser_loop(
     let ctx_enrich_recv = Arc::clone(&ctx_geyser_acc);
     let worker_high_enrich = Arc::clone(&worker_high_recv);
     let enrich_ingress_enrich = Arc::clone(&enrich_ingress_recv);
+    let route_states_enrich = Arc::clone(&account_broadcast_route_states);
     let geyser_account_stream_stopped_enrich = geyser_account_stream_stopped_tx.clone();
     tokio::spawn(async move {
         loop {
@@ -9396,6 +9437,7 @@ async fn run_geyser_loop(
                             recv_at,
                             worker_high_enrich.as_ref(),
                             enrich_ingress_enrich.as_ref(),
+                            route_states_enrich.as_ref(),
                             &geyser_account_stream_stopped_enrich,
                         ),
                         AccountBroadcastRecvOutcome::StopStream
@@ -14664,10 +14706,12 @@ mod pr_b_geyser_tracking_tests {
 
         let worker_high = Arc::new(high_txs);
         let enrich_ingress = Arc::new(enrich_ingress_txs);
+        let route_states = Arc::new(DashMap::<(Pubkey, u64), AccountBroadcastRouteState>::new());
 
         let ctx_exec = Arc::clone(&ctx);
         let worker_high_exec = Arc::clone(&worker_high);
         let enrich_ingress_exec = Arc::clone(&enrich_ingress);
+        let route_states_exec = Arc::clone(&route_states);
         let stream_stopped_exec = stream_stopped_tx.clone();
         let exec_recv = tokio::spawn(async move {
             loop {
@@ -14682,6 +14726,7 @@ mod pr_b_geyser_tracking_tests {
                                 recv_at,
                                 worker_high_exec.as_ref(),
                                 enrich_ingress_exec.as_ref(),
+                                route_states_exec.as_ref(),
                                 &stream_stopped_exec,
                             ),
                             AccountBroadcastRecvOutcome::StopStream
@@ -14698,6 +14743,7 @@ mod pr_b_geyser_tracking_tests {
         let ctx_enrich = Arc::clone(&ctx);
         let worker_high_enrich = Arc::clone(&worker_high);
         let enrich_ingress_enrich = Arc::clone(&enrich_ingress);
+        let route_states_enrich = Arc::clone(&route_states);
         let stream_stopped_enrich = stream_stopped_tx.clone();
         let enrich_recv = tokio::spawn(async move {
             loop {
@@ -14712,6 +14758,7 @@ mod pr_b_geyser_tracking_tests {
                                 recv_at,
                                 worker_high_enrich.as_ref(),
                                 enrich_ingress_enrich.as_ref(),
+                                route_states_enrich.as_ref(),
                                 &stream_stopped_enrich,
                             ),
                             AccountBroadcastRecvOutcome::StopStream

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -123,7 +123,7 @@ use ironcrab::metrics::{
     market_data_geyser_head_slot_value, market_data_geyser_tracking_enqueue_dropped_value,
     market_data_geyser_tracking_jobs_processed_value, market_data_md_state_bursts_completed_value,
     market_data_request_account_session_reconnect, market_data_request_tx_session_reconnect,
-    market_data_tx_handler_processed_value, record_market_data_account_broadcast_lagged,
+    market_data_tx_handler_processed_value, record_market_data_account_broadcast_lagged_for_class,
     record_market_data_account_channel_lag_ms, record_market_data_account_channel_lag_ms_for_class,
     record_market_data_account_early_drop, record_market_data_account_handler_duration_us,
     record_market_data_account_recv_classify_duration_us,
@@ -137,9 +137,10 @@ use ironcrab::metrics::{
     record_market_data_momentum_active_pool_messages_total,
     record_market_data_tokio_liveness_stall, record_market_data_tokio_progress,
     record_market_data_tx_broadcast_lagged, serve_metrics,
-    set_market_data_account_broadcast_queue_depth, set_market_data_account_enrich_worker_count,
-    set_market_data_account_exec_hot_worker_count, set_market_data_account_worker_count,
-    set_market_data_arb_pinned_pools_gauge, set_market_data_enrichment_registry_pools_gauge,
+    set_market_data_account_broadcast_queue_depth_for_class,
+    set_market_data_account_enrich_worker_count, set_market_data_account_exec_hot_worker_count,
+    set_market_data_account_worker_count, set_market_data_arb_pinned_pools_gauge,
+    set_market_data_enrichment_registry_pools_gauge,
     set_market_data_explicit_set_snapshot_restore_duration_ms,
     set_market_data_explicit_set_snapshot_restore_pubkeys,
     set_market_data_geyser_explicit_admitted_accounts,
@@ -8083,6 +8084,177 @@ enum AccountHighIngressSend {
     Closed,
 }
 
+/// Scope L1: split account broadcast recv paths (EXEC_HOT vs ENRICH).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AccountBroadcastRecvPath {
+    ExecHot,
+    Enrich,
+}
+
+impl AccountBroadcastRecvPath {
+    fn metrics_class(self) -> &'static str {
+        match self {
+            Self::ExecHot => "exec_hot",
+            Self::Enrich => "enrich",
+        }
+    }
+}
+
+/// Result of one successful account `broadcast::recv` iteration on a split recv path.
+#[derive(Debug, PartialEq, Eq)]
+enum AccountBroadcastRecvOutcome {
+    Continue,
+    StopStream,
+}
+
+/// Handle one `Ok(account_update)` from the account broadcast channel (Scope L1 split recv).
+fn handle_account_broadcast_recv_ok(
+    path: AccountBroadcastRecvPath,
+    ctx: &MarketDataContext,
+    account_update: GeyserAccountUpdate,
+    recv_at: Instant,
+    worker_high: &[mpsc::Sender<AccountWorkItem>],
+    enrich_ingress: &[mpsc::Sender<AccountWorkItem>],
+    stream_stopped: &watch::Sender<bool>,
+) -> AccountBroadcastRecvOutcome {
+    let iteration_start = Instant::now();
+    if matches!(path, AccountBroadcastRecvPath::ExecHot) {
+        inc_market_data_account_recv_iterations_total();
+    }
+
+    let classify_start = Instant::now();
+    let (class, early_drop_reason) =
+        ironcrab::market_data::ingest::classify_account_geyser_update(ctx, &account_update);
+    if matches!(path, AccountBroadcastRecvPath::ExecHot)
+        || matches!(
+            class,
+            ironcrab::market_data::ingest::AccountUpdateClass::Enrich
+        )
+    {
+        record_market_data_account_recv_classify_duration_us(
+            classify_start
+                .elapsed()
+                .as_micros()
+                .min(u128::from(u64::MAX)) as u64,
+        );
+    }
+
+    if let Some(reason) = early_drop_reason {
+        if matches!(path, AccountBroadcastRecvPath::ExecHot) {
+            record_market_data_account_early_drop(reason);
+            record_market_data_account_recv_iteration_duration_us(
+                iteration_start
+                    .elapsed()
+                    .as_micros()
+                    .min(u128::from(u64::MAX)) as u64,
+            );
+        }
+        return AccountBroadcastRecvOutcome::Continue;
+    }
+
+    match path {
+        AccountBroadcastRecvPath::ExecHot => {
+            if !matches!(
+                class,
+                ironcrab::market_data::ingest::AccountUpdateClass::ExecHot
+            ) {
+                if matches!(
+                    class,
+                    ironcrab::market_data::ingest::AccountUpdateClass::Drop
+                ) {
+                    inc_market_data_account_updates_total(class.as_prometheus_label());
+                }
+                return AccountBroadcastRecvOutcome::Continue;
+            }
+        }
+        AccountBroadcastRecvPath::Enrich => {
+            if !matches!(
+                class,
+                ironcrab::market_data::ingest::AccountUpdateClass::Enrich
+            ) {
+                return AccountBroadcastRecvOutcome::Continue;
+            }
+        }
+    }
+
+    record_market_data_account_channel_lag_ms(account_update.grpc_recv_at, recv_at);
+    record_market_data_account_channel_lag_ms_for_class(
+        class.as_prometheus_label(),
+        account_update.grpc_recv_at,
+        recv_at,
+    );
+    inc_market_data_account_updates_total(class.as_prometheus_label());
+
+    match path {
+        AccountBroadcastRecvPath::ExecHot => {
+            let shard = market_data_account_exec_hot_shard(&account_update.pubkey);
+            let enqueue_start = Instant::now();
+            match account_high_ingress_try_send(
+                &worker_high[shard],
+                AccountWorkItem {
+                    update: account_update,
+                    recv_at,
+                    class,
+                },
+            ) {
+                AccountHighIngressSend::Ok => {}
+                AccountHighIngressSend::ContendedFull => {}
+                AccountHighIngressSend::Closed => {
+                    error!(
+                        shard = shard,
+                        class = "exec_hot",
+                        "account HIGH worker queue closed; stopping Geyser account stream"
+                    );
+                    let _ = stream_stopped.send(true);
+                    return AccountBroadcastRecvOutcome::StopStream;
+                }
+            }
+            record_market_data_account_recv_high_enqueue_duration_us(
+                enqueue_start
+                    .elapsed()
+                    .as_micros()
+                    .min(u128::from(u64::MAX)) as u64,
+            );
+        }
+        AccountBroadcastRecvPath::Enrich => {
+            let shard = market_data_account_enrich_shard(&account_update.pubkey);
+            let work = AccountWorkItem {
+                update: account_update,
+                recv_at,
+                class,
+            };
+            let ingress_start = Instant::now();
+            match account_enrich_ingress_try_send(&enrich_ingress[shard], work) {
+                AccountEnrichIngressSend::Ok => {}
+                AccountEnrichIngressSend::ContendedFull => {}
+                AccountEnrichIngressSend::Closed => {
+                    error!(
+                        shard = shard,
+                        class = "enrich",
+                        "account ENRICH ingress channel closed; stopping Geyser account stream"
+                    );
+                    let _ = stream_stopped.send(true);
+                    return AccountBroadcastRecvOutcome::StopStream;
+                }
+            }
+            record_market_data_account_recv_enrich_ingress_duration_us(
+                ingress_start
+                    .elapsed()
+                    .as_micros()
+                    .min(u128::from(u64::MAX)) as u64,
+            );
+        }
+    }
+
+    record_market_data_account_recv_iteration_duration_us(
+        iteration_start
+            .elapsed()
+            .as_micros()
+            .min(u128::from(u64::MAX)) as u64,
+    );
+    AccountBroadcastRecvOutcome::Continue
+}
+
 /// Enqueue EXEC_HOT work into the per-shard HIGH channel without blocking the recv task.
 fn account_high_ingress_try_send(
     high_tx: &mpsc::Sender<AccountWorkItem>,
@@ -8681,6 +8853,7 @@ async fn run_geyser_loop(
     );
 
     let pool_discovery_account_rx = account_listener.subscribe_account_updates();
+    let account_rx_enrich = account_listener.subscribe_account_updates();
     let pool_discovery_transaction_rx = tx_listener.subscribe_transaction_updates();
     let pool_discovery_event_rx = PoolDiscoveryIngest::spawn_unified(
         pool_discovery_account_rx,
@@ -8991,7 +9164,8 @@ async fn run_geyser_loop(
     let ctx_geyser_acc = Arc::clone(&ctx);
     let run_id_geyser_acc = run_id.to_string();
     let account_count_geyser_acc = Arc::clone(&account_count);
-    let mut account_rx_geyser = account_rx;
+    let mut account_rx_exec_hot = account_rx;
+    let mut account_rx_enrich = account_rx_enrich;
 
     set_market_data_account_exec_hot_worker_count(MARKET_DATA_ACCOUNT_EXEC_HOT_WORKER_COUNT);
     set_market_data_account_enrich_worker_count(MARKET_DATA_ACCOUNT_ENRICH_WORKER_COUNT);
@@ -9154,122 +9328,90 @@ async fn run_geyser_loop(
 
     let worker_high_recv = Arc::clone(&worker_high_dispatch);
     let enrich_ingress_recv = Arc::clone(&enrich_ingress_dispatch);
+    let ctx_exec_hot_recv = Arc::clone(&ctx_geyser_acc);
+    let worker_high_exec_hot = Arc::clone(&worker_high_recv);
+    let enrich_ingress_exec_hot = Arc::clone(&enrich_ingress_recv);
+    let geyser_account_stream_stopped_exec_hot = geyser_account_stream_stopped_tx.clone();
     tokio::spawn(async move {
         loop {
-            match account_rx_geyser.recv().await {
+            match account_rx_exec_hot.recv().await {
                 Ok(account_update) => {
-                    let iteration_start = Instant::now();
                     let recv_at = Instant::now();
-                    inc_market_data_account_recv_iterations_total();
-                    record_market_data_account_channel_lag_ms(account_update.grpc_recv_at, recv_at);
-                    set_market_data_account_broadcast_queue_depth(account_rx_geyser.len());
+                    set_market_data_account_broadcast_queue_depth_for_class(
+                        AccountBroadcastRecvPath::ExecHot.metrics_class(),
+                        account_rx_exec_hot.len(),
+                    );
                     market_data_bump_geyser_head_slot(account_update.slot);
 
-                    let classify_start = Instant::now();
-                    let (class, early_drop_reason) =
-                        ironcrab::market_data::ingest::classify_account_geyser_update(
-                            &ctx_geyser_acc,
-                            &account_update,
-                        );
-                    record_market_data_account_recv_classify_duration_us(
-                        classify_start
-                            .elapsed()
-                            .as_micros()
-                            .min(u128::from(u64::MAX)) as u64,
-                    );
-                    inc_market_data_account_updates_total(class.as_prometheus_label());
-
-                    if let Some(reason) = early_drop_reason {
-                        record_market_data_account_early_drop(reason);
-                        record_market_data_account_recv_iteration_duration_us(
-                            iteration_start
-                                .elapsed()
-                                .as_micros()
-                                .min(u128::from(u64::MAX)) as u64,
-                        );
-                        continue;
-                    }
-
-                    record_market_data_account_channel_lag_ms_for_class(
-                        class.as_prometheus_label(),
-                        account_update.grpc_recv_at,
-                        recv_at,
-                    );
-
-                    let high = matches!(
-                        class,
-                        ironcrab::market_data::ingest::AccountUpdateClass::ExecHot
-                    );
-                    if high {
-                        let shard = market_data_account_exec_hot_shard(&account_update.pubkey);
-                        let enqueue_start = Instant::now();
-                        match account_high_ingress_try_send(
-                            &worker_high_recv[shard],
-                            AccountWorkItem {
-                                update: account_update,
-                                recv_at,
-                                class,
-                            },
-                        ) {
-                            AccountHighIngressSend::Ok => {}
-                            AccountHighIngressSend::ContendedFull => {}
-                            AccountHighIngressSend::Closed => {
-                                error!(
-                                    shard = shard,
-                                    class = "exec_hot",
-                                    "account HIGH worker queue closed; stopping Geyser account stream"
-                                );
-                                let _ = geyser_account_stream_stopped_tx.send(true);
-                                break;
-                            }
-                        }
-                        record_market_data_account_recv_high_enqueue_duration_us(
-                            enqueue_start
-                                .elapsed()
-                                .as_micros()
-                                .min(u128::from(u64::MAX)) as u64,
-                        );
-                    } else {
-                        let shard = market_data_account_enrich_shard(&account_update.pubkey);
-                        let work = AccountWorkItem {
-                            update: account_update,
+                    if matches!(
+                        handle_account_broadcast_recv_ok(
+                            AccountBroadcastRecvPath::ExecHot,
+                            ctx_exec_hot_recv.as_ref(),
+                            account_update,
                             recv_at,
-                            class,
-                        };
-                        let ingress_start = Instant::now();
-                        match account_enrich_ingress_try_send(&enrich_ingress_recv[shard], work) {
-                            AccountEnrichIngressSend::Ok => {}
-                            AccountEnrichIngressSend::ContendedFull => {}
-                            AccountEnrichIngressSend::Closed => {
-                                error!(
-                                    shard = shard,
-                                    class = "enrich",
-                                    "account ENRICH ingress channel closed; stopping Geyser account stream"
-                                );
-                                let _ = geyser_account_stream_stopped_tx.send(true);
-                                break;
-                            }
-                        }
-                        record_market_data_account_recv_enrich_ingress_duration_us(
-                            ingress_start
-                                .elapsed()
-                                .as_micros()
-                                .min(u128::from(u64::MAX)) as u64,
-                        );
+                            worker_high_exec_hot.as_ref(),
+                            enrich_ingress_exec_hot.as_ref(),
+                            &geyser_account_stream_stopped_exec_hot,
+                        ),
+                        AccountBroadcastRecvOutcome::StopStream
+                    ) {
+                        break;
                     }
-                    record_market_data_account_recv_iteration_duration_us(
-                        iteration_start
-                            .elapsed()
-                            .as_micros()
-                            .min(u128::from(u64::MAX)) as u64,
-                    );
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    record_market_data_account_broadcast_lagged(n);
+                    record_market_data_account_broadcast_lagged_for_class(
+                        AccountBroadcastRecvPath::ExecHot.metrics_class(),
+                        n,
+                    );
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                    warn!("Geyser account broadcast channel closed");
-                    let _ = geyser_account_stream_stopped_tx.send(true);
+                    warn!("Geyser account broadcast channel closed (EXEC_HOT recv)");
+                    let _ = geyser_account_stream_stopped_exec_hot.send(true);
+                    break;
+                }
+            }
+        }
+    });
+
+    let ctx_enrich_recv = Arc::clone(&ctx_geyser_acc);
+    let worker_high_enrich = Arc::clone(&worker_high_recv);
+    let enrich_ingress_enrich = Arc::clone(&enrich_ingress_recv);
+    let geyser_account_stream_stopped_enrich = geyser_account_stream_stopped_tx.clone();
+    tokio::spawn(async move {
+        loop {
+            match account_rx_enrich.recv().await {
+                Ok(account_update) => {
+                    let recv_at = Instant::now();
+                    set_market_data_account_broadcast_queue_depth_for_class(
+                        AccountBroadcastRecvPath::Enrich.metrics_class(),
+                        account_rx_enrich.len(),
+                    );
+                    market_data_bump_geyser_head_slot(account_update.slot);
+
+                    if matches!(
+                        handle_account_broadcast_recv_ok(
+                            AccountBroadcastRecvPath::Enrich,
+                            ctx_enrich_recv.as_ref(),
+                            account_update,
+                            recv_at,
+                            worker_high_enrich.as_ref(),
+                            enrich_ingress_enrich.as_ref(),
+                            &geyser_account_stream_stopped_enrich,
+                        ),
+                        AccountBroadcastRecvOutcome::StopStream
+                    ) {
+                        break;
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    record_market_data_account_broadcast_lagged_for_class(
+                        AccountBroadcastRecvPath::Enrich.metrics_class(),
+                        n,
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    warn!("Geyser account broadcast channel closed (ENRICH recv)");
+                    let _ = geyser_account_stream_stopped_enrich.send(true);
                     break;
                 }
             }
@@ -14464,6 +14606,145 @@ mod pr_b_geyser_tracking_tests {
             MARKET_DATA_ACCOUNT_HIGH_ENQUEUE_DROPPED_TOTAL.load(Ordering::Relaxed),
             1
         );
+    }
+
+    /// Scope L1: EXEC_HOT broadcast recv must enqueue under ENRICH ingress backlog (split cursors).
+    #[tokio::test]
+    async fn split_account_broadcast_recv_exec_hot_progresses_under_enrich_backlog() {
+        use ironcrab::market_data::ingest::{classify_account_geyser_update, AccountUpdateClass};
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = Arc::new(minimal_market_data_context_for_pr_d_tests(jsonl));
+        let exec_pool = Pubkey::new_unique();
+        let enrich_pool = Pubkey::new_unique();
+        ctx.hot_pool_registry.pin_arb_pool(exec_pool);
+        ctx.pool_mint_map
+            .write()
+            .insert(enrich_pool.to_string(), Pubkey::new_unique().to_string());
+
+        let mk_update = |pubkey: Pubkey, slot: u64| GeyserAccountUpdate {
+            pubkey,
+            slot,
+            owner: RAYDIUM_CPMM_OWNER,
+            data: vec![],
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        };
+        let (exec_class, _) = classify_account_geyser_update(&ctx, &mk_update(exec_pool, 0));
+        let (enrich_class, _) = classify_account_geyser_update(&ctx, &mk_update(enrich_pool, 0));
+        assert_eq!(exec_class, AccountUpdateClass::ExecHot);
+        assert_eq!(enrich_class, AccountUpdateClass::Enrich);
+
+        let (broadcast_tx, mut exec_hot_broadcast_rx) = tokio::sync::broadcast::channel(256);
+        let mut enrich_broadcast_rx = broadcast_tx.subscribe();
+        let (stream_stopped_tx, _) = watch::channel(false);
+
+        let mut high_txs = Vec::with_capacity(MARKET_DATA_ACCOUNT_EXEC_HOT_WORKER_COUNT);
+        let mut high_rxs = Vec::with_capacity(MARKET_DATA_ACCOUNT_EXEC_HOT_WORKER_COUNT);
+        for _ in 0..MARKET_DATA_ACCOUNT_EXEC_HOT_WORKER_COUNT {
+            let (tx, rx) = mpsc::channel(8);
+            high_txs.push(tx);
+            high_rxs.push(rx);
+        }
+        let exec_shard = market_data_account_exec_hot_shard(&exec_pool);
+        let mut high_rx = high_rxs.remove(exec_shard);
+
+        let mut enrich_ingress_txs = Vec::with_capacity(MARKET_DATA_ACCOUNT_ENRICH_WORKER_COUNT);
+        for _ in 0..MARKET_DATA_ACCOUNT_ENRICH_WORKER_COUNT {
+            let (tx, mut rx) = mpsc::channel(4);
+            enrich_ingress_txs.push(tx);
+            tokio::spawn(async move {
+                while let Some(_work) = rx.recv().await {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+            });
+        }
+
+        let worker_high = Arc::new(high_txs);
+        let enrich_ingress = Arc::new(enrich_ingress_txs);
+
+        let ctx_exec = Arc::clone(&ctx);
+        let worker_high_exec = Arc::clone(&worker_high);
+        let enrich_ingress_exec = Arc::clone(&enrich_ingress);
+        let stream_stopped_exec = stream_stopped_tx.clone();
+        let exec_recv = tokio::spawn(async move {
+            loop {
+                match exec_hot_broadcast_rx.recv().await {
+                    Ok(account_update) => {
+                        let recv_at = Instant::now();
+                        if matches!(
+                            handle_account_broadcast_recv_ok(
+                                AccountBroadcastRecvPath::ExecHot,
+                                ctx_exec.as_ref(),
+                                account_update,
+                                recv_at,
+                                worker_high_exec.as_ref(),
+                                enrich_ingress_exec.as_ref(),
+                                &stream_stopped_exec,
+                            ),
+                            AccountBroadcastRecvOutcome::StopStream
+                        ) {
+                            break;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+
+        let ctx_enrich = Arc::clone(&ctx);
+        let worker_high_enrich = Arc::clone(&worker_high);
+        let enrich_ingress_enrich = Arc::clone(&enrich_ingress);
+        let stream_stopped_enrich = stream_stopped_tx.clone();
+        let enrich_recv = tokio::spawn(async move {
+            loop {
+                match enrich_broadcast_rx.recv().await {
+                    Ok(account_update) => {
+                        let recv_at = Instant::now();
+                        if matches!(
+                            handle_account_broadcast_recv_ok(
+                                AccountBroadcastRecvPath::Enrich,
+                                ctx_enrich.as_ref(),
+                                account_update,
+                                recv_at,
+                                worker_high_enrich.as_ref(),
+                                enrich_ingress_enrich.as_ref(),
+                                &stream_stopped_enrich,
+                            ),
+                            AccountBroadcastRecvOutcome::StopStream
+                        ) {
+                            break;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+
+        for slot in 0..40 {
+            broadcast_tx
+                .send(mk_update(enrich_pool, slot))
+                .expect("enrich flood");
+        }
+        broadcast_tx
+            .send(mk_update(exec_pool, 1000))
+            .expect("exec_hot update");
+
+        let received = tokio::time::timeout(Duration::from_millis(200), high_rx.recv())
+            .await
+            .expect("EXEC_HOT must enqueue promptly while ENRICH ingress is backlogged")
+            .expect("HIGH queue item");
+        assert!(matches!(received.class, AccountUpdateClass::ExecHot));
+        assert_eq!(received.update.pubkey, exec_pool);
+        assert_eq!(received.update.slot, 1000);
+
+        drop(broadcast_tx);
+        let _ = exec_recv.await;
+        let _ = enrich_recv.await;
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -20,7 +20,6 @@
 use anyhow::Result;
 use arc_swap::ArcSwap;
 use clap::Parser;
-use dashmap::DashMap;
 use serde::Serialize;
 use solana_sdk::pubkey::Pubkey;
 use std::collections::hash_map::DefaultHasher;
@@ -8108,15 +8107,12 @@ enum AccountBroadcastRecvOutcome {
     StopStream,
 }
 
-/// Per-update routing state for split EXEC_HOT / ENRICH broadcast recv (Scope L1).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum AccountBroadcastRouteState {
-    PendingEnrichPath,
-    Done,
-}
-
 /// Handle one `Ok(account_update)` from the account broadcast channel (Scope L1 split recv).
-#[allow(clippy::too_many_arguments)]
+///
+/// EXEC_HOT and ENRICH use independent broadcast receivers. If the ENRICH cursor lags behind
+/// and a pool is later promoted to EXEC_HOT, that update may be skipped on the ENRICH path;
+/// the next account update for the same pubkey will classify and enqueue on EXEC_HOT. No shared
+/// routing state — avoids unbounded map growth and recv-path contention (I-4b).
 fn handle_account_broadcast_recv_ok(
     path: AccountBroadcastRecvPath,
     ctx: &MarketDataContext,
@@ -8124,7 +8120,6 @@ fn handle_account_broadcast_recv_ok(
     recv_at: Instant,
     worker_high: &[mpsc::Sender<AccountWorkItem>],
     enrich_ingress: &[mpsc::Sender<AccountWorkItem>],
-    route_states: &DashMap<(Pubkey, u64), AccountBroadcastRouteState>,
     stream_stopped: &watch::Sender<bool>,
 ) -> AccountBroadcastRecvOutcome {
     let iteration_start = Instant::now();
@@ -8163,42 +8158,25 @@ fn handle_account_broadcast_recv_ok(
         return AccountBroadcastRecvOutcome::Continue;
     }
 
-    let route_key = (account_update.pubkey, account_update.slot);
-
     match path {
-        AccountBroadcastRecvPath::ExecHot => match class {
-            ironcrab::market_data::ingest::AccountUpdateClass::ExecHot => {
-                if matches!(
-                    route_states.get(&route_key).map(|entry| *entry),
-                    Some(AccountBroadcastRouteState::Done)
-                ) {
-                    return AccountBroadcastRecvOutcome::Continue;
-                }
-            }
-            ironcrab::market_data::ingest::AccountUpdateClass::Enrich => {
-                if route_states.contains_key(&route_key) {
-                    return AccountBroadcastRecvOutcome::Continue;
-                }
-                route_states.insert(route_key, AccountBroadcastRouteState::PendingEnrichPath);
-                return AccountBroadcastRecvOutcome::Continue;
-            }
-            ironcrab::market_data::ingest::AccountUpdateClass::Drop => {
-                inc_market_data_account_updates_total(class.as_prometheus_label());
-                return AccountBroadcastRecvOutcome::Continue;
-            }
-        },
-        AccountBroadcastRecvPath::Enrich => {
-            if matches!(
-                route_states.get(&route_key).map(|entry| *entry),
-                Some(AccountBroadcastRouteState::Done)
+        AccountBroadcastRecvPath::ExecHot => {
+            if !matches!(
+                class,
+                ironcrab::market_data::ingest::AccountUpdateClass::ExecHot
             ) {
+                if matches!(
+                    class,
+                    ironcrab::market_data::ingest::AccountUpdateClass::Drop
+                ) {
+                    inc_market_data_account_updates_total(class.as_prometheus_label());
+                }
                 return AccountBroadcastRecvOutcome::Continue;
             }
-            route_states.remove(&route_key);
+        }
+        AccountBroadcastRecvPath::Enrich => {
             if !matches!(
                 class,
                 ironcrab::market_data::ingest::AccountUpdateClass::Enrich
-                    | ironcrab::market_data::ingest::AccountUpdateClass::ExecHot
             ) {
                 return AccountBroadcastRecvOutcome::Continue;
             }
@@ -8213,11 +8191,11 @@ fn handle_account_broadcast_recv_ok(
     );
     inc_market_data_account_updates_total(class.as_prometheus_label());
 
-    let enqueue_outcome = match class {
-        ironcrab::market_data::ingest::AccountUpdateClass::ExecHot => {
+    match path {
+        AccountBroadcastRecvPath::ExecHot => {
             let shard = market_data_account_exec_hot_shard(&account_update.pubkey);
             let enqueue_start = Instant::now();
-            let outcome = match account_high_ingress_try_send(
+            match account_high_ingress_try_send(
                 &worker_high[shard],
                 AccountWorkItem {
                     update: account_update,
@@ -8225,8 +8203,8 @@ fn handle_account_broadcast_recv_ok(
                     class,
                 },
             ) {
-                AccountHighIngressSend::Ok => AccountBroadcastRecvOutcome::Continue,
-                AccountHighIngressSend::ContendedFull => AccountBroadcastRecvOutcome::Continue,
+                AccountHighIngressSend::Ok => {}
+                AccountHighIngressSend::ContendedFull => {}
                 AccountHighIngressSend::Closed => {
                     error!(
                         shard = shard,
@@ -8234,18 +8212,23 @@ fn handle_account_broadcast_recv_ok(
                         "account HIGH worker queue closed; stopping Geyser account stream"
                     );
                     let _ = stream_stopped.send(true);
-                    AccountBroadcastRecvOutcome::StopStream
+                    record_market_data_account_recv_iteration_duration_us(
+                        iteration_start
+                            .elapsed()
+                            .as_micros()
+                            .min(u128::from(u64::MAX)) as u64,
+                    );
+                    return AccountBroadcastRecvOutcome::StopStream;
                 }
-            };
+            }
             record_market_data_account_recv_high_enqueue_duration_us(
                 enqueue_start
                     .elapsed()
                     .as_micros()
                     .min(u128::from(u64::MAX)) as u64,
             );
-            outcome
         }
-        ironcrab::market_data::ingest::AccountUpdateClass::Enrich => {
+        AccountBroadcastRecvPath::Enrich => {
             let shard = market_data_account_enrich_shard(&account_update.pubkey);
             let work = AccountWorkItem {
                 update: account_update,
@@ -8253,9 +8236,9 @@ fn handle_account_broadcast_recv_ok(
                 class,
             };
             let ingress_start = Instant::now();
-            let outcome = match account_enrich_ingress_try_send(&enrich_ingress[shard], work) {
-                AccountEnrichIngressSend::Ok => AccountBroadcastRecvOutcome::Continue,
-                AccountEnrichIngressSend::ContendedFull => AccountBroadcastRecvOutcome::Continue,
+            match account_enrich_ingress_try_send(&enrich_ingress[shard], work) {
+                AccountEnrichIngressSend::Ok => {}
+                AccountEnrichIngressSend::ContendedFull => {}
                 AccountEnrichIngressSend::Closed => {
                     error!(
                         shard = shard,
@@ -8263,23 +8246,22 @@ fn handle_account_broadcast_recv_ok(
                         "account ENRICH ingress channel closed; stopping Geyser account stream"
                     );
                     let _ = stream_stopped.send(true);
-                    AccountBroadcastRecvOutcome::StopStream
+                    record_market_data_account_recv_iteration_duration_us(
+                        iteration_start
+                            .elapsed()
+                            .as_micros()
+                            .min(u128::from(u64::MAX)) as u64,
+                    );
+                    return AccountBroadcastRecvOutcome::StopStream;
                 }
-            };
+            }
             record_market_data_account_recv_enrich_ingress_duration_us(
                 ingress_start
                     .elapsed()
                     .as_micros()
                     .min(u128::from(u64::MAX)) as u64,
             );
-            outcome
         }
-        ironcrab::market_data::ingest::AccountUpdateClass::Drop => {
-            unreachable!("drop updates are handled by early_drop_reason")
-        }
-    };
-    if matches!(enqueue_outcome, AccountBroadcastRecvOutcome::Continue) {
-        route_states.insert(route_key, AccountBroadcastRouteState::Done);
     }
 
     record_market_data_account_recv_iteration_duration_us(
@@ -8288,7 +8270,7 @@ fn handle_account_broadcast_recv_ok(
             .as_micros()
             .min(u128::from(u64::MAX)) as u64,
     );
-    enqueue_outcome
+    AccountBroadcastRecvOutcome::Continue
 }
 
 /// Enqueue EXEC_HOT work into the per-shard HIGH channel without blocking the recv task.
@@ -9364,12 +9346,9 @@ async fn run_geyser_loop(
 
     let worker_high_recv = Arc::clone(&worker_high_dispatch);
     let enrich_ingress_recv = Arc::clone(&enrich_ingress_dispatch);
-    let account_broadcast_route_states =
-        Arc::new(DashMap::<(Pubkey, u64), AccountBroadcastRouteState>::new());
     let ctx_exec_hot_recv = Arc::clone(&ctx_geyser_acc);
     let worker_high_exec_hot = Arc::clone(&worker_high_recv);
     let enrich_ingress_exec_hot = Arc::clone(&enrich_ingress_recv);
-    let route_states_exec_hot = Arc::clone(&account_broadcast_route_states);
     let geyser_account_stream_stopped_exec_hot = geyser_account_stream_stopped_tx.clone();
     tokio::spawn(async move {
         loop {
@@ -9390,7 +9369,6 @@ async fn run_geyser_loop(
                             recv_at,
                             worker_high_exec_hot.as_ref(),
                             enrich_ingress_exec_hot.as_ref(),
-                            route_states_exec_hot.as_ref(),
                             &geyser_account_stream_stopped_exec_hot,
                         ),
                         AccountBroadcastRecvOutcome::StopStream
@@ -9416,7 +9394,6 @@ async fn run_geyser_loop(
     let ctx_enrich_recv = Arc::clone(&ctx_geyser_acc);
     let worker_high_enrich = Arc::clone(&worker_high_recv);
     let enrich_ingress_enrich = Arc::clone(&enrich_ingress_recv);
-    let route_states_enrich = Arc::clone(&account_broadcast_route_states);
     let geyser_account_stream_stopped_enrich = geyser_account_stream_stopped_tx.clone();
     tokio::spawn(async move {
         loop {
@@ -9437,7 +9414,6 @@ async fn run_geyser_loop(
                             recv_at,
                             worker_high_enrich.as_ref(),
                             enrich_ingress_enrich.as_ref(),
-                            route_states_enrich.as_ref(),
                             &geyser_account_stream_stopped_enrich,
                         ),
                         AccountBroadcastRecvOutcome::StopStream
@@ -14651,6 +14627,9 @@ mod pr_b_geyser_tracking_tests {
     }
 
     /// Scope L1: EXEC_HOT broadcast recv must enqueue under ENRICH ingress backlog (split cursors).
+    ///
+    /// Enrich→ExecHot promotion while the ENRICH cursor lags is intentionally not deduplicated here;
+    /// the next account update for the same pubkey re-classifies on the EXEC_HOT path.
     #[tokio::test]
     async fn split_account_broadcast_recv_exec_hot_progresses_under_enrich_backlog() {
         use ironcrab::market_data::ingest::{classify_account_geyser_update, AccountUpdateClass};
@@ -14706,12 +14685,10 @@ mod pr_b_geyser_tracking_tests {
 
         let worker_high = Arc::new(high_txs);
         let enrich_ingress = Arc::new(enrich_ingress_txs);
-        let route_states = Arc::new(DashMap::<(Pubkey, u64), AccountBroadcastRouteState>::new());
 
         let ctx_exec = Arc::clone(&ctx);
         let worker_high_exec = Arc::clone(&worker_high);
         let enrich_ingress_exec = Arc::clone(&enrich_ingress);
-        let route_states_exec = Arc::clone(&route_states);
         let stream_stopped_exec = stream_stopped_tx.clone();
         let exec_recv = tokio::spawn(async move {
             loop {
@@ -14726,7 +14703,6 @@ mod pr_b_geyser_tracking_tests {
                                 recv_at,
                                 worker_high_exec.as_ref(),
                                 enrich_ingress_exec.as_ref(),
-                                route_states_exec.as_ref(),
                                 &stream_stopped_exec,
                             ),
                             AccountBroadcastRecvOutcome::StopStream
@@ -14743,7 +14719,6 @@ mod pr_b_geyser_tracking_tests {
         let ctx_enrich = Arc::clone(&ctx);
         let worker_high_enrich = Arc::clone(&worker_high);
         let enrich_ingress_enrich = Arc::clone(&enrich_ingress);
-        let route_states_enrich = Arc::clone(&route_states);
         let stream_stopped_enrich = stream_stopped_tx.clone();
         let enrich_recv = tokio::spawn(async move {
             loop {
@@ -14758,7 +14733,6 @@ mod pr_b_geyser_tracking_tests {
                                 recv_at,
                                 worker_high_enrich.as_ref(),
                                 enrich_ingress_enrich.as_ref(),
-                                route_states_enrich.as_ref(),
                                 &stream_stopped_enrich,
                             ),
                             AccountBroadcastRecvOutcome::StopStream

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1816,9 +1816,22 @@ pub static MARKET_DATA_TX_BROADCAST_LAGGED_TOTAL: Lazy<AtomicU64> = Lazy::new(||
 /// (ingest task only). Under healthy fairness this should stay near 0.
 pub static MARKET_DATA_TX_BROADCAST_QUEUE_DEPTH: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// Remaining account updates in the Geyser→market-data `broadcast` buffer after each successful `recv`.
+/// Legacy gauge: max of EXEC_HOT and ENRICH recv depths (Scope L1 split).
 pub static MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// Scope L1: EXEC_HOT-dedicated broadcast receiver backlog.
+pub static MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_EXEC_HOT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Scope L1: ENRICH-dedicated broadcast receiver backlog.
+pub static MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_ENRICH: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 pub static MARKET_DATA_ACCOUNT_BROADCAST_LAGGED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Scope L1: skipped messages on the EXEC_HOT broadcast receiver (`RecvError::Lagged`).
+pub static MARKET_DATA_ACCOUNT_BROADCAST_LAGGED_TOTAL_EXEC_HOT: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Scope L1: skipped messages on the ENRICH broadcast receiver (`RecvError::Lagged`).
+pub static MARKET_DATA_ACCOUNT_BROADCAST_LAGGED_TOTAL_ENRICH: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
 /// Configured account worker pool size (total EXEC_HOT + ENRICH; backward-compat ops gauge).
@@ -2202,11 +2215,54 @@ pub fn set_market_data_account_broadcast_queue_depth(depth: usize) {
     MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH.store(depth as u64, Ordering::Relaxed);
 }
 
+/// Scope L1: per-recv-path broadcast backlog (`class` = `exec_hot` | `enrich`).
+#[inline]
+pub fn set_market_data_account_broadcast_queue_depth_for_class(class: &str, depth: usize) {
+    match class {
+        "exec_hot" => {
+            MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_EXEC_HOT
+                .store(depth as u64, Ordering::Relaxed);
+        }
+        "enrich" => {
+            MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_ENRICH.store(depth as u64, Ordering::Relaxed);
+        }
+        _ => return,
+    }
+    refresh_market_data_account_broadcast_queue_depth_legacy();
+}
+
+#[inline]
+fn refresh_market_data_account_broadcast_queue_depth_legacy() {
+    let exec_hot = MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_EXEC_HOT.load(Ordering::Relaxed);
+    let enrich = MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_ENRICH.load(Ordering::Relaxed);
+    MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH.store(exec_hot.max(enrich), Ordering::Relaxed);
+}
+
 #[inline]
 pub fn record_market_data_account_broadcast_lagged(skipped_messages: u64) {
     if skipped_messages > 0 {
         MARKET_DATA_ACCOUNT_BROADCAST_LAGGED_TOTAL.fetch_add(skipped_messages, Ordering::Relaxed);
     }
+}
+
+/// Scope L1: per-recv-path `RecvError::Lagged` (`class` = `exec_hot` | `enrich`).
+#[inline]
+pub fn record_market_data_account_broadcast_lagged_for_class(class: &str, skipped_messages: u64) {
+    if skipped_messages == 0 {
+        return;
+    }
+    match class {
+        "exec_hot" => {
+            MARKET_DATA_ACCOUNT_BROADCAST_LAGGED_TOTAL_EXEC_HOT
+                .fetch_add(skipped_messages, Ordering::Relaxed);
+        }
+        "enrich" => {
+            MARKET_DATA_ACCOUNT_BROADCAST_LAGGED_TOTAL_ENRICH
+                .fetch_add(skipped_messages, Ordering::Relaxed);
+        }
+        _ => return,
+    }
+    MARKET_DATA_ACCOUNT_BROADCAST_LAGGED_TOTAL.fetch_add(skipped_messages, Ordering::Relaxed);
 }
 
 #[inline]
@@ -7331,8 +7387,24 @@ async fn metrics_response() -> Response<Body> {
         MARKET_DATA_ACCOUNT_BROADCAST_LAGGED_TOTAL.load(Ordering::Relaxed)
     );
     line!(
+        "market_data_account_broadcast_lagged_total{class=\"exec_hot\"}",
+        MARKET_DATA_ACCOUNT_BROADCAST_LAGGED_TOTAL_EXEC_HOT.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_account_broadcast_lagged_total{class=\"enrich\"}",
+        MARKET_DATA_ACCOUNT_BROADCAST_LAGGED_TOTAL_ENRICH.load(Ordering::Relaxed)
+    );
+    line!(
         "market_data_account_broadcast_queue_depth",
         MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_account_broadcast_queue_depth{class=\"exec_hot\"}",
+        MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_EXEC_HOT.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_account_broadcast_queue_depth{class=\"enrich\"}",
+        MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_ENRICH.load(Ordering::Relaxed)
     );
     line!(
         "market_data_account_worker_count",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scope **L1** of the Realtime SLO hard-split plan: physically separate the account Geyser `broadcast` recv stage for `EXEC_HOT` vs `ENRICH` so ENRICH volume cannot push EXEC_HOT behind a shared classify+fanout loop.

## Changes

- **Two independent recv tasks** subscribe to the same account broadcast channel:
  - `EXEC_HOT` recv: classify → enqueue only `ExecHot` via `account_high_ingress_try_send`
  - `ENRICH` recv: classify → enqueue only `Enrich` via `account_enrich_ingress_try_send`
- `pool_discovery` third subscriber unchanged.
- Worker counts (4/2), queue caps, and try_send helpers unchanged.
- **Metrics (per class)**:
  - `market_data_account_broadcast_queue_depth{class="exec_hot|enrich"}`
  - `market_data_account_broadcast_lagged_total{class="exec_hot|enrich"}`
  - Legacy unlabeled depth gauge = `max(exec_hot, enrich)` for backward-compatible ops dashboards.
- **Test**: `split_account_broadcast_recv_exec_hot_progresses_under_enrich_backlog` — EXEC_HOT enqueues promptly while ENRICH ingress consumer is artificially slow/backlogged.

## STOP-CHECK

- I-7: no new RPC in hot path
- I-4b: recv tasks remain await-free except `recv().await`; ingress uses try_send only
- Worker counts unchanged (J3)
- Broadcast cap unchanged (200k)

## Verification

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59ea296b-3057-40e8-be97-272b5b4e7d7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59ea296b-3057-40e8-be97-272b5b4e7d7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

