### PR TITLE
fix(ci): bump event-listener 5.4.1 → 5.4.2 (RUSTSEC-2026-0221)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -1390,11 +1390,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1405,7 +1404,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 

--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -1665,3 +1665,15 @@ BUY cost bevorzugt jetzt value_sol (fill_in) — die tatsächlich für den Swap 
 | **Betroffene Module** | `src/market_data/cold/ensure_pumpfun.rs`, `ensure_pump.rs`, `publish_slot.rs`, `src/solana/rpc.rs`, `src/bin/momentum_bot.rs` |
 | **Regression-Prüfung** | Unit-Tests Slot-0/positiv/stale; `cargo fmt`, `cargo clippy -D warnings`, `cargo test`. |
 | **Tags** | [momentum, pumpfun, stop-loss, cold-path, jetstream, i-16, i-7, quote-first] |
+
+---
+
+## FIX-52: P0 — CI `cargo audit` RUSTSEC-2026-0221 `event-listener` (2026-07-31)
+
+| Symptom | CI Job `Security audit (cargo-audit)` failt mit `RUSTSEC-2026-0221` (unsound `event-listener` 5.4.1 via `async-lock` → `solana-quic-client`). |
+|---------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Root Cause** | Lockfile pinnte `event-listener` 5.4.1; Advisory verlangt `>= 5.4.2`. |
+| **Fix** | `cargo update -p event-listener@5.4.1 --precise 5.4.2` (nur `Cargo.lock`; kein Solana-Bump, kein `audit.toml`-Ignore). |
+| **Betroffene Module** | `Cargo.lock` |
+| **Regression-Prüfung** | `cargo audit --deny warnings`, `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test`. |
+| **Tags** | [ci, security, rustsec, supply-chain, event-listener] |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Behebt den CI-Fail im Job **Security audit (cargo-audit)** (`cargo audit --deny warnings`).

| Feld | Wert |
|------|------|
| **Advisory** | [RUSTSEC-2026-0221](https://rustsec.org/advisories/RUSTSEC-2026-0221) |
| **Typ** | unsound — `!Send` tags via `StackSlot` |
| **Alt** | `event-listener` **5.4.1** |
| **Neu** | `event-listener` **5.4.2** |

### Dependency tree

```text
event-listener 5.4.2
└── event-listener-strategy 0.5.4
    └── async-lock 3.4.2
        └── solana-quic-client 3.0.0
            └── solana-client 3.0.0
```

## Änderungen

- `cargo update -p event-listener@5.4.1 --precise 5.4.2` (nur `Cargo.lock`)
- Kurzer Eintrag in `docs/BUGS_FIXES.md` (FIX-52)

**Nicht geändert:** Solana `=3.0.0`, kein `audit.toml`-Ignore, keine Src-Logik.

## Verifikation

- [x] `cargo audit --deny warnings` — exit 0
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — alle Tests grün

## STOP-CHECK

Nur Lockfile/Doku — keine Hot-Path-, RPC- oder Architektur-Änderung (I-7/I-9/I-12 unberührt).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-323fade7-298f-45ad-9d04-0aadc1b5d0c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-323fade7-298f-45ad-9d04-0aadc1b5d0c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

