### PR TITLE
fix(momentum): reject exit quotes with TPS scale mismatch (false TAKE_PROFIT)

### DIFF
--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -1072,6 +1072,8 @@ fn sell_fail_cooldown_secs(error_code: Option<&str>, sell_fail_count: u32) -> u6
 /// Below `quote_calculator`'s 5s warning so we do not SELL-trigger on long-stale reserve snapshots
 /// when the chain may have moved (I-16).
 const EXIT_QUOTE_MAX_CACHE_AGE_MS: u64 = 4_000;
+/// Max ratio between executable quote TPS and entry/mark TPS before rejecting price exits.
+const EXIT_QUOTE_TPS_MAX_SCALE_RATIO: f64 = 100.0;
 /// Max `LivePoolCache` age for imminent-entry hot-set readiness (I-MD-9; same conservatism as exits).
 const ENTRY_HOT_SET_MAX_CACHE_AGE_MS: u64 = EXIT_QUOTE_MAX_CACHE_AGE_MS;
 
@@ -1096,6 +1098,32 @@ fn dex_pool_accounts_include_wsol_and_position_mint(
     let has_wsol = accounts.iter().any(|a| a == WSOL_MINT);
     let has_mint = accounts.iter().any(|a| a == position_token_mint);
     has_wsol && has_mint
+}
+
+#[inline]
+fn exit_quote_tps_scale_mismatch(pos: &PositionTracker, q: &ExitExecutableQuote) -> bool {
+    let max_ratio = EXIT_QUOTE_TPS_MAX_SCALE_RATIO;
+    if pos.entry_price > 0.0
+        && q.tokens_per_sol > 0.0
+        && tokens_per_sol::exit_quote_tps_scale_ratio_exceeded(
+            pos.entry_price,
+            q.tokens_per_sol,
+            max_ratio,
+        )
+    {
+        return true;
+    }
+    if pos.current_price > 0.0
+        && q.tokens_per_sol > 0.0
+        && tokens_per_sol::exit_quote_tps_scale_ratio_exceeded(
+            pos.current_price,
+            q.tokens_per_sol,
+            max_ratio,
+        )
+    {
+        return true;
+    }
+    false
 }
 
 /// Returns `Some(reason_code)` when this quote must **not** drive price-based exits.
@@ -1129,6 +1157,10 @@ fn exit_quote_price_exit_guard_violation(
         {
             return Some("QUOTE_POOL_ACCOUNTS_NOT_VERIFIED_SOL_PAIR");
         }
+    }
+    if exit_quote_tps_scale_mismatch(pos, q) {
+        ironcrab::metrics::record_momentum_exit_quote_scale_mismatch_total();
+        return Some("QUOTE_TPS_SCALE_MISMATCH");
     }
     None
 }
@@ -15135,7 +15167,7 @@ mod tests {
                     &mint,
                     &pool,
                     "raydium",
-                    5_727_593.0,
+                    12_000.0, // above executable ~10k tps → modest probe gain (I-14)
                     6,
                     7_159_492_133,
                     250_000_000,
@@ -19118,6 +19150,64 @@ mod tests {
         );
         let ok = vec!["x".to_string(), WSOL_MINT.to_string(), "mint9".to_string()];
         assert!(exit_quote_price_exit_guard_violation(&pos, &ex, Some(&ok)).is_none());
+    }
+
+    #[test]
+    fn scale_mismatch_guard_rejects_absurd_quote_tps_vs_entry() {
+        let pos = PositionTracker::new("m", "p", "dex", 1.0e7, 6, 69_000_000_000, 0);
+        let ex = sample_exit_quote(0.17);
+        assert_eq!(
+            exit_quote_price_exit_guard_violation(&pos, &ex, None),
+            Some("QUOTE_TPS_SCALE_MISMATCH")
+        );
+    }
+
+    #[test]
+    fn scale_mismatch_guard_allows_quote_within_100x_of_entry() {
+        let pos = PositionTracker::new("m", "p", "dex", 1.0e7, 6, 1_000_000, 0);
+        let ex = sample_exit_quote(9.0e6);
+        assert!(exit_quote_price_exit_guard_violation(&pos, &ex, None).is_none());
+    }
+
+    #[test]
+    fn take_profit_suppressed_on_quote_tps_scale_mismatch_despite_absurd_pnl() {
+        let mut c = make_exit_config();
+        c.take_profit_pct = 20.0;
+        c.take_profit_min_hold_secs = 0;
+        c.hard_stop_loss_pct = 1_000.0;
+        let entry = 1.0e7;
+        let mut pos = PositionTracker::new("m", "p", "dex", entry, 6, 69_000_000_000, 0);
+        pos.current_price = entry * 1.05; // mark slightly negative PnL
+        pos.highest_price = entry;
+        let ex = sample_exit_quote(0.17);
+        let absurd_pnl = tokens_per_sol::pnl_pct(entry, ex.tokens_per_sol);
+        assert!(
+            absurd_pnl > c.take_profit_pct,
+            "sanity: absurd quote would trip TP without guard, pnl={absurd_pnl}"
+        );
+        assert!(
+            pos.should_exit(&c, Some(&ex), "test", 9_000_000_000u64, None)
+                .is_none(),
+            "scale mismatch must suppress TAKE_PROFIT"
+        );
+    }
+
+    #[test]
+    fn take_profit_still_quote_first_when_scale_matches_entry() {
+        let mut c = make_exit_config();
+        c.take_profit_pct = 20.0;
+        c.take_profit_min_hold_secs = 0;
+        c.hard_stop_loss_pct = 1_000.0;
+        let entry = 1.0e7;
+        let exec_tps = 8.0e6; // ~+25% executable gain (within 100× of entry)
+        let mut pos = PositionTracker::new("m", "p", "dex", entry, 6, 1_000_000, 0);
+        pos.current_price = entry;
+        pos.highest_price = entry;
+        let ex = sample_exit_quote(exec_tps);
+        let (ty, _) = pos
+            .should_exit(&c, Some(&ex), "test", 9_000_000_000u64, None)
+            .expect("TAKE_PROFIT");
+        assert_eq!(ty, "TAKE_PROFIT");
     }
 
     /// Lower executable tps than entry → positive PnL in our convention

