### PR TITLE
PA-6c1: BUY max_open gate authority-primary + EE readonly KV watch

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -70,9 +70,10 @@ use ironcrab::ipc::{
     CheckResult, ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, DecisionOutcome,
     DecisionRecord, DexPoolReadiness, ExecutionResult, ExecutionStatus, ExplicitAmount,
     FairnessPolicy, FeePolicy, FillStatus, FillUnavailableReason, IntentOrigin, IntentTier,
-    KillSwitchContext, MarketEvent, MarketEventKind, PoolCacheUpdate, PriorityFeePercentiles,
-    RecordHeader, RejectReason, SimulationResult, TradeExecutionConstraints, TradeIntent,
-    TradeResources, TradeSide, TradingRegime,
+    KillSwitchContext, MarketEvent, MarketEventKind, PoolCacheUpdate, PositionAuthoritySnapshot,
+    PriorityFeePercentiles, RecordHeader, RejectReason, SimulationResult,
+    TradeExecutionConstraints, TradeIntent, TradeResources, TradeSide, TradingRegime,
+    POSITION_AUTHORITY_KV_BUCKET,
 };
 use ironcrab::ipc::{ControlRequest, ControlRequestKind, ControlResponse, ControlResponseStatus};
 use ironcrab::metrics::{
@@ -95,7 +96,8 @@ use ironcrab::metrics::{
     IN_FLIGHT_CAPITAL_RESERVATIONS, JITO_BUNDLES_LANDED_TOTAL, JITO_BUNDLES_REJECTED_TOTAL,
     JITO_BUNDLES_SUBMITTED_TOTAL, JITO_BUNDLES_TIMEOUT_TOTAL, JITO_TIP_LAMPORTS_TOTAL,
     KILL_SWITCH_ACTIVE, NATS_MESSAGES_RECEIVED_TOTAL, OPEN_POSITIONS_GAUGE,
-    POSITION_AUTHORITY_DRIFT_LOCKMANAGER, POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE,
+    POSITION_AUTHORITY_DRIFT_EE_VS_KV, POSITION_AUTHORITY_DRIFT_LOCKMANAGER,
+    POSITION_AUTHORITY_KV_OPEN_POSITIONS, POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE,
     POSITION_AUTHORITY_OPEN_GAUGE, POSITION_AUTHORITY_RECONCILE_NEEDED_GAUGE,
     PUMPSWAP_HOT_PATH_HEALING_ASYNC_PUBLISH_FAIL_TOTAL,
     PUMPSWAP_HOT_PATH_HEALING_ASYNC_PUBLISH_SUCCESS_TOTAL,
@@ -121,6 +123,7 @@ use ironcrab::nats::{
     TRADE_INTENTS_STREAM_NAME, WALLET_SNAPSHOT_STREAM_NAME, WALLET_TX_CONFIRM_STREAM_NAME,
 };
 use ironcrab::position_authority::{
+    open_positions_count_from_kv_snapshots, position_authority_drift_ee_vs_kv,
     position_authority_drift_lockmanager, reconcile_position_authority_kv_after_restart,
     PositionAuthority, PositionAuthorityChange, PositionAuthorityKvMetricsSink,
     PositionAuthorityKvPublisher,
@@ -2460,6 +2463,10 @@ struct ExecutionContext {
     position_authority: Arc<ParkingMutex<PositionAuthority>>,
     /// PA-5.1 / PA-6b: FIFO queue for ordered PositionAuthority KV publishes (disabled when PM is writer).
     position_authority_kv_publisher: PositionAuthorityKvPublisher,
+    /// PA-6c1: readonly JetStream KV bucket handle (no EE writes; observability + PA-6c2 prep).
+    position_authority_kv: tokio::sync::OnceCell<async_nats::jetstream::kv::Store>,
+    /// PA-6c1: latest KV snapshots from readonly watch (cross-check vs in-process authority).
+    authority_kv_by_mint: parking_lot::RwLock<HashMap<String, PositionAuthoritySnapshot>>,
     log_base: PathBuf, // P1: For state persistence
     decision_counter: std::sync::atomic::AtomicU64,
     execution_counter: std::sync::atomic::AtomicU64,
@@ -2604,6 +2611,8 @@ impl ExecutionContext {
             lock_manager,
             position_authority: Arc::new(ParkingMutex::new(position_authority)),
             position_authority_kv_publisher: PositionAuthorityKvPublisher::disabled(),
+            position_authority_kv: tokio::sync::OnceCell::new(),
+            authority_kv_by_mint: parking_lot::RwLock::new(HashMap::new()),
             log_base: log_dir,
             decision_counter: std::sync::atomic::AtomicU64::new(0),
             execution_counter: std::sync::atomic::AtomicU64::new(0),
@@ -6680,12 +6689,146 @@ impl ExecutionContext {
         let lock_open = self.lock_manager.count_non_zero_token_balances();
         let drift = position_authority_drift_lockmanager(auth_open, lock_open);
         drop(a);
+        let kv_open = self.position_authority_kv_open_count();
+        let drift_ee_kv = position_authority_drift_ee_vs_kv(auth_open, kv_open);
         // PA-2 Rest: primary `open_positions` gauge follows PositionAuthority (I-24a).
         OPEN_POSITIONS_GAUGE.store(auth_open as u64, Ordering::Relaxed);
         POSITION_AUTHORITY_OPEN_GAUGE.store(auth_open as u64, Ordering::Relaxed);
         POSITION_AUTHORITY_RECONCILE_NEEDED_GAUGE.store(reconcile as u64, Ordering::Relaxed);
         POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE.store(lock_open as u64, Ordering::Relaxed);
         POSITION_AUTHORITY_DRIFT_LOCKMANAGER.store(drift, Ordering::Relaxed);
+        POSITION_AUTHORITY_KV_OPEN_POSITIONS.store(kv_open as u64, Ordering::Relaxed);
+        POSITION_AUTHORITY_DRIFT_EE_VS_KV.store(drift_ee_kv, Ordering::Relaxed);
+    }
+
+    fn apply_authority_kv_snapshot_update(
+        &self,
+        mint: &str,
+        snap: Option<PositionAuthoritySnapshot>,
+    ) {
+        let mut map = self.authority_kv_by_mint.write();
+        match snap {
+            Some(s) => {
+                map.insert(mint.to_string(), s);
+            }
+            None => {
+                map.remove(mint);
+            }
+        }
+        drop(map);
+        self.refresh_position_authority_metrics();
+    }
+
+    fn position_authority_kv_open_count(&self) -> usize {
+        open_positions_count_from_kv_snapshots(self.authority_kv_by_mint.read().values())
+    }
+
+    async fn get_position_authority_kv(&self) -> Option<&async_nats::jetstream::kv::Store> {
+        let nats = self.nats.as_ref()?;
+        if let Some(store) = self.position_authority_kv.get() {
+            return Some(store);
+        }
+        match nats
+            .get_or_create_kv_bucket(POSITION_AUTHORITY_KV_BUCKET)
+            .await
+        {
+            Ok(store) => {
+                let _ = self.position_authority_kv.set(store);
+                self.position_authority_kv.get()
+            }
+            Err(e) => {
+                error!(error = %e, "Failed to create PositionAuthority KV bucket");
+                None
+            }
+        }
+    }
+
+    /// Bootstrap + live watch on `POSITION_AUTHORITY` KV (readonly, no RPC; PA-6c1).
+    async fn bootstrap_and_watch_position_authority_kv(self: Arc<Self>) {
+        let Some(nats) = self.nats.as_ref() else {
+            return;
+        };
+        let Some(store) = self.get_position_authority_kv().await else {
+            return;
+        };
+
+        match nats.kv_get_all::<PositionAuthoritySnapshot>(store).await {
+            Ok(entries) => {
+                info!(
+                    count = entries.len(),
+                    "Bootstrapped PositionAuthority snapshots from JetStream KV (readonly)"
+                );
+                for (mint, snap) in entries {
+                    self.apply_authority_kv_snapshot_update(&mint, Some(snap));
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to bootstrap PositionAuthority KV");
+            }
+        }
+
+        let ctx = Arc::clone(&self);
+        let store = store.clone();
+        tokio::spawn(async move {
+            use futures::StreamExt;
+            use std::time::Duration;
+
+            const WATCH_BACKOFF_INITIAL_MS: u64 = 500;
+            const WATCH_BACKOFF_MAX_MS: u64 = 30_000;
+            let mut backoff_ms = WATCH_BACKOFF_INITIAL_MS;
+
+            loop {
+                let mut watch = match store.watch_all().await {
+                    Ok(w) => w,
+                    Err(e) => {
+                        error!(
+                            error = %e,
+                            backoff_ms,
+                            "PositionAuthority KV watch failed to start"
+                        );
+                        tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                        backoff_ms = (backoff_ms * 2).min(WATCH_BACKOFF_MAX_MS);
+                        continue;
+                    }
+                };
+                info!("PositionAuthority KV watch started (execution-engine readonly)");
+                backoff_ms = WATCH_BACKOFF_INITIAL_MS;
+
+                while let Some(entry_res) = watch.next().await {
+                    match entry_res {
+                        Ok(entry) => {
+                            let mint = entry.key;
+                            if entry.operation == async_nats::jetstream::kv::Operation::Delete
+                                || entry.value.is_empty()
+                            {
+                                ctx.apply_authority_kv_snapshot_update(&mint, None);
+                                continue;
+                            }
+                            match serde_json::from_slice::<PositionAuthoritySnapshot>(&entry.value)
+                            {
+                                Ok(snap) => {
+                                    ctx.apply_authority_kv_snapshot_update(&mint, Some(snap));
+                                }
+                                Err(e) => {
+                                    warn!(mint = %mint, error = %e, "Invalid PositionAuthority KV payload");
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                error = %e,
+                                backoff_ms,
+                                "PositionAuthority KV watch error"
+                            );
+                            break;
+                        }
+                    }
+                }
+                warn!(backoff_ms, "PositionAuthority KV watch ended, reconnecting");
+                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                backoff_ms = (backoff_ms * 2).min(WATCH_BACKOFF_MAX_MS);
+            }
+        });
     }
 }
 
@@ -8176,6 +8319,8 @@ async fn main() -> Result<()> {
         lock_manager,
         position_authority: Arc::new(ParkingMutex::new(PositionAuthority::new())),
         position_authority_kv_publisher,
+        position_authority_kv: tokio::sync::OnceCell::new(),
+        authority_kv_by_mint: parking_lot::RwLock::new(HashMap::new()),
         log_base: log_base.clone(),
         decision_counter: std::sync::atomic::AtomicU64::new(initial_decision_counter),
         execution_counter: std::sync::atomic::AtomicU64::new(initial_execution_counter),
@@ -8332,6 +8477,14 @@ async fn main() -> Result<()> {
 
     // Publish initial gauge values immediately (before the first 30s heartbeat).
     ctx.refresh_position_authority_metrics();
+
+    // PA-6c1: readonly POSITION_AUTHORITY KV watch for drift observability (no EE writes).
+    {
+        let ctx_kv = Arc::clone(&ctx);
+        tokio::spawn(async move {
+            ctx_kv.bootstrap_and_watch_position_authority_kv().await;
+        });
+    }
 
     // === WsolManager: Background WSOL balance maintenance ===
     // Professional arb bots don't wrap/unwrap in the arb TX itself
@@ -9554,6 +9707,8 @@ async fn build_replay_context(
         lock_manager,
         position_authority: Arc::new(ParkingMutex::new(PositionAuthority::new())),
         position_authority_kv_publisher: PositionAuthorityKvPublisher::disabled(),
+        position_authority_kv: tokio::sync::OnceCell::new(),
+        authority_kv_by_mint: parking_lot::RwLock::new(HashMap::new()),
         log_base: log_dir,
         decision_counter: std::sync::atomic::AtomicU64::new(0),
         execution_counter: std::sync::atomic::AtomicU64::new(0),
@@ -9723,35 +9878,38 @@ fn create_test_intent(run_id: &str) -> TradeIntent {
     .with_ttl_ms(5000)
 }
 
-/// BUY max-open-positions gate: conservative count vs config limit (A.28 / Scope 49 / PA-3).
+/// BUY max-open-positions gate: conservative count vs config limit (A.28 / Scope 49 / PA-3 / PA-6c1).
 ///
 /// In-process only — no wallet scan / RPC.
 /// `authority_current` is [`PositionAuthority::open_positions_count`] when available.
-/// `lockmanager_current` is [`LockManager::count_non_zero_token_balances`].
+/// `lockmanager_current` is [`LockManager::count_non_zero_token_balances`] (observability only after PA-6c1).
 /// `metadata_current` is strategy-reported (`current_open_positions`).
-/// Effective count is the max of all available sources so neither ghost locks nor stale metadata
-/// alone can bypass the limit.
+/// When authority is available, effective count is `max(metadata, authority)` — LockManager ghosts
+/// must not inflate the limit. Fallback when authority unavailable: `max(metadata, lockmanager)`.
 fn max_open_positions_buy_gate(
     metadata_current: usize,
     authority_current: Option<usize>,
     lockmanager_current: usize,
     max_open: usize,
 ) -> (bool, String) {
-    let (effective_current, source, authority_suffix) = match authority_current {
-        Some(authority) => (
-            metadata_current.max(authority).max(lockmanager_current),
-            "position_authority(+lockmanager)",
-            format!("authority_current={authority} "),
-        ),
-        None => (
-            metadata_current.max(lockmanager_current),
-            "lockmanager",
-            "authority_unavailable=true ".to_string(),
-        ),
-    };
+    let (effective_current, source, authority_suffix, lockmanager_in_effective) =
+        match authority_current {
+            Some(authority) => (
+                metadata_current.max(authority),
+                "position_authority",
+                format!("authority_current={authority} "),
+                false,
+            ),
+            None => (
+                metadata_current.max(lockmanager_current),
+                "lockmanager",
+                "authority_unavailable=true ".to_string(),
+                true,
+            ),
+        };
     let passed = effective_current < max_open;
     let details = format!(
-        "{authority_suffix}lockmanager_current={lockmanager_current} metadata_current={metadata_current} effective_current={effective_current} {} max={max_open} source={source}",
+        "{authority_suffix}lockmanager_current={lockmanager_current} metadata_current={metadata_current} effective_current={effective_current} {} max={max_open} source={source} lockmanager_in_effective={lockmanager_in_effective}",
         if passed { "<" } else { ">=" },
     );
     (passed, details)
@@ -14370,20 +14528,26 @@ mod execution_engine_tests {
         assert!(details.contains("lockmanager_current=1"));
         assert!(details.contains("metadata_current=1"));
         assert!(details.contains("effective_current=5"));
-        assert!(details.contains("source=position_authority(+lockmanager)"));
+        assert!(details.contains("source=position_authority"));
+        assert!(details.contains("lockmanager_in_effective=false"));
         assert!(details.contains("max=5"));
     }
 
     #[test]
-    fn max_open_positions_gate_rejects_when_lock_manager_exceeds_metadata() {
+    fn max_open_positions_gate_passes_when_lockmanager_exceeds_authority_but_authority_below_max() {
         let max_open = 5usize;
         let (passed, details) = max_open_positions_buy_gate(1, Some(1), 5, max_open);
-        assert!(!passed);
+        assert!(
+            passed,
+            "PA-6c1: lockmanager ghosts must not inflate effective count"
+        );
         assert!(details.contains("authority_current=1"));
         assert!(details.contains("lockmanager_current=5"));
         assert!(details.contains("metadata_current=1"));
-        assert!(details.contains("effective_current=5"));
-        assert!(details.contains("max=5"));
+        assert!(details.contains("effective_current=1"));
+        assert!(details.contains("source=position_authority"));
+        assert!(details.contains("lockmanager_in_effective=false"));
+        assert!(details.contains("< max=5"));
     }
 
     #[test]
@@ -14395,6 +14559,7 @@ mod execution_engine_tests {
         assert!(details.contains("authority_current=1"));
         assert!(details.contains("lockmanager_current=1"));
         assert!(details.contains("effective_current=5"));
+        assert!(details.contains("lockmanager_in_effective=false"));
     }
 
     #[test]
@@ -14407,7 +14572,8 @@ mod execution_engine_tests {
         assert!(details.contains("metadata_current=2"));
         assert!(details.contains("effective_current=3"));
         assert!(details.contains("< max=5"));
-        assert!(details.contains("source=position_authority(+lockmanager)"));
+        assert!(details.contains("source=position_authority"));
+        assert!(details.contains("lockmanager_in_effective=false"));
     }
 
     #[test]
@@ -14420,6 +14586,7 @@ mod execution_engine_tests {
         assert!(details.contains("metadata_current=1"));
         assert!(details.contains("effective_current=5"));
         assert!(details.contains("source=lockmanager"));
+        assert!(details.contains("lockmanager_in_effective=true"));
     }
 
     #[test]

--- a/src/ipc/schema.rs
+++ b/src/ipc/schema.rs
@@ -23,9 +23,10 @@ pub const SCHEMA_VERSION: u32 = 1;
 /// Native SOL mint address
 pub const NATIVE_SOL_MINT: &str = "So11111111111111111111111111111111111111112";
 
-/// JetStream KV bucket for PositionAuthority snapshots (PA-5.1 / PA-6b, I-24a).
+/// JetStream KV bucket for PositionAuthority snapshots (PA-5.1 / PA-6b / PA-6c1, I-24a).
 /// Key = mint (base58), value = [`PositionAuthoritySnapshot`] JSON.
 /// Writer after PA-6b: `position-manager` only (EE rollback via `publish_position_authority_kv`).
+/// EE and momentum-bot subscribe readonly for drift observability (PA-6c1); gates stay in-process until PA-6c2.
 pub const POSITION_AUTHORITY_KV_BUCKET: &str = "POSITION_AUTHORITY";
 
 /// Default quote mint for backward compatibility (SOL)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3352,6 +3352,16 @@ pub fn set_position_authority_drift_momentum(drift: i64) {
 }
 
 #[inline]
+pub fn set_position_authority_kv_open_positions(count: u64) {
+    POSITION_AUTHORITY_KV_OPEN_POSITIONS.store(count, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn set_position_authority_drift_ee_vs_kv(drift: i64) {
+    POSITION_AUTHORITY_DRIFT_EE_VS_KV.store(drift, Ordering::Relaxed);
+}
+
+#[inline]
 pub fn record_liquidation_seed_skipped_authority_total() {
     LIQUIDATION_SEED_SKIPPED_AUTHORITY_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
@@ -6452,6 +6462,10 @@ pub static POSITION_AUTHORITY_LOCKMANAGER_OPEN_GAUGE: Lazy<AtomicU64> =
 pub static POSITION_AUTHORITY_DRIFT_LOCKMANAGER: Lazy<AtomicI64> = Lazy::new(|| AtomicI64::new(0));
 /// PA-5.1: `authority_open - momentum_overlay_count` (signed; Prometheus scalar).
 pub static POSITION_AUTHORITY_DRIFT_MOMENTUM: Lazy<AtomicI64> = Lazy::new(|| AtomicI64::new(0));
+/// PA-6c1: open positions from readonly `POSITION_AUTHORITY` KV snapshots (EE cross-check).
+pub static POSITION_AUTHORITY_KV_OPEN_POSITIONS: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// PA-6c1: `ee_in_process_open - kv_open` (signed; Prometheus scalar).
+pub static POSITION_AUTHORITY_DRIFT_EE_VS_KV: Lazy<AtomicI64> = Lazy::new(|| AtomicI64::new(0));
 /// PA-6a shadow: position-manager process heartbeat (1 = up).
 pub static POSITION_MANAGER_UP_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// PA-6a shadow: open positions from local PositionAuthority reducer.
@@ -10260,6 +10274,14 @@ async fn metrics_response() -> Response<Body> {
     out.push_str(&format!(
         "position_authority_drift_momentum {}\n",
         POSITION_AUTHORITY_DRIFT_MOMENTUM.load(Ordering::Relaxed)
+    ));
+    line!(
+        "position_authority_kv_open_positions",
+        POSITION_AUTHORITY_KV_OPEN_POSITIONS.load(Ordering::Relaxed)
+    );
+    out.push_str(&format!(
+        "position_authority_drift_ee_vs_kv {}\n",
+        POSITION_AUTHORITY_DRIFT_EE_VS_KV.load(Ordering::Relaxed)
     ));
     line!(
         "liquidation_seed_skipped_authority_total",

--- a/src/position_authority/mod.rs
+++ b/src/position_authority/mod.rs
@@ -10,7 +10,8 @@ pub use kv_publish::{
     PositionAuthorityKvPublisher,
 };
 pub use state::{
-    is_sol_or_wsol_mint, position_authority_drift_lockmanager, position_authority_drift_momentum,
-    PositionAuthority, PositionAuthorityChange, PositionEvent, PositionState, PositionStatus,
-    UpdateSource,
+    is_sol_or_wsol_mint, open_positions_count_from_kv_snapshots, position_authority_drift_ee_vs_kv,
+    position_authority_drift_lockmanager, position_authority_drift_momentum,
+    snapshot_counts_as_open_position, PositionAuthority, PositionAuthorityChange, PositionEvent,
+    PositionState, PositionStatus, UpdateSource,
 };

--- a/src/position_authority/state.rs
+++ b/src/position_authority/state.rs
@@ -201,6 +201,28 @@ pub fn position_authority_drift_lockmanager(authority_open: usize, lockmanager_o
     authority_open as i64 - lockmanager_open as i64
 }
 
+/// `ee in-process open count` minus `JetStream KV open count` (PA-6c1 drift metric).
+#[inline]
+pub fn position_authority_drift_ee_vs_kv(ee_open: usize, kv_open: usize) -> i64 {
+    ee_open as i64 - kv_open as i64
+}
+
+/// Whether a KV snapshot counts as an open trade position (PA-5.1 / PA-6c1).
+#[inline]
+pub fn snapshot_counts_as_open_position(snap: &PositionAuthoritySnapshot) -> bool {
+    snap.balance_raw > 0 && snap.status != PositionAuthorityStatus::Closed
+}
+
+/// Open-position count from readonly JetStream KV snapshots (same semantics as momentum overlay).
+pub fn open_positions_count_from_kv_snapshots<'a>(
+    snapshots: impl IntoIterator<Item = &'a PositionAuthoritySnapshot>,
+) -> usize {
+    snapshots
+        .into_iter()
+        .filter(|s| snapshot_counts_as_open_position(s))
+        .count()
+}
+
 /// KV publish delta after a reducer apply (PA-5.1).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PositionAuthorityChange {
@@ -857,6 +879,85 @@ mod tests {
         a.apply_from_confirmed_execution_result(&r);
         assert_eq!(a.open_positions_count(), 1);
         assert_eq!(a.get(&m).unwrap().balance_raw, 10);
+    }
+
+    #[test]
+    fn apply_from_confirmed_exec_buy_returns_kv_put_change() {
+        use std::collections::HashMap;
+
+        let m = mint();
+        let mut meta = HashMap::new();
+        meta.insert("side".to_string(), "BUY".to_string());
+        meta.insert("token_program".to_string(), default_spl_token_program());
+        let r = ExecutionResult {
+            header: RecordHeader::new("test", "0", "run"),
+            execution_id: "e1".to_string(),
+            decision_id: "d1".to_string(),
+            intent_id: "i1".to_string(),
+            source: "test".to_string(),
+            token_mint: Some(m.clone()),
+            signature: None,
+            bundle_id: None,
+            status: ExecutionStatus::Confirmed,
+            fill_in: None,
+            fill_out: Some(ExplicitAmount::new(10, 6)),
+            fill_status: None,
+            fill_unavailable_reason: None,
+            confirmed_slot: None,
+            block_time_unix_ms: None,
+            fees: None,
+            pnl: None,
+            wallet_sol_delta_lamports: None,
+            error_message: None,
+            error_code: None,
+            latency_ms: None,
+            metadata: meta,
+        };
+        let mut a = PositionAuthority::new();
+        let changes = a.apply_from_confirmed_execution_result(&r);
+        assert_eq!(changes.len(), 1);
+        match &changes[0] {
+            PositionAuthorityChange::Put(snap) => {
+                assert_eq!(snap.mint, m);
+                assert_eq!(snap.balance_raw, 10);
+                assert_eq!(snap.status, PositionAuthorityStatus::Open);
+            }
+            other => panic!("expected Put change, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_positions_count_from_kv_snapshots_ignores_closed_and_zero_balance() {
+        use crate::ipc::schema::PositionAuthorityUpdateSource;
+
+        let open = PositionAuthoritySnapshot {
+            mint: mint(),
+            balance_raw: 100,
+            decimals: 6,
+            status: PositionAuthorityStatus::Open,
+            last_update_source: PositionAuthorityUpdateSource::Execution,
+            sold_raw_total: None,
+        };
+        let closed = PositionAuthoritySnapshot {
+            mint: "closed".to_string(),
+            balance_raw: 0,
+            decimals: 6,
+            status: PositionAuthorityStatus::Closed,
+            last_update_source: PositionAuthorityUpdateSource::Execution,
+            sold_raw_total: None,
+        };
+        let zero_open_status = PositionAuthoritySnapshot {
+            mint: "zero".to_string(),
+            balance_raw: 0,
+            decimals: 6,
+            status: PositionAuthorityStatus::Open,
+            last_update_source: PositionAuthorityUpdateSource::Execution,
+            sold_raw_total: None,
+        };
+        assert_eq!(
+            open_positions_count_from_kv_snapshots([&open, &closed, &zero_open_status]),
+            1
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First slice of PA-6c (Position Authority SOT migration): the BUY `max_open_positions` gate no longer uses LockManager open-count in the effective calculation when in-process PositionAuthority is available.

## Changes

### BUY max_open gate (authority-primary)
- When authority is available: `effective = max(authority_current, metadata_current)` — LockManager is **not** included
- `lockmanager_current` still logged in DecisionRecord details for observability
- New detail field: `lockmanager_in_effective=false` (or `true` in fallback path)
- Fallback when authority unavailable: unchanged (`max(metadata, lockmanager)`)

### EE readonly KV watch (PA-6c1 observability)
- EE subscribes to `POSITION_AUTHORITY` JetStream KV readonly (Momentum PA-5.1 pattern)
- No EE KV writes (`publish_position_authority_kv` default false unchanged)
- Gate remains on in-process authority (no KV roundtrip in hot path)

### New metrics
- `position_authority_kv_open_positions` — open count from KV snapshots
- `position_authority_drift_ee_vs_kv` — `ee_in_process_open - kv_open`

### Helpers (`position_authority/state.rs`)
- `open_positions_count_from_kv_snapshots`
- `position_authority_drift_ee_vs_kv`
- `snapshot_counts_as_open_position`

## Not in this PR (PA-6c2)
- Momentum overlay persistence removal
- EE in-process reducer shutdown / KV-first gates
- LockManager token balance removal
- SELL preflight changes (still `min(lock, authority tradable)`)

## Tests
- Gate passes when lockmanager ghosts exceed authority but authority+metadata below max
- Details contain `lockmanager_in_effective=false`
- `apply_from_confirmed_execution_result` returns KV Put change on confirmed BUY
- KV snapshot open-count helper ignores closed/zero balances

## Verification
```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```
All green locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f5bf79a-ac70-49f8-8112-e6b6e44132c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f5bf79a-ac70-49f8-8112-e6b6e44132c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

