### PR TITLE
fix(momentum): P0 open-position PumpFun exit-quote STALE pipeline (E2E)

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -459,7 +459,7 @@ impl SidefxWorkerHost for MarketDataSidefxHost {
     }
 
     fn nats_enabled(&self) -> bool {
-        self.ctx.nats.is_some()
+        self.ctx.nats.is_some() || self.publish_tx.is_some()
     }
 
     fn enqueue_core_market_event(
@@ -634,6 +634,16 @@ impl SidefxWorkerHost for MarketDataSidefxHost {
 
     fn is_hot_pool(&self, pool: &Pubkey) -> bool {
         self.ctx.hot_pool_registry.is_hot_pool(*pool)
+    }
+
+    fn is_open_position_pumpfun_pin(&self, pool: &Pubkey) -> bool {
+        if !self.ctx.hot_pool_registry.is_position_pin_for_pool(*pool) {
+            return false;
+        }
+        matches!(
+            self.ctx.live_pool_cache.get(pool),
+            Some(CachedPoolState::PumpFun(_))
+        )
     }
 
     fn is_enrichment_member(&self, pool: &Pubkey) -> bool {
@@ -2390,6 +2400,16 @@ impl IngestHost for MarketDataContext {
 
     fn ingest_is_hot_pool(&self, pool: &Pubkey) -> bool {
         self.hot_pool_registry.ingest_is_hot_pool(pool)
+    }
+
+    fn ingest_is_open_position_pumpfun_pin(&self, pool: &Pubkey) -> bool {
+        if !self.hot_pool_registry.is_position_pin_for_pool(*pool) {
+            return false;
+        }
+        matches!(
+            self.live_pool_cache.get(pool),
+            Some(CachedPoolState::PumpFun(_))
+        )
     }
 
     fn ingest_is_enrichment_member(&self, pool: &Pubkey) -> bool {
@@ -4635,6 +4655,11 @@ impl MarketDataContext {
         else {
             return;
         };
+        let publish_slot = self
+            .live_pool_cache
+            .get_with_metadata(&pool)
+            .map(|(_, slot, _)| slot)
+            .unwrap_or(0);
         let Some(nats) = self
             .nats
             .as_ref()
@@ -4655,7 +4680,7 @@ impl MarketDataContext {
                 quote_mint.to_string(),
                 base_reserve,
                 quote_reserve,
-                0,
+                publish_slot,
             );
             if dex == "raydium_cpmm" {
                 if let CachedPoolState::RaydiumCpmm(ref s) = state {
@@ -5382,6 +5407,7 @@ impl MarketDataContext {
         active: &[MomentumActivePoolEntry],
     ) -> bool {
         let mut batch_dirty = false;
+        let mut had_position_pin = false;
         for a in active {
             let Ok(mint_pk) = Pubkey::from_str(a.mint.trim()) else {
                 warn!(mint = %a.mint, "MomentumActivePoolsUpdate.active: invalid mint");
@@ -5392,6 +5418,9 @@ impl MarketDataContext {
                 continue;
             };
             let is_position = a.pin_reason == MomentumActivePinReason::Position;
+            if is_position {
+                had_position_pin = true;
+            }
             let explicit_entry = ExplicitEntry {
                 consumers: HashSet::from([if is_position {
                     ConsumerId::MomentumPosition
@@ -5478,6 +5507,9 @@ impl MarketDataContext {
                 let _ =
                     admission.touch_group(Self::pool_consumer_owner(pool_pk, momentum_consumer));
             }
+        }
+        if had_position_pin {
+            batch_dirty |= self.remediate_open_position_pumpfun_registration(admission);
         }
         batch_dirty
     }
@@ -13403,6 +13435,79 @@ mod pr_b_geyser_tracking_tests {
                 .get_with_metadata(&pool)
                 .map(|(_, slot, _)| slot),
             Some(42)
+        );
+    }
+
+    /// P0: open-position PumpFun pin must publish JetStream on ENRICH + unchanged reserves.
+    #[test]
+    fn open_position_pumpfun_pin_enrich_publishes_on_balance_unchanged() {
+        use ironcrab::market_data::sidefx::handlers::md_sidefx_process_live_pool_cache_account_update;
+        use ironcrab::market_data::sidefx::MdSidefxCommand;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let (md_state, _depth, _md_state_rx) = test_md_state_sender_no_worker();
+        let (publish_tx, mut publish_rx) = tokio::sync::mpsc::channel(8);
+        let worker = MarketDataSidefxHost {
+            ctx: ctx.clone(),
+            publish_tx: Some(publish_tx),
+            md_state: md_state.clone(),
+            track_worker: test_noop_track_worker_sender(),
+        };
+
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let creator = Pubkey::new_unique();
+        let account_data = test_pumpfun_bonding_curve_account_data(
+            1_073_000_000_000_000,
+            30_000_000_000,
+            500_000_000_000_000,
+            10_000_000_000,
+            creator,
+        );
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::PumpFun(PumpFunState {
+                token_mint: mint,
+                bonding_curve: pool,
+                associated_bonding_curve: Pubkey::new_unique(),
+                virtual_sol_reserves: 30_000_000_000,
+                virtual_token_reserves: 1_073_000_000_000_000,
+                real_sol_reserves: 10_000_000_000,
+                real_token_reserves: 500_000_000_000_000,
+                complete: false,
+                creator,
+                cashback_enabled: false,
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool_with_reason(mint, pool, true);
+
+        let mk_job = |slot: u64| MdSidefxCommand::LivePoolCacheAccountUpdate {
+            run_id: "open-pos-pumpfun".into(),
+            pool_pubkey: pool,
+            owner: PUMPFUN_PROGRAM_OWNER,
+            account_data: account_data.clone(),
+            slot,
+            grpc_recv_at: Instant::now(),
+            update_class: SidefxUpdateClass::Enrich,
+        };
+
+        let mut scratch = MdSidefxBurstScratch::new();
+        md_sidefx_process_live_pool_cache_account_update(&worker, &mk_job(20), &mut scratch);
+        assert!(
+            publish_rx.try_recv().is_ok(),
+            "first ENRICH upsert must publish for open-position PumpFun pin"
+        );
+        while publish_rx.try_recv().is_ok() {}
+
+        let mut scratch2 = MdSidefxBurstScratch::new();
+        md_sidefx_process_live_pool_cache_account_update(&worker, &mk_job(21), &mut scratch2);
+        assert!(
+            publish_rx.try_recv().is_ok(),
+            "unchanged reserves on ENRICH must still publish for open-position PumpFun pin"
         );
     }
 

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -226,8 +226,11 @@ fn open_position_pool_recovery_cooldown(
     recovery_kind: OpenPositionPoolRecoveryKind,
     reason_tag: &'static str,
 ) -> Duration {
-    if reason_tag == "quote_missing_retry"
-        && recovery_kind == OpenPositionPoolRecoveryKind::PumpfunBonding
+    if recovery_kind == OpenPositionPoolRecoveryKind::PumpfunBonding
+        && matches!(
+            reason_tag,
+            "quote_missing_retry" | "stale_cache_age_retry" | "exit_blind_retry"
+        )
     {
         OPEN_POSITION_EXIT_BLIND_PUMPFUN_RECOVERY_COOLDOWN
     } else {
@@ -1213,6 +1216,53 @@ fn exit_quote_price_exit_guard_violation(
         return Some("QUOTE_TPS_SCALE_MISMATCH");
     }
     None
+}
+
+/// True when the **position pool** specifically lacks a usable exit quote (stale SLAVE age or cache miss).
+/// Unlike [`MomentumContext::executable_exit_quote`], does not accept a fresher alternate pool row.
+fn position_pool_exit_blind(pos: &PositionTracker, live_pool_cache: &LivePoolCache) -> bool {
+    if pos.pool.is_empty() || pos.token_amount == 0 {
+        return false;
+    }
+    let Ok(pool_pk) = solana_sdk::pubkey::Pubkey::from_str(&pos.pool) else {
+        return true;
+    };
+    let Some((state, _slot, age_ms)) = live_pool_cache.get_with_metadata(&pool_pk) else {
+        return true;
+    };
+    if age_ms > EXIT_QUOTE_MAX_CACHE_AGE_MS {
+        return true;
+    }
+    let Ok(token_mint) = solana_sdk::pubkey::Pubkey::from_str(&pos.mint) else {
+        return true;
+    };
+    let Ok(sol_out) = quote_calculator::quote_output_amount(&state, pos.token_amount, &token_mint)
+    else {
+        return true;
+    };
+    if sol_out == 0 {
+        return true;
+    }
+    let tps = tokens_per_sol::ui_tokens_per_sol(pos.token_amount, pos.token_decimals, sol_out);
+    if !tps.is_finite() || tps <= 0.0 {
+        return true;
+    }
+    let candidate = ExitExecutableQuote {
+        tokens_per_sol: tps,
+        pool_sourced: true,
+        quote_pool: pos.pool.clone(),
+        quote_dex: pos.dex.clone(),
+        marks_position_pool: true,
+        source_slot: Some(_slot),
+        cache_age_ms: Some(age_ms),
+    };
+    exit_quote_price_exit_guard_violation(
+        pos,
+        &candidate,
+        None,
+        ExitQuoteGuardOpts::RelaxPositionMarkSlotForHardPriceExit,
+    )
+    .is_some()
 }
 
 /// `exit_quote` = optional reserve quote; `price_exit_quote` = same row after freshness / SOL-leg
@@ -4163,6 +4213,9 @@ impl MomentumContext {
             }
             match nats.publish(TOPIC_CONTROL_REQUESTS, &req).await {
                 Ok(true) => {
+                    ironcrab::metrics::inc_momentum_open_position_exit_blind_ensure_total(
+                        reason_tag,
+                    );
                     info!(
                         mint = %mint,
                         pool = %pool,
@@ -4209,37 +4262,42 @@ impl MomentumContext {
     }
 
     async fn tick_open_position_pool_recovery_retries(self: &Arc<Self>) {
-        let mut rows: Vec<(String, String, String)> = Vec::new();
+        let mut rows: Vec<(String, String, String, &'static str)> = Vec::new();
         {
             let positions = self.positions.read();
             for (mint, pos) in positions.iter() {
                 if pos.pool.is_empty() || pos.token_amount == 0 {
                     continue;
                 }
-                if self
+                let pool_blind = position_pool_exit_blind(pos, &self.live_pool_cache);
+                let no_usable_exit_quote = self
                     .executable_exit_quote(
                         pos,
                         None,
                         ExitQuoteGuardOpts::RelaxPositionMarkSlotForHardPriceExit,
                     )
-                    .is_some()
-                {
+                    .is_none();
+                if !pool_blind && !no_usable_exit_quote {
                     continue;
                 }
-                rows.push((mint.clone(), pos.pool.clone(), pos.dex.clone()));
+                let reason_tag = if pool_blind {
+                    if Self::normalize_dex_for_execution_engine(&pos.dex) == "pumpfun" {
+                        "stale_cache_age_retry"
+                    } else {
+                        "exit_blind_retry"
+                    }
+                } else {
+                    "quote_missing_retry"
+                };
+                rows.push((mint.clone(), pos.pool.clone(), pos.dex.clone(), reason_tag));
             }
         }
-        for (mint, pool, dex) in rows
+        for (mint, pool, dex, reason_tag) in rows
             .into_iter()
             .take(OPEN_POSITION_POOL_RECOVERY_RETRY_MAX_PER_TICK)
         {
-            self.publish_open_position_pool_recovery_if_allowed(
-                &mint,
-                &pool,
-                &dex,
-                "quote_missing_retry",
-            )
-            .await;
+            self.publish_open_position_pool_recovery_if_allowed(&mint, &pool, &dex, reason_tag)
+                .await;
         }
     }
 
@@ -13151,6 +13209,49 @@ mod tests {
     }
 
     #[test]
+    fn position_pool_exit_blind_detects_stale_position_pool_cache() {
+        use ironcrab::execution::live_pool_cache::{CachedPoolState, PumpFunState};
+
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let mint_pk = Pubkey::new_unique();
+        cache.upsert(
+            pool,
+            CachedPoolState::PumpFun(PumpFunState {
+                token_mint: mint_pk,
+                bonding_curve: pool,
+                associated_bonding_curve: Pubkey::new_unique(),
+                virtual_sol_reserves: 30_000_000_000,
+                virtual_token_reserves: 1_073_000_000_000_000,
+                real_sol_reserves: 10_000_000_000,
+                real_token_reserves: 500_000_000_000_000,
+                complete: false,
+                creator: Pubkey::new_unique(),
+                cashback_enabled: false,
+            }),
+            1,
+        );
+        std::thread::sleep(std::time::Duration::from_millis(
+            (EXIT_QUOTE_MAX_CACHE_AGE_MS + 50) as u64,
+        ));
+        let mut pos = PositionTracker::new(
+            &mint_pk.to_string(),
+            &pool.to_string(),
+            "pumpfun",
+            1.0,
+            6,
+            1_000_000,
+            0,
+        );
+        pos.entry_confirmed_slot = 0;
+        pos.last_price_slot = 0;
+        assert!(
+            position_pool_exit_blind(&pos, &cache),
+            "stale position-pool SLAVE age must count as exit blind"
+        );
+    }
+
+    #[test]
     fn open_position_pool_recovery_kinds_mapping() {
         assert_eq!(
             open_position_pool_recovery_kinds_for_normalized_dex("pumpfun"),
@@ -13168,13 +13269,20 @@ mod tests {
 
     #[test]
     fn open_position_exit_blind_pumpfun_recovery_uses_short_cooldown() {
-        assert_eq!(
-            open_position_pool_recovery_cooldown(
-                OpenPositionPoolRecoveryKind::PumpfunBonding,
-                "quote_missing_retry"
-            ),
-            OPEN_POSITION_EXIT_BLIND_PUMPFUN_RECOVERY_COOLDOWN
-        );
+        for reason in [
+            "quote_missing_retry",
+            "stale_cache_age_retry",
+            "exit_blind_retry",
+        ] {
+            assert_eq!(
+                open_position_pool_recovery_cooldown(
+                    OpenPositionPoolRecoveryKind::PumpfunBonding,
+                    reason
+                ),
+                OPEN_POSITION_EXIT_BLIND_PUMPFUN_RECOVERY_COOLDOWN,
+                "reason={reason}"
+            );
+        }
         assert_eq!(
             open_position_pool_recovery_cooldown(
                 OpenPositionPoolRecoveryKind::PumpfunBonding,

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -13232,7 +13232,7 @@ mod tests {
             1,
         );
         std::thread::sleep(std::time::Duration::from_millis(
-            (EXIT_QUOTE_MAX_CACHE_AGE_MS + 50) as u64,
+            EXIT_QUOTE_MAX_CACHE_AGE_MS + 50,
         ));
         let mut pos = PositionTracker::new(
             &mint_pk.to_string(),

--- a/src/market_data/ingest/account_filter.rs
+++ b/src/market_data/ingest/account_filter.rs
@@ -102,6 +102,9 @@ pub fn account_geyser_update_relevance<H: IngestHost>(
     }
 
     let pool_pk = u.pubkey;
+    if u.owner == PUMPFUN_PROGRAM_OWNER && host.ingest_is_open_position_pumpfun_pin(&pool_pk) {
+        return AccountGeyserRelevance::Relevant;
+    }
     if host.ingest_is_enrichment_member(&pool_pk) {
         inc_market_data_account_relevance_enrichment_hit_total();
         return AccountGeyserRelevance::Relevant;
@@ -203,6 +206,9 @@ pub fn account_geyser_dispatch_priority_high<H: IngestHost>(
     u: &GeyserAccountUpdate,
 ) -> bool {
     let pool_pk = u.pubkey;
+    if host.ingest_is_open_position_pumpfun_pin(&pool_pk) {
+        return true;
+    }
     if account_geyser_update_is_dex_pool_owner(&u.owner) && host.ingest_is_hot_pool(&pool_pk) {
         return true;
     }
@@ -292,6 +298,10 @@ mod tests {
 
         fn ingest_is_hot_pool(&self, pool: &Pubkey) -> bool {
             self.hot_pools.contains(pool)
+        }
+
+        fn ingest_is_open_position_pumpfun_pin(&self, _pool: &Pubkey) -> bool {
+            false
         }
 
         fn ingest_is_enrichment_member(&self, pool: &Pubkey) -> bool {

--- a/src/market_data/ingest/host.rs
+++ b/src/market_data/ingest/host.rs
@@ -27,6 +27,9 @@ pub trait IngestHost: Send + Sync {
 
     fn ingest_is_hot_pool(&self, pool: &Pubkey) -> bool;
 
+    /// Scope C: open-position pin on a PumpFun bonding-curve pool (never drop Geyser updates).
+    fn ingest_is_open_position_pumpfun_pin(&self, pool: &Pubkey) -> bool;
+
     /// P2 EnrichmentRegistry: pool_mint_map ∪ bonding-curve priority ∪ hot-pool pins.
     fn ingest_is_enrichment_member(&self, pool: &Pubkey) -> bool;
 

--- a/src/market_data/ingest/mod.rs
+++ b/src/market_data/ingest/mod.rs
@@ -75,6 +75,10 @@ impl<T: IngestHost + ?Sized> IngestHost for Arc<T> {
         (**self).ingest_is_hot_pool(pool)
     }
 
+    fn ingest_is_open_position_pumpfun_pin(&self, pool: &solana_sdk::pubkey::Pubkey) -> bool {
+        (**self).ingest_is_open_position_pumpfun_pin(pool)
+    }
+
     fn ingest_is_enrichment_member(&self, pool: &solana_sdk::pubkey::Pubkey) -> bool {
         (**self).ingest_is_enrichment_member(pool)
     }

--- a/src/market_data/sidefx/handlers.rs
+++ b/src/market_data/sidefx/handlers.rs
@@ -25,6 +25,7 @@ use crate::metrics::{
     inc_market_data_enrichment_balance_updated_total,
     inc_market_data_enrichment_pool_state_publish_total,
     inc_market_data_md_sidefx_enrich_publish_skipped_total,
+    inc_market_data_open_position_pumpfun_jetstream_publish_total,
     inc_market_data_pool_state_publish_skipped_balance_unchanged_total,
     record_market_data_bonding_curve_grpc_to_devwallet_ms,
     record_market_data_pool_mint_map_to_devwallet_ms, MarketDataLatencySegment,
@@ -167,6 +168,43 @@ fn md_sidefx_build_balance_updated_from_cache(
     Some(balance_update)
 }
 
+#[inline]
+fn md_sidefx_is_open_position_pumpfun_pin(
+    host: &dyn SidefxWorkerHost,
+    pool_pubkey: &Pubkey,
+    cached_state: &CachedPoolState,
+) -> bool {
+    matches!(cached_state, CachedPoolState::PumpFun(_))
+        && host.is_open_position_pumpfun_pin(pool_pubkey)
+}
+
+/// P0: force JetStream BalanceUpdated for open-position PumpFun pins (no vault Geyser feed).
+fn md_sidefx_publish_open_position_pumpfun_balance_refresh(
+    host: &dyn SidefxWorkerHost,
+    run_id: &str,
+    pool_pubkey: &Pubkey,
+    slot: u64,
+) {
+    if !host.nats_enabled() {
+        return;
+    }
+    let Some(balance_update) =
+        md_sidefx_build_balance_updated_from_cache(host, run_id, pool_pubkey, slot)
+    else {
+        return;
+    };
+    let subject = pool_subject(&pool_pubkey.to_string());
+    sidefx_host_enqueue_jetstream(
+        host,
+        subject,
+        &balance_update,
+        "PoolCacheUpdate::BalanceUpdated (open-position PumpFun pin)",
+        false,
+    );
+    inc_market_data_open_position_pumpfun_jetstream_publish_total();
+    inc_market_data_enrichment_balance_updated_total();
+}
+
 /// P2: JetStream BalanceUpdated + Core PoolStateUpdate after MASTER cache upsert (I-MD-4).
 fn md_sidefx_publish_enrichment_from_cache_upsert(
     host: &dyn SidefxWorkerHost,
@@ -186,16 +224,25 @@ fn md_sidefx_publish_enrichment_from_cache_upsert(
     if !cached_pool_has_fresh_reserve_basis(cached_state) {
         return;
     }
+    let open_position_pumpfun_pin =
+        md_sidefx_is_open_position_pumpfun_pin(host, pool_pubkey, cached_state);
     let balance_unchanged = prev_state
         .as_ref()
         .is_some_and(|prev| cache_balance_fields_unchanged(prev, cached_state));
-    if balance_unchanged {
+    if balance_unchanged && !open_position_pumpfun_pin {
         inc_market_data_pool_state_publish_skipped_balance_unchanged_total();
         return;
     }
 
     if host.nats_enabled() {
-        if let Some(balance_update) =
+        if open_position_pumpfun_pin {
+            md_sidefx_publish_open_position_pumpfun_balance_refresh(
+                host,
+                run_id,
+                pool_pubkey,
+                slot,
+            );
+        } else if let Some(balance_update) =
             md_sidefx_build_balance_updated_from_cache(host, run_id, pool_pubkey, slot)
         {
             let subject = pool_subject(&pool_pubkey.to_string());
@@ -1446,7 +1493,10 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
         };
 
         // Publish PoolCacheUpdate to JetStream (Single Source of Truth for pool state)
+        let open_position_pumpfun_pin =
+            md_sidefx_is_open_position_pumpfun_pin(host, pool_pubkey, &cached_state);
         let should_publish_pool_cache = update_class.is_exec_hot()
+            || open_position_pumpfun_pin
             || md_sidefx_should_publish_enrich_pool_cache_update(
                 host,
                 pool_pubkey,

--- a/src/market_data/sidefx/host.rs
+++ b/src/market_data/sidefx/host.rs
@@ -75,6 +75,9 @@ pub trait SidefxWorkerHost: Send + Sync {
     /// True when pool is in momentum/arb hot set (arb-pinned DLMM PoolStateUpdate gate).
     fn is_hot_pool(&self, pool: &Pubkey) -> bool;
 
+    /// Scope C: open-position pin on a PumpFun bonding-curve pool (EXEC_HOT publish guarantee).
+    fn is_open_position_pumpfun_pin(&self, pool: &Pubkey) -> bool;
+
     /// P2 EnrichmentRegistry membership (pool_mint_map ∪ pins ∪ bonding-curve priority).
     fn is_enrichment_member(&self, pool: &Pubkey) -> bool;
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3305,6 +3305,24 @@ pub fn inc_market_data_open_position_pumpfun_registration_remediate_total() {
     MARKET_DATA_OPEN_POSITION_PUMPFUN_REGISTRATION_REMEDIATE_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+static MARKET_DATA_OPEN_POSITION_PUMPFUN_JETSTREAM_PUBLISH_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn inc_market_data_open_position_pumpfun_jetstream_publish_total() {
+    MARKET_DATA_OPEN_POSITION_PUMPFUN_JETSTREAM_PUBLISH_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+static MOMENTUM_OPEN_POSITION_EXIT_BLIND_ENSURE_TOTAL: Lazy<RwLock<HashMap<&'static str, u64>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+
+/// Labeled: `momentum_open_position_exit_blind_ensure_total{reason=...}`.
+#[inline]
+pub fn inc_momentum_open_position_exit_blind_ensure_total(reason: &'static str) {
+    let mut map = MOMENTUM_OPEN_POSITION_EXIT_BLIND_ENSURE_TOTAL.write();
+    *map.entry(reason).or_insert(0) += 1;
+}
+
 #[inline]
 pub fn record_momentum_overlay_closed_by_authority_total() {
     MOMENTUM_OVERLAY_CLOSED_BY_AUTHORITY_TOTAL.fetch_add(1, Ordering::Relaxed);
@@ -8582,6 +8600,17 @@ async fn metrics_response() -> Response<Body> {
         "market_data_open_position_pumpfun_registration_remediate_total",
         MARKET_DATA_OPEN_POSITION_PUMPFUN_REGISTRATION_REMEDIATE_TOTAL.load(Ordering::Relaxed)
     );
+    line!(
+        "market_data_open_position_pumpfun_jetstream_publish_total",
+        MARKET_DATA_OPEN_POSITION_PUMPFUN_JETSTREAM_PUBLISH_TOTAL.load(Ordering::Relaxed)
+    );
+    for (reason, count) in MOMENTUM_OPEN_POSITION_EXIT_BLIND_ENSURE_TOTAL.read().iter() {
+        out.push_str("momentum_open_position_exit_blind_ensure_total{reason=\"");
+        out.push_str(reason);
+        out.push_str("\"} ");
+        out.push_str(&count.to_string());
+        out.push('\n');
+    }
     line!(
         "momentum_overlay_closed_by_authority_total",
         MOMENTUM_OVERLAY_CLOSED_BY_AUTHORITY_TOTAL.load(Ordering::Relaxed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Kontext / Prod-Evidence

Nach #349/#350 blieb `STALE_CACHE_AGE_MS` in Prod-Soak dominant für offene PumpFun-Positionen: Pin/Remediate zählten, aber Mom-SLAVE-`updated_at` für die Positions-Bonding-Curve blieb oft >4s (`EXIT_QUOTE_MAX_CACHE_AGE_MS`). **Pin ≠ frische Exit-Quote** — Engpass war die Kette bis Mom `updated_at`.

## Was gefixt wurde (A/B/C)

### A) MD: EXEC_HOT Publish-Garantie für Open-Position PumpFun
- Position-Pin + PumpFun-Bonding: `PoolCacheUpdate` wird auch bei **ENRICH + unveränderten Reserves** publiziert (nicht nur Enrich-Member-Pfad mit `balance_unchanged`-Skip).
- Ingest: Open-Position-PumpFun-Pins sind immer **relevant** und **EXEC_HOT**-klassifiziert.
- Registration-Remediate läuft **sofort** bei Position-Pin-Apply (nicht nur 2s-Heartbeat).
- Heartbeat `try_publish_balance_updated_from_cache` nutzt den **Cache-Slot** statt `0`.

### B) Mom-SLAVE Age-Refresh
- Bestehende `pool_cache_sync`-Regression (`PumpFun BalanceUpdated` refresht `updated_at`) unverändert.
- Kein Age-Spoof ohne Reserve-Basis (`live_pool_cache.upsert`-Regel beibehalten).

### C) Ensure bei Exit-Blindheit (STALE-koppelt)
- Neuer Check `position_pool_exit_blind`: stale/fehlender Cache **am Positions-Pool** (nicht nur „kein usable quote irgendwo“).
- PumpFun-Bonding-Ensure mit **5s Cooldown** auch für `stale_cache_age_retry` / `exit_blind_retry`.
- Metrik: `momentum_open_position_exit_blind_ensure_total{reason}` + `market_data_open_position_pumpfun_jetstream_publish_total`.

## Explizit nicht
- Kein Anheben von `EXIT_QUOTE_MAX_CACHE_AGE_MS`
- Kein Hot-Path-RPC im Exit-Scan
- Kein Deploy

## Verifikation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test` (inkl. neuer Tests für ENRICH+Position-Pin-Publish und `position_pool_exit_blind`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbf338a3-b4c2-41e4-9f31-280c8685cab5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbf338a3-b4c2-41e4-9f31-280c8685cab5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

