### PR TITLE
fix(momentum): wait-hot-set metrics + protect imminent pins from lag shed

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4816,6 +4816,9 @@ impl MarketDataContext {
         registered: bool,
     ) {
         if registered {
+            ironcrab::metrics::inc_market_data_momentum_pin_vault_register_total(
+                ironcrab::metrics::MomentumPinVaultRegisterResult::Ok,
+            );
             self.clear_deferred_hot_pool_reserve_registration(pool);
             if is_position {
                 inc_market_data_open_position_pin_applied_total();
@@ -4823,6 +4826,9 @@ impl MarketDataContext {
             return;
         }
         if self.live_pool_cache.get(&pool).is_none() {
+            ironcrab::metrics::inc_market_data_momentum_pin_vault_register_total(
+                ironcrab::metrics::MomentumPinVaultRegisterResult::CacheMiss,
+            );
             self.note_deferred_hot_pool_reserve_registration(pool, pin);
             if is_position {
                 inc_market_data_open_position_pin_deferred_cache_miss_total();
@@ -4830,9 +4836,15 @@ impl MarketDataContext {
             return;
         }
         if self.hot_pool_reserve_registration_satisfied(pool) {
+            ironcrab::metrics::inc_market_data_momentum_pin_vault_register_total(
+                ironcrab::metrics::MomentumPinVaultRegisterResult::AlreadySatisfied,
+            );
             self.maybe_clear_deferred_hot_pool_reserve_if_satisfied(pool);
             return;
         }
+        ironcrab::metrics::inc_market_data_momentum_pin_vault_register_total(
+            ironcrab::metrics::MomentumPinVaultRegisterResult::Deferred,
+        );
         self.note_deferred_hot_pool_reserve_registration(pool, pin);
     }
 
@@ -5125,11 +5137,8 @@ impl MarketDataContext {
             {
                 inc_market_data_exec_hot_pressure_admit_rejected_total(ExecHotShedTier::Momentum);
                 inc_market_data_momentum_admission_rejected_total();
-                self.record_momentum_active_pool_reserve_registration_outcome(
-                    pool_pk,
-                    GeyserPinReason::MomentumActive,
-                    is_position,
-                    false,
+                ironcrab::metrics::inc_market_data_momentum_pin_vault_register_total(
+                    ironcrab::metrics::MomentumPinVaultRegisterResult::AdmissionRejected,
                 );
                 self.sync_explicit_pool_admitted_from_admission(
                     admission,
@@ -8246,7 +8255,6 @@ fn select_exec_hot_shed_tier(
         || (tracker_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS
             && depth >= EXEC_HOT_SHED_D_CRITICAL);
     let momentum_trigger = depth >= EXEC_HOT_SHED_D_EMERGENCY
-        || (lag_alarm && lag_arb_shed_ticks >= EXEC_HOT_SHED_LAG_ARB_ESCALATE_TICKS)
         || (arb_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS && depth >= EXEC_HOT_SHED_D_SEVERE);
 
     let tracker_escalate_threshold = if lag_alarm {
@@ -8292,12 +8300,7 @@ fn exec_hot_shed_tier_lag_triggered(
         return false;
     }
     let tracker_idle_ticks = escalation.tracker_idle_ticks;
-    let arb_idle_ticks = escalation.arb_idle_ticks;
     let lag_tracker_shed_ticks = escalation.lag_tracker_shed_ticks;
-    let lag_arb_shed_ticks = escalation.lag_arb_shed_ticks;
-    if !lag_alarm {
-        return false;
-    }
     match tier {
         ExecHotShedTier::Tracker => true,
         ExecHotShedTier::Arb => {
@@ -8305,11 +8308,7 @@ fn exec_hot_shed_tier_lag_triggered(
                 || tracker_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS
                 || lag_tracker_shed_ticks >= EXEC_HOT_SHED_LAG_ARB_ESCALATE_TICKS
         }
-        ExecHotShedTier::Momentum => {
-            depth < EXEC_HOT_SHED_D_EMERGENCY
-                || arb_idle_ticks >= EXEC_HOT_SHED_IDLE_ESCALATE_TICKS
-                || lag_arb_shed_ticks >= EXEC_HOT_SHED_LAG_ARB_ESCALATE_TICKS
-        }
+        ExecHotShedTier::Momentum => false,
         ExecHotShedTier::None => false,
     }
 }
@@ -8423,9 +8422,8 @@ fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
             let tracker_admit_suppress =
                 soft_shed || depth >= EXEC_HOT_SHED_D_CRITICAL || lag_alarm;
             let arb_admit_suppress = depth >= EXEC_HOT_SHED_D_ARB || lag_alarm;
-            let momentum_admit_suppress = shed_tier == ExecHotShedTier::Momentum
-                || depth >= EXEC_HOT_SHED_D_EMERGENCY
-                || (lag_alarm && lag_arb_shed_ticks >= EXEC_HOT_SHED_LAG_ARB_ESCALATE_TICKS);
+            let momentum_admit_suppress =
+                shed_tier == ExecHotShedTier::Momentum || depth >= EXEC_HOT_SHED_D_EMERGENCY;
             set_market_data_exec_hot_admit_suppress(
                 tracker_admit_suppress,
                 momentum_admit_suppress,
@@ -15287,6 +15285,21 @@ mod pr_b_geyser_tracking_tests {
         };
         assert_eq!(
             select_exec_hot_shed_tier(500, true, false, 0, lag_arb_done),
+            ExecHotShedTier::None
+        );
+    }
+
+    #[test]
+    fn exec_hot_shed_tier_depth_emergency_still_sheds_momentum_under_lag() {
+        use ironcrab::metrics::ExecHotShedTier;
+
+        let lag_arb_done = ExecHotShedEscalationState {
+            lag_tracker_shed_ticks: 1,
+            lag_arb_shed_ticks: 1,
+            ..ExecHotShedEscalationState::default()
+        };
+        assert_eq!(
+            select_exec_hot_shed_tier(12_000, true, false, 0, lag_arb_done),
             ExecHotShedTier::Momentum
         );
     }
@@ -15515,7 +15528,7 @@ mod pr_b_geyser_tracking_tests {
     #[test]
     fn account_enrich_dispatch_upsert_and_flush_preserves_latest_wins() {
         use ironcrab::metrics::MARKET_DATA_ACCOUNT_ENRICH_COALESCE_TOTAL;
-        MARKET_DATA_ACCOUNT_ENRICH_COALESCE_TOTAL.store(0, Ordering::Relaxed);
+        let coalesce_before = MARKET_DATA_ACCOUNT_ENRICH_COALESCE_TOTAL.load(Ordering::Relaxed);
         let (low_tx, mut low_rx) = mpsc::channel(4);
         let mut shard = AccountEnrichCoalesceShard::new();
         let pk = Pubkey::new_unique();
@@ -15541,7 +15554,7 @@ mod pr_b_geyser_tracking_tests {
         );
         assert_eq!(
             MARKET_DATA_ACCOUNT_ENRICH_COALESCE_TOTAL.load(Ordering::Relaxed),
-            1
+            coalesce_before + 1
         );
         let flushed = low_rx.try_recv().expect("first flush");
         assert_eq!(flushed.update.slot, 1);

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -19598,6 +19598,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn wait_hot_set_timeout_unpins_without_intent() {
         use ironcrab::metrics::wait_hot_set_test_counters;
         wait_hot_set_test_counters::reset();
@@ -19691,12 +19692,14 @@ mod tests {
                 .any(|r| r.reason == "hot_set_timeout"),
             "timeout must publish removed hot_set_timeout"
         );
-        assert!(
-            wait_hot_set_test_counters::wait_hot_set_exit_timeout_total() > 0,
+        assert_eq!(
+            wait_hot_set_test_counters::wait_hot_set_exit_timeout_total(),
+            1,
             "timeout must record wait_hot_set exit reason=timeout"
         );
-        assert!(
-            wait_hot_set_test_counters::wait_hot_set_duration_count() > 0,
+        assert_eq!(
+            wait_hot_set_test_counters::wait_hot_set_duration_count(),
+            1,
             "timeout must record wait_hot_set duration histogram sample"
         );
     }
@@ -19746,6 +19749,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn wait_hot_set_stale_cache_enters_and_records_metrics() {
         use ironcrab::metrics::wait_hot_set_test_counters;
         wait_hot_set_test_counters::reset();
@@ -19760,9 +19764,6 @@ mod tests {
         let pool = "poolWaitHotStale8888888888888888888888888888";
         let sk = seed_probe_ready_tracker(&ctx, &cfg, mint, pool);
 
-        let enter_before = wait_hot_set_test_counters::wait_hot_set_enter_total();
-        let fresh_false_before = wait_hot_set_test_counters::filter_pass_hot_fresh_false();
-
         let signals = ctx.check_for_signals();
         assert!(signals.is_empty());
         assert!(ctx
@@ -19770,17 +19771,12 @@ mod tests {
             .read()
             .get(&sk)
             .is_some_and(|t| matches!(t.state, TrackerState::WaitHotSet { .. })));
-        assert_eq!(
-            wait_hot_set_test_counters::wait_hot_set_enter_total(),
-            enter_before + 1
-        );
-        assert_eq!(
-            wait_hot_set_test_counters::filter_pass_hot_fresh_false(),
-            fresh_false_before + 1
-        );
+        assert_eq!(wait_hot_set_test_counters::wait_hot_set_enter_total(), 1);
+        assert_eq!(wait_hot_set_test_counters::filter_pass_hot_fresh_false(), 1);
     }
 
     #[test]
+    #[serial_test::serial]
     fn filter_pass_fresh_emits_immediate_hot_without_wait_hot_set() {
         use ironcrab::metrics::wait_hot_set_test_counters;
         wait_hot_set_test_counters::reset();
@@ -19796,10 +19792,6 @@ mod tests {
         let sk = seed_probe_ready_tracker(&ctx, &cfg, mint.as_str(), pool.as_str());
         assert!(seed_test_entry_hot_set(&ctx, mint.as_str(), pool.as_str()));
 
-        let enter_before = wait_hot_set_test_counters::wait_hot_set_enter_total();
-        let immediate_before = wait_hot_set_test_counters::intent_path_immediate_hot_total();
-        let fresh_true_before = wait_hot_set_test_counters::filter_pass_hot_fresh_true();
-
         let signals = ctx.check_for_signals();
         assert_eq!(signals.len(), 1);
         assert_eq!(signals[0].kind, EntryKind::Probe);
@@ -19807,18 +19799,12 @@ mod tests {
             ctx.token_trackers.read().get(&sk).map(|t| &t.state),
             Some(TrackerState::WaitHotSet { .. })
         ));
-        assert_eq!(
-            wait_hot_set_test_counters::wait_hot_set_enter_total(),
-            enter_before
-        );
+        assert_eq!(wait_hot_set_test_counters::wait_hot_set_enter_total(), 0);
         assert_eq!(
             wait_hot_set_test_counters::intent_path_immediate_hot_total(),
-            immediate_before + 1
+            1
         );
-        assert_eq!(
-            wait_hot_set_test_counters::filter_pass_hot_fresh_true(),
-            fresh_true_before + 1
-        );
+        assert_eq!(wait_hot_set_test_counters::filter_pass_hot_fresh_true(), 1);
     }
 
     #[test]

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -5472,6 +5472,14 @@ impl MomentumContext {
                                 > Duration::from_secs(config.wait_hot_set_timeout_secs)
                     );
                     if wait_hot_timed_out {
+                        if let TrackerState::WaitHotSet { entered_at } = tracker.state {
+                            let duration_ms =
+                                wall_now.duration_since(entered_at).as_millis() as u64;
+                            ironcrab::metrics::record_momentum_wait_hot_set_exit(
+                                ironcrab::metrics::MomentumWaitHotSetExitReason::Timeout,
+                                duration_ms,
+                            );
+                        }
                         tracker.state = TrackerState::Validation;
                         tracker.last_wait_filter_obs_key = None;
                         self.queue_momentum_active_pool_removed(
@@ -5481,6 +5489,10 @@ impl MomentumContext {
                         );
                         continue 'tracker_keys;
                     }
+                    let wait_hot_entered_at = match tracker.state {
+                        TrackerState::WaitHotSet { entered_at } => Some(entered_at),
+                        _ => None,
+                    };
                     let (should_trade, reason) = tracker.should_generate_intent(
                         config,
                         mint_info,
@@ -5488,6 +5500,16 @@ impl MomentumContext {
                         wall_now,
                     );
                     if was_not_rejected && tracker.is_rejected() {
+                        if was_wait_hot_set {
+                            if let Some(entered_at) = wait_hot_entered_at {
+                                let duration_ms =
+                                    wall_now.duration_since(entered_at).as_millis() as u64;
+                                ironcrab::metrics::record_momentum_wait_hot_set_exit(
+                                    ironcrab::metrics::MomentumWaitHotSetExitReason::FilterFailed,
+                                    duration_ms,
+                                );
+                            }
+                        }
                         self.record_token_blacklisted_once(&mint);
                         let removed_reason = if was_wait_hot_set {
                             "filter_failed"
@@ -5506,6 +5528,9 @@ impl MomentumContext {
                             self.mark_entry_eval_dirty_key(key);
                             continue 'tracker_keys;
                         }
+                        let entry_hot_fresh =
+                            self.entry_hot_set_fresh(&mint, tracker.pool.as_str());
+                        ironcrab::metrics::record_momentum_filter_pass_hot_fresh(entry_hot_fresh);
                         if probe_sol == 0 {
                             warn!(
                                 mint = %mint,
@@ -5521,9 +5546,20 @@ impl MomentumContext {
                             continue 'tracker_keys;
                         }
                         if matches!(tracker.state, TrackerState::WaitHotSet { .. }) {
-                            if self.entry_hot_set_fresh(&mint, tracker.pool.as_str()) {
+                            if entry_hot_fresh {
+                                if let TrackerState::WaitHotSet { entered_at } = tracker.state {
+                                    let duration_ms =
+                                        wall_now.duration_since(entered_at).as_millis() as u64;
+                                    ironcrab::metrics::record_momentum_wait_hot_set_exit(
+                                        ironcrab::metrics::MomentumWaitHotSetExitReason::Intent,
+                                        duration_ms,
+                                    );
+                                }
                                 tracker.state = TrackerState::ProbeBuyPending { sent_at: wall_now };
                                 mint_emitted_entry_this_tick.insert(mint.clone());
+                                ironcrab::metrics::record_momentum_intent_path(
+                                    ironcrab::metrics::MomentumIntentPath::AfterWaitHot,
+                                );
                                 signals.push(EntrySignal {
                                     mint,
                                     pool: tracker.pool.clone(),
@@ -5535,10 +5571,25 @@ impl MomentumContext {
                             } else {
                                 self.mark_entry_eval_dirty_key(key);
                             }
+                        } else if entry_hot_fresh {
+                            tracker.state = TrackerState::ProbeBuyPending { sent_at: wall_now };
+                            mint_emitted_entry_this_tick.insert(mint.clone());
+                            ironcrab::metrics::record_momentum_intent_path(
+                                ironcrab::metrics::MomentumIntentPath::ImmediateHot,
+                            );
+                            signals.push(EntrySignal {
+                                mint,
+                                pool: tracker.pool.clone(),
+                                dex: tracker.dex.clone(),
+                                sol_amount: probe_sol,
+                                kind: EntryKind::Probe,
+                                reason: format!("ENTER_PROBE_BUY: {reason}"),
+                            });
                         } else {
                             tracker.state = TrackerState::WaitHotSet {
                                 entered_at: wall_now,
                             };
+                            ironcrab::metrics::inc_momentum_wait_hot_set_enter_total();
                             self.queue_momentum_active_pool_active(
                                 &mint,
                                 tracker.pool.as_str(),
@@ -13183,9 +13234,6 @@ mod tests {
         ctx.mark_entry_eval_dirty_key(&hot_key);
 
         seed_test_entry_hot_set(&ctx, mint.as_str(), pool_hot.as_str());
-        let _ = ctx.check_for_signals_dirty_priority_tick();
-        ctx.dirty_entry_tracker_keys.write().clear();
-        ctx.mark_entry_eval_dirty_key(&hot_key);
         let signals = ctx.check_for_signals_dirty_priority_tick();
         assert_eq!(signals.len(), 1);
         assert_eq!(signals[0].pool, pool_hot);
@@ -13303,17 +13351,6 @@ mod tests {
 
         seed_test_entry_hot_set(&ctx, mint.as_str(), pool_first.as_str());
         seed_test_entry_hot_set(&ctx, mint.as_str(), pool_second.as_str());
-        let _ = ctx.check_for_signals_dirty_priority_tick();
-        ctx.dirty_entry_tracker_keys.write().clear();
-        ctx.mark_entry_eval_dirty_key(&MomentumContext::tracker_storage_key(
-            mint.as_str(),
-            pool_first.as_str(),
-        ));
-        ctx.mark_entry_eval_dirty_key(&MomentumContext::tracker_storage_key(
-            mint.as_str(),
-            pool_second.as_str(),
-        ));
-
         let signals = ctx.check_for_signals_dirty_priority_tick();
         assert_eq!(signals.len(), 1);
         assert_eq!(signals[0].pool, pool_first);
@@ -19555,13 +19592,6 @@ mod tests {
         ));
 
         seed_test_entry_hot_set(&ctx, mint.as_str(), pool.as_str());
-        let _ = ctx.check_for_signals_dirty_priority_tick();
-        ctx.dirty_entry_tracker_keys.write().clear();
-        ctx.mark_entry_eval_dirty_key(&MomentumContext::tracker_storage_key(
-            mint.as_str(),
-            pool.as_str(),
-        ));
-
         let signals = ctx.check_for_signals_dirty_priority_tick();
         assert_eq!(signals.len(), 1);
         assert_eq!(signals[0].pool, pool);
@@ -19569,6 +19599,9 @@ mod tests {
 
     #[test]
     fn wait_hot_set_timeout_unpins_without_intent() {
+        use ironcrab::metrics::wait_hot_set_test_counters;
+        wait_hot_set_test_counters::reset();
+
         let cfg = {
             let mut c = MomentumConfig::default();
             c.default_position_lamports = 1_000;
@@ -19657,6 +19690,134 @@ mod tests {
                 .iter()
                 .any(|r| r.reason == "hot_set_timeout"),
             "timeout must publish removed hot_set_timeout"
+        );
+        assert!(
+            wait_hot_set_test_counters::wait_hot_set_exit_timeout_total() > 0,
+            "timeout must record wait_hot_set exit reason=timeout"
+        );
+        assert!(
+            wait_hot_set_test_counters::wait_hot_set_duration_count() > 0,
+            "timeout must record wait_hot_set duration histogram sample"
+        );
+    }
+
+    fn probe_entry_filter_pass_config() -> MomentumConfig {
+        let mut c = MomentumConfig::default();
+        c.default_position_lamports = 1_000;
+        c.probe_buy_pct = 0.25;
+        c.early_min_liquidity_sol = 0.0;
+        c.min_unique_buyers = 0;
+        c.min_trades_per_min = 0.0;
+        c.min_buy_dominance = 0.0;
+        c.min_sol_inflow_lamports = 0;
+        c.require_mint_authority_renounced = false;
+        c.require_freeze_authority_none = false;
+        c.top1_buyer_share_cap = 1.0;
+        c.top3_buyer_share_cap = 1.0;
+        c.repeat_buyer_min_ratio = 0.0;
+        c.min_trade_size_lamports = 0;
+        c.small_buy_ratio_cap = 1.0;
+        c.min_token_age_secs = 0;
+        c
+    }
+
+    fn seed_probe_ready_tracker(
+        ctx: &MomentumContext,
+        cfg: &MomentumConfig,
+        mint: &str,
+        pool: &str,
+    ) -> String {
+        let sk = MomentumContext::tracker_storage_key(mint, pool);
+        assert!(ctx.get_or_create_tracker(mint, pool, "raydium", 1, 10_000_000_000));
+        let mut trackers = ctx.token_trackers.write();
+        let tr = trackers.get_mut(&sk).expect("tracker");
+        for i in 0..20 {
+            tr.record_trade(
+                &format!("buy{i:03}"),
+                true,
+                200_000_000,
+                2_000_000,
+                &format!("sig{i:03}"),
+                1 + i as u64,
+                cfg,
+            );
+        }
+        sk
+    }
+
+    #[test]
+    fn wait_hot_set_stale_cache_enters_and_records_metrics() {
+        use ironcrab::metrics::wait_hot_set_test_counters;
+        wait_hot_set_test_counters::reset();
+
+        let cfg = probe_entry_filter_pass_config();
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+        *ctx.config.write() = cfg.clone();
+
+        let mint = "MintWaitHotStale88888888888888888888888888888";
+        let pool = "poolWaitHotStale8888888888888888888888888888";
+        let sk = seed_probe_ready_tracker(&ctx, &cfg, mint, pool);
+
+        let enter_before = wait_hot_set_test_counters::wait_hot_set_enter_total();
+        let fresh_false_before = wait_hot_set_test_counters::filter_pass_hot_fresh_false();
+
+        let signals = ctx.check_for_signals();
+        assert!(signals.is_empty());
+        assert!(ctx
+            .token_trackers
+            .read()
+            .get(&sk)
+            .is_some_and(|t| matches!(t.state, TrackerState::WaitHotSet { .. })));
+        assert_eq!(
+            wait_hot_set_test_counters::wait_hot_set_enter_total(),
+            enter_before + 1
+        );
+        assert_eq!(
+            wait_hot_set_test_counters::filter_pass_hot_fresh_false(),
+            fresh_false_before + 1
+        );
+    }
+
+    #[test]
+    fn filter_pass_fresh_emits_immediate_hot_without_wait_hot_set() {
+        use ironcrab::metrics::wait_hot_set_test_counters;
+        wait_hot_set_test_counters::reset();
+
+        let cfg = probe_entry_filter_pass_config();
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+        *ctx.config.write() = cfg.clone();
+
+        let mint = Pubkey::new_from_array([0x66u8; 32]).to_string();
+        let pool = Pubkey::new_from_array([0x67u8; 32]).to_string();
+        let sk = seed_probe_ready_tracker(&ctx, &cfg, mint.as_str(), pool.as_str());
+        assert!(seed_test_entry_hot_set(&ctx, mint.as_str(), pool.as_str()));
+
+        let enter_before = wait_hot_set_test_counters::wait_hot_set_enter_total();
+        let immediate_before = wait_hot_set_test_counters::intent_path_immediate_hot_total();
+        let fresh_true_before = wait_hot_set_test_counters::filter_pass_hot_fresh_true();
+
+        let signals = ctx.check_for_signals();
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].kind, EntryKind::Probe);
+        assert!(!matches!(
+            ctx.token_trackers.read().get(&sk).map(|t| &t.state),
+            Some(TrackerState::WaitHotSet { .. })
+        ));
+        assert_eq!(
+            wait_hot_set_test_counters::wait_hot_set_enter_total(),
+            enter_before
+        );
+        assert_eq!(
+            wait_hot_set_test_counters::intent_path_immediate_hot_total(),
+            immediate_before + 1
+        );
+        assert_eq!(
+            wait_hot_set_test_counters::filter_pass_hot_fresh_true(),
+            fresh_true_before + 1
         );
     }
 

--- a/src/market_data/track/explicit_admission.rs
+++ b/src/market_data/track/explicit_admission.rs
@@ -6556,4 +6556,22 @@ mod tests {
         assert!(admission.owner_group(&tracker).is_none());
         assert!(admission.owner_group(&momentum).is_some());
     }
+
+    #[test]
+    fn shed_momentum_owner_groups_never_touches_wallet_or_position() {
+        let wallet = pool_owner(ExplicitConsumer::Wallet, 0);
+        let momentum_pos = pool_owner(ExplicitConsumer::MomentumPosition, 3);
+        let momentum = pool_owner(ExplicitConsumer::Momentum, 2);
+
+        let mut admission = FixedCapAdmission::new(8);
+        assert_admitted(admission.try_admit_new_group(wallet.clone(), vec![pk(10)]));
+        assert_admitted(admission.try_admit_new_group(momentum_pos.clone(), vec![pk(11)]));
+        assert_admitted(admission.try_admit_new_group(momentum.clone(), vec![pk(12)]));
+
+        let result = admission.shed_momentum_owner_groups(8);
+        assert_eq!(result.groups_evicted, 1);
+        assert!(admission.owner_group(&wallet).is_some());
+        assert!(admission.owner_group(&momentum_pos).is_some());
+        assert!(admission.owner_group(&momentum).is_none());
+    }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3309,6 +3309,166 @@ pub fn record_momentum_scale_in_gate_blocked_total(reason: MomentumScaleInGateBl
     counter.fetch_add(1, Ordering::Relaxed);
 }
 
+/// I-MD-9 WaitHotSet observability: hot-set freshness at pre-entry filter pass.
+#[inline]
+pub fn record_momentum_filter_pass_hot_fresh(fresh: bool) {
+    let counter = if fresh {
+        &*MOMENTUM_FILTER_PASS_HOT_FRESH_TRUE
+    } else {
+        &*MOMENTUM_FILTER_PASS_HOT_FRESH_FALSE
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_momentum_wait_hot_set_enter_total() {
+    MOMENTUM_WAIT_HOT_SET_ENTER_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// WaitHotSet exit reason (Prometheus label `reason`).
+#[derive(Debug, Clone, Copy)]
+pub enum MomentumWaitHotSetExitReason {
+    Intent,
+    Timeout,
+    FilterFailed,
+}
+
+#[inline]
+pub fn record_momentum_wait_hot_set_exit(reason: MomentumWaitHotSetExitReason, duration_ms: u64) {
+    let counter = match reason {
+        MomentumWaitHotSetExitReason::Intent => &*MOMENTUM_WAIT_HOT_SET_EXIT_INTENT,
+        MomentumWaitHotSetExitReason::Timeout => &*MOMENTUM_WAIT_HOT_SET_EXIT_TIMEOUT,
+        MomentumWaitHotSetExitReason::FilterFailed => &*MOMENTUM_WAIT_HOT_SET_EXIT_FILTER_FAILED,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+    record_histogram_u64_into(
+        EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS,
+        MOMENTUM_WAIT_HOT_SET_DURATION_MS_BUCKET_COUNTS.as_slice(),
+        &MOMENTUM_WAIT_HOT_SET_DURATION_MS_SUM,
+        &MOMENTUM_WAIT_HOT_SET_DURATION_MS_COUNT,
+        duration_ms,
+        MOMENTUM_LATENCY_MS_SUM_CAP,
+    );
+}
+
+/// Probe-buy intent path after I-MD-9 hot-set gate (Prometheus label `path`).
+#[derive(Debug, Clone, Copy)]
+pub enum MomentumIntentPath {
+    ImmediateHot,
+    AfterWaitHot,
+}
+
+#[inline]
+pub fn record_momentum_intent_path(path: MomentumIntentPath) {
+    let counter = match path {
+        MomentumIntentPath::ImmediateHot => &*MOMENTUM_INTENT_PATH_IMMEDIATE_HOT,
+        MomentumIntentPath::AfterWaitHot => &*MOMENTUM_INTENT_PATH_AFTER_WAIT_HOT,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+/// `register_geyser_reserves_impl` / momentum-active pin registration outcome.
+#[derive(Debug, Clone, Copy)]
+pub enum MomentumPinVaultRegisterResult {
+    Ok,
+    CacheMiss,
+    AdmissionRejected,
+    AlreadySatisfied,
+    Deferred,
+}
+
+#[inline]
+pub fn inc_market_data_momentum_pin_vault_register_total(result: MomentumPinVaultRegisterResult) {
+    let counter = match result {
+        MomentumPinVaultRegisterResult::Ok => &*MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_OK,
+        MomentumPinVaultRegisterResult::CacheMiss => {
+            &*MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_CACHE_MISS
+        }
+        MomentumPinVaultRegisterResult::AdmissionRejected => {
+            &*MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_ADMISSION_REJECTED
+        }
+        MomentumPinVaultRegisterResult::AlreadySatisfied => {
+            &*MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_ALREADY_SATISFIED
+        }
+        MomentumPinVaultRegisterResult::Deferred => {
+            &*MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_DEFERRED
+        }
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+static MOMENTUM_FILTER_PASS_HOT_FRESH_TRUE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static MOMENTUM_FILTER_PASS_HOT_FRESH_FALSE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static MOMENTUM_WAIT_HOT_SET_ENTER_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static MOMENTUM_WAIT_HOT_SET_EXIT_INTENT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static MOMENTUM_WAIT_HOT_SET_EXIT_TIMEOUT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static MOMENTUM_WAIT_HOT_SET_EXIT_FILTER_FAILED: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static MOMENTUM_WAIT_HOT_SET_DURATION_MS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS
+        .iter()
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+static MOMENTUM_WAIT_HOT_SET_DURATION_MS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static MOMENTUM_WAIT_HOT_SET_DURATION_MS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static MOMENTUM_INTENT_PATH_IMMEDIATE_HOT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static MOMENTUM_INTENT_PATH_AFTER_WAIT_HOT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_OK: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_CACHE_MISS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_ADMISSION_REJECTED: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_ALREADY_SATISFIED: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+static MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_DEFERRED: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+pub mod wait_hot_set_test_counters {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    pub fn reset() {
+        MOMENTUM_FILTER_PASS_HOT_FRESH_TRUE.store(0, Ordering::Relaxed);
+        MOMENTUM_FILTER_PASS_HOT_FRESH_FALSE.store(0, Ordering::Relaxed);
+        MOMENTUM_WAIT_HOT_SET_ENTER_TOTAL.store(0, Ordering::Relaxed);
+        MOMENTUM_WAIT_HOT_SET_EXIT_INTENT.store(0, Ordering::Relaxed);
+        MOMENTUM_WAIT_HOT_SET_EXIT_TIMEOUT.store(0, Ordering::Relaxed);
+        MOMENTUM_WAIT_HOT_SET_EXIT_FILTER_FAILED.store(0, Ordering::Relaxed);
+        MOMENTUM_WAIT_HOT_SET_DURATION_MS_COUNT.store(0, Ordering::Relaxed);
+        MOMENTUM_INTENT_PATH_IMMEDIATE_HOT.store(0, Ordering::Relaxed);
+        MOMENTUM_INTENT_PATH_AFTER_WAIT_HOT.store(0, Ordering::Relaxed);
+    }
+
+    pub fn filter_pass_hot_fresh_true() -> u64 {
+        MOMENTUM_FILTER_PASS_HOT_FRESH_TRUE.load(Ordering::Relaxed)
+    }
+
+    pub fn filter_pass_hot_fresh_false() -> u64 {
+        MOMENTUM_FILTER_PASS_HOT_FRESH_FALSE.load(Ordering::Relaxed)
+    }
+
+    pub fn wait_hot_set_enter_total() -> u64 {
+        MOMENTUM_WAIT_HOT_SET_ENTER_TOTAL.load(Ordering::Relaxed)
+    }
+
+    pub fn wait_hot_set_exit_timeout_total() -> u64 {
+        MOMENTUM_WAIT_HOT_SET_EXIT_TIMEOUT.load(Ordering::Relaxed)
+    }
+
+    pub fn wait_hot_set_duration_count() -> u64 {
+        MOMENTUM_WAIT_HOT_SET_DURATION_MS_COUNT.load(Ordering::Relaxed)
+    }
+
+    pub fn intent_path_immediate_hot_total() -> u64 {
+        MOMENTUM_INTENT_PATH_IMMEDIATE_HOT.load(Ordering::Relaxed)
+    }
+
+    pub fn intent_path_after_wait_hot_total() -> u64 {
+        MOMENTUM_INTENT_PATH_AFTER_WAIT_HOT.load(Ordering::Relaxed)
+    }
+}
+
 // PR170: tracker trade ingest forensics (static metric names — no dynamic labels).
 pub static MOMENTUM_TRACKER_TRADES_RECORDED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -8153,6 +8313,102 @@ async fn metrics_response() -> Response<Body> {
     out.push_str("momentum_scale_in_gate_blocked_total{reason=\"no_quote\"} ");
     out.push_str(
         &MOMENTUM_SCALE_IN_GATE_BLOCKED_NO_QUOTE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("momentum_filter_pass_hot_fresh_total{fresh=\"true\"} ");
+    out.push_str(
+        &MOMENTUM_FILTER_PASS_HOT_FRESH_TRUE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("momentum_filter_pass_hot_fresh_total{fresh=\"false\"} ");
+    out.push_str(
+        &MOMENTUM_FILTER_PASS_HOT_FRESH_FALSE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    line!(
+        "momentum_wait_hot_set_enter_total",
+        MOMENTUM_WAIT_HOT_SET_ENTER_TOTAL.load(Ordering::Relaxed)
+    );
+    out.push_str("momentum_wait_hot_set_exit_total{reason=\"intent\"} ");
+    out.push_str(
+        &MOMENTUM_WAIT_HOT_SET_EXIT_INTENT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("momentum_wait_hot_set_exit_total{reason=\"timeout\"} ");
+    out.push_str(
+        &MOMENTUM_WAIT_HOT_SET_EXIT_TIMEOUT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("momentum_wait_hot_set_exit_total{reason=\"filter_failed\"} ");
+    out.push_str(
+        &MOMENTUM_WAIT_HOT_SET_EXIT_FILTER_FAILED
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    append_momentum_latency_histogram_prometheus(
+        &mut out,
+        "momentum_wait_hot_set_duration_ms",
+        EXECUTION_INTENT_TO_CONFIRM_MS_BUCKETS,
+        &MOMENTUM_WAIT_HOT_SET_DURATION_MS_BUCKET_COUNTS,
+        &MOMENTUM_WAIT_HOT_SET_DURATION_MS_SUM,
+        &MOMENTUM_WAIT_HOT_SET_DURATION_MS_COUNT,
+    );
+    out.push_str("momentum_intent_path_total{path=\"immediate_hot\"} ");
+    out.push_str(
+        &MOMENTUM_INTENT_PATH_IMMEDIATE_HOT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("momentum_intent_path_total{path=\"after_wait_hot\"} ");
+    out.push_str(
+        &MOMENTUM_INTENT_PATH_AFTER_WAIT_HOT
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("market_data_momentum_pin_vault_register_total{result=\"ok\"} ");
+    out.push_str(
+        &MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_OK
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("market_data_momentum_pin_vault_register_total{result=\"cache_miss\"} ");
+    out.push_str(
+        &MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_CACHE_MISS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("market_data_momentum_pin_vault_register_total{result=\"admission_rejected\"} ");
+    out.push_str(
+        &MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_ADMISSION_REJECTED
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("market_data_momentum_pin_vault_register_total{result=\"already_satisfied\"} ");
+    out.push_str(
+        &MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_ALREADY_SATISFIED
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("market_data_momentum_pin_vault_register_total{result=\"deferred\"} ");
+    out.push_str(
+        &MARKET_DATA_MOMENTUM_PIN_VAULT_REGISTER_DEFERRED
             .load(Ordering::Relaxed)
             .to_string(),
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Nach I-MD-9 Filter-Pass pinnt Momentum (`WaitHotSet`), aber unter Lag sheddete `ShedMomentumUnderExecHotPressure` alle `ExplicitConsumer::Momentum`-Pins inkl. `pin_reason=tracker` — WaitHotSet baute das Hot-Set faktisch nicht auf, bevor Vault-Daten ankamen.

## Änderungen

### Metriken (A1–A5, optional A7)
- `momentum_filter_pass_hot_fresh_total{fresh="true|false"}`
- `momentum_wait_hot_set_enter_total`
- `momentum_wait_hot_set_exit_total{reason="intent"|"timeout"|"filter_failed"}`
- `momentum_wait_hot_set_duration_ms` (Histogram)
- `momentum_intent_path_total{path="immediate_hot"|"after_wait_hot"}`
- `market_data_momentum_pin_vault_register_total{result=...}` (Pin-Register-Outcomes)

### Lag-Shed-Fix (Variante A)
- `select_exec_hot_shed_tier`: **kein Momentum-Tier mehr allein wegen `lag_alarm`**
- Momentum-Shed nur noch bei Depth-Emergency (`D_EMERGENCY` / bestehender Depth-Pfad mit Arb-Idle)
- Tracker- und Arb-Lag-Shed unverändert
- **Wallet / `MomentumPosition` weiterhin immun** (bestehendes Pattern)

### Verhalten
- Filter-Pass + frisches Hot-Set → direkter `immediate_hot`-Intent (kein unnötiger WaitHotSet-Roundtrip)
- Filter-Pass + !fresh → WaitHotSet + Tracker-Pin wie I-MD-9

## Tests
- WaitHotSet enter/exit/metrics, immediate_hot, timeout+duration
- Lag-Alarm eskaliert nicht zu Momentum; Depth-Emergency bleibt
- Regression: `shed_momentum_owner_groups` berührt Wallet/Position nicht

## Tip-SHA
`545f108`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84255bbe-2a2a-47d1-b441-1123af64eacf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84255bbe-2a2a-47d1-b441-1123af64eacf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

