### PR TITLE
fix(md): sustain jetstream refresh for wait-hot-set via trade wire and heartbeat

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -1832,6 +1832,12 @@ fn note_trade_pool_lru_touches_from_cache(
             }
         }
     }
+
+    // Sustained JetStream SLAVE refresh during WaitHotSet (I-MD-9): trade → cache-first publish.
+    if ctx.hot_pool_registry.pool_has_momentum(pool) && cached_pool_has_fresh_reserve_basis(&state)
+    {
+        ctx.register_geyser_reserves_after_trade(pool);
+    }
 }
 
 /// Phase1: pair reserve balances from snapshot vault views (no `tracked_vaults` map lock).
@@ -2157,6 +2163,10 @@ impl TrackWorkerContext for MarketDataContext {
 
     fn refresh_hot_pool_registry_gauges(&self) {
         self.refresh_hot_pool_registry_gauges();
+    }
+
+    fn tick_momentum_hot_balance_refresh_heartbeat(&self) {
+        self.tick_momentum_hot_balance_refresh_heartbeat();
     }
 
     fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
@@ -4428,6 +4438,18 @@ impl MarketDataContext {
         }
     }
 
+    /// Periodic heartbeat for momentum-hot pins: sustain SLAVE `LivePoolCache` age during WaitHotSet.
+    fn tick_momentum_hot_balance_refresh_heartbeat(&self) {
+        if self.hot_pool_registry.hot_pool_count_momentum() == 0 {
+            return;
+        }
+        for pool in self.hot_pool_registry.snapshot_hot_pool_pubkeys() {
+            if self.hot_pool_registry.pool_has_momentum(pool) {
+                self.try_publish_balance_updated_from_cache(pool);
+            }
+        }
+    }
+
     /// After explicit Geyser sync, refresh SLAVE age once when a momentum-hot pool's feed becomes live.
     fn publish_momentum_hot_balance_refresh_after_explicit_sync(
         &self,
@@ -4455,7 +4477,6 @@ impl MarketDataContext {
     }
 
     /// Cache-first JetStream BalanceUpdated for pools with fresh reserve basis (no vault Geyser sub required).
-    #[cfg_attr(not(test), allow(dead_code))]
     fn try_publish_balance_updated_from_cache(&self, pool: Pubkey) {
         if self.balance_updated_from_cache_skipped_for_live_feed(pool) {
             return;
@@ -4544,8 +4565,7 @@ impl MarketDataContext {
     }
 
     /// PR-B: after a parsed swap trade — cache-first BalanceUpdated; vault/bin registration only for hot pools.
-    #[cfg_attr(not(test), allow(dead_code))]
-    fn register_geyser_reserves_after_trade(self: &Arc<Self>, pool: Pubkey) -> bool {
+    fn register_geyser_reserves_after_trade(&self, pool: Pubkey) -> bool {
         self.try_publish_balance_updated_from_cache(pool);
         if !self.hot_pool_registry.pool_has_momentum(pool) {
             return false;
@@ -16521,6 +16541,213 @@ mod pr_b_geyser_tracking_tests {
             MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.load(Ordering::Relaxed),
             counter_before,
             "without NATS/handle publish is a no-op, but live-feed gate must not block"
+        );
+    }
+
+    #[test]
+    fn trade_path_wires_momentum_hot_balance_refresh_after_trade() {
+        use ironcrab::market_data::sidefx::worker::MdSidefxBurstScratch;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let pool = Pubkey::new_unique();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool(base, pool);
+        ctx.note_explicit_momentum_pool_admitted(pool);
+
+        let mut scratch = MdSidefxBurstScratch::default();
+        note_trade_pool_lru_touches_from_cache(&ctx, pool, &mut scratch);
+        assert!(
+            !ctx.balance_updated_from_cache_skipped_for_live_feed(pool),
+            "momentum-hot trade path must reach cache-first publish (not live-feed skip)"
+        );
+        assert!(
+            ctx.tracked_vaults.read().contains_key(&coin),
+            "trade path must wire register_geyser_reserves_after_trade for momentum-hot pool"
+        );
+    }
+
+    #[test]
+    fn trade_path_skips_balance_refresh_for_arb_only_hot_pool() {
+        use ironcrab::market_data::sidefx::worker::MdSidefxBurstScratch;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let pool = Pubkey::new_unique();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+
+        let vaults_before = ctx.tracked_vaults.read().len();
+        let mut scratch = MdSidefxBurstScratch::default();
+        note_trade_pool_lru_touches_from_cache(&ctx, pool, &mut scratch);
+        assert_eq!(
+            ctx.tracked_vaults.read().len(),
+            vaults_before,
+            "arb-only hot pool must not trigger momentum trade register path"
+        );
+    }
+
+    #[test]
+    fn momentum_hot_heartbeat_publishes_balance_refresh() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::PumpFun(PumpFunState {
+                token_mint: mint,
+                bonding_curve: pool,
+                associated_bonding_curve: Pubkey::new_unique(),
+                virtual_sol_reserves: 30_000_000_000,
+                virtual_token_reserves: 1_073_000_000_000_000,
+                real_sol_reserves: 10_000_000_000,
+                real_token_reserves: 500_000_000_000_000,
+                complete: false,
+                creator: Pubkey::new_unique(),
+                cashback_enabled: false,
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool(mint, pool);
+
+        assert!(ctx.hot_pool_registry.pool_has_momentum(pool));
+        assert!(!ctx.balance_updated_from_cache_skipped_for_live_feed(pool));
+        ctx.tick_momentum_hot_balance_refresh_heartbeat();
+        assert!(
+            cached_pool_has_fresh_reserve_basis(&ctx.live_pool_cache.get(&pool).unwrap()),
+            "heartbeat must target momentum-hot pool with publishable reserve basis"
+        );
+    }
+
+    #[test]
+    fn momentum_hot_heartbeat_skips_arb_only_pool() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let pool = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: Pubkey::new_unique(),
+                token_1_vault: Pubkey::new_unique(),
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+
+        assert!(!ctx.hot_pool_registry.pool_has_momentum(pool));
+        ctx.tick_momentum_hot_balance_refresh_heartbeat();
+    }
+
+    #[test]
+    fn momentum_hot_heartbeat_stops_after_unpin() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::PumpFun(PumpFunState {
+                token_mint: mint,
+                bonding_curve: pool,
+                associated_bonding_curve: Pubkey::new_unique(),
+                virtual_sol_reserves: 30_000_000_000,
+                virtual_token_reserves: 1_073_000_000_000_000,
+                real_sol_reserves: 10_000_000_000,
+                real_token_reserves: 500_000_000_000_000,
+                complete: false,
+                creator: Pubkey::new_unique(),
+                cashback_enabled: false,
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool(mint, pool);
+        ctx.hot_pool_registry.unpin_pool(mint, pool);
+
+        assert!(!ctx.hot_pool_registry.pool_has_momentum(pool));
+        assert!(
+            !ctx.hot_pool_registry
+                .snapshot_hot_pool_pubkeys()
+                .contains(&pool),
+            "unpinned pool must leave hot registry before heartbeat tick"
+        );
+        ctx.tick_momentum_hot_balance_refresh_heartbeat();
+    }
+
+    #[test]
+    fn trade_path_source_wires_register_geyser_reserves_after_trade() {
+        let src = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/bin/market_data.rs"
+        ));
+        let start = src
+            .find("fn note_trade_pool_lru_touches_from_cache")
+            .expect("note_trade_pool_lru_touches_from_cache");
+        let end = src[start..]
+            .find("\n/// Phase1: pair reserve balances")
+            .map(|off| start + off)
+            .unwrap_or(start + 4000);
+        let block = &src[start..end];
+        assert!(
+            block.contains("register_geyser_reserves_after_trade"),
+            "trade LRU touch must wire register_geyser_reserves_after_trade for momentum-hot"
+        );
+        assert!(
+            block.contains("pool_has_momentum"),
+            "trade refresh must be gated to momentum-hot pools"
         );
     }
 

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -39,6 +39,9 @@ use std::time::{Duration, Instant};
 
 /// Phase 2a: track-worker Geyser push coalesce window (I-4d prep).
 pub const MARKET_DATA_TRACK_WORKER_COALESCE_MS: u64 = 500;
+
+/// Momentum-hot JetStream balance refresh heartbeat interval (must stay below 4s entry-age gate).
+pub const MARKET_DATA_MOMENTUM_HOT_BALANCE_REFRESH_HEARTBEAT_MS: u64 = 2000;
 /// Phase 2a: bounded queue for md-track-worker commands.
 pub const MARKET_DATA_TRACK_WORKER_QUEUE_CAP: usize = 8192;
 /// PR169c: chunk large momentum applies so the tracking actor yields to ingest tasks.
@@ -104,6 +107,8 @@ pub trait TrackWorkerContext: Send + Sync {
     fn hot_pool_registry_pair_count(&self) -> usize;
     fn hot_pool_registry_arb_pool_count(&self) -> usize;
     fn refresh_hot_pool_registry_gauges(&self);
+    /// Periodic JetStream refresh for momentum-hot pins (WaitHotSet sustained freshness).
+    fn tick_momentum_hot_balance_refresh_heartbeat(&self);
     fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey>;
     fn sync_geyser_tracked_accounts_batched_flush_with_deadline(
         &self,
@@ -553,6 +558,11 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
             MARKET_DATA_EXPLICIT_SET_SNAPSHOT_INTERVAL_SECS,
         ))
         .unwrap_or_else(Instant::now);
+    let mut last_momentum_hot_balance_heartbeat = Instant::now()
+        .checked_sub(Duration::from_millis(
+            MARKET_DATA_MOMENTUM_HOT_BALANCE_REFRESH_HEARTBEAT_MS,
+        ))
+        .unwrap_or_else(Instant::now);
 
     loop {
         let timeout = match coalesce_deadline {
@@ -644,6 +654,13 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
                 last_snapshot_write = Instant::now();
                 try_write_explicit_set_snapshot_from_ctx(ctx.as_ref(), &admission);
             }
+        }
+
+        if last_momentum_hot_balance_heartbeat.elapsed()
+            >= Duration::from_millis(MARKET_DATA_MOMENTUM_HOT_BALANCE_REFRESH_HEARTBEAT_MS)
+        {
+            last_momentum_hot_balance_heartbeat = Instant::now();
+            ctx.tick_momentum_hot_balance_refresh_heartbeat();
         }
     }
 }
@@ -985,6 +1002,8 @@ mod tests {
 
         fn refresh_hot_pool_registry_gauges(&self) {}
 
+        fn tick_momentum_hot_balance_refresh_heartbeat(&self) {}
+
         fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
             HashSet::new()
         }
@@ -1293,6 +1312,8 @@ mod tests {
 
             fn refresh_hot_pool_registry_gauges(&self) {}
 
+            fn tick_momentum_hot_balance_refresh_heartbeat(&self) {}
+
             fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
                 HashSet::new()
             }
@@ -1546,6 +1567,8 @@ mod tests {
 
         fn refresh_hot_pool_registry_gauges(&self) {}
 
+        fn tick_momentum_hot_balance_refresh_heartbeat(&self) {}
+
         fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
             HashSet::new()
         }
@@ -1796,6 +1819,7 @@ mod tests {
                 0
             }
             fn refresh_hot_pool_registry_gauges(&self) {}
+            fn tick_momentum_hot_balance_refresh_heartbeat(&self) {}
             fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
                 HashSet::new()
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Nach PR #329 feuerte `balance_updated_from_cache` praktisch 1:1 mit Pin-ok (~95≈92) — nur Pin-Satisfy/Sync, **kein sustained Refresh** während WaitHotSet. `register_geyser_reserves_after_trade` war `dead_code` in Prod (nur Tests). Ohne wiederholte JetStream-Applies läuft SLAVE-Cache-Age (>4s Gate) tot → ~83% WaitHotSet-Timeouts.

## Fix

### A) Trade-Pfad verdrahtet
`note_trade_pool_lru_touches_from_cache` (TX → `TradePoolLruTouch` → md-sidefx) ruft für **Momentum-hot** Pools mit frischer Reserve-Basis `register_geyser_reserves_after_trade` auf:
- Cache-first `BalanceUpdated` via JetStream
- Vault-Registrierung wie bisher (nur Momentum-hot)
- `dead_code` entfernt

### B) Heartbeat ≤2s für Momentum-hot Pins
Neuer `tick_momentum_hot_balance_refresh_heartbeat()` im **track-worker**-Loop (`MARKET_DATA_MOMENTUM_HOT_BALANCE_REFRESH_HEARTBEAT_MS = 2000`):
- Nur `pool_has_momentum` Pools aus `snapshot_hot_pool_pubkeys()`
- Per-Pool-Throttle via globalem 2s-Intervall
- Unpin → Pool fällt aus Registry → kein weiterer Publish

## Invarianten

- **I-7 / I-4**: Cache-first JetStream aus MASTER, kein RPC
- **I-4b**: Heartbeat im track-worker (nicht im gRPC-Recv)
- **I-MD-9**: 4s Age-Gate unverändert; sustained Refresh statt Einmal-Pin-Publish
- **#329 Skip-Semantik**: Momentum bypass / non-momentum skip unverändert

## Tests

- `trade_path_wires_momentum_hot_balance_refresh_after_trade`
- `trade_path_skips_balance_refresh_for_arb_only_hot_pool`
- `momentum_hot_heartbeat_*` (publish / arb-skip / unpin-guard)
- `trade_path_source_wires_register_geyser_reserves_after_trade`

## Erwartetes Prod-Signal

`market_data_balance_updated_from_cache_total` Rate ≫ Pin-ok-Rate; `fresh=true` steigt; WaitHotSet-Timeout-Anteil sinkt.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1e10bcc-e780-4d1d-8085-24934d6eb881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1e10bcc-e780-4d1d-8085-24934d6eb881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