--- a/src/execution/quote_calculator.rs
+++ b/src/execution/quote_calculator.rs
@@ -22,6 +22,21 @@ use anyhow::{anyhow, Result};
 use solana_sdk::pubkey::Pubkey;
 use std::str::FromStr;
 
+/// Native SOL / WSOL mint (lamport-denominated input for PumpFun buys).
+const WSOL_MINT_PK: Pubkey = solana_sdk::pubkey!("So11111111111111111111111111111111111111112");
+
+/// Infer PumpFun swap direction when `input_mint` is the token being sold or SOL being spent.
+fn pumpfun_is_buy_input(state: &PumpFunState, input_mint: &Pubkey) -> bool {
+    if state.token_mint != Pubkey::default() {
+        // SOL/WSOL in → buy tokens; position token mint in → sell for SOL.
+        *input_mint != state.token_mint
+    } else {
+        // `parse_pumpfun_bonding` leaves `token_mint` default until market-data enrichment.
+        // Without a known curve mint, only native SOL input is a buy; token input is a sell.
+        *input_mint == WSOL_MINT_PK
+    }
+}
+
 // ============================================================================
 // Main API
 // ============================================================================
@@ -141,7 +156,7 @@ pub fn quote_output_amount(
 ) -> Result<u64> {
     match state {
         CachedPoolState::PumpFun(s) => {
-            let is_buy = *input_mint != s.token_mint; // SOL in → buy tokens
+            let is_buy = pumpfun_is_buy_input(s, input_mint);
             calculate_pumpfun_quote(s, amount_in, is_buy)
         }
         CachedPoolState::PumpAmm(s) => {
@@ -700,6 +715,38 @@ mod tests {
         // Expected from virtual: (100M * 30 SOL) / (1B + 100M) ≈ 2.73 SOL; capped by real (5 SOL)
         assert!(amount_out > 2_500_000_000);
         assert!(amount_out <= 5_000_000_000); // cannot exceed real_sol_reserves
+    }
+
+    /// Prod-scale: missing `token_mint` in cache must not flip sell → buy (token out as lamports).
+    #[test]
+    fn pumpfun_sell_quote_tps_same_order_when_token_mint_missing_from_cache() {
+        use crate::execution::tokens_per_sol;
+
+        let token_mint = Pubkey::new_unique();
+        let state = PumpFunState {
+            token_mint: Pubkey::default(),
+            bonding_curve: Pubkey::new_unique(),
+            associated_bonding_curve: Pubkey::new_unique(),
+            virtual_sol_reserves: 30_000_000_000,
+            virtual_token_reserves: 1_000_000_000_000_000,
+            real_sol_reserves: 5_000_000_000,
+            real_token_reserves: 793_100_000_000_000,
+            complete: false,
+            creator: Pubkey::new_unique(),
+            cashback_enabled: false,
+        };
+        let sell_raw = 69_000_000_000u64;
+        let sol_out = quote_output_amount(&CachedPoolState::PumpFun(state), sell_raw, &token_mint)
+            .expect("sell quote");
+        let tps = tokens_per_sol::ui_tokens_per_sol(sell_raw, 6, sol_out);
+        assert!(
+            tps > 1_000_000.0 && tps < 100_000_000.0,
+            "expected entry-scale tps (not ~0.17), got {tps}"
+        );
+        let entry_tps = 1.0e7;
+        assert!(!tokens_per_sol::exit_quote_tps_scale_ratio_exceeded(
+            entry_tps, tps, 100.0
+        ));
     }
 
     #[test]

--- a/src/execution/tokens_per_sol.rs
+++ b/src/execution/tokens_per_sol.rs
@@ -58,6 +58,20 @@ pub fn drawdown_from_ath_pct(highest_price: f64, current_price: f64) -> f64 {
     ((current_price / highest_price) - 1.0) * 100.0
 }
 
+/// True when `quote_tps` deviates from `reference_tps` by more than `max_ratio` (either direction).
+/// Used to reject absurd executable exit quotes whose scale does not match entry/mark (I-14).
+pub fn exit_quote_tps_scale_ratio_exceeded(
+    reference_tps: f64,
+    quote_tps: f64,
+    max_ratio: f64,
+) -> bool {
+    if reference_tps <= 0.0 || quote_tps <= 0.0 || max_ratio <= 1.0 {
+        return false;
+    }
+    let ratio = quote_tps / reference_tps;
+    ratio > max_ratio || ratio < 1.0 / max_ratio
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,5 +153,23 @@ mod tests {
     fn higher_exec_tps_than_entry_is_loss_stop_loss_range() {
         let p = pnl_pct(1_000.0, 2_000.0);
         assert!(p < 0.0, "higher tps = loss");
+    }
+
+    #[test]
+    fn exit_quote_tps_scale_ratio_exceeded_prod_absurd_quote() {
+        let entry = 1.0e7;
+        let absurd_quote = 0.17;
+        assert!(exit_quote_tps_scale_ratio_exceeded(
+            entry,
+            absurd_quote,
+            100.0
+        ));
+    }
+
+    #[test]
+    fn exit_quote_tps_scale_ratio_ok_within_100x() {
+        let entry = 1.0e7;
+        let quote = 9.0e6;
+        assert!(!exit_quote_tps_scale_ratio_exceeded(entry, quote, 100.0));
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3237,6 +3237,9 @@ pub static MOMENTUM_ORPHAN_SCALE_IN_RECOVERY_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static MOMENTUM_EXIT_AMOUNT_OVERLAY_ONLY_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// Exit quote rejected: `tokens_per_sol` scale incompatible with entry/mark (false TAKE_PROFIT guard).
+pub static MOMENTUM_EXIT_QUOTE_SCALE_MISMATCH_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// PA-5.1: overlay closed because PositionAuthority signaled closed/absent/zero.
 pub static MOMENTUM_OVERLAY_CLOSED_BY_AUTHORITY_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -3268,6 +3271,11 @@ pub fn record_momentum_orphan_scale_in_recovery_total() {
 #[inline]
 pub fn record_momentum_exit_amount_overlay_only_total() {
     MOMENTUM_EXIT_AMOUNT_OVERLAY_ONLY_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_momentum_exit_quote_scale_mismatch_total() {
+    MOMENTUM_EXIT_QUOTE_SCALE_MISMATCH_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -8465,6 +8473,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "momentum_exit_amount_overlay_only_total",
         MOMENTUM_EXIT_AMOUNT_OVERLAY_ONLY_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_exit_quote_scale_mismatch_total",
+        MOMENTUM_EXIT_QUOTE_SCALE_MISMATCH_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "momentum_overlay_closed_by_authority_total",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (P0 — prod 2026-07-29)

Three `TAKE_PROFIT` decisions with `marks_position_pool=true` showed **+6–9×10⁹% quote PnL** while mark PnL was **−2% to −7%**. `quote_tokens_per_sol ≈ 0.17` vs `entry_tps ≈ 1×10⁷` — scale off by ~10⁸×.

## Mitigation (A) — Scale sanity guard

- New `QUOTE_TPS_SCALE_MISMATCH` in `exit_quote_price_exit_guard_violation`
- Rejects executable quotes whose TPS deviates > **100×** from `entry_price` or `current_price`
- Price exits (TP/SL/Trailing on quote) fall back to mark path / suppress with structured log
- Metric: `momentum_exit_quote_scale_mismatch_total`

## Root cause (B) — PumpFun direction flip

`quote_output_amount` used `is_buy = input_mint != token_mint`. When `PumpFunState.token_mint` is still `Pubkey::default()` (bonding-curve parse does not embed mint), **every token sell was treated as a buy**. Token output was then passed to `ui_tokens_per_sol` as `sol_out_lamports` → tps ≈ 0.17.

**Fix:** `pumpfun_is_buy_input()` — when `token_mint` unknown, infer buy only for WSOL input; token input → sell.

## Tests

- Guard: `entry=1e7`, `quote=0.17` → `QUOTE_TPS_SCALE_MISMATCH`
- Guard: `quote=9e6` within 100× → OK
- `should_exit`: no TP on scale mismatch despite absurd `pnl_pct`
- Regression: normal quote (`8e6` vs `1e7`) still quote-first TP
- PumpFun: sell quote with missing `token_mint` stays entry-scale (not ~0.17)

## STOP-CHECK

- No Hot Path RPC added (I-7)
- I-14 PnL formula unchanged
- Simulation gate unchanged (I-9)

## Verification

```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
cargo test -p ironcrab --bin momentum-bot -- scale_mismatch
cargo test -p ironcrab --lib tokens_per_sol
cargo test -p ironcrab --lib quote_calculator
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62fafaad-b3d1-4fc4-a125-460b98dc6dd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62fafaad-b3d1-4fc4-a125-460b98dc6dd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

