### PR TITLE
feat(PA-6a): position-manager shadow binary scaffold

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,10 @@ path = "src/bin/burn_manual_keyless.rs"
 name = "manual-swap"
 path = "src/bin/manual_swap.rs"
 
+[[bin]]
+name = "position-manager"
+path = "src/bin/position_manager.rs"
+
 [[test]]
 name = "multi_hop_sanity"
 path = "tests/multi_hop_sanity.rs"

--- a/config/position_manager.toml.example
+++ b/config/position_manager.toml.example
@@ -1,0 +1,9 @@
+# PA-6a shadow position-manager — NOT the productive PositionAuthority KV writer.
+# EE remains writer on POSITION_AUTHORITY until PA-6b cutover.
+
+[position_manager]
+# Default false in production deploy; set true to run shadow reducer.
+enabled = false
+metrics_port = 9805
+# Trading wallet pubkey (or use IRONCRAB_WALLET_PUBKEY env / --wallet-pubkey CLI).
+# wallet_pubkey = "YourWalletPubkeyHere"

--- a/deploy_new.sh
+++ b/deploy_new.sh
@@ -79,6 +79,9 @@ if [ "$SKIP_BUILD" = false ]; then
     
     log_info "Building execution-engine..."
     cargo build --release --bin execution-engine
+
+    log_info "Building position-manager (PA-6a shadow, optional service)..."
+    cargo build --release --bin position-manager
     
     log_info "All binaries built successfully."
 else

--- a/docs/systemd/position-manager.service
+++ b/docs/systemd/position-manager.service
@@ -1,0 +1,43 @@
+[Unit]
+Description=IronCrab Position Manager (PA-6a Shadow, Keyless)
+After=network-online.target nats.service market-data.service execution-engine.service
+Wants=network-online.target
+# PA-6a: deliberately NOT PartOf=ironcrab.target until PA-6b cutover approval.
+
+StartLimitBurst=10
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+User=ironcrab
+Group=ironcrab
+WorkingDirectory=/home/ironcrab/Iron_crab
+
+ExecStart=/home/ironcrab/Iron_crab/target/release/position-manager \
+    --config /home/ironcrab/Iron_crab/my_config.server.toml \
+    --nats-url nats://localhost:4222 \
+    --metrics-port 9805
+
+Environment=RUST_LOG=info,position_manager=info
+# Wallet pubkey for JetStream wallet-snapshot filter (set by deploy or override):
+# Environment=IRONCRAB_WALLET_PUBKEY=
+
+# IMPORTANT: No wallet keys (keyless shadow reducer)
+# Do NOT set IRONCRAB_KEYPAIR_PATH/KEYPAIR_PATH in this service.
+
+Restart=on-failure
+RestartSec=3
+
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+CPUWeight=50
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=read-only
+
+[Install]
+# PA-6a shadow: enable manually after validation — not auto-started with ironcrab.target.
+# WantedBy=ironcrab.target

