### PR TITLE
fix: FailedConfirmed kein Phantom-SELL + SELL Proceeds (WSOL)

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,13 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### FIX-FAILEDCONFIRMED-PHANTOM-SELL: FailedConfirmed ≠ Success-Accounting + WSOL Proceeds
+**Datum**: 2026-08-02  
+**Problem**: `FailedConfirmed` SELL (on-chain fail, z.B. Slippage/Curve complete) lief durch denselben Post-Confirm-Block wie `Confirmed`: LockManager `set_available(0)` („confirmed full SELL“), `record_recent_trade` → Phantom −100% SELL in Trades-UI. Separat: Mom Full-SELL Close nutzte `wallet_sol_delta_lamports` statt WSOL `fill_out` → `sell_proceeds=-5000` bei PumpSwap-SELL.  
+**Fix**: (1) EE: LockManager seed/clear + `recent_trade` nur bei `DecisionOutcome::Confirmed`; `FailedConfirmed` → `release_locks` (restore) + Metric `failed_confirmed_no_fill_accounting_total`. (2) Mom: `sell_proceeds_lamports_from_execution` — prefer SOL/WSOL `fill_out`, dann positives wallet_delta, sonst 0+WARN. (3) `trades_server.parse_execution_result`: `status=failed|timeout|sent` → skip.  
+**Evidence**: Prod 2026-08-02 Mint `2q76mnMQ…` — BC-Exit FailedConfirmed + spaeterer PumpSwap-Close mit falscher Realized-PnL.  
+**Dateien**: `src/bin/execution_engine.rs`, `src/bin/momentum_bot.rs`, `scripts/trades_server.py`, `src/metrics.rs`, `docs/BUGS_FIXES.md`
+
 ### FIX-WSOL-ATA-CLOSE-ZERO: Phantom WSOL-ATA-Close → JetStream WSOL=0 + EE-Heal
 **Datum**: 2026-07-31  
 **Problem**: Externes Schliessen der WSOL-ATA (z.B. Phantom „Close Account“ nach Dust-Sell) liess EE Heartbeat/Metrics bei `available_wsol=1e9` haengen. MD publizierte kein `WalletBalanceSnapshot` WSOL=0 wenn (a) Geyser-Daten unparsebar waren (`return` ohne Publish), oder (b) MD `last_wsol_balance` bei 0 blieb waehrend EE den Wrap-Callback schon auf 1e9 gesetzt hatte (`prev==balance` → kein JetStream-Zero).  

--- a/scripts/trades_server.py
+++ b/scripts/trades_server.py
@@ -950,6 +950,11 @@ class TradesHandler(http.server.BaseHTTPRequestHandler):
     def parse_execution_result(self, record: dict) -> dict:
         """Parse execution_results JSONL record into Grafana-compatible trade format"""
         try:
+            # Defense-in-depth: terminal failures are not successful fills for the trades UI.
+            status = str(record.get("status") or "").lower()
+            if status in ("failed", "timeout", "sent"):
+                return None
+
             # Extract data from execution result
             ts_ms = _effective_timestamp_ms_from_record(record)
             run_id = record.get('run_id', '')
@@ -1282,6 +1287,36 @@ def _self_check():
         }
     )
     assert parsed_legacy and parsed_legacy["timestamp_ms"] == 888
