### PR TITLE
fix(momentum): PumpFun open-position exit-quote freshness (P0 follow-up)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -118,6 +118,7 @@ use ironcrab::metrics::{
     inc_market_data_momentum_admission_rejected_total,
     inc_market_data_open_position_pin_applied_total,
     inc_market_data_open_position_pin_deferred_cache_miss_total,
+    inc_market_data_open_position_pumpfun_registration_remediate_total,
     inc_market_data_open_position_pumpfun_registration_unsatisfied_warn_total,
     inc_market_data_tracker_admission_admitted_total,
     inc_market_data_tracker_admission_rejected_total,
@@ -2195,8 +2196,11 @@ impl TrackWorkerContext for MarketDataContext {
         self.refresh_hot_pool_registry_gauges();
     }
 
-    fn tick_momentum_hot_balance_refresh_heartbeat(&self) {
-        self.tick_momentum_hot_balance_refresh_heartbeat();
+    fn tick_momentum_hot_balance_refresh_heartbeat(
+        &self,
+        admission: &mut FixedCapAdmission,
+    ) -> bool {
+        self.tick_momentum_hot_balance_refresh_heartbeat(admission)
     }
 
     fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
@@ -4469,16 +4473,82 @@ impl MarketDataContext {
     }
 
     /// Periodic heartbeat for momentum-hot pins: sustain SLAVE `LivePoolCache` age during WaitHotSet.
-    fn tick_momentum_hot_balance_refresh_heartbeat(&self) {
+    /// Returns `true` when explicit Geyser sync should be coalesced (registration remediation).
+    fn tick_momentum_hot_balance_refresh_heartbeat(
+        &self,
+        admission: &mut FixedCapAdmission,
+    ) -> bool {
         if self.hot_pool_registry.hot_pool_count_momentum() == 0 {
-            return;
+            return false;
         }
         for pool in self.hot_pool_registry.snapshot_hot_pool_pubkeys() {
             if self.hot_pool_registry.pool_has_momentum(pool) {
                 self.try_publish_balance_updated_from_cache(pool);
             }
         }
+        let batch_dirty = self.remediate_open_position_pumpfun_registration(admission);
         self.tick_open_position_pumpfun_registration_observability();
+        batch_dirty
+    }
+
+    /// Admit/register/resync bonding-curve explicit for position-pinned PumpFun when unsatisfied.
+    fn remediate_open_position_pumpfun_registration(
+        &self,
+        admission: &mut FixedCapAdmission,
+    ) -> bool {
+        let mut batch_dirty = false;
+        for (mint, pool) in self.hot_pool_registry.snapshot_pairs() {
+            if !self.hot_pool_registry.is_position_pin(mint, pool) {
+                continue;
+            }
+            let Some(state) = self.live_pool_cache.get(&pool) else {
+                self.note_deferred_hot_pool_reserve_registration(
+                    pool,
+                    GeyserPinReason::MomentumActive,
+                );
+                continue;
+            };
+            if !matches!(state, CachedPoolState::PumpFun(_)) {
+                continue;
+            }
+            if self.hot_pool_reserve_registration_satisfied(pool) {
+                continue;
+            }
+
+            inc_market_data_open_position_pumpfun_registration_remediate_total();
+            let consumer = ExplicitConsumer::MomentumPosition;
+            let admitted_before: HashSet<Pubkey> =
+                admission.snapshot_pubkeys().into_iter().collect();
+            if !self.try_admit_pool_consumer_group(admission, pool, consumer) {
+                self.note_deferred_hot_pool_reserve_registration(
+                    pool,
+                    GeyserPinReason::MomentumActive,
+                );
+                continue;
+            }
+            let registered = self
+                .register_geyser_reserves_for_active_pool(pool, GeyserPinReason::MomentumActive);
+            let admitted_after: HashSet<Pubkey> =
+                admission.snapshot_pubkeys().into_iter().collect();
+            self.sync_explicit_pool_admitted_from_admission(admission, pool, consumer);
+            if self.hot_pool_reserve_registration_satisfied(pool) {
+                self.clear_deferred_hot_pool_reserve_registration(pool);
+                inc_market_data_open_position_pin_applied_total();
+                self.publish_momentum_hot_balance_refresh_from_cache(pool);
+            } else {
+                self.note_deferred_hot_pool_reserve_registration(
+                    pool,
+                    GeyserPinReason::MomentumActive,
+                );
+            }
+            if admitted_before != admitted_after || registered {
+                batch_dirty = true;
+            }
+            if self.explicit_physical_publish_needed(admission) {
+                batch_dirty = true;
+            }
+        }
+        batch_dirty
     }
 
     /// WARN once per episode when position-pinned PumpFun lacks bonding-curve Geyser registration.
@@ -16855,7 +16925,8 @@ mod pr_b_geyser_tracking_tests {
 
         assert!(ctx.hot_pool_registry.pool_has_momentum(pool));
         assert!(!ctx.balance_updated_from_cache_skipped_for_live_feed(pool));
-        ctx.tick_momentum_hot_balance_refresh_heartbeat();
+        let mut admission = test_admission_for(&ctx);
+        ctx.tick_momentum_hot_balance_refresh_heartbeat(&mut admission);
         assert!(
             cached_pool_has_fresh_reserve_basis(&ctx.live_pool_cache.get(&pool).unwrap()),
             "heartbeat must target momentum-hot pool with publishable reserve basis"
@@ -16887,7 +16958,55 @@ mod pr_b_geyser_tracking_tests {
         ctx.hot_pool_registry.pin_arb_pool(pool);
 
         assert!(!ctx.hot_pool_registry.pool_has_momentum(pool));
-        ctx.tick_momentum_hot_balance_refresh_heartbeat();
+        let mut admission = test_admission_for(&ctx);
+        ctx.tick_momentum_hot_balance_refresh_heartbeat(&mut admission);
+    }
+
+    #[test]
+    fn open_position_pumpfun_unsatisfied_registration_remediates_admission() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::PumpFun(PumpFunState {
+                token_mint: mint,
+                bonding_curve: pool,
+                associated_bonding_curve: Pubkey::new_unique(),
+                virtual_sol_reserves: 30_000_000_000,
+                virtual_token_reserves: 1_073_000_000_000_000,
+                real_sol_reserves: 10_000_000_000,
+                real_token_reserves: 500_000_000_000_000,
+                complete: false,
+                creator: Pubkey::new_unique(),
+                cashback_enabled: false,
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool_with_reason(mint, pool, true);
+
+        assert!(
+            !ctx.hot_pool_reserve_registration_satisfied(pool),
+            "position pin must require bonding curve explicit sync"
+        );
+
+        let mut admission = test_admission_for(&ctx);
+        assert!(
+            ctx.remediate_open_position_pumpfun_registration(&mut admission),
+            "remediation must admit bonding curve and request Geyser sync"
+        );
+        assert!(
+            admission.snapshot_pubkeys().contains(&pool),
+            "bonding curve must be in admitted explicit set"
+        );
+        assert!(
+            ctx.explicit_physical_publish_needed(&admission),
+            "physical Geyser publish must be scheduled after admission delta"
+        );
     }
 
     #[test]
@@ -16925,7 +17044,11 @@ mod pr_b_geyser_tracking_tests {
                 .contains(&pool),
             "unpinned pool must leave hot registry before heartbeat tick"
         );
-        ctx.tick_momentum_hot_balance_refresh_heartbeat();
+        let mut admission = test_admission_for(&ctx);
+        assert!(
+            !ctx.tick_momentum_hot_balance_refresh_heartbeat(&mut admission),
+            "heartbeat must no-op when no momentum-hot pools remain"
+        );
     }
 
     #[test]

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -157,6 +157,8 @@ struct MomentumActivePoolPublishQueue {
 
 /// Cooldown between repeated `Ensure*` ControlRequests for the same open-position pool recovery key.
 const OPEN_POSITION_POOL_RECOVERY_COOLDOWN: Duration = Duration::from_secs(60);
+/// Aggressive cooldown when an open PumpFun position lacks a usable exit quote (exit blindness).
+const OPEN_POSITION_EXIT_BLIND_PUMPFUN_RECOVERY_COOLDOWN: Duration = Duration::from_secs(5);
 
 /// Max recovery publishes per timed reconcile tick when executable quotes are still missing.
 const OPEN_POSITION_POOL_RECOVERY_RETRY_MAX_PER_TICK: usize = 8;
@@ -218,6 +220,19 @@ fn open_position_pool_recovery_dedupe_key(
     kind: OpenPositionPoolRecoveryKind,
 ) -> String {
     format!("{mint}\x1f{pool}\x1f{kind:?}")
+}
+
+fn open_position_pool_recovery_cooldown(
+    recovery_kind: OpenPositionPoolRecoveryKind,
+    reason_tag: &'static str,
+) -> Duration {
+    if reason_tag == "quote_missing_retry"
+        && recovery_kind == OpenPositionPoolRecoveryKind::PumpfunBonding
+    {
+        OPEN_POSITION_EXIT_BLIND_PUMPFUN_RECOVERY_COOLDOWN
+    } else {
+        OPEN_POSITION_POOL_RECOVERY_COOLDOWN
+    }
 }
 
 /// Core NATS delivers no publisher discovery: subscribing to [`TOPIC_MOMENTUM_MARKET_EVENTS`]
@@ -4123,11 +4138,12 @@ impl MomentumContext {
                 recovery_kind,
             );
             let key = open_position_pool_recovery_dedupe_key(mint, pool, kind);
+            let cooldown = open_position_pool_recovery_cooldown(kind, reason_tag);
             let now = Instant::now();
             {
                 let map = self.open_position_pool_recovery_last_sent.read();
                 if let Some(prev) = map.get(&key) {
-                    if now.duration_since(*prev) < OPEN_POSITION_POOL_RECOVERY_COOLDOWN {
+                    if now.duration_since(*prev) < cooldown {
                         debug!(
                             mint = %mint,
                             pool = %pool,
@@ -13148,6 +13164,31 @@ mod tests {
             &[OpenPositionPoolRecoveryKind::PumpAmmAccounts]
         );
         assert!(open_position_pool_recovery_kinds_for_normalized_dex("unknown_dex").is_empty());
+    }
+
+    #[test]
+    fn open_position_exit_blind_pumpfun_recovery_uses_short_cooldown() {
+        assert_eq!(
+            open_position_pool_recovery_cooldown(
+                OpenPositionPoolRecoveryKind::PumpfunBonding,
+                "quote_missing_retry"
+            ),
+            OPEN_POSITION_EXIT_BLIND_PUMPFUN_RECOVERY_COOLDOWN
+        );
+        assert_eq!(
+            open_position_pool_recovery_cooldown(
+                OpenPositionPoolRecoveryKind::PumpfunBonding,
+                "startup"
+            ),
+            OPEN_POSITION_POOL_RECOVERY_COOLDOWN
+        );
+        assert_eq!(
+            open_position_pool_recovery_cooldown(
+                OpenPositionPoolRecoveryKind::PumpAmmAccounts,
+                "quote_missing_retry"
+            ),
+            OPEN_POSITION_POOL_RECOVERY_COOLDOWN
+        );
     }
 
     #[test]

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -1776,6 +1776,59 @@ mod tests {
     }
 
     #[test]
+    fn test_pumpfun_balance_updated_refreshes_existing_cache_age() {
+        use std::time::Duration;
+
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+
+        let mut discovered = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1_073_000_000_000_000,
+            30_000_000_000,
+            Some(0),
+            1,
+        );
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("complete".to_string(), "false".to_string());
+        discovered.metadata = Some(meta);
+        assert!(apply_pool_cache_update(&cache, &discovered));
+
+        std::thread::sleep(Duration::from_millis(40));
+        let (_, _, age_before) = cache.get_with_metadata(&pool).expect("cached");
+        assert!(age_before >= 30, "seed row must age before refresh");
+
+        let mut bal = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1_050_000_000_000_000,
+            32_000_000_000,
+            2,
+        );
+        bal.set_dex_readiness_in_metadata(DexPoolReadiness::Observed);
+        assert!(apply_pool_cache_update(&cache, &bal));
+
+        let (_, _, age_after) = cache.get_with_metadata(&pool).expect("cached");
+        assert!(
+            age_after < 20,
+            "PumpFun BalanceUpdated with reserve basis must refresh SLAVE cache age"
+        );
+    }
+
+    #[test]
     fn test_raydium_cpmm_balance_updated_preserves_vaults_and_merges_readiness() {
         let cache = LivePoolCache::new();
         let pool = Pubkey::new_unique();

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -110,7 +110,11 @@ pub trait TrackWorkerContext: Send + Sync {
     fn arb_pool_is_must_hot(&self, pool: Pubkey) -> bool;
     fn refresh_hot_pool_registry_gauges(&self);
     /// Periodic JetStream refresh for momentum-hot pins (WaitHotSet sustained freshness).
-    fn tick_momentum_hot_balance_refresh_heartbeat(&self);
+    /// Returns `true` when explicit Geyser sync should be coalesced (registration remediation).
+    fn tick_momentum_hot_balance_refresh_heartbeat(
+        &self,
+        admission: &mut FixedCapAdmission,
+    ) -> bool;
     fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey>;
     fn sync_geyser_tracked_accounts_batched_flush_with_deadline(
         &self,
@@ -667,7 +671,16 @@ fn track_worker_loop<C: TrackWorkerContext + 'static>(
             >= Duration::from_millis(MARKET_DATA_MOMENTUM_HOT_BALANCE_REFRESH_HEARTBEAT_MS)
         {
             last_momentum_hot_balance_heartbeat = Instant::now();
-            ctx.tick_momentum_hot_balance_refresh_heartbeat();
+            if ctx.tick_momentum_hot_balance_refresh_heartbeat(&mut admission) {
+                track_worker_prepare_command_delivery(
+                    &ctx,
+                    &TrackWorkerCommand::ScheduleGeyserPush,
+                    &mut coalesce_deadline,
+                    &mut push_before_keys,
+                    &mut pending_continue_evict,
+                    &mut pending_release_flush_slot,
+                );
+            }
         }
     }
 }
@@ -1013,7 +1026,12 @@ mod tests {
 
         fn refresh_hot_pool_registry_gauges(&self) {}
 
-        fn tick_momentum_hot_balance_refresh_heartbeat(&self) {}
+        fn tick_momentum_hot_balance_refresh_heartbeat(
+            &self,
+            _admission: &mut FixedCapAdmission,
+        ) -> bool {
+            false
+        }
 
         fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
             HashSet::new()
@@ -1327,7 +1345,12 @@ mod tests {
 
             fn refresh_hot_pool_registry_gauges(&self) {}
 
-            fn tick_momentum_hot_balance_refresh_heartbeat(&self) {}
+            fn tick_momentum_hot_balance_refresh_heartbeat(
+                &self,
+                _admission: &mut FixedCapAdmission,
+            ) -> bool {
+                false
+            }
 
             fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
                 HashSet::new()
@@ -1586,7 +1609,12 @@ mod tests {
 
         fn refresh_hot_pool_registry_gauges(&self) {}
 
-        fn tick_momentum_hot_balance_refresh_heartbeat(&self) {}
+        fn tick_momentum_hot_balance_refresh_heartbeat(
+            &self,
+            _admission: &mut FixedCapAdmission,
+        ) -> bool {
+            false
+        }
 
         fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
             HashSet::new()
@@ -1841,7 +1869,12 @@ mod tests {
                 false
             }
             fn refresh_hot_pool_registry_gauges(&self) {}
-            fn tick_momentum_hot_balance_refresh_heartbeat(&self) {}
+            fn tick_momentum_hot_balance_refresh_heartbeat(
+                &self,
+                _admission: &mut FixedCapAdmission,
+            ) -> bool {
+                false
+            }
             fn snapshot_explicit_subscription_pubkeys(&self) -> HashSet<Pubkey> {
                 HashSet::new()
             }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3297,6 +3297,14 @@ pub fn inc_market_data_open_position_pumpfun_registration_unsatisfied_warn_total
         .fetch_add(1, Ordering::Relaxed);
 }
 
+static MARKET_DATA_OPEN_POSITION_PUMPFUN_REGISTRATION_REMEDIATE_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn inc_market_data_open_position_pumpfun_registration_remediate_total() {
+    MARKET_DATA_OPEN_POSITION_PUMPFUN_REGISTRATION_REMEDIATE_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
 #[inline]
 pub fn record_momentum_overlay_closed_by_authority_total() {
     MOMENTUM_OVERLAY_CLOSED_BY_AUTHORITY_TOTAL.fetch_add(1, Ordering::Relaxed);
@@ -8569,6 +8577,10 @@ async fn metrics_response() -> Response<Body> {
         "market_data_open_position_pumpfun_registration_unsatisfied_warn_total",
         MARKET_DATA_OPEN_POSITION_PUMPFUN_REGISTRATION_UNSATISFIED_WARN_TOTAL
             .load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_open_position_pumpfun_registration_remediate_total",
+        MARKET_DATA_OPEN_POSITION_PUMPFUN_REGISTRATION_REMEDIATE_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "momentum_overlay_closed_by_authority_total",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Kontext

Follow-up zu PR #349 nach Prod-Soak (~02:53–03:14 CEST): `STALE_CACHE_AGE_MS` dominierte weiterhin Exit-Guards für offene PumpFun-Positionen; `registration_unsatisfied_warn` ≥2; Ensure-Retries nur alle 60s.

## Änderungen (3 Schichten)

### A) Open-Position PumpFun: Registration-Remediation (sofort)
- Neuer Pfad `remediate_open_position_pumpfun_registration` im 2s-Momentum-Hot-Heartbeat
- Bei position-pinned PumpFun + unsatisfied `hot_pool_reserve_registration_satisfied`:
  - `MomentumPosition`-Explicit admit (Bonding-Curve in planned pubkeys)
  - Reserve-Register + deferred-clear bei Erfolg
  - Coalesced `ScheduleGeyserPush` vom Track-Worker (kein 10s-WARN-only mehr)
- Metrik: `market_data_open_position_pumpfun_registration_remediate_total`

### B) Mom-SLAVE Age-Frische (Regression)
- Test `test_pumpfun_balance_updated_refreshes_existing_cache_age`: bestehender PumpFun-Cache + `BalanceUpdated` mit Reserve-Basis → `updated_at`/age refresh ≤20ms

### C) Cold-Path Ensure aggressiver bei Exit-Blindheit
- `OPEN_POSITION_EXIT_BLIND_PUMPFUN_RECOVERY_COOLDOWN = 5s` nur für `PumpfunBonding` + `quote_missing_retry`
- Startup/andere DEX/kinds bleiben bei 60s

## Invarianten
- Kein Hot-Path-RPC (I-7): Remediation + Ensure bleiben Cold Path / JetStream / Geyser-Explicit
- `STALE_CACHE_AGE_MS` Guard unverändert (I-9/I-12)

## Tests
- `open_position_pumpfun_unsatisfied_registration_remediates_admission`
- `test_pumpfun_balance_updated_refreshes_existing_cache_age`
- `open_position_exit_blind_pumpfun_recovery_uses_short_cooldown`
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` grün

## Nicht im Scope
- Quote-first abschaffen / Trailing-ATH / Cap-Bump / Deploy
- Gap-Overshoot ohne STALE (z.B. lange Blindheit ohne Reject-WARNs) — beobachtet, separater Follow-up

## Abnahme (fachlich)
Offene PumpFun-Position unter aktivem Handel: Hard-Stop nahe Limit, keine Minuten-`STALE`-Blindheit, Ensure-Retry ≤5s bei fehlendem Exit-Quote.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2af0926c-0601-40be-ac9e-5c7acf59ce68?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2af0926c-0601-40be-ac9e-5c7acf59ce68&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

