### PR TITLE
feat(arb): slot-skew histogram and stale-leg attribution (C1b2)

### DIFF
--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -3283,11 +3283,10 @@ impl TokenArbTracker {
 
         arb_two_hop_v2_round_trip_formable_inc();
 
-        let slot_delta = selection
-            .buy_quote
-            .as_of_slot
-            .abs_diff(selection.sell_quote.as_of_slot);
-        record_arb_quote_pair_slot_delta(slot_delta);
+        let buy_as_of_slot = selection.buy_quote.as_of_slot;
+        let sell_as_of_slot = selection.sell_quote.as_of_slot;
+        let slot_delta = buy_as_of_slot.abs_diff(sell_as_of_slot);
+        record_arb_quote_pair_slot_delta(buy_as_of_slot, sell_as_of_slot);
         if config.arb_max_leg_slot_delta > 0 && slot_delta > config.arb_max_leg_slot_delta {
             arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::SlotDeltaExceeded);
             return None;
@@ -9808,6 +9807,140 @@ mod two_hop_price_tests {
         assert!(
             ironcrab::metrics::ARB_TWO_HOP_V2_REJECTED_SLOT_DELTA_EXCEEDED.load(Ordering::Relaxed)
                 > before
+        );
+    }
+
+    fn run_v2_slot_skew_screen(buy_slot: u64, sell_slot: u64) {
+        let cache = create_shared_cache();
+        let token_mint = Pubkey::new_unique();
+        let pool_a = Pubkey::new_unique();
+        let pool_b = Pubkey::new_unique();
+        let mint_str = token_mint.to_string();
+
+        let update_orca = PoolCacheUpdate::new_balance_updated(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            pool_a.to_string(),
+            "orca".to_string(),
+            mint_str.clone(),
+            NATIVE_SOL_MINT.to_string(),
+            1_000_000_000_000,
+            980_000_000,
+            buy_slot,
+        );
+        let update_pump = PoolCacheUpdate::new_balance_updated(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            pool_b.to_string(),
+            "pump_amm".to_string(),
+            mint_str.clone(),
+            NATIVE_SOL_MINT.to_string(),
+            1_000_000_000_000,
+            1_020_000_000,
+            sell_slot,
+        );
+        ironcrab::execution::pool_cache_sync::apply_pool_cache_update(&cache, &update_orca);
+        ironcrab::execution::pool_cache_sync::apply_pool_cache_update(&cache, &update_pump);
+
+        let mut trackers = HashMap::new();
+        let mut vault_balances = HashMap::new();
+        seed_token_tracker_from_live_pool_cache(
+            &mint_str,
+            &cache,
+            &mut trackers,
+            &mut vault_balances,
+            None,
+        );
+
+        let mut known_pools = HashSet::new();
+        known_pools.insert(pool_a.to_string());
+        known_pools.insert(pool_b.to_string());
+
+        let tracker = trackers.get_mut(&mint_str).unwrap();
+        tracker.token_decimals = Some(6);
+
+        let config = ArbConfig {
+            arb_two_hop_v2_enabled: true,
+            arb_max_leg_slot_delta: 0,
+            min_spread_bps: 1,
+            min_profit_lamports: 1,
+            est_tx_cost_lamports: 1,
+            ..Default::default()
+        };
+
+        let bin_arrays: HashMap<String, HashMap<i64, BinArrayCache>> = HashMap::new();
+        let spread_warn_last = RwLock::new(HashMap::new());
+        let data_quality_rejects = AtomicU64::new(0);
+        let _ = tracker.check_arbitrage(
+            &config,
+            &known_pools,
+            &vault_balances,
+            &bin_arrays,
+            &ArbCheckContext {
+                spread_warn_last: &spread_warn_last,
+                data_quality_rejects: &data_quality_rejects,
+                forensics: None,
+                v2_forensics: None,
+                selected_mints: None,
+                pinned_pools: None,
+            },
+        );
+    }
+
+    #[test]
+    fn check_arbitrage_v2_records_slot_skew_histogram_and_leg_attribution() {
+        use ironcrab::metrics::{
+            ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_COUNT, ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM,
+            ARB_QUOTE_PAIR_SLOT_SKEW_LEG_BUY_TOTAL, ARB_QUOTE_PAIR_SLOT_SKEW_LEG_EQUAL_TOTAL,
+            ARB_QUOTE_PAIR_SLOT_SKEW_LEG_SELL_TOTAL,
+        };
+
+        let count_before = ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_COUNT.load(Ordering::Relaxed);
+        let equal_before = ARB_QUOTE_PAIR_SLOT_SKEW_LEG_EQUAL_TOTAL.load(Ordering::Relaxed);
+        let sum_before = ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM.load(Ordering::Relaxed);
+        run_v2_slot_skew_screen(50, 50);
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_COUNT.load(Ordering::Relaxed),
+            count_before + 1
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_SKEW_LEG_EQUAL_TOTAL.load(Ordering::Relaxed),
+            equal_before + 1
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM.load(Ordering::Relaxed),
+            sum_before
+        );
+
+        let buy_before = ARB_QUOTE_PAIR_SLOT_SKEW_LEG_BUY_TOTAL.load(Ordering::Relaxed);
+        let sum_before = ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM.load(Ordering::Relaxed);
+        run_v2_slot_skew_screen(48, 50);
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_SKEW_LEG_BUY_TOTAL.load(Ordering::Relaxed),
+            buy_before + 1
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM.load(Ordering::Relaxed),
+            sum_before + 2
+        );
+
+        let buy_before = ARB_QUOTE_PAIR_SLOT_SKEW_LEG_BUY_TOTAL.load(Ordering::Relaxed);
+        let sell_before = ARB_QUOTE_PAIR_SLOT_SKEW_LEG_SELL_TOTAL.load(Ordering::Relaxed);
+        let sum_before = ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM.load(Ordering::Relaxed);
+        run_v2_slot_skew_screen(1, 101);
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_SKEW_LEG_BUY_TOTAL.load(Ordering::Relaxed),
+            buy_before + 1
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_SKEW_LEG_SELL_TOTAL.load(Ordering::Relaxed),
+            sell_before
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM.load(Ordering::Relaxed),
+            sum_before + 100
         );
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4449,15 +4449,22 @@ pub static ARB_TRACK_SELECTION_QUEUE_OVERFLOW_TOTAL: Lazy<AtomicU64> =
 pub static ARB_TRACK_SELECTION_BLOCKING_JOIN_FAILED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
