### PR TITLE
P0: Event-driven exit-quote freshness for open-position PumpFun pins

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -13511,6 +13511,83 @@ mod pr_b_geyser_tracking_tests {
         );
     }
 
+    /// P0: open-position PumpFun pin must publish JetStream even when not EnrichmentRegistry member
+    /// (e.g. hot_pool_pubkeys_snapshot lag while position pin is already active).
+    #[test]
+    fn open_position_pumpfun_pin_publishes_without_enrichment_membership() {
+        use ironcrab::market_data::sidefx::handlers::md_sidefx_process_live_pool_cache_account_update;
+        use ironcrab::market_data::sidefx::MdSidefxCommand;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+        let (md_state, _depth, _md_state_rx) = test_md_state_sender_no_worker();
+        let (publish_tx, mut publish_rx) = tokio::sync::mpsc::channel(8);
+        let worker = MarketDataSidefxHost {
+            ctx: ctx.clone(),
+            publish_tx: Some(publish_tx),
+            md_state: md_state.clone(),
+            track_worker: test_noop_track_worker_sender(),
+        };
+
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let creator = Pubkey::new_unique();
+        let account_data = test_pumpfun_bonding_curve_account_data(
+            1_073_000_000_000_000,
+            30_000_000_000,
+            500_000_000_000_000,
+            10_000_000_000,
+            creator,
+        );
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::PumpFun(PumpFunState {
+                token_mint: mint,
+                bonding_curve: pool,
+                associated_bonding_curve: Pubkey::new_unique(),
+                virtual_sol_reserves: 30_000_000_000,
+                virtual_token_reserves: 1_073_000_000_000_000,
+                real_sol_reserves: 10_000_000_000,
+                real_token_reserves: 500_000_000_000_000,
+                complete: false,
+                creator,
+                cashback_enabled: false,
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_pool_with_reason(mint, pool, true);
+        // Simulate ingest snapshot lag: position pin active but pool not in enrichment hot set.
+        ctx.hot_pool_registry
+            .hot_pool_pubkeys_snapshot
+            .store(std::sync::Arc::new(std::collections::HashSet::new()));
+        assert!(
+            !ctx.ingest_is_enrichment_member(&pool),
+            "test setup: pool must not be enrichment member"
+        );
+        assert!(
+            ctx.hot_pool_registry.is_position_pin_for_pool(pool),
+            "test setup: position pin must remain active"
+        );
+
+        let job = MdSidefxCommand::LivePoolCacheAccountUpdate {
+            run_id: "open-pos-no-enrich".into(),
+            pool_pubkey: pool,
+            owner: PUMPFUN_PROGRAM_OWNER,
+            account_data,
+            slot: 30,
+            grpc_recv_at: Instant::now(),
+            update_class: SidefxUpdateClass::Enrich,
+        };
+        let mut scratch = MdSidefxBurstScratch::new();
+        md_sidefx_process_live_pool_cache_account_update(&worker, &job, &mut scratch);
+        assert!(
+            publish_rx.try_recv().is_ok(),
+            "open-position PumpFun pin must publish JetStream without enrichment membership"
+        );
+    }
+
     #[test]
     fn md_sidefx_live_pool_cache_update_skips_md_state_for_non_hot_pool() {
         let tmp = tempfile::TempDir::new().expect("tempdir");

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -3929,7 +3929,7 @@ impl MomentumContext {
         try_rows.retain(|p| seen.insert(p.pool_address.clone()));
 
         let mut best: Option<(ExitExecutableQuote, u64)> = None;
-        let mut guard_reject_sample: Option<(&'static str, String)> = None;
+        let mut guard_reject_sample: Option<(&'static str, String, u64, u64)> = None;
 
         for pool_row in try_rows {
             let pool_addr = pool_row.pool_address.clone();
@@ -3976,7 +3976,7 @@ impl MomentumContext {
             ) {
                 ironcrab::metrics::record_momentum_exit_quote_guard_reject_total(reason);
                 if guard_reject_sample.is_none() {
-                    guard_reject_sample = Some((reason, pool_addr.clone()));
+                    guard_reject_sample = Some((reason, pool_addr.clone(), age_ms, slot));
                 }
                 trace!(
                     mint = %pos.mint,
@@ -4004,12 +4004,16 @@ impl MomentumContext {
         }
 
         if best.is_none() {
-            if let Some((reason, quote_pool)) = guard_reject_sample {
+            if let Some((reason, quote_pool, cache_age_ms, quote_slot)) = guard_reject_sample {
                 warn!(
                     mint = %pos.mint,
                     position_pool = %pos.pool,
                     quote_pool = %quote_pool,
                     reason = %reason,
+                    cache_age_ms = cache_age_ms,
+                    quote_slot = quote_slot,
+                    entry_confirmed_slot = pos.entry_confirmed_slot,
+                    last_price_slot = pos.last_price_slot,
                     "executable_exit_quote: all reserve quote candidates rejected by exit guards"
                 );
             }
@@ -4262,6 +4266,7 @@ impl MomentumContext {
     }
 
     async fn tick_open_position_pool_recovery_retries(self: &Arc<Self>) {
+        // Cold-path Ensure* fallback when SLAVE cache is blind/stale — not a Hot Path freshness ticker.
         let mut rows: Vec<(String, String, String, &'static str)> = Vec::new();
         {
             let positions = self.positions.read();
@@ -11762,7 +11767,9 @@ async fn main() -> Result<()> {
                 }
             }
 
-            // Timed-exit reconciliation (retry exits that were generated but never confirmed)
+            // Timed-exit reconciliation (retry exits that were generated but never confirmed).
+            // Cold-path recovery only: `tick_open_position_pool_recovery_retries` issues Ensure*
+            // via NATS — not the event-driven Hot Path for exit-quote freshness (I-16).
             _ = reconcile_interval.tick() => {
                 ironcrab::metrics::record_activity();
                 ctx.reconcile_timed_exits().await;

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -1829,6 +1829,65 @@ mod tests {
     }
 
     #[test]
+    fn pumpfun_balance_updated_same_reserves_new_slot_refreshes_slave_age() {
+        use std::time::Duration;
+
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let token_reserves = 1_073_000_000_000_000u64;
+        let sol_reserves = 30_000_000_000u64;
+
+        let mut discovered = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            token_reserves,
+            sol_reserves,
+            Some(0),
+            10,
+        );
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("complete".to_string(), "false".to_string());
+        discovered.metadata = Some(meta);
+        assert!(apply_pool_cache_update(&cache, &discovered));
+
+        std::thread::sleep(Duration::from_millis(40));
+        let (_, slot_before, age_before) = cache.get_with_metadata(&pool).expect("cached");
+        assert_eq!(slot_before, 10);
+        assert!(
+            age_before >= 30,
+            "seed row must age before slot-only refresh"
+        );
+
+        let bal = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            token_reserves,
+            sol_reserves,
+            11,
+        );
+        assert!(apply_pool_cache_update(&cache, &bal));
+
+        let (_, slot_after, age_after) = cache.get_with_metadata(&pool).expect("cached");
+        assert_eq!(slot_after, 11, "slot must advance from Geyser event");
+        assert!(
+            age_after < 20,
+            "unchanged reserves with newer slot must refresh SLAVE cache age (event-driven pin path)"
+        );
+    }
+
+    #[test]
     fn test_raydium_cpmm_balance_updated_preserves_vaults_and_merges_readiness() {
         let cache = LivePoolCache::new();
         let pool = Pubkey::new_unique();

--- a/src/market_data/sidefx/handlers.rs
+++ b/src/market_data/sidefx/handlers.rs
@@ -215,6 +215,35 @@ fn md_sidefx_publish_enrichment_from_cache_upsert(
     slot: u64,
     grpc_recv_at: Instant,
 ) {
+    let open_position_pumpfun_pin =
+        md_sidefx_is_open_position_pumpfun_pin(host, pool_pubkey, cached_state);
+
+    // P0: open-position PumpFun pins must refresh JetStream even without EnrichmentRegistry
+    // membership (account path already guarantees PoolDiscovered; this path is BalanceUpdated).
+    if open_position_pumpfun_pin {
+        if !cached_pool_has_fresh_reserve_basis(cached_state) {
+            return;
+        }
+        if host.nats_enabled() {
+            md_sidefx_publish_open_position_pumpfun_balance_refresh(
+                host,
+                run_id,
+                pool_pubkey,
+                slot,
+            );
+        }
+        if md_sidefx_publish_pool_state_update_from_cache(
+            host,
+            run_id,
+            pool_pubkey,
+            slot,
+            grpc_recv_at,
+        ) {
+            inc_market_data_enrichment_pool_state_publish_total();
+        }
+        return;
+    }
+
     if !host.is_enrichment_member(pool_pubkey) {
         return;
     }
@@ -224,25 +253,16 @@ fn md_sidefx_publish_enrichment_from_cache_upsert(
     if !cached_pool_has_fresh_reserve_basis(cached_state) {
         return;
     }
-    let open_position_pumpfun_pin =
-        md_sidefx_is_open_position_pumpfun_pin(host, pool_pubkey, cached_state);
     let balance_unchanged = prev_state
         .as_ref()
         .is_some_and(|prev| cache_balance_fields_unchanged(prev, cached_state));
-    if balance_unchanged && !open_position_pumpfun_pin {
+    if balance_unchanged {
         inc_market_data_pool_state_publish_skipped_balance_unchanged_total();
         return;
     }
 
     if host.nats_enabled() {
-        if open_position_pumpfun_pin {
-            md_sidefx_publish_open_position_pumpfun_balance_refresh(
-                host,
-                run_id,
-                pool_pubkey,
-                slot,
-            );
-        } else if let Some(balance_update) =
+        if let Some(balance_update) =
             md_sidefx_build_balance_updated_from_cache(host, run_id, pool_pubkey, slot)
         {
             let subject = pool_subject(&pool_pubkey.to_string());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes event-driven Publish/Apply gaps for **open-position PumpFun pins** so Mom SLAVE cache age stays fresh from Geyser→JetStream→LivePoolCache without relying on Ensure/reconcile polling.

## Changes

### A) Pin publish before EnrichmentRegistry gate (`handlers.rs`)
- `md_sidefx_publish_enrichment_from_cache_upsert` now checks `is_open_position_pumpfun_pin` **first**
- Open-position PumpFun pins publish `BalanceUpdated` via `md_sidefx_publish_open_position_pumpfun_balance_refresh` even when `!is_enrichment_member` (e.g. hot_pool snapshot lag)
- Pin fast-path bypasses vault-feed skip and balance-unchanged throttle — every successful MASTER upsert with reserve basis triggers JetStream refresh

### B) Event-driven slot progress (unchanged balances)
- Account path already forces publish via `open_position_pumpfun_pin` in `should_publish_pool_cache`
- Enrichment upsert pin fast-path always publishes on upsert (no `balance_unchanged` skip)

### C) Tests
- `open_position_pumpfun_pin_publishes_without_enrichment_membership` — simulates snapshot lag with active position pin
- `pumpfun_balance_updated_same_reserves_new_slot_refreshes_slave_age` — Mom SLAVE age refresh on slot-only `BalanceUpdated`
- Existing `open_position_pumpfun_pin_enrich_publishes_on_balance_unchanged` retained

### D/E) Observability / docs only
- `executable_exit_quote` guard-reject warn logs now include `cache_age_ms`, `quote_slot`, `entry_confirmed_slot`, `last_price_slot`
- Comments on `reconcile_interval` / `tick_open_position_pool_recovery_retries`: cold-path Ensure* recovery, not Hot Path freshness

## Explicitly NOT changed
- No Ensure/reconcile cadence increase
- No `EXIT_QUOTE_MAX_CACHE_AGE_MS` change
- No `QUOTE_SLOT_NOT_AFTER_ENTRY_*` guard changes
- No RPC in Momentum Hot Path

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ecc3022-9b8c-4a91-b307-007b9d17507f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ecc3022-9b8c-4a91-b307-007b9d17507f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