--- a/src/bin/position_manager.rs
+++ b/src/bin/position_manager.rs
@@ -1,0 +1,582 @@
+//! position-manager binary — PA-6a shadow PositionAuthority reducer.
+//!
+//! Keyless process that mirrors execution-engine PositionAuthority updates from JetStream
+//! (ExecutionResult + WalletBalanceSnapshot) without writing to the productive
+//! `POSITION_AUTHORITY` KV bucket. EE remains the sole KV writer until PA-6b cutover.
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use futures::StreamExt;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::watch;
+use tracing::{debug, error, info, warn};
+
+use ironcrab::config::Config;
+use ironcrab::ipc::schema::{ExecutionResult, ExecutionStatus, MarketEvent, MarketEventKind};
+use ironcrab::metrics::{
+    record_activity, record_position_manager_event_applied,
+    refresh_position_manager_authority_gauges, serve_metrics, set_readiness_nats_connected,
+    MetricsComponent, NATS_MESSAGES_RECEIVED_TOTAL,
+};
+use ironcrab::nats::jetstream::{
+    ensure_execution_results_stream, execution_results_consumer_config,
+    wallet_snapshot_consumer_config, wallet_snapshot_live_consumer_config_position_manager,
+    EXECUTION_RESULTS_STREAM_NAME, WALLET_SNAPSHOT_STREAM_NAME,
+};
+use ironcrab::nats::{NatsClient, NatsConfig, TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS};
+use ironcrab::position_authority::PositionAuthority;
+
+type JetStreamPullConsumer =
+    async_nats::jetstream::consumer::Consumer<async_nats::jetstream::consumer::pull::Config>;
+
+const PM_JETSTREAM_CONSUMER_BATCH_MAX: usize = 15;
+const PM_JETSTREAM_CONSUMER_FETCH_EXPIRES: Duration = Duration::from_millis(100);
+const PM_EXECUTION_RESULT_FETCH_EXPIRES: Duration = Duration::from_millis(250);
+
+#[derive(Parser, Debug)]
+#[command(name = "position-manager")]
+#[command(about = "IronCrab PA-6a shadow PositionAuthority reducer (keyless, no KV writes)")]
+struct Args {
+    /// Path to configuration file (optional; reads [position_manager] when present).
+    #[arg(short, long, default_value = "config.toml")]
+    config: PathBuf,
+
+    /// NATS server URL
+    #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
+    nats_url: String,
+
+    /// Prometheus metrics port
+    #[arg(long, default_value = "9805")]
+    metrics_port: u16,
+
+    /// Trading wallet pubkey for wallet-snapshot JetStream filter
+    #[arg(long, env = "IRONCRAB_WALLET_PUBKEY")]
+    wallet_pubkey: Option<String>,
+}
+
+struct PositionManagerContext {
+    position_authority: Mutex<PositionAuthority>,
+}
+
+impl PositionManagerContext {
+    fn new() -> Self {
+        Self {
+            position_authority: Mutex::new(PositionAuthority::new()),
+        }
+    }
+
+    fn apply_execution_result(&self, exec: &ExecutionResult) {
+        if exec.status != ExecutionStatus::Confirmed {
+            return;
+        }
+        {
+            let mut pa = self.position_authority.lock();
+            let _changes = pa.apply_from_confirmed_execution_result(exec);
+        }
+        record_position_manager_event_applied();
+        self.refresh_metrics();
+    }
+
+    fn apply_wallet_event_kind(&self, kind: &MarketEventKind) {
+        {
+            let mut pa = self.position_authority.lock();
+            let _changes = pa.apply_from_wallet_market_event_kind(kind);
+        }
+        record_position_manager_event_applied();
+        self.refresh_metrics();
+    }
+
+    fn refresh_metrics(&self) {
+        let pa = self.position_authority.lock();
+        refresh_position_manager_authority_gauges(
+            pa.open_positions_count() as u64,
+            pa.reconcile_needed_positions_count() as u64,
+        );
+    }
+}
+
+fn ensure_keyless_or_exit() {
+    let key_vars = [
+        "IRONCRAB_KEYPAIR_JSON",
+        "IRONCRAB_KEYPAIR_B64",
+        "IRONCRAB_KEYPAIR_PATH",
+        "IRONCRAB_KEYPAIR_BASE58",
+    ];
+
+    if key_vars.iter().any(|v| std::env::var(v).is_ok()) {
+        error!(
+            "ERROR: Wallet key environment variables detected! position-manager is KEYLESS per architecture."
+        );
+        error!("Only execution-engine should have access to wallet keys.");
+        std::process::exit(1);
+    }
+}
+
+fn resolve_wallet_pubkey(args: &Args) -> Result<String> {
+    if let Some(ref pk) = args.wallet_pubkey {
+        return Ok(pk.clone());
+    }
+
+    if let Ok(pk) = std::env::var("IRONCRAB_WALLET_PUBKEY") {
+        return Ok(pk);
+    }
+
+    if args.config.exists() {
+        let cfg = Config::load(&args.config).context("load config for wallet_pubkey")?;
+        if let Some(pm) = cfg.position_manager {
+            if let Some(pk) = pm.wallet_pubkey {
+                return Ok(pk);
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "wallet pubkey required: pass --wallet-pubkey, set IRONCRAB_WALLET_PUBKEY, or [position_manager].wallet_pubkey in config"
+    );
+}
+
+fn resolve_metrics_port(args: &Args) -> u16 {
+    if args.config.exists() {
+        if let Ok(cfg) = Config::load(&args.config) {
+            if let Some(pm) = cfg.position_manager {
+                return pm.metrics_port;
+            }
+        }
+    }
+    args.metrics_port
+}
+
+fn is_enabled(args: &Args) -> bool {
+    if args.config.exists() {
+        if let Ok(cfg) = Config::load(&args.config) {
+            if let Some(pm) = cfg.position_manager {
+                return pm.enabled;
+            }
+        }
+    }
+    // CLI-only runs default to enabled so operators can smoke-test without config edits.
+    true
+}
+
+/// Bootstrap wallet snapshots from JetStream (LastPerSubject per mint) into PositionAuthority.
+async fn bootstrap_position_authority_from_wallet_snapshot(
+    nats: &NatsClient,
+    wallet: &str,
+    ctx: &Arc<PositionManagerContext>,
+) -> usize {
+    use async_nats::jetstream;
+
+    let jetstream = jetstream::new(nats.client().clone());
+    let stream = match jetstream.get_stream(WALLET_SNAPSHOT_STREAM_NAME).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                error = %e,
+                stream = WALLET_SNAPSHOT_STREAM_NAME,
+                "Wallet snapshot stream not found during bootstrap (market-data may not be running)"
+            );
+            return 0;
+        }
+    };
+
+    let mut consumer_config = wallet_snapshot_consumer_config();
+    consumer_config.filter_subject = format!("ironcrab.wallet_snapshot.{}.*", wallet);
+
+    let consumer = match stream.create_consumer(consumer_config).await {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, "Failed to create wallet snapshot bootstrap consumer");
+            return 0;
+        }
+    };
+
+    let batch_size = 1000;
+    let mut observed = 0usize;
+
+    loop {
+        let mut messages = match consumer.fetch().max_messages(batch_size).messages().await {
+            Ok(m) => m,
+            Err(e) => {
+                debug!(error = %e, "Wallet snapshot bootstrap fetch ended");
+                break;
+            }
+        };
+
+        let mut batch_count = 0;
+        while let Some(msg_result) = messages.next().await {
+            batch_count += 1;
+            let msg = match msg_result {
+                Ok(m) => m,
+                Err(e) => {
+                    debug!(error = %e, "Wallet snapshot bootstrap message error");
+                    continue;
+                }
+            };
+
+            match serde_json::from_slice::<MarketEvent>(&msg.payload) {
+                Ok(event) => {
+                    observed += 1;
+                    ctx.apply_wallet_event_kind(&event.kind);
+                }
+                Err(e) => {
+                    debug!(error = %e, "Failed to deserialize wallet snapshot MarketEvent");
+                }
+            }
+
+            if let Err(e) = msg.ack().await {
+                debug!(error = %e, "Failed to ack wallet snapshot bootstrap message");
+            }
+        }
+
+        if batch_count < batch_size {
+            break;
+        }
+    }
+
+    info!(
+        wallet = %wallet,
+        snapshots = observed,
+        open_positions = ctx.position_authority.lock().open_positions_count(),
+        "Wallet snapshot bootstrap applied to shadow PositionAuthority"
+    );
+
+    observed
+}
+
+async fn create_wallet_snapshot_live_consumer(
+    nats: &NatsClient,
+    wallet: &str,
+    bootstrap_observed: usize,
+) -> Option<JetStreamPullConsumer> {
+    use async_nats::jetstream;
+
+    let jetstream = jetstream::new(nats.client().clone());
+    let stream = match jetstream.get_stream(WALLET_SNAPSHOT_STREAM_NAME).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                error = %e,
+                stream = WALLET_SNAPSHOT_STREAM_NAME,
+                "JetStream wallet snapshot stream not found (market-data may not be running)"
+            );
+            return None;
+        }
+    };
+
+    let mut cfg = wallet_snapshot_live_consumer_config_position_manager(wallet);
+    if bootstrap_observed == 0 {
+        cfg.deliver_policy = jetstream::consumer::DeliverPolicy::LastPerSubject;
+    }
+
+    match stream.create_consumer(cfg).await {
+        Ok(consumer) => {
+            info!(
+                stream = WALLET_SNAPSHOT_STREAM_NAME,
+                wallet = %wallet,
+                deliver_policy = if bootstrap_observed == 0 {
+                    "LastPerSubject"
+                } else {
+                    "New"
+                },
+                "Subscribed to JetStream WalletBalanceSnapshot (shadow live)"
+            );
+            Some(consumer)
+        }
+        Err(e) => {
+            warn!(error = %e, "Failed to create JetStream wallet snapshot live consumer");
+            None
+        }
+    }
+}
+
+async fn run_wallet_snapshot_consumer_task(
+    ctx: Arc<PositionManagerContext>,
+    consumer: JetStreamPullConsumer,
+    shutdown_rx: watch::Receiver<bool>,
+) {
+    loop {
+        if *shutdown_rx.borrow() {
+            info!("Wallet snapshot consumer task shutting down");
+            break;
+        }
+
+        match consumer
+            .fetch()
+            .max_messages(PM_JETSTREAM_CONSUMER_BATCH_MAX)
+            .expires(PM_JETSTREAM_CONSUMER_FETCH_EXPIRES)
+            .messages()
+            .await
+        {
+            Ok(mut messages) => {
+                let mut batch: Vec<(async_nats::jetstream::Message, MarketEvent)> = Vec::new();
+                while let Some(msg_result) = messages.next().await {
+                    match msg_result {
+                        Ok(msg) => match serde_json::from_slice::<MarketEvent>(&msg.payload) {
+                            Ok(event) => batch.push((msg, event)),
+                            Err(e) => {
+                                debug!(error = %e, "Failed to deserialize wallet snapshot MarketEvent");
+                                let _ = msg.ack().await;
+                            }
+                        },
+                        Err(e) => {
+                            debug!(error = %e, "JetStream wallet snapshot fetch returned error");
+                        }
+                    }
+                }
+
+                let mut last_index_by_mint: HashMap<String, usize> = HashMap::new();
+                for (idx, (_, event)) in batch.iter().enumerate() {
+                    if let MarketEventKind::WalletBalanceSnapshot { mint, .. } = &event.kind {
+                        last_index_by_mint.insert(mint.clone(), idx);
+                    }
+                }
+
+                for (idx, (msg, event)) in batch.into_iter().enumerate() {
+                    let apply =
+                        if let MarketEventKind::WalletBalanceSnapshot { mint, .. } = &event.kind {
+                            last_index_by_mint.get(mint) == Some(&idx)
+                        } else {
+                            true
+                        };
+                    if apply {
+                        record_activity();
+                        NATS_MESSAGES_RECEIVED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                        ctx.apply_wallet_event_kind(&event.kind);
+                    }
+                    if let Err(e) = msg.ack().await {
+                        debug!(error = %e, "Failed to ack wallet snapshot message");
+                    }
+                }
+            }
+            Err(e) => {
+                debug!(error = %e, "No new wallet snapshot messages in JetStream");
+            }
+        }
+
+        tokio::task::yield_now().await;
+    }
+}
+
+async fn drain_execution_results(
+    consumer: &JetStreamPullConsumer,
+    ctx: &Arc<PositionManagerContext>,
+    max_messages: usize,
+    fetch_expires: Duration,
+) -> u32 {
+    let mut messages = match consumer
+        .fetch()
+        .max_messages(max_messages)
+        .expires(fetch_expires)
+        .messages()
+        .await
+    {
+        Ok(m) => m,
+        Err(e) => {
+            debug!(error = %e, "ExecutionResult JetStream fetch failed (may be empty)");
+            return 0;
+        }
+    };
+
+    let mut processed: u32 = 0;
+    while let Some(msg_res) = messages.next().await {
+        match msg_res {
+            Ok(msg) => {
+                record_activity();
+                NATS_MESSAGES_RECEIVED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                match serde_json::from_slice::<ExecutionResult>(&msg.payload) {
+                    Ok(result) => {
+                        ctx.apply_execution_result(&result);
+                        processed = processed.saturating_add(1);
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "Failed to deserialize ExecutionResult");
+                    }
+                }
+                if let Err(e) = msg.ack().await {
+                    warn!(error = %e, "Failed to ack ExecutionResult");
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "ExecutionResult stream message error");
+            }
+        }
+    }
+
+    processed
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("position_manager=info".parse()?)
+                .add_directive("ironcrab=info".parse()?),
+        )
+        .init();
+
+    let args = Args::parse();
+    ensure_keyless_or_exit();
+
+    if !is_enabled(&args) {
+        info!(
+            config = %args.config.display(),
+            "position-manager disabled via [position_manager].enabled=false — exiting"
+        );
+        return Ok(());
+    }
+
+    let wallet = resolve_wallet_pubkey(&args)?;
+    let metrics_port = resolve_metrics_port(&args);
+
+    info!(
+        wallet = %wallet,
+        metrics_port,
+        nats_url = %args.nats_url,
+        "Starting position-manager (PA-6a shadow — not prod KV writer)"
+    );
+
+    let metrics_addr = SocketAddr::from(([0, 0, 0, 0], metrics_port));
+    tokio::spawn(async move {
+        if let Err(e) = serve_metrics(metrics_addr, MetricsComponent::PositionManager).await {
+            error!(error = %e, "Metrics server failed");
+        }
+    });
+
+    let mut nats_config = NatsConfig::new(&args.nats_url, "position-manager");
+    nats_config.request_timeout = NatsConfig::request_timeout_from_env(180);
+    let mut nats = NatsClient::new(nats_config);
+    nats.connect()
+        .await
+        .context("connect to NATS for position-manager")?;
+    set_readiness_nats_connected(true);
+    info!(url = %args.nats_url, "Connected to NATS");
+
+    if let Err(e) = ensure_execution_results_stream(nats.client()).await {
+        warn!(error = %e, "Failed to ensure EXECUTION_RESULTS stream (may already exist)");
+    }
+
+    let ctx = Arc::new(PositionManagerContext::new());
+
+    let bootstrap_observed =
+        bootstrap_position_authority_from_wallet_snapshot(&nats, &wallet, &ctx).await;
+
+    let wallet_snapshot_consumer =
+        create_wallet_snapshot_live_consumer(&nats, &wallet, bootstrap_observed).await;
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    if let Some(consumer) = wallet_snapshot_consumer {
+        let wallet_ctx = Arc::clone(&ctx);
+        let wallet_shutdown = shutdown_rx.clone();
+        tokio::spawn(async move {
+            run_wallet_snapshot_consumer_task(wallet_ctx, consumer, wallet_shutdown).await;
+        });
+    }
+
+    let execution_js_consumer = {
+        use async_nats::jetstream;
+
+        let jetstream = jetstream::new(nats.client().clone());
+        match jetstream.get_stream(EXECUTION_RESULTS_STREAM_NAME).await {
+            Ok(stream) => match stream
+                .create_consumer(execution_results_consumer_config("position-manager"))
+                .await
+            {
+                Ok(consumer) => {
+                    info!(
+                        stream = EXECUTION_RESULTS_STREAM_NAME,
+                        topic = TOPIC_EXECUTION_RESULTS,
+                        "Subscribed to ExecutionResults via JetStream (shadow reducer)"
+                    );
+                    Some(consumer)
+                }
+                Err(e) => {
+                    warn!(error = %e, "Failed to create execution results consumer");
+                    None
+                }
+            },
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    stream = EXECUTION_RESULTS_STREAM_NAME,
+                    "Failed to get execution results stream"
+                );
+                None
+            }
+        }
+    };
+
+    let mut market_events_sub = match nats.subscribe(TOPIC_MARKET_EVENTS).await {
+        Ok(sub) => {
+            info!(
+                topic = TOPIC_MARKET_EVENTS,
+                "Subscribed to MarketEvents for WalletSnapshotComplete"
+            );
+            Some(sub)
+        }
+        Err(e) => {
+            warn!(error = %e, topic = TOPIC_MARKET_EVENTS, "Failed to subscribe to MarketEvents");
+            None
+        }
+    };
+
+    ctx.refresh_metrics();
+
+    loop {
+        tokio::select! {
+            biased;
+
+            _ = tokio::signal::ctrl_c() => {
+                info!("Shutdown signal received");
+                let _ = shutdown_tx.send(true);
+                break;
+            }
+
+            msg = async {
+                match market_events_sub.as_mut() {
+                    Some(sub) => sub.next().await,
+                    None => std::future::pending().await,
+                }
+            } => {
+                if let Some(msg) = msg {
+                    record_activity();
+                    NATS_MESSAGES_RECEIVED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                    match serde_json::from_slice::<MarketEvent>(&msg.payload) {
+                        Ok(event) => {
+                            if matches!(event.kind, MarketEventKind::WalletSnapshotComplete { .. }) {
+                                ctx.apply_wallet_event_kind(&event.kind);
+                            }
+                        }
+                        Err(e) => {
+                            debug!(error = %e, "Failed to deserialize MarketEvent");
+                        }
+                    }
+                }
+            }
+
+            _ = async {
+                if let Some(ref consumer) = execution_js_consumer {
+                    let _ = drain_execution_results(
+                        consumer,
+                        &ctx,
+                        PM_JETSTREAM_CONSUMER_BATCH_MAX,
+                        PM_EXECUTION_RESULT_FETCH_EXPIRES,
+                    )
+                    .await;
+                } else {
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+            } => {}
+        }
+    }
+
+    info!("position-manager shutdown complete");
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -267,6 +267,28 @@ pub struct Config {
     pub execution_engine: Option<ExecutionEngineCfg>,
     #[serde(default)]
     pub market_data_geyser: MarketDataGeyserCfg,
+    /// PA-6a shadow position-manager (keyless; not prod KV writer until PA-6b).
+    #[serde(default)]
+    pub position_manager: Option<PositionManagerCfg>,
+}
+
+/// Position Manager Configuration (PA-6a shadow binary)
+/// TOML section: [position_manager]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PositionManagerCfg {
+    /// When false, binary exits early (deploy keeps service disabled by default).
+    #[serde(default)]
+    pub enabled: bool,
+    /// Prometheus metrics HTTP port. Default: 9805
+    #[serde(default = "default_position_manager_metrics_port")]
+    pub metrics_port: u16,
+    /// Trading wallet pubkey for wallet-snapshot JetStream filter.
+    #[serde(default)]
+    pub wallet_pubkey: Option<String>,
+}
+
+fn default_position_manager_metrics_port() -> u16 {
+    9805
 }
 
 /// Execution Engine Configuration (for execution-engine binary)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3320,6 +3320,18 @@ pub fn record_momentum_soft_exit_suppressed_authority_total(
 }
 
 #[inline]
