### PR TITLE
PA-6b: position-manager sole POSITION_AUTHORITY KV writer

### DIFF
--- a/config/position_manager.toml.example
+++ b/config/position_manager.toml.example
@@ -1,9 +1,7 @@
-# PA-6a shadow position-manager — NOT the productive PositionAuthority KV writer.
-# EE remains writer on POSITION_AUTHORITY until PA-6b cutover.
+# PA-6b position-manager — sole productive PositionAuthority KV writer.
 
 [position_manager]
-# Default false in production deploy; set true to run shadow reducer.
-enabled = false
+enabled = true
 metrics_port = 9805
 # Trading wallet pubkey (or use IRONCRAB_WALLET_PUBKEY env / --wallet-pubkey CLI).
 # wallet_pubkey = "YourWalletPubkeyHere"

--- a/deploy_new.sh
+++ b/deploy_new.sh
@@ -48,7 +48,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Components
-COMPONENTS=("market-data" "momentum-bot" "arb-strategy" "execution-engine")
+COMPONENTS=("market-data" "position-manager" "momentum-bot" "arb-strategy" "execution-engine")
 SYSTEMD_DIR="/etc/systemd/system"
 SYSTEMD_SRC_DIR="$SCRIPT_DIR/docs/systemd"
 
@@ -80,7 +80,7 @@ if [ "$SKIP_BUILD" = false ]; then
     log_info "Building execution-engine..."
     cargo build --release --bin execution-engine
 
-    log_info "Building position-manager (PA-6a shadow, optional service)..."
+    log_info "Building position-manager (PA-6b POSITION_AUTHORITY KV writer)..."
     cargo build --release --bin position-manager
     
     log_info "All binaries built successfully."
@@ -131,7 +131,13 @@ EOF
 [Service]
 Environment="IRONCRAB_WALLET_PUBKEY=$WALLET_PUBKEY"
 EOF
+        sudo mkdir -p /etc/systemd/system/position-manager.service.d/
+        sudo tee /etc/systemd/system/position-manager.service.d/wallet.conf > /dev/null <<EOF
+[Service]
+Environment="IRONCRAB_WALLET_PUBKEY=$WALLET_PUBKEY"
+EOF
         log_info "market-data will publish wallet balance snapshot at startup"
+        log_info "position-manager will filter wallet snapshots for $WALLET_PUBKEY"
     else
         log_warn "Could not extract wallet pubkey (position reconciliation disabled)"
     fi
