### PR TITLE
fix(momentum): Master→Slave PoolCache slot bridge via PoolStateUpdate (post-#356)

### DIFF
--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -7295,6 +7295,23 @@ impl MomentumContext {
         self.positions.read().len()
     }
 
+    /// Pool addresses with an open momentum position (for PoolCache apply prioritization / bridge).
+    fn open_position_pool_addresses(&self) -> std::collections::HashSet<String> {
+        self.positions
+            .read()
+            .values()
+            .map(|p| p.pool.clone())
+            .collect()
+    }
+
+    /// True when `pool_address` is the sell pool for an open PumpFun position.
+    fn has_open_pumpfun_position_for_pool(&self, pool_address: &str) -> bool {
+        self.positions
+            .read()
+            .values()
+            .any(|p| p.pool == pool_address && p.dex == "pumpfun")
+    }
+
     /// Get pending intent count for heartbeat
     fn pending_count(&self) -> usize {
         self.pending_intents.read().len()
@@ -12585,7 +12602,7 @@ struct PoolCacheJetstreamBatchOutcome {
 /// optional exit scan + bounded `ExecutionResult` drain).
 async fn momentum_apply_pool_cache_jetstream_batch_items(
     ctx: &Arc<MomentumContext>,
-    batch_items: Vec<(
+    mut batch_items: Vec<(
         async_nats::jetstream::message::Message,
         ironcrab::ipc::PoolCacheUpdate,
     )>,
@@ -12599,6 +12616,17 @@ async fn momentum_apply_pool_cache_jetstream_batch_items(
     let mut pool_cache_process_accounted = Duration::ZERO;
     let mut position_price_updates_applied: u32 = 0;
 
+    let open_pools = ctx.open_position_pool_addresses();
+    if !open_pools.is_empty() {
+        batch_items.sort_by_key(|(_, u)| {
+            if open_pools.contains(u.pool_address.as_str()) {
+                0u8
+            } else {
+                1u8
+            }
+        });
+    }
+
     let phase1_t0 = Instant::now();
     let now_ms_js = wall_clock_unix_ms_now();
     for (_, update) in &batch_items {
@@ -12606,15 +12634,23 @@ async fn momentum_apply_pool_cache_jetstream_batch_items(
             now_ms_js,
             update.header.ts_unix_ms,
         );
-        if !pool_cache_sync::apply_pool_cache_update(&ctx.live_pool_cache, update)
+        let outcome =
+            pool_cache_sync::apply_pool_cache_update_outcome(&ctx.live_pool_cache, update);
+        ironcrab::metrics::record_momentum_pool_cache_apply_outcome(
+            update.dex.as_str(),
+            outcome.metrics_reason_label(),
+        );
+        if outcome.reject_reason_label().is_some()
             && ironcrab::metrics::record_momentum_pool_cache_apply_rejected()
         {
+            let reason = outcome.reject_reason_label().unwrap_or("unknown");
             warn!(
                 pool = %update.pool_address,
                 dex = %update.dex,
                 geyser_slot = update.geyser_slot,
                 update_type = ?update.update_type,
-                "Mom apply_pool_cache_update rejected (stale slot or no-op)"
+                reject_reason = reason,
+                "Mom apply_pool_cache_update rejected"
             );
         }
         ctx.mark_entry_eval_dirty_for_mint(&update.base_mint);
@@ -20920,6 +20956,88 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn pool_state_update_bridge_raises_slave_slot_past_entry_confirm() {
+        let tmp = TempDir::new().expect("tempdir");
+        let jsonl_writer = test_queued_jsonl_writer(tmp.path());
+        let ctx = empty_test_context(jsonl_writer);
+
+        let mint = Pubkey::new_unique().to_string();
+        let pool = Pubkey::new_unique().to_string();
+        let quote_mint = ironcrab::ipc::NATIVE_SOL_MINT.to_string();
+        let entry_slot = 436_803_351u64;
+        let publish_slot = 436_803_366u64;
+        let token_reserves = 1_073_000_000_000_000u64;
+        let sol_reserves = 30_000_000_000u64;
+
+        let mut seed = ironcrab::ipc::PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.clone(),
+            "pumpfun".to_string(),
+            mint.clone(),
+            quote_mint.clone(),
+            token_reserves,
+            sol_reserves,
+            Some(0),
+            entry_slot,
+        );
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("complete".to_string(), "false".to_string());
+        seed.metadata = Some(meta);
+        pool_cache_sync::apply_pool_cache_update(&ctx.live_pool_cache, &seed);
+
+        let mut pos = PositionTracker::new(
+            mint.as_str(),
+            pool.as_str(),
+            "pumpfun",
+            100.0,
+            6,
+            1_000_000,
+            1_000_000_000,
+        );
+        pos.entry_confirmed_slot = entry_slot;
+        ctx.positions.write().insert(mint.clone(), pos);
+
+        let evt = MarketEvent::new(
+            "market-data",
+            "0.1.0",
+            "run",
+            "evt-psu-bridge".to_string(),
+            "geyser_dlmm_cache",
+            Some(publish_slot),
+            MarketEventKind::PoolStateUpdate {
+                pool_address: pool.clone(),
+                dex: "pumpfun".to_string(),
+                reserve_base: token_reserves.saturating_sub(5_000_000),
+                reserve_quote: sol_reserves.saturating_add(1_000_000),
+                base_mint: mint.clone(),
+                quote_mint,
+                update_slot: publish_slot,
+                active_id: None,
+                bin_step: None,
+            },
+        );
+        process_market_event(&ctx, &evt, false)
+            .await
+            .expect("process");
+
+        let pool_pk = Pubkey::from_str(pool.as_str()).unwrap();
+        let (_, cache_slot, _) = ctx
+            .live_pool_cache
+            .get_with_metadata(&pool_pk)
+            .expect("slave cache");
+        assert!(
+            cache_slot >= publish_slot,
+            "PoolStateUpdate bridge must advance SLAVE slot to MD publish_slot S"
+        );
+        assert!(
+            cache_slot > entry_slot,
+            "after bridge, exit guard must not stay on QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM solely due to stale slave slot"
+        );
+    }
+
     #[test]
     #[serial_test::serial]
     fn wait_hot_set_stays_dirty_when_filter_rotates() {
@@ -23373,6 +23491,57 @@ async fn process_market_event(
                     is_periodic = is_periodic,
                     "WalletSnapshotComplete: no ghost positions found"
                 );
+            }
+        }
+
+        MarketEventKind::PoolStateUpdate {
+            pool_address,
+            dex,
+            reserve_base,
+            reserve_quote,
+            base_mint,
+            quote_mint,
+            update_slot,
+            ..
+        } => {
+            // B2: Core bridge — MD publishes reserves+slot on Core for open-position PumpFun pins;
+            // BondingCurveProgress alone has no reserves and does not touch LivePoolCache.
+            if ctx.has_open_pumpfun_position_for_pool(pool_address.as_str()) {
+                let outcome = pool_cache_sync::apply_pool_state_update_to_cache(
+                    &ctx.live_pool_cache,
+                    &pool_cache_sync::PoolStateUpdateBridge {
+                        pool_address: pool_address.as_str(),
+                        dex: dex.as_str(),
+                        reserve_base: *reserve_base,
+                        reserve_quote: *reserve_quote,
+                        base_mint: base_mint.as_str(),
+                        quote_mint: quote_mint.as_str(),
+                        update_slot: *update_slot,
+                    },
+                );
+                ironcrab::metrics::record_momentum_pool_cache_apply_outcome(
+                    dex.as_str(),
+                    outcome.metrics_reason_label(),
+                );
+                if outcome.is_applied() {
+                    trace!(
+                        pool = %pool_address,
+                        dex = %dex,
+                        update_slot = update_slot,
+                        "PoolStateUpdate bridge applied to SLAVE LivePoolCache (open PumpFun position)"
+                    );
+                    ctx.mark_entry_eval_dirty_for_mint(base_mint.as_str());
+                } else if let Some(reason) = outcome.reject_reason_label() {
+                    if ironcrab::metrics::record_momentum_pool_cache_apply_rejected() {
+                        warn!(
+                            pool = %pool_address,
+                            dex = %dex,
+                            update_slot = update_slot,
+                            reject_reason = reason,
+                            "PoolStateUpdate bridge rejected for open PumpFun position"
+                        );
+                    }
+                }
             }
         }
 

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -21019,9 +21019,13 @@ mod tests {
                 bin_step: None,
             },
         );
-        process_market_event(&ctx, &evt, false)
+        let need_exit = process_market_event(&ctx, &evt, false)
             .await
             .expect("process");
+        assert!(
+            need_exit,
+            "applied PoolStateUpdate bridge must return Ok(true) so caller runs process_exit_signals immediately"
+        );
 
         let pool_pk = Pubkey::from_str(pool.as_str()).unwrap();
         let (_, cache_slot, _) = ctx
@@ -23531,6 +23535,7 @@ async fn process_market_event(
                         "PoolStateUpdate bridge applied to SLAVE LivePoolCache (open PumpFun position)"
                     );
                     ctx.mark_entry_eval_dirty_for_mint(base_mint.as_str());
+                    return Ok(true);
                 } else if let Some(reason) = outcome.reject_reason_label() {
                     if ironcrab::metrics::record_momentum_pool_cache_apply_rejected() {
                         warn!(

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -506,6 +506,48 @@ fn apply_decimals_from_metadata(cache: &LivePoolCache, update: &PoolCacheUpdate)
     }
 }
 
+/// Outcome of applying a `PoolCacheUpdate` or Core `PoolStateUpdate` bridge to SLAVE cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PoolCacheApplyOutcome {
+    Applied,
+    /// `dex == "restored"` vault snapshot rows — not a quotable pool cache update.
+    SkippedRestoredDex,
+    /// No-op paths (`PoolRemoved`, etc.) — not a reject.
+    SkippedNoOp,
+    RejectedStaleSlot,
+    RejectedBuildNone,
+    RejectedUnsupportedDex,
+    RejectedInvalidPoolAddress,
+}
+
+impl PoolCacheApplyOutcome {
+    pub fn reject_reason_label(self) -> Option<&'static str> {
+        match self {
+            Self::Applied | Self::SkippedRestoredDex | Self::SkippedNoOp => None,
+            Self::RejectedStaleSlot => Some("stale_slot"),
+            Self::RejectedBuildNone => Some("build_none"),
+            Self::RejectedUnsupportedDex => Some("unsupported_dex"),
+            Self::RejectedInvalidPoolAddress => Some("invalid_pool_address"),
+        }
+    }
+
+    pub fn is_applied(self) -> bool {
+        matches!(self, Self::Applied)
+    }
+
+    pub fn metrics_reason_label(self) -> &'static str {
+        match self {
+            Self::Applied => "applied",
+            Self::SkippedRestoredDex => "skipped_restored_dex",
+            Self::SkippedNoOp => "skipped_noop",
+            Self::RejectedStaleSlot => "stale_slot",
+            Self::RejectedBuildNone => "build_none",
+            Self::RejectedUnsupportedDex => "unsupported_dex",
+            Self::RejectedInvalidPoolAddress => "invalid_pool_address",
+        }
+    }
+}
+
 /// Apply a single PoolCacheUpdate to a LivePoolCache.
 ///
 /// For BalanceUpdated: merges partial updates (one vault at a time) with existing cache state.
@@ -514,6 +556,24 @@ fn apply_decimals_from_metadata(cache: &LivePoolCache, update: &PoolCacheUpdate)
 ///
 /// Returns true if the cache was modified.
 pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) -> bool {
+    apply_pool_cache_update_outcome(cache, update).is_applied()
+}
+
+/// Detailed apply outcome for observability (reason + dex metrics).
+pub fn apply_pool_cache_update_outcome(
+    cache: &LivePoolCache,
+    update: &PoolCacheUpdate,
+) -> PoolCacheApplyOutcome {
+    if update.dex == "restored" {
+        return PoolCacheApplyOutcome::SkippedRestoredDex;
+    }
+    apply_pool_cache_update_outcome_inner(cache, update)
+}
+
+fn apply_pool_cache_update_outcome_inner(
+    cache: &LivePoolCache,
+    update: &PoolCacheUpdate,
+) -> PoolCacheApplyOutcome {
     match update.update_type {
         PoolCacheUpdateType::PoolDiscovered => {
             if let Some((pool_addr, mut minimal_state)) = build_minimal_pool_state(update) {
@@ -597,7 +657,7 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                     if update.geyser_slot > 0 {
                         crate::metrics::inc_pool_cache_apply_rejected_stale_slot_total();
                     }
-                    return false;
+                    return PoolCacheApplyOutcome::RejectedStaleSlot;
                 }
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_sell_layout_from_metadata(
@@ -655,13 +715,14 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 }
                 // P3 #13: Propagate base_decimals and quote_decimals to SLAVE cache
                 apply_decimals_from_metadata(cache, update);
-                return true;
+                return PoolCacheApplyOutcome::Applied;
             }
+            return PoolCacheApplyOutcome::RejectedBuildNone;
         }
         PoolCacheUpdateType::BalanceUpdated => {
             let pool_addr = match Pubkey::from_str(&update.pool_address) {
                 Ok(p) => p,
-                Err(_) => return false,
+                Err(_) => return PoolCacheApplyOutcome::RejectedInvalidPoolAddress,
             };
             let existing = cache.get(&pool_addr);
             let (base_reserve, quote_reserve) = if let Some(ref ex) = existing {
@@ -1083,7 +1144,7 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                     if update.geyser_slot > 0 {
                         crate::metrics::inc_pool_cache_apply_rejected_stale_slot_total();
                     }
-                    return false;
+                    return PoolCacheApplyOutcome::RejectedStaleSlot;
                 }
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_sell_layout_from_metadata(&addr, update.metadata.as_ref());
@@ -1123,14 +1184,56 @@ pub fn apply_pool_cache_update(cache: &LivePoolCache, update: &PoolCacheUpdate) 
                 }
                 // P3 #13: Apply decimals from metadata when present (e.g. BalanceUpdated with metadata)
                 apply_decimals_from_metadata(cache, update);
-                return true;
+                return PoolCacheApplyOutcome::Applied;
             }
