### PR TITLE
feat(metrics): PA-2 Rest primary open_positions from PositionAuthority

### DIFF
--- a/docs/grafana_dashboard_example.json
+++ b/docs/grafana_dashboard_example.json
@@ -6,7 +6,7 @@
   "panels": [
     { "type": "timeseries", "title": "Sharpe Ratio", "targets": [{ "expr": "ironcrab_sharpe_ratio" }], "gridPos": {"h":6,"w":8,"x":0,"y":0} },
     { "type": "timeseries", "title": "Drawdown %", "targets": [{ "expr": "ironcrab_drawdown_pct" }], "gridPos": {"h":6,"w":8,"x":8,"y":0} },
-    { "type": "timeseries", "title": "Open Positions", "targets": [{ "expr": "open_positions" }], "gridPos": {"h":6,"w":8,"x":16,"y":0} },
+    { "type": "timeseries", "title": "Open Positions", "description": "PA-2 Rest: `open_positions` is PositionAuthority open count (not LockManager ghosts).", "targets": [{ "expr": "open_positions" }], "gridPos": {"h":6,"w":8,"x":16,"y":0} },
 
     { "type": "timeseries", "title": "Gross vs Net Realized PnL (SOL)", "targets": [
         { "expr": "gross_realized_pnl_sol" },

--- a/docs/grafana_multiprocess_dashboard.json
+++ b/docs/grafana_multiprocess_dashboard.json
@@ -1688,6 +1688,7 @@
     {
       "type": "stat",
       "title": "Open Positions",
+      "description": "PA-2 Rest: `open_positions` is PositionAuthority open count (not LockManager ghosts).",
       "targets": [
         {
           "expr": "open_positions{job=\"execution-engine\"}",

--- a/docs/grafana_sniper_dashboard.json
+++ b/docs/grafana_sniper_dashboard.json
@@ -8,6 +8,7 @@
     {
       "type": "stat",
       "title": "Open Positions",
+      "description": "PA-2 Rest: `open_positions` is PositionAuthority open count (not LockManager ghosts).",
       "targets": [{ "expr": "open_positions", "refId": "A" }],
       "gridPos": {"h":4,"w":4,"x":0,"y":0},
       "fieldConfig": {

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -2557,6 +2557,80 @@ struct ExecutionContext {
     pump_amm_hot_path_refresh_last: Arc<ParkingMutex<HashMap<Pubkey, Instant>>>,
 }
 
+#[cfg(test)]
+impl ExecutionContext {
+    fn test_for_pa2_metrics(
+        lock_manager: LockManager,
+        position_authority: PositionAuthority,
+    ) -> Self {
+        use ironcrab::storage::JsonlWriterConfig;
+        let log_dir =
+            std::env::temp_dir().join(format!("ironcrab_ee_pa2_metrics_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&log_dir);
+        let decision_writer = JsonlWriter::new(
+            JsonlWriterConfig::new("test_decisions").with_log_dir(log_dir.join("decisions")),
+        )
+        .expect("decision writer");
+        let execution_writer = JsonlWriter::new(
+            JsonlWriterConfig::new("test_executions").with_log_dir(log_dir.join("executions")),
+        )
+        .expect("execution writer");
+        let burn_writer = JsonlWriter::new(
+            JsonlWriterConfig::new("test_burns").with_log_dir(log_dir.join("burns")),
+        )
+        .expect("burn writer");
+        let rpc = Arc::new(SolanaRpc::new("http://127.0.0.1:0"));
+        Self {
+            run_id: "test".to_string(),
+            rpc_url: "test".to_string(),
+            helius_rpc_url: None,
+            wallet_pubkey: None,
+            treasury: None,
+            config: parking_lot::RwLock::new(ExecutionConfig::default()),
+            config_snapshot_id: parking_lot::RwLock::new("test".to_string()),
+            nats: None,
+            decision_writer,
+            execution_writer,
+            burn_writer,
+            lock_manager,
+            position_authority: Arc::new(ParkingMutex::new(position_authority)),
+            position_authority_kv_tx: None,
+            log_base: log_dir,
+            decision_counter: std::sync::atomic::AtomicU64::new(0),
+            execution_counter: std::sync::atomic::AtomicU64::new(0),
+            current_day: parking_lot::RwLock::new(chrono::Utc::now().date_naive()),
+            daily_loss_lamports: std::sync::atomic::AtomicI64::new(0),
+            kill_switch_active: AtomicBool::new(false),
+            liquidation_in_progress: AtomicBool::new(false),
+            kill_switch_context: parking_lot::RwLock::new(None),
+            burn_in_progress: AtomicBool::new(false),
+            jito_client: None,
+            bundles_submitted: std::sync::atomic::AtomicU64::new(0),
+            bundles_confirmed: std::sync::atomic::AtomicU64::new(0),
+            cross_dex_handler: None,
+            rpc,
+            address_lookup_table: None,
+            tx_sender: None,
+            dynamic_fee_percentiles: parking_lot::RwLock::new(None),
+            cached_blockhash: parking_lot::RwLock::new(None),
+            live_pool_cache: None,
+            intent_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
+            pending_discovery_responses: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            wsol_balance_tx: None,
+            pending_tx_confirms: Arc::new(parking_lot::RwLock::new(HashMap::new())),
+            recent_orphan_tx_confirms: Arc::new(parking_lot::RwLock::new(HashMap::new())),
+            intents_received: std::sync::atomic::AtomicU64::new(0),
+            intents_rejected: std::sync::atomic::AtomicU64::new(0),
+            sim_failures: std::sync::atomic::AtomicU64::new(0),
+            tx_sent: std::sync::atomic::AtomicU64::new(0),
+            arb_validated: std::sync::atomic::AtomicU64::new(0),
+            arb_executed: std::sync::atomic::AtomicU64::new(0),
+            replay_mode: true,
+            pump_amm_hot_path_refresh_last: Arc::new(ParkingMutex::new(HashMap::new())),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct BurnOpRecord {
     #[serde(flatten)]
@@ -6449,7 +6523,7 @@ impl ExecutionContext {
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
-    /// Get current open positions count (LockManager — snapshot/metrics; not BUY gate authority).
+    /// LockManager non-zero token balances (state snapshot persistence; not primary metrics / BUY gate).
     fn get_open_positions(&self) -> usize {
         self.lock_manager.count_non_zero_token_balances()
     }
@@ -6579,6 +6653,8 @@ impl ExecutionContext {
         let lock_open = self.lock_manager.count_non_zero_token_balances();
         let drift = position_authority_drift_lockmanager(auth_open, lock_open);
         drop(a);
+        // PA-2 Rest: primary `open_positions` gauge follows PositionAuthority (I-24a).
+        OPEN_POSITIONS_GAUGE.store(auth_open as u64, Ordering::Relaxed);
         POSITION_AUTHORITY_OPEN_GAUGE.store(auth_open as u64, Ordering::Relaxed);
         POSITION_AUTHORITY_RECONCILE_NEEDED_GAUGE.store(reconcile as u64, Ordering::Relaxed);
         POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE.store(lock_open as u64, Ordering::Relaxed);
@@ -8327,7 +8403,6 @@ async fn main() -> Result<()> {
     // No longer spawning cache_geyser_task - execution-engine subscribes to PoolCacheUpdates instead
 
     // Publish initial gauge values immediately (before the first 30s heartbeat).
-    OPEN_POSITIONS_GAUGE.store(ctx.get_open_positions() as u64, Ordering::Relaxed);
     ctx.refresh_position_authority_metrics();
 
     // === WsolManager: Background WSOL balance maintenance ===
@@ -9351,7 +9426,6 @@ async fn main() -> Result<()> {
                     INTENTS_RECEIVED_TOTAL.store(received, Ordering::Relaxed);
                     INTENTS_REJECTED_TOTAL.store(rejected, Ordering::Relaxed);
                     SIMULATION_FAILURES_TOTAL.store(sim_fail, Ordering::Relaxed);
-                    OPEN_POSITIONS_GAUGE.store(ctx.get_open_positions() as u64, Ordering::Relaxed);
                     ctx.refresh_position_authority_metrics();
                     ACTIVE_CAPITAL_LOCKS.store(cap_locks as u64, Ordering::Relaxed);
                     ACTIVE_RESOURCE_LOCKS.store(res_locks as u64, Ordering::Relaxed);
@@ -12493,8 +12567,8 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
     ) {
         INTENTS_EXECUTED_TOTAL.fetch_add(1, Ordering::Relaxed);
 
-        // open_positions is derived from LockManager.count_non_zero_token_balances()
-        // (Single Source of Truth). No separate counter — avoids dual-path drift.
+        // Primary `open_positions` gauge is refreshed from PositionAuthority (PA-2 Rest).
+        // LockManager balance updates below affect lockmanager overlay gauge only.
         match intent.side {
             TradeSide::Buy => {
                 // Immediately update LockManager with bought token balance so that
@@ -12693,7 +12767,7 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
         decision.outcome,
         DecisionOutcome::Confirmed | DecisionOutcome::FailedConfirmed
     ) {
-        OPEN_POSITIONS_GAUGE.store(ctx.get_open_positions() as u64, Ordering::Relaxed);
+        ctx.refresh_position_authority_metrics();
     }
 
     info!(
@@ -14388,6 +14462,52 @@ mod execution_engine_tests {
             decimals: 6,
             token_program: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string(),
         }
+    }
+
+    #[test]
+    fn primary_open_positions_gauge_uses_authority_not_lockmanager_ghost() {
+        use super::ExecutionContext;
+        use crate::{
+            OPEN_POSITIONS_GAUGE, POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE,
+            POSITION_AUTHORITY_OPEN_GAUGE,
+        };
+        use std::sync::atomic::Ordering;
+
+        const M1: &str = "MintA1111111111111111111111111111111111111";
+        const M2: &str = "MintB1111111111111111111111111111111111111";
+        const M3: &str = "MintC1111111111111111111111111111111111111";
+
+        let lm = LockManager::new(1_000_000_000);
+        lm.set_available_token_balance(M1.to_string(), 100);
+        lm.set_available_token_balance(M2.to_string(), 200);
+        lm.set_available_token_balance(M3.to_string(), 300);
+
+        let mut pa = PositionAuthority::new();
+        pa.apply(&pa_buy(M1, 100));
+
+        let ctx = ExecutionContext::test_for_pa2_metrics(lm, pa);
+        ctx.refresh_position_authority_metrics();
+
+        assert_eq!(POSITION_AUTHORITY_OPEN_GAUGE.load(Ordering::Relaxed), 1);
+        assert_eq!(OPEN_POSITIONS_GAUGE.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE.load(Ordering::Relaxed),
+            3
+        );
+
+        {
+            let mut pa = ctx.position_authority.lock();
+            pa.apply(&pa_sell(M1, 100));
+        }
+        ctx.refresh_position_authority_metrics();
+
+        assert_eq!(OPEN_POSITIONS_GAUGE.load(Ordering::Relaxed), 0);
+        assert_eq!(POSITION_AUTHORITY_OPEN_GAUGE.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE.load(Ordering::Relaxed),
+            3,
+            "lockmanager ghost gauge must still reflect non-zero balances"
+        );
     }
 
     #[test]

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -70,7 +70,7 @@ use ironcrab::metrics::{
     FILTER_REJECTED_INFLOW, FILTER_REJECTED_LIQUIDITY, FILTER_REJECTED_TOKEN_AGE,
     FILTER_REJECTED_TOTAL, FILTER_REJECTED_VELOCITY, INTENTS_GENERATED_TOTAL,
     MARKET_EVENTS_CONSUMED_TOTAL, NATS_ERRORS_TOTAL, NATS_MESSAGES_PUBLISHED_TOTAL,
-    NATS_MESSAGES_RECEIVED_TOTAL, POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
+    NATS_MESSAGES_RECEIVED_TOTAL, OPEN_POSITIONS_GAUGE, POOLS_TRACKED_GAUGE, TOKENS_TRACKED_GAUGE,
 };
 use ironcrab::nats::{
     config_consumer_config, config_subject, ensure_execution_results_stream,
@@ -6282,6 +6282,8 @@ impl MomentumContext {
             .filter(|s| s.balance_raw > 0 && s.status != PositionAuthorityStatus::Closed)
             .count();
         let overlay_count = self.positions.read().len();
+        // PA-2 Rest: primary `open_positions` on momentum-bot /metrics follows authority KV.
+        OPEN_POSITIONS_GAUGE.store(authority_open as u64, std::sync::atomic::Ordering::Relaxed);
         set_position_authority_drift_momentum(position_authority_drift_momentum(
             authority_open,
             overlay_count,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -6399,8 +6399,9 @@ pub static RPC_BACKOFF_MS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0
 pub static RPC_CONCURRENCY_ADJUSTMENTS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static RPC_INFLIGHT_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static RPC_ALLOWED_CONCURRENCY: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// PA-2 Rest: primary open-position count for dashboards (`open_positions`); sourced from PositionAuthority.
 pub static OPEN_POSITIONS_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
-/// PA-2: PositionAuthority model open count (read-only; does not replace `open_positions`).
+/// PA-2: PositionAuthority model open count (mirrors `open_positions` after PA-2 Rest).
 pub static POSITION_AUTHORITY_OPEN_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// Count of authority positions in `ReconcileNeeded` with non-zero balance.
 pub static POSITION_AUTHORITY_RECONCILE_NEEDED_GAUGE: Lazy<AtomicU64> =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PA-2 Rest: the primary Prometheus gauge `open_positions` now reflects **PositionAuthority** open count (I-24a), not LockManager non-zero token balances.

- **execution-engine**: `refresh_position_authority_metrics()` sets `OPEN_POSITIONS_GAUGE` from `PositionAuthority::open_positions_count()`. Removed direct `OPEN_POSITIONS_GAUGE.store(get_open_positions())` call sites; terminal intent handling calls `refresh_position_authority_metrics()` instead.
- **momentum-bot**: `refresh_position_authority_drift_metrics()` also updates `OPEN_POSITIONS_GAUGE` from authority KV overlay (authority open count, not local position overlay).
- **LockManager drift gauge** `position_authority_lockmanager_open_positions` unchanged and still refreshed on every authority metrics tick.
- **`get_open_positions()`** (LockManager) kept for state snapshot persistence only — not used for primary gauge / BUY gate (PA-3 unchanged).
- **Grafana**: panel descriptions note PA-2 Rest semantics; queries stay on `open_positions`.

## Tests

- New unit test `primary_open_positions_gauge_uses_authority_not_lockmanager_ghost`: authority open/close drives `open_positions`; LockManager ghost balances only affect lockmanager gauge.
- Existing PA-3 `max_open_positions_buy_gate` tests unchanged (8/8 pass).

## STOP-CHECK

- I-7: in-memory counts only, no RPC added
- I-24a: primary gauge no longer LockManager SOT
- PA-3 BUY gate untouched
- PA-6 / LockManager removal out of scope

## Verification

```text
cargo fmt --check
cargo clippy -- -D warnings
cargo test primary_open_positions
cargo test max_open_positions_gate
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de3cbdf7-35a8-4851-ba98-b2167df1be31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de3cbdf7-35a8-4851-ba98-b2167df1be31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

