### PR TITLE
fix(execution-engine): LockManager WSOL capital sync after wrap

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -63,7 +63,9 @@ use ironcrab::execution::live_pool_cache::{
 };
 use ironcrab::execution::quote_calculator;
 use ironcrab::execution::tx_builder;
-use ironcrab::execution::wsol_manager::{WsolManager, WsolManagerConfig, WSOL_MINT};
+use ironcrab::execution::wsol_manager::{
+    PendingWrapState, WsolManager, WsolManagerConfig, WSOL_MINT,
+};
 use ironcrab::ipc::{
     CheckResult, ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, DecisionOutcome,
     DecisionRecord, DexPoolReadiness, ExecutionResult, ExecutionStatus, ExplicitAmount,
@@ -2527,6 +2529,9 @@ struct ExecutionContext {
     /// When Some, WalletBalanceSnapshot for NATIVE_SOL/WSOL are forwarded here.
     wsol_balance_tx: Option<tokio::sync::mpsc::Sender<(u64, Option<u64>)>>,
 
+    /// Shared with WsolManager: pending-wrap floor for LockManager capital sync.
+    wsol_pending_wrap: Option<Arc<PendingWrapState>>,
+
     // === PR3: JetStream TX Confirmation ===
     /// Pending signature → oneshot notify (filled by main-loop JetStream WalletTxConfirmed consumer).
     pending_tx_confirms: Arc<
@@ -2617,6 +2622,7 @@ impl ExecutionContext {
             intent_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
             pending_discovery_responses: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             wsol_balance_tx: None,
+            wsol_pending_wrap: None,
             pending_tx_confirms: Arc::new(parking_lot::RwLock::new(HashMap::new())),
             recent_orphan_tx_confirms: Arc::new(parking_lot::RwLock::new(HashMap::new())),
             intents_received: std::sync::atomic::AtomicU64::new(0),
@@ -6617,10 +6623,32 @@ impl ExecutionContext {
                     let _ = tx.try_send((*balance_raw, Some(wsol)));
                 }
             } else if mint == WSOL_MINT || mint == SOL_MINT {
-                self.lock_manager.update_wsol_only(*balance_raw);
+                let incoming = *balance_raw;
+                let effective_wsol = if let Some(ref pending) = self.wsol_pending_wrap {
+                    let (effective, confirms, was_floored) =
+                        pending.effective_wsol_for_snapshot(incoming);
+                    if was_floored {
+                        ironcrab::metrics::WSOL_LOCK_MANAGER_SNAPSHOT_FLOORED_TOTAL
+                            .fetch_add(1, Ordering::Relaxed);
+                        warn!(
+                            event = "lock_manager_stale_wsol_snapshot_floored_due_to_pending_wrap",
+                            incoming_wsol_lamports = incoming,
+                            pending_expected_wsol_lamports = pending.pending_expected(),
+                            effective_wsol_lamports = effective,
+                            "Floored LockManager WSOL snapshot while pending post-wrap confirmation"
+                        );
+                    }
+                    if confirms {
+                        pending.clear();
+                    }
+                    effective
+                } else {
+                    incoming
+                };
+                self.lock_manager.update_wsol_only(effective_wsol);
                 if let Some(ref tx) = self.wsol_balance_tx {
                     let sol = self.lock_manager.total_native_sol();
-                    let _ = tx.try_send((sol, Some(*balance_raw)));
+                    let _ = tx.try_send((sol, Some(incoming)));
                 }
             } else {
                 let old = self.lock_manager.available_token_balance(mint);
@@ -8291,6 +8319,7 @@ async fn main() -> Result<()> {
         recent_orphan_tx_confirms,
         // WsolManager balance updates (from JetStream); set when WsolManager enabled
         wsol_balance_tx: None,
+        wsol_pending_wrap: None,
         // Metrics
         intents_received: std::sync::atomic::AtomicU64::new(0),
         intents_rejected: std::sync::atomic::AtomicU64::new(0),
@@ -8389,9 +8418,14 @@ async fn main() -> Result<()> {
     }
 
     // Create WsolManager balance channel when treasury exists (JetStream → WsolManager)
+    let wsol_pending_wrap_state = ctx
+        .treasury
+        .as_ref()
+        .map(|_| Arc::new(PendingWrapState::new()));
     let wsol_balance_rx = if ctx.treasury.is_some() {
         let (tx, rx) = tokio::sync::mpsc::channel(256);
         ctx.wsol_balance_tx = Some(tx);
+        ctx.wsol_pending_wrap = wsol_pending_wrap_state.clone();
         Some(rx)
     } else {
         None
@@ -8429,6 +8463,16 @@ async fn main() -> Result<()> {
 
         if wsol_config.enabled {
             let ctx_for_kill_switch = Arc::clone(&ctx);
+            let ctx_for_lock_sync = Arc::clone(&ctx);
+            let lock_sync: ironcrab::execution::wsol_manager::WsolLockSyncCallback =
+                Arc::new(move |wsol_lamports| {
+                    ctx_for_lock_sync
+                        .lock_manager
+                        .update_wsol_only(wsol_lamports);
+                });
+            let pending_wrap = wsol_pending_wrap_state
+                .clone()
+                .expect("pending wrap state set when treasury exists");
             let wsol_manager = WsolManager::with_jsonl_writer(
                 wsol_config.clone(),
                 Arc::new(treasury.clone()),
@@ -8437,7 +8481,9 @@ async fn main() -> Result<()> {
                 &run_id,
                 Arc::clone(&wsol_writer),
             )
-            .with_kill_switch(move || ctx_for_kill_switch.is_kill_switch_active());
+            .with_kill_switch(move || ctx_for_kill_switch.is_kill_switch_active())
+            .with_pending_wrap_state(pending_wrap)
+            .with_lock_manager_sync(lock_sync);
             let shutdown_rx_wsol = shutdown_rx.clone();
 
             let balance_rx = wsol_balance_rx.expect("wsol_balance_rx set when treasury exists");
@@ -9638,6 +9684,7 @@ async fn build_replay_context(
             std::collections::HashMap::new(),
         )),
         wsol_balance_tx: None,
+        wsol_pending_wrap: None,
         pending_tx_confirms: Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new())),
         recent_orphan_tx_confirms: Arc::new(parking_lot::RwLock::new(
             std::collections::HashMap::new(),
@@ -14058,6 +14105,8 @@ mod execution_engine_tests {
     };
     use ironcrab::execution::pool_cache_sync::apply_pool_cache_update;
     use ironcrab::execution::tx_builder::TxPlan;
+    use ironcrab::execution::wsol_manager::PendingWrapState;
+    use ironcrab::ipc::MarketEvent;
     use ironcrab::ipc::RejectReason;
     use ironcrab::ipc::{
         CheckResult, ControlResponse, ControlResponseStatus, DecisionOutcome, DecisionRecord,
@@ -14079,6 +14128,7 @@ mod execution_engine_tests {
     };
     use std::collections::HashMap;
     use std::str::FromStr;
+    use std::sync::Arc;
     use std::time::Instant;
 
     fn test_system_transfer(from: &Pubkey, to: &Pubkey, lamports: u64) -> Instruction {
@@ -14108,6 +14158,70 @@ mod execution_engine_tests {
 
         assert_eq!(unsigned.message, signed.message);
         assert!(matches!(unsigned.message, VersionedMessage::Legacy(_)));
+    }
+
+    fn wsol_wallet_snapshot_event(balance_raw: u64) -> MarketEvent {
+        MarketEvent::new(
+            "test",
+            "test",
+            "run",
+            "evt-wsol-snapshot".to_string(),
+            "geyser",
+            None,
+            MarketEventKind::WalletBalanceSnapshot {
+                mint: WSOL_MINT.to_string(),
+                balance_raw,
+                decimals: 9,
+                token_program: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string(),
+            },
+        )
+    }
+
+    fn test_ctx_with_pending_wrap(
+        lock_manager: LockManager,
+    ) -> (super::ExecutionContext, Arc<PendingWrapState>) {
+        let pending = Arc::new(PendingWrapState::new());
+        let mut ctx =
+            super::ExecutionContext::test_for_pa2_metrics(lock_manager, PositionAuthority::new());
+        ctx.wsol_pending_wrap = Some(Arc::clone(&pending));
+        (ctx, pending)
+    }
+
+    #[test]
+    fn lock_manager_pending_wrap_floors_stale_zero_snapshot() {
+        let (ctx, pending) = test_ctx_with_pending_wrap(LockManager::new(3_000_000_000));
+        pending.arm(1_000_000_000);
+        ctx.lock_manager.update_wsol_only(1_000_000_000);
+
+        ctx.apply_wallet_balance_snapshot_event(&wsol_wallet_snapshot_event(0));
+
+        assert_eq!(ctx.lock_manager.available_wsol(), 1_000_000_000);
+        assert_eq!(pending.pending_expected(), 1_000_000_000);
+    }
+
+    #[test]
+    fn lock_manager_pending_wrap_confirms_on_matching_snapshot() {
+        let (ctx, pending) = test_ctx_with_pending_wrap(LockManager::new(3_000_000_000));
+        pending.arm(1_000_000_000);
+        ctx.lock_manager.update_wsol_only(0);
+
+        ctx.apply_wallet_balance_snapshot_event(&wsol_wallet_snapshot_event(1_000_000_000));
+
+        assert_eq!(ctx.lock_manager.available_wsol(), 1_000_000_000);
+        assert_eq!(pending.pending_expected(), 0);
+    }
+
+    #[test]
+    fn lock_manager_without_pending_accepts_zero_unwrap_snapshot() {
+        let ctx = super::ExecutionContext::test_for_pa2_metrics(
+            LockManager::new(3_000_000_000),
+            PositionAuthority::new(),
+        );
+        ctx.lock_manager.update_wsol_only(1_000_000_000);
+
+        ctx.apply_wallet_balance_snapshot_event(&wsol_wallet_snapshot_event(0));
+
+        assert_eq!(ctx.lock_manager.available_wsol(), 0);
     }
 
     #[test]

--- a/src/execution/wsol_manager.rs
+++ b/src/execution/wsol_manager.rs
@@ -55,7 +55,10 @@ const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
 
 /// After a successful on-chain wrap, hold this effective WSOL floor until a snapshot confirms
 /// `wsol >= pending_expected` or we hit the confirmation timeout (then one RPC resync, cold path).
-fn compute_effective_wsol_on_snapshot(pending_expected: u64, incoming_wsol: u64) -> (u64, bool) {
+pub fn compute_effective_wsol_on_snapshot(
+    pending_expected: u64,
+    incoming_wsol: u64,
+) -> (u64, bool) {
     if pending_expected == 0 {
         return (incoming_wsol, false);
     }
@@ -65,6 +68,70 @@ fn compute_effective_wsol_on_snapshot(pending_expected: u64, incoming_wsol: u64)
         (pending_expected, false)
     }
 }
+
+/// Shared pending-wrap confirmation state between WsolManager and execution-engine LockManager.
+pub struct PendingWrapState {
+    pending_wrap_expected_wsol: AtomicU64,
+    pending_wrap_started_ts: AtomicU64,
+    pending_wrap_rpc_resync_done: AtomicBool,
+}
+
+impl PendingWrapState {
+    pub fn new() -> Self {
+        Self {
+            pending_wrap_expected_wsol: AtomicU64::new(0),
+            pending_wrap_started_ts: AtomicU64::new(0),
+            pending_wrap_rpc_resync_done: AtomicBool::new(false),
+        }
+    }
+
+    pub fn pending_expected(&self) -> u64 {
+        self.pending_wrap_expected_wsol.load(Ordering::Relaxed)
+    }
+
+    pub fn pending_started_ts(&self) -> u64 {
+        self.pending_wrap_started_ts.load(Ordering::Relaxed)
+    }
+
+    pub fn arm(&self, expected_wsol_lamports: u64) {
+        let now = unix_secs();
+        self.pending_wrap_expected_wsol
+            .store(expected_wsol_lamports, Ordering::SeqCst);
+        self.pending_wrap_started_ts.store(now, Ordering::SeqCst);
+        self.pending_wrap_rpc_resync_done
+            .store(false, Ordering::SeqCst);
+    }
+
+    pub fn clear(&self) {
+        self.pending_wrap_expected_wsol.store(0, Ordering::SeqCst);
+        self.pending_wrap_started_ts.store(0, Ordering::SeqCst);
+        self.pending_wrap_rpc_resync_done
+            .store(false, Ordering::SeqCst);
+    }
+
+    /// Returns `(effective_wsol, confirms_pending, was_floored)`.
+    pub fn effective_wsol_for_snapshot(&self, incoming_wsol: u64) -> (u64, bool, bool) {
+        let pending = self.pending_wrap_expected_wsol.load(Ordering::Relaxed);
+        let (effective, confirms) = compute_effective_wsol_on_snapshot(pending, incoming_wsol);
+        let was_floored = pending > 0 && incoming_wsol < pending;
+        (effective, confirms, was_floored)
+    }
+
+    pub fn try_mark_rpc_resync_done(&self) -> bool {
+        self.pending_wrap_rpc_resync_done
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+}
+
+impl Default for PendingWrapState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Sync authoritative WSOL lamports into LockManager (execution-engine callback).
+pub type WsolLockSyncCallback = Arc<dyn Fn(u64) + Send + Sync>;
 
 #[inline]
 fn unix_secs() -> u64 {
@@ -228,13 +295,11 @@ pub struct WsolManager {
     /// Wrap in progress flag (prevents double-wrap race condition)
     wrap_in_progress: AtomicBool,
 
-    /// After successful wrap: minimum WSOL (lamports) we treat as authoritative until snapshot
-    /// confirms at least this level, or timeout + optional RPC resync clears the pending state.
-    pending_wrap_expected_wsol: AtomicU64,
-    /// UNIX seconds when `pending_wrap_expected_wsol` was armed (`0` = no pending confirmation).
-    pending_wrap_started_ts: AtomicU64,
-    /// At most one RPC resync per pending-wrap episode (after confirmation timeout).
-    pending_wrap_rpc_resync_done: AtomicBool,
+    /// Shared with execution-engine for LockManager capital sync during pending wrap.
+    pending_wrap: Arc<PendingWrapState>,
+
+    /// Optional hook to seed LockManager after wrap success / cold-path RPC resync.
+    lock_manager_sync: Option<WsolLockSyncCallback>,
 
     /// Build version for records
     build_version: String,
@@ -269,9 +334,8 @@ impl WsolManager {
             last_action_ts: AtomicU64::new(0),
             running: AtomicBool::new(true),
             wrap_in_progress: AtomicBool::new(false),
-            pending_wrap_expected_wsol: AtomicU64::new(0),
-            pending_wrap_started_ts: AtomicU64::new(0),
-            pending_wrap_rpc_resync_done: AtomicBool::new(false),
+            pending_wrap: Arc::new(PendingWrapState::new()),
+            lock_manager_sync: None,
             build_version: build_version.to_string(),
             run_id: run_id.to_string(),
             jsonl_writer: None,
@@ -300,14 +364,25 @@ impl WsolManager {
             last_action_ts: AtomicU64::new(0),
             running: AtomicBool::new(true),
             wrap_in_progress: AtomicBool::new(false),
-            pending_wrap_expected_wsol: AtomicU64::new(0),
-            pending_wrap_started_ts: AtomicU64::new(0),
-            pending_wrap_rpc_resync_done: AtomicBool::new(false),
+            pending_wrap: Arc::new(PendingWrapState::new()),
+            lock_manager_sync: None,
             build_version: build_version.to_string(),
             run_id: run_id.to_string(),
             jsonl_writer: Some(jsonl_writer),
             kill_switch_checker: None,
         }
+    }
+
+    /// Share pending-wrap atomics with execution-engine (LockManager snapshot floor).
+    pub fn with_pending_wrap_state(mut self, state: Arc<PendingWrapState>) -> Self {
+        self.pending_wrap = state;
+        self
+    }
+
+    /// Seed LockManager after successful wrap or cold-path RPC resync.
+    pub fn with_lock_manager_sync(mut self, sync: WsolLockSyncCallback) -> Self {
+        self.lock_manager_sync = Some(sync);
+        self
     }
 
     /// Set kill switch checker function
@@ -392,23 +467,26 @@ impl WsolManager {
         Ok(())
     }
 
+    fn notify_lock_manager_wsol(&self, wsol_lamports: u64) {
+        if let Some(ref sync) = self.lock_manager_sync {
+            sync(wsol_lamports);
+        }
+    }
+
     /// Apply SOL/WSOL balance update (from JetStream WalletBalanceSnapshot)
     async fn apply_balance_update(&self, sol: u64, wsol_opt: Option<u64>) -> Result<()> {
         self.sol_balance.store(sol, Ordering::Relaxed);
 
         if let Some(incoming_wsol) = wsol_opt {
-            let pending_expected = self.pending_wrap_expected_wsol.load(Ordering::Relaxed);
-            let pending_started = self.pending_wrap_started_ts.load(Ordering::Relaxed);
+            let pending_expected = self.pending_wrap.pending_expected();
+            let pending_started = self.pending_wrap.pending_started_ts();
             let now = unix_secs();
 
             if pending_expected > 0 && pending_started > 0 {
                 let age = now.saturating_sub(pending_started);
                 if age > self.config.cooldown_secs.saturating_mul(4)
                     && incoming_wsol < pending_expected
-                    && self
-                        .pending_wrap_rpc_resync_done
-                        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-                        .is_ok()
+                    && self.pending_wrap.try_mark_rpc_resync_done()
                 {
                     match self
                         .treasury
@@ -424,10 +502,7 @@ impl WsolManager {
                                 rpc_wsol_lamports = b,
                                 "Pending wrap confirmation timed out; applied one bounded WSOL ATA RPC resync (cold path)"
                             );
-                            self.clear_pending_wrap_state();
-                            self.wsol_balance.store(b, Ordering::Relaxed);
-                            self.wsol_initialized.store(true, Ordering::Relaxed);
-                            WSOL_BALANCE_LAMPORTS.store(b, Ordering::Relaxed);
+                            self.apply_authoritative_wsol_resync(b);
                             debug!(
                                 sol = sol as f64 / LAMPORTS_PER_SOL as f64,
                                 wsol = Some(b as f64 / LAMPORTS_PER_SOL as f64),
@@ -449,7 +524,7 @@ impl WsolManager {
                 }
             }
 
-            let pending_expected = self.pending_wrap_expected_wsol.load(Ordering::Relaxed);
+            let pending_expected = self.pending_wrap.pending_expected();
             let (effective_wsol, snapshot_confirms_pending) =
                 compute_effective_wsol_on_snapshot(pending_expected, incoming_wsol);
 
@@ -481,20 +556,20 @@ impl WsolManager {
         self.check_and_act().await
     }
 
+    fn apply_authoritative_wsol_resync(&self, wsol_lamports: u64) {
+        self.clear_pending_wrap_state();
+        self.wsol_balance.store(wsol_lamports, Ordering::Relaxed);
+        self.wsol_initialized.store(true, Ordering::Relaxed);
+        WSOL_BALANCE_LAMPORTS.store(wsol_lamports, Ordering::Relaxed);
+        self.notify_lock_manager_wsol(wsol_lamports);
+    }
+
     fn clear_pending_wrap_state(&self) {
-        self.pending_wrap_expected_wsol.store(0, Ordering::SeqCst);
-        self.pending_wrap_started_ts.store(0, Ordering::SeqCst);
-        self.pending_wrap_rpc_resync_done
-            .store(false, Ordering::SeqCst);
+        self.pending_wrap.clear();
     }
 
     fn arm_pending_wrap_confirmation(&self, expected_wsol_lamports: u64) {
-        let now = unix_secs();
-        self.pending_wrap_expected_wsol
-            .store(expected_wsol_lamports, Ordering::SeqCst);
-        self.pending_wrap_started_ts.store(now, Ordering::SeqCst);
-        self.pending_wrap_rpc_resync_done
-            .store(false, Ordering::SeqCst);
+        self.pending_wrap.arm(expected_wsol_lamports);
     }
 
     #[cfg(test)]
@@ -511,8 +586,14 @@ impl WsolManager {
         let new_wsol = wsol_before.saturating_add(amount_lamports);
         self.wsol_balance.store(new_wsol, Ordering::Relaxed);
         self.arm_pending_wrap_confirmation(new_wsol);
+        self.notify_lock_manager_wsol(new_wsol);
         WSOL_BALANCE_LAMPORTS.store(new_wsol, Ordering::Relaxed);
         self.wsol_initialized.store(true, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    fn test_apply_authoritative_wsol_resync(&self, wsol_lamports: u64) {
+        self.apply_authoritative_wsol_resync(wsol_lamports);
     }
 
     #[cfg(test)]
@@ -525,7 +606,7 @@ impl WsolManager {
 
     #[cfg(test)]
     pub(crate) fn test_pending_expected_wsol(&self) -> u64 {
-        self.pending_wrap_expected_wsol.load(Ordering::Relaxed)
+        self.pending_wrap.pending_expected()
     }
 
     /// Check current balances and wrap/unwrap if needed
@@ -552,7 +633,7 @@ impl WsolManager {
         // Do not start another wrap while a successful wrap is not yet confirmed by snapshot
         // (or timeout + bounded RPC resync). Cooldown alone is insufficient when stale snapshots
         // carry wsol=0 across the cooldown window.
-        if self.pending_wrap_expected_wsol.load(Ordering::Relaxed) > 0 {
+        if self.pending_wrap.pending_expected() > 0 {
             debug!("Pending post-wrap snapshot confirmation; skipping new wrap attempts");
             return Ok(());
         }
@@ -708,6 +789,7 @@ impl WsolManager {
                     .fetch_add(amount_lamports, Ordering::Relaxed)
                     + amount_lamports;
                 self.arm_pending_wrap_confirmation(new_wsol);
+                self.notify_lock_manager_wsol(new_wsol);
                 // Update Prometheus metrics
                 WSOL_WRAP_TOTAL.fetch_add(1, Ordering::Relaxed);
                 WSOL_WRAP_LAMPORTS_TOTAL.fetch_add(amount_lamports, Ordering::Relaxed);
@@ -1113,6 +1195,38 @@ mod tests {
 
         // Should NOT unwrap (below max)
         assert!(current_wsol <= max_wsol);
+    }
+
+    #[test]
+    fn successful_wrap_syncs_lock_manager_callback() {
+        let treasury = Arc::new(Treasury::from_signer(Arc::new(Keypair::new())));
+        let rpc = Arc::new(SolanaRpc::new("http://127.0.0.1:0"));
+        let synced = Arc::new(AtomicU64::new(0));
+        let synced_cb = Arc::clone(&synced);
+        let mgr = WsolManager::new(WsolManagerConfig::default(), treasury, rpc, "test", "run")
+            .with_lock_manager_sync(Arc::new(move |wsol| {
+                synced_cb.store(wsol, Ordering::SeqCst);
+            }));
+
+        mgr.test_simulate_successful_wrap_optimistic(1_000_000_000, 3_000_000_000, 0);
+        assert_eq!(synced.load(Ordering::SeqCst), 1_000_000_000);
+        assert_eq!(mgr.wsol_balance(), 1_000_000_000);
+    }
+
+    #[test]
+    fn rpc_resync_success_syncs_lock_manager_callback() {
+        let treasury = Arc::new(Treasury::from_signer(Arc::new(Keypair::new())));
+        let rpc = Arc::new(SolanaRpc::new("http://127.0.0.1:0"));
+        let synced = Arc::new(AtomicU64::new(0));
+        let synced_cb = Arc::clone(&synced);
+        let mgr = WsolManager::new(WsolManagerConfig::default(), treasury, rpc, "test", "run")
+            .with_lock_manager_sync(Arc::new(move |wsol| {
+                synced_cb.store(wsol, Ordering::SeqCst);
+            }));
+
+        mgr.test_apply_authoritative_wsol_resync(1_000_000_000);
+        assert_eq!(synced.load(Ordering::SeqCst), 1_000_000_000);
+        assert_eq!(mgr.test_pending_expected_wsol(), 0);
     }
 
     #[tokio::test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4375,6 +4375,8 @@ pub static WSOL_WRAP_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static WSOL_UNWRAP_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static WSOL_WRAP_LAMPORTS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static WSOL_UNWRAP_LAMPORTS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static WSOL_LOCK_MANAGER_SNAPSHOT_FLOORED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 // --- AccountJanitor metrics ---
 pub static JANITOR_CLOSE_ATA_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -9190,6 +9192,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "wsol_unwrap_lamports_total",
         WSOL_UNWRAP_LAMPORTS_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "wsol_lock_manager_snapshot_floored_total",
+        WSOL_LOCK_MANAGER_SNAPSHOT_FLOORED_TOTAL.load(Ordering::Relaxed)
     );
 
     // --- AccountJanitor ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After kill-reset wrap, LockManager stayed at `available_wsol=0` while WsolManager held the optimistic post-wrap balance. BUY intents failed with `LOCK_CAPITAL_CONFLICT` (33×) despite on-chain WSOL.

## Root cause

- Capital heartbeat / `try_lock_capital` read LockManager only, not WsolManager atomics
- Successful wrap updated WsolManager but not LockManager
- `apply_wallet_balance_snapshot_event` blindly set LockManager to stale `wsol=0` before WsolManager floor logic
- Cold-path RPC resync updated WsolManager only

## Fix

- **Shared `PendingWrapState`** between WsolManager and execution-engine
- **LockManager callback** on wrap success and cold-path `pending_wrap_timeout_rpc_resync`
- **Snapshot apply floor**: LockManager uses `effective_wsol_for_snapshot` (same semantics as WsolManager)
- Metric `wsol_lock_manager_snapshot_floored_total` + unit tests

## Invariants

- No new RPC in hot path (I-7)
- Pending-wrap floor does not overbook (I-20)
- Simulation gate unchanged (I-9)

## Tests

- `successful_wrap_syncs_lock_manager_callback`
- `rpc_resync_success_syncs_lock_manager_callback`
- `lock_manager_pending_wrap_floors_stale_zero_snapshot`
- `lock_manager_pending_wrap_confirms_on_matching_snapshot`
- `lock_manager_without_pending_accepts_zero_unwrap_snapshot`

## Changed files

- `src/execution/wsol_manager.rs`
- `src/bin/execution_engine.rs`
- `src/metrics.rs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf2d9b16-c403-4fe3-848b-8a2468a5e885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf2d9b16-c403-4fe3-848b-8a2468a5e885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

