### PR TITLE
fix(market-data): escalate EXEC_HOT pressure shed to Momentum/Arb (Scope L2b)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -110,7 +110,8 @@ use ironcrab::metrics::{
     inc_market_data_arb_admission_rejected_total,
     inc_market_data_arb_pin_geyser_register_deferred_total,
     inc_market_data_balance_updated_from_cache_total,
-    inc_market_data_exec_hot_hard_shed_steps_total,
+    inc_market_data_exec_hot_hard_shed_steps_for_tier,
+    inc_market_data_exec_hot_pressure_admit_rejected_total,
     inc_market_data_geyser_sync_skipped_rate_limit_total,
     inc_market_data_ingest_membership_snapshot_hits_total,
     inc_market_data_jsonl_enqueue_dropped_total, inc_market_data_momentum_admission_admitted_total,
@@ -122,7 +123,9 @@ use ironcrab::metrics::{
     inc_market_data_vault_high_priority_dispatch_total,
     inc_market_data_wallet_admission_admitted_total,
     inc_market_data_wallet_admission_rejected_total, market_data_bump_geyser_head_slot,
-    market_data_enrich_shed_active, market_data_geyser_head_slot_value,
+    market_data_enrich_shed_active, market_data_exec_hot_arb_admit_suppress,
+    market_data_exec_hot_last_shed_groups, market_data_exec_hot_momentum_admit_suppress,
+    market_data_exec_hot_tracker_admit_suppress, market_data_geyser_head_slot_value,
     market_data_geyser_tracking_enqueue_dropped_value,
     market_data_geyser_tracking_jobs_processed_value, market_data_md_state_bursts_completed_value,
     market_data_request_account_session_reconnect, market_data_request_tx_session_reconnect,
@@ -143,7 +146,8 @@ use ironcrab::metrics::{
     set_market_data_account_broadcast_queue_depth_for_class,
     set_market_data_account_enrich_worker_count, set_market_data_account_exec_hot_worker_count,
     set_market_data_account_worker_count, set_market_data_arb_pinned_pools_gauge,
-    set_market_data_enrichment_registry_pools_gauge, set_market_data_exec_hot_shed_soft_active,
+    set_market_data_enrichment_registry_pools_gauge, set_market_data_exec_hot_admit_suppress,
+    set_market_data_exec_hot_shed_soft_active, set_market_data_exec_hot_shed_tier,
     set_market_data_explicit_set_snapshot_restore_duration_ms,
     set_market_data_explicit_set_snapshot_restore_pubkeys,
     set_market_data_geyser_explicit_admitted_accounts,
@@ -153,7 +157,8 @@ use ironcrab::metrics::{
     set_market_data_tx_broadcast_queue_depth, set_readiness_control_sub_active, set_readiness_mode,
     set_readiness_nats_connected, touch_market_data_global_ingest_progress,
     touch_market_data_tracked_membership_snapshot_refresh, update_readiness_market_data_current,
-    MarketDataLatencySegment, MetricsComponent, MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_EXEC_HOT,
+    ExecHotShedTier, MarketDataLatencySegment, MetricsComponent,
+    MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_EXEC_HOT,
     MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS, MARKET_EVENTS_RECEIVED_TOTAL,
     POOLS_TRACKED_GAUGE,
 };
@@ -218,9 +223,12 @@ const MARKET_DATA_MD_STATE_STALL_EXIT_ENABLED: bool = false;
 /// Scope L2: EXEC_HOT broadcast depth thresholds for enrich/tracker pressure shed.
 const EXEC_HOT_SHED_D_WARN: usize = 64;
 const EXEC_HOT_SHED_D_CRITICAL: usize = 256;
+const EXEC_HOT_SHED_D_SEVERE: usize = 2_000;
+const EXEC_HOT_SHED_D_EMERGENCY: usize = 10_000;
 const EXEC_HOT_SHED_D_CLEAR: usize = 16;
 const EXEC_HOT_SHED_HARD_MAX_GROUPS: usize = 16;
 const EXEC_HOT_SHED_SOFT_SAMPLES_FOR_HARD: u32 = 3;
+const EXEC_HOT_SHED_IDLE_ESCALATE_TICKS: u32 = 3;
 const EXEC_HOT_SHED_CONTROLLER_INTERVAL: Duration = Duration::from_millis(300);
 
 /// ExecutionResult dedup: prevents replay storms from re-tracking the same ATA/mint over and over.
@@ -2875,6 +2883,13 @@ impl MarketDataContext {
                     .get(&mint)
                     .is_some_and(|info| info.pin.is_some());
                 if !skip_tracker_admit {
+                    if market_data_exec_hot_tracker_admit_suppress() {
+                        inc_market_data_exec_hot_pressure_admit_rejected_total(
+                            ExecHotShedTier::Tracker,
+                        );
+                        inc_market_data_tracker_admission_rejected_total();
+                        return false;
+                    }
                     if !try_admit_owner_group(admission, Self::tracker_mint_owner(mint), vec![mint])
                     {
                         inc_market_data_tracker_admission_rejected_total();
@@ -5033,6 +5048,24 @@ impl MarketDataContext {
             let superseded_present = admission
                 .owner_group(&Self::pool_consumer_owner(pool_pk, superseded_consumer))
                 .is_some();
+            if momentum_consumer == ExplicitConsumer::Momentum
+                && market_data_exec_hot_momentum_admit_suppress()
+            {
+                inc_market_data_exec_hot_pressure_admit_rejected_total(ExecHotShedTier::Momentum);
+                inc_market_data_momentum_admission_rejected_total();
+                self.record_momentum_active_pool_reserve_registration_outcome(
+                    pool_pk,
+                    GeyserPinReason::MomentumActive,
+                    is_position,
+                    false,
+                );
+                self.sync_explicit_pool_admitted_from_admission(
+                    admission,
+                    pool_pk,
+                    momentum_consumer,
+                );
+                continue;
+            }
             if self.try_admit_pool_consumer_group(admission, pool_pk, momentum_consumer) {
                 if superseded_present {
                     self.release_pool_consumer_group(admission, pool_pk, superseded_consumer);
@@ -5248,6 +5281,17 @@ impl MarketDataContext {
                 continue;
             };
             self.hot_pool_registry.pin_arb_pool(pool_pk);
+            if market_data_exec_hot_arb_admit_suppress() {
+                inc_market_data_exec_hot_pressure_admit_rejected_total(ExecHotShedTier::Arb);
+                inc_market_data_arb_admission_rejected_total();
+                self.sync_explicit_pool_admitted_from_admission(
+                    admission,
+                    pool_pk,
+                    ExplicitConsumer::Arb,
+                );
+                let _ = &a.reason;
+                continue;
+            }
             if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Arb) {
                 inc_market_data_arb_admission_admitted_total();
                 if self.register_geyser_reserves_for_arb_active_pool(pool_pk) {
@@ -8096,42 +8140,128 @@ enum AccountHighIngressSend {
     Closed,
 }
 
-/// Scope L2: monitor EXEC_HOT broadcast depth and shed ENRICH/Tracker under pressure.
+/// Pure tier selection for EXEC_HOT pressure shed (Scope L2b); one action per controller tick.
+fn select_exec_hot_shed_tier(
+    depth: usize,
+    soft_shed: bool,
+    soft_shed_samples: u32,
+    tracker_idle_ticks: u32,
+    momentum_idle_ticks: u32,
+) -> ExecHotShedTier {
+    let tracker_trigger = depth >= EXEC_HOT_SHED_D_CRITICAL
+        || (soft_shed && soft_shed_samples >= EXEC_HOT_SHED_SOFT_SAMPLES_FOR_HARD);
+    let momentum_trigger = depth >= EXEC_HOT_SHED_D_SEVERE
+        || (tracker_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS
+            && depth >= EXEC_HOT_SHED_D_CRITICAL);
+    let arb_trigger = depth >= EXEC_HOT_SHED_D_EMERGENCY
+        || (momentum_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS
+            && depth >= EXEC_HOT_SHED_D_SEVERE);
+
+    if tracker_trigger && tracker_idle_ticks < EXEC_HOT_SHED_IDLE_ESCALATE_TICKS {
+        ExecHotShedTier::Tracker
+    } else if momentum_trigger && momentum_idle_ticks < EXEC_HOT_SHED_IDLE_ESCALATE_TICKS {
+        ExecHotShedTier::Momentum
+    } else if arb_trigger {
+        ExecHotShedTier::Arb
+    } else {
+        ExecHotShedTier::None
+    }
+}
+
+/// Scope L2 / L2b: monitor EXEC_HOT broadcast depth and shed ENRICH/Tracker/Momentum/Arb under pressure.
 fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
     tokio::spawn(async move {
         let mut soft_shed = false;
         let mut soft_shed_samples = 0u32;
+        let mut tracker_idle_ticks = 0u32;
+        let mut momentum_idle_ticks = 0u32;
+        let mut last_enqueued_tier: Option<ExecHotShedTier> = None;
         let mut interval = tokio::time::interval(EXEC_HOT_SHED_CONTROLLER_INTERVAL);
         loop {
             interval.tick().await;
             let depth =
                 MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_EXEC_HOT.load(Ordering::Relaxed) as usize;
 
+            if let Some(tier) = last_enqueued_tier.take() {
+                let groups = market_data_exec_hot_last_shed_groups(tier);
+                match tier {
+                    ExecHotShedTier::Tracker => {
+                        if groups == 0 && depth >= EXEC_HOT_SHED_D_CRITICAL {
+                            tracker_idle_ticks = tracker_idle_ticks.saturating_add(1);
+                        } else {
+                            tracker_idle_ticks = 0;
+                        }
+                    }
+                    ExecHotShedTier::Momentum => {
+                        if groups == 0 && depth >= EXEC_HOT_SHED_D_SEVERE {
+                            momentum_idle_ticks = momentum_idle_ticks.saturating_add(1);
+                        } else {
+                            momentum_idle_ticks = 0;
+                        }
+                    }
+                    ExecHotShedTier::Arb | ExecHotShedTier::None => {}
+                }
+            }
+
             if depth >= EXEC_HOT_SHED_D_WARN {
                 soft_shed = true;
             } else if depth < EXEC_HOT_SHED_D_CLEAR {
                 soft_shed = false;
                 soft_shed_samples = 0;
+                tracker_idle_ticks = 0;
+                momentum_idle_ticks = 0;
             }
 
             set_market_data_exec_hot_shed_soft_active(soft_shed);
+
+            let tracker_admit_suppress = soft_shed || depth >= EXEC_HOT_SHED_D_CRITICAL;
+            let momentum_admit_suppress = depth >= EXEC_HOT_SHED_D_SEVERE
+                || tracker_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS;
+            let arb_admit_suppress = depth >= EXEC_HOT_SHED_D_EMERGENCY
+                || momentum_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS;
+            set_market_data_exec_hot_admit_suppress(
+                tracker_admit_suppress,
+                momentum_admit_suppress,
+                arb_admit_suppress,
+            );
 
             if soft_shed {
                 soft_shed_samples = soft_shed_samples.saturating_add(1);
             }
 
-            let trigger_hard = depth >= EXEC_HOT_SHED_D_CRITICAL
-                || (soft_shed && soft_shed_samples >= EXEC_HOT_SHED_SOFT_SAMPLES_FOR_HARD);
-            if trigger_hard {
+            let shed_tier = select_exec_hot_shed_tier(
+                depth,
+                soft_shed,
+                soft_shed_samples,
+                tracker_idle_ticks,
+                momentum_idle_ticks,
+            );
+            set_market_data_exec_hot_shed_tier(shed_tier);
+
+            if shed_tier == ExecHotShedTier::None {
+                continue;
+            }
+
+            if soft_shed && shed_tier == ExecHotShedTier::Tracker {
                 soft_shed_samples = 0;
-                if track_worker_try_enqueue(
-                    &track_worker,
-                    TrackWorkerCommand::ShedTrackerUnderExecHotPressure {
-                        max_groups: EXEC_HOT_SHED_HARD_MAX_GROUPS,
-                    },
-                ) {
-                    inc_market_data_exec_hot_hard_shed_steps_total();
-                }
+            }
+
+            let cmd = match shed_tier {
+                ExecHotShedTier::Tracker => TrackWorkerCommand::ShedTrackerUnderExecHotPressure {
+                    max_groups: EXEC_HOT_SHED_HARD_MAX_GROUPS,
+                },
+                ExecHotShedTier::Momentum => TrackWorkerCommand::ShedMomentumUnderExecHotPressure {
+                    max_groups: EXEC_HOT_SHED_HARD_MAX_GROUPS,
+                },
+                ExecHotShedTier::Arb => TrackWorkerCommand::ShedArbUnderExecHotPressure {
+                    max_groups: EXEC_HOT_SHED_HARD_MAX_GROUPS,
+                },
+                ExecHotShedTier::None => continue,
+            };
+
+            if track_worker_try_enqueue(&track_worker, cmd) {
+                inc_market_data_exec_hot_hard_shed_steps_for_tier(shed_tier);
+                last_enqueued_tier = Some(shed_tier);
             }
         }
     });
@@ -14738,6 +14868,56 @@ mod pr_b_geyser_tracking_tests {
         assert!(enrich_ingress_rx.try_recv().is_err());
 
         MARKET_DATA_ENRICH_SHED_ACTIVE.store(false, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn exec_hot_shed_tier_prefers_tracker_then_escalates_on_idle() {
+        use ironcrab::metrics::ExecHotShedTier;
+
+        assert_eq!(
+            select_exec_hot_shed_tier(300, false, 0, 0, 0),
+            ExecHotShedTier::Tracker
+        );
+        assert_eq!(
+            select_exec_hot_shed_tier(300, false, 0, 3, 0),
+            ExecHotShedTier::Momentum
+        );
+        assert_eq!(
+            select_exec_hot_shed_tier(262_000, false, 0, 3, 0),
+            ExecHotShedTier::Momentum
+        );
+        assert_eq!(
+            select_exec_hot_shed_tier(5_000, false, 0, 3, 0),
+            ExecHotShedTier::Momentum
+        );
+        assert_eq!(
+            select_exec_hot_shed_tier(5_000, false, 0, 3, 3),
+            ExecHotShedTier::Arb
+        );
+        assert_eq!(
+            select_exec_hot_shed_tier(12_000, false, 0, 3, 3),
+            ExecHotShedTier::Arb
+        );
+        assert_eq!(
+            select_exec_hot_shed_tier(12_000, false, 0, 3, 0),
+            ExecHotShedTier::Momentum
+        );
+        assert_eq!(
+            select_exec_hot_shed_tier(10, false, 0, 0, 0),
+            ExecHotShedTier::None
+        );
+    }
+
+    #[test]
+    fn exec_hot_tracker_admit_suppress_under_soft_or_critical_depth() {
+        use ironcrab::metrics::{
+            market_data_exec_hot_tracker_admit_suppress, set_market_data_exec_hot_admit_suppress,
+        };
+
+        set_market_data_exec_hot_admit_suppress(true, false, false);
+        assert!(market_data_exec_hot_tracker_admit_suppress());
+        set_market_data_exec_hot_admit_suppress(false, false, false);
+        assert!(!market_data_exec_hot_tracker_admit_suppress());
     }
 
     /// Scope L1: EXEC_HOT broadcast recv must enqueue under ENRICH ingress backlog (split cursors).

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -2885,15 +2885,17 @@ impl MarketDataContext {
                     .get(&mint)
                     .is_some_and(|info| info.pin.is_some());
                 if !skip_tracker_admit {
-                    if market_data_exec_hot_tracker_admit_suppress() {
+                    let owner = Self::tracker_mint_owner(mint);
+                    if admission.owner_group(&owner).is_none()
+                        && market_data_exec_hot_tracker_admit_suppress()
+                    {
                         inc_market_data_exec_hot_pressure_admit_rejected_total(
                             ExecHotShedTier::Tracker,
                         );
                         inc_market_data_tracker_admission_rejected_total();
                         return false;
                     }
-                    if !try_admit_owner_group(admission, Self::tracker_mint_owner(mint), vec![mint])
-                    {
+                    if !try_admit_owner_group(admission, owner, vec![mint]) {
                         inc_market_data_tracker_admission_rejected_total();
                         return false;
                     }
@@ -8188,6 +8190,7 @@ fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
                 let groups = market_data_exec_hot_last_shed_groups(tier);
                 if groups == EXEC_HOT_SHED_GROUPS_PENDING {
                     last_enqueued_tier = Some(tier);
+                    continue;
                 } else {
                     match tier {
                         ExecHotShedTier::Tracker => {

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -147,8 +147,8 @@ use ironcrab::metrics::{
     set_market_data_account_enrich_worker_count, set_market_data_account_exec_hot_worker_count,
     set_market_data_account_worker_count, set_market_data_arb_pinned_pools_gauge,
     set_market_data_enrichment_registry_pools_gauge, set_market_data_exec_hot_admit_suppress,
-    set_market_data_exec_hot_shed_soft_active, set_market_data_exec_hot_shed_tier,
-    set_market_data_explicit_set_snapshot_restore_duration_ms,
+    set_market_data_exec_hot_last_shed_groups, set_market_data_exec_hot_shed_soft_active,
+    set_market_data_exec_hot_shed_tier, set_market_data_explicit_set_snapshot_restore_duration_ms,
     set_market_data_explicit_set_snapshot_restore_pubkeys,
     set_market_data_geyser_explicit_admitted_accounts,
     set_market_data_geyser_explicit_cap_overflow, set_market_data_geyser_explicit_set_size,
@@ -229,6 +229,8 @@ const EXEC_HOT_SHED_D_CLEAR: usize = 16;
 const EXEC_HOT_SHED_HARD_MAX_GROUPS: usize = 16;
 const EXEC_HOT_SHED_SOFT_SAMPLES_FOR_HARD: u32 = 3;
 const EXEC_HOT_SHED_IDLE_ESCALATE_TICKS: u32 = 3;
+/// Sentinel written at shed enqueue; worker overwrites when the command completes.
+const EXEC_HOT_SHED_GROUPS_PENDING: u64 = u64::MAX;
 const EXEC_HOT_SHED_CONTROLLER_INTERVAL: Duration = Duration::from_millis(300);
 
 /// ExecutionResult dedup: prevents replay storms from re-tracking the same ATA/mint over and over.
@@ -8184,22 +8186,26 @@ fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
 
             if let Some(tier) = last_enqueued_tier.take() {
                 let groups = market_data_exec_hot_last_shed_groups(tier);
-                match tier {
-                    ExecHotShedTier::Tracker => {
-                        if groups == 0 && depth >= EXEC_HOT_SHED_D_CRITICAL {
-                            tracker_idle_ticks = tracker_idle_ticks.saturating_add(1);
-                        } else {
-                            tracker_idle_ticks = 0;
+                if groups == EXEC_HOT_SHED_GROUPS_PENDING {
+                    last_enqueued_tier = Some(tier);
+                } else {
+                    match tier {
+                        ExecHotShedTier::Tracker => {
+                            if groups == 0 && depth >= EXEC_HOT_SHED_D_CRITICAL {
+                                tracker_idle_ticks = tracker_idle_ticks.saturating_add(1);
+                            } else {
+                                tracker_idle_ticks = 0;
+                            }
                         }
-                    }
-                    ExecHotShedTier::Momentum => {
-                        if groups == 0 && depth >= EXEC_HOT_SHED_D_SEVERE {
-                            momentum_idle_ticks = momentum_idle_ticks.saturating_add(1);
-                        } else {
-                            momentum_idle_ticks = 0;
+                        ExecHotShedTier::Momentum => {
+                            if groups == 0 && depth >= EXEC_HOT_SHED_D_SEVERE {
+                                momentum_idle_ticks = momentum_idle_ticks.saturating_add(1);
+                            } else {
+                                momentum_idle_ticks = 0;
+                            }
                         }
+                        ExecHotShedTier::Arb | ExecHotShedTier::None => {}
                     }
-                    ExecHotShedTier::Arb | ExecHotShedTier::None => {}
                 }
             }
 
@@ -8216,9 +8222,11 @@ fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
 
             let tracker_admit_suppress = soft_shed || depth >= EXEC_HOT_SHED_D_CRITICAL;
             let momentum_admit_suppress = depth >= EXEC_HOT_SHED_D_SEVERE
-                || tracker_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS;
+                || (tracker_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS
+                    && depth >= EXEC_HOT_SHED_D_CRITICAL);
             let arb_admit_suppress = depth >= EXEC_HOT_SHED_D_EMERGENCY
-                || momentum_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS;
+                || (momentum_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS
+                    && depth >= EXEC_HOT_SHED_D_SEVERE);
             set_market_data_exec_hot_admit_suppress(
                 tracker_admit_suppress,
                 momentum_admit_suppress,
@@ -8261,6 +8269,7 @@ fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
 
             if track_worker_try_enqueue(&track_worker, cmd) {
                 inc_market_data_exec_hot_hard_shed_steps_for_tier(shed_tier);
+                set_market_data_exec_hot_last_shed_groups(shed_tier, EXEC_HOT_SHED_GROUPS_PENDING);
                 last_enqueued_tier = Some(shed_tier);
             }
         }

--- a/src/market_data/track/explicit_admission.rs
+++ b/src/market_data/track/explicit_admission.rs
@@ -133,12 +133,15 @@ pub enum CapShrinkResult {
     InternalInvariantViolation,
 }
 
-/// Result of shedding tracker-only owner groups under EXEC_HOT pressure (Scope L2).
+/// Result of shedding owner groups under EXEC_HOT pressure (Scope L2 / L2b).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ShedTrackerGroupsResult {
+pub struct ShedOwnerGroupsResult {
     pub groups_evicted: usize,
     pub pubkeys_evicted: usize,
 }
+
+/// Back-compat alias for L2 tracker shed tests and call sites.
+pub type ShedTrackerGroupsResult = ShedOwnerGroupsResult;
 
 /// Result of an explicit owner-group LRU touch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1551,27 +1554,34 @@ impl FixedCapAdmission {
         }
     }
 
-    /// Evict up to `max_groups` tracker-only owner groups (LRU first). Never touches Wallet,
-    /// MomentumPosition, Momentum, or Arb groups (Scope L2 EXEC_HOT pressure shed).
-    pub fn shed_tracker_owner_groups(&mut self, max_groups: usize) -> ShedTrackerGroupsResult {
-        if max_groups == 0 {
-            return ShedTrackerGroupsResult {
+    /// Evict up to `max_groups` owner groups whose consumer is in `consumers` (LRU first).
+    /// Only the listed consumers are eligible; Wallet and MomentumPosition are never passed here.
+    pub fn shed_owner_groups_for_consumers(
+        &mut self,
+        consumers: &[ExplicitConsumer],
+        max_groups: usize,
+    ) -> ShedOwnerGroupsResult {
+        if max_groups == 0 || consumers.is_empty() {
+            return ShedOwnerGroupsResult {
                 groups_evicted: 0,
                 pubkeys_evicted: 0,
             };
         }
 
-        let mut tracker_owners: Vec<(ExplicitOwner, u64)> = self
+        let allowed: std::collections::HashSet<ExplicitConsumer> =
+            consumers.iter().copied().collect();
+
+        let mut victims: Vec<(ExplicitOwner, u64)> = self
             .snapshot_lru_entries()
             .into_iter()
-            .filter(|entry| entry.owner.consumer == ExplicitConsumer::Tracker)
+            .filter(|entry| allowed.contains(&entry.owner.consumer))
             .map(|entry| (entry.owner, entry.last_touch))
             .collect();
-        tracker_owners.sort_by_key(|(_, touch)| *touch);
+        victims.sort_by_key(|(_, touch)| *touch);
 
         let mut groups_evicted = 0usize;
         let mut pubkeys_evicted = 0usize;
-        for (owner, _) in tracker_owners.into_iter().take(max_groups) {
+        for (owner, _) in victims.into_iter().take(max_groups) {
             match self.remove_group(owner) {
                 FixedCapRemoveResult::Removed { physical_removed } => {
                     groups_evicted += 1;
@@ -1583,10 +1593,26 @@ impl FixedCapAdmission {
             }
         }
 
-        ShedTrackerGroupsResult {
+        ShedOwnerGroupsResult {
             groups_evicted,
             pubkeys_evicted,
         }
+    }
+
+    /// Evict up to `max_groups` tracker-only owner groups (LRU first). Never touches Wallet,
+    /// MomentumPosition, Momentum, or Arb groups (Scope L2 EXEC_HOT pressure shed).
+    pub fn shed_tracker_owner_groups(&mut self, max_groups: usize) -> ShedOwnerGroupsResult {
+        self.shed_owner_groups_for_consumers(&[ExplicitConsumer::Tracker], max_groups)
+    }
+
+    /// Evict up to `max_groups` momentum-active (non-position) owner groups (Scope L2b).
+    pub fn shed_momentum_owner_groups(&mut self, max_groups: usize) -> ShedOwnerGroupsResult {
+        self.shed_owner_groups_for_consumers(&[ExplicitConsumer::Momentum], max_groups)
+    }
+
+    /// Evict up to `max_groups` arb owner groups (Scope L2b).
+    pub fn shed_arb_owner_groups(&mut self, max_groups: usize) -> ShedOwnerGroupsResult {
+        self.shed_owner_groups_for_consumers(&[ExplicitConsumer::Arb], max_groups)
     }
 
     fn plan_insert(&mut self, normalized: &[Pubkey]) -> InsertPlanOutcome {
@@ -6443,6 +6469,91 @@ mod tests {
         assert!(admission.owner_group(&tracker_new).is_none());
         assert!(admission.owner_group(&wallet).is_some());
         assert!(admission.owner_group(&arb).is_some());
+        assert!(admission.owner_group(&momentum).is_some());
+    }
+
+    #[test]
+    fn shed_momentum_owner_groups_evicts_lru_momentum_only() {
+        let wallet = ExplicitOwner {
+            consumer: ExplicitConsumer::Wallet,
+            owner_key: ExplicitOwnerKey::Wallet,
+        };
+        let momentum_old = pool_owner(ExplicitConsumer::Momentum, 1);
+        let momentum_new = pool_owner(ExplicitConsumer::Momentum, 2);
+        let momentum_pos = pool_owner(ExplicitConsumer::MomentumPosition, 3);
+        let arb = pool_owner(ExplicitConsumer::Arb, 4);
+        let tracker = pool_owner(ExplicitConsumer::Tracker, 5);
+
+        let mut admission = FixedCapAdmission::new(16);
+        assert_admitted(admission.try_admit_new_group(wallet.clone(), vec![pk(10)]));
+        assert_admitted(admission.try_admit_new_group(momentum_old.clone(), vec![pk(1)]));
+        assert_admitted(admission.try_admit_new_group(momentum_new.clone(), vec![pk(2)]));
+        assert_admitted(admission.try_admit_new_group(momentum_pos.clone(), vec![pk(3)]));
+        assert_admitted(admission.try_admit_new_group(arb.clone(), vec![pk(4)]));
+        assert_admitted(admission.try_admit_new_group(tracker.clone(), vec![pk(5)]));
+
+        admission.set_test_owner_stamp(momentum_old.clone(), 1);
+        admission.set_test_owner_stamp(momentum_new.clone(), 2);
+        admission.set_test_owner_stamp(momentum_pos.clone(), 3);
+        admission.set_test_owner_stamp(arb.clone(), 4);
+        admission.set_test_owner_stamp(tracker.clone(), 5);
+        admission.set_test_owner_stamp(wallet.clone(), 6);
+
+        let result = admission.shed_momentum_owner_groups(8);
+        assert_eq!(result.groups_evicted, 2);
+        assert!(admission.owner_group(&momentum_old).is_none());
+        assert!(admission.owner_group(&momentum_new).is_none());
+        assert!(admission.owner_group(&momentum_pos).is_some());
+        assert!(admission.owner_group(&wallet).is_some());
+        assert!(admission.owner_group(&arb).is_some());
+        assert!(admission.owner_group(&tracker).is_some());
+    }
+
+    #[test]
+    fn shed_arb_owner_groups_evicts_lru_arb_only() {
+        let wallet = ExplicitOwner {
+            consumer: ExplicitConsumer::Wallet,
+            owner_key: ExplicitOwnerKey::Wallet,
+        };
+        let arb_old = pool_owner(ExplicitConsumer::Arb, 1);
+        let arb_new = pool_owner(ExplicitConsumer::Arb, 2);
+        let momentum_pos = pool_owner(ExplicitConsumer::MomentumPosition, 3);
+        let momentum = pool_owner(ExplicitConsumer::Momentum, 4);
+
+        let mut admission = FixedCapAdmission::new(16);
+        assert_admitted(admission.try_admit_new_group(wallet.clone(), vec![pk(10)]));
+        assert_admitted(admission.try_admit_new_group(arb_old.clone(), vec![pk(1)]));
+        assert_admitted(admission.try_admit_new_group(arb_new.clone(), vec![pk(2)]));
+        assert_admitted(admission.try_admit_new_group(momentum_pos.clone(), vec![pk(3)]));
+        assert_admitted(admission.try_admit_new_group(momentum.clone(), vec![pk(4)]));
+
+        admission.set_test_owner_stamp(arb_old.clone(), 1);
+        admission.set_test_owner_stamp(arb_new.clone(), 2);
+        admission.set_test_owner_stamp(momentum_pos.clone(), 3);
+        admission.set_test_owner_stamp(momentum.clone(), 4);
+        admission.set_test_owner_stamp(wallet.clone(), 5);
+
+        let result = admission.shed_arb_owner_groups(8);
+        assert_eq!(result.groups_evicted, 2);
+        assert!(admission.owner_group(&arb_old).is_none());
+        assert!(admission.owner_group(&arb_new).is_none());
+        assert!(admission.owner_group(&momentum_pos).is_some());
+        assert!(admission.owner_group(&wallet).is_some());
+        assert!(admission.owner_group(&momentum).is_some());
+    }
+
+    #[test]
+    fn shed_owner_groups_for_consumers_respects_consumer_filter() {
+        let tracker = pool_owner(ExplicitConsumer::Tracker, 1);
+        let momentum = pool_owner(ExplicitConsumer::Momentum, 2);
+
+        let mut admission = FixedCapAdmission::new(8);
+        assert_admitted(admission.try_admit_new_group(tracker.clone(), vec![pk(1)]));
+        assert_admitted(admission.try_admit_new_group(momentum.clone(), vec![pk(2)]));
+
+        let result = admission.shed_owner_groups_for_consumers(&[ExplicitConsumer::Tracker], 4);
+        assert_eq!(result.groups_evicted, 1);
+        assert!(admission.owner_group(&tracker).is_none());
         assert!(admission.owner_group(&momentum).is_some());
     }
 }

--- a/src/market_data/track/mod.rs
+++ b/src/market_data/track/mod.rs
@@ -42,7 +42,7 @@ pub use eviction_planner::{
 pub use explicit_admission::{
     AdmissionEvictionPlanResult, CapShrinkResult, EvictingAdmissionResult, FixedCapAdmission,
     FixedCapAdmissionResult, FixedCapRemoveRecovery, FixedCapRemoveResult, FixedCapReplaceResult,
-    InvariantViolationRecovery, ShedTrackerGroupsResult, TouchResult,
+    InvariantViolationRecovery, ShedOwnerGroupsResult, ShedTrackerGroupsResult, TouchResult,
 };
 pub use explicit_ownership::{
     EmptyOwnerGroupError, ExplicitConsumer, ExplicitOwner, ExplicitOwnerKey, ExplicitOwnership,

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -12,7 +12,7 @@ use super::worker_commands::track_command_kind;
 use super::worker_commands::ImmutableTrackCommand;
 pub use super::worker_commands::{TrackCommandStream, TrackPinReason, TrackWorkerCommand};
 use crate::metrics::{
-    add_market_data_exec_hot_hard_shed_groups_evicted_total,
+    add_market_data_exec_hot_hard_shed_groups_for_tier,
     inc_market_data_explicit_set_snapshot_write_errors_total,
     inc_market_data_explicit_set_snapshot_write_total,
     inc_market_data_geyser_tracking_enqueue_dropped_total,
@@ -22,7 +22,8 @@ use crate::metrics::{
     inc_market_data_track_worker_enqueue_deduped_total,
     record_market_data_arb_track_requests_messages_total,
     record_market_data_momentum_active_pool_messages_total, set_market_data_arb_pinned_pools_gauge,
-    set_market_data_momentum_active_pool_pins_gauge, set_market_data_track_worker_queue_depth,
+    set_market_data_exec_hot_last_shed_groups, set_market_data_momentum_active_pool_pins_gauge,
+    set_market_data_track_worker_queue_depth, ExecHotShedTier,
 };
 use crate::nats::{
     ArbTrackActiveEntry, ArbTrackRemovedEntry, ArbTrackRequestsUpdate, MomentumActivePoolEntry,
@@ -291,6 +292,29 @@ pub fn apply_arb_track_requests_on_track_worker<C: TrackWorkerContext>(
     batch_dirty
 }
 
+fn apply_exec_hot_pressure_shed<C: TrackWorkerContext>(
+    ctx: &Arc<C>,
+    admission: &mut FixedCapAdmission,
+    tier: ExecHotShedTier,
+    max_groups: usize,
+) -> bool {
+    let result = match tier {
+        ExecHotShedTier::Tracker => admission.shed_tracker_owner_groups(max_groups),
+        ExecHotShedTier::Momentum => admission.shed_momentum_owner_groups(max_groups),
+        ExecHotShedTier::Arb => admission.shed_arb_owner_groups(max_groups),
+        ExecHotShedTier::None => {
+            return false;
+        }
+    };
+    set_market_data_exec_hot_last_shed_groups(tier, result.groups_evicted as u64);
+    if result.groups_evicted > 0 {
+        add_market_data_exec_hot_hard_shed_groups_for_tier(tier, result.groups_evicted as u64);
+        ctx.prune_tracked_maps_to_admitted(admission);
+        ctx.refresh_tracked_membership_snapshot();
+    }
+    result.groups_evicted > 0
+}
+
 pub fn track_worker_process_command<C: TrackWorkerContext>(
     ctx: &Arc<C>,
     admission: &mut FixedCapAdmission,
@@ -338,15 +362,13 @@ pub fn track_worker_process_command<C: TrackWorkerContext>(
             false
         }
         TrackWorkerCommand::ShedTrackerUnderExecHotPressure { max_groups } => {
-            let result = admission.shed_tracker_owner_groups(max_groups);
-            if result.groups_evicted > 0 {
-                add_market_data_exec_hot_hard_shed_groups_evicted_total(
-                    result.groups_evicted as u64,
-                );
-                ctx.prune_tracked_maps_to_admitted(admission);
-                ctx.refresh_tracked_membership_snapshot();
-            }
-            result.groups_evicted > 0
+            apply_exec_hot_pressure_shed(ctx, admission, ExecHotShedTier::Tracker, max_groups)
+        }
+        TrackWorkerCommand::ShedMomentumUnderExecHotPressure { max_groups } => {
+            apply_exec_hot_pressure_shed(ctx, admission, ExecHotShedTier::Momentum, max_groups)
+        }
+        TrackWorkerCommand::ShedArbUnderExecHotPressure { max_groups } => {
+            apply_exec_hot_pressure_shed(ctx, admission, ExecHotShedTier::Arb, max_groups)
         }
         TrackWorkerCommand::FlushExplicitSetSnapshot { done } => {
             try_write_explicit_set_snapshot_from_ctx(ctx.as_ref(), admission);
@@ -1890,6 +1912,8 @@ mod tests {
             TrackWorkerCommand::ScheduleGeyserPushDebounced,
             TrackWorkerCommand::ContinueGeyserEvict,
             TrackWorkerCommand::ShedTrackerUnderExecHotPressure { max_groups: 8 },
+            TrackWorkerCommand::ShedMomentumUnderExecHotPressure { max_groups: 8 },
+            TrackWorkerCommand::ShedArbUnderExecHotPressure { max_groups: 8 },
         ] {
             let cmd = store.wrap_command(payload);
             store.mark_applied(&cmd);

--- a/src/market_data/track/worker_commands.rs
+++ b/src/market_data/track/worker_commands.rs
@@ -49,6 +49,14 @@ pub enum TrackWorkerCommand {
     ShedTrackerUnderExecHotPressure {
         max_groups: usize,
     },
+    /// Scope L2b: evict momentum-active (non-position) owner groups under EXEC_HOT pressure.
+    ShedMomentumUnderExecHotPressure {
+        max_groups: usize,
+    },
+    /// Scope L2b: evict arb owner groups under EXEC_HOT pressure.
+    ShedArbUnderExecHotPressure {
+        max_groups: usize,
+    },
     /// Scope C: retry deferred hot-pool vault/bin registration after LivePoolCache fill.
     RetryDeferredHotPoolReserves,
 }
@@ -126,6 +134,8 @@ pub fn stream_for_command(cmd: &TrackWorkerCommand) -> TrackCommandStream {
         | TrackWorkerCommand::RestoreExplicitSnapshot(_)
         | TrackWorkerCommand::ContinueGeyserEvict
         | TrackWorkerCommand::ShedTrackerUnderExecHotPressure { .. }
+        | TrackWorkerCommand::ShedMomentumUnderExecHotPressure { .. }
+        | TrackWorkerCommand::ShedArbUnderExecHotPressure { .. }
         | TrackWorkerCommand::RetryDeferredHotPoolReserves
         | TrackWorkerCommand::FlushExplicitSetSnapshot { .. } => TrackCommandStream::Control,
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1889,6 +1889,46 @@ pub static MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_TOTAL: Lazy<AtomicU64> =
 pub static MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_EVICTED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
+/// Scope L2b: EXEC_HOT pressure shed tier (0=none, 1=tracker, 2=momentum, 3=arb).
+pub static MARKET_DATA_EXEC_HOT_SHED_TIER: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// Scope L2b: per-tier hard shed steps (`tier` = tracker|momentum|arb).
+pub static MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_TRACKER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_ARB: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Scope L2b: per-tier owner groups evicted by hard shed.
+pub static MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_TRACKER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_ARB: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Scope L2b: last shed result groups evicted (feedback for controller idle escalation).
+pub static MARKET_DATA_EXEC_HOT_LAST_SHED_GROUPS_TRACKER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_EXEC_HOT_LAST_SHED_GROUPS_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_EXEC_HOT_LAST_SHED_GROUPS_ARB: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// Scope L2b: lock-free admit suppress flags (controller sets, track-worker reads).
+pub static MARKET_DATA_EXEC_HOT_TRACKER_ADMIT_SUPPRESS: AtomicBool = AtomicBool::new(false);
+pub static MARKET_DATA_EXEC_HOT_MOMENTUM_ADMIT_SUPPRESS: AtomicBool = AtomicBool::new(false);
+pub static MARKET_DATA_EXEC_HOT_ARB_ADMIT_SUPPRESS: AtomicBool = AtomicBool::new(false);
+
+/// Scope L2b: admits rejected due to EXEC_HOT pressure suppress.
+pub static MARKET_DATA_EXEC_HOT_PRESSURE_ADMIT_REJECTED_TRACKER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_EXEC_HOT_PRESSURE_ADMIT_REJECTED_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_EXEC_HOT_PRESSURE_ADMIT_REJECTED_ARB: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
 /// Account ingest: jobs waiting in the dedicated NATS publish `mpsc` (JetStream + core publish).
 pub static MARKET_DATA_ACCOUNT_PUBLISH_QUEUE_DEPTH: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -2377,11 +2417,124 @@ pub fn inc_market_data_exec_hot_hard_shed_steps_total() {
     MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+/// Scope L2b: EXEC_HOT hard shed tier for controller / worker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecHotShedTier {
+    None = 0,
+    Tracker = 1,
+    Momentum = 2,
+    Arb = 3,
+}
+
+impl ExecHotShedTier {
+    #[inline]
+    pub fn as_u64(self) -> u64 {
+        self as u64
+    }
+
+    #[inline]
+    pub fn prometheus_label(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Tracker => "tracker",
+            Self::Momentum => "momentum",
+            Self::Arb => "arb",
+        }
+    }
+}
+
+#[inline]
+pub fn set_market_data_exec_hot_shed_tier(tier: ExecHotShedTier) {
+    MARKET_DATA_EXEC_HOT_SHED_TIER.store(tier.as_u64(), Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_exec_hot_hard_shed_steps_for_tier(tier: ExecHotShedTier) {
+    inc_market_data_exec_hot_hard_shed_steps_total();
+    let cell = match tier {
+        ExecHotShedTier::Tracker => &*MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_TRACKER,
+        ExecHotShedTier::Momentum => &*MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_MOMENTUM,
+        ExecHotShedTier::Arb => &*MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_ARB,
+        ExecHotShedTier::None => return,
+    };
+    cell.fetch_add(1, Ordering::Relaxed);
+}
+
 #[inline]
 pub fn add_market_data_exec_hot_hard_shed_groups_evicted_total(n: u64) {
     if n > 0 {
         MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_EVICTED_TOTAL.fetch_add(n, Ordering::Relaxed);
     }
+}
+
+#[inline]
+pub fn add_market_data_exec_hot_hard_shed_groups_for_tier(tier: ExecHotShedTier, n: u64) {
+    if n == 0 {
+        return;
+    }
+    add_market_data_exec_hot_hard_shed_groups_evicted_total(n);
+    let cell = match tier {
+        ExecHotShedTier::Tracker => &*MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_TRACKER,
+        ExecHotShedTier::Momentum => &*MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_MOMENTUM,
+        ExecHotShedTier::Arb => &*MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_ARB,
+        ExecHotShedTier::None => return,
+    };
+    cell.fetch_add(n, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn set_market_data_exec_hot_last_shed_groups(tier: ExecHotShedTier, groups: u64) {
+    let cell = match tier {
+        ExecHotShedTier::Tracker => &*MARKET_DATA_EXEC_HOT_LAST_SHED_GROUPS_TRACKER,
+        ExecHotShedTier::Momentum => &*MARKET_DATA_EXEC_HOT_LAST_SHED_GROUPS_MOMENTUM,
+        ExecHotShedTier::Arb => &*MARKET_DATA_EXEC_HOT_LAST_SHED_GROUPS_ARB,
+        ExecHotShedTier::None => return,
+    };
+    cell.store(groups, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn market_data_exec_hot_last_shed_groups(tier: ExecHotShedTier) -> u64 {
+    let cell = match tier {
+        ExecHotShedTier::Tracker => &*MARKET_DATA_EXEC_HOT_LAST_SHED_GROUPS_TRACKER,
+        ExecHotShedTier::Momentum => &*MARKET_DATA_EXEC_HOT_LAST_SHED_GROUPS_MOMENTUM,
+        ExecHotShedTier::Arb => &*MARKET_DATA_EXEC_HOT_LAST_SHED_GROUPS_ARB,
+        ExecHotShedTier::None => return 0,
+    };
+    cell.load(Ordering::Relaxed)
+}
+
+#[inline]
+pub fn set_market_data_exec_hot_admit_suppress(tracker: bool, momentum: bool, arb: bool) {
+    MARKET_DATA_EXEC_HOT_TRACKER_ADMIT_SUPPRESS.store(tracker, Ordering::Relaxed);
+    MARKET_DATA_EXEC_HOT_MOMENTUM_ADMIT_SUPPRESS.store(momentum, Ordering::Relaxed);
+    MARKET_DATA_EXEC_HOT_ARB_ADMIT_SUPPRESS.store(arb, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn market_data_exec_hot_tracker_admit_suppress() -> bool {
+    MARKET_DATA_EXEC_HOT_TRACKER_ADMIT_SUPPRESS.load(Ordering::Relaxed)
+}
+
+#[inline]
+pub fn market_data_exec_hot_momentum_admit_suppress() -> bool {
+    MARKET_DATA_EXEC_HOT_MOMENTUM_ADMIT_SUPPRESS.load(Ordering::Relaxed)
+}
+
+#[inline]
+pub fn market_data_exec_hot_arb_admit_suppress() -> bool {
+    MARKET_DATA_EXEC_HOT_ARB_ADMIT_SUPPRESS.load(Ordering::Relaxed)
+}
+
+#[inline]
+pub fn inc_market_data_exec_hot_pressure_admit_rejected_total(tier: ExecHotShedTier) {
+    let cell = match tier {
+        ExecHotShedTier::Tracker => &*MARKET_DATA_EXEC_HOT_PRESSURE_ADMIT_REJECTED_TRACKER,
+        ExecHotShedTier::Momentum => &*MARKET_DATA_EXEC_HOT_PRESSURE_ADMIT_REJECTED_MOMENTUM,
+        ExecHotShedTier::Arb => &*MARKET_DATA_EXEC_HOT_PRESSURE_ADMIT_REJECTED_ARB,
+        ExecHotShedTier::None => return,
+    };
+    cell.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -7509,6 +7662,46 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_exec_hot_hard_shed_groups_evicted_total",
         MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_EVICTED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_shed_tier",
+        MARKET_DATA_EXEC_HOT_SHED_TIER.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_hard_shed_steps_total{tier=\"tracker\"}",
+        MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_TRACKER.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_hard_shed_steps_total{tier=\"momentum\"}",
+        MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_MOMENTUM.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_hard_shed_steps_total{tier=\"arb\"}",
+        MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_ARB.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_hard_shed_groups_evicted_total{tier=\"tracker\"}",
+        MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_TRACKER.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_hard_shed_groups_evicted_total{tier=\"momentum\"}",
+        MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_MOMENTUM.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_hard_shed_groups_evicted_total{tier=\"arb\"}",
+        MARKET_DATA_EXEC_HOT_HARD_SHED_GROUPS_ARB.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_pressure_admit_rejected_total{tier=\"tracker\"}",
+        MARKET_DATA_EXEC_HOT_PRESSURE_ADMIT_REJECTED_TRACKER.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_pressure_admit_rejected_total{tier=\"momentum\"}",
+        MARKET_DATA_EXEC_HOT_PRESSURE_ADMIT_REJECTED_MOMENTUM.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_pressure_admit_rejected_total{tier=\"arb\"}",
+        MARKET_DATA_EXEC_HOT_PRESSURE_ADMIT_REJECTED_ARB.load(Ordering::Relaxed)
     );
     line!(
         "market_data_account_publish_queue_depth",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Scope L2b**: under sustained EXEC_HOT broadcast pressure, admission demotion escalates beyond Tracker to Momentum (non-position) and Arb, while **Wallet** and **MomentumPosition** remain protected.

### Behavior

- **Soft shed** (unchanged): `depth >= D_warn (64)` → ENRICH drain-only
- **Hard tiers** (one action per controller tick):
  1. `depth >= D_critical (256)` → shed Tracker (LRU batch)
  2. `depth >= D_severe (2000)` **or** tracker shed idle for 3 ticks at `D_critical` → shed Momentum
  3. `depth >= D_emergency (10000)` **or** momentum shed idle for 3 ticks at `D_severe` → shed Arb

### Re-admit suppression (anti-thrash)

While under pressure, new admits are rejected for demoted tiers only:
- Tracker: soft shed active **or** `depth >= D_critical`
- Momentum (active pools, not position): `depth >= D_severe` or tracker-idle escalation
- Arb: `depth >= D_emergency` or momentum-idle escalation

Wallet / MomentumPosition admits always allowed.

### API / commands

- `shed_owner_groups_for_consumers(consumers, max_groups)` generalizes L2 tracker shed
- `ShedMomentumUnderExecHotPressure` / `ShedArbUnderExecHotPressure` track-worker commands
- Post-evict: `prune_tracked_maps_to_admitted` + membership refresh (existing L2 pattern)

### Metrics

- Per-tier hard-shed steps/groups (`tier=tracker|momentum|arb`)
- `market_data_exec_hot_shed_tier` gauge (0–3)
- `market_data_exec_hot_pressure_admit_rejected_total{tier=...}`

### Tests

- Momentum/Arb shed protects Wallet/MomentumPosition/other tiers
- Controller tier selection + idle escalation unit tests
- Existing L2 tests remain green

## STOP-CHECK (performed)

1. **I-7 Hot Path RPC**: No RPC added
2. **Existing pattern**: Reuses L2 shed + prune/refresh; atomics for controller→worker flags (I-4b)
3. **Architecture boundaries**: market-data admission only, no cap/worker-count changes
4. **I-9 Simulation**: N/A
5. **Level-5 separation**: No eval test reads

## Verification

```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-086b9280-1d6d-45f0-bb57-73acbcf14d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-086b9280-1d6d-45f0-bb57-73acbcf14d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

