### PR TITLE
fix(momentum): WaitHotSet dirty wakeup, fresh-fail reasons, reject 0-reserve age spoof

### DIFF
--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -3789,24 +3789,38 @@ impl MomentumContext {
     }
 
     /// I-MD-9: Geyser hot-set readiness for imminent entry — fresh `LivePoolCache` reserves, no RPC.
-    fn entry_hot_set_fresh(&self, mint: &str, pool: &str) -> bool {
+    fn entry_hot_set_fresh(&self, mint: &str, pool: &str, dex: &str) -> bool {
+        match self.entry_hot_set_fresh_reason(mint, pool) {
+            Ok(()) => true,
+            Err(reason) => {
+                ironcrab::metrics::record_momentum_entry_hot_fresh_fail(reason, dex);
+                false
+            }
+        }
+    }
+
+    fn entry_hot_set_fresh_reason(
+        &self,
+        mint: &str,
+        pool: &str,
+    ) -> Result<(), ironcrab::metrics::MomentumEntryHotFreshFailReason> {
         let Ok(pool_pk) = solana_sdk::pubkey::Pubkey::from_str(pool) else {
-            return false;
+            return Err(ironcrab::metrics::MomentumEntryHotFreshFailReason::Missing);
         };
         let Ok(token_mint) = solana_sdk::pubkey::Pubkey::from_str(mint) else {
-            return false;
+            return Err(ironcrab::metrics::MomentumEntryHotFreshFailReason::Missing);
         };
         let Some((state, _slot, age_ms)) = self.live_pool_cache.get_with_metadata(&pool_pk) else {
-            return false;
+            return Err(ironcrab::metrics::MomentumEntryHotFreshFailReason::Missing);
         };
         if age_ms > ENTRY_HOT_SET_MAX_CACHE_AGE_MS {
-            return false;
+            return Err(ironcrab::metrics::MomentumEntryHotFreshFailReason::Age);
         }
         const PROBE_TOKENS: u64 = 1_000;
-        matches!(
-            quote_calculator::quote_output_amount(&state, PROBE_TOKENS, &token_mint),
-            Ok(sol_out) if sol_out > 0
-        )
+        match quote_calculator::quote_output_amount(&state, PROBE_TOKENS, &token_mint) {
+            Ok(sol_out) if sol_out > 0 => Ok(()),
+            _ => Err(ironcrab::metrics::MomentumEntryHotFreshFailReason::Quote),
+        }
     }
 
     /// A.2: Normalize DEX names for execution-engine compatibility (pumpswap/PumpFunAmm → pump_amm)
@@ -5528,8 +5542,11 @@ impl MomentumContext {
                             self.mark_entry_eval_dirty_key(key);
                             continue 'tracker_keys;
                         }
-                        let entry_hot_fresh =
-                            self.entry_hot_set_fresh(&mint, tracker.pool.as_str());
+                        let entry_hot_fresh = self.entry_hot_set_fresh(
+                            &mint,
+                            tracker.pool.as_str(),
+                            tracker.dex.as_str(),
+                        );
                         ironcrab::metrics::record_momentum_filter_pass_hot_fresh(entry_hot_fresh);
                         if probe_sol == 0 {
                             warn!(
@@ -5596,6 +5613,9 @@ impl MomentumContext {
                                 MomentumActivePinReason::Tracker,
                             );
                         }
+                    } else if matches!(tracker.state, TrackerState::WaitHotSet { .. }) {
+                        // I-MD-9: stay dirty through transient filter rot until timeout/intent/exit.
+                        self.mark_entry_eval_dirty_key(key);
                     } else if matches!(tracker.state, TrackerState::Discovery) {
                         // Move to validation state if not yet there
                         tracker.state = TrackerState::Validation;
@@ -5689,7 +5709,11 @@ impl MomentumContext {
                             self.mark_entry_eval_dirty_key(key);
                             continue 'tracker_keys;
                         }
-                        if !self.entry_hot_set_fresh(&mint, tracker.pool.as_str()) {
+                        if !self.entry_hot_set_fresh(
+                            &mint,
+                            tracker.pool.as_str(),
+                            tracker.dex.as_str(),
+                        ) {
                             self.mark_entry_eval_dirty_key(key);
                             continue 'tracker_keys;
                         }
@@ -12119,6 +12143,7 @@ async fn momentum_apply_pool_cache_jetstream_batch_items(
             update.header.ts_unix_ms,
         );
         pool_cache_sync::apply_pool_cache_update(&ctx.live_pool_cache, update);
+        ctx.mark_entry_eval_dirty_for_mint(&update.base_mint);
     }
     pool_cache_process_accounted = pool_cache_process_accounted.saturating_add(phase1_t0.elapsed());
 
@@ -19805,6 +19830,171 @@ mod tests {
             1
         );
         assert_eq!(wait_hot_set_test_counters::filter_pass_hot_fresh_true(), 1);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn entry_hot_fresh_fail_reasons_record_distinct_metrics() {
+        use ironcrab::metrics::{wait_hot_set_test_counters, MomentumEntryHotFreshFailReason};
+        wait_hot_set_test_counters::reset();
+
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+
+        let mint = Pubkey::new_from_array([0x68u8; 32]).to_string();
+        let pool = Pubkey::new_from_array([0x69u8; 32]).to_string();
+
+        assert!(
+            !ctx.entry_hot_set_fresh(mint.as_str(), pool.as_str(), "raydium"),
+            "missing cache row"
+        );
+        assert_eq!(
+            wait_hot_set_test_counters::entry_hot_fresh_fail_total(
+                MomentumEntryHotFreshFailReason::Missing,
+                "raydium"
+            ),
+            1
+        );
+
+        let zero_quote = pool_cache_update_stub(
+            mint.as_str(),
+            pool.as_str(),
+            0,
+            0,
+            1,
+            wall_clock_unix_ms_now(),
+        );
+        pool_cache_sync::apply_pool_cache_update(&ctx.live_pool_cache, &zero_quote);
+        assert!(
+            !ctx.entry_hot_set_fresh(mint.as_str(), pool.as_str(), "raydium"),
+            "zero reserves must fail quote gate"
+        );
+        assert_eq!(
+            wait_hot_set_test_counters::entry_hot_fresh_fail_total(
+                MomentumEntryHotFreshFailReason::Quote,
+                "raydium"
+            ),
+            1
+        );
+
+        assert!(seed_test_entry_hot_set(&ctx, mint.as_str(), pool.as_str()));
+        std::thread::sleep(Duration::from_millis(ENTRY_HOT_SET_MAX_CACHE_AGE_MS + 200));
+        assert!(
+            !ctx.entry_hot_set_fresh(mint.as_str(), pool.as_str(), "raydium"),
+            "stale cache must fail age gate"
+        );
+        assert_eq!(
+            wait_hot_set_test_counters::entry_hot_fresh_fail_total(
+                MomentumEntryHotFreshFailReason::Age,
+                "raydium"
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn jetstream_pool_cache_apply_marks_entry_eval_dirty() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+
+        let mint = Pubkey::new_from_array([0x6au8; 32]).to_string();
+        let pool = Pubkey::new_from_array([0x6bu8; 32]).to_string();
+        let sk = MomentumContext::tracker_storage_key(mint.as_str(), pool.as_str());
+        assert!(ctx.get_or_create_tracker(
+            mint.as_str(),
+            pool.as_str(),
+            "raydium",
+            1,
+            10_000_000_000
+        ));
+        ctx.dirty_entry_tracker_keys.write().clear();
+
+        let update = pool_cache_update_stub(
+            mint.as_str(),
+            pool.as_str(),
+            10_000_000_000_000,
+            1_000_000_000_000,
+            10,
+            wall_clock_unix_ms_now(),
+        );
+        pool_cache_sync::apply_pool_cache_update(&ctx.live_pool_cache, &update);
+        ctx.mark_entry_eval_dirty_for_mint(&update.base_mint);
+
+        assert!(
+            ctx.dirty_entry_tracker_keys.read().contains(&sk),
+            "JetStream apply path must mark tracker dirty for re-eval"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn wait_hot_set_stays_dirty_when_filter_rotates() {
+        let cfg = probe_entry_filter_pass_config();
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+        *ctx.config.write() = cfg.clone();
+
+        let mint = "MintWaitHotDirty88888888888888888888888888888";
+        let pool = "poolWaitHotDirty8888888888888888888888888888";
+        let sk = seed_probe_ready_tracker(&ctx, &cfg, mint, pool);
+
+        let _ = ctx.check_for_signals();
+        assert!(ctx
+            .token_trackers
+            .read()
+            .get(&sk)
+            .is_some_and(|t| matches!(t.state, TrackerState::WaitHotSet { .. })));
+
+        ctx.config.write().min_unique_buyers = 100;
+        ctx.mark_entry_eval_dirty_key(&sk);
+        let _ = ctx.check_for_signals_dirty_priority_tick();
+        assert!(
+            ctx.dirty_entry_tracker_keys.read().contains(&sk),
+            "WaitHotSet must stay dirty through transient !should_trade"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn zero_reserve_discover_then_quotable_balance_allows_hot_fresh() {
+        use ironcrab::ipc::PoolCacheUpdateType;
+
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+
+        let mint = Pubkey::new_from_array([0x6cu8; 32]).to_string();
+        let pool = Pubkey::new_from_array([0x6du8; 32]).to_string();
+
+        let mut discover = pool_cache_update_stub(
+            mint.as_str(),
+            pool.as_str(),
+            0,
+            0,
+            1,
+            wall_clock_unix_ms_now(),
+        );
+        discover.update_type = PoolCacheUpdateType::PoolDiscovered;
+        pool_cache_sync::apply_pool_cache_update(&ctx.live_pool_cache, &discover);
+        std::thread::sleep(Duration::from_millis(30));
+        pool_cache_sync::apply_pool_cache_update(&ctx.live_pool_cache, &discover);
+        let (_, _, age_after_repeat) = ctx
+            .live_pool_cache
+            .get_with_metadata(&Pubkey::from_str(pool.as_str()).unwrap())
+            .expect("pool cached");
+        assert!(
+            age_after_repeat >= 25,
+            "repeated 0/0 discover must not spoof fresh age"
+        );
+
+        assert!(seed_test_entry_hot_set(&ctx, mint.as_str(), pool.as_str()));
+        assert!(
+            ctx.entry_hot_set_fresh(mint.as_str(), pool.as_str(), "raydium"),
+            "quotable balance update must allow fresh=true"
+        );
     }
 
     #[test]

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -340,6 +340,23 @@ impl CachedPoolState {
     }
 }
 
+/// True when the cached pool row has at least one non-zero reserve / vault balance.
+pub fn pool_state_has_reserve_basis(state: &CachedPoolState) -> bool {
+    let fresh = |opt: Option<u64>| opt.is_some_and(|v| v > 0);
+    let fresh_u64 = |v: u64| v > 0;
+    match state {
+        CachedPoolState::RaydiumCpmm(s) => fresh(s.reserve_0) || fresh(s.reserve_1),
+        CachedPoolState::MeteoraCpmm(s) => fresh_u64(s.reserve_0) || fresh_u64(s.reserve_1),
+        CachedPoolState::Meteora(s) => fresh(s.reserve_x_balance) || fresh(s.reserve_y_balance),
+        CachedPoolState::PumpAmm(s) => fresh(s.base_reserve) || fresh(s.quote_reserve),
+        CachedPoolState::Orca(s) => fresh(s.vault_a_balance) || fresh(s.vault_b_balance),
+        CachedPoolState::RaydiumAmm(s) => fresh(s.coin_reserve) || fresh(s.pc_reserve),
+        CachedPoolState::PumpFun(s) => {
+            !s.complete && s.virtual_sol_reserves > 0 && s.virtual_token_reserves > 0
+        }
+    }
+}
+
 // ============================================================================
 // Cache entry with metadata
 // ============================================================================
@@ -581,7 +598,11 @@ impl LivePoolCache {
     /// `slot == 0` means "no Geyser slot" (e.g. cold-path RPC hydration): the state is applied,
     /// but an existing non-zero slot watermark is preserved so later stale Geyser snapshots are
     /// still rejected.
+    ///
+    /// Updates without quotable reserve basis (e.g. 0/0 `PoolDiscovered`) do **not** refresh
+    /// `updated_at` on an existing row — prevents age-gate spoofing without quote readiness.
     pub fn upsert(&self, pool: Pubkey, state: CachedPoolState, slot: u64) -> bool {
+        let refresh_age = pool_state_has_reserve_basis(&state);
         match self.pools.entry(pool) {
             Entry::Vacant(v) => {
                 let stored_slot = if slot == 0 { 0 } else { slot };
@@ -596,8 +617,13 @@ impl LivePoolCache {
                     return false;
                 }
                 let stored_slot = if slot == 0 { prev_slot } else { slot };
+                let prev_updated_at = o.get().updated_at;
                 self.register_vaults(&pool, &state);
-                *o.get_mut() = CacheEntry::new(state, stored_slot);
+                let mut entry = CacheEntry::new(state, stored_slot);
+                if !refresh_age {
+                    entry.updated_at = prev_updated_at;
+                }
+                *o.get_mut() = entry;
                 self.updates_total.fetch_add(1, Ordering::Relaxed);
                 true
             }
@@ -2478,6 +2504,51 @@ mod tests {
             entry.is_stale(1000)
         };
         assert!(!is_stale); // Not stale within 1s
+    }
+
+    #[test]
+    fn upsert_without_reserve_basis_does_not_refresh_updated_at() {
+        use std::time::Duration;
+
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let zero_state = CachedPoolState::PumpAmm(PumpAmmState {
+            base_mint: Pubkey::new_unique(),
+            quote_mint: Pubkey::new_unique(),
+            pool_base_token_account: Pubkey::new_unique(),
+            pool_quote_token_account: Pubkey::new_unique(),
+            base_reserve: Some(0),
+            quote_reserve: Some(0),
+            pool_accounts: Vec::new(),
+            creator: None,
+        });
+
+        cache.upsert(pool, zero_state.clone(), 1);
+        std::thread::sleep(Duration::from_millis(40));
+        let (_, _, age_before_repeat) = cache.get_with_metadata(&pool).expect("cached");
+        cache.upsert(pool, zero_state, 2);
+        let (_, _, age_after_repeat) = cache.get_with_metadata(&pool).expect("cached");
+        assert!(
+            age_after_repeat >= age_before_repeat,
+            "0/0 upsert must not reset cache age"
+        );
+
+        let with_reserves = CachedPoolState::PumpAmm(PumpAmmState {
+            base_mint: Pubkey::new_unique(),
+            quote_mint: Pubkey::new_unique(),
+            pool_base_token_account: Pubkey::new_unique(),
+            pool_quote_token_account: Pubkey::new_unique(),
+            base_reserve: Some(1_000_000),
+            quote_reserve: Some(50_000_000_000),
+            pool_accounts: Vec::new(),
+            creator: None,
+        });
+        cache.upsert(pool, with_reserves, 3);
+        let (_, _, age_after_quotable) = cache.get_with_metadata(&pool).expect("cached");
+        assert!(
+            age_after_quotable < 20,
+            "quotable upsert must refresh cache age"
+        );
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3320,6 +3320,49 @@ pub fn record_momentum_filter_pass_hot_fresh(fresh: bool) {
     counter.fetch_add(1, Ordering::Relaxed);
 }
 
+/// Why `entry_hot_set_fresh` failed (Prometheus labels `reason`, `dex`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MomentumEntryHotFreshFailReason {
+    Missing,
+    Age,
+    Quote,
+}
+
+impl MomentumEntryHotFreshFailReason {
+    fn as_label(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::Age => "age",
+            Self::Quote => "quote",
+        }
+    }
+}
+
+fn normalize_momentum_entry_hot_fresh_fail_dex(dex: &str) -> String {
+    match dex {
+        "pumpswap" | "PumpFunAmm" | "PumpFun AMM" => "pump_amm".to_string(),
+        "pumpfun" | "PumpFun" => "pumpfun".to_string(),
+        "orca" => "orca".to_string(),
+        "raydium" => "raydium".to_string(),
+        "raydium_cpmm" => "raydium_cpmm".to_string(),
+        "meteora_dlmm" => "meteora_dlmm".to_string(),
+        "meteora_cpmm" => "meteora_cpmm".to_string(),
+        _ => "other".to_string(),
+    }
+}
+
+/// Increment `momentum_entry_hot_fresh_fail_total{reason,dex}`.
+#[inline]
+pub fn record_momentum_entry_hot_fresh_fail(reason: MomentumEntryHotFreshFailReason, dex: &str) {
+    let key = format!(
+        "{}|{}",
+        reason.as_label(),
+        normalize_momentum_entry_hot_fresh_fail_dex(dex)
+    );
+    let mut map = MOMENTUM_ENTRY_HOT_FRESH_FAIL_TOTAL.write();
+    *map.entry(key).or_insert(0) += 1;
+}
+
 #[inline]
 pub fn inc_momentum_wait_hot_set_enter_total() {
     MOMENTUM_WAIT_HOT_SET_ENTER_TOTAL.fetch_add(1, Ordering::Relaxed);
@@ -3399,6 +3442,8 @@ pub fn inc_market_data_momentum_pin_vault_register_total(result: MomentumPinVaul
 
 static MOMENTUM_FILTER_PASS_HOT_FRESH_TRUE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 static MOMENTUM_FILTER_PASS_HOT_FRESH_FALSE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static MOMENTUM_ENTRY_HOT_FRESH_FAIL_TOTAL: Lazy<RwLock<HashMap<String, u64>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
 static MOMENTUM_WAIT_HOT_SET_ENTER_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 static MOMENTUM_WAIT_HOT_SET_EXIT_INTENT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 static MOMENTUM_WAIT_HOT_SET_EXIT_TIMEOUT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -3431,6 +3476,7 @@ pub mod wait_hot_set_test_counters {
     pub fn reset() {
         MOMENTUM_FILTER_PASS_HOT_FRESH_TRUE.store(0, Ordering::Relaxed);
         MOMENTUM_FILTER_PASS_HOT_FRESH_FALSE.store(0, Ordering::Relaxed);
+        MOMENTUM_ENTRY_HOT_FRESH_FAIL_TOTAL.write().clear();
         MOMENTUM_WAIT_HOT_SET_ENTER_TOTAL.store(0, Ordering::Relaxed);
         MOMENTUM_WAIT_HOT_SET_EXIT_INTENT.store(0, Ordering::Relaxed);
         MOMENTUM_WAIT_HOT_SET_EXIT_TIMEOUT.store(0, Ordering::Relaxed);
@@ -3446,6 +3492,19 @@ pub mod wait_hot_set_test_counters {
 
     pub fn filter_pass_hot_fresh_false() -> u64 {
         MOMENTUM_FILTER_PASS_HOT_FRESH_FALSE.load(Ordering::Relaxed)
+    }
+
+    pub fn entry_hot_fresh_fail_total(reason: MomentumEntryHotFreshFailReason, dex: &str) -> u64 {
+        let key = format!(
+            "{}|{}",
+            reason.as_label(),
+            normalize_momentum_entry_hot_fresh_fail_dex(dex)
+        );
+        MOMENTUM_ENTRY_HOT_FRESH_FAIL_TOTAL
+            .read()
+            .get(&key)
+            .copied()
+            .unwrap_or(0)
     }
 
     pub fn wait_hot_set_enter_total() -> u64 {
@@ -8331,6 +8390,16 @@ async fn metrics_response() -> Response<Body> {
             .to_string(),
     );
     out.push('\n');
+    for (key, count) in MOMENTUM_ENTRY_HOT_FRESH_FAIL_TOTAL.read().iter() {
+        let (reason, dex) = key.split_once('|').unwrap_or((key.as_str(), "other"));
+        out.push_str("momentum_entry_hot_fresh_fail_total{reason=\"");
+        out.push_str(reason);
+        out.push_str("\",dex=\"");
+        out.push_str(dex);
+        out.push_str("\"} ");
+        out.push_str(&count.to_string());
+        out.push('\n');
+    }
     line!(
         "momentum_wait_hot_set_enter_total",
         MOMENTUM_WAIT_HOT_SET_ENTER_TOTAL.load(Ordering::Relaxed)


### PR DESCRIPTION
## Summary
- Fresh-fail metrics: `momentum_entry_hot_fresh_fail_total{reason=missing|age|quote,dex}`
- Dirty-on-Apply after JetStream pool cache update + WaitHotSet sticky dirty until Intent/Timeout/FilterFailed
- LivePoolCache upsert: 0-reserve / non-quotable tips do not refresh `updated_at` on existing rows (no age spoof)

## Context
Post-#330 soak: heartbeat publishes (balance_updated >> pin-ok) but `fresh=true` ≈ 0 and WaitHotSet timeouts ~60%. Finding: quote/dirty wakeup, not publish lack. Handoff: `Iron_crab-eval/docs/supervisor/handoff_impl_waithotset_quote_dirty_observability_20260728.md`

## Test plan
- [ ] `cargo fmt --check` / `clippy -D warnings` / `cargo test` (agent reported green)
- [ ] CI green on PR
- [ ] Prod soak after deploy: fail-reason split visible; PumpFun quotable pins `fresh=true` >0; Wait timeout << 60%
- [ ] Bugbot final gate before merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes momentum entry gating and LivePoolCache freshness semantics on the trading hot path; mis-tuning could delay entries or affect WaitHotSet timeouts, but scope is bounded with tests.
> 
> **Overview**
> Fixes **WaitHotSet** stalls and misleading **entry hot-set freshness** by tightening cache age semantics, re-waking entry evaluation on pool updates, and adding labeled failure metrics.
> 
> **LivePoolCache** now treats upserts without quotable reserves (e.g. 0/0 `PoolDiscovered`) as not refreshing `updated_at` on an existing row, so repeated zero-reserve discovers cannot pass the entry age gate before quotes are viable. A new `pool_state_has_reserve_basis` helper drives that behavior.
> 
> **Momentum bot** splits `entry_hot_set_fresh` into a reason-returning path and records `momentum_entry_hot_fresh_fail_total{reason,dex}` for **missing**, **age**, and **quote** failures. JetStream pool-cache applies call `mark_entry_eval_dirty_for_mint` so trackers re-evaluate when reserves arrive. Trackers in **WaitHotSet** stay dirty when filters briefly fail (`!should_trade`), instead of dropping off the dirty set until intent, timeout, or filter-failed exit.
> 
> Tests cover distinct fail metrics, dirty marking on apply, WaitHotSet stickiness, and zero-reserve age behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 362b766a748b290089fe04bddf27ff9f2fc8eb12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->