+            return PoolCacheApplyOutcome::RejectedBuildNone;
         }
         PoolCacheUpdateType::PoolRemoved => {
             // Skip removed pools
         }
     }
-    false
+    PoolCacheApplyOutcome::SkippedNoOp
+}
+
+/// Fields from Core NATS `MarketEventKind::PoolStateUpdate` for SLAVE cache bridge.
+#[derive(Debug, Clone)]
+pub struct PoolStateUpdateBridge<'a> {
+    pub pool_address: &'a str,
+    pub dex: &'a str,
+    pub reserve_base: u64,
+    pub reserve_quote: u64,
+    pub base_mint: &'a str,
+    pub quote_mint: &'a str,
+    pub update_slot: u64,
+}
+
+/// Bridge Core NATS `PoolStateUpdate` (reserves + `update_slot`) into SLAVE `LivePoolCache`.
+///
+/// JetStream `PoolCacheUpdate` remains SSOT; this path is a low-latency supplement when MD
+/// already published reserves on Core (e.g. open-position PumpFun pin after BondingCurve upsert).
+pub fn apply_pool_state_update_to_cache(
+    cache: &LivePoolCache,
+    bridge: &PoolStateUpdateBridge<'_>,
+) -> PoolCacheApplyOutcome {
+    if bridge.dex == "restored" {
+        return PoolCacheApplyOutcome::SkippedRestoredDex;
+    }
+    if bridge.reserve_base == 0 && bridge.reserve_quote == 0 {
+        return PoolCacheApplyOutcome::SkippedNoOp;
+    }
+    let update = PoolCacheUpdate::new_balance_updated(
+        "market-data",
+        "",
+        "",
+        bridge.pool_address.to_string(),
+        bridge.dex.to_string(),
+        bridge.base_mint.to_string(),
+        bridge.quote_mint.to_string(),
+        bridge.reserve_base,
+        bridge.reserve_quote,
+        bridge.update_slot,
+    );
+    apply_pool_cache_update_outcome(cache, &update)
 }
 
 /// Bootstrap LivePoolCache from JetStream (state recovery after restart)