-const ARB_QUOTE_PAIR_SLOT_DELTA_BUCKETS: &[u64] = &[0, 1, 2, 3, 4, 5, 8, 16, 32];
-static ARB_QUOTE_PAIR_SLOT_DELTA_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
-    ARB_QUOTE_PAIR_SLOT_DELTA_BUCKETS
+const ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_BUCKETS: &[u64] =
+    &[0, 1, 2, 3, 5, 10, 20, 50, 100, 500, 1000, 5000];
+static ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_BUCKET_COUNTS: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_BUCKETS
         .iter()
         .map(|_| AtomicU64::new(0))
         .collect()
 });
-pub static ARB_QUOTE_PAIR_SLOT_DELTA_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
-pub static ARB_QUOTE_PAIR_SLOT_DELTA_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_COUNT: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_QUOTE_PAIR_SLOT_SKEW_LEG_BUY_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_QUOTE_PAIR_SLOT_SKEW_LEG_SELL_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_QUOTE_PAIR_SLOT_SKEW_LEG_EQUAL_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 const ARB_TRACK_PIN_BEFORE_FIRST_SCREEN_MS_BUCKETS: &[u64] = &[
     10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000,
@@ -5039,16 +5046,65 @@ pub fn arb_two_hop_v2_rejected_inc(reason: ArbTwoHopV2RejectReason) {
     counter.fetch_add(1, Ordering::Relaxed);
 }
 
-/// Record `|buy.as_of_slot - sell.as_of_slot|` for a v2 round-trip screen.
-pub fn record_arb_quote_pair_slot_delta(delta_slots: u64) {
+/// Which v2 round-trip leg has the older `as_of_slot` (lower slot = staler quote).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArbQuotePairSlotSkewLeg {
+    Buy,
+    Sell,
+    Equal,
+}
+
+/// Classify which leg is staler for slot-skew attribution.
+#[inline]
+pub fn classify_arb_quote_pair_slot_skew_leg(
+    buy_as_of_slot: u64,
+    sell_as_of_slot: u64,
+) -> ArbQuotePairSlotSkewLeg {
+    match buy_as_of_slot.cmp(&sell_as_of_slot) {
+        std::cmp::Ordering::Less => ArbQuotePairSlotSkewLeg::Buy,
+        std::cmp::Ordering::Greater => ArbQuotePairSlotSkewLeg::Sell,
+        std::cmp::Ordering::Equal => ArbQuotePairSlotSkewLeg::Equal,
+    }
+}
+
+/// Increment `arb_quote_pair_slot_skew_leg_total{leg=...}`.
+#[inline]
+pub fn arb_quote_pair_slot_skew_leg_inc(leg: ArbQuotePairSlotSkewLeg) {
+    let counter = match leg {
+        ArbQuotePairSlotSkewLeg::Buy => &*ARB_QUOTE_PAIR_SLOT_SKEW_LEG_BUY_TOTAL,
+        ArbQuotePairSlotSkewLeg::Sell => &*ARB_QUOTE_PAIR_SLOT_SKEW_LEG_SELL_TOTAL,
+        ArbQuotePairSlotSkewLeg::Equal => &*ARB_QUOTE_PAIR_SLOT_SKEW_LEG_EQUAL_TOTAL,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record `|buy.as_of_slot - sell.as_of_slot|` histogram and stale-leg attribution for a v2 screen.
+pub fn record_arb_quote_pair_slot_delta(buy_as_of_slot: u64, sell_as_of_slot: u64) {
+    let slot_delta = buy_as_of_slot.abs_diff(sell_as_of_slot);
     record_histogram_u64_into(
-        ARB_QUOTE_PAIR_SLOT_DELTA_BUCKETS,
-        ARB_QUOTE_PAIR_SLOT_DELTA_BUCKET_COUNTS.as_slice(),
-        &ARB_QUOTE_PAIR_SLOT_DELTA_SUM,
-        &ARB_QUOTE_PAIR_SLOT_DELTA_COUNT,
-        delta_slots,
+        ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_BUCKETS,
+        ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_BUCKET_COUNTS.as_slice(),
+        &ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM,
+        &ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_COUNT,
+        slot_delta,
         u64::MAX,
     );
+    arb_quote_pair_slot_skew_leg_inc(classify_arb_quote_pair_slot_skew_leg(
+        buy_as_of_slot,
+        sell_as_of_slot,
+    ));
+}
+
+#[cfg(any(test, feature = "test_helpers"))]
+pub fn reset_arb_quote_pair_slot_skew_metrics_for_test() {
+    for bucket in ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_BUCKET_COUNTS.iter() {
+        bucket.store(0, Ordering::Relaxed);
+    }
+    ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM.store(0, Ordering::Relaxed);
+    ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_COUNT.store(0, Ordering::Relaxed);
+    ARB_QUOTE_PAIR_SLOT_SKEW_LEG_BUY_TOTAL.store(0, Ordering::Relaxed);
+    ARB_QUOTE_PAIR_SLOT_SKEW_LEG_SELL_TOTAL.store(0, Ordering::Relaxed);
+    ARB_QUOTE_PAIR_SLOT_SKEW_LEG_EQUAL_TOTAL.store(0, Ordering::Relaxed);
 }
 
 /// Record first proactive multi-DEX pin publish for pin-before-first-screen latency.
@@ -9232,12 +9288,33 @@ async fn metrics_response() -> Response<Body> {
     append_arb_two_hop_v2_sell_quote_none_detail_total(&mut out);
     append_momentum_latency_histogram_prometheus(
         &mut out,
-        "arb_quote_pair_slot_delta",
-        ARB_QUOTE_PAIR_SLOT_DELTA_BUCKETS,
-        ARB_QUOTE_PAIR_SLOT_DELTA_BUCKET_COUNTS.as_slice(),
-        &ARB_QUOTE_PAIR_SLOT_DELTA_SUM,
-        &ARB_QUOTE_PAIR_SLOT_DELTA_COUNT,
+        "arb_quote_pair_slot_delta_slots",
+        ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_BUCKETS,
+        ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_BUCKET_COUNTS.as_slice(),
+        &ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM,
+        &ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_COUNT,
     );
+    out.push_str("arb_quote_pair_slot_skew_leg_total{leg=\"buy\"} ");
+    out.push_str(
+        &ARB_QUOTE_PAIR_SLOT_SKEW_LEG_BUY_TOTAL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_quote_pair_slot_skew_leg_total{leg=\"sell\"} ");
+    out.push_str(
+        &ARB_QUOTE_PAIR_SLOT_SKEW_LEG_SELL_TOTAL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_quote_pair_slot_skew_leg_total{leg=\"equal\"} ");
+    out.push_str(
+        &ARB_QUOTE_PAIR_SLOT_SKEW_LEG_EQUAL_TOTAL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
     append_momentum_latency_histogram_prometheus(
         &mut out,
         "arb_track_pin_before_first_screen_ms",
@@ -10935,6 +11012,93 @@ mod market_data_account_recv_metrics_tests {
         assert_eq!(
             MARKET_DATA_ACCOUNT_RECV_ITERATIONS_TOTAL.load(Ordering::Relaxed),
             recv_iters_before + 1
+        );
+    }
+}
+
+#[cfg(test)]
+mod arb_quote_pair_slot_skew_metrics_tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn record_slot_delta_histogram_and_leg_attribution() {
+        reset_arb_quote_pair_slot_skew_metrics_for_test();
+
+        record_arb_quote_pair_slot_delta(50, 50);
+        assert_eq!(
+            classify_arb_quote_pair_slot_skew_leg(50, 50),
+            ArbQuotePairSlotSkewLeg::Equal
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM.load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_COUNT.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_SKEW_LEG_EQUAL_TOTAL.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_BUCKET_COUNTS[0].load(Ordering::Relaxed),
+            1
+        );
+
+        reset_arb_quote_pair_slot_skew_metrics_for_test();
+        record_arb_quote_pair_slot_delta(48, 50);
+        assert_eq!(
+            classify_arb_quote_pair_slot_skew_leg(48, 50),
+            ArbQuotePairSlotSkewLeg::Buy
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM.load(Ordering::Relaxed),
+            2
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_SKEW_LEG_BUY_TOTAL.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_BUCKET_COUNTS[2].load(Ordering::Relaxed),
+            1
+        );
+
+        reset_arb_quote_pair_slot_skew_metrics_for_test();
+        record_arb_quote_pair_slot_delta(1, 101);
+        assert_eq!(
+            classify_arb_quote_pair_slot_skew_leg(1, 101),
+            ArbQuotePairSlotSkewLeg::Buy
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_SUM.load(Ordering::Relaxed),
+            100
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_SKEW_LEG_BUY_TOTAL.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_SKEW_LEG_SELL_TOTAL.load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_DELTA_SLOTS_BUCKET_COUNTS[8].load(Ordering::Relaxed),
+            1
+        );
+
+        reset_arb_quote_pair_slot_skew_metrics_for_test();
+        record_arb_quote_pair_slot_delta(120, 20);
+        assert_eq!(
+            classify_arb_quote_pair_slot_skew_leg(120, 20),
+            ArbQuotePairSlotSkewLeg::Sell
+        );
+        assert_eq!(
+            ARB_QUOTE_PAIR_SLOT_SKEW_LEG_SELL_TOTAL.load(Ordering::Relaxed),
+            1
         );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Observability-only follow-up to C1b (#336) for diagnosing why ~96% of formable v2 round-trips die on `slot_delta_exceeded`.

- **Histogram** `arb_quote_pair_slot_delta_slots` with wide buckets (`0,1,2,3,5,10,20,50,100,500,1000,5000,+`) replacing the prior narrow `arb_quote_pair_slot_delta` histogram (same sum/count, renamed export).
- **Attribution counter** `arb_quote_pair_slot_skew_leg_total{leg="buy"|"sell"|"equal"}` — labels which leg has the older `as_of_slot`.
- Recorded at the existing v2 screen point (after formable, before slot-delta reject).

## Not in scope

- No change to `arb_max_leg_slot_delta` default/threshold
- No profit tuning, MD-shed, or RPC

## Tests

- `record_slot_delta_histogram_and_leg_attribution` (metrics unit test: delta 0/2/100 + sell-stale)
- `check_arbitrage_v2_records_slot_skew_histogram_and_leg_attribution` (arb-strategy integration)

## STOP-CHECK

- I-7: no RPC; atomic histogram/counter records only
- I-9/I-12: no execution changes
- Scope limited to `metrics.rs` + `arb_strategy.rs`

## Verification

```bash
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c631433-dc79-4ec2-b87c-0726bbae887f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c631433-dc79-4ec2-b87c-0726bbae887f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

