### PR TITLE
perf(market-data): lag-closed-loop EXEC_HOT shed (L2c-MD)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -96,8 +96,9 @@ use ironcrab::metrics::{
     dec_market_data_account_enrich_ingress_queue_depth,
     dec_market_data_account_high_priority_queue_depth,
     dec_market_data_account_low_priority_queue_depth, dec_market_data_account_worker_queue_depth,
-    geyser_account_listener_account_updates_value, geyser_metrics_set_subscription_accounts,
-    geyser_metrics_set_tracked_pinned_accounts, inc_market_data_account_enrich_coalesce_total,
+    exec_hot_lag_raw_alarm, exec_hot_lag_raw_clear, geyser_account_listener_account_updates_value,
+    geyser_metrics_set_subscription_accounts, geyser_metrics_set_tracked_pinned_accounts,
+    inc_market_data_account_enrich_coalesce_total,
     inc_market_data_account_enrich_dispatch_contended_total,
     inc_market_data_account_enrich_enqueue_dropped_total,
     inc_market_data_account_enrich_ingress_queue_depth,
@@ -110,7 +111,7 @@ use ironcrab::metrics::{
     inc_market_data_arb_admission_rejected_total,
     inc_market_data_arb_pin_geyser_register_deferred_total,
     inc_market_data_balance_updated_from_cache_total,
-    inc_market_data_exec_hot_hard_shed_steps_for_tier,
+    inc_market_data_exec_hot_hard_shed_steps_for_tier_reason,
     inc_market_data_exec_hot_pressure_admit_rejected_total,
     inc_market_data_geyser_sync_skipped_rate_limit_total,
     inc_market_data_ingest_membership_snapshot_hits_total,
@@ -124,6 +125,7 @@ use ironcrab::metrics::{
     inc_market_data_wallet_admission_admitted_total,
     inc_market_data_wallet_admission_rejected_total, market_data_bump_geyser_head_slot,
     market_data_enrich_shed_active, market_data_exec_hot_arb_admit_suppress,
+    market_data_exec_hot_lag_p50_est_ms, market_data_exec_hot_lag_p99_est_ms,
     market_data_exec_hot_last_shed_groups, market_data_exec_hot_momentum_admit_suppress,
     market_data_exec_hot_tracker_admit_suppress, market_data_geyser_head_slot_value,
     market_data_geyser_tracking_enqueue_dropped_value,
@@ -142,13 +144,14 @@ use ironcrab::metrics::{
     record_market_data_md_state_writer_wait_us,
     record_market_data_momentum_active_pool_messages_total,
     record_market_data_tokio_liveness_stall, record_market_data_tokio_progress,
-    record_market_data_tx_broadcast_lagged, serve_metrics,
-    set_market_data_account_broadcast_queue_depth_for_class,
+    record_market_data_tx_broadcast_lagged, refresh_exec_hot_lag_percentile_estimates,
+    serve_metrics, set_market_data_account_broadcast_queue_depth_for_class,
     set_market_data_account_enrich_worker_count, set_market_data_account_exec_hot_worker_count,
     set_market_data_account_worker_count, set_market_data_arb_pinned_pools_gauge,
     set_market_data_enrichment_registry_pools_gauge, set_market_data_exec_hot_admit_suppress,
-    set_market_data_exec_hot_last_shed_groups, set_market_data_exec_hot_shed_soft_active,
-    set_market_data_exec_hot_shed_tier, set_market_data_explicit_set_snapshot_restore_duration_ms,
+    set_market_data_exec_hot_lag_alarm, set_market_data_exec_hot_last_shed_groups,
+    set_market_data_exec_hot_shed_soft_active, set_market_data_exec_hot_shed_tier,
+    set_market_data_explicit_set_snapshot_restore_duration_ms,
     set_market_data_explicit_set_snapshot_restore_pubkeys,
     set_market_data_geyser_explicit_admitted_accounts,
     set_market_data_geyser_explicit_cap_overflow, set_market_data_geyser_explicit_set_size,
@@ -223,12 +226,15 @@ const MARKET_DATA_MD_STATE_STALL_EXIT_ENABLED: bool = false;
 /// Scope L2: EXEC_HOT broadcast depth thresholds for enrich/tracker pressure shed.
 const EXEC_HOT_SHED_D_WARN: usize = 64;
 const EXEC_HOT_SHED_D_CRITICAL: usize = 256;
+const EXEC_HOT_SHED_D_ARB: usize = 1_024;
 const EXEC_HOT_SHED_D_SEVERE: usize = 2_000;
 const EXEC_HOT_SHED_D_EMERGENCY: usize = 10_000;
 const EXEC_HOT_SHED_D_CLEAR: usize = 16;
 const EXEC_HOT_SHED_HARD_MAX_GROUPS: usize = 16;
 const EXEC_HOT_SHED_SOFT_SAMPLES_FOR_HARD: u32 = 3;
 const EXEC_HOT_SHED_IDLE_ESCALATE_TICKS: u32 = 3;
+/// Scope L2c-MD: consecutive controller ticks below clear thresholds before lag alarm clears.
+const EXEC_HOT_SHED_LAG_ALARM_CLEAR_TICKS: u32 = 3;
 /// Sentinel written at shed enqueue; worker overwrites when the command completes.
 const EXEC_HOT_SHED_GROUPS_PENDING: u64 = u64::MAX;
 const EXEC_HOT_SHED_CONTROLLER_INTERVAL: Duration = Duration::from_millis(300);
@@ -8144,45 +8150,93 @@ enum AccountHighIngressSend {
     Closed,
 }
 
-/// Pure tier selection for EXEC_HOT pressure shed (Scope L2b); one action per controller tick.
+/// Pure tier selection for EXEC_HOT pressure shed (Scope L2b/L2c-MD); one action per controller tick.
+/// Escalation order: Tracker → Arb → Momentum (non-position).
 fn select_exec_hot_shed_tier(
     depth: usize,
+    lag_alarm: bool,
     soft_shed: bool,
     soft_shed_samples: u32,
     tracker_idle_ticks: u32,
-    momentum_idle_ticks: u32,
+    arb_idle_ticks: u32,
 ) -> ExecHotShedTier {
     let tracker_trigger = depth >= EXEC_HOT_SHED_D_CRITICAL
+        || lag_alarm
         || (soft_shed && soft_shed_samples >= EXEC_HOT_SHED_SOFT_SAMPLES_FOR_HARD);
-    let momentum_trigger = depth >= EXEC_HOT_SHED_D_SEVERE
+    let arb_trigger = depth >= EXEC_HOT_SHED_D_ARB
+        || (lag_alarm && tracker_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS)
         || (tracker_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS
             && depth >= EXEC_HOT_SHED_D_CRITICAL);
-    let arb_trigger = depth >= EXEC_HOT_SHED_D_EMERGENCY
-        || (momentum_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS
-            && depth >= EXEC_HOT_SHED_D_SEVERE);
+    let momentum_trigger = depth >= EXEC_HOT_SHED_D_EMERGENCY
+        || (lag_alarm && arb_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS)
+        || (arb_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS && depth >= EXEC_HOT_SHED_D_SEVERE);
 
     if tracker_trigger && tracker_idle_ticks < EXEC_HOT_SHED_IDLE_ESCALATE_TICKS {
         ExecHotShedTier::Tracker
-    } else if momentum_trigger && momentum_idle_ticks < EXEC_HOT_SHED_IDLE_ESCALATE_TICKS {
-        ExecHotShedTier::Momentum
-    } else if arb_trigger {
+    } else if arb_trigger && arb_idle_ticks < EXEC_HOT_SHED_IDLE_ESCALATE_TICKS {
         ExecHotShedTier::Arb
+    } else if momentum_trigger {
+        ExecHotShedTier::Momentum
     } else {
         ExecHotShedTier::None
     }
 }
 
-/// Scope L2 / L2b: monitor EXEC_HOT broadcast depth and shed ENRICH/Tracker/Momentum/Arb under pressure.
+/// Returns whether the chosen tier was primarily driven by lag (for shed reason metrics).
+fn exec_hot_shed_tier_lag_triggered(
+    tier: ExecHotShedTier,
+    depth: usize,
+    lag_alarm: bool,
+    tracker_idle_ticks: u32,
+    arb_idle_ticks: u32,
+) -> bool {
+    if !lag_alarm {
+        return false;
+    }
+    match tier {
+        ExecHotShedTier::Tracker => true,
+        ExecHotShedTier::Arb => {
+            depth < EXEC_HOT_SHED_D_ARB || tracker_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS
+        }
+        ExecHotShedTier::Momentum => {
+            depth < EXEC_HOT_SHED_D_EMERGENCY || arb_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS
+        }
+        ExecHotShedTier::None => false,
+    }
+}
+
+/// Scope L2 / L2b / L2c-MD: monitor EXEC_HOT broadcast depth + lag and shed under pressure.
 fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
     tokio::spawn(async move {
         let mut soft_shed = false;
         let mut soft_shed_samples = 0u32;
         let mut tracker_idle_ticks = 0u32;
-        let mut momentum_idle_ticks = 0u32;
+        let mut arb_idle_ticks = 0u32;
+        let mut lag_alarm = false;
+        let mut lag_clear_ticks = 0u32;
         let mut last_enqueued_tier: Option<ExecHotShedTier> = None;
         let mut interval = tokio::time::interval(EXEC_HOT_SHED_CONTROLLER_INTERVAL);
         loop {
             interval.tick().await;
+            refresh_exec_hot_lag_percentile_estimates();
+            let lag_p50 = market_data_exec_hot_lag_p50_est_ms();
+            let lag_p99 = market_data_exec_hot_lag_p99_est_ms();
+            if lag_alarm {
+                if exec_hot_lag_raw_clear(lag_p50, lag_p99) {
+                    lag_clear_ticks = lag_clear_ticks.saturating_add(1);
+                    if lag_clear_ticks >= EXEC_HOT_SHED_LAG_ALARM_CLEAR_TICKS {
+                        lag_alarm = false;
+                        lag_clear_ticks = 0;
+                    }
+                } else {
+                    lag_clear_ticks = 0;
+                }
+            } else if exec_hot_lag_raw_alarm(lag_p50, lag_p99) {
+                lag_alarm = true;
+                lag_clear_ticks = 0;
+            }
+            set_market_data_exec_hot_lag_alarm(lag_alarm);
+
             let depth =
                 MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_EXEC_HOT.load(Ordering::Relaxed) as usize;
 
@@ -8194,42 +8248,54 @@ fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
                 } else {
                     match tier {
                         ExecHotShedTier::Tracker => {
-                            if groups == 0 && depth >= EXEC_HOT_SHED_D_CRITICAL {
+                            if groups == 0 && (depth >= EXEC_HOT_SHED_D_CRITICAL || lag_alarm) {
                                 tracker_idle_ticks = tracker_idle_ticks.saturating_add(1);
                             } else {
                                 tracker_idle_ticks = 0;
                             }
                         }
-                        ExecHotShedTier::Momentum => {
-                            if groups == 0 && depth >= EXEC_HOT_SHED_D_SEVERE {
-                                momentum_idle_ticks = momentum_idle_ticks.saturating_add(1);
+                        ExecHotShedTier::Arb => {
+                            if groups == 0
+                                && (depth >= EXEC_HOT_SHED_D_ARB
+                                    || (lag_alarm
+                                        && tracker_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS))
+                            {
+                                arb_idle_ticks = arb_idle_ticks.saturating_add(1);
                             } else {
-                                momentum_idle_ticks = 0;
+                                arb_idle_ticks = 0;
                             }
                         }
-                        ExecHotShedTier::Arb | ExecHotShedTier::None => {}
+                        ExecHotShedTier::Momentum | ExecHotShedTier::None => {}
                     }
                 }
             }
 
-            if depth >= EXEC_HOT_SHED_D_WARN {
+            if depth >= EXEC_HOT_SHED_D_WARN || lag_alarm {
                 soft_shed = true;
-            } else if depth < EXEC_HOT_SHED_D_CLEAR {
+            } else if depth < EXEC_HOT_SHED_D_CLEAR && !lag_alarm {
                 soft_shed = false;
                 soft_shed_samples = 0;
                 tracker_idle_ticks = 0;
-                momentum_idle_ticks = 0;
+                arb_idle_ticks = 0;
             }
 
             set_market_data_exec_hot_shed_soft_active(soft_shed);
 
-            let tracker_admit_suppress = soft_shed || depth >= EXEC_HOT_SHED_D_CRITICAL;
-            let momentum_admit_suppress = depth >= EXEC_HOT_SHED_D_SEVERE
-                || (tracker_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS
-                    && depth >= EXEC_HOT_SHED_D_CRITICAL);
-            let arb_admit_suppress = depth >= EXEC_HOT_SHED_D_EMERGENCY
-                || (momentum_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS
-                    && depth >= EXEC_HOT_SHED_D_SEVERE);
+            let shed_tier = select_exec_hot_shed_tier(
+                depth,
+                lag_alarm,
+                soft_shed,
+                soft_shed_samples,
+                tracker_idle_ticks,
+                arb_idle_ticks,
+            );
+
+            let tracker_admit_suppress =
+                soft_shed || depth >= EXEC_HOT_SHED_D_CRITICAL || lag_alarm;
+            let arb_admit_suppress = depth >= EXEC_HOT_SHED_D_ARB || lag_alarm;
+            let momentum_admit_suppress = shed_tier == ExecHotShedTier::Momentum
+                || depth >= EXEC_HOT_SHED_D_EMERGENCY
+                || (lag_alarm && arb_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS);
             set_market_data_exec_hot_admit_suppress(
                 tracker_admit_suppress,
                 momentum_admit_suppress,
@@ -8240,13 +8306,6 @@ fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
                 soft_shed_samples = soft_shed_samples.saturating_add(1);
             }
 
-            let shed_tier = select_exec_hot_shed_tier(
-                depth,
-                soft_shed,
-                soft_shed_samples,
-                tracker_idle_ticks,
-                momentum_idle_ticks,
-            );
             set_market_data_exec_hot_shed_tier(shed_tier);
 
             if shed_tier == ExecHotShedTier::None {
@@ -8256,6 +8315,14 @@ fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
             if soft_shed && shed_tier == ExecHotShedTier::Tracker {
                 soft_shed_samples = 0;
             }
+
+            let lag_triggered = exec_hot_shed_tier_lag_triggered(
+                shed_tier,
+                depth,
+                lag_alarm,
+                tracker_idle_ticks,
+                arb_idle_ticks,
+            );
 
             let cmd = match shed_tier {
                 ExecHotShedTier::Tracker => TrackWorkerCommand::ShedTrackerUnderExecHotPressure {
@@ -8271,7 +8338,7 @@ fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
             };
 
             if track_worker_try_enqueue(&track_worker, cmd) {
-                inc_market_data_exec_hot_hard_shed_steps_for_tier(shed_tier);
+                inc_market_data_exec_hot_hard_shed_steps_for_tier_reason(shed_tier, lag_triggered);
                 set_market_data_exec_hot_last_shed_groups(shed_tier, EXEC_HOT_SHED_GROUPS_PENDING);
                 last_enqueued_tier = Some(shed_tier);
             }
@@ -14887,37 +14954,91 @@ mod pr_b_geyser_tracking_tests {
         use ironcrab::metrics::ExecHotShedTier;
 
         assert_eq!(
-            select_exec_hot_shed_tier(300, false, 0, 0, 0),
+            select_exec_hot_shed_tier(300, false, false, 0, 0, 0),
             ExecHotShedTier::Tracker
         );
         assert_eq!(
-            select_exec_hot_shed_tier(300, false, 0, 3, 0),
-            ExecHotShedTier::Momentum
-        );
-        assert_eq!(
-            select_exec_hot_shed_tier(262_000, false, 0, 3, 0),
-            ExecHotShedTier::Momentum
-        );
-        assert_eq!(
-            select_exec_hot_shed_tier(5_000, false, 0, 3, 0),
-            ExecHotShedTier::Momentum
-        );
-        assert_eq!(
-            select_exec_hot_shed_tier(5_000, false, 0, 3, 3),
+            select_exec_hot_shed_tier(300, false, false, 0, 3, 0),
             ExecHotShedTier::Arb
         );
         assert_eq!(
-            select_exec_hot_shed_tier(12_000, false, 0, 3, 3),
+            select_exec_hot_shed_tier(262_000, false, false, 0, 3, 0),
             ExecHotShedTier::Arb
         );
         assert_eq!(
-            select_exec_hot_shed_tier(12_000, false, 0, 3, 0),
+            select_exec_hot_shed_tier(5_000, false, false, 0, 3, 0),
+            ExecHotShedTier::Arb
+        );
+        assert_eq!(
+            select_exec_hot_shed_tier(5_000, false, false, 0, 3, 3),
             ExecHotShedTier::Momentum
         );
         assert_eq!(
-            select_exec_hot_shed_tier(10, false, 0, 0, 0),
+            select_exec_hot_shed_tier(12_000, false, false, 0, 3, 3),
+            ExecHotShedTier::Momentum
+        );
+        assert_eq!(
+            select_exec_hot_shed_tier(12_000, false, false, 0, 3, 0),
+            ExecHotShedTier::Arb
+        );
+        assert_eq!(
+            select_exec_hot_shed_tier(10, false, false, 0, 0, 0),
             ExecHotShedTier::None
         );
+    }
+
+    #[test]
+    fn exec_hot_shed_tier_lag_alarm_triggers_arb_without_emergency_depth() {
+        use ironcrab::metrics::ExecHotShedTier;
+
+        assert_eq!(
+            select_exec_hot_shed_tier(100, true, false, 0, 0, 0),
+            ExecHotShedTier::Tracker
+        );
+        assert_eq!(
+            select_exec_hot_shed_tier(100, true, false, 0, 3, 0),
+            ExecHotShedTier::Arb
+        );
+        assert_eq!(
+            select_exec_hot_shed_tier(500, true, false, 0, 3, 3),
+            ExecHotShedTier::Momentum
+        );
+    }
+
+    #[test]
+    fn exec_hot_lag_alarm_hysteresis_requires_clear_ticks() {
+        use ironcrab::metrics::{exec_hot_lag_raw_alarm, exec_hot_lag_raw_clear};
+
+        assert!(exec_hot_lag_raw_alarm(60, 100));
+        assert!(!exec_hot_lag_raw_clear(60, 100));
+        assert!(exec_hot_lag_raw_clear(30, 100));
+    }
+
+    #[test]
+    fn exec_hot_shed_tier_lag_triggered_attributes_lag_reason() {
+        use ironcrab::metrics::ExecHotShedTier;
+
+        assert!(exec_hot_shed_tier_lag_triggered(
+            ExecHotShedTier::Tracker,
+            10,
+            true,
+            0,
+            0
+        ));
+        assert!(exec_hot_shed_tier_lag_triggered(
+            ExecHotShedTier::Arb,
+            100,
+            true,
+            3,
+            0
+        ));
+        assert!(!exec_hot_shed_tier_lag_triggered(
+            ExecHotShedTier::Arb,
+            2_000,
+            false,
+            3,
+            0
+        ));
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1929,6 +1929,28 @@ pub static MARKET_DATA_EXEC_HOT_PRESSURE_ADMIT_REJECTED_MOMENTUM: Lazy<AtomicU64
 pub static MARKET_DATA_EXEC_HOT_PRESSURE_ADMIT_REJECTED_ARB: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
+/// Scope L2c-MD: rolling EXEC_HOT channel lag estimates (ms), updated from recv samples.
+pub static MARKET_DATA_EXEC_HOT_LAG_P50_EST_MS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_EXEC_HOT_LAG_P99_EST_MS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// Scope L2c-MD: controller hysteresis output (0/1).
+pub static MARKET_DATA_EXEC_HOT_LAG_ALARM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// Scope L2c-MD: hard shed steps attributed to lag (vs depth) per tier.
+pub static MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_TRACKER_LAG: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_MOMENTUM_LAG: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_ARB_LAG: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+const EXEC_HOT_LAG_RING_CAP: usize = 64;
+static EXEC_HOT_LAG_RING: Lazy<[AtomicU64; EXEC_HOT_LAG_RING_CAP]> =
+    Lazy::new(|| std::array::from_fn(|_| AtomicU64::new(0)));
+static EXEC_HOT_LAG_RING_WRITE_IDX: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static EXEC_HOT_LAG_SAMPLE_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static EXEC_HOT_LAG_EWMA_P50_MS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static EXEC_HOT_LAG_EWMA_P99_MS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
 /// Account ingest: jobs waiting in the dedicated NATS publish `mpsc` (JetStream + core publish).
 pub static MARKET_DATA_ACCOUNT_PUBLISH_QUEUE_DEPTH: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -2205,14 +2227,17 @@ pub fn record_market_data_account_channel_lag_ms_for_class(
         .as_millis()
         .min(u128::from(u64::MAX)) as u64;
     match class {
-        "exec_hot" => record_histogram_u64_into(
-            MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
-            &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_BUCKET_COUNTS,
-            &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_SUM,
-            &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_COUNT,
-            ms,
-            MARKET_DATA_LATENCY_MS_SUM_CAP,
-        ),
+        "exec_hot" => {
+            record_histogram_u64_into(
+                MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
+                &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_BUCKET_COUNTS,
+                &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_SUM,
+                &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_EXEC_HOT_COUNT,
+                ms,
+                MARKET_DATA_LATENCY_MS_SUM_CAP,
+            );
+            record_exec_hot_channel_lag_sample(ms);
+        }
         "enrich" => record_histogram_u64_into(
             MARKET_DATA_GEYSER_TO_PUBLISH_MS_BUCKETS,
             &MARKET_DATA_ACCOUNT_CHANNEL_LAG_MS_ENRICH_BUCKET_COUNTS,
@@ -2535,6 +2560,144 @@ pub fn inc_market_data_exec_hot_pressure_admit_rejected_total(tier: ExecHotShedT
         ExecHotShedTier::None => return,
     };
     cell.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Scope L2c-MD: SLO breach thresholds for EXEC_HOT channel lag alarm (ms).
+pub const EXEC_HOT_LAG_ALARM_P50_MS: u64 = 50;
+pub const EXEC_HOT_LAG_ALARM_P99_MS: u64 = 200;
+/// Hysteresis clear thresholds (ms).
+pub const EXEC_HOT_LAG_CLEAR_P50_MS: u64 = 40;
+pub const EXEC_HOT_LAG_CLEAR_P99_MS: u64 = 150;
+
+/// Pure alarm predicate for unit tests and controller hysteresis input.
+#[inline]
+pub fn exec_hot_lag_raw_alarm(p50_ms: u64, p99_ms: u64) -> bool {
+    p99_ms > EXEC_HOT_LAG_ALARM_P99_MS || p50_ms > EXEC_HOT_LAG_ALARM_P50_MS
+}
+
+/// Pure clear predicate for controller hysteresis.
+#[inline]
+pub fn exec_hot_lag_raw_clear(p50_ms: u64, p99_ms: u64) -> bool {
+    p99_ms < EXEC_HOT_LAG_CLEAR_P99_MS && p50_ms < EXEC_HOT_LAG_CLEAR_P50_MS
+}
+
+/// Lock-free recv-path sample: ring slot + EWMA p50/p99 estimates.
+#[inline]
+pub fn record_exec_hot_channel_lag_sample(lag_ms: u64) {
+    let idx = EXEC_HOT_LAG_RING_WRITE_IDX.fetch_add(1, Ordering::Relaxed) as usize
+        % EXEC_HOT_LAG_RING_CAP;
+    EXEC_HOT_LAG_RING[idx].store(lag_ms, Ordering::Relaxed);
+    EXEC_HOT_LAG_SAMPLE_COUNT.fetch_add(1, Ordering::Relaxed);
+
+    let old_p50 = EXEC_HOT_LAG_EWMA_P50_MS.load(Ordering::Relaxed);
+    let new_p50 = if old_p50 == 0 {
+        lag_ms
+    } else {
+        (lag_ms * 2 + old_p50 * 8) / 10
+    };
+    EXEC_HOT_LAG_EWMA_P50_MS.store(new_p50, Ordering::Relaxed);
+
+    let old_p99 = EXEC_HOT_LAG_EWMA_P99_MS.load(Ordering::Relaxed);
+    let new_p99 = if old_p99 == 0 {
+        lag_ms
+    } else if lag_ms >= old_p99 {
+        (lag_ms * 3 + old_p99 * 7) / 10
+    } else {
+        (lag_ms + old_p99 * 19) / 20
+    };
+    EXEC_HOT_LAG_EWMA_P99_MS.store(new_p99, Ordering::Relaxed);
+
+    MARKET_DATA_EXEC_HOT_LAG_P50_EST_MS.store(new_p50, Ordering::Relaxed);
+    MARKET_DATA_EXEC_HOT_LAG_P99_EST_MS.store(new_p99, Ordering::Relaxed);
+}
+
+/// Recompute percentile estimates from the ring (controller tick; not on recv hot path).
+pub fn refresh_exec_hot_lag_percentile_estimates() {
+    let count = EXEC_HOT_LAG_SAMPLE_COUNT.load(Ordering::Relaxed);
+    if count == 0 {
+        return;
+    }
+    let take = (count as usize).min(EXEC_HOT_LAG_RING_CAP);
+    let mut samples: Vec<u64> = (0..take)
+        .map(|i| EXEC_HOT_LAG_RING[i].load(Ordering::Relaxed))
+        .filter(|&v| v > 0)
+        .collect();
+    if samples.is_empty() {
+        return;
+    }
+    samples.sort_unstable();
+    let p50 = samples[samples.len() * 50 / 100];
+    let p99 = samples[samples
+        .len()
+        .saturating_sub(1)
+        .max(samples.len() * 99 / 100)];
+    MARKET_DATA_EXEC_HOT_LAG_P50_EST_MS.store(p50, Ordering::Relaxed);
+    MARKET_DATA_EXEC_HOT_LAG_P99_EST_MS.store(p99, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn market_data_exec_hot_lag_p50_est_ms() -> u64 {
+    MARKET_DATA_EXEC_HOT_LAG_P50_EST_MS.load(Ordering::Relaxed)
+}
+
+#[inline]
+pub fn market_data_exec_hot_lag_p99_est_ms() -> u64 {
+    MARKET_DATA_EXEC_HOT_LAG_P99_EST_MS.load(Ordering::Relaxed)
+}
+
+#[inline]
+pub fn set_market_data_exec_hot_lag_alarm(active: bool) {
+    MARKET_DATA_EXEC_HOT_LAG_ALARM.store(u64::from(active), Ordering::Relaxed);
+}
+
+#[inline]
+pub fn market_data_exec_hot_lag_alarm() -> bool {
+    MARKET_DATA_EXEC_HOT_LAG_ALARM.load(Ordering::Relaxed) != 0
+}
+
+/// Hard shed step with optional lag attribution (reason label `depth|lag`).
+#[inline]
+pub fn inc_market_data_exec_hot_hard_shed_steps_for_tier_reason(
+    tier: ExecHotShedTier,
+    lag_triggered: bool,
+) {
+    inc_market_data_exec_hot_hard_shed_steps_for_tier(tier);
+    if !lag_triggered {
+        return;
+    }
+    let cell = match tier {
+        ExecHotShedTier::Tracker => &*MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_TRACKER_LAG,
+        ExecHotShedTier::Momentum => &*MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_MOMENTUM_LAG,
+        ExecHotShedTier::Arb => &*MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_ARB_LAG,
+        ExecHotShedTier::None => return,
+    };
+    cell.fetch_add(1, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod exec_hot_lag_tests {
+    use super::*;
+
+    #[test]
+    fn exec_hot_lag_alarm_and_clear_thresholds() {
+        assert!(!exec_hot_lag_raw_alarm(50, 200));
+        assert!(exec_hot_lag_raw_alarm(51, 100));
+        assert!(exec_hot_lag_raw_alarm(30, 201));
+        assert!(exec_hot_lag_raw_clear(39, 149));
+        assert!(!exec_hot_lag_raw_clear(40, 149));
+        assert!(!exec_hot_lag_raw_clear(39, 150));
+    }
+
+    #[test]
+    fn exec_hot_lag_samples_raise_alarm_estimate() {
+        for ms in [10_u64, 20, 300, 400, 500] {
+            record_exec_hot_channel_lag_sample(ms);
+        }
+        refresh_exec_hot_lag_percentile_estimates();
+        let p50 = market_data_exec_hot_lag_p50_est_ms();
+        let p99 = market_data_exec_hot_lag_p99_est_ms();
+        assert!(exec_hot_lag_raw_alarm(p50, p99), "p50={p50} p99={p99}");
+    }
 }
 
 #[inline]
@@ -7702,6 +7865,30 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_exec_hot_pressure_admit_rejected_total{tier=\"arb\"}",
         MARKET_DATA_EXEC_HOT_PRESSURE_ADMIT_REJECTED_ARB.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_lag_p50_est_ms",
+        MARKET_DATA_EXEC_HOT_LAG_P50_EST_MS.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_lag_p99_est_ms",
+        MARKET_DATA_EXEC_HOT_LAG_P99_EST_MS.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_lag_alarm",
+        MARKET_DATA_EXEC_HOT_LAG_ALARM.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_hard_shed_steps_total{tier=\"tracker\",reason=\"lag\"}",
+        MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_TRACKER_LAG.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_hard_shed_steps_total{tier=\"momentum\",reason=\"lag\"}",
+        MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_MOMENTUM_LAG.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_exec_hot_hard_shed_steps_total{tier=\"arb\",reason=\"lag\"}",
+        MARKET_DATA_EXEC_HOT_HARD_SHED_STEPS_ARB_LAG.load(Ordering::Relaxed)
     );
     line!(
         "market_data_account_publish_queue_depth",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Koppelt EXEC_HOT Pressure-Shed und Re-Admit-Suppress an **Channel-Lag-SLO** zusätzlich zu Broadcast-Depth (Scope L2c-MD).

**Prod-Problem:** Unter Last kann Lag Sekunden betragen, während Depth nur mittelhoch ist → Arb-Tier (`D_emergency` ~10k) wurde nicht erreicht.

## Changes

### Lag-Signal (`metrics.rs`)
- Lock-freier Lag-Estimator am EXEC_HOT Recv-Pfad (`record_exec_hot_channel_lag_sample`)
- Ring-Buffer (64) + EWMA → `exec_hot_lag_p50_est_ms`, `exec_hot_lag_p99_est_ms`
- Alarm: p50 > 50ms OR p99 > 200ms; Clear mit Hysterese (p50 < 40ms AND p99 < 150ms, 3 Ticks)
- Shed-Counter mit optionalem `reason="lag"` Label

### Controller (`market_data.rs`)
- `lag_alarm` als Eskalationsgrund neben Depth
- Neuer `D_ARB = 1024` (deutlich unter altem `D_EMERGENCY = 10k`)
- Eskalation: **Tracker → Arb → Momentum** (Momentum non-position als letzte Stufe)
- Re-Admit-Suppress an `lag_alarm` gekoppelt
- Wallet / MomentumPosition bleiben immun (bestehende Worker-Logik)

## Invarianten

- I-7: Kein RPC im Hot Path
- I-MD-7: Kein runtime Cap-Increase
- I-MD-8/9: Wallet + MomentumPosition geschützt

## Tests

- Lag-Alarm → Arb ohne Emergency-Depth
- Depth-Pfad Regression (Tracker→Arb→Momentum)
- Hysteresis / Lag-Reason-Attribution
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` grün

## Explicitly NOT in scope

- Worker/Cap-Bump, Deploy, L2d/L2e, Momentum Imminent-Entry Änderungen
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9096e8ee-516f-4a46-88b4-6b61e6df1e4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9096e8ee-516f-4a46-88b4-6b61e6df1e4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