@@ -3244,5 +3347,77 @@ mod tests {
         );
         let (_, slot, _) = cache.get_with_metadata(&pool).expect("cached");
         assert_eq!(slot, 500);
+    }
+
+    #[test]
+    fn apply_pool_state_update_bridge_advances_pumpfun_slave_slot() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let token_reserves = 1_073_000_000_000_000u64;
+        let sol_reserves = 30_000_000_000u64;
+
+        let mut seed = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "pumpfun".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            token_reserves,
+            sol_reserves,
+            Some(0),
+            436_803_351,
+        );
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("complete".to_string(), "false".to_string());
+        seed.metadata = Some(meta);
+        assert!(apply_pool_cache_update(&cache, &seed));
+
+        let outcome = apply_pool_state_update_to_cache(
+            &cache,
+            &PoolStateUpdateBridge {
+                pool_address: &pool.to_string(),
+                dex: "pumpfun",
+                reserve_base: token_reserves.saturating_sub(1_000_000),
+                reserve_quote: sol_reserves.saturating_add(1_000_000),
+                base_mint: &base_mint.to_string(),
+                quote_mint: &quote_mint.to_string(),
+                update_slot: 436_803_366,
+            },
+        );
+        assert_eq!(outcome, PoolCacheApplyOutcome::Applied);
+        let (_, slot_after, _) = cache.get_with_metadata(&pool).expect("cached");
+        assert!(
+            slot_after >= 436_803_366,
+            "Core PoolStateUpdate bridge must raise SLAVE slot to >= publish_slot S"
+        );
+    }
+
+    #[test]
+    fn apply_skips_restored_dex_without_reject() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let update = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "restored".to_string(),
+            Pubkey::new_unique().to_string(),
+            Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT)
+                .unwrap()
+                .to_string(),
+            1_000,
+            2_000,
+            100,
+        );
+        assert_eq!(
+            apply_pool_cache_update_outcome(&cache, &update),
+            PoolCacheApplyOutcome::SkippedRestoredDex
+        );
+        assert!(cache.get(&pool).is_none());
     }
 }

