### PR TITLE
fix(poolcache): P0 JetStream→Mom slot + open-position explicit sticky

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -3903,18 +3903,22 @@ impl MarketDataContext {
         out
     }
 
-    /// PumpFun bonding curve must be in the last Geyser explicit flush (not vacuous vault satisfied).
+    /// PumpFun bonding curve must be in the last Geyser explicit flush **or** admitted pending flush.
     fn pool_pumpfun_bonding_curve_registration_satisfied(
         &self,
         pool: Pubkey,
         state: &CachedPoolState,
+        admission: Option<&FixedCapAdmission>,
     ) -> bool {
         match state {
             CachedPoolState::PumpFun(_) => {
                 if !self.hot_pool_registry.is_hot_pool(pool) {
                     return true;
                 }
-                self.last_synced_explicit_pubkeys.read().contains(&pool)
+                if self.last_synced_explicit_pubkeys.read().contains(&pool) {
+                    return true;
+                }
+                admission.is_some_and(|a| a.snapshot_pubkeys().contains(&pool))
             }
             _ => true,
         }
@@ -4557,14 +4561,13 @@ impl MarketDataContext {
             let admitted_after: HashSet<Pubkey> =
                 admission.snapshot_pubkeys().into_iter().collect();
             self.sync_explicit_pool_admitted_from_admission(admission, pool, consumer);
-            // Sticky explicit: reflect admission in last_synced before satisfied check (flush may lag).
-            if admitted_before != admitted_after && admitted_after.contains(&pool) {
-                self.last_synced_explicit_pubkeys.write().insert(pool);
-                if self.explicit_physical_publish_needed(admission) {
-                    inc_market_data_open_position_pumpfun_remediate_flush_pending_total();
-                }
+            if admitted_before != admitted_after
+                && admitted_after.contains(&pool)
+                && self.explicit_physical_publish_needed(admission)
+            {
+                inc_market_data_open_position_pumpfun_remediate_flush_pending_total();
             }
-            if self.hot_pool_reserve_registration_satisfied(pool) {
+            if self.hot_pool_reserve_registration_satisfied_with_admission(pool, Some(admission)) {
                 self.clear_deferred_hot_pool_reserve_registration(pool);
                 inc_market_data_open_position_pin_applied_total();
                 inc_market_data_open_position_pumpfun_remediate_ok_total();
@@ -5026,6 +5029,14 @@ impl MarketDataContext {
 
     /// True when cache has layout and expected vault/bin rows are already tracked (registration no-op).
     fn hot_pool_reserve_registration_satisfied(&self, pool: Pubkey) -> bool {
+        self.hot_pool_reserve_registration_satisfied_with_admission(pool, None)
+    }
+
+    fn hot_pool_reserve_registration_satisfied_with_admission(
+        &self,
+        pool: Pubkey,
+        admission: Option<&FixedCapAdmission>,
+    ) -> bool {
         if !self.hot_pool_registry.is_hot_pool(pool) {
             return true;
         }
@@ -5034,7 +5045,7 @@ impl MarketDataContext {
         };
         self.pool_vaults_fully_tracked_for_cache(pool, &state)
             && self.pool_geyser_bins_fully_tracked_for_cache(pool, &state)
-            && self.pool_pumpfun_bonding_curve_registration_satisfied(pool, &state)
+            && self.pool_pumpfun_bonding_curve_registration_satisfied(pool, &state, admission)
     }
 
     /// C1b: gauge arb pins with incomplete vault/bin Geyser registration (no RPC).
@@ -17205,12 +17216,23 @@ mod pr_b_geyser_tracking_tests {
             "physical Geyser publish must be scheduled after admission delta"
         );
         assert!(
-            ctx.hot_pool_reserve_registration_satisfied(pool),
-            "remediation must satisfy bonding-curve explicit registration after admit sticky sync"
+            !ctx.last_synced_explicit_pubkeys.read().contains(&pool),
+            "last_synced must not be faked before physical flush"
         );
         assert!(
+            ctx.hot_pool_reserve_registration_satisfied_with_admission(pool, Some(&admission)),
+            "remediation must satisfy registration via admission pending flush"
+        );
+
+        *ctx.last_synced_explicit_pubkeys.write() =
+            admission.snapshot_pubkeys().into_iter().collect();
+        assert!(
             ctx.last_synced_explicit_pubkeys.read().contains(&pool),
-            "bonding curve must be in last_synced_explicit_pubkeys after remediate"
+            "bonding curve must be in last_synced only after explicit flush simulation"
+        );
+        assert!(
+            ctx.hot_pool_reserve_registration_satisfied(pool),
+            "after flush simulation, satisfied without admission context"
         );
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -120,6 +120,10 @@ use ironcrab::metrics::{
     inc_market_data_open_position_pin_deferred_cache_miss_total,
     inc_market_data_open_position_pumpfun_registration_remediate_total,
     inc_market_data_open_position_pumpfun_registration_unsatisfied_warn_total,
+    inc_market_data_open_position_pumpfun_remediate_admit_fail_total,
+    inc_market_data_open_position_pumpfun_remediate_flush_pending_total,
+    inc_market_data_open_position_pumpfun_remediate_ok_total,
+    inc_market_data_open_position_pumpfun_remediate_still_unsatisfied_total,
     inc_market_data_tracker_admission_admitted_total,
     inc_market_data_tracker_admission_rejected_total,
     inc_market_data_vault_high_priority_dispatch_total,
@@ -4526,6 +4530,7 @@ impl MarketDataContext {
                     pool,
                     GeyserPinReason::MomentumActive,
                 );
+                inc_market_data_open_position_pumpfun_remediate_still_unsatisfied_total();
                 continue;
             };
             if !matches!(state, CachedPoolState::PumpFun(_)) {
@@ -4544,6 +4549,7 @@ impl MarketDataContext {
                     pool,
                     GeyserPinReason::MomentumActive,
                 );
+                inc_market_data_open_position_pumpfun_remediate_admit_fail_total();
                 continue;
             }
             let registered = self
@@ -4551,15 +4557,24 @@ impl MarketDataContext {
             let admitted_after: HashSet<Pubkey> =
                 admission.snapshot_pubkeys().into_iter().collect();
             self.sync_explicit_pool_admitted_from_admission(admission, pool, consumer);
+            // Sticky explicit: reflect admission in last_synced before satisfied check (flush may lag).
+            if admitted_before != admitted_after && admitted_after.contains(&pool) {
+                self.last_synced_explicit_pubkeys.write().insert(pool);
+                if self.explicit_physical_publish_needed(admission) {
+                    inc_market_data_open_position_pumpfun_remediate_flush_pending_total();
+                }
+            }
             if self.hot_pool_reserve_registration_satisfied(pool) {
                 self.clear_deferred_hot_pool_reserve_registration(pool);
                 inc_market_data_open_position_pin_applied_total();
+                inc_market_data_open_position_pumpfun_remediate_ok_total();
                 self.publish_momentum_hot_balance_refresh_from_cache(pool);
             } else {
                 self.note_deferred_hot_pool_reserve_registration(
                     pool,
                     GeyserPinReason::MomentumActive,
                 );
+                inc_market_data_open_position_pumpfun_remediate_still_unsatisfied_total();
             }
             if admitted_before != admitted_after || registered {
                 batch_dirty = true;
@@ -17188,6 +17203,14 @@ mod pr_b_geyser_tracking_tests {
         assert!(
             ctx.explicit_physical_publish_needed(&admission),
             "physical Geyser publish must be scheduled after admission delta"
+        );
+        assert!(
+            ctx.hot_pool_reserve_registration_satisfied(pool),
+            "remediation must satisfy bonding-curve explicit registration after admit sticky sync"
+        );
+        assert!(
+            ctx.last_synced_explicit_pubkeys.read().contains(&pool),
+            "bonding curve must be in last_synced_explicit_pubkeys after remediate"
         );
     }
 

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -12606,7 +12606,17 @@ async fn momentum_apply_pool_cache_jetstream_batch_items(
             now_ms_js,
             update.header.ts_unix_ms,
         );
-        pool_cache_sync::apply_pool_cache_update(&ctx.live_pool_cache, update);
+        if !pool_cache_sync::apply_pool_cache_update(&ctx.live_pool_cache, update)
+            && ironcrab::metrics::record_momentum_pool_cache_apply_rejected()
+        {
+            warn!(
+                pool = %update.pool_address,
+                dex = %update.dex,
+                geyser_slot = update.geyser_slot,
+                update_type = ?update.update_type,
+                "Mom apply_pool_cache_update rejected (stale slot or no-op)"
+            );
+        }
         ctx.mark_entry_eval_dirty_for_mint(&update.base_mint);
     }
     pool_cache_process_accounted = pool_cache_process_accounted.saturating_add(phase1_t0.elapsed());

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -593,7 +593,12 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         }
                     }
                 }
-                cache.upsert(pool_addr, minimal_state, update.geyser_slot);
+                if !cache.upsert(pool_addr, minimal_state, update.geyser_slot) {
+                    if update.geyser_slot > 0 {
+                        crate::metrics::inc_pool_cache_apply_rejected_stale_slot_total();
+                    }
+                    return false;
+                }
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_sell_layout_from_metadata(
                         &pool_addr,
@@ -1074,7 +1079,12 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                         }
                     }
                 }
-                cache.upsert(addr, minimal_state, update.geyser_slot);
+                if !cache.upsert(addr, minimal_state, update.geyser_slot) {
+                    if update.geyser_slot > 0 {
+                        crate::metrics::inc_pool_cache_apply_rejected_stale_slot_total();
+                    }
+                    return false;
+                }
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_sell_layout_from_metadata(&addr, update.metadata.as_ref());
                     if update
@@ -3142,5 +3152,97 @@ mod tests {
         } else {
             panic!("expected Orca state");
         }
+    }
+
+    /// P0-B: Ensure-equivalent JetStream publish must advance SLAVE slot when S ≫ prior cache.
+    #[test]
+    fn ensure_equivalent_pool_cache_update_advances_slave_slot() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let token_reserves = 1_073_000_000_000_000u64;
+        let sol_reserves = 30_000_000_000u64;
+
+        let mut seed = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            token_reserves,
+            sol_reserves,
+            Some(0),
+            436_771_116,
+        );
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("complete".to_string(), "false".to_string());
+        seed.metadata = Some(meta);
+        assert!(apply_pool_cache_update(&cache, &seed));
+
+        let ensure_refresh = PoolCacheUpdate::new_balance_updated(
+            "market-data",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            token_reserves,
+            sol_reserves,
+            436_771_200,
+        );
+        assert!(
+            apply_pool_cache_update(&cache, &ensure_refresh),
+            "Ensure-equivalent BalanceUpdated must apply when slot advances"
+        );
+        let (_, slot_after, _) = cache.get_with_metadata(&pool).expect("cached");
+        assert!(
+            slot_after >= 436_771_200,
+            "SLAVE slot must be >= publish_slot S after apply"
+        );
+    }
+
+    #[test]
+    fn apply_rejects_stale_lower_slot_monotonic() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+
+        let fresh = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1_000,
+            2_000,
+            500,
+        );
+        assert!(apply_pool_cache_update(&cache, &fresh));
+
+        let stale = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            1_000,
+            2_000,
+            400,
+        );
+        assert!(
+            !apply_pool_cache_update(&cache, &stale),
+            "stale slot must be rejected"
+        );
+        let (_, slot, _) = cache.get_with_metadata(&pool).expect("cached");
+        assert_eq!(slot, 500);
     }
 }

