### PR TITLE
fix(momentum): P0 EnsurePumpfun geyser_slot=0 breaks STOP_LOSS

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -1653,3 +1653,15 @@ BUY cost bevorzugt jetzt value_sol (fill_in) — die tatsächlich für den Swap 
 | **Betroffene Module** | `src/market_data/ingest/`, `src/bin/market_data.rs` |
 | **Regression-Prüfung** | `cargo fmt`, `cargo clippy -D warnings`, `cargo test`, `cargo test phase4_`; Eval Level 5. |
 | **Tags** | [market-data, hybrid-rollback, phase4b, account-ingest, monolith-slice, i-md-2, i-md-4, pr-phase4b] |
+
+---
+
+## FIX-51: P0 — EnsurePumpfun `geyser_slot=0` bricht STOP_LOSS (CIRCUS 2026-07-31)
+
+| Symptom | Offene PumpFun-Position: wiederholte `quote_missing_retry` → `MOMENTUM_EXIT` statt `STOP_LOSS`, obwohl Hard-Stop per Chart/PnL erreicht. MD `EnsurePumpfunBondingCurve` publizierte erfolgreich, Momentum verwarf Quote dauerhaft (`executable_exit_quote == None`). Mint `5kvbzaiVLHZw7jHynCocxvPnyf14J8HtcCoSLQ8Xpump`. |
+|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Root Cause** | Cold-Path Ensure schrieb `geyser_slot=0` in JetStream + `LivePoolCache::upsert`. Exit-Guard `QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM` wertete `source_slot=Some(0)` als `0 <= entry_confirmed_slot` → permanenter Reject; quote-first STOP_LOSS blind. |
+| **Fix** | (A) `ensure_pumpfun.rs` / `ensure_pump.rs`: RPC `context.slot` (bzw. Geyser-Head/`getSlot`-Fallback) in `upsert` + `PoolCacheUpdate::geyser_slot`. (B) `exit_quote_price_exit_guard_violation`: Slot-Guards nur bei `source_slot > 0`. (C) WARN wenn alle `executable_exit_quote`-Kandidaten an Guards scheitern. |
+| **Betroffene Module** | `src/market_data/cold/ensure_pumpfun.rs`, `ensure_pump.rs`, `publish_slot.rs`, `src/solana/rpc.rs`, `src/bin/momentum_bot.rs` |
+| **Regression-Prüfung** | Unit-Tests Slot-0/positiv/stale; `cargo fmt`, `cargo clippy -D warnings`, `cargo test`. |
+| **Tags** | [momentum, pumpfun, stop-loss, cold-path, jetstream, i-16, i-7, quote-first] |

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -1144,11 +1144,15 @@ fn exit_quote_price_exit_guard_violation(
         }
     }
     if let Some(slot) = q.source_slot {
-        if pos.entry_confirmed_slot > 0 && slot <= pos.entry_confirmed_slot {
-            return Some("QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM");
-        }
-        if pos.last_price_slot > 0 && slot < pos.last_price_slot {
-            return Some("QUOTE_SLOT_BEFORE_LAST_POSITION_MARK_SLOT");
+        // Unknown watermark (`None` handled above; `Some(0)` = cold-path / missing Geyser slot):
+        // do not apply slot ordering guards — other freshness guards still apply.
+        if slot > 0 {
+            if pos.entry_confirmed_slot > 0 && slot <= pos.entry_confirmed_slot {
+                return Some("QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM");
+            }
+            if pos.last_price_slot > 0 && slot < pos.last_price_slot {
+                return Some("QUOTE_SLOT_BEFORE_LAST_POSITION_MARK_SLOT");
+            }
         }
     }
     if let Some(accs) = dex_pool_accounts {
@@ -3808,6 +3812,7 @@ impl MomentumContext {
         try_rows.retain(|p| seen.insert(p.pool_address.clone()));
 
         let mut best: Option<(ExitExecutableQuote, u64)> = None;
+        let mut guard_reject_sample: Option<(&'static str, String)> = None;
 
         for pool_row in try_rows {
             let pool_addr = pool_row.pool_address.clone();
@@ -3849,6 +3854,9 @@ impl MomentumContext {
             if let Some(reason) =
                 exit_quote_price_exit_guard_violation(pos, &candidate, merged_accounts.as_deref())
             {
+                if guard_reject_sample.is_none() {
+                    guard_reject_sample = Some((reason, pool_addr.clone()));
+                }
                 trace!(
                     mint = %pos.mint,
                     quote_pool = %candidate.quote_pool,
@@ -3871,6 +3879,18 @@ impl MomentumContext {
                 None => best = Some((candidate, sol_out)),
                 Some((_, best_sol)) if sol_out > best_sol => best = Some((candidate, sol_out)),
                 _ => {}
+            }
+        }
+
+        if best.is_none() {
+            if let Some((reason, quote_pool)) = guard_reject_sample {
+                warn!(
+                    mint = %pos.mint,
+                    position_pool = %pos.pool,
+                    quote_pool = %quote_pool,
+                    reason = %reason,
+                    "executable_exit_quote: all reserve quote candidates rejected by exit guards"
+                );
             }
         }
 
@@ -19092,6 +19112,61 @@ mod tests {
             pos.should_exit(&c, Some(&ex), "test", 9_000_000_000u64, None)
                 .is_none(),
             "older on-chain slot than BUY confirm must not authorize price exit"
+        );
+    }
+
+    #[test]
+    fn exit_guard_ignores_slot_zero_watermark_for_entry_confirm_check() {
+        let mut pos = PositionTracker::new("m", "p", "dex", 100.0, 6, 1_000_000, 0);
+        pos.entry_confirmed_slot = 436_375_627;
+        let mut ex = sample_exit_quote(50.0);
+        ex.source_slot = Some(0);
+        ex.cache_age_ms = Some(0);
+        assert_ne!(
+            exit_quote_price_exit_guard_violation(&pos, &ex, None),
+            Some("QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM"),
+            "slot=0 is unknown watermark and must not trip entry-confirm slot guard"
+        );
+    }
+
+    #[test]
+    fn exit_guard_rejects_positive_slot_at_or_before_entry_confirm() {
+        let mut pos = PositionTracker::new("m", "p", "dex", 100.0, 6, 1_000_000, 0);
+        pos.entry_confirmed_slot = 500;
+        let mut ex = sample_exit_quote(50.0);
+        ex.cache_age_ms = Some(0);
+        ex.source_slot = Some(500);
+        assert_eq!(
+            exit_quote_price_exit_guard_violation(&pos, &ex, None),
+            Some("QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM")
+        );
+        ex.source_slot = Some(499);
+        assert_eq!(
+            exit_quote_price_exit_guard_violation(&pos, &ex, None),
+            Some("QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM")
+        );
+    }
+
+    #[test]
+    fn exit_guard_allows_positive_slot_after_entry_confirm() {
+        let mut pos = PositionTracker::new("m", "p", "dex", 100.0, 6, 1_000_000, 0);
+        pos.entry_confirmed_slot = 500;
+        let mut ex = sample_exit_quote(100.0);
+        ex.source_slot = Some(501);
+        ex.cache_age_ms = Some(0);
+        assert!(exit_quote_price_exit_guard_violation(&pos, &ex, None).is_none());
+    }
+
+    #[test]
+    fn exit_guard_stale_cache_age_still_rejects_when_slot_unknown() {
+        let mut pos = PositionTracker::new("m", "p", "dex", 100.0, 6, 1_000_000, 0);
+        pos.entry_confirmed_slot = 500;
+        let mut ex = sample_exit_quote(50.0);
+        ex.source_slot = Some(0);
+        ex.cache_age_ms = Some(EXIT_QUOTE_MAX_CACHE_AGE_MS + 1);
+        assert_eq!(
+            exit_quote_price_exit_guard_violation(&pos, &ex, None),
+            Some("STALE_CACHE_AGE_MS")
         );
     }
 

--- a/src/market_data/cold/ensure_pump.rs
+++ b/src/market_data/cold/ensure_pump.rs
@@ -1,6 +1,7 @@
 //! I-24d EnsurePumpAmmPoolAccounts cold-path handler.
 
 use super::host::{publish_control_response, ColdHost};
+use super::publish_slot::resolve_cold_path_publish_slot;
 use crate::execution::live_pool_cache::{CachedPoolState, PumpAmmState};
 use crate::ipc::{ControlResponseStatus, PoolCacheUpdate};
 use crate::nats::jetstream::pool_subject;
@@ -351,7 +352,16 @@ pub async fn handle_ensure_pump_amm_pool_accounts(
                 pool_accounts: accounts.clone(),
                 creator: creator_opt,
             });
-            host.live_pool_cache().upsert(pool_address, state, 0);
+            let publish_slot = resolve_cold_path_publish_slot(0);
+            if publish_slot == 0 {
+                warn!(
+                    request_id = %request_id,
+                    pool = %pool_address_str,
+                    "EnsurePumpAmmPoolAccounts: no publish slot watermark (Geyser head zero)"
+                );
+            }
+            host.live_pool_cache()
+                .upsert(pool_address, state, publish_slot);
             if force_refresh {
                 host.live_pool_cache()
                     .set_pump_amm_sell_layout_authoritative(
@@ -407,7 +417,7 @@ pub async fn handle_ensure_pump_amm_pool_accounts(
                     base_reserve,
                     quote_reserve,
                     None,
-                    0,
+                    publish_slot,
                 );
                 let mut meta = std::collections::HashMap::new();
                 let accounts_str: Vec<String> = accounts.iter().map(|p| p.to_string()).collect();

--- a/src/market_data/cold/ensure_pumpfun.rs
+++ b/src/market_data/cold/ensure_pumpfun.rs
@@ -1,6 +1,7 @@
 //! I-24d EnsurePumpfunBondingCurve cold-path handler.
 
 use super::host::{publish_control_response, ColdHost};
+use super::publish_slot::resolve_cold_path_publish_slot;
 use crate::execution::live_pool_cache::{CachedPoolState, PumpFunState};
 use crate::ipc::{ControlResponseStatus, DexPoolReadiness, PoolCacheUpdate, NATIVE_SOL_MINT};
 use crate::nats::jetstream::pool_subject;
@@ -101,30 +102,8 @@ pub async fn handle_ensure_pumpfun_bonding_curve(
         );
     }
 
-    let state = match rpc.get_account_retry(&bonding_curve).await {
-        Ok(acct) => match BondingCurveState::parse(&acct.data) {
-            Ok(s) => s,
-            Err(e) => {
-                warn!(
-                    request_id = %request_id,
-                    pool = %bonding_curve_str,
-                    error = %e,
-                    "EnsurePumpfunBondingCurve: parse bonding curve failed"
-                );
-                if let Some(nats) = host.nats() {
-                    publish_control_response(
-                        nats,
-                        host.run_id(),
-                        request_id,
-                        ControlResponseStatus::Error,
-                        Some(bonding_curve_str),
-                        Some(format!("parse error: {e}")),
-                    )
-                    .await;
-                }
-                return;
-            }
-        },
+    let (acct, rpc_context_slot) = match rpc.get_account_with_slot_retry(&bonding_curve).await {
+        Ok(pair) => pair,
         Err(e) => {
             warn!(
                 request_id = %request_id,
@@ -146,6 +125,44 @@ pub async fn handle_ensure_pumpfun_bonding_curve(
             return;
         }
     };
+    let state = match BondingCurveState::parse(&acct.data) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                request_id = %request_id,
+                pool = %bonding_curve_str,
+                error = %e,
+                "EnsurePumpfunBondingCurve: parse bonding curve failed"
+            );
+            if let Some(nats) = host.nats() {
+                publish_control_response(
+                    nats,
+                    host.run_id(),
+                    request_id,
+                    ControlResponseStatus::Error,
+                    Some(bonding_curve_str),
+                    Some(format!("parse error: {e}")),
+                )
+                .await;
+            }
+            return;
+        }
+    };
+
+    let mut publish_slot = resolve_cold_path_publish_slot(rpc_context_slot);
+    if publish_slot == 0 {
+        if let Ok(slot) = rpc.get_slot_retry().await {
+            publish_slot = slot;
+        }
+    }
+    if publish_slot == 0 {
+        warn!(
+            request_id = %request_id,
+            pool = %bonding_curve_str,
+            rpc_context_slot,
+            "EnsurePumpfunBondingCurve: no publish slot watermark (RPC context, Geyser head, getSlot all zero)"
+        );
+    }
 
     let token_program = host
         .live_pool_cache()
@@ -166,7 +183,8 @@ pub async fn handle_ensure_pumpfun_bonding_curve(
         creator: state.creator,
         cashback_enabled: state.cashback_enabled,
     });
-    host.live_pool_cache().upsert(bonding_curve, cached, 0);
+    host.live_pool_cache()
+        .upsert(bonding_curve, cached, publish_slot);
 
     let jetstream_ok = if let Some(nats) = host.nats() {
         let mut pool_update = PoolCacheUpdate::new_pool_discovered(
@@ -179,8 +197,8 @@ pub async fn handle_ensure_pumpfun_bonding_curve(
             NATIVE_SOL_MINT.to_string(),
             state.virtual_token_reserves,
             state.virtual_sol_reserves,
-            Some(0),
-            0,
+            Some(publish_slot),
+            publish_slot,
         );
         let mut meta = std::collections::HashMap::new();
         meta.insert("creator".to_string(), state.creator.to_string());

--- a/src/market_data/cold/mod.rs
+++ b/src/market_data/cold/mod.rs
@@ -5,6 +5,7 @@ pub mod ensure_pump;
 pub mod ensure_pumpfun;
 pub mod ensure_raydium;
 pub mod host;
+pub mod publish_slot;
 pub mod pump_layout;
 pub mod rpc_refresh;
 

--- a/src/market_data/cold/publish_slot.rs
+++ b/src/market_data/cold/publish_slot.rs
@@ -1,0 +1,31 @@
+//! Cold-path JetStream publish slot resolution (I-16).
+
+/// Watermark for cold-path `LivePoolCache::upsert` and `PoolCacheUpdate::geyser_slot`.
+///
+/// Prefers the RPC account response `context.slot`. When that is zero (unknown), falls back to
+/// the monotonic Geyser head tracked by market-data ingest — never silently treats `0` as a
+/// valid exit-quote watermark when a head is available.
+pub fn resolve_cold_path_publish_slot(rpc_context_slot: u64) -> u64 {
+    if rpc_context_slot > 0 {
+        return rpc_context_slot;
+    }
+    crate::metrics::market_data_geyser_head_slot_value()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn resolve_prefers_rpc_context_slot_when_positive() {
+        assert_eq!(resolve_cold_path_publish_slot(436_375_700), 436_375_700);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_geyser_head_when_rpc_context_zero() {
+        let head = 99_001_234u64;
+        crate::metrics::MARKET_DATA_GEYSER_HEAD_SLOT.store(head, Ordering::Relaxed);
+        assert_eq!(resolve_cold_path_publish_slot(0), head);
+    }
+}

--- a/src/solana/rpc.rs
+++ b/src/solana/rpc.rs
@@ -2,6 +2,7 @@ use solana_client::client_error::ClientError;
 use solana_client::rpc_config::RpcProgramAccountsConfig;
 use solana_client::rpc_config::RpcTransactionConfig;
 use solana_client::rpc_response::Response;
+use solana_commitment_config::CommitmentConfig;
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{hash::Hash, message::Message, pubkey::Pubkey, signature::Signature};
 // no UiTransactionEncoding needed here
@@ -413,13 +414,79 @@ impl SolanaRpc {
         &self,
         key: &Pubkey,
     ) -> Result<solana_sdk::account::Account, ClientError> {
+        Ok(self.get_account_with_slot_retry(key).await?.0)
+    }
+
+    /// Like [`get_account_retry`] but also returns the RPC response `context.slot` (Cold Path).
+    pub async fn get_account_with_slot_retry(
+        &self,
+        key: &Pubkey,
+    ) -> Result<(solana_sdk::account::Account, u64), ClientError> {
+        let commitment = CommitmentConfig::confirmed();
         let _permit = self.limiter.acquire().await;
         let mut attempt = 0u32;
         loop {
-            match self.with_timeout(self.rpc.get_account(key)).await {
-                Some(Ok(acc)) => {
+            match self
+                .with_timeout(self.rpc.get_account_with_commitment(key, commitment))
+                .await
+            {
+                Some(Ok(response)) => {
                     self.limiter.on_success();
-                    return Ok(acc);
+                    let slot = response.context.slot;
+                    let acc = response.value.ok_or_else(|| {
+                        ClientError::from(solana_client::client_error::ClientErrorKind::Custom(
+                            "account not found".into(),
+                        ))
+                    })?;
+                    return Ok((acc, slot));
+                }
+                Some(Err(e)) => {
+                    let class = Self::classify_client_error(&e);
+                    match class {
+                        ErrorClass::RateLimited
+                        | ErrorClass::Http(429)
+                        | ErrorClass::Http(503)
+                        | ErrorClass::Http(504) => {
+                            self.limiter.on_rate_limit();
+                            crate::metrics::RPC_RATE_LIMIT_HITS_TOTAL
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        }
+                        ErrorClass::Timeout => {
+                            self.limiter.on_timeout();
+                        }
+                        ErrorClass::Other => {}
+                        ErrorClass::Http(_) => {}
+                    }
+                    if !Self::is_transient_error(&e) || attempt >= 2 {
+                        return Err(e);
+                    }
+                    attempt += 1;
+                    crate::metrics::RPC_RETRY_ATTEMPTS_TOTAL
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    Self::sleep_with_backoff(attempt, class).await;
+                }
+                None => {
+                    if attempt >= 2 {
+                        return Err(e_against_timeout());
+                    }
+                    attempt += 1;
+                    crate::metrics::RPC_RETRY_ATTEMPTS_TOTAL
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    Self::sleep_with_backoff(attempt, ErrorClass::Timeout).await;
+                }
+            }
+        }
+    }
+
+    /// Chain head slot via RPC (Cold Path fallback when account context and Geyser head are zero).
+    pub async fn get_slot_retry(&self) -> Result<u64, ClientError> {
+        let _permit = self.limiter.acquire().await;
+        let mut attempt = 0u32;
+        loop {
+            match self.with_timeout(self.rpc.get_slot()).await {
+                Some(Ok(slot)) => {
+                    self.limiter.on_success();
+                    return Ok(slot);
                 }
                 Some(Err(e)) => {
                     let class = Self::classify_client_error(&e);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Evidence (CIRCUS 2026-07-31)

Mint `5kvbzaiVLHZw7jHynCocxvPnyf14J8HtcCoSLQ8Xpump`: wiederholte `quote_missing_retry` trotz erfolgreichem `EnsurePumpfunBondingCurve` → `MOMENTUM_EXIT` statt `STOP_LOSS` bei −27.9% (Limit −30%).

## Root Cause

Cold-Path `EnsurePumpfunBondingCurve` schrieb `geyser_slot=0` in JetStream + `LivePoolCache::upsert`. Momentum Exit-Guard `QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM` wertete `source_slot=Some(0)` als `0 <= entry_confirmed_slot` → permanenter Reject → `executable_exit_quote == None` → quote-first STOP_LOSS blind.

## Fix

**A — Cold-Path Publish mit echtem Slot**
- `ensure_pumpfun.rs`: RPC `context.slot` via `get_account_with_slot_retry`; Fallback Geyser-Head / `getSlot`
- `ensure_pump.rs`: Geyser-Head via `resolve_cold_path_publish_slot`
- `publish_slot.rs` + `rpc.rs` Helper

**B — Guard-Defense**
- `exit_quote_price_exit_guard_violation`: Slot-Vergleiche nur bei `source_slot > 0`

**C — Observability**
- WARN wenn alle `executable_exit_quote`-Kandidaten an Guards scheitern

## CI

```text
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```

Alle drei lokal grün.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18b35195-1954-4628-83d0-c7318b1b71f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18b35195-1954-4628-83d0-c7318b1b71f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

