### PR TITLE
fix(market-data): lag-triggered enrich/tracker shed under EXEC_HOT pressure (Scope L2)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -101,6 +101,7 @@ use ironcrab::metrics::{
     inc_market_data_account_enrich_dispatch_contended_total,
     inc_market_data_account_enrich_enqueue_dropped_total,
     inc_market_data_account_enrich_ingress_queue_depth,
+    inc_market_data_account_enrich_shed_dropped_total,
     inc_market_data_account_high_enqueue_dropped_total,
     inc_market_data_account_high_priority_queue_depth,
     inc_market_data_account_low_priority_queue_depth,
@@ -109,6 +110,7 @@ use ironcrab::metrics::{
     inc_market_data_arb_admission_rejected_total,
     inc_market_data_arb_pin_geyser_register_deferred_total,
     inc_market_data_balance_updated_from_cache_total,
+    inc_market_data_exec_hot_hard_shed_steps_total,
     inc_market_data_geyser_sync_skipped_rate_limit_total,
     inc_market_data_ingest_membership_snapshot_hits_total,
     inc_market_data_jsonl_enqueue_dropped_total, inc_market_data_momentum_admission_admitted_total,
@@ -120,7 +122,8 @@ use ironcrab::metrics::{
     inc_market_data_vault_high_priority_dispatch_total,
     inc_market_data_wallet_admission_admitted_total,
     inc_market_data_wallet_admission_rejected_total, market_data_bump_geyser_head_slot,
-    market_data_geyser_head_slot_value, market_data_geyser_tracking_enqueue_dropped_value,
+    market_data_enrich_shed_active, market_data_geyser_head_slot_value,
+    market_data_geyser_tracking_enqueue_dropped_value,
     market_data_geyser_tracking_jobs_processed_value, market_data_md_state_bursts_completed_value,
     market_data_request_account_session_reconnect, market_data_request_tx_session_reconnect,
     market_data_tx_handler_processed_value, record_market_data_account_broadcast_lagged_for_class,
@@ -140,7 +143,7 @@ use ironcrab::metrics::{
     set_market_data_account_broadcast_queue_depth_for_class,
     set_market_data_account_enrich_worker_count, set_market_data_account_exec_hot_worker_count,
     set_market_data_account_worker_count, set_market_data_arb_pinned_pools_gauge,
-    set_market_data_enrichment_registry_pools_gauge,
+    set_market_data_enrichment_registry_pools_gauge, set_market_data_exec_hot_shed_soft_active,
     set_market_data_explicit_set_snapshot_restore_duration_ms,
     set_market_data_explicit_set_snapshot_restore_pubkeys,
     set_market_data_geyser_explicit_admitted_accounts,
@@ -150,8 +153,9 @@ use ironcrab::metrics::{
     set_market_data_tx_broadcast_queue_depth, set_readiness_control_sub_active, set_readiness_mode,
     set_readiness_nats_connected, touch_market_data_global_ingest_progress,
     touch_market_data_tracked_membership_snapshot_refresh, update_readiness_market_data_current,
-    MarketDataLatencySegment, MetricsComponent, MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS,
-    MARKET_EVENTS_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE,
+    MarketDataLatencySegment, MetricsComponent, MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_EXEC_HOT,
+    MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS, MARKET_EVENTS_RECEIVED_TOTAL,
+    POOLS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
@@ -210,6 +214,14 @@ const MARKET_DATA_MD_STATE_STALL_EXIT_AFTER: Duration = Duration::from_secs(120)
 const MARKET_DATA_MD_STATE_STALL_QUEUE_FRAC: f64 = 0.95;
 /// PR235: when false, md-state liveness records stalls but does not exit(1) for systemd restart.
 const MARKET_DATA_MD_STATE_STALL_EXIT_ENABLED: bool = false;
+
+/// Scope L2: EXEC_HOT broadcast depth thresholds for enrich/tracker pressure shed.
+const EXEC_HOT_SHED_D_WARN: usize = 64;
+const EXEC_HOT_SHED_D_CRITICAL: usize = 256;
+const EXEC_HOT_SHED_D_CLEAR: usize = 16;
+const EXEC_HOT_SHED_HARD_MAX_GROUPS: usize = 16;
+const EXEC_HOT_SHED_SOFT_SAMPLES_FOR_HARD: u32 = 3;
+const EXEC_HOT_SHED_CONTROLLER_INTERVAL: Duration = Duration::from_millis(300);
 
 /// ExecutionResult dedup: prevents replay storms from re-tracking the same ATA/mint over and over.
 ///
@@ -8084,6 +8096,47 @@ enum AccountHighIngressSend {
     Closed,
 }
 
+/// Scope L2: monitor EXEC_HOT broadcast depth and shed ENRICH/Tracker under pressure.
+fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
+    tokio::spawn(async move {
+        let mut soft_shed = false;
+        let mut soft_shed_samples = 0u32;
+        let mut interval = tokio::time::interval(EXEC_HOT_SHED_CONTROLLER_INTERVAL);
+        loop {
+            interval.tick().await;
+            let depth =
+                MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_EXEC_HOT.load(Ordering::Relaxed) as usize;
+
+            if depth >= EXEC_HOT_SHED_D_WARN {
+                soft_shed = true;
+            } else if depth < EXEC_HOT_SHED_D_CLEAR {
+                soft_shed = false;
+                soft_shed_samples = 0;
+            }
+
+            set_market_data_exec_hot_shed_soft_active(soft_shed);
+
+            if soft_shed {
+                soft_shed_samples = soft_shed_samples.saturating_add(1);
+            }
+
+            let trigger_hard = depth >= EXEC_HOT_SHED_D_CRITICAL
+                || (soft_shed && soft_shed_samples >= EXEC_HOT_SHED_SOFT_SAMPLES_FOR_HARD);
+            if trigger_hard {
+                soft_shed_samples = 0;
+                if track_worker_try_enqueue(
+                    &track_worker,
+                    TrackWorkerCommand::ShedTrackerUnderExecHotPressure {
+                        max_groups: EXEC_HOT_SHED_HARD_MAX_GROUPS,
+                    },
+                ) {
+                    inc_market_data_exec_hot_hard_shed_steps_total();
+                }
+            }
+        }
+    });
+}
+
 /// Scope L1: split account broadcast recv paths (EXEC_HOT vs ENRICH).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum AccountBroadcastRecvPath {
@@ -9404,6 +9457,10 @@ async fn run_geyser_loop(
                         AccountBroadcastRecvPath::Enrich.metrics_class(),
                         account_rx_enrich.len(),
                     );
+                    if market_data_enrich_shed_active() {
+                        inc_market_data_account_enrich_shed_dropped_total();
+                        continue;
+                    }
                     market_data_bump_geyser_head_slot(account_update.slot);
 
                     if matches!(
@@ -9435,6 +9492,8 @@ async fn run_geyser_loop(
             }
         }
     });
+
+    spawn_exec_hot_pressure_shed_controller(track_worker.clone());
 
     loop {
         tokio::select! {
@@ -14624,6 +14683,61 @@ mod pr_b_geyser_tracking_tests {
             MARKET_DATA_ACCOUNT_HIGH_ENQUEUE_DROPPED_TOTAL.load(Ordering::Relaxed),
             1
         );
+    }
+
+    #[test]
+    fn enrich_recv_soft_shed_skips_classify_and_ingress_enqueue() {
+        use ironcrab::metrics::{
+            MARKET_DATA_ACCOUNT_ENRICH_SHED_DROPPED_TOTAL, MARKET_DATA_ENRICH_SHED_ACTIVE,
+        };
+        use std::sync::atomic::Ordering;
+
+        MARKET_DATA_ENRICH_SHED_ACTIVE.store(true, Ordering::Relaxed);
+        MARKET_DATA_ACCOUNT_ENRICH_SHED_DROPPED_TOTAL.store(0, Ordering::Relaxed);
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = Arc::new(minimal_market_data_context_for_pr_d_tests(jsonl));
+        let enrich_pool = Pubkey::new_unique();
+        ctx.pool_mint_map
+            .write()
+            .insert(enrich_pool.to_string(), Pubkey::new_unique().to_string());
+
+        let (high_tx, _high_rx) = mpsc::channel(4);
+        let (enrich_ingress_tx, mut enrich_ingress_rx) = mpsc::channel(4);
+        let (stream_stopped_tx, _) = watch::channel(false);
+
+        let update = GeyserAccountUpdate {
+            pubkey: enrich_pool,
+            slot: 1,
+            owner: RAYDIUM_CPMM_OWNER,
+            data: vec![],
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        };
+
+        if market_data_enrich_shed_active() {
+            inc_market_data_account_enrich_shed_dropped_total();
+        } else {
+            let _ = handle_account_broadcast_recv_ok(
+                AccountBroadcastRecvPath::Enrich,
+                ctx.as_ref(),
+                update,
+                Instant::now(),
+                std::slice::from_ref(&high_tx),
+                std::slice::from_ref(&enrich_ingress_tx),
+                &stream_stopped_tx,
+            );
+        }
+
+        assert_eq!(
+            MARKET_DATA_ACCOUNT_ENRICH_SHED_DROPPED_TOTAL.load(Ordering::Relaxed),
+            1
+        );
+        assert!(enrich_ingress_rx.try_recv().is_err());
+
+        MARKET_DATA_ENRICH_SHED_ACTIVE.store(false, Ordering::Relaxed);
     }
 
     /// Scope L1: EXEC_HOT broadcast recv must enqueue under ENRICH ingress backlog (split cursors).

--- a/src/market_data/track/explicit_admission.rs
+++ b/src/market_data/track/explicit_admission.rs
@@ -133,6 +133,13 @@ pub enum CapShrinkResult {
     InternalInvariantViolation,
 }
 
+/// Result of shedding tracker-only owner groups under EXEC_HOT pressure (Scope L2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShedTrackerGroupsResult {
+    pub groups_evicted: usize,
+    pub pubkeys_evicted: usize,
+}
+
 /// Result of an explicit owner-group LRU touch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TouchResult {
@@ -1541,6 +1548,44 @@ impl FixedCapAdmission {
         self.apply_stamp_plan(stamp_plan);
         FixedCapRemoveResult::Removed {
             physical_removed: plan.physical_removed,
+        }
+    }
+
+    /// Evict up to `max_groups` tracker-only owner groups (LRU first). Never touches Wallet,
+    /// MomentumPosition, Momentum, or Arb groups (Scope L2 EXEC_HOT pressure shed).
+    pub fn shed_tracker_owner_groups(&mut self, max_groups: usize) -> ShedTrackerGroupsResult {
+        if max_groups == 0 {
+            return ShedTrackerGroupsResult {
+                groups_evicted: 0,
+                pubkeys_evicted: 0,
+            };
+        }
+
+        let mut tracker_owners: Vec<(ExplicitOwner, u64)> = self
+            .snapshot_lru_entries()
+            .into_iter()
+            .filter(|entry| entry.owner.consumer == ExplicitConsumer::Tracker)
+            .map(|entry| (entry.owner, entry.last_touch))
+            .collect();
+        tracker_owners.sort_by_key(|(_, touch)| *touch);
+
+        let mut groups_evicted = 0usize;
+        let mut pubkeys_evicted = 0usize;
+        for (owner, _) in tracker_owners.into_iter().take(max_groups) {
+            match self.remove_group(owner) {
+                FixedCapRemoveResult::Removed { physical_removed } => {
+                    groups_evicted += 1;
+                    pubkeys_evicted += physical_removed.len();
+                }
+                FixedCapRemoveResult::NotFound
+                | FixedCapRemoveResult::PlanningInvariantViolation
+                | FixedCapRemoveResult::InternalInvariantViolation { .. } => {}
+            }
+        }
+
+        ShedTrackerGroupsResult {
+            groups_evicted,
+            pubkeys_evicted,
         }
     }
 
@@ -6366,5 +6411,38 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn shed_tracker_owner_groups_evicts_lru_tracker_only() {
+        let wallet = ExplicitOwner {
+            consumer: ExplicitConsumer::Wallet,
+            owner_key: ExplicitOwnerKey::Wallet,
+        };
+        let tracker_old = pool_owner(ExplicitConsumer::Tracker, 1);
+        let tracker_new = pool_owner(ExplicitConsumer::Tracker, 2);
+        let arb = pool_owner(ExplicitConsumer::Arb, 3);
+        let momentum = pool_owner(ExplicitConsumer::Momentum, 4);
+
+        let mut admission = FixedCapAdmission::new(16);
+        assert_admitted(admission.try_admit_new_group(wallet.clone(), vec![pk(10)]));
+        assert_admitted(admission.try_admit_new_group(tracker_old.clone(), vec![pk(1)]));
+        assert_admitted(admission.try_admit_new_group(tracker_new.clone(), vec![pk(2)]));
+        assert_admitted(admission.try_admit_new_group(arb.clone(), vec![pk(3)]));
+        assert_admitted(admission.try_admit_new_group(momentum.clone(), vec![pk(4)]));
+
+        admission.set_test_owner_stamp(tracker_old.clone(), 1);
+        admission.set_test_owner_stamp(tracker_new.clone(), 2);
+        admission.set_test_owner_stamp(arb.clone(), 3);
+        admission.set_test_owner_stamp(momentum.clone(), 4);
+        admission.set_test_owner_stamp(wallet.clone(), 5);
+
+        let result = admission.shed_tracker_owner_groups(8);
+        assert_eq!(result.groups_evicted, 2);
+        assert!(admission.owner_group(&tracker_old).is_none());
+        assert!(admission.owner_group(&tracker_new).is_none());
+        assert!(admission.owner_group(&wallet).is_some());
+        assert!(admission.owner_group(&arb).is_some());
+        assert!(admission.owner_group(&momentum).is_some());
     }
 }

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -42,7 +42,7 @@ pub use eviction_planner::{
 pub use explicit_admission::{
     AdmissionEvictionPlanResult, CapShrinkResult, EvictingAdmissionResult, FixedCapAdmission,
     FixedCapAdmissionResult, FixedCapRemoveRecovery, FixedCapRemoveResult, FixedCapReplaceResult,
-    InvariantViolationRecovery, TouchResult,
+    InvariantViolationRecovery, ShedTrackerGroupsResult, TouchResult,
 };
 pub use explicit_ownership::{
     EmptyOwnerGroupError, ExplicitConsumer, ExplicitOwner, ExplicitOwnerKey, ExplicitOwnership,

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -12,6 +12,7 @@ use super::worker_commands::track_command_kind;
 use super::worker_commands::ImmutableTrackCommand;
 pub use super::worker_commands::{TrackCommandStream, TrackPinReason, TrackWorkerCommand};
 use crate::metrics::{
+    add_market_data_exec_hot_hard_shed_groups_evicted_total,
     inc_market_data_explicit_set_snapshot_write_errors_total,
     inc_market_data_explicit_set_snapshot_write_total,
     inc_market_data_geyser_tracking_enqueue_dropped_total,
@@ -335,6 +336,17 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
                 *restore_barrier_pending = true;
             }
             false
+        }
+        TrackWorkerCommand::ShedTrackerUnderExecHotPressure { max_groups } => {
+            let result = admission.shed_tracker_owner_groups(max_groups);
+            if result.groups_evicted > 0 {
+                add_market_data_exec_hot_hard_shed_groups_evicted_total(
+                    result.groups_evicted as u64,
+                );
+                ctx.prune_tracked_maps_to_admitted(admission);
+                ctx.refresh_tracked_membership_snapshot();
+            }
+            result.groups_evicted > 0
         }
         TrackWorkerCommand::FlushExplicitSetSnapshot { done } => {
             try_write_explicit_set_snapshot_from_ctx(ctx.as_ref(), admission);
@@ -1877,6 +1889,7 @@ mod tests {
             TrackWorkerCommand::ScheduleGeyserPush,
             TrackWorkerCommand::ScheduleGeyserPushDebounced,
             TrackWorkerCommand::ContinueGeyserEvict,
+            TrackWorkerCommand::ShedTrackerUnderExecHotPressure { max_groups: 8 },
         ] {
             let cmd = store.wrap_command(payload);
             store.mark_applied(&cmd);

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -45,6 +45,10 @@ pub enum TrackWorkerCommand {
     FlushExplicitSetSnapshot {
         done: std::sync::mpsc::Sender<()>,
     },
+    /// Scope L2: evict tracker-only owner groups under EXEC_HOT broadcast pressure (LRU).
+    ShedTrackerUnderExecHotPressure {
+        max_groups: usize,
+    },
     /// Scope C: retry deferred hot-pool vault/bin registration after LivePoolCache fill.
     RetryDeferredHotPoolReserves,
 }
@@ -121,6 +125,7 @@ pub fn stream_for_command(cmd: &TrackWorkerCommand) -> TrackCommandStream {
         | TrackWorkerCommand::ScheduleGeyserPushDebounced
         | TrackWorkerCommand::RestoreExplicitSnapshot(_)
         | TrackWorkerCommand::ContinueGeyserEvict
+        | TrackWorkerCommand::ShedTrackerUnderExecHotPressure { .. }
         | TrackWorkerCommand::RetryDeferredHotPoolReserves
         | TrackWorkerCommand::FlushExplicitSetSnapshot { .. } => TrackCommandStream::Control,
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1875,6 +1875,20 @@ pub static MARKET_DATA_ACCOUNT_ENRICH_DISPATCH_CONTENDED_TOTAL: Lazy<AtomicU64> 
 pub static MARKET_DATA_ACCOUNT_HIGH_ENQUEUE_DROPPED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
+/// Scope L2: soft enrich shed active under EXEC_HOT broadcast pressure (0/1).
+pub static MARKET_DATA_EXEC_HOT_SHED_SOFT_ACTIVE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// Scope L2: lock-free flag read from ENRICH broadcast recv (drain-only, no classify/enqueue).
+pub static MARKET_DATA_ENRICH_SHED_ACTIVE: AtomicBool = AtomicBool::new(false);
+/// Scope L2: ENRICH recv messages dropped while soft shed is active.
+pub static MARKET_DATA_ACCOUNT_ENRICH_SHED_DROPPED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Scope L2: hard shed controller steps (tracker group eviction under EXEC_HOT pressure).
+pub static MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Scope L2: tracker owner groups evicted by hard shed.
+pub static MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_EVICTED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 /// Account ingest: jobs waiting in the dedicated NATS publish `mpsc` (JetStream + core publish).
 pub static MARKET_DATA_ACCOUNT_PUBLISH_QUEUE_DEPTH: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -2338,6 +2352,36 @@ pub fn inc_market_data_account_enrich_dispatch_contended_total() {
 #[inline]
 pub fn inc_market_data_account_high_enqueue_dropped_total() {
     MARKET_DATA_ACCOUNT_HIGH_ENQUEUE_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Scope L2: true when ENRICH recv should drain-only (no classify/enqueue).
+#[inline]
+pub fn market_data_enrich_shed_active() -> bool {
+    MARKET_DATA_ENRICH_SHED_ACTIVE.load(Ordering::Relaxed)
+}
+
+/// Scope L2: set soft enrich shed active (also updates prometheus gauge).
+#[inline]
+pub fn set_market_data_exec_hot_shed_soft_active(active: bool) {
+    MARKET_DATA_ENRICH_SHED_ACTIVE.store(active, Ordering::Relaxed);
+    MARKET_DATA_EXEC_HOT_SHED_SOFT_ACTIVE.store(u64::from(active), Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_account_enrich_shed_dropped_total() {
+    MARKET_DATA_ACCOUNT_ENRICH_SHED_DROPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_exec_hot_hard_shed_steps_total() {
+    MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn add_market_data_exec_hot_hard_shed_groups_evicted_total(n: u64) {
+    if n > 0 {
+        MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_EVICTED_TOTAL.fetch_add(n, Ordering::Relaxed);
+    }
 }
 
 #[inline]
@@ -7449,6 +7493,22 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_account_high_enqueue_dropped_total",
         MARKET_DATA_ACCOUNT_HIGH_ENQUEUE_DROPPED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_shed_soft_active",
+        MARKET_DATA_EXEC_HOT_SHED_SOFT_ACTIVE.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_account_enrich_shed_dropped_total",
+        MARKET_DATA_ACCOUNT_ENRICH_SHED_DROPPED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_hard_shed_steps_total",
+        MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_hard_shed_groups_evicted_total",
+        MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_EVICTED_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_account_publish_queue_depth",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scope L2: Under EXEC_HOT broadcast pressure, automatically shed ENRICH/Tracker load without throttling EXEC_HOT, Wallet, MomentumPosition, Momentum, or Arb.

### Soft shed (CPU relief)
- Lock-free `MARKET_DATA_ENRICH_SHED_ACTIVE` flag read from ENRICH broadcast recv
- When active: ENRICH recv drains messages only (no classify, no ingress enqueue)
- EXEC_HOT recv unchanged

### Hard shed (ingress reduction)
- New `TrackWorkerCommand::ShedTrackerUnderExecHotPressure { max_groups }`
- `FixedCapAdmission::shed_tracker_owner_groups()` evicts Tracker-only owner groups (LRU)
- Protected consumers (Wallet / MomentumPosition / Momentum / Arb) are never victims
- After eviction: prune tracked maps + coalesced Geyser push (existing track-worker pattern)
- No `try_shrink_cap` (I-MD-7)

### Controller
- Separate tokio interval (~300ms) sampling `MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_EXEC_HOT`
- Thresholds: `D_WARN=64`, `D_CRITICAL=256`, `D_CLEAR=16` with hysteresis
- Hard shed on critical depth or sustained soft-shed samples (max 16 tracker groups/step)

### Metrics
- `market_data_exec_hot_shed_soft_active`
- `market_data_account_enrich_shed_dropped_total`
- `market_data_exec_hot_hard_shed_steps_total`
- `market_data_exec_hot_hard_shed_groups_evicted_total`

### Tests
- `shed_tracker_owner_groups_evicts_lru_tracker_only` (admission)
- `enrich_recv_soft_shed_skips_classify_and_ingress_enqueue` (market-data bin)

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`

## STOP-CHECK
All 5 checks passed: no Hot Path RPC, existing eviction/track-worker patterns, scope-limited files, no simulation-gate violation, no eval test reads.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1253c386-43de-4419-aa4a-73e393cae009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1253c386-43de-4419-aa4a-73e393cae009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