+
+    failed_confirmed = h.parse_execution_result(
+        {
+            "status": "failed",
+            "ts_unix_ms": 1_700_000_000_000,
+            "signature": "failed_sig",
+            "metadata": {"side": "SELL"},
+            "fill_in": {"raw": 16455755302, "decimals": 6},
+            "fill_out": {"raw": 0, "decimals": 9},
+            "wallet_sol_delta_lamports": -5000,
+            "token_mint": "2q76mnMQAT5qbqapPx2R3f1dHvzCYUiUo8oGhfB6pump",
+            "intent_id": "int-failed-confirmed",
+        }
+    )
+    assert failed_confirmed is None, "FailedConfirmed-equivalent status must not produce a trade row"
+
+    wsol_proceeds = h.parse_execution_result(
+        {
+            "status": "confirmed",
+            "ts_unix_ms": 1_700_000_000_000,
+            "signature": "wsol_sig",
+            "metadata": {"side": "SELL"},
+            "fill_in": {"raw": 16455755302, "decimals": 6},
+            "fill_out": {"raw": 50_000_000, "decimals": 9},
+            "wallet_sol_delta_lamports": -5000,
+            "token_mint": "2q76mnMQAT5qbqapPx2R3f1dHvzCYUiUo8oGhfB6pump",
+            "intent_id": "int-wsol-sell",
+        }
+    )
+    assert wsol_proceeds and wsol_proceeds.get("value_sol") == 0.05
 
     ts_ms = 1_700_000_000_000
     expected_utc = (

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -81,6 +81,7 @@ use ironcrab::metrics::{
     inc_execution_pool_cache_messages_processed, record_execution_engine_interval_tick_duration_ms,
     record_execution_intent_channel_wait_ms, record_execution_intent_jetstream_to_channel_ms,
     record_execution_process_intent_us, record_execution_slot_lag_at_send_slots,
+    record_failed_confirmed_no_fill_accounting_total,
     record_liquidation_seed_skipped_authority_total, record_recent_trade,
     record_tx_confirmed_slot_delta_slots, record_tx_priority_fee_source, record_tx_rebroadcast,
     record_tx_rebroadcast_during_confirm_ms, record_tx_rebroadcast_method,
@@ -586,6 +587,12 @@ struct Scope48ConfirmedSellCloseDecision {
     full_close: bool,
     sell_token_account_closed: bool,
     sell_untracked_ata: bool,
+}
+
+/// Success fill accounting (LockManager seed/clear, recent_trades) applies only to Confirmed outcomes.
+#[inline]
+fn should_apply_success_fill_accounting(outcome: DecisionOutcome) -> bool {
+    outcome == DecisionOutcome::Confirmed
 }
 
 fn scope48_confirmed_sell_close_decision(
@@ -12922,7 +12929,9 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
         DecisionOutcome::Confirmed | DecisionOutcome::FailedConfirmed
     ) {
         INTENTS_EXECUTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+    }
 
+    if should_apply_success_fill_accounting(decision.outcome) {
         // Primary `open_positions` gauge is refreshed from PositionAuthority (PA-2 Rest).
         // LockManager balance updates below affect lockmanager overlay gauge only.
         match intent.side {
@@ -13103,6 +13112,14 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
             pnl_pct: None,
             latency_ms: None,
         });
+    } else if decision.outcome == DecisionOutcome::FailedConfirmed {
+        record_failed_confirmed_no_fill_accounting_total();
+        info!(
+            intent_id = %intent.intent_id,
+            side = ?intent.side,
+            outcome = ?decision.outcome,
+            "FailedConfirmed: skipping success fill accounting (LockManager seed/clear + recent_trade)"
+        );
     }
 
     IN_FLIGHT_CAPITAL_RESERVATIONS.store(
@@ -14398,10 +14415,11 @@ mod execution_engine_tests {
         pump_amm_liquidation_quote_timeout_str, pump_amm_pool_market_hint_merge,
         pump_amm_slave_recovery_snapshot, record_pump_amm_hot_path_refresh_after_success,
         scale_in_max_open_positions_skip_details, scope48_confirmed_sell_close_decision,
-        sell_token_balance_gate, should_publish_open_position_pool_pin_after_confirmed_buy,
-        sim_failure_reject_reason, simulation_result_on_rpc_timeout,
-        sort_route_candidates_by_amount_out, take_next_multi_pool_buildable_fallback_route,
-        try_pump_amm_hot_path_refresh_publish, wait_for_meteora_dlmm_slave_after_recovery,
+        sell_token_balance_gate, should_apply_success_fill_accounting,
+        should_publish_open_position_pool_pin_after_confirmed_buy, sim_failure_reject_reason,
+        simulation_result_on_rpc_timeout, sort_route_candidates_by_amount_out,
+        take_next_multi_pool_buildable_fallback_route, try_pump_amm_hot_path_refresh_publish,
+        wait_for_meteora_dlmm_slave_after_recovery,
         wait_for_pump_amm_pool_hint_ready_for_tx_plan_builder,
         wait_for_pump_amm_slave_after_recovery, wait_for_pumpfun_bonding_cache_refresh,
         ComputedIntentFills, DiscoveryRequestOutcome, ExecutionConfig, LiquidationSeedDecision,
@@ -16348,6 +16366,23 @@ mod execution_engine_tests {
             !stuck,
             "with before == post-recovery evidence, wait must not succeed (guards Bug #34 ordering)"
         );
+    }
+
+    /// FailedConfirmed must not run success fill accounting (LockManager clear / recent_trade).
+    #[test]
+    fn should_apply_success_fill_accounting_only_for_confirmed() {
+        assert!(should_apply_success_fill_accounting(
+            DecisionOutcome::Confirmed
+        ));
+        assert!(!should_apply_success_fill_accounting(
+            DecisionOutcome::FailedConfirmed
+        ));
+        assert!(!should_apply_success_fill_accounting(
+            DecisionOutcome::Rejected
+        ));
+        assert!(!should_apply_success_fill_accounting(
+            DecisionOutcome::SimFailed
+        ));
     }
 
     /// Production Scope 48 failure: `close_token_ata=true` + complete fills + probe-only sold amount

--- a/src/bin/momentum_bot.rs
+++ b/src/bin/momentum_bot.rs
@@ -1098,6 +1098,31 @@ const SPL_TOKEN_PROGRAM: &str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
 const SPL_TOKEN_2022_PROGRAM: &str = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
 const WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
 
+/// SELL proceeds SSOT (Pattern #11 / FIX-39): prefer SOL/WSOL `fill_out` over native wallet delta.
+fn sell_proceeds_lamports_from_execution(result: &ExecutionResult) -> i128 {
+    if let Some(ref fo) = result.fill_out {
+        if fo.decimals == 9 && fo.raw > 0 {
+            return fo.raw as i128;
+        }
+    }
+    if let Some(delta) = result.wallet_sol_delta_lamports {
+        if delta > 0 {
+            return delta;
+        }
+    }
+    if result.wallet_sol_delta_lamports.is_some()
+        || result.fill_out.as_ref().is_some_and(|fo| fo.raw > 0)
+    {
+        warn!(
+            intent_id = %result.intent_id,
+            wallet_sol_delta_lamports = ?result.wallet_sol_delta_lamports,
+            fill_out_raw = result.fill_out.as_ref().map(|fo| fo.raw),
+            "SELL proceeds unavailable from fill_out or positive wallet_sol_delta; using 0"
+        );
+    }
+    0
+}
+
 /// Controls slot-ordering relaxations in [`exit_quote_price_exit_guard_violation`].
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 enum ExitQuoteGuardOpts {
@@ -8725,9 +8750,9 @@ impl MomentumContext {
                             }
                         } else {
                             // Full sell — close position entirely.
-                            // Calculate realized PnL from wallet SOL delta.
+                            // Calculate realized PnL from SELL proceeds (fill_out preferred over wallet delta).
                             let sell_proceeds_lamports =
-                                result.wallet_sol_delta_lamports.unwrap_or(0);
+                                sell_proceeds_lamports_from_execution(result);
                             let cost_basis_lamports = {
                                 self.positions
                                     .read()
@@ -13401,6 +13426,55 @@ mod tests {
             req.kind,
             ControlRequestKind::EnsurePumpAmmPoolAccounts { .. }
         ));
+    }
+
+    #[test]
+    fn sell_proceeds_lamports_prefers_wsol_fill_out_over_negative_wallet_delta() {
+        use ironcrab::ipc::{ExecutionResult, ExecutionStatus, ExplicitAmount};
+
+        let result = ExecutionResult::new_sent(
+            "test",
+            "0",
+            "run",
+            "exec-1".to_string(),
+            "dec-1".to_string(),
+            "int-1".to_string(),
+            "momentum-bot".to_string(),
+            Some("mint".to_string()),
+            Some("sig".to_string()),
+            None,
+        )
+        .with_fills(
+            Some(ExplicitAmount::new(1_000_000, 6)),
+            Some(ExplicitAmount::new(50_000_000, 9)),
+        )
+        .with_sol_delta(-5_000);
+        let mut result = result;
+        result.status = ExecutionStatus::Confirmed;
+        assert_eq!(sell_proceeds_lamports_from_execution(&result), 50_000_000);
+    }
+
+    #[test]
+    fn sell_proceeds_lamports_zero_when_only_negative_wallet_delta() {
+        use ironcrab::ipc::{ExecutionResult, ExecutionStatus};
+
+        let result = ExecutionResult::new_sent(
+            "test",
+            "0",
+            "run",
+            "exec-2".to_string(),
+            "dec-2".to_string(),
+            "int-2".to_string(),
+            "momentum-bot".to_string(),
+            Some("mint".to_string()),
+            Some("sig".to_string()),
+            None,
+        )
+        .with_sol_delta(-5_000);
+        let mut result = result;
+        result.status = ExecutionStatus::Failed;
+        result.error_message = Some("execution_failed".to_string());
+        assert_eq!(sell_proceeds_lamports_from_execution(&result), 0);
     }
 
     const WSOL_MINT: &str = "So11111111111111111111111111111111111111112";

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3497,6 +3497,11 @@ pub fn record_liquidation_seed_skipped_authority_total() {
     LIQUIDATION_SEED_SKIPPED_AUTHORITY_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+#[inline]
+pub fn record_failed_confirmed_no_fill_accounting_total() {
+    FAILED_CONFIRMED_NO_FILL_ACCOUNTING_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
 /// Per-mint signed divergence: `position.token_amount_raw - wallet_snapshot.balance_raw`.
 /// Cardinality bounded to open positions with non-zero drift (pruned on close / align).
 pub static MOMENTUM_WALLET_BALANCE_DIVERGENCE_BY_MINT: Lazy<RwLock<HashMap<String, i64>>> =
@@ -6615,6 +6620,9 @@ pub static POSITION_MANAGER_KV_PUBLISH_ERRORS_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 /// PA-4: liquidation skipped LockManager seed because PositionAuthority reports closed/zero.
 pub static LIQUIDATION_SEED_SKIPPED_AUTHORITY_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// FailedConfirmed on-chain outcome: skipped LockManager success accounting + recent_trade fill row.
+pub static FAILED_CONFIRMED_NO_FILL_ACCOUNTING_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static CONCURRENT_INTENTS_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// Pending TradeIntents in `intent_rx` between JetStream enqueue and dispatcher recv.
@@ -10489,6 +10497,10 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "liquidation_seed_skipped_authority_total",
         LIQUIDATION_SEED_SKIPPED_AUTHORITY_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "failed_confirmed_no_fill_accounting_total",
+        FAILED_CONFIRMED_NO_FILL_ACCOUNTING_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "position_manager_up",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Prod-Evidenz (2026-08-02, Mint `2q76mnMQ…`):

1. BC-Exit `FailedConfirmed` → EE loggte „LockManager: cleared token balance after confirmed full SELL“, dann `outcome=FailedConfirmed`. Trades-UI zeigte Phantom-SELL (−100%, Preis 0).
2. Spaeterer echter PumpSwap-Close: `sell_proceeds_lamports=-5000` weil Mom `wallet_sol_delta` statt WSOL `fill_out` nutzte.

## Root Cause

- EE Post-Confirm-Block behandelte `Confirmed` und `FailedConfirmed` gleich: LockManager Success-Clear + `record_recent_trade`.
- Mom Full-SELL Close: `sell_proceeds = wallet_sol_delta_lamports` (Pattern #11 / FIX-39 Verstoss bei WSOL-ATA Output).

## Fix

### A) execution-engine
- `should_apply_success_fill_accounting`: LockManager seed/clear + `recent_trade` **nur** bei `Confirmed`.
- `FailedConfirmed`: `release_locks` (restore) bleibt; Metric `failed_confirmed_no_fill_accounting_total` + INFO-Log.
- `INTENTS_EXECUTED_TOTAL` weiter fuer beide Outcomes (Dashboard on-chain).

### B) momentum-bot
- `sell_proceeds_lamports_from_execution`: prefer SOL/WSOL `fill_out` (decimals 9, raw>0) → positives wallet_delta → 0+WARN.

### C) trades_server
- `parse_execution_result`: skip `status=failed|timeout|sent` (Defense-in-depth).
- Self-check Fixtures fuer FailedConfirmed + WSOL proceeds.

## Tests
- `should_apply_success_fill_accounting_only_for_confirmed`
- `sell_proceeds_lamports_prefers_wsol_fill_out_over_negative_wallet_delta`
- `sell_proceeds_lamports_zero_when_only_negative_wallet_delta`
- `trades_server --self-check`

## CI
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` lokal gruen.

## Invarianten
- I-10/I-11/I-12: FailedConfirmed bleibt eigenes Outcome; kein Fill-Accounting.
- I-15/I-20: Proceeds aus fill_out; keine Ghost-Balance bei FailedConfirmed.
- Kein Hot-Path RPC.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b18e3b9-e18c-4cf3-9dff-879ef45feeb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b18e3b9-e18c-4cf3-9dff-879ef45feeb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