--- a/src/market_data/sidefx/handlers.rs
+++ b/src/market_data/sidefx/handlers.rs
@@ -1782,6 +1782,9 @@ pub fn md_sidefx_process_vault_balance_tick(
     let Some(vault_view) = host.vault_membership_view(vault_pubkey) else {
         return;
     };
+    if vault_view.dex == "restored" {
+        return;
+    }
     let prev_balance = vault_view
         .last_balance
         .swap(*balance, std::sync::atomic::Ordering::Relaxed);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3331,6 +3331,18 @@ pub fn inc_pool_cache_apply_rejected_stale_slot_total() {
 
 static MOMENTUM_POOL_CACHE_APPLY_REJECTED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
+static MOMENTUM_POOL_CACHE_APPLY_OUTCOME_TOTAL: Lazy<RwLock<HashMap<(String, String), u64>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+
+/// Record Mom pool-cache apply outcome with `reason` + `dex` labels.
+/// `reason`: `applied` | `stale_slot` | `build_none` | `unsupported_dex` | `invalid_pool_address` | `skipped_noop` | `skipped_restored_dex`
+#[inline]
+pub fn record_momentum_pool_cache_apply_outcome(dex: &str, reason: &'static str) {
+    let mut map = MOMENTUM_POOL_CACHE_APPLY_OUTCOME_TOTAL.write();
+    *map.entry((reason.to_string(), dex.to_string()))
+        .or_insert(0) += 1;
+}
+
 /// Increment Mom apply-reject counter; returns true when a rate-limited WARN should be emitted.
 #[inline]
 pub fn record_momentum_pool_cache_apply_rejected() -> bool {
@@ -8690,6 +8702,15 @@ async fn metrics_response() -> Response<Body> {
         "momentum_pool_cache_apply_rejected_total",
         MOMENTUM_POOL_CACHE_APPLY_REJECTED_TOTAL.load(Ordering::Relaxed)
     );
+    for ((reason, dex), count) in MOMENTUM_POOL_CACHE_APPLY_OUTCOME_TOTAL.read().iter() {
+        out.push_str("momentum_pool_cache_apply_outcome_total{reason=\"");
+        out.push_str(reason);
+        out.push_str("\",dex=\"");
+        out.push_str(dex);
+        out.push_str("\"} ");
+        out.push_str(&count.to_string());
+        out.push('\n');
+    }
     line!(
         "market_data_open_position_pumpfun_remediate_admit_fail_total",
         MARKET_DATA_OPEN_POSITION_PUMPFUN_REMEDIATE_ADMIT_FAIL_TOTAL.load(Ordering::Relaxed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Post-#356 soak: MD MASTER publishes correct `geyser_slot` via JetStream `PoolCacheUpdate` and Core `PoolStateUpdate`, but Mom SLAVE `LivePoolCache` stayed behind `entry_confirmed_slot` for open PumpFun exits.

**Root cause (proven):** `PoolStateUpdate` on Core NATS carries reserves + `update_slot` for open-position PumpFun pins (published by `md_sidefx_publish_enrichment_from_cache_upsert`), but `process_market_event` did not handle it — only `BondingCurveProgress` (no reserves, no `LivePoolCache` upsert). JetStream alone could lag when Core NATS stayed hot.

## Fix

### B2 — Core bridge (primary)
- `apply_pool_state_update_to_cache` in `pool_cache_sync.rs` merges Core `PoolStateUpdate` into SLAVE cache with same monotonic slot semantics as JetStream apply
- `momentum_bot`: handle `PoolStateUpdate` for **open PumpFun positions** in `process_market_event`

### B1 — JetStream fairness
- Sort JetStream apply batch so open-position pool updates apply first

### B3 — Hygiene / observability
- `PoolCacheApplyOutcome` with reason labels; metric `momentum_pool_cache_apply_outcome_total{reason,dex}`
- Early skip `dex=restored` at Mom apply + MD vault tick (stops dominant false rejects)

## Tests
- `apply_pool_state_update_bridge_advances_pumpfun_slave_slot` (lib)
- `apply_skips_restored_dex_without_reject` (lib)
- `pool_state_update_bridge_raises_slave_slot_past_entry_confirm` (momentum-bot integration)

## Invariants preserved
- No guard semantic change (`QUOTE_SLOT_NOT_AFTER_ENTRY_CONFIRM` unchanged)
- No hot-path RPC
- JetStream remains SSOT; Core bridge is supplement only

## CI
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71dd1b73-12ef-4ab8-a326-d7f721fd5ef5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71dd1b73-12ef-4ab8-a326-d7f721fd5ef5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

