### PR TITLE
fix(liq+wsol): creator retry after preferred skip; clear pending on WSOL=0

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -2573,6 +2573,11 @@ struct ExecutionContext {
     pump_amm_hot_path_refresh_last: Arc<ParkingMutex<HashMap<Pubkey, Instant>>>,
 }
 
+struct PumpfunLiquidationSellOutcome {
+    min_out: Option<u64>,
+    missing_creator: bool,
+}
+
 #[cfg(test)]
 impl ExecutionContext {
     fn test_for_pa2_metrics(
@@ -2839,8 +2844,52 @@ impl ExecutionContext {
         ((quoted_out as u128) * (keep_bps as u128) / 10_000u128) as u64
     }
 
+    /// Cold-path: resolve PumpFun bonding-curve creator (cache first, then RPC).
+    async fn liquidation_fetch_pumpfun_creator(
+        &self,
+        bonding_curve: &Pubkey,
+        mint: &Pubkey,
+    ) -> Result<Pubkey, String> {
+        if let Some(cache) = self.live_pool_cache.as_ref() {
+            if let Some(creator) = cache.get_pumpfun_creator(bonding_curve) {
+                return Ok(creator);
+            }
+        }
+
+        warn!(
+            mint = %mint,
+            bonding_curve = %bonding_curve,
+            "LIQUIDATION: Creator not in cache, falling back to RPC"
+        );
+
+        let account = self
+            .rpc
+            .get_account(bonding_curve)
+            .await
+            .map_err(|e| format!("rpc_fetch_failed: {e:#}"))?;
+
+        let state = BondingCurveState::parse(&account.data)
+            .map_err(|e| format!("rpc_parse_failed: {e:#}"))?;
+
+        if state.creator == Pubkey::default() {
+            return Err("rpc_parse_default_creator".to_string());
+        }
+
+        if let Some(cache) = self.live_pool_cache.as_ref() {
+            cache.seed_pumpfun_creator_if_missing(bonding_curve, state.creator);
+        }
+
+        info!(
+            mint = %mint,
+            bonding_curve = %bonding_curve,
+            creator = %state.creator,
+            "LIQUIDATION: Creator fetched via RPC fallback"
+        );
+        Ok(state.creator)
+    }
+
     /// Cold-path: build a PumpFun bonding-curve SELL quote. `route_label` is `pumpfun_preferred`
-    /// (Scope 51: try before multi-pool) or `pumpfun_fallback` (legacy: last resort after multi-pool).
+    /// (Scope 51: try before multi-pool), `pumpfun_creator_retry`, or `pumpfun_fallback`.
     #[allow(clippy::too_many_arguments)] // Consolidates duplicated liquidation pumpfun SELL build path
     async fn liquidation_build_pumpfun_sell(
         &self,
@@ -2853,8 +2902,9 @@ impl ExecutionContext {
         metadata: &mut HashMap<String, String>,
         resources: &mut TradeResources,
         quote_attempts: &mut Vec<String>,
-    ) -> Option<u64> {
+    ) -> PumpfunLiquidationSellOutcome {
         let mut min_out: Option<u64> = None;
+        let mut missing_creator = false;
         match pumpfun
             .quote_exact_in(&mint.to_string(), &sol_mint.to_string(), amount_in)
             .await
@@ -2863,50 +2913,30 @@ impl ExecutionContext {
                 if let Some(bc_str) = q.route.first() {
                     resources.pools = vec![bc_str.clone()];
 
-                    let mut _creator_found = false;
                     if let Ok(bc) = Pubkey::from_str(bc_str) {
-                        if let Some(cache) = self.live_pool_cache.as_ref() {
-                            if let Some(creator) = cache.get_pumpfun_creator(&bc) {
+                        match self.liquidation_fetch_pumpfun_creator(&bc, mint).await {
+                            Ok(creator) => {
                                 metadata.insert("creator".to_string(), creator.to_string());
-                                _creator_found = true;
+                            }
+                            Err(reason) => {
+                                missing_creator = true;
+                                warn!(
+                                    mint = %mint,
+                                    bonding_curve = %bc,
+                                    reason = %reason,
+                                    "LIQUIDATION: Creator resolution failed"
+                                );
+                                quote_attempts.push(format!(
+                                    "{route_label}=skip missing_creator reason={reason}"
+                                ));
                             }
                         }
-
-                        if !_creator_found {
-                            warn!(
-                                mint = %mint,
-                                bonding_curve = %bc,
-                                "LIQUIDATION: Creator not in cache, falling back to RPC"
-                            );
-                            match self.rpc.get_account(&bc).await {
-                                Ok(account) => {
-                                    if account.data.len() >= 81 {
-                                        let creator_bytes: [u8; 32] = account.data[49..81]
-                                            .try_into()
-                                            .expect("slice is exactly 32 bytes");
-                                        let creator = Pubkey::new_from_array(creator_bytes);
-                                        if creator != Pubkey::default() {
-                                            metadata
-                                                .insert("creator".to_string(), creator.to_string());
-                                            _creator_found = true;
-                                            info!(
-                                                mint = %mint,
-                                                creator = %creator,
-                                                "LIQUIDATION: Creator fetched via RPC fallback"
-                                            );
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    warn!(
-                                        error = %e,
-                                        mint = %mint,
-                                        "LIQUIDATION: RPC fallback for creator failed"
-                                    );
-                                }
-                            }
-                        }
+                    } else {
+                        quote_attempts.push(format!(
+                            "{route_label}=skip invalid_bonding_curve_pubkey pool={bc_str}"
+                        ));
                     }
+
                     if metadata.contains_key("creator") && resources.pools.len() == 1 {
                         metadata.insert("sell_routing".to_string(), route_label.to_string());
                         metadata.insert("dex".to_string(), "pumpfun".to_string());
@@ -2922,7 +2952,7 @@ impl ExecutionContext {
                                 .map(|s| s.as_str())
                                 .unwrap_or("<none>")
                         ));
-                    } else {
+                    } else if !missing_creator {
                         quote_attempts.push(format!(
                             "{}=skip missing_creator_or_pool creator_present={} pools_len={}",
                             route_label,
@@ -2941,7 +2971,10 @@ impl ExecutionContext {
                 quote_attempts.push(format!("{route_label}=err {e:#}"));
             }
         }
-        min_out
+        PumpfunLiquidationSellOutcome {
+            min_out,
+            missing_creator,
+        }
     }
 
     /// 6005-Retry: Bei BondingCurveComplete (PumpFun) Retry mit PumpSwap AMM.
@@ -4154,9 +4187,11 @@ impl ExecutionContext {
             let try_pumpfun_first =
                 liquidation_pumpfun_sell_preference(ctx.live_pool_cache.as_deref(), &mint);
 
+            let mut pumpfun_preferred_missing_creator = false;
+
             if try_pumpfun_first {
                 if let Some(ref pfun) = pumpfun {
-                    min_out_sol = ctx
+                    let outcome = ctx
                         .liquidation_build_pumpfun_sell(
                             pfun,
                             &mint,
@@ -4169,6 +4204,8 @@ impl ExecutionContext {
                             &mut quote_attempts,
                         )
                         .await;
+                    min_out_sol = outcome.min_out;
+                    pumpfun_preferred_missing_creator = outcome.missing_creator;
                     #[cfg(unix)]
                     maybe_ping_watchdog();
                 }
@@ -4347,21 +4384,51 @@ impl ExecutionContext {
                             });
                         };
 
+                    // Bonding curve was quotable but creator missed on preferred pass — retry PumpFun
+                    // before blocking on the 45s PumpSwap quote/discovery timeout.
+                    if pumpfun_preferred_missing_creator {
+                        if let Some(ref pfun) = pumpfun {
+                            let outcome = ctx
+                                .liquidation_build_pumpfun_sell(
+                                    pfun,
+                                    &mint,
+                                    &sol_mint,
+                                    amount_in,
+                                    max_slippage_bps,
+                                    "pumpfun_creator_retry",
+                                    &mut metadata,
+                                    &mut resources,
+                                    &mut quote_attempts,
+                                )
+                                .await;
+                            min_out_sol = outcome.min_out;
+                            if outcome.min_out.is_some() {
+                                pumpfun_preferred_missing_creator = false;
+                            }
+                            #[cfg(unix)]
+                            maybe_ping_watchdog();
+                        }
+                    }
+
                     // PumpSwap (Pump.fun AMM) with timeout guard.
                     // For LIQUIDATION: always try PumpSwap AMM regardless of bonding_curve_known_complete.
                     // The LivePoolCache may not know the curve is complete, but PumpSwap AMM
                     // might still have a pool. The RPC-based discovery in quote_exact_in handles this.
-                    let pump_amm_quote = Some(
-                        tokio::time::timeout(
-                            Duration::from_secs(PUMPSWAP_LIQUIDATION_QUOTE_TIMEOUT_SECS),
-                            pump_amm.quote_exact_in(
-                                &mint.to_string(),
-                                &sol_mint.to_string(),
-                                amount_in,
-                            ),
+                    let pump_amm_quote = if min_out_sol.is_none() {
+                        Some(
+                            tokio::time::timeout(
+                                Duration::from_secs(PUMPSWAP_LIQUIDATION_QUOTE_TIMEOUT_SECS),
+                                pump_amm.quote_exact_in(
+                                    &mint.to_string(),
+                                    &sol_mint.to_string(),
+                                    amount_in,
+                                ),
+                            )
+                            .await,
                         )
-                        .await,
-                    );
+                    } else {
+                        None
+                    };
                     match pump_amm_quote {
                         None => {} // Already logged above
                         Some(Err(_timeout)) => {
@@ -5003,22 +5070,30 @@ impl ExecutionContext {
                 }
 
                 // Last resort: PumpFun bonding-curve SELL when multi-pool + cache had no route.
-                // (Skip if we already tried pumpfun_preferred at the start — no duplicate work.)
-                if min_out_sol.is_none() && !try_pumpfun_first {
+                // Retry when preferred skipped only due to missing_creator (not a duplicate ok-quote).
+                let allow_pumpfun_fallback =
+                    !try_pumpfun_first || pumpfun_preferred_missing_creator;
+                if min_out_sol.is_none() && allow_pumpfun_fallback {
                     if let Some(ref pfun) = pumpfun {
-                        min_out_sol = ctx
+                        let route_label = if pumpfun_preferred_missing_creator {
+                            "pumpfun_creator_retry"
+                        } else {
+                            "pumpfun_fallback"
+                        };
+                        let outcome = ctx
                             .liquidation_build_pumpfun_sell(
                                 pfun,
                                 &mint,
                                 &sol_mint,
                                 amount_in,
                                 max_slippage_bps,
-                                "pumpfun_fallback",
+                                route_label,
                                 &mut metadata,
                                 &mut resources,
                                 &mut quote_attempts,
                             )
                             .await;
+                        min_out_sol = outcome.min_out;
                     }
                 }
             } // end if min_out_sol.is_none() (Meteora/Raydium recovery + multi-pool + cache; last-resort pumpfun_fallback inside)
@@ -6656,16 +6731,21 @@ impl ExecutionContext {
                 };
                 if incoming == 0
                     && effective_wsol == 0
-                    && prev_wsol_on_chain > 0
-                    && self
-                        .wsol_pending_wrap
-                        .as_ref()
-                        .map(|p| p.pending_expected() == 0)
-                        .unwrap_or(true)
+                    && (prev_wsol_on_chain > 0
+                        || self
+                            .wsol_pending_wrap
+                            .as_ref()
+                            .map(|p| p.pending_expected() > 0)
+                            .unwrap_or(false))
                 {
                     warn!(
                         event = "wsol_external_zero",
                         previous_wsol_lamports = prev_wsol_on_chain,
+                        pending_expected_wsol_lamports = self
+                            .wsol_pending_wrap
+                            .as_ref()
+                            .map(|p| p.pending_expected())
+                            .unwrap_or(0),
                         slot = ?event.slot,
                         "WSOL WalletBalanceSnapshot dropped to zero (external unwrap/ATA close)"
                     );
@@ -14258,15 +14338,27 @@ mod execution_engine_tests {
     }
 
     #[test]
-    fn lock_manager_pending_wrap_floors_stale_zero_snapshot() {
+    fn lock_manager_pending_wrap_floors_stale_partial_snapshot() {
+        let (ctx, pending) = test_ctx_with_pending_wrap(LockManager::new(3_000_000_000));
+        pending.arm(1_000_000_000);
+        ctx.lock_manager.update_wsol_only(1_000_000_000);
+
+        ctx.apply_wallet_balance_snapshot_event(&wsol_wallet_snapshot_event(500_000_000));
+
+        assert_eq!(ctx.lock_manager.available_wsol(), 1_000_000_000);
+        assert_eq!(pending.pending_expected(), 1_000_000_000);
+    }
+
+    #[test]
+    fn lock_manager_pending_wrap_clears_on_authoritative_zero_snapshot() {
         let (ctx, pending) = test_ctx_with_pending_wrap(LockManager::new(3_000_000_000));
         pending.arm(1_000_000_000);
         ctx.lock_manager.update_wsol_only(1_000_000_000);
 
         ctx.apply_wallet_balance_snapshot_event(&wsol_wallet_snapshot_event(0));
 
-        assert_eq!(ctx.lock_manager.available_wsol(), 1_000_000_000);
-        assert_eq!(pending.pending_expected(), 1_000_000_000);
+        assert_eq!(ctx.lock_manager.available_wsol(), 0);
+        assert_eq!(pending.pending_expected(), 0);
     }
 
     #[test]

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -870,6 +870,21 @@ impl LivePoolCache {
         None
     }
 
+    /// Cold-path: seed creator on an existing PumpFun bonding-curve row (e.g. after liquidation RPC).
+    pub fn seed_pumpfun_creator_if_missing(&self, bonding_curve: &Pubkey, creator: Pubkey) {
+        if creator == Pubkey::default() {
+            return;
+        }
+        if let Some(mut entry) = self.pools.get_mut(bonding_curve) {
+            if let CachedPoolState::PumpFun(ref mut s) = entry.state {
+                if s.creator == Pubkey::default() {
+                    s.creator = creator;
+                    entry.updated_at = Instant::now();
+                }
+            }
+        }
+    }
+
     /// Check if a PumpFun bonding curve for a given mint is marked as `complete`.
     /// Returns Some(true) if complete, Some(false) if not, None if not found.
     pub fn is_pumpfun_complete_for_mint(&self, mint: &Pubkey) -> Option<bool> {

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -871,6 +871,8 @@ impl LivePoolCache {
     }
 
     /// Cold-path: seed creator on an existing PumpFun bonding-curve row (e.g. after liquidation RPC).
+    /// Does not touch `updated_at` — EE/Momentum share this SLAVE cache; creator-only RPC must not
+    /// refresh cache age or STALE/executable_exit_quote guards may treat stale reserves as fresh.
     pub fn seed_pumpfun_creator_if_missing(&self, bonding_curve: &Pubkey, creator: Pubkey) {
         if creator == Pubkey::default() {
             return;
@@ -879,7 +881,6 @@ impl LivePoolCache {
             if let CachedPoolState::PumpFun(ref mut s) = entry.state {
                 if s.creator == Pubkey::default() {
                     s.creator = creator;
-                    entry.updated_at = Instant::now();
                 }
             }
         }

--- a/src/execution/wsol_manager.rs
+++ b/src/execution/wsol_manager.rs
@@ -55,12 +55,18 @@ const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
 
 /// After a successful on-chain wrap, hold this effective WSOL floor until a snapshot confirms
 /// `wsol >= pending_expected` or we hit the confirmation timeout (then one RPC resync, cold path).
+///
+/// `incoming_wsol == 0` is authoritative (external unwrap / ATA close): effective is 0 and pending
+/// clears. The post-wrap floor applies only when `incoming_wsol > 0` but has not yet caught up.
 pub fn compute_effective_wsol_on_snapshot(
     pending_expected: u64,
     incoming_wsol: u64,
 ) -> (u64, bool) {
     if pending_expected == 0 {
         return (incoming_wsol, false);
+    }
+    if incoming_wsol == 0 {
+        return (0, true);
     }
     if incoming_wsol >= pending_expected {
         (incoming_wsol, true)
@@ -113,7 +119,7 @@ impl PendingWrapState {
     pub fn effective_wsol_for_snapshot(&self, incoming_wsol: u64) -> (u64, bool, bool) {
         let pending = self.pending_wrap_expected_wsol.load(Ordering::Relaxed);
         let (effective, confirms) = compute_effective_wsol_on_snapshot(pending, incoming_wsol);
-        let was_floored = pending > 0 && incoming_wsol < pending;
+        let was_floored = pending > 0 && incoming_wsol > 0 && incoming_wsol < pending;
         (effective, confirms, was_floored)
     }
 
@@ -528,18 +534,17 @@ impl WsolManager {
             let (effective_wsol, snapshot_confirms_pending) =
                 compute_effective_wsol_on_snapshot(pending_expected, incoming_wsol);
 
-            if pending_expected == 0 && incoming_wsol == 0 {
+            if incoming_wsol == 0 {
                 let current = self.wsol_balance.load(Ordering::Relaxed);
-                if current > 0 {
+                if current > 0 || pending_expected > 0 {
                     warn!(
                         event = "wsol_external_zero",
                         previous_wsol_lamports = current,
+                        pending_expected_wsol_lamports = pending_expected,
                         "WSOL balance snapshot dropped to zero (external unwrap/ATA close)"
                     );
                 }
-            }
-
-            if pending_expected > 0 && incoming_wsol < pending_expected {
+            } else if pending_expected > 0 && incoming_wsol < pending_expected {
                 warn!(
                     event = "stale_wsol_snapshot_ignored_due_to_pending_wrap",
                     incoming_wsol_lamports = incoming_wsol,
@@ -1241,7 +1246,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pending_wrap_blocks_second_wrap_on_stale_zero_snapshot() {
+    async fn pending_wrap_floors_stale_partial_snapshot_not_zero() {
         let treasury = Arc::new(Treasury::from_signer(Arc::new(Keypair::new())));
         let rpc = Arc::new(SolanaRpc::new("http://127.0.0.1:0"));
         let mgr = WsolManager::new(
@@ -1267,14 +1272,15 @@ mod tests {
         assert_eq!(mgr.wsol_balance(), 1_000_000_000);
         assert_eq!(mgr.test_pending_expected_wsol(), 1_000_000_000);
 
-        mgr.apply_balance_update(2_247_213_376, Some(0))
+        // Partial snapshot (non-zero but below pending) must not clobber optimistic WSOL.
+        mgr.apply_balance_update(2_247_213_376, Some(500_000_000))
             .await
             .unwrap();
 
         assert_eq!(
             mgr.wsol_balance(),
             1_000_000_000,
-            "stale wsol=0 must not clobber optimistic WSOL"
+            "stale partial wsol must not clobber optimistic WSOL"
         );
         assert_eq!(
             mgr.test_pending_expected_wsol(),
@@ -1289,6 +1295,39 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(mgr.wsol_balance(), 1_000_000_000);
+        assert_eq!(mgr.test_pending_expected_wsol(), 0);
+    }
+
+    #[tokio::test]
+    async fn pending_wrap_clears_on_authoritative_external_zero_snapshot() {
+        let treasury = Arc::new(Treasury::from_signer(Arc::new(Keypair::new())));
+        let rpc = Arc::new(SolanaRpc::new("http://127.0.0.1:0"));
+        let mgr = WsolManager::new(
+            WsolManagerConfig {
+                enabled: true,
+                dry_run: true,
+                ..WsolManagerConfig::default()
+            },
+            treasury,
+            rpc,
+            "test",
+            "run",
+        );
+
+        mgr.test_seed_balances(3_000_000_000, 0);
+        mgr.test_simulate_successful_wrap_optimistic(1_000_000_000, 3_000_000_000, 0);
+        assert_eq!(mgr.wsol_balance(), 1_000_000_000);
+        assert_eq!(mgr.test_pending_expected_wsol(), 1_000_000_000);
+
+        mgr.apply_balance_update(2_000_000_000, Some(0))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            mgr.wsol_balance(),
+            0,
+            "external wsol=0 must clear pending floor"
+        );
         assert_eq!(mgr.test_pending_expected_wsol(), 0);
     }
 
@@ -1323,7 +1362,13 @@ mod tests {
     fn compute_effective_wsol_unit() {
         assert_eq!(
             compute_effective_wsol_on_snapshot(1_000_000_000, 0),
-            (1_000_000_000, false)
+            (0, true),
+            "external zero clears pending floor"
+        );
+        assert_eq!(
+            compute_effective_wsol_on_snapshot(1_000_000_000, 500_000_000),
+            (1_000_000_000, false),
+            "partial snapshot below pending keeps floor"
         );
         assert_eq!(
             compute_effective_wsol_on_snapshot(1_000_000_000, 1_000_000_000),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

P0 Kombi-Fix für zwei Prod-Evidence-Punkte (Kill+Liquidate Creator-Miss + EE Sticky WSOL Zero).

### Layer L — Liquidation PumpFun Creator-Miss

**Evidence:** Kill+liquidate Token `EVdyXRZa…pbWC` — `pumpfun_preferred=skip missing_creator_or_pool` → 45s `pump_amm` timeout → `QUOTE_UNAVAILABLE`; ~3 min später TIME_EXIT desselben Tokens.

**Fixes:**
- Creator-RPC gehärtet: `BondingCurveState::parse`, explizite Miss-Gründe in `quote_attempts` (`rpc_fetch_failed`, `rpc_parse_failed`, `rpc_parse_default_creator`)
- Erfolgreicher RPC-Seed in `LivePoolCache.seed_pumpfun_creator_if_missing`
- `pumpfun_creator_retry` **vor** dem 45s PumpSwap-Timeout wenn `pumpfun_preferred` wegen fehlendem Creator skippte
- `pumpfun_fallback` / `pumpfun_creator_retry` erlaubt auch nach `try_pumpfun_first` wenn nur Creator fehlte (kein Dead-End mehr)

### Layer W — EE Sticky `available_wsol=1e9`

**Evidence:** MD publiziert WSOL=0; EE Heartbeat bleibt `available_wsol=1000000000` bis Restart.

**Fixes:**
- `compute_effective_wsol_on_snapshot`: `incoming==0` ist autoritativ → `effective=0`, pending clear
- Post-wrap-Floor nur noch bei `incoming>0` aber `< pending_expected` (echte Snapshot-Race)
- LockManager + WsolManager Tests angepasst/ergänzt

## Gates / Floors gefixt

| Gate | Vorher | Nachher |
|------|--------|---------|
| WSOL pending-wrap floor | `incoming < pending` inkl. `incoming==0` → sticky 1e9 | Floor nur bei `incoming>0`; `incoming==0` → 0 + pending clear |
| Liquidation pumpfun preferred skip | blockiert `pumpfun_fallback` komplett | Creator-Retry vor PumpAmm + Fallback bei `missing_creator` |
| Creator-RPC | stille byte-slice Miss | `BondingCurveState::parse` + reason in logs/`quote_attempts` |

## Tests

- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test` ✓

Kein Deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2809e66f-4992-4389-a3dc-020d6c48eb4c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2809e66f-4992-4389-a3dc-020d6c48eb4c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