@@ -150,6 +156,7 @@ install_service() {
 
 log_info "Installing systemd services..."
 install_service "market-data"
+install_service "position-manager"
 install_service "momentum-bot"
 install_service "arb-strategy"
 install_service "execution-engine"
@@ -184,7 +191,7 @@ else
     # systemctl start ironcrab.target does NOT restart already-running Wants= units;
     # after cargo build replaces binaries, stale processes keep the old inode until restarted.
     log_info "Restarting all IronCrab services..."
-    SERVICES=(market-data momentum-bot arb-strategy execution-engine control-plane trades-server)
+    SERVICES=(market-data position-manager momentum-bot arb-strategy execution-engine control-plane trades-server)
     for svc in "${SERVICES[@]}"; do
         log_info "Restarting $svc..."
         sudo systemctl restart "$svc"
@@ -203,7 +210,7 @@ sudo systemctl enable ironcrab.target
 sleep 2
 log_info "Service status:"
 echo ""
-for svc in market-data momentum-bot execution-engine control-plane trades-server; do
+for svc in market-data position-manager momentum-bot execution-engine control-plane trades-server; do
     status=$(systemctl is-active "$svc" 2>/dev/null || echo "inactive")
     if [ "$status" = "active" ]; then
         echo -e "  ${GREEN}●${NC} $svc: $status"
@@ -227,6 +234,7 @@ echo "   - market-data:      http://localhost:9801/metrics"
 echo "   - momentum-bot:     http://localhost:9802/metrics"
 echo "   - arb-strategy:     http://localhost:9803/metrics"
 echo "   - execution-engine: http://localhost:9804/metrics"
+echo "   - position-manager: http://localhost:9805/metrics"
 echo ""
 echo "🔧 Control Plane:      http://localhost:8080"
 echo "📈 Trades API:         http://localhost:9899/trades (Grafana Infinity)"
@@ -236,6 +244,7 @@ echo "   journalctl -u market-data -f"
 echo "   journalctl -u momentum-bot -f"
 echo "   journalctl -u arb-strategy -f"
 echo "   journalctl -u execution-engine -f"
+echo "   journalctl -u position-manager -f"
 echo "   journalctl -u control-plane -f"
 echo "   journalctl -u trades-server -f"
 echo ""

--- a/docs/systemd/position-manager.service
+++ b/docs/systemd/position-manager.service
@@ -1,8 +1,8 @@
 [Unit]
-Description=IronCrab Position Manager (PA-6a Shadow, Keyless)
-After=network-online.target nats.service market-data.service execution-engine.service
+Description=IronCrab Position Manager (PA-6b KV Writer, Keyless)
+After=network-online.target nats.service market-data.service
 Wants=network-online.target
-# PA-6a: deliberately NOT PartOf=ironcrab.target until PA-6b cutover approval.
+Before=execution-engine.service momentum-bot.service
 
 StartLimitBurst=10
 StartLimitIntervalSec=300
@@ -22,7 +22,7 @@ Environment=RUST_LOG=info,position_manager=info
 # Wallet pubkey for JetStream wallet-snapshot filter (set by deploy or override):
 # Environment=IRONCRAB_WALLET_PUBKEY=
 
-# IMPORTANT: No wallet keys (keyless shadow reducer)
+# IMPORTANT: No wallet keys (keyless PositionAuthority reducer + KV writer)
 # Do NOT set IRONCRAB_KEYPAIR_PATH/KEYPAIR_PATH in this service.
 
 Restart=on-failure
@@ -39,5 +39,4 @@ ProtectSystem=strict
 ProtectHome=read-only
 
 [Install]
-# PA-6a shadow: enable manually after validation — not auto-started with ironcrab.target.
-# WantedBy=ironcrab.target
+WantedBy=ironcrab.target

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -70,9 +70,9 @@ use ironcrab::ipc::{
     CheckResult, ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, DecisionOutcome,
     DecisionRecord, DexPoolReadiness, ExecutionResult, ExecutionStatus, ExplicitAmount,
     FairnessPolicy, FeePolicy, FillStatus, FillUnavailableReason, IntentOrigin, IntentTier,
-    KillSwitchContext, MarketEvent, MarketEventKind, PoolCacheUpdate,
-    PriorityFeePercentiles, RecordHeader, RejectReason, SimulationResult,
-    TradeExecutionConstraints, TradeIntent, TradeResources, TradeSide, TradingRegime,
+    KillSwitchContext, MarketEvent, MarketEventKind, PoolCacheUpdate, PriorityFeePercentiles,
+    RecordHeader, RejectReason, SimulationResult, TradeExecutionConstraints, TradeIntent,
+    TradeResources, TradeSide, TradingRegime,
 };
 use ironcrab::ipc::{ControlRequest, ControlRequestKind, ControlResponse, ControlResponseStatus};
 use ironcrab::metrics::{

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -70,10 +70,9 @@ use ironcrab::ipc::{
     CheckResult, ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, DecisionOutcome,
     DecisionRecord, DexPoolReadiness, ExecutionResult, ExecutionStatus, ExplicitAmount,
     FairnessPolicy, FeePolicy, FillStatus, FillUnavailableReason, IntentOrigin, IntentTier,
-    KillSwitchContext, MarketEvent, MarketEventKind, PoolCacheUpdate, PositionAuthoritySnapshot,
+    KillSwitchContext, MarketEvent, MarketEventKind, PoolCacheUpdate,
     PriorityFeePercentiles, RecordHeader, RejectReason, SimulationResult,
     TradeExecutionConstraints, TradeIntent, TradeResources, TradeSide, TradingRegime,
-    POSITION_AUTHORITY_KV_BUCKET,
 };
 use ironcrab::ipc::{ControlRequest, ControlRequestKind, ControlResponse, ControlResponseStatus};
 use ironcrab::metrics::{
@@ -122,7 +121,9 @@ use ironcrab::nats::{
     TRADE_INTENTS_STREAM_NAME, WALLET_SNAPSHOT_STREAM_NAME, WALLET_TX_CONFIRM_STREAM_NAME,
 };
 use ironcrab::position_authority::{
-    position_authority_drift_lockmanager, PositionAuthority, PositionAuthorityChange,
+    position_authority_drift_lockmanager, reconcile_position_authority_kv_after_restart,
+    PositionAuthority, PositionAuthorityChange, PositionAuthorityKvMetricsSink,
+    PositionAuthorityKvPublisher,
 };
 use ironcrab::solana::cross_dex_handler::CrossDexHandler;
 use ironcrab::solana::dex::meteora_dlmm::MeteoraDlmm;
@@ -1571,6 +1572,9 @@ struct ExecutionConfig {
     janitor_swap_dust_max_slippage_bps: u32,
     janitor_swap_dust_max_per_run: usize,
     janitor_dry_run: bool,
+
+    /// PA-6b: EE publishes PositionAuthority KV when true (rollback only; default false).
+    publish_position_authority_kv: bool,
 }
 
 impl Default for ExecutionConfig {
@@ -1631,6 +1635,7 @@ impl Default for ExecutionConfig {
             janitor_swap_dust_max_slippage_bps: 500,
             janitor_swap_dust_max_per_run: 5,
             janitor_dry_run: false,
+            publish_position_authority_kv: false,
         }
     }
 }
@@ -2453,9 +2458,8 @@ struct ExecutionContext {
     lock_manager: LockManager,
     /// PA-2: passive PositionAuthority (metrics only; not used for gating or reservations).
     position_authority: Arc<ParkingMutex<PositionAuthority>>,
-    /// PA-5.1: FIFO queue for ordered PositionAuthority KV publishes (per reducer apply order).
-    position_authority_kv_tx:
-        Option<tokio::sync::mpsc::UnboundedSender<Vec<PositionAuthorityChange>>>,
+    /// PA-5.1 / PA-6b: FIFO queue for ordered PositionAuthority KV publishes (disabled when PM is writer).
+    position_authority_kv_publisher: PositionAuthorityKvPublisher,
     log_base: PathBuf, // P1: For state persistence
     decision_counter: std::sync::atomic::AtomicU64,
     execution_counter: std::sync::atomic::AtomicU64,
@@ -2599,7 +2603,7 @@ impl ExecutionContext {
             burn_writer,
             lock_manager,
             position_authority: Arc::new(ParkingMutex::new(position_authority)),
-            position_authority_kv_tx: None,
+            position_authority_kv_publisher: PositionAuthorityKvPublisher::disabled(),
             log_base: log_dir,
             decision_counter: std::sync::atomic::AtomicU64::new(0),
             execution_counter: std::sync::atomic::AtomicU64::new(0),
@@ -6596,14 +6600,9 @@ impl ExecutionContext {
         self.refresh_position_authority_metrics();
     }
 
-    /// PA-5.1: enqueue KV publish while holding reducer lock (preserves apply order).
+    /// PA-5.1 / PA-6b: enqueue KV publish while holding reducer lock (preserves apply order).
     fn enqueue_position_authority_kv_publish(&self, changes: &[PositionAuthorityChange]) {
-        if changes.is_empty() {
-            return;
-        }
-        if let Some(tx) = &self.position_authority_kv_tx {
-            let _ = tx.send(changes.to_vec());
-        }
+        self.position_authority_kv_publisher.enqueue(changes);
     }
 
     /// Apply a WalletBalanceSnapshot MarketEvent to LockManager + decimals cache.
@@ -6688,134 +6687,6 @@ impl ExecutionContext {
         POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE.store(lock_open as u64, Ordering::Relaxed);
         POSITION_AUTHORITY_DRIFT_LOCKMANAGER.store(drift, Ordering::Relaxed);
     }
-}
-
-/// PA-5.1: single worker preserves reducer apply order for PositionAuthority KV writes.
-fn spawn_position_authority_kv_publish_worker(
-    nats: NatsClient,
-    kv_cell: tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
-) -> tokio::sync::mpsc::UnboundedSender<Vec<PositionAuthorityChange>> {
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    tokio::spawn(async move {
-        while let Some(changes) = rx.recv().await {
-            if let Err(e) = publish_position_authority_changes_to_kv(&nats, &kv_cell, changes).await
-            {
-                warn!(error = %e, "PositionAuthority KV publish failed");
-            }
-        }
-    });
-    tx
-}
-
-/// PA-5.1: write PositionAuthority deltas to JetStream KV (`POSITION_AUTHORITY` bucket).
-async fn publish_position_authority_changes_to_kv(
-    nats: &NatsClient,
-    kv_cell: &tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
-    changes: Vec<PositionAuthorityChange>,
-) -> anyhow::Result<()> {
-    if changes.is_empty() {
-        return Ok(());
-    }
-    let store = if let Some(store) = kv_cell.get() {
-        store.clone()
-    } else {
-        let store = nats
-            .get_or_create_kv_bucket(POSITION_AUTHORITY_KV_BUCKET)
-            .await?;
-        let _ = kv_cell.set(store.clone());
-        store
-    };
-    for change in changes {
-        match change {
-            PositionAuthorityChange::Put(snapshot) => {
-                let mint = snapshot.mint.clone();
-                nats.kv_put(&store, &mint, &snapshot).await?;
-            }
-            PositionAuthorityChange::Tombstone { mint } => {
-                if let Err(e) = nats.kv_delete(&store, &mint).await {
-                    debug!(mint = %mint, error = %e, "PositionAuthority KV tombstone delete (may not exist)");
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-/// PA-5.1: tombstone sweep only when bootstrap included `WalletSnapshotComplete`
-/// (partial balance snapshots alone are not a complete wallet picture).
-fn wallet_bootstrap_allows_pa_kv_tombstone_sweep(
-    wallet_snapshot_kinds: &[MarketEventKind],
-) -> bool {
-    wallet_snapshot_kinds
-        .iter()
-        .any(|k| matches!(k, MarketEventKind::WalletSnapshotComplete { .. }))
-}
-
-/// PA-5.1: after EE restart, seed in-process PositionAuthority from wallet bootstrap and
-/// tombstone JetStream KV keys that no longer exist in the authority model.
-async fn reconcile_position_authority_kv_after_restart(
-    nats: &NatsClient,
-    position_authority: &ParkingMutex<PositionAuthority>,
-    kv_cell: &tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
-    wallet_snapshot_kinds: &[MarketEventKind],
-) -> anyhow::Result<()> {
-    let (changes, tracked) = {
-        let mut pa = position_authority.lock();
-        let mut changes = Vec::new();
-        for kind in wallet_snapshot_kinds {
-            changes.extend(pa.apply_from_wallet_market_event_kind(kind));
-        }
-        let tracked: std::collections::HashSet<String> = pa.tracked_mints().into_iter().collect();
-        (changes, tracked)
-    };
-
-    let mut changes = changes;
-
-    let store = if let Some(store) = kv_cell.get() {
-        store.clone()
-    } else {
-        let store = nats
-            .get_or_create_kv_bucket(POSITION_AUTHORITY_KV_BUCKET)
-            .await?;
-        let _ = kv_cell.set(store.clone());
-        store
-    };
-
-    let allow_tombstone_sweep =
-        wallet_bootstrap_allows_pa_kv_tombstone_sweep(wallet_snapshot_kinds);
-
-    if allow_tombstone_sweep {
-        let kv_entries = nats
-            .kv_get_all::<PositionAuthoritySnapshot>(&store)
-            .await
-            .unwrap_or_default();
-        for mint in kv_entries.keys() {
-            if !tracked.contains(mint) {
-                changes.push(PositionAuthorityChange::Tombstone { mint: mint.clone() });
-            }
-        }
-        if !changes.is_empty() {
-            publish_position_authority_changes_to_kv(nats, kv_cell, changes).await?;
-            info!(
-                wallet_snapshots = wallet_snapshot_kinds.len(),
-                kv_keys = kv_entries.len(),
-                tracked_mints = tracked.len(),
-                "PositionAuthority KV reconciled after execution-engine restart (tombstone sweep)"
-            );
-        }
-    } else {
-        if !changes.is_empty() {
-            publish_position_authority_changes_to_kv(nats, kv_cell, changes).await?;
-        }
-        warn!(
-            wallet_snapshots = wallet_snapshot_kinds.len(),
-            has_snapshot_complete = false,
-            tracked_mints = tracked.len(),
-            "PositionAuthority KV reconcile: tombstone sweep skipped (wallet bootstrap missing WalletSnapshotComplete or empty)"
-        );
-    }
-
-    Ok(())
 }
 
 #[allow(dead_code)]
@@ -7927,8 +7798,20 @@ async fn main() -> Result<()> {
         capital_lock_ttl_buffer_ms: exec_eng_cfg
             .and_then(|e| e.capital_lock_ttl_buffer_ms)
             .unwrap_or(10_000),
+        publish_position_authority_kv: exec_eng_cfg
+            .and_then(|e| e.publish_position_authority_kv)
+            .unwrap_or(false),
         ..Default::default()
     };
+
+    if exec_config.publish_position_authority_kv {
+        warn!(
+            "execution-engine publish_position_authority_kv=true: EE will write POSITION_AUTHORITY KV. \
+             Stop position-manager to avoid split-brain (PA-6b rollback mode only)."
+        );
+    } else {
+        info!("PositionAuthority JetStream KV writes disabled in execution-engine (position-manager is sole writer)");
+    }
 
     info!(
         jito_enabled = exec_config.jito_enabled,
@@ -8258,13 +8141,19 @@ async fn main() -> Result<()> {
         parking_lot::RwLock<std::collections::HashMap<String, OrphanTxConfirmEntry>>,
     > = Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new()));
 
+    let publish_position_authority_kv = exec_config.publish_position_authority_kv;
     let position_authority_kv = tokio::sync::OnceCell::new();
-    let position_authority_kv_tx = nats.as_ref().map(|n| {
-        spawn_position_authority_kv_publish_worker(
-            n.clone_for_spawned_publish(),
-            position_authority_kv.clone(),
-        )
-    });
+    let position_authority_kv_publisher = if publish_position_authority_kv {
+        nats.as_ref()
+            .map_or(PositionAuthorityKvPublisher::disabled(), |n| {
+                PositionAuthorityKvPublisher::spawn(
+                    n.clone_for_spawned_publish(),
+                    PositionAuthorityKvMetricsSink::None,
+                )
+            })
+    } else {
+        PositionAuthorityKvPublisher::disabled()
+    };
 
     let mut ctx = ExecutionContext {
         run_id: run_id.clone(),
@@ -8286,7 +8175,7 @@ async fn main() -> Result<()> {
         burn_writer,
         lock_manager,
         position_authority: Arc::new(ParkingMutex::new(PositionAuthority::new())),
-        position_authority_kv_tx,
+        position_authority_kv_publisher,
         log_base: log_base.clone(),
         decision_counter: std::sync::atomic::AtomicU64::new(initial_decision_counter),
         execution_counter: std::sync::atomic::AtomicU64::new(initial_execution_counter),
@@ -8331,20 +8220,25 @@ async fn main() -> Result<()> {
         pump_amm_hot_path_refresh_last: Arc::new(ParkingMutex::new(HashMap::new())),
     };
 
-    if let Some(ref nats_client) = ctx.nats {
-        if let Err(e) = reconcile_position_authority_kv_after_restart(
-            nats_client,
-            &ctx.position_authority,
-            &position_authority_kv,
-            &wallet_snapshot_kinds,
-        )
-        .await
-        {
-            warn!(
-                error = %e,
-                "PositionAuthority KV startup reconcile failed (Momentum may see stale KV until next update)"
-            );
+    if publish_position_authority_kv {
+        if let Some(ref nats_client) = ctx.nats {
+            if let Err(e) = reconcile_position_authority_kv_after_restart(
+                nats_client,
+                &ctx.position_authority,
+                &position_authority_kv,
+                &wallet_snapshot_kinds,
+                PositionAuthorityKvMetricsSink::None,
+            )
+            .await
+            {
+                warn!(
+                    error = %e,
+                    "PositionAuthority KV startup reconcile failed (Momentum may see stale KV until next update)"
+                );
+            }
         }
+    }
+    if ctx.nats.is_some() {
         ctx.refresh_position_authority_metrics();
     }
 
@@ -9659,7 +9553,7 @@ async fn build_replay_context(
         burn_writer,
         lock_manager,
         position_authority: Arc::new(ParkingMutex::new(PositionAuthority::new())),
-        position_authority_kv_tx: None,
+        position_authority_kv_publisher: PositionAuthorityKvPublisher::disabled(),
         log_base: log_dir,
         decision_counter: std::sync::atomic::AtomicU64::new(0),
         execution_counter: std::sync::atomic::AtomicU64::new(0),
@@ -14095,8 +13989,7 @@ mod execution_engine_tests {
         try_pump_amm_hot_path_refresh_publish, wait_for_meteora_dlmm_slave_after_recovery,
         wait_for_pump_amm_pool_hint_ready_for_tx_plan_builder,
         wait_for_pump_amm_slave_after_recovery, wait_for_pumpfun_bonding_cache_refresh,
-        wallet_bootstrap_allows_pa_kv_tombstone_sweep, ComputedIntentFills,
-        DiscoveryRequestOutcome, ExecutionConfig, LiquidationSeedDecision,
+        ComputedIntentFills, DiscoveryRequestOutcome, ExecutionConfig, LiquidationSeedDecision,
         PumpAmmHotPathRefreshDecision, RouteCandidate, PUMP_AMM_HOT_PATH_REFRESH_COOLDOWN,
         WSOL_MINT,
     };
@@ -14114,7 +14007,9 @@ mod execution_engine_tests {
         IntentOrigin, IntentTier, MarketEventKind, PoolCacheUpdate, TradeIntent, TradeResources,
         TradeSide, TradingRegime,
     };
-    use ironcrab::position_authority::{PositionAuthority, PositionEvent};
+    use ironcrab::position_authority::{
+        wallet_bootstrap_allows_pa_kv_tombstone_sweep, PositionAuthority, PositionEvent,
+    };
     use ironcrab::solana::address_lookup_table::LoadedAlt;
     use ironcrab::solana::dex::pumpfun::PumpFunDex;
     use ironcrab::storage::locks::{LockHolder, LockManager, LockResult};
@@ -14222,6 +14117,15 @@ mod execution_engine_tests {
         ctx.apply_wallet_balance_snapshot_event(&wsol_wallet_snapshot_event(0));
 
         assert_eq!(ctx.lock_manager.available_wsol(), 0);
+    }
+
+    #[test]
+    fn execution_config_default_disables_position_authority_kv_publish() {
+        let cfg = ExecutionConfig::default();
+        assert!(
+            !cfg.publish_position_authority_kv,
+            "PA-6b: EE must not publish PositionAuthority KV by default"
+        );
     }
 
     #[test]

--- a/src/bin/position_manager.rs
+++ b/src/bin/position_manager.rs
@@ -1,8 +1,8 @@
-//! position-manager binary — PA-6a shadow PositionAuthority reducer.
+//! position-manager binary — PA-6b PositionAuthority reducer + sole KV writer.
 //!
-//! Keyless process that mirrors execution-engine PositionAuthority updates from JetStream
-//! (ExecutionResult + WalletBalanceSnapshot) without writing to the productive
-//! `POSITION_AUTHORITY` KV bucket. EE remains the sole KV writer until PA-6b cutover.
+//! Keyless process that maintains PositionAuthority from JetStream
+//! (ExecutionResult + WalletBalanceSnapshot) and publishes to the productive
+//! `POSITION_AUTHORITY` KV bucket. EE keeps an in-process reducer for PA-3/4 gates only.
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -30,7 +30,10 @@ use ironcrab::nats::jetstream::{
     EXECUTION_RESULTS_STREAM_NAME, WALLET_SNAPSHOT_STREAM_NAME,
 };
 use ironcrab::nats::{NatsClient, NatsConfig, TOPIC_EXECUTION_RESULTS, TOPIC_MARKET_EVENTS};
-use ironcrab::position_authority::PositionAuthority;
+use ironcrab::position_authority::{
+    reconcile_position_authority_kv_after_restart, PositionAuthority,
+    PositionAuthorityKvMetricsSink, PositionAuthorityKvPublisher,
+};
 
 type JetStreamPullConsumer =
     async_nats::jetstream::consumer::Consumer<async_nats::jetstream::consumer::pull::Config>;
@@ -41,7 +44,7 @@ const PM_EXECUTION_RESULT_FETCH_EXPIRES: Duration = Duration::from_millis(250);
 
 #[derive(Parser, Debug)]
 #[command(name = "position-manager")]
-#[command(about = "IronCrab PA-6a shadow PositionAuthority reducer (keyless, no KV writes)")]
+#[command(about = "IronCrab PositionAuthority reducer + POSITION_AUTHORITY KV writer (keyless)")]
 struct Args {
     /// Path to configuration file (optional; reads [position_manager] when present).
     #[arg(short, long, default_value = "config.toml")]
@@ -62,12 +65,14 @@ struct Args {
 
 struct PositionManagerContext {
     position_authority: Mutex<PositionAuthority>,
+    kv_publisher: PositionAuthorityKvPublisher,
 }
 
 impl PositionManagerContext {
-    fn new() -> Self {
+    fn new(kv_publisher: PositionAuthorityKvPublisher) -> Self {
         Self {
             position_authority: Mutex::new(PositionAuthority::new()),
+            kv_publisher,
         }
     }
 
@@ -75,19 +80,21 @@ impl PositionManagerContext {
         if exec.status != ExecutionStatus::Confirmed {
             return;
         }
-        {
+        let changes = {
             let mut pa = self.position_authority.lock();
-            let _changes = pa.apply_from_confirmed_execution_result(exec);
-        }
+            pa.apply_from_confirmed_execution_result(exec)
+        };
+        self.kv_publisher.enqueue(&changes);
         record_position_manager_event_applied();
         self.refresh_metrics();
     }
 
     fn apply_wallet_event_kind(&self, kind: &MarketEventKind) {
-        {
+        let changes = {
             let mut pa = self.position_authority.lock();
-            let _changes = pa.apply_from_wallet_market_event_kind(kind);
-        }
+            pa.apply_from_wallet_market_event_kind(kind)
+        };
+        self.kv_publisher.enqueue(&changes);
         record_position_manager_event_applied();
         self.refresh_metrics();
     }
@@ -164,12 +171,12 @@ fn is_enabled(args: &Args) -> bool {
     true
 }
 
-/// Bootstrap wallet snapshots from JetStream (LastPerSubject per mint) into PositionAuthority.
-async fn bootstrap_position_authority_from_wallet_snapshot(
+/// Bootstrap wallet snapshots from JetStream (LastPerSubject per mint).
+/// Returns observed count and event kinds for KV reconcile (apply deferred to reconcile).
+async fn bootstrap_wallet_snapshot_kinds(
     nats: &NatsClient,
     wallet: &str,
-    ctx: &Arc<PositionManagerContext>,
-) -> usize {
+) -> (usize, Vec<MarketEventKind>) {
     use async_nats::jetstream;
 
     let jetstream = jetstream::new(nats.client().clone());
@@ -181,7 +188,7 @@ async fn bootstrap_position_authority_from_wallet_snapshot(
                 stream = WALLET_SNAPSHOT_STREAM_NAME,
                 "Wallet snapshot stream not found during bootstrap (market-data may not be running)"
             );
-            return 0;
+            return (0, Vec::new());
         }
     };
 
@@ -192,12 +199,13 @@ async fn bootstrap_position_authority_from_wallet_snapshot(
         Ok(c) => c,
         Err(e) => {
             warn!(error = %e, "Failed to create wallet snapshot bootstrap consumer");
-            return 0;
+            return (0, Vec::new());
         }
     };
 
     let batch_size = 1000;
     let mut observed = 0usize;
+    let mut wallet_snapshot_kinds = Vec::new();
 
     loop {
         let mut messages = match consumer.fetch().max_messages(batch_size).messages().await {
@@ -222,7 +230,13 @@ async fn bootstrap_position_authority_from_wallet_snapshot(
             match serde_json::from_slice::<MarketEvent>(&msg.payload) {
                 Ok(event) => {
                     observed += 1;
-                    ctx.apply_wallet_event_kind(&event.kind);
+                    if matches!(
+                        event.kind,
+                        MarketEventKind::WalletBalanceSnapshot { .. }
+                            | MarketEventKind::WalletSnapshotComplete { .. }
+                    ) {
+                        wallet_snapshot_kinds.push(event.kind);
+                    }
                 }
                 Err(e) => {
                     debug!(error = %e, "Failed to deserialize wallet snapshot MarketEvent");
@@ -242,11 +256,11 @@ async fn bootstrap_position_authority_from_wallet_snapshot(
     info!(
         wallet = %wallet,
         snapshots = observed,
-        open_positions = ctx.position_authority.lock().open_positions_count(),
-        "Wallet snapshot bootstrap applied to shadow PositionAuthority"
+        kinds = wallet_snapshot_kinds.len(),
+        "Wallet snapshot bootstrap kinds collected for PositionAuthority KV reconcile"
     );
 
-    observed
+    (observed, wallet_snapshot_kinds)
 }
 
 async fn create_wallet_snapshot_live_consumer(
@@ -284,7 +298,7 @@ async fn create_wallet_snapshot_live_consumer(
                 } else {
                     "New"
                 },
-                "Subscribed to JetStream WalletBalanceSnapshot (shadow live)"
+                "Subscribed to JetStream WalletBalanceSnapshot (live)"
             );
             Some(consumer)
         }
@@ -439,7 +453,7 @@ async fn main() -> Result<()> {
         wallet = %wallet,
         metrics_port,
         nats_url = %args.nats_url,
-        "Starting position-manager (PA-6a shadow — not prod KV writer)"
+        "Starting position-manager (PA-6b — sole POSITION_AUTHORITY KV writer)"
     );
 
     let metrics_addr = SocketAddr::from(([0, 0, 0, 0], metrics_port));
@@ -462,10 +476,31 @@ async fn main() -> Result<()> {
         warn!(error = %e, "Failed to ensure EXECUTION_RESULTS stream (may already exist)");
     }
 
-    let ctx = Arc::new(PositionManagerContext::new());
+    let kv_publisher = PositionAuthorityKvPublisher::spawn(
+        nats.clone_for_spawned_publish(),
+        PositionAuthorityKvMetricsSink::PositionManager,
+    );
+    let ctx = Arc::new(PositionManagerContext::new(kv_publisher));
 
-    let bootstrap_observed =
-        bootstrap_position_authority_from_wallet_snapshot(&nats, &wallet, &ctx).await;
+    let (bootstrap_observed, wallet_snapshot_kinds) =
+        bootstrap_wallet_snapshot_kinds(&nats, &wallet).await;
+
+    let position_authority_kv = tokio::sync::OnceCell::new();
+    if let Err(e) = reconcile_position_authority_kv_after_restart(
+        &nats,
+        &ctx.position_authority,
+        &position_authority_kv,
+        &wallet_snapshot_kinds,
+        PositionAuthorityKvMetricsSink::PositionManager,
+    )
+    .await
+    {
+        warn!(
+            error = %e,
+            "PositionAuthority KV startup reconcile failed (Momentum may see stale KV until next update)"
+        );
+    }
+    ctx.refresh_metrics();
 
     let wallet_snapshot_consumer =
         create_wallet_snapshot_live_consumer(&nats, &wallet, bootstrap_observed).await;
@@ -493,7 +528,7 @@ async fn main() -> Result<()> {
                     info!(
                         stream = EXECUTION_RESULTS_STREAM_NAME,
                         topic = TOPIC_EXECUTION_RESULTS,
-                        "Subscribed to ExecutionResults via JetStream (shadow reducer)"
+                        "Subscribed to ExecutionResults via JetStream"
                     );
                     Some(consumer)
                 }
@@ -526,8 +561,6 @@ async fn main() -> Result<()> {
             None
         }
     };
-
-    ctx.refresh_metrics();
 
     loop {
         tokio::select! {

--- a/src/config.rs
+++ b/src/config.rs
@@ -331,6 +331,10 @@ pub struct ExecutionEngineCfg {
     /// Buffer (ms) added to discovery + simulation when computing pre-send capital-lock TTL. Default: 10000.
     #[serde(default)]
     pub capital_lock_ttl_buffer_ms: Option<u64>,
+    /// PA-6b: when true, EE publishes PositionAuthority to JetStream KV (rollback / emergency).
+    /// Default false — `position-manager` is the sole writer. Enabling while PM runs causes split-brain.
+    #[serde(default)]
+    pub publish_position_authority_kv: Option<bool>,
 }
 
 /// Fee Policy Configuration

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -23,8 +23,9 @@ pub const SCHEMA_VERSION: u32 = 1;
 /// Native SOL mint address
 pub const NATIVE_SOL_MINT: &str = "So11111111111111111111111111111111111111112";
 
-/// JetStream KV bucket for PositionAuthority snapshots (PA-5.1, I-24a).
+/// JetStream KV bucket for PositionAuthority snapshots (PA-5.1 / PA-6b, I-24a).
 /// Key = mint (base58), value = [`PositionAuthoritySnapshot`] JSON.
+/// Writer after PA-6b: `position-manager` only (EE rollback via `publish_position_authority_kv`).
 pub const POSITION_AUTHORITY_KV_BUCKET: &str = "POSITION_AUTHORITY";
 
 /// Default quote mint for backward compatibility (SOL)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3332,6 +3332,21 @@ pub fn record_position_manager_event_applied() {
     POSITION_MANAGER_EVENTS_APPLIED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+#[inline]
+pub fn record_position_manager_kv_put() {
+    POSITION_MANAGER_KV_PUT_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_position_manager_kv_tombstone() {
+    POSITION_MANAGER_KV_TOMBSTONE_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_position_manager_kv_publish_error() {
+    POSITION_MANAGER_KV_PUBLISH_ERRORS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
 pub fn set_position_authority_drift_momentum(drift: i64) {
     POSITION_AUTHORITY_DRIFT_MOMENTUM.store(drift, Ordering::Relaxed);
 }
@@ -6446,6 +6461,13 @@ pub static POSITION_MANAGER_RECONCILE_NEEDED_GAUGE: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 /// PA-6a shadow: total events applied to local PositionAuthority reducer.
 pub static POSITION_MANAGER_EVENTS_APPLIED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+pub static POSITION_MANAGER_KV_PUT_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+pub static POSITION_MANAGER_KV_TOMBSTONE_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+pub static POSITION_MANAGER_KV_PUBLISH_ERRORS_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// PA-4: liquidation skipped LockManager seed because PositionAuthority reports closed/zero.
 pub static LIQUIDATION_SEED_SKIPPED_AUTHORITY_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -10258,6 +10280,18 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "position_manager_events_applied_total",
         POSITION_MANAGER_EVENTS_APPLIED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "position_manager_kv_put_total",
+        POSITION_MANAGER_KV_PUT_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "position_manager_kv_tombstone_total",
+        POSITION_MANAGER_KV_TOMBSTONE_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "position_manager_kv_publish_errors_total",
+        POSITION_MANAGER_KV_PUBLISH_ERRORS_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "concurrent_intents",

--- a/src/position_authority/kv_publish.rs
+++ b/src/position_authority/kv_publish.rs
@@ -1,0 +1,246 @@
+//! JetStream KV publish helpers for PositionAuthority (PA-5.1 / PA-6b).
+//!
+//! Shared by `position-manager` (sole writer after PA-6b) and `execution-engine`
+//! (optional rollback via `publish_position_authority_kv`).
+
+use parking_lot::Mutex as ParkingMutex;
+use std::collections::HashSet;
+use tracing::{debug, info, warn};
+
+use crate::ipc::schema::{
+    MarketEventKind, PositionAuthoritySnapshot, POSITION_AUTHORITY_KV_BUCKET,
+};
+use crate::metrics::{
+    record_position_manager_kv_publish_error, record_position_manager_kv_put,
+    record_position_manager_kv_tombstone,
+};
+use crate::nats::NatsClient;
+use crate::position_authority::{PositionAuthority, PositionAuthorityChange};
+
+/// Who records Prometheus counters for KV publish operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PositionAuthorityKvMetricsSink {
+    #[default]
+    None,
+    PositionManager,
+}
+
+/// FIFO worker for ordered PositionAuthority KV publishes (preserves reducer apply order).
+pub struct PositionAuthorityKvPublisher {
+    tx: Option<tokio::sync::mpsc::UnboundedSender<Vec<PositionAuthorityChange>>>,
+}
+
+impl PositionAuthorityKvPublisher {
+    pub fn disabled() -> Self {
+        Self { tx: None }
+    }
+
+    pub fn spawn(nats: NatsClient, metrics_sink: PositionAuthorityKvMetricsSink) -> Self {
+        let kv_cell = tokio::sync::OnceCell::new();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            while let Some(changes) = rx.recv().await {
+                if let Err(e) =
+                    publish_position_authority_changes_to_kv(&nats, &kv_cell, changes, metrics_sink)
+                        .await
+                {
+                    warn!(error = %e, "PositionAuthority KV publish failed");
+                    if metrics_sink == PositionAuthorityKvMetricsSink::PositionManager {
+                        record_position_manager_kv_publish_error();
+                    }
+                }
+            }
+        });
+        Self { tx: Some(tx) }
+    }
+
+    pub fn enqueue(&self, changes: &[PositionAuthorityChange]) {
+        if changes.is_empty() {
+            return;
+        }
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(changes.to_vec());
+        }
+    }
+}
+
+/// PA-5.1: write PositionAuthority deltas to JetStream KV (`POSITION_AUTHORITY` bucket).
+pub async fn publish_position_authority_changes_to_kv(
+    nats: &NatsClient,
+    kv_cell: &tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
+    changes: Vec<PositionAuthorityChange>,
+    metrics_sink: PositionAuthorityKvMetricsSink,
+) -> anyhow::Result<()> {
+    if changes.is_empty() {
+        return Ok(());
+    }
+    let store = if let Some(store) = kv_cell.get() {
+        store.clone()
+    } else {
+        let store = nats
+            .get_or_create_kv_bucket(POSITION_AUTHORITY_KV_BUCKET)
+            .await?;
+        let _ = kv_cell.set(store.clone());
+        store
+    };
+    for change in changes {
+        match change {
+            PositionAuthorityChange::Put(snapshot) => {
+                let mint = snapshot.mint.clone();
+                nats.kv_put(&store, &mint, &snapshot).await?;
+                if metrics_sink == PositionAuthorityKvMetricsSink::PositionManager {
+                    record_position_manager_kv_put();
+                }
+            }
+            PositionAuthorityChange::Tombstone { mint } => {
+                if let Err(e) = nats.kv_delete(&store, &mint).await {
+                    debug!(mint = %mint, error = %e, "PositionAuthority KV tombstone delete (may not exist)");
+                } else if metrics_sink == PositionAuthorityKvMetricsSink::PositionManager {
+                    record_position_manager_kv_tombstone();
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// PA-5.1: tombstone sweep only when bootstrap included `WalletSnapshotComplete`
+/// (partial balance snapshots alone are not a complete wallet picture).
+pub fn wallet_bootstrap_allows_pa_kv_tombstone_sweep(
+    wallet_snapshot_kinds: &[MarketEventKind],
+) -> bool {
+    wallet_snapshot_kinds
+        .iter()
+        .any(|k| matches!(k, MarketEventKind::WalletSnapshotComplete { .. }))
+}
+
+/// PA-5.1: after restart, seed PositionAuthority from wallet bootstrap and
+/// tombstone JetStream KV keys that no longer exist in the authority model.
+pub async fn reconcile_position_authority_kv_after_restart(
+    nats: &NatsClient,
+    position_authority: &ParkingMutex<PositionAuthority>,
+    kv_cell: &tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
+    wallet_snapshot_kinds: &[MarketEventKind],
+    metrics_sink: PositionAuthorityKvMetricsSink,
+) -> anyhow::Result<()> {
+    let (changes, tracked) = {
+        let mut pa = position_authority.lock();
+        let mut changes = Vec::new();
+        for kind in wallet_snapshot_kinds {
+            changes.extend(pa.apply_from_wallet_market_event_kind(kind));
+        }
+        let tracked: HashSet<String> = pa.tracked_mints().into_iter().collect();
+        (changes, tracked)
+    };
+
+    let mut changes = changes;
+
+    let store = if let Some(store) = kv_cell.get() {
+        store.clone()
+    } else {
+        let store = nats
+            .get_or_create_kv_bucket(POSITION_AUTHORITY_KV_BUCKET)
+            .await?;
+        let _ = kv_cell.set(store.clone());
+        store
+    };
+
+    let allow_tombstone_sweep =
+        wallet_bootstrap_allows_pa_kv_tombstone_sweep(wallet_snapshot_kinds);
+
+    if allow_tombstone_sweep {
+        let kv_entries = nats
+            .kv_get_all::<PositionAuthoritySnapshot>(&store)
+            .await
+            .unwrap_or_default();
+        for mint in kv_entries.keys() {
+            if !tracked.contains(mint) {
+                changes.push(PositionAuthorityChange::Tombstone { mint: mint.clone() });
+            }
+        }
+        if !changes.is_empty() {
+            publish_position_authority_changes_to_kv(nats, kv_cell, changes, metrics_sink).await?;
+            info!(
+                wallet_snapshots = wallet_snapshot_kinds.len(),
+                kv_keys = kv_entries.len(),
+                tracked_mints = tracked.len(),
+                "PositionAuthority KV reconciled after restart (tombstone sweep)"
+            );
+        }
+    } else {
+        if !changes.is_empty() {
+            publish_position_authority_changes_to_kv(nats, kv_cell, changes, metrics_sink).await?;
+        }
+        warn!(
+            wallet_snapshots = wallet_snapshot_kinds.len(),
+            has_snapshot_complete = false,
+            tracked_mints = tracked.len(),
+            "PositionAuthority KV reconcile: tombstone sweep skipped (wallet bootstrap missing WalletSnapshotComplete or empty)"
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ipc::schema::PositionAuthorityStatus;
+
+    fn sample_put(mint: &str) -> PositionAuthorityChange {
+        PositionAuthorityChange::Put(PositionAuthoritySnapshot {
+            mint: mint.to_string(),
+            balance_raw: 100,
+            decimals: 6,
+            status: PositionAuthorityStatus::Open,
+            last_update_source: crate::ipc::schema::PositionAuthorityUpdateSource::Execution,
+            sold_raw_total: None,
+        })
+    }
+
+    #[test]
+    fn put_and_tombstone_change_variants_distinct() {
+        let put = sample_put("mintA");
+        let tombstone = PositionAuthorityChange::Tombstone {
+            mint: "mintA".to_string(),
+        };
+        assert!(matches!(put, PositionAuthorityChange::Put(_)));
+        assert!(matches!(
+            tombstone,
+            PositionAuthorityChange::Tombstone { .. }
+        ));
+    }
+
+    #[test]
+    fn wallet_bootstrap_tombstone_sweep_requires_snapshot_complete() {
+        let balance_only = vec![MarketEventKind::WalletBalanceSnapshot {
+            mint: "mintA".to_string(),
+            balance_raw: 1,
+            decimals: 6,
+            token_program: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string(),
+        }];
+        assert!(
+            !wallet_bootstrap_allows_pa_kv_tombstone_sweep(&balance_only),
+            "partial balance snapshots must not authorize tombstone sweep"
+        );
+        assert!(
+            !wallet_bootstrap_allows_pa_kv_tombstone_sweep(&[]),
+            "empty bootstrap must not authorize tombstone sweep"
+        );
+        let with_complete = vec![MarketEventKind::WalletSnapshotComplete {
+            wallet: "wallet".to_string(),
+            mints_in_wallet: vec!["mintA".to_string()],
+            is_periodic: true,
+        }];
+        assert!(
+            wallet_bootstrap_allows_pa_kv_tombstone_sweep(&with_complete),
+            "WalletSnapshotComplete authorizes tombstone sweep"
+        );
+    }
+
+    #[test]
+    fn kv_publisher_enqueue_noop_when_disabled() {
+        let publisher = PositionAuthorityKvPublisher::disabled();
+        publisher.enqueue(&[sample_put("mintA")]);
+    }
+}

--- a/src/position_authority/mod.rs
+++ b/src/position_authority/mod.rs
@@ -1,8 +1,14 @@
-//! Read-only **PositionAuthority** reducer + JetStream snapshot types (PA-1 / PA-5.1).
-//! EE publishes KV snapshots; Momentum consumes readonly.
+//! **PositionAuthority** reducer + JetStream snapshot types (PA-1 / PA-5.1 / PA-6b).
+//! `position-manager` is the sole JetStream KV writer; Momentum consumes readonly.
 
+mod kv_publish;
 mod state;
 
+pub use kv_publish::{
+    publish_position_authority_changes_to_kv, reconcile_position_authority_kv_after_restart,
+    wallet_bootstrap_allows_pa_kv_tombstone_sweep, PositionAuthorityKvMetricsSink,
+    PositionAuthorityKvPublisher,
+};
 pub use state::{
     is_sol_or_wsol_mint, position_authority_drift_lockmanager, position_authority_drift_momentum,
     PositionAuthority, PositionAuthorityChange, PositionEvent, PositionState, PositionStatus,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PA-6b cutover: `position-manager` becomes the **sole writer** of the JetStream KV bucket `POSITION_AUTHORITY`. `execution-engine` disables KV publishing by default but keeps the in-process `PositionAuthority` reducer for PA-3/4 gates.

## Changes

### Shared KV helper (`src/position_authority/kv_publish.rs`)
- Extracted EE KV publish logic into reusable module
- `publish_position_authority_changes_to_kv`, `reconcile_position_authority_kv_after_restart`, `wallet_bootstrap_allows_pa_kv_tombstone_sweep`
- `PositionAuthorityKvPublisher` worker (unbounded channel, ordered apply)

### `position-manager`
- Publishes Put/Tombstone after each successful reduce
- Startup reconcile + tombstone sweep when `WalletSnapshotComplete` present
- PM KV metrics: `position_manager_kv_put_total`, `position_manager_kv_tombstone_total`, `position_manager_kv_publish_errors_total`

### `execution-engine`
- New config `[execution_engine] publish_position_authority_kv` — **default `false`**
- KV worker + startup reconcile only when flag `true` (rollback / emergency)
- Warns on split-brain if EE KV write enabled while PM may run

### Deploy / ops
- `deploy_new.sh`: build, install, restart `position-manager` (before momentum-bot)
- `docs/systemd/position-manager.service`: `WantedBy=ironcrab.target`
- `config/position_manager.toml.example`: `enabled = true`

## Rollback

```toml
[execution_engine]
publish_position_authority_kv = true
```

Stop `position-manager` when enabling EE KV write to avoid split-brain.

## Verification

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo build --release --bin position-manager`
- `cargo build --release --bin execution-engine`

## Not in scope (PA-6c)

- EE gates on KV read
- Momentum overlay persist removal
- LockManager SOT removal
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01420714-de4d-4796-8a9a-f0003622aff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01420714-de4d-4796-8a9a-f0003622aff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