--- a/src/market_data/cold/ensure_pumpfun.rs
+++ b/src/market_data/cold/ensure_pumpfun.rs
@@ -71,6 +71,7 @@ pub async fn handle_ensure_pumpfun_bonding_curve(
         .and_then(|s| Pubkey::from_str(s).ok())
         .unwrap_or(bonding_curve);
     let bonding_curve_str = bonding_curve.to_string();
+    let had_master_pool = host.live_pool_cache().get(&bonding_curve).is_some();
 
     if !force_refresh {
         if let Some(CachedPoolState::PumpFun(_)) = host.live_pool_cache().get(&bonding_curve) {
@@ -186,8 +187,44 @@ pub async fn handle_ensure_pumpfun_bonding_curve(
     host.live_pool_cache()
         .upsert(bonding_curve, cached, publish_slot);
 
-    let jetstream_ok = if let Some(nats) = host.nats() {
-        let mut pool_update = PoolCacheUpdate::new_pool_discovered(
+    let mut meta = std::collections::HashMap::new();
+    meta.insert("creator".to_string(), state.creator.to_string());
+    meta.insert(
+        "associated_bonding_curve".to_string(),
+        associated_bonding_curve.to_string(),
+    );
+    meta.insert("complete".to_string(), state.complete.to_string());
+    meta.insert(
+        "real_token_reserves".to_string(),
+        state.real_token_reserves.to_string(),
+    );
+    meta.insert(
+        "real_sol_reserves".to_string(),
+        state.real_sol_reserves.to_string(),
+    );
+    meta.insert(
+        "cashback_enabled".to_string(),
+        state.cashback_enabled.to_string(),
+    );
+
+    let use_balance_updated = had_master_pool || force_refresh;
+    let mut pool_update = if use_balance_updated {
+        let mut bal = PoolCacheUpdate::new_balance_updated(
+            "market-data",
+            BUILD_VERSION,
+            run_id,
+            bonding_curve_str.clone(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            NATIVE_SOL_MINT.to_string(),
+            state.virtual_token_reserves,
+            state.virtual_sol_reserves,
+            publish_slot,
+        );
+        bal.metadata = Some(meta.clone());
+        bal
+    } else {
+        let mut disc = PoolCacheUpdate::new_pool_discovered(
             "market-data",
             BUILD_VERSION,
             run_id,
@@ -200,36 +237,24 @@ pub async fn handle_ensure_pumpfun_bonding_curve(
             Some(publish_slot),
             publish_slot,
         );
-        let mut meta = std::collections::HashMap::new();
-        meta.insert("creator".to_string(), state.creator.to_string());
-        meta.insert(
-            "associated_bonding_curve".to_string(),
-            associated_bonding_curve.to_string(),
-        );
-        meta.insert("complete".to_string(), state.complete.to_string());
-        meta.insert(
-            "real_token_reserves".to_string(),
-            state.real_token_reserves.to_string(),
-        );
-        meta.insert(
-            "real_sol_reserves".to_string(),
-            state.real_sol_reserves.to_string(),
-        );
-        meta.insert(
-            "cashback_enabled".to_string(),
-            state.cashback_enabled.to_string(),
-        );
-        pool_update.metadata = Some(meta);
-        // Cold-path RPC refresh: explicit Ready for JetStream / SLAVE (Bug #36).
-        pool_update.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
-        host.live_pool_cache()
-            .merge_pumpfun_bonding_readiness(bonding_curve, DexPoolReadiness::Ready);
+        disc.metadata = Some(meta);
+        disc
+    };
+    // Cold-path RPC refresh: explicit Ready for JetStream / SLAVE (Bug #36).
+    pool_update.set_dex_readiness_in_metadata(DexPoolReadiness::Ready);
+    host.live_pool_cache()
+        .merge_pumpfun_bonding_readiness(bonding_curve, DexPoolReadiness::Ready);
+
+    let jetstream_ok = if let Some(nats) = host.nats() {
         let subject = pool_subject(&bonding_curve_str);
         match nats.jetstream_publish(&subject, &pool_update).await {
             Ok(true) => {
                 info!(
                     pool = %bonding_curve_str,
                     base_mint = %base_mint_str,
+                    publish_slot,
+                    rpc_context_slot,
+                    update_type = if use_balance_updated { "BalanceUpdated" } else { "PoolDiscovered" },
                     "EnsurePumpfunBondingCurve: Published PoolCacheUpdate to JetStream"
                 );
                 true

--- a/src/market_data/cold/ensure_pumpfun.rs
+++ b/src/market_data/cold/ensure_pumpfun.rs
@@ -2,7 +2,7 @@
 
 use super::host::{publish_control_response, ColdHost};
 use super::publish_slot::{observe_cold_path_rpc_context_slot_lag, resolve_cold_path_publish_slot};
-use crate::execution::live_pool_cache::{CachedPoolState, PumpFunState};
+use crate::execution::live_pool_cache::{CachedPoolState, LivePoolCache, PumpFunState};
 use crate::ipc::{ControlResponseStatus, DexPoolReadiness, PoolCacheUpdate, NATIVE_SOL_MINT};
 use crate::nats::jetstream::pool_subject;
 use crate::solana::dex::pumpfun::{BondingCurveState, PumpFunDex};
@@ -13,6 +13,24 @@ use std::sync::Arc;
 use tracing::{info, warn};
 
 const BUILD_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// True when Ensure must **not** publish JetStream: MASTER monotonic slot rejected the upsert.
+pub(crate) fn ensure_pumpfun_should_skip_jetstream_publish(
+    master_upsert_applied: bool,
+    publish_slot: u64,
+) -> bool {
+    !master_upsert_applied && publish_slot > 0
+}
+
+/// Apply RPC-fetched PumpFun row to MASTER cache (monotonic slot).
+pub(crate) fn apply_ensure_pumpfun_master_cache_upsert(
+    cache: &LivePoolCache,
+    pool: Pubkey,
+    state: CachedPoolState,
+    publish_slot: u64,
+) -> bool {
+    cache.upsert(pool, state, publish_slot)
+}
 
 /// Cold-path recovery: fetch PumpFun bonding curve account via RPC (force_refresh), update MASTER
 /// cache, publish JetStream PoolCacheUpdate. Does not short-circuit on cache when `force_refresh`.
@@ -185,8 +203,42 @@ pub async fn handle_ensure_pumpfun_bonding_curve(
         creator: state.creator,
         cashback_enabled: state.cashback_enabled,
     });
-    host.live_pool_cache()
-        .upsert(bonding_curve, cached, publish_slot);
+    let master_upsert_applied = apply_ensure_pumpfun_master_cache_upsert(
+        host.live_pool_cache(),
+        bonding_curve,
+        cached,
+        publish_slot,
+    );
+    if ensure_pumpfun_should_skip_jetstream_publish(master_upsert_applied, publish_slot) {
+        let master_slot = host
+            .live_pool_cache()
+            .get_with_metadata(&bonding_curve)
+            .map(|(_, slot, _)| slot)
+            .unwrap_or(0);
+        crate::metrics::inc_market_data_ensure_pumpfun_master_upsert_stale_reject_total();
+        warn!(
+            request_id = %request_id,
+            pool = %bonding_curve_str,
+            publish_slot,
+            master_slot,
+            rpc_context_slot,
+            "EnsurePumpfunBondingCurve: MASTER upsert rejected stale RPC slot — skipping JetStream publish"
+        );
+        if let Some(nats) = host.nats() {
+            publish_control_response(
+                nats,
+                host.run_id(),
+                request_id,
+                ControlResponseStatus::Error,
+                Some(bonding_curve_str),
+                Some(format!(
+                    "MASTER cache slot {master_slot} newer than publish_slot {publish_slot}; JetStream publish skipped"
+                )),
+            )
+            .await;
+        }
+        return;
+    }
 
     let mut meta = std::collections::HashMap::new();
     meta.insert("creator".to_string(), state.creator.to_string());
@@ -294,5 +346,70 @@ pub async fn handle_ensure_pumpfun_bonding_curve(
             message,
         )
         .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution::live_pool_cache::{LivePoolCache, PumpFunState};
+
+    fn sample_pumpfun_state(pool: Pubkey, mint: Pubkey) -> CachedPoolState {
+        CachedPoolState::PumpFun(PumpFunState {
+            token_mint: mint,
+            bonding_curve: pool,
+            associated_bonding_curve: Pubkey::new_unique(),
+            virtual_sol_reserves: 30_000_000_000,
+            virtual_token_reserves: 1_073_000_000_000_000,
+            real_sol_reserves: 10_000_000_000,
+            real_token_reserves: 500_000_000_000_000,
+            complete: false,
+            creator: Pubkey::new_unique(),
+            cashback_enabled: false,
+        })
+    }
+
+    #[test]
+    fn ensure_skips_jetstream_when_master_upsert_rejects_stale_slot() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let state = sample_pumpfun_state(pool, mint);
+
+        assert!(apply_ensure_pumpfun_master_cache_upsert(
+            &cache,
+            pool,
+            state.clone(),
+            436_771_131
+        ));
+        let rejected = apply_ensure_pumpfun_master_cache_upsert(&cache, pool, state, 436_771_116);
+        assert!(!rejected, "MASTER must reject lower RPC slot");
+        assert!(
+            ensure_pumpfun_should_skip_jetstream_publish(rejected, 436_771_116),
+            "JetStream publish must be skipped when MASTER upsert rejects"
+        );
+        let (_, master_slot, _) = cache.get_with_metadata(&pool).expect("cached");
+        assert_eq!(master_slot, 436_771_131);
+    }
+
+    #[test]
+    fn ensure_allows_jetstream_when_master_upsert_advances_slot() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let state = sample_pumpfun_state(pool, mint);
+
+        assert!(apply_ensure_pumpfun_master_cache_upsert(
+            &cache,
+            pool,
+            state.clone(),
+            436_771_116
+        ));
+        let applied = apply_ensure_pumpfun_master_cache_upsert(&cache, pool, state, 436_771_200);
+        assert!(applied);
+        assert!(!ensure_pumpfun_should_skip_jetstream_publish(
+            applied,
+            436_771_200
+        ));
     }
 }

--- a/src/market_data/cold/ensure_pumpfun.rs
+++ b/src/market_data/cold/ensure_pumpfun.rs
@@ -1,7 +1,7 @@
 //! I-24d EnsurePumpfunBondingCurve cold-path handler.
 
 use super::host::{publish_control_response, ColdHost};
-use super::publish_slot::resolve_cold_path_publish_slot;
+use super::publish_slot::{observe_cold_path_rpc_context_slot_lag, resolve_cold_path_publish_slot};
 use crate::execution::live_pool_cache::{CachedPoolState, PumpFunState};
 use crate::ipc::{ControlResponseStatus, DexPoolReadiness, PoolCacheUpdate, NATIVE_SOL_MINT};
 use crate::nats::jetstream::pool_subject;
@@ -151,6 +151,7 @@ pub async fn handle_ensure_pumpfun_bonding_curve(
     };
 
     let mut publish_slot = resolve_cold_path_publish_slot(rpc_context_slot);
+    observe_cold_path_rpc_context_slot_lag(rpc_context_slot);
     if publish_slot == 0 {
         if let Ok(slot) = rpc.get_slot_retry().await {
             publish_slot = slot;

--- a/src/market_data/cold/publish_slot.rs
+++ b/src/market_data/cold/publish_slot.rs
@@ -2,14 +2,12 @@
 
 /// Watermark for cold-path `LivePoolCache::upsert` and `PoolCacheUpdate::geyser_slot`.
 ///
-/// Prefers the RPC account response `context.slot`. When that is zero (unknown), falls back to
-/// the monotonic Geyser head tracked by market-data ingest — never silently treats `0` as a
-/// valid exit-quote watermark when a head is available.
+/// Uses `max(rpc_context_slot, geyser_head)` so a stale RPC `context.slot` cannot publish a slot
+/// below the live Geyser head (Mom SLAVE monotonic reject would drop the JetStream update).
+/// When both are zero, returns `0` (callers may fall back to `getSlot`).
 pub fn resolve_cold_path_publish_slot(rpc_context_slot: u64) -> u64 {
-    if rpc_context_slot > 0 {
-        return rpc_context_slot;
-    }
-    crate::metrics::market_data_geyser_head_slot_value()
+    let head = crate::metrics::market_data_geyser_head_slot_value();
+    rpc_context_slot.max(head)
 }
 
 #[cfg(test)]
@@ -19,6 +17,7 @@ mod tests {
 
     #[test]
     fn resolve_prefers_rpc_context_slot_when_positive() {
+        crate::metrics::MARKET_DATA_GEYSER_HEAD_SLOT.store(0, Ordering::Relaxed);
         assert_eq!(resolve_cold_path_publish_slot(436_375_700), 436_375_700);
     }
 
@@ -27,5 +26,20 @@ mod tests {
         let head = 99_001_234u64;
         crate::metrics::MARKET_DATA_GEYSER_HEAD_SLOT.store(head, Ordering::Relaxed);
         assert_eq!(resolve_cold_path_publish_slot(0), head);
+    }
+
+    #[test]
+    fn resolve_merges_rpc_context_with_geyser_head_monotonic() {
+        crate::metrics::MARKET_DATA_GEYSER_HEAD_SLOT.store(436_771_131, Ordering::Relaxed);
+        assert_eq!(
+            resolve_cold_path_publish_slot(436_771_116),
+            436_771_131,
+            "stale RPC context must not publish below Geyser head"
+        );
+        assert_eq!(
+            resolve_cold_path_publish_slot(436_771_200),
+            436_771_200,
+            "fresh RPC context above head must win"
+        );
     }
 }

--- a/src/market_data/cold/publish_slot.rs
+++ b/src/market_data/cold/publish_slot.rs
@@ -1,13 +1,42 @@
 //! Cold-path JetStream publish slot resolution (I-16).
 
+use tracing::warn;
+
+/// Minimum Geyser-head lead over RPC `context.slot` before we WARN (slots, not wall-clock).
+const RPC_CONTEXT_LAG_WARN_THRESHOLD_SLOTS: u64 = 32;
+
 /// Watermark for cold-path `LivePoolCache::upsert` and `PoolCacheUpdate::geyser_slot`.
 ///
-/// Uses `max(rpc_context_slot, geyser_head)` so a stale RPC `context.slot` cannot publish a slot
-/// below the live Geyser head (Mom SLAVE monotonic reject would drop the JetStream update).
-/// When both are zero, returns `0` (callers may fall back to `getSlot`).
+/// I-16: When `rpc_context_slot > 0`, the publish watermark is **exactly** that slot — the bytes
+/// came from that RPC context and must not be labeled with a higher Geyser head (slot spoofing).
+/// When zero, falls back to the monotonic Geyser head tracked by market-data ingest.
 pub fn resolve_cold_path_publish_slot(rpc_context_slot: u64) -> u64 {
+    if rpc_context_slot > 0 {
+        return rpc_context_slot;
+    }
+    crate::metrics::market_data_geyser_head_slot_value()
+}
+
+/// Observability when RPC `context.slot` lags Geyser head. Does **not** change the publish watermark.
+pub fn observe_cold_path_rpc_context_slot_lag(rpc_context_slot: u64) {
+    if rpc_context_slot == 0 {
+        return;
+    }
     let head = crate::metrics::market_data_geyser_head_slot_value();
-    rpc_context_slot.max(head)
+    if head <= rpc_context_slot {
+        return;
+    }
+    let delta = head - rpc_context_slot;
+    if delta < RPC_CONTEXT_LAG_WARN_THRESHOLD_SLOTS {
+        return;
+    }
+    crate::metrics::inc_market_data_cold_path_rpc_context_lags_geyser_head_total();
+    warn!(
+        rpc_context_slot,
+        geyser_head = head,
+        delta,
+        "Cold-path RPC context.slot lags Geyser head — publish watermark stays rpc_context_slot (I-16 honest slot)"
+    );
 }
 
 #[cfg(test)]
@@ -17,8 +46,12 @@ mod tests {
 
     #[test]
     fn resolve_prefers_rpc_context_slot_when_positive() {
-        crate::metrics::MARKET_DATA_GEYSER_HEAD_SLOT.store(0, Ordering::Relaxed);
-        assert_eq!(resolve_cold_path_publish_slot(436_375_700), 436_375_700);
+        crate::metrics::MARKET_DATA_GEYSER_HEAD_SLOT.store(436_771_131, Ordering::Relaxed);
+        assert_eq!(
+            resolve_cold_path_publish_slot(436_375_700),
+            436_375_700,
+            "positive RPC context must win over Geyser head (no max spoofing)"
+        );
     }
 
     #[test]
@@ -29,17 +62,12 @@ mod tests {
     }
 
     #[test]
-    fn resolve_merges_rpc_context_with_geyser_head_monotonic() {
+    fn resolve_does_not_elevate_stale_rpc_context_to_head() {
         crate::metrics::MARKET_DATA_GEYSER_HEAD_SLOT.store(436_771_131, Ordering::Relaxed);
         assert_eq!(
             resolve_cold_path_publish_slot(436_771_116),
-            436_771_131,
-            "stale RPC context must not publish below Geyser head"
-        );
-        assert_eq!(
-            resolve_cold_path_publish_slot(436_771_200),
-            436_771_200,
-            "fresh RPC context above head must win"
+            436_771_116,
+            "stale-but-honest RPC context must not be elevated to geyser_head"
         );
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3321,6 +3321,56 @@ pub fn inc_market_data_open_position_pumpfun_jetstream_publish_total() {
     MARKET_DATA_OPEN_POSITION_PUMPFUN_JETSTREAM_PUBLISH_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+static POOL_CACHE_APPLY_REJECTED_STALE_SLOT_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn inc_pool_cache_apply_rejected_stale_slot_total() {
+    POOL_CACHE_APPLY_REJECTED_STALE_SLOT_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+static MOMENTUM_POOL_CACHE_APPLY_REJECTED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+
+/// Increment Mom apply-reject counter; returns true when a rate-limited WARN should be emitted.
+#[inline]
+pub fn record_momentum_pool_cache_apply_rejected() -> bool {
+    let n = MOMENTUM_POOL_CACHE_APPLY_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed) + 1;
+    n == 1 || n.is_multiple_of(64)
+}
+
+static MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_ADMIT_FAIL_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn inc_market_data_open_position_pumpfun_remediate_admit_fail_total() {
+    MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_ADMIT_FAIL_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+static MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_FLUSH_PENDING_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn inc_market_data_open_position_pumpfun_remediate_flush_pending_total() {
+    MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_FLUSH_PENDING_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+static MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_STILL_UNSATISFIED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn inc_market_data_open_position_pumpfun_remediate_still_unsatisfied_total() {
+    MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_STILL_UNSATISFIED_TOTAL
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+static MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_OK_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn inc_market_data_open_position_pumpfun_remediate_ok_total() {
+    MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_OK_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
 static MOMENTUM_OPEN_POSITION_EXIT_BLIND_ENSURE_TOTAL: Lazy<RwLock<HashMap<&'static str, u64>>> =
     Lazy::new(|| RwLock::new(HashMap::new()));
 
@@ -8615,6 +8665,30 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_open_position_pumpfun_jetstream_publish_total",
         MARKET_DATA_OPEN_POSITION_PUMPFUN_JETSTREAM_PUBLISH_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "pool_cache_apply_rejected_stale_slot_total",
+        POOL_CACHE_APPLY_REJECTED_STALE_SLOT_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "momentum_pool_cache_apply_rejected_total",
+        MOMENTUM_POOL_CACHE_APPLY_REJECTED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_open_position_pumpfun_remediate_admit_fail_total",
+        MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_ADMIT_FAIL_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_open_position_pumpfun_remediate_flush_pending_total",
+        MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_FLUSH_PENDING_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_open_position_pumpfun_remediate_still_unsatisfied_total",
+        MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_STILL_UNSATISFIED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_open_position_pumpfun_remediate_ok_total",
+        MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_OK_TOTAL.load(Ordering::Relaxed)
     );
     for (reason, count) in MOMENTUM_OPEN_POSITION_EXIT_BLIND_ENSURE_TOTAL.read().iter() {
         out.push_str("momentum_open_position_exit_blind_ensure_total{reason=\"");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3379,6 +3379,14 @@ pub fn inc_market_data_cold_path_rpc_context_lags_geyser_head_total() {
     MARKET_DATA_COLD_PATH_RPC_CONTEXT_LAGS_GEYSER_HEAD_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+static MARKET_DATA_ENSURE_PUMPFUN_MASTER_UPSERT_STALE_REJECT_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn inc_market_data_ensure_pumpfun_master_upsert_stale_reject_total() {
+    MARKET_DATA_ENSURE_PUMPFUN_MASTER_UPSERT_STALE_REJECT_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
 static MOMENTUM_OPEN_POSITION_EXIT_BLIND_ENSURE_TOTAL: Lazy<RwLock<HashMap<&'static str, u64>>> =
     Lazy::new(|| RwLock::new(HashMap::new()));
 
@@ -8701,6 +8709,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_cold_path_rpc_context_lags_geyser_head_total",
         MARKET_DATA_COLD_PATH_RPC_CONTEXT_LAGS_GEYSER_HEAD_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_ensure_pumpfun_master_upsert_stale_reject_total",
+        MARKET_DATA_ENSURE_PUMPFUN_MASTER_UPSERT_STALE_REJECT_TOTAL.load(Ordering::Relaxed)
     );
     for (reason, count) in MOMENTUM_OPEN_POSITION_EXIT_BLIND_ENSURE_TOTAL.read().iter() {
         out.push_str("momentum_open_position_exit_blind_ensure_total{reason=\"");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3371,6 +3371,14 @@ pub fn inc_market_data_open_position_pumpfun_remediate_ok_total() {
     MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_OK_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+static MARKET_DATA_COLD_PATH_RPC_CONTEXT_LAGS_GEYSER_HEAD_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+#[inline]
+pub fn inc_market_data_cold_path_rpc_context_lags_geyser_head_total() {
+    MARKET_DATA_COLD_PATH_RPC_CONTEXT_LAGS_GEYSER_HEAD_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
 static MOMENTUM_OPEN_POSITION_EXIT_BLIND_ENSURE_TOTAL: Lazy<RwLock<HashMap<&'static str, u64>>> =
     Lazy::new(|| RwLock::new(HashMap::new()));
 
@@ -8689,6 +8697,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_open_position_pumpfun_remediate_ok_total",
         MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_OK_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_cold_path_rpc_context_lags_geyser_head_total",
+        MARKET_DATA_COLD_PATH_RPC_CONTEXT_LAGS_GEYSER_HEAD_TOTAL.load(Ordering::Relaxed)
     );
     for (reason, count) in MOMENTUM_OPEN_POSITION_EXIT_BLIND_ENSURE_TOTAL.read().iter() {
         out.push_str("momentum_open_position_exit_blind_ensure_total{reason=\"");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes P0 pipeline break (9NzJ soak): MD Ensure publishes did not advance Mom `quote_slot` past `entry_confirmed_slot` → `QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM` blocked STOP_LOSS.

**Review follow-up (I-16 + explicit SSOT):** reverted `max(rpc, geyser_head)` slot spoofing; explicit registration uses admission OR `last_synced` without faking flush state.

### Root cause 9NzJ (evidence-based)

| Observation | Implication |
|-------------|-------------|
| Mom `quote_slot` ∈ {436771101, 436771104, 436771116}; `entry_confirmed_slot=436771131` | Guard correctly blocks — cache watermark never advanced past entry |
| MD logged many `EnsurePumpfunBondingCurve: Published PoolCacheUpdate` | Publish path ran; failure is downstream (Mom apply / update type / slot honesty) |
| `hot_pool_reserve_registration_satisfied=false` | Explicit Geyser filter missing → no owner-stream BondingCurve updates between Ensure bursts |

**Not** fixed by elevating slot to `geyser_head` when RPC `context.slot` is lower: that would label **stale reserve bytes** with a post-entry slot and let `QUOTE_SLOT_NOT_AFTER_ENTRY` pass falsely (I-16 slot spoofing). Prod symptom (slot stuck at 116) is consistent with either (a) honest `publish_slot ≤ 116` rejected by Mom monotonic upsert, or (b) `PoolDiscovered`-only refresh not advancing SLAVE slot on the BalanceUpdated path — not with “publish_slot already high but ignored”.

**Actual fixes:**
1. **Ensure → `BalanceUpdated` on refresh** (`force_refresh` / existing MASTER row): proven SLAVE slot-advance path (same reserves, newer slot).
2. **Honest `publish_slot`**: `rpc_context_slot > 0` → use as-is; `== 0` → Geyser head / `getSlot`. Lag vs head ≥32 slots → `WARN` + `market_data_cold_path_rpc_context_lags_geyser_head_total` (no watermark inflation).
3. **`apply_pool_cache_update`**: honors `upsert` monotonic reject + metrics/WARN on Mom.
4. **Explicit sticky (SSOT-correct)**: `registration_satisfied = last_synced.contains(pool) OR admission.contains(pool)`; `last_synced` written only in real flush path. Remediate schedules physical publish via `batch_dirty` / `explicit_physical_publish_needed`.

### Schicht A — Observability (kept)
- Ensure log: `publish_slot`, `rpc_context_slot`, `update_type`
- Mom: rate-limited WARN on apply reject
- MD remediate outcome counters

### Explicitly NOT changed
- Slot guards (`QUOTE_SLOT_NOT_AFTER_ENTRY_*`)
- Wall-clock STALE hard-reject
- Hot-path RPC in Mom
- Ensure cadence expansion

## CI
- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test` ✓ (779 tests)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47b2ea5f-4005-42a5-81ad-d8913e8fa8ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47b2ea5f-4005-42a5-81ad-d8913e8fa8ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