+/// PA-6a shadow: refresh position-manager authority gauges from local reducer state.
+pub fn refresh_position_manager_authority_gauges(open: u64, reconcile_needed: u64) {
+    POSITION_MANAGER_OPEN_POSITIONS_GAUGE.store(open, Ordering::Relaxed);
+    POSITION_MANAGER_RECONCILE_NEEDED_GAUGE.store(reconcile_needed, Ordering::Relaxed);
+    POSITION_MANAGER_UP_GAUGE.store(1, Ordering::Relaxed);
+}
+
+/// PA-6a shadow: increment events-applied counter after a reducer apply.
+pub fn record_position_manager_event_applied() {
+    POSITION_MANAGER_EVENTS_APPLIED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
 pub fn set_position_authority_drift_momentum(drift: i64) {
     POSITION_AUTHORITY_DRIFT_MOMENTUM.store(drift, Ordering::Relaxed);
 }
@@ -4296,6 +4308,8 @@ pub enum MetricsComponent {
     ExecutionEngine,
     MomentumBot,
     ArbStrategy,
+    /// PA-6a shadow: position-manager reduces PositionAuthority locally (not prod KV writer).
+    PositionManager,
 }
 
 /// Set readiness: NATS connected
@@ -6423,6 +6437,15 @@ pub static POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE: Lazy<AtomicU64> =
 pub static POSITION_AUTHORITY_DRIFT_LOCKMANAGER: Lazy<AtomicI64> = Lazy::new(|| AtomicI64::new(0));
 /// PA-5.1: `authority_open - momentum_overlay_count` (signed; Prometheus scalar).
 pub static POSITION_AUTHORITY_DRIFT_MOMENTUM: Lazy<AtomicI64> = Lazy::new(|| AtomicI64::new(0));
+/// PA-6a shadow: position-manager process heartbeat (1 = up).
+pub static POSITION_MANAGER_UP_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// PA-6a shadow: open positions from local PositionAuthority reducer.
+pub static POSITION_MANAGER_OPEN_POSITIONS_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// PA-6a shadow: reconcile-needed positions from local PositionAuthority reducer.
+pub static POSITION_MANAGER_RECONCILE_NEEDED_GAUGE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// PA-6a shadow: total events applied to local PositionAuthority reducer.
+pub static POSITION_MANAGER_EVENTS_APPLIED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// PA-4: liquidation skipped LockManager seed because PositionAuthority reports closed/zero.
 pub static LIQUIDATION_SEED_SKIPPED_AUTHORITY_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -10221,6 +10244,22 @@ async fn metrics_response() -> Response<Body> {
         LIQUIDATION_SEED_SKIPPED_AUTHORITY_TOTAL.load(Ordering::Relaxed)
     );
     line!(
+        "position_manager_up",
+        POSITION_MANAGER_UP_GAUGE.load(Ordering::Relaxed)
+    );
+    line!(
+        "position_manager_open_positions",
+        POSITION_MANAGER_OPEN_POSITIONS_GAUGE.load(Ordering::Relaxed)
+    );
+    line!(
+        "position_manager_reconcile_needed_positions",
+        POSITION_MANAGER_RECONCILE_NEEDED_GAUGE.load(Ordering::Relaxed)
+    );
+    line!(
+        "position_manager_events_applied_total",
+        POSITION_MANAGER_EVENTS_APPLIED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
         "concurrent_intents",
         CONCURRENT_INTENTS_GAUGE.load(Ordering::Relaxed)
     );
@@ -10654,6 +10693,15 @@ fn status_response(component: MetricsComponent) -> String {
                 },
             )
         }
