### PR TITLE
fix(ws): WSOL ATA close → force-publish zero + EE/LockManager heal

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,13 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### FIX-WSOL-ATA-CLOSE-ZERO: Phantom WSOL-ATA-Close → JetStream WSOL=0 + EE-Heal
+**Datum**: 2026-07-31  
+**Problem**: Externes Schliessen der WSOL-ATA (z.B. Phantom „Close Account“ nach Dust-Sell) liess EE Heartbeat/Metrics bei `available_wsol=1e9` haengen. MD publizierte kein `WalletBalanceSnapshot` WSOL=0 wenn (a) Geyser-Daten unparsebar waren (`return` ohne Publish), oder (b) MD `last_wsol_balance` bei 0 blieb waehrend EE den Wrap-Callback schon auf 1e9 gesetzt hatte (`prev==balance` → kein JetStream-Zero).  
+**Fix**: (1) `account_handler`: leere/unparseable WSOL-ATA-Daten → autoritatives `balance=0`, `force_zero_publish` auch bei `prev=0`, INFO `reason=wsol_ata_closed_or_unparseable`. (2) `wallet_geyser_snapshots_to_publish`: `force_zero_publish` fuer ATA-Close-Heal. (3) EE/WsolManager: `wsol_external_zero` WARN bei Snapshot 0 nach vorher >0 ohne aktives pending-wrap. Pending-wrap-Floor unveraendert waehrend Confirmation.  
+**Evidence**: Prod 2026-07-31 — Phantom Close, native SOL Snapshots ok, WSOL Heartbeat stale 1e9.  
+**Dateien**: `src/market_data/ingest/{account_handler,account_parse}.rs`, `src/bin/market_data.rs`, `src/bin/execution_engine.rs`, `src/execution/wsol_manager.rs`, `docs/BUGS_FIXES.md`
+
 ### HYBRID-PHASE5e: ingest/jsonl/md-state Modul-Extraktion + Legacy-Cleanup (Monolith-Slice)
 **Datum**: 2026-06-26  
 **Problem**: `market_data.rs` (~14.4k LOC nach 5d) — JSONL-Filter/Enqueue, Geyser-Account-Ingest-Filter und md-state Worker/Command-Enum lagen inline im Bin; verbotene `RegisterReservesAfterTrade` / `RegisterPoolVaultsFromAccount` md-state Commands noch im Enum.  

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -6632,6 +6632,7 @@ impl ExecutionContext {
                 }
             } else if mint == WSOL_MINT || mint == SOL_MINT {
                 let incoming = *balance_raw;
+                let prev_wsol_on_chain = self.lock_manager.wsol_balance();
                 let effective_wsol = if let Some(ref pending) = self.wsol_pending_wrap {
                     let (effective, confirms, was_floored) =
                         pending.effective_wsol_for_snapshot(incoming);
@@ -6653,6 +6654,22 @@ impl ExecutionContext {
                 } else {
                     incoming
                 };
+                if incoming == 0
+                    && effective_wsol == 0
+                    && prev_wsol_on_chain > 0
+                    && self
+                        .wsol_pending_wrap
+                        .as_ref()
+                        .map(|p| p.pending_expected() == 0)
+                        .unwrap_or(true)
+                {
+                    warn!(
+                        event = "wsol_external_zero",
+                        previous_wsol_lamports = prev_wsol_on_chain,
+                        slot = ?event.slot,
+                        "WSOL WalletBalanceSnapshot dropped to zero (external unwrap/ATA close)"
+                    );
+                }
                 self.lock_manager.update_wsol_only(effective_wsol);
                 if let Some(ref tx) = self.wsol_balance_tx {
                     let sol = self.lock_manager.total_native_sol();

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -12132,9 +12132,8 @@ mod wsol_ata_update_tests {
     }
 
     #[test]
-    fn short_corrupt_wsol_ata_data_skips_update() {
-        // Not enough bytes for a standard token account; must not be treated as 0
-        // (avoids clobbering state on transient garbage).
+    fn short_corrupt_wsol_ata_data_is_unparseable_not_zero() {
+        // Parser alone returns None; account_handler treats WSOL ATA unparseable as authoritative 0.
         assert_eq!(wsol_ata_balance_lamports_from_geyser_data(&[1, 2, 3]), None);
     }
 
@@ -12186,6 +12185,7 @@ mod wallet_geyser_snapshot_decouple_tests {
         let snapshot = wallet_geyser_snapshots_to_publish(WalletGeyserUpdateSource::WsolAta {
             balance: 1_000_000_000,
             prev_balance: 0,
+            force_zero_publish: false,
         })
         .expect("wsol balance changed");
         assert_eq!(snapshot.mint, WalletGeyserSnapshotMint::Wsol);
@@ -12197,6 +12197,7 @@ mod wallet_geyser_snapshot_decouple_tests {
         let snapshot = wallet_geyser_snapshots_to_publish(WalletGeyserUpdateSource::WsolAta {
             balance: 0,
             prev_balance: 1_000_000_000,
+            force_zero_publish: false,
         })
         .expect("unwrap must publish WSOL=0");
         assert_eq!(snapshot.mint, WalletGeyserSnapshotMint::Wsol);
@@ -12209,6 +12210,32 @@ mod wallet_geyser_snapshot_decouple_tests {
             wallet_geyser_snapshots_to_publish(WalletGeyserUpdateSource::WsolAta {
                 balance: 1_000_000_000,
                 prev_balance: 1_000_000_000,
+                force_zero_publish: false,
+            })
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn wsol_ata_closed_force_zero_publishes_even_when_prev_already_zero() {
+        // MD cache drift: EE saw wrap via callback but MD last_wsol_balance stayed 0.
+        let snapshot = wallet_geyser_snapshots_to_publish(WalletGeyserUpdateSource::WsolAta {
+            balance: 0,
+            prev_balance: 0,
+            force_zero_publish: true,
+        })
+        .expect("ATA close must force-publish WSOL=0 to heal EE drift");
+        assert_eq!(snapshot.mint, WalletGeyserSnapshotMint::Wsol);
+        assert_eq!(snapshot.balance_raw, 0);
+    }
+
+    #[test]
+    fn wsol_ata_zero_without_force_skips_when_prev_already_zero() {
+        assert!(
+            wallet_geyser_snapshots_to_publish(WalletGeyserUpdateSource::WsolAta {
+                balance: 0,
+                prev_balance: 0,
+                force_zero_publish: false,
             })
             .is_none()
         );

--- a/src/execution/wsol_manager.rs
+++ b/src/execution/wsol_manager.rs
@@ -528,6 +528,17 @@ impl WsolManager {
             let (effective_wsol, snapshot_confirms_pending) =
                 compute_effective_wsol_on_snapshot(pending_expected, incoming_wsol);
 
+            if pending_expected == 0 && incoming_wsol == 0 {
+                let current = self.wsol_balance.load(Ordering::Relaxed);
+                if current > 0 {
+                    warn!(
+                        event = "wsol_external_zero",
+                        previous_wsol_lamports = current,
+                        "WSOL balance snapshot dropped to zero (external unwrap/ATA close)"
+                    );
+                }
+            }
+
             if pending_expected > 0 && incoming_wsol < pending_expected {
                 warn!(
                     event = "stale_wsol_snapshot_ignored_due_to_pending_wrap",
@@ -1278,6 +1289,33 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(mgr.wsol_balance(), 1_000_000_000);
+        assert_eq!(mgr.test_pending_expected_wsol(), 0);
+    }
+
+    #[tokio::test]
+    async fn external_zero_snapshot_applies_when_no_pending_wrap() {
+        let treasury = Arc::new(Treasury::from_signer(Arc::new(Keypair::new())));
+        let rpc = Arc::new(SolanaRpc::new("http://127.0.0.1:0"));
+        let mgr = WsolManager::new(
+            WsolManagerConfig {
+                enabled: true,
+                dry_run: true,
+                ..WsolManagerConfig::default()
+            },
+            treasury,
+            rpc,
+            "test",
+            "run",
+        );
+
+        mgr.test_seed_balances(3_000_000_000, 1_000_000_000);
+        assert_eq!(mgr.test_pending_expected_wsol(), 0);
+
+        mgr.apply_balance_update(4_000_000_000, Some(0))
+            .await
+            .unwrap();
+
+        assert_eq!(mgr.wsol_balance(), 0);
         assert_eq!(mgr.test_pending_expected_wsol(), 0);
     }
 

--- a/src/market_data/ingest/account_handler.rs
+++ b/src/market_data/ingest/account_handler.rs
@@ -112,20 +112,21 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
             }
         } else if is_wsol_ata {
             // WSOL ATA — parse token account balance. Publish WSOL only.
-            // When the ATA is closed (unwrap), Geyser often delivers an update with
-            // `data` empty (account gone) — not parseable as SPL token state.
-            // That means WSOL=0. Previously we `continue`d and kept a stale balance
-            // with no zero WalletBalanceSnapshot to JetStream.
-            let Some(balance) = wsol_ata_balance_lamports_from_geyser_data(&account_update.data)
-            else {
-                return;
-            };
+            // When the ATA is closed (unwrap / external Phantom close), Geyser often delivers
+            // an update with `data` empty (account gone) or non-empty but unparseable.
+            // Both mean WSOL=0. Must always publish WalletBalanceSnapshot so EE LockManager
+            // and WsolManager heal (including MD prev=0 drift after EE wrap callback).
+            let parsed = wsol_ata_balance_lamports_from_geyser_data(&account_update.data);
+            let closed_or_unparseable = account_update.data.is_empty() || parsed.is_none();
+            let balance = parsed.unwrap_or(0);
             let prev = host.account_wallet_wsol_swap(balance);
             host.account_wallet_wsol_seen_set();
+            let force_zero_publish = closed_or_unparseable && balance == 0;
             if let Some(snapshot) =
                 wallet_geyser_snapshots_to_publish(WalletGeyserUpdateSource::WsolAta {
                     balance,
                     prev_balance: prev,
+                    force_zero_publish,
                 })
             {
                 if host.account_nats().is_some() {
@@ -156,12 +157,23 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
                     )
                     .await;
 
-                    info!(
-                        wallet = %wallet_str,
-                        wsol_lamports = snapshot.balance_raw,
-                        slot = account_update.slot,
-                        "WalletBalanceSnapshot (WSOL) enqueued for JetStream"
-                    );
+                    if closed_or_unparseable {
+                        info!(
+                            wallet = %wallet_str,
+                            wsol_lamports = snapshot.balance_raw,
+                            slot = account_update.slot,
+                            reason = "wsol_ata_closed_or_unparseable",
+                            prev_wsol_lamports = prev,
+                            "WalletBalanceSnapshot (WSOL=0) enqueued after ATA close or unparseable data"
+                        );
+                    } else {
+                        info!(
+                            wallet = %wallet_str,
+                            wsol_lamports = snapshot.balance_raw,
+                            slot = account_update.slot,
+                            "WalletBalanceSnapshot (WSOL) enqueued for JetStream"
+                        );
+                    }
                 }
             }
         } else if is_token_ata

--- a/src/market_data/ingest/account_parse.rs
+++ b/src/market_data/ingest/account_parse.rs
@@ -65,8 +65,17 @@ pub fn wsol_ata_balance_lamports_from_geyser_data(data: &[u8]) -> Option<u64> {
 /// Which tracked-wallet Geyser account produced a balance update.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WalletGeyserUpdateSource {
-    NativeSol { lamports: u64, prev_lamports: u64 },
-    WsolAta { balance: u64, prev_balance: u64 },
+    NativeSol {
+        lamports: u64,
+        prev_lamports: u64,
+    },
+    WsolAta {
+        balance: u64,
+        prev_balance: u64,
+        /// When true, publish WSOL=0 even if `prev_balance` already equals 0 (ATA closed /
+        /// unparseable while MD cache drifted vs EE wrap callback).
+        force_zero_publish: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -96,10 +105,20 @@ pub fn wallet_geyser_snapshots_to_publish(
         WalletGeyserUpdateSource::WsolAta {
             balance,
             prev_balance,
-        } => (balance != prev_balance).then_some(WalletGeyserSnapshotToPublish {
-            mint: WalletGeyserSnapshotMint::Wsol,
-            balance_raw: balance,
-        }),
+            force_zero_publish,
+        } => {
+            if force_zero_publish && balance == 0 {
+                Some(WalletGeyserSnapshotToPublish {
+                    mint: WalletGeyserSnapshotMint::Wsol,
+                    balance_raw: 0,
+                })
+            } else {
+                (balance != prev_balance).then_some(WalletGeyserSnapshotToPublish {
+                    mint: WalletGeyserSnapshotMint::Wsol,
+                    balance_raw: balance,
+                })
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (P0 — Prod 2026-07-31)

After external Phantom **Close Account** on the WSOL ATA (post dust-sell):

- Chain: no WSOL; capital in native SOL
- Dashboard / EE heartbeat: `available_wsol=1_000_000_000` stuck
- `wallet_total_sol_lamports` inflated by phantom WSOL
- No re-wrap because `WsolManager` never saw WSOL=0

## Root cause

1. **Unparseable Geyser data** on closed ATA → early `return` without zero publish
2. **MD cache drift**: EE got wrap via callback (1e9) but MD `last_wsol_balance` stayed 0 → close with `balance=0, prev=0` → no JetStream snapshot (`unchanged`)

## Fix

### A) market-data (`account_handler` + `account_parse`)
- Empty **or** unparseable WSOL ATA data → authoritative `balance=0`
- `force_zero_publish` when ATA closed/unparseable (publishes WSOL=0 even if `prev=0`)
- INFO log: `reason=wsol_ata_closed_or_unparseable`

### B) execution-engine + WsolManager
- `wsol_external_zero` WARN when WSOL snapshot drops to 0 after previously >0 (no active pending-wrap)
- Pending-wrap confirmation floor **unchanged** (stale zero during wrap still blocked)

### C) Tests
- `force_zero_publish` with `prev=0` → publishes WSOL=0
- `external_zero_snapshot_applies_when_no_pending_wrap`
- Existing pending-wrap floor tests still pass

## Invariants

- **I-4 / I-7**: Geyser-only hot path; no new RPC in MD account handler
- **I-16 / I-24a**: Closed ATA → authoritative JetStream `WalletBalanceSnapshot` WSOL=0

## Verification

```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```

All 772 tests pass locally.

## Acceptance

- [x] External WSOL ATA close → JetStream WSOL=0 (including MD prev=0 drift)
- [x] LockManager / metrics path accepts zero when no pending wrap
- [x] WsolManager can re-wrap after zero (existing `check_and_act` path)
- [x] CI commands green locally

**No deploy** in this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ead95daa-98a0-4415-bdb0-4d7147e5b1bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ead95daa-98a0-4415-bdb0-4d7147e5b1bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

