### PR TITLE
fix(momentum): PumpFun exit-quote freshness + SL/TP guard relaxation (P0)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -118,6 +118,7 @@ use ironcrab::metrics::{
     inc_market_data_momentum_admission_rejected_total,
     inc_market_data_open_position_pin_applied_total,
     inc_market_data_open_position_pin_deferred_cache_miss_total,
+    inc_market_data_open_position_pumpfun_registration_unsatisfied_warn_total,
     inc_market_data_tracker_admission_admitted_total,
     inc_market_data_tracker_admission_rejected_total,
     inc_market_data_vault_high_priority_dispatch_total,
@@ -1288,6 +1289,10 @@ struct MarketDataContext {
     dlmm_registered_active_id: parking_lot::RwLock<HashMap<Pubkey, i32>>,
     /// Scope C: hot pools awaiting LivePoolCache layout for vault/bin Geyser registration.
     deferred_hot_pool_reserve_pins: parking_lot::RwLock<HashMap<Pubkey, GeyserPinReason>>,
+    /// Open-position PumpFun pools with unsatisfied bonding-curve Geyser registration (observability).
+    open_position_pumpfun_registration_unsatisfied_since:
+        parking_lot::RwLock<HashMap<Pubkey, Instant>>,
+    open_position_pumpfun_registration_warned: parking_lot::RwLock<HashSet<Pubkey>>,
     /// PR3: startup restore / first physical publish barrier before Geyser connect.
     geyser_connect_barrier: Arc<GeyserConnectBarrier>,
     /// PR3: explicit admission readiness (wallet-over-cap fail-closed).
@@ -4471,6 +4476,49 @@ impl MarketDataContext {
         for pool in self.hot_pool_registry.snapshot_hot_pool_pubkeys() {
             if self.hot_pool_registry.pool_has_momentum(pool) {
                 self.try_publish_balance_updated_from_cache(pool);
+            }
+        }
+        self.tick_open_position_pumpfun_registration_observability();
+    }
+
+    /// WARN once per episode when position-pinned PumpFun lacks bonding-curve Geyser registration.
+    fn tick_open_position_pumpfun_registration_observability(&self) {
+        const WARN_AFTER: std::time::Duration = std::time::Duration::from_secs(10);
+        for (mint, pool) in self.hot_pool_registry.snapshot_pairs() {
+            if !self.hot_pool_registry.is_position_pin(mint, pool) {
+                continue;
+            }
+            let Some(state) = self.live_pool_cache.get(&pool) else {
+                continue;
+            };
+            if !matches!(state, CachedPoolState::PumpFun(_)) {
+                continue;
+            }
+            if self.hot_pool_reserve_registration_satisfied(pool) {
+                self.open_position_pumpfun_registration_unsatisfied_since
+                    .write()
+                    .remove(&pool);
+                self.open_position_pumpfun_registration_warned
+                    .write()
+                    .remove(&pool);
+                continue;
+            }
+            let mut since_map = self
+                .open_position_pumpfun_registration_unsatisfied_since
+                .write();
+            let since = since_map.entry(pool).or_insert_with(Instant::now);
+            if since.elapsed() < WARN_AFTER {
+                continue;
+            }
+            drop(since_map);
+            let mut warned = self.open_position_pumpfun_registration_warned.write();
+            if warned.insert(pool) {
+                inc_market_data_open_position_pumpfun_registration_unsatisfied_warn_total();
+                warn!(
+                    pool = %pool,
+                    mint = %mint,
+                    "open-position PumpFun hot_pool_reserve_registration_satisfied=false for >10s — bonding curve Geyser explicit may be missing"
+                );
             }
         }
     }
@@ -7814,6 +7862,10 @@ async fn main() -> Result<()> {
         last_arb_snapshot_target: parking_lot::RwLock::new(None),
         dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
         deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
+        open_position_pumpfun_registration_unsatisfied_since: parking_lot::RwLock::new(
+            HashMap::new(),
+        ),
+        open_position_pumpfun_registration_warned: parking_lot::RwLock::new(HashSet::new()),
         geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
         geyser_explicit_ready: AtomicBool::new(true),
         geyser_explicit_config_error: parking_lot::RwLock::new(None),
@@ -12360,6 +12412,10 @@ mod wallet_snapshot_stale_cleanup_tests {
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
             deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
+            open_position_pumpfun_registration_unsatisfied_since: parking_lot::RwLock::new(
+                HashMap::new(),
+            ),
+            open_position_pumpfun_registration_warned: parking_lot::RwLock::new(HashSet::new()),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
@@ -12589,6 +12645,10 @@ mod wallet_tx_meta_balance_tests {
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
             deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
+            open_position_pumpfun_registration_unsatisfied_since: parking_lot::RwLock::new(
+                HashMap::new(),
+            ),
+            open_position_pumpfun_registration_warned: parking_lot::RwLock::new(HashSet::new()),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
@@ -13206,6 +13266,73 @@ mod pr_b_geyser_tracking_tests {
         assert!(
             pool_cache_balance_fields_from_state(&state).is_some(),
             "PumpFun must expose balance fields for JetStream publish path"
+        );
+    }
+
+    #[test]
+    fn pumpfun_hot_bonding_curve_sidefx_refreshes_existing_cache_reserves() {
+        use ironcrab::market_data::sidefx::handlers::md_sidefx_process_bonding_curve;
+        use ironcrab::market_data::sidefx::MdSidefxCommand;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let (md_state, _depth, _md_state_rx) = test_md_state_sender_no_worker();
+        let worker = test_sidefx_host(&ctx, md_state, test_noop_track_worker_sender());
+
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let creator = Pubkey::new_unique();
+        ctx.pool_mint_map
+            .write()
+            .insert(pool.to_string(), mint.to_string());
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::PumpFun(PumpFunState {
+                token_mint: mint,
+                bonding_curve: pool,
+                associated_bonding_curve: Pubkey::new_unique(),
+                virtual_sol_reserves: 30_000_000_000,
+                virtual_token_reserves: 1_073_000_000_000_000,
+                real_sol_reserves: 10_000_000_000,
+                real_token_reserves: 500_000_000_000_000,
+                complete: false,
+                creator,
+                cashback_enabled: false,
+            }),
+            10,
+        );
+        ctx.hot_pool_registry.pin_pool(mint, pool);
+
+        md_sidefx_process_bonding_curve(
+            &worker,
+            &MdSidefxCommand::BondingCurveDevWallet {
+                run_id: "hot-bonding-refresh".into(),
+                pool_address: pool,
+                creator,
+                slot: 42,
+                grpc_recv_at: Instant::now(),
+                virtual_token_reserves: 900_000_000_000_000,
+                virtual_sol_reserves: 35_000_000_000,
+                real_token_reserves: 400_000_000_000_000,
+                real_sol_reserves: 12_000_000_000,
+                complete: false,
+                cashback_enabled: false,
+            },
+        );
+
+        let state = ctx.live_pool_cache.get(&pool).expect("cache row");
+        let CachedPoolState::PumpFun(s) = state else {
+            panic!("expected PumpFun cache row");
+        };
+        assert_eq!(s.virtual_token_reserves, 900_000_000_000_000);
+        assert_eq!(s.virtual_sol_reserves, 35_000_000_000);
+        assert_eq!(
+            ctx.live_pool_cache
+                .get_with_metadata(&pool)
+                .map(|(_, slot, _)| slot),
+            Some(42)
         );
     }
 
@@ -13965,6 +14092,10 @@ mod pr_b_geyser_tracking_tests {
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
             deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
+            open_position_pumpfun_registration_unsatisfied_since: parking_lot::RwLock::new(
+                HashMap::new(),
+            ),
+            open_position_pumpfun_registration_warned: parking_lot::RwLock::new(HashSet::new()),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),
@@ -14046,6 +14177,10 @@ mod pr_b_geyser_tracking_tests {
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
             deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
+            open_position_pumpfun_registration_unsatisfied_since: parking_lot::RwLock::new(
+                HashMap::new(),
+            ),
+            open_position_pumpfun_registration_warned: parking_lot::RwLock::new(HashSet::new()),
             geyser_connect_barrier: Arc::new(GeyserConnectBarrier::new()),
             geyser_explicit_ready: AtomicBool::new(true),
             geyser_explicit_config_error: parking_lot::RwLock::new(None),

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -1081,6 +1081,32 @@ const SPL_TOKEN_PROGRAM: &str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
 const SPL_TOKEN_2022_PROGRAM: &str = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
 const WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
 
+/// Controls slot-ordering relaxations in [`exit_quote_price_exit_guard_violation`].
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+enum ExitQuoteGuardOpts {
+    #[default]
+    Strict,
+    /// STOP_LOSS / TAKE_PROFIT: fresh post-entry bonding-curve quotes may trail trade-mark slots.
+    RelaxPositionMarkSlotForHardPriceExit,
+}
+
+#[inline]
+fn exit_quote_hard_price_exit_may_relax_mark_slot_guard(
+    pos: &PositionTracker,
+    q: &ExitExecutableQuote,
+) -> bool {
+    let fresh = q
+        .cache_age_ms
+        .is_some_and(|age| age <= EXIT_QUOTE_MAX_CACHE_AGE_MS);
+    if !fresh {
+        return false;
+    }
+    match q.source_slot {
+        Some(slot) if slot > 0 => pos.entry_confirmed_slot == 0 || slot > pos.entry_confirmed_slot,
+        _ => false,
+    }
+}
+
 #[inline]
 fn exit_quote_address_is_token_program_pseudopool(addr: &str) -> bool {
     addr == SPL_TOKEN_PROGRAM || addr == SPL_TOKEN_2022_PROGRAM
@@ -1131,6 +1157,7 @@ fn exit_quote_price_exit_guard_violation(
     pos: &PositionTracker,
     q: &ExitExecutableQuote,
     dex_pool_accounts: Option<&[String]>,
+    opts: ExitQuoteGuardOpts,
 ) -> Option<&'static str> {
     if !exit_executable_quote_is_usable(q) {
         return Some("NOT_POOL_SOURCED_OR_INVALID_TPS");
@@ -1151,7 +1178,11 @@ fn exit_quote_price_exit_guard_violation(
                 return Some("QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM");
             }
             if pos.last_price_slot > 0 && slot < pos.last_price_slot {
-                return Some("QUOTE_SLOT_BEFORE_LAST_POSITION_MARK_SLOT");
+                let relax = opts == ExitQuoteGuardOpts::RelaxPositionMarkSlotForHardPriceExit
+                    && exit_quote_hard_price_exit_may_relax_mark_slot_guard(pos, q);
+                if !relax {
+                    return Some("QUOTE_SLOT_BEFORE_LAST_POSITION_MARK_SLOT");
+                }
             }
         }
     }
@@ -1643,8 +1674,15 @@ impl PositionTracker {
         live_trades_per_min: Option<f64>,
     ) -> Option<(String, String)> {
         let structural_q = exit_quote.filter(|q| exit_executable_quote_is_usable(q));
-        let price_exit_q =
-            exit_quote.filter(|q| exit_quote_price_exit_guard_violation(self, q, None).is_none());
+        let price_exit_q = exit_quote.filter(|q| {
+            exit_quote_price_exit_guard_violation(
+                self,
+                q,
+                None,
+                ExitQuoteGuardOpts::RelaxPositionMarkSlotForHardPriceExit,
+            )
+            .is_none()
+        });
         let pnl = self.pnl_pct();
         let hold_secs = self.entry_time.elapsed().as_secs();
 
@@ -1687,9 +1725,16 @@ impl PositionTracker {
                 ));
             }
         } else if pnl <= -effective_hard_stop {
-            let suppressed =
-                exit_quote.and_then(|q| exit_quote_price_exit_guard_violation(self, q, None));
+            let suppressed = exit_quote.and_then(|q| {
+                exit_quote_price_exit_guard_violation(
+                    self,
+                    q,
+                    None,
+                    ExitQuoteGuardOpts::RelaxPositionMarkSlotForHardPriceExit,
+                )
+            });
             if let Some(code) = suppressed {
+                ironcrab::metrics::record_momentum_exit_quote_guard_reject_total(code);
                 log_momentum_exit_price_decision(
                     self,
                     exit_quote,
@@ -1749,7 +1794,13 @@ impl PositionTracker {
                 }
             } else if pnl >= config.take_profit_pct {
                 if let Some(q) = exit_quote {
-                    if let Some(code) = exit_quote_price_exit_guard_violation(self, q, None) {
+                    if let Some(code) = exit_quote_price_exit_guard_violation(
+                        self,
+                        q,
+                        None,
+                        ExitQuoteGuardOpts::RelaxPositionMarkSlotForHardPriceExit,
+                    ) {
+                        ironcrab::metrics::record_momentum_exit_quote_guard_reject_total(code);
                         log_momentum_exit_price_decision(
                             self,
                             exit_quote,
@@ -3779,6 +3830,7 @@ impl MomentumContext {
         &self,
         pos: &PositionTracker,
         token_trackers: Option<&HashMap<String, TokenTracker>>,
+        guard_opts: ExitQuoteGuardOpts,
     ) -> Option<ExitExecutableQuote> {
         let token_mint = solana_sdk::pubkey::Pubkey::from_str(&pos.mint).ok()?;
         if pos.pool.is_empty() || pos.token_amount == 0 {
@@ -3851,9 +3903,13 @@ impl MomentumContext {
                 pool_row.dex_pool_accounts.clone().or_else(|| {
                     self.dex_pool_accounts_for_mint_pool(&pos.mint, &pool_addr, token_trackers)
                 });
-            if let Some(reason) =
-                exit_quote_price_exit_guard_violation(pos, &candidate, merged_accounts.as_deref())
-            {
+            if let Some(reason) = exit_quote_price_exit_guard_violation(
+                pos,
+                &candidate,
+                merged_accounts.as_deref(),
+                guard_opts,
+            ) {
+                ironcrab::metrics::record_momentum_exit_quote_guard_reject_total(reason);
                 if guard_reject_sample.is_none() {
                     guard_reject_sample = Some((reason, pool_addr.clone()));
                 }
@@ -4144,7 +4200,14 @@ impl MomentumContext {
                 if pos.pool.is_empty() || pos.token_amount == 0 {
                     continue;
                 }
-                if self.executable_exit_quote(pos, None).is_some() {
+                if self
+                    .executable_exit_quote(
+                        pos,
+                        None,
+                        ExitQuoteGuardOpts::RelaxPositionMarkSlotForHardPriceExit,
+                    )
+                    .is_some()
+                {
                     continue;
                 }
                 rows.push((mint.clone(), pos.pool.clone(), pos.dex.clone()));
@@ -5771,7 +5834,9 @@ impl MomentumContext {
                     self.mark_entry_eval_dirty_key(key);
                     continue;
                 };
-                let Some(ex_q) = self.executable_exit_quote(pos, Some(trackers)) else {
+                let Some(ex_q) =
+                    self.executable_exit_quote(pos, Some(trackers), ExitQuoteGuardOpts::Strict)
+                else {
                     ironcrab::metrics::record_momentum_scale_in_gate_blocked_total(
                         ironcrab::metrics::MomentumScaleInGateBlockedReason::NoQuote,
                     );
@@ -6867,7 +6932,11 @@ impl MomentumContext {
                 continue;
             }
 
-            let exit_q = self.executable_exit_quote(pos, None);
+            let exit_q = self.executable_exit_quote(
+                pos,
+                None,
+                ExitQuoteGuardOpts::RelaxPositionMarkSlotForHardPriceExit,
+            );
             let live_trades_per_min = trades_per_min_by_tracker_key
                 .get(&Self::tracker_storage_key(mint, &pos.pool))
                 .copied();
@@ -7035,9 +7104,13 @@ impl MomentumContext {
             let config = self.config.read().clone();
             let exit_q = {
                 let positions = self.positions.read();
-                positions
-                    .get(&candidate.mint)
-                    .and_then(|p| self.executable_exit_quote(p, None))
+                positions.get(&candidate.mint).and_then(|p| {
+                    self.executable_exit_quote(
+                        p,
+                        None,
+                        ExitQuoteGuardOpts::RelaxPositionMarkSlotForHardPriceExit,
+                    )
+                })
             };
             let chain_head_slot = self
                 .last_event_slot
@@ -19123,7 +19196,7 @@ mod tests {
         ex.source_slot = Some(0);
         ex.cache_age_ms = Some(0);
         assert_ne!(
-            exit_quote_price_exit_guard_violation(&pos, &ex, None),
+            exit_quote_price_exit_guard_violation(&pos, &ex, None, ExitQuoteGuardOpts::Strict),
             Some("QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM"),
             "slot=0 is unknown watermark and must not trip entry-confirm slot guard"
         );
@@ -19137,12 +19210,12 @@ mod tests {
         ex.cache_age_ms = Some(0);
         ex.source_slot = Some(500);
         assert_eq!(
-            exit_quote_price_exit_guard_violation(&pos, &ex, None),
+            exit_quote_price_exit_guard_violation(&pos, &ex, None, ExitQuoteGuardOpts::Strict),
             Some("QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM")
         );
         ex.source_slot = Some(499);
         assert_eq!(
-            exit_quote_price_exit_guard_violation(&pos, &ex, None),
+            exit_quote_price_exit_guard_violation(&pos, &ex, None, ExitQuoteGuardOpts::Strict),
             Some("QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM")
         );
     }
@@ -19154,7 +19227,84 @@ mod tests {
         let mut ex = sample_exit_quote(100.0);
         ex.source_slot = Some(501);
         ex.cache_age_ms = Some(0);
-        assert!(exit_quote_price_exit_guard_violation(&pos, &ex, None).is_none());
+        assert!(
+            exit_quote_price_exit_guard_violation(&pos, &ex, None, ExitQuoteGuardOpts::Strict)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn exit_guard_strict_rejects_fresh_quote_before_last_position_mark_slot() {
+        let mut pos = PositionTracker::new("m", "p", "dex", 100.0, 6, 1_000_000, 0);
+        pos.entry_confirmed_slot = 500;
+        pos.last_price_slot = 900;
+        let mut ex = sample_exit_quote(50.0);
+        ex.source_slot = Some(850);
+        ex.cache_age_ms = Some(500);
+        assert_eq!(
+            exit_quote_price_exit_guard_violation(&pos, &ex, None, ExitQuoteGuardOpts::Strict),
+            Some("QUOTE_SLOT_BEFORE_LAST_POSITION_MARK_SLOT")
+        );
+    }
+
+    #[test]
+    fn exit_guard_hard_price_exit_relaxes_mark_slot_when_fresh_and_after_entry() {
+        let mut pos = PositionTracker::new("m", "p", "dex", 100.0, 6, 1_000_000, 0);
+        pos.entry_confirmed_slot = 500;
+        pos.last_price_slot = 900;
+        let mut ex = sample_exit_quote(50.0);
+        ex.source_slot = Some(850);
+        ex.cache_age_ms = Some(500);
+        assert!(
+            exit_quote_price_exit_guard_violation(
+                &pos,
+                &ex,
+                None,
+                ExitQuoteGuardOpts::RelaxPositionMarkSlotForHardPriceExit,
+            )
+            .is_none(),
+            "fresh post-entry bonding-curve quote must not be vetoed by trade-mark slot"
+        );
+    }
+
+    #[test]
+    fn exit_guard_hard_price_exit_keeps_mark_slot_veto_when_cache_stale() {
+        let mut pos = PositionTracker::new("m", "p", "dex", 100.0, 6, 1_000_000, 0);
+        pos.entry_confirmed_slot = 500;
+        pos.last_price_slot = 900;
+        let mut ex = sample_exit_quote(50.0);
+        ex.source_slot = Some(850);
+        ex.cache_age_ms = Some(EXIT_QUOTE_MAX_CACHE_AGE_MS + 1);
+        assert_eq!(
+            exit_quote_price_exit_guard_violation(
+                &pos,
+                &ex,
+                None,
+                ExitQuoteGuardOpts::RelaxPositionMarkSlotForHardPriceExit,
+            ),
+            Some("STALE_CACHE_AGE_MS")
+        );
+    }
+
+    #[test]
+    fn stop_loss_allows_fresh_quote_when_bonding_curve_slot_trails_trade_mark() {
+        let mut c = make_exit_config();
+        c.hard_stop_loss_pct = 20.0;
+        c.take_profit_pct = 1_000.0;
+        let entry = 100.0;
+        let mut pos = PositionTracker::new("m", "p", "dex", entry, 6, 1_000_000, 0);
+        pos.entry_confirmed_slot = 500;
+        pos.last_price_slot = 900;
+        pos.current_price = 110.0;
+        pos.highest_price = entry;
+        let mut ex = sample_exit_quote(250.0);
+        ex.source_slot = Some(850);
+        ex.cache_age_ms = Some(500);
+        assert_eq!(
+            pos.should_exit(&c, Some(&ex), "test", 9_000_000_000u64, None)
+                .map(|(t, _)| t),
+            Some("STOP_LOSS".to_string())
+        );
     }
 
     #[test]
@@ -19165,7 +19315,7 @@ mod tests {
         ex.source_slot = Some(0);
         ex.cache_age_ms = Some(EXIT_QUOTE_MAX_CACHE_AGE_MS + 1);
         assert_eq!(
-            exit_quote_price_exit_guard_violation(&pos, &ex, None),
+            exit_quote_price_exit_guard_violation(&pos, &ex, None, ExitQuoteGuardOpts::Strict),
             Some("STALE_CACHE_AGE_MS")
         );
     }
@@ -19220,11 +19370,22 @@ mod tests {
         };
         let bad = vec!["a".to_string(), "b".to_string()];
         assert_eq!(
-            exit_quote_price_exit_guard_violation(&pos, &ex, Some(&bad)),
+            exit_quote_price_exit_guard_violation(
+                &pos,
+                &ex,
+                Some(&bad),
+                ExitQuoteGuardOpts::Strict
+            ),
             Some("QUOTE_POOL_ACCOUNTS_NOT_VERIFIED_SOL_PAIR")
         );
         let ok = vec!["x".to_string(), WSOL_MINT.to_string(), "mint9".to_string()];
-        assert!(exit_quote_price_exit_guard_violation(&pos, &ex, Some(&ok)).is_none());
+        assert!(exit_quote_price_exit_guard_violation(
+            &pos,
+            &ex,
+            Some(&ok),
+            ExitQuoteGuardOpts::Strict
+        )
+        .is_none());
     }
 
     #[test]
@@ -19232,7 +19393,7 @@ mod tests {
         let pos = PositionTracker::new("m", "p", "dex", 1.0e7, 6, 69_000_000_000, 0);
         let ex = sample_exit_quote(0.17);
         assert_eq!(
-            exit_quote_price_exit_guard_violation(&pos, &ex, None),
+            exit_quote_price_exit_guard_violation(&pos, &ex, None, ExitQuoteGuardOpts::Strict),
             Some("QUOTE_TPS_SCALE_MISMATCH")
         );
     }
@@ -19241,7 +19402,10 @@ mod tests {
     fn scale_mismatch_guard_allows_quote_within_100x_of_entry() {
         let pos = PositionTracker::new("m", "p", "dex", 1.0e7, 6, 1_000_000, 0);
         let ex = sample_exit_quote(9.0e6);
-        assert!(exit_quote_price_exit_guard_violation(&pos, &ex, None).is_none());
+        assert!(
+            exit_quote_price_exit_guard_violation(&pos, &ex, None, ExitQuoteGuardOpts::Strict)
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/market_data/sidefx/handlers.rs
+++ b/src/market_data/sidefx/handlers.rs
@@ -1228,6 +1228,41 @@ pub fn md_sidefx_process_bonding_curve(host: &dyn SidefxWorkerHost, job: &MdSide
                 "P2#7: BondingCurveUpdate fallback PoolCacheUpdate enqueued for JetStream"
             );
         }
+    } else if host.is_hot_pool(pool_address) {
+        if let Some(CachedPoolState::PumpFun(mut s)) = host.live_pool_cache().get(pool_address) {
+            s.virtual_token_reserves = *virtual_token_reserves;
+            s.virtual_sol_reserves = *virtual_sol_reserves;
+            s.real_token_reserves = *real_token_reserves;
+            s.real_sol_reserves = *real_sol_reserves;
+            s.complete = *complete;
+            s.cashback_enabled = *cashback_enabled;
+            if s.creator == Pubkey::default() {
+                s.creator = *creator;
+            }
+            if host
+                .live_pool_cache()
+                .upsert(*pool_address, CachedPoolState::PumpFun(s), *slot)
+                && host.nats_enabled()
+            {
+                if let Some(balance_update) =
+                    md_sidefx_build_balance_updated_from_cache(host, run_id, pool_address, *slot)
+                {
+                    let subject = pool_subject(&pool_str);
+                    sidefx_host_enqueue_jetstream(
+                        host,
+                        subject,
+                        &balance_update,
+                        "hot PumpFun BondingCurve reserve refresh PoolCacheUpdate",
+                        false,
+                    );
+                    debug!(
+                        pool = %pool_str,
+                        slot = *slot,
+                        "hot PumpFun BondingCurve reserve refresh enqueued for JetStream"
+                    );
+                }
+            }
+        }
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3278,6 +3278,25 @@ pub fn record_momentum_exit_quote_scale_mismatch_total() {
     MOMENTUM_EXIT_QUOTE_SCALE_MISMATCH_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+static MOMENTUM_EXIT_QUOTE_GUARD_REJECT_TOTAL: Lazy<RwLock<HashMap<&'static str, u64>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+
+/// Labeled: `momentum_exit_quote_guard_reject_total{reason=...}`.
+#[inline]
+pub fn record_momentum_exit_quote_guard_reject_total(reason: &'static str) {
+    let mut map = MOMENTUM_EXIT_QUOTE_GUARD_REJECT_TOTAL.write();
+    *map.entry(reason).or_insert(0) += 1;
+}
+
+static MARKET_DATA_OPEN_POSITION_PUMPFUN_REGISTRATION_UNSATISFIED_WARN_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn inc_market_data_open_position_pumpfun_registration_unsatisfied_warn_total() {
+    MARKET_DATA_OPEN_POSITION_PUMPFUN_REGISTRATION_UNSATISFIED_WARN_TOTAL
+        .fetch_add(1, Ordering::Relaxed);
+}
+
 #[inline]
 pub fn record_momentum_overlay_closed_by_authority_total() {
     MOMENTUM_OVERLAY_CLOSED_BY_AUTHORITY_TOTAL.fetch_add(1, Ordering::Relaxed);
@@ -8538,6 +8557,18 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "momentum_exit_quote_scale_mismatch_total",
         MOMENTUM_EXIT_QUOTE_SCALE_MISMATCH_TOTAL.load(Ordering::Relaxed)
+    );
+    for (reason, count) in MOMENTUM_EXIT_QUOTE_GUARD_REJECT_TOTAL.read().iter() {
+        out.push_str("momentum_exit_quote_guard_reject_total{reason=\"");
+        out.push_str(reason);
+        out.push_str("\"} ");
+        out.push_str(&count.to_string());
+        out.push('\n');
+    }
+    line!(
+        "market_data_open_position_pumpfun_registration_unsatisfied_warn_total",
+        MARKET_DATA_OPEN_POSITION_PUMPFUN_REGISTRATION_UNSATISFIED_WARN_TOTAL
+            .load(Ordering::Relaxed)
     );
     line!(
         "momentum_overlay_closed_by_authority_total",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Open PumpFun positions could miss hard STOP_LOSS/TAKE_PROFIT for minutes when:
1. SLAVE `LivePoolCache` age stayed stale (>4s) between sparse Ensure refreshes
2. Fresh bonding-curve quotes were vetoed by `QUOTE_SLOT_BEFORE_LAST_POSITION_MARK_SLOT` racing ahead of trade-mark slots

Evidence: Rocketman `BYMGdhV…pump` — STOP_LOSS at −43.5% vs −30% limit after ~4.5 min (`findings_rocketman_sl_stale_blindness_20260801.md`).

## Changes

### A) Continuous freshness (hot/position-pinned PumpFun)
- `md_sidefx_process_bonding_curve`: when pool is hot-pinned and PumpFun cache already exists, upsert virtual/real reserves from Geyser and enqueue JetStream `BalanceUpdated` (no silent drop after first insert)
- Existing explicit/satisfied checks, ExecHot account-update publish path, and momentum-hot cache-first publish bypass remain unchanged

### B) Hard-stop guard relaxation (STOP_LOSS / TAKE_PROFIT only)
- New `ExitQuoteGuardOpts::RelaxPositionMarkSlotForHardPriceExit` used by exit scan + `should_exit`
- Skips `QUOTE_SLOT_BEFORE_LAST_POSITION_MARK_SLOT` only when `cache_age_ms ≤ 4s` **and** `source_slot > entry_confirmed_slot`
- Scale-in gate keeps `Strict` slot ordering; trailing-stop path unchanged

### C) Observability
- `momentum_exit_quote_guard_reject_total{reason=...}` counter on guard rejects
- WARN + `market_data_open_position_pumpfun_registration_unsatisfied_warn_total` when open-position PumpFun `hot_pool_reserve_registration_satisfied == false` for >10s

## Invariants preserved
- I-4/I-7: no Hot-Path RPC; Geyser→JetStream→SLAVE remains SSOT
- I-9/I-12: simulation gate + exit decision logging unchanged
- `STALE_CACHE_AGE_MS` and `QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM` guards retained

## Tests
- Guard relaxation unit tests (strict vs relaxed, stale veto, integrated STOP_LOSS)
- `pumpfun_hot_bonding_curve_sidefx_refreshes_existing_cache_reserves`
- Existing PumpFun explicit/satisfied/publish tests pass

## Verification
```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f1d9f5a-046c-4af5-9ed0-4d43e7d9f470?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f1d9f5a-046c-4af5-9ed0-4d43e7d9f470&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