+        MetricsComponent::PositionManager => (
+            "position-manager",
+            nats,
+            if nats {
+                vec![]
+            } else {
+                vec!["nats_connected".to_string()]
+            },
+        ),
     };
 
     let reason_not_ready = if !ready && !missing_checks.is_empty() {

--- a/src/nats/jetstream.rs
+++ b/src/nats/jetstream.rs
@@ -502,6 +502,21 @@ pub fn wallet_snapshot_live_consumer_config_execution_engine(
     }
 }
 
+/// Consumer config for live WalletBalanceSnapshot updates in position-manager (PA-6a shadow).
+/// Durable consumer scoped per wallet; DeliverPolicy may be overridden at create time.
+pub fn wallet_snapshot_live_consumer_config_position_manager(
+    wallet: &str,
+) -> jetstream::consumer::pull::Config {
+    jetstream::consumer::pull::Config {
+        deliver_policy: jetstream::consumer::DeliverPolicy::New,
+        ack_policy: jetstream::consumer::AckPolicy::Explicit,
+        durable_name: Some(format!("position-manager-wallet-snapshot-{}", wallet)),
+        max_ack_pending: 1000,
+        filter_subject: format!("ironcrab.wallet_snapshot.{}.*", wallet),
+        ..Default::default()
+    }
+}
+
 /// Consumer config for live WalletTxConfirmed updates in execution-engine.
 /// Durable consumer scoped per wallet; `DeliverPolicy::All` includes confirms published
 /// before the consumer exists (e.g. stream/EE startup ordering gap).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PA-6a introduces a keyless `position-manager` binary that reduces `PositionAuthority` locally from JetStream events (ExecutionResult + WalletBalanceSnapshot) **without** writing to the productive `POSITION_AUTHORITY` KV bucket. EE remains the sole KV writer until PA-6b cutover.

## Changes

- **New binary** `src/bin/position_manager.rs` — JetStream consumers, Core NATS WalletSnapshotComplete, graceful shutdown
- **Shadow metrics** — `position_manager_up`, `position_manager_open_positions`, `position_manager_reconcile_needed_positions`, `position_manager_events_applied_total` (port 9805)
- **Config** — optional `[position_manager]` section + `config/position_manager.toml.example` (`enabled = false`)
- **Deploy** — `deploy_new.sh` builds binary; `docs/systemd/position-manager.service` (not auto-enabled in ironcrab.target)
- **JetStream** — `wallet_snapshot_live_consumer_config_position_manager`

## Invariants (verified)

- **I-1/I-2**: Keyless — no keypair loading
- **I-7**: No RPC — JetStream/Core NATS only
- **No KV write** on `POSITION_AUTHORITY`
- **No changes** to EE/Momentum trading gates

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --bin position-manager -- -D warnings`
- [x] `cargo test`
- [x] `cargo build --release --bin position-manager`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f94e9eca-38cf-4d70-92b1-e0d318161005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f94e9eca-38cf-4d70-92b1-e0d318161005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

