### PR TITLE
fix(arb): C1c deferred vault registration for arb pins

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,13 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### FIX-ARB-C1c: Arb Pin Vault Completeness — Deferred Retry Queue
+**Datum**: 2026-08-03  
+**Problem**: Arb screent aktiv, aber `sell_missing_vault` ~15k Rejects und `arb_registered_vaults_total=0`. `apply_arb_active_entries` inkrementierte nur deferred-Metriken/WARN bei Register-Miss, ohne `note_deferred_hot_pool_reserve_registration` — Retry-Queue blieb leer. Admit-Suppress (`market_data_exec_hot_arb_admit_suppress`) skippte warmable und must-hot still ohne Completeness-Pfad.  
+**Fix**: (1) Arb apply notiert deferred bei Cache-Miss, Register-No-Op, Admit-Reject und Admit-Suppress (warmable); must-hot bypassed Suppress und versucht Register. (2) `retry_deferred_hot_pool_reserve_registrations` metrisiert Arb still-unsatisfied/cleared. (3) Unpin cleart deferred. (4) Metriken: `market_data_arb_tracked_vaults` Gauge, `arb_pin_deferred_cleared_total`, deferred still-unsatisfied by reason, `admit_suppress` deferred counter. **Invarianten**: I-4/I-7 — kein RPC im Apply/Retry.  
+**Evidence**: `findings_arb_zero_opp_20260803.md`, Prod Tip `30978a0`.  
+**Dateien**: `src/bin/market_data.rs`, `src/metrics.rs`, `docs/BUGS_FIXES.md`
+
 ### FIX-FAILEDCONFIRMED-PHANTOM-SELL: FailedConfirmed ≠ Success-Accounting + WSOL Proceeds
 **Datum**: 2026-08-02  
 **Problem**: `FailedConfirmed` SELL (on-chain fail, z.B. Slippage/Curve complete) lief durch denselben Post-Confirm-Block wie `Confirmed`: LockManager `set_available(0)` („confirmed full SELL“), `record_recent_trade` → Phantom −100% SELL in Trades-UI. Separat: Mom Full-SELL Close nutzte `wallet_sol_delta_lamports` statt WSOL `fill_out` → `sell_proceeds=-5000` bei PumpSwap-SELL.  

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -107,8 +107,10 @@ use ironcrab::metrics::{
     inc_market_data_account_low_priority_queue_depth,
     inc_market_data_account_recv_iterations_total, inc_market_data_account_updates_total,
     inc_market_data_account_worker_queue_depth, inc_market_data_arb_admission_admitted_total,
-    inc_market_data_arb_admission_rejected_total,
+    inc_market_data_arb_admission_rejected_total, inc_market_data_arb_pin_deferred_cleared_total,
+    inc_market_data_arb_pin_deferred_still_unsatisfied_total,
     inc_market_data_arb_pin_geyser_register_deferred_total,
+    inc_market_data_arb_pin_vault_register_ok_total,
     inc_market_data_balance_updated_from_cache_total,
     inc_market_data_exec_hot_hard_shed_steps_for_tier_reason,
     inc_market_data_exec_hot_pressure_admit_rejected_total,
@@ -153,10 +155,11 @@ use ironcrab::metrics::{
     serve_metrics, set_market_data_account_broadcast_queue_depth_for_class,
     set_market_data_account_enrich_worker_count, set_market_data_account_exec_hot_worker_count,
     set_market_data_account_worker_count, set_market_data_arb_pin_registration_incomplete_gauge,
-    set_market_data_arb_pinned_pools_gauge, set_market_data_enrichment_registry_pools_gauge,
-    set_market_data_exec_hot_admit_suppress, set_market_data_exec_hot_lag_alarm,
-    set_market_data_exec_hot_last_shed_groups, set_market_data_exec_hot_shed_soft_active,
-    set_market_data_exec_hot_shed_tier, set_market_data_explicit_set_snapshot_restore_duration_ms,
+    set_market_data_arb_pinned_pools_gauge, set_market_data_arb_tracked_vaults_gauge,
+    set_market_data_enrichment_registry_pools_gauge, set_market_data_exec_hot_admit_suppress,
+    set_market_data_exec_hot_lag_alarm, set_market_data_exec_hot_last_shed_groups,
+    set_market_data_exec_hot_shed_soft_active, set_market_data_exec_hot_shed_tier,
+    set_market_data_explicit_set_snapshot_restore_duration_ms,
     set_market_data_explicit_set_snapshot_restore_pubkeys,
     set_market_data_geyser_explicit_admitted_accounts,
     set_market_data_geyser_explicit_cap_overflow, set_market_data_geyser_explicit_set_size,
@@ -1470,10 +1473,11 @@ mod fixed_category_log_throttle {
 enum ArbPinDeferredLogCategory {
     LivePoolCacheMiss = 0,
     VaultRegisterNoChange = 1,
+    AdmitSuppress = 2,
 }
 
 static ARB_PIN_DEFERRED_LOG_THROTTLE: std::sync::LazyLock<
-    parking_lot::Mutex<fixed_category_log_throttle::FixedCategoryLogThrottle<2>>,
+    parking_lot::Mutex<fixed_category_log_throttle::FixedCategoryLogThrottle<3>>,
 > = std::sync::LazyLock::new(|| {
     parking_lot::Mutex::new(fixed_category_log_throttle::FixedCategoryLogThrottle::new(
         Duration::from_secs(HOT_PATH_LOG_THROTTLE_SECS),
@@ -5059,6 +5063,53 @@ impl MarketDataContext {
         set_market_data_arb_pin_registration_incomplete_gauge(incomplete);
     }
 
+    /// C1c: gauge vault rows pinned for arb multi-dex tracking.
+    fn refresh_arb_tracked_vaults_gauge(&self) {
+        let count = self
+            .tracked_vaults
+            .read()
+            .values()
+            .filter(|v| v.pin == Some(GeyserPinReason::ArbMultiDex))
+            .count();
+        set_market_data_arb_tracked_vaults_gauge(count);
+    }
+
+    fn log_arb_pin_deferred_throttled(&self, pool: Pubkey, reason: &'static str) {
+        let category = match reason {
+            "live_pool_cache_miss" => ArbPinDeferredLogCategory::LivePoolCacheMiss,
+            "vault_register_no_change" => ArbPinDeferredLogCategory::VaultRegisterNoChange,
+            "admit_suppress" => ArbPinDeferredLogCategory::AdmitSuppress,
+            _ => return,
+        };
+        inc_market_data_arb_pin_geyser_register_deferred_total(reason);
+        let now = Instant::now();
+        if ARB_PIN_DEFERRED_LOG_THROTTLE
+            .lock()
+            .should_emit(category as usize, now)
+        {
+            warn!(
+                run_id = %self.run_id,
+                pool = %pool,
+                pin = "ArbMultiDex",
+                reason = reason,
+                "Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)"
+            );
+        }
+    }
+
+    fn clear_arb_pin_deferred_with_metric(&self, pool: Pubkey) {
+        if self
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(&pool)
+        {
+            self.clear_deferred_hot_pool_reserve_registration(pool);
+            inc_market_data_arb_pin_deferred_cleared_total();
+        } else {
+            self.clear_deferred_hot_pool_reserve_registration(pool);
+        }
+    }
+
     fn note_deferred_hot_pool_reserve_registration(&self, pool: Pubkey, pin: GeyserPinReason) {
         if !self.hot_pool_registry.is_hot_pool(pool) {
             return;
@@ -5084,12 +5135,33 @@ impl MarketDataContext {
         if !self.hot_pool_reserve_registration_satisfied(pool) {
             return false;
         }
-        self.clear_deferred_hot_pool_reserve_registration(pool);
+        self.clear_arb_pin_deferred_with_metric(pool);
         if self.hot_pool_registry.is_position_pin_for_pool(pool) {
             inc_market_data_open_position_pin_applied_total();
         }
         self.publish_momentum_hot_balance_refresh_from_cache(pool);
         true
+    }
+
+    fn record_arb_active_pool_reserve_registration_outcome(&self, pool: Pubkey, registered: bool) {
+        if registered {
+            inc_market_data_arb_pin_vault_register_ok_total();
+            self.clear_arb_pin_deferred_with_metric(pool);
+            self.refresh_arb_tracked_vaults_gauge();
+            return;
+        }
+        if self.live_pool_cache.get(&pool).is_none() {
+            self.note_deferred_hot_pool_reserve_registration(pool, GeyserPinReason::ArbMultiDex);
+            self.log_arb_pin_deferred_throttled(pool, "live_pool_cache_miss");
+            return;
+        }
+        if self.hot_pool_reserve_registration_satisfied(pool) {
+            self.clear_arb_pin_deferred_with_metric(pool);
+            self.refresh_arb_tracked_vaults_gauge();
+            return;
+        }
+        self.note_deferred_hot_pool_reserve_registration(pool, GeyserPinReason::ArbMultiDex);
+        self.log_arb_pin_deferred_throttled(pool, "vault_register_no_change");
     }
 
     /// Bounded retry when LivePoolCache gains layout for a pinned hot pool (no RPC).
@@ -5113,6 +5185,11 @@ impl MarketDataContext {
                 continue;
             }
             if self.live_pool_cache.get(&pool).is_none() {
+                if pin == GeyserPinReason::ArbMultiDex {
+                    inc_market_data_arb_pin_deferred_still_unsatisfied_total(
+                        "live_pool_cache_miss",
+                    );
+                }
                 continue;
             }
             let consumer = match pin {
@@ -5122,12 +5199,20 @@ impl MarketDataContext {
                 }
             };
             if !self.try_admit_pool_consumer_group(admission, pool, consumer) {
+                if pin == GeyserPinReason::ArbMultiDex {
+                    inc_market_data_arb_pin_deferred_still_unsatisfied_total("admit_fail");
+                }
                 continue;
             }
             let changed = self.register_geyser_reserves_for_active_pool(pool, pin);
             let reserves_satisfied = changed || self.hot_pool_reserve_registration_satisfied(pool);
             if reserves_satisfied {
-                self.clear_deferred_hot_pool_reserve_registration(pool);
+                if pin == GeyserPinReason::ArbMultiDex {
+                    self.clear_arb_pin_deferred_with_metric(pool);
+                    self.refresh_arb_tracked_vaults_gauge();
+                } else {
+                    self.clear_deferred_hot_pool_reserve_registration(pool);
+                }
                 if self.hot_pool_registry.is_position_pin_for_pool(pool) {
                     inc_market_data_open_position_pin_applied_total();
                 }
@@ -5135,6 +5220,10 @@ impl MarketDataContext {
                 if changed {
                     batch_dirty = true;
                 }
+            } else if pin == GeyserPinReason::ArbMultiDex {
+                inc_market_data_arb_pin_deferred_still_unsatisfied_total(
+                    "vault_register_no_change",
+                );
             }
             self.sync_explicit_pool_admitted_from_admission(admission, pool, consumer);
         }
@@ -5649,6 +5738,7 @@ impl MarketDataContext {
         }
         set_market_data_arb_pinned_pools_gauge(self.hot_pool_registry.arb_pool_count());
         self.refresh_arb_pin_registration_incomplete_gauge();
+        self.refresh_arb_tracked_vaults_gauge();
         batch_dirty
     }
 
@@ -5714,9 +5804,15 @@ impl MarketDataContext {
             self.hot_pool_registry.pin_arb_pool(pool_pk);
             self.hot_pool_registry
                 .set_arb_pool_readiness(pool_pk, a.readiness);
-            if market_data_exec_hot_arb_admit_suppress() {
+            let is_must_hot = a.readiness.is_must_hot();
+            if market_data_exec_hot_arb_admit_suppress() && !is_must_hot {
                 inc_market_data_exec_hot_pressure_admit_rejected_total(ExecHotShedTier::Arb);
                 inc_market_data_arb_admission_rejected_total();
+                self.note_deferred_hot_pool_reserve_registration(
+                    pool_pk,
+                    GeyserPinReason::ArbMultiDex,
+                );
+                self.log_arb_pin_deferred_throttled(pool_pk, "admit_suppress");
                 self.sync_explicit_pool_admitted_from_admission(
                     admission,
                     pool_pk,
@@ -5727,52 +5823,14 @@ impl MarketDataContext {
             }
             if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Arb) {
                 inc_market_data_arb_admission_admitted_total();
-                if self.register_geyser_reserves_for_arb_active_pool(pool_pk) {
+                let registered = self.register_geyser_reserves_for_arb_active_pool(pool_pk);
+                self.record_arb_active_pool_reserve_registration_outcome(pool_pk, registered);
+                if registered {
                     batch_dirty = true;
-                } else {
-                    let category = if self.live_pool_cache.get(&pool_pk).is_none() {
-                        ArbPinDeferredLogCategory::LivePoolCacheMiss
-                    } else {
-                        ArbPinDeferredLogCategory::VaultRegisterNoChange
-                    };
-                    let reason: &'static str = match category {
-                        ArbPinDeferredLogCategory::LivePoolCacheMiss => "live_pool_cache_miss",
-                        ArbPinDeferredLogCategory::VaultRegisterNoChange => {
-                            "vault_register_no_change"
-                        }
-                    };
-                    inc_market_data_arb_pin_geyser_register_deferred_total(reason);
-                    let now = Instant::now();
-                    if ARB_PIN_DEFERRED_LOG_THROTTLE
-                        .lock()
-                        .should_emit(category as usize, now)
-                    {
-                        warn!(
-                            run_id = %self.run_id,
-                            pool = %pool_pk,
-                            pin = "ArbMultiDex",
-                            reason = reason,
-                            "Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)"
-                        );
-                    }
-                }
-            } else if self.live_pool_cache.get(&pool_pk).is_none() {
-                inc_market_data_arb_pin_geyser_register_deferred_total("live_pool_cache_miss");
-                let now = Instant::now();
-                if ARB_PIN_DEFERRED_LOG_THROTTLE
-                    .lock()
-                    .should_emit(ArbPinDeferredLogCategory::LivePoolCacheMiss as usize, now)
-                {
-                    warn!(
-                        run_id = %self.run_id,
-                        pool = %pool_pk,
-                        pin = "ArbMultiDex",
-                        reason = "live_pool_cache_miss",
-                        "Arb pin: Geyser reserve registration deferred (geyser-only, no RPC)"
-                    );
                 }
             } else {
                 inc_market_data_arb_admission_rejected_total();
+                self.record_arb_active_pool_reserve_registration_outcome(pool_pk, false);
             }
             self.sync_explicit_pool_admitted_from_admission(
                 admission,
@@ -5781,6 +5839,7 @@ impl MarketDataContext {
             );
             let _ = &a.reason;
         }
+        self.refresh_arb_tracked_vaults_gauge();
         batch_dirty
     }
 
@@ -5806,6 +5865,7 @@ impl MarketDataContext {
         admission: &mut FixedCapAdmission,
         pool: Pubkey,
     ) -> bool {
+        self.clear_deferred_hot_pool_reserve_registration(pool);
         self.release_pool_consumer_group(admission, pool, ExplicitConsumer::Arb);
         self.hot_pool_registry.unpin_arb_pool(pool);
         let mut changed = false;
@@ -5855,6 +5915,7 @@ impl MarketDataContext {
                 }
             }
         }
+        self.refresh_arb_tracked_vaults_gauge();
         changed
     }
 
@@ -20350,8 +20411,8 @@ mod pr_b_geyser_tracking_tests {
     fn apply_arb_active_entries_throttle_has_no_dynamic_string_keys() {
         let bin_src = include_str!("market_data.rs");
         let anchor = bin_src
-            .find("ArbPinDeferredLogCategory::LivePoolCacheMiss")
-            .expect("apply_arb_active_entries deferred category");
+            .find("let is_must_hot = a.readiness.is_must_hot()")
+            .expect("apply_arb_active_entries must_hot gate");
         let start = bin_src[..anchor]
             .rfind("fn apply_arb_active_entries(")
             .expect("apply_arb_active_entries");
@@ -20361,7 +20422,7 @@ mod pr_b_geyser_tracking_tests {
         let fn_body = &bin_src[start..anchor + end];
         assert!(
             !fn_body.contains("format!("),
-            "throttle decision must not allocate dynamic string keys"
+            "apply_arb_active_entries throttle decision must not allocate dynamic string keys"
         );
     }
 
@@ -20807,5 +20868,181 @@ mod pr_b_geyser_tracking_tests {
             Some(GeyserPinReason::Wallet)
         );
         assert!(vs.get(&pc_vault).is_some_and(|v| v.pinned));
+    }
+
+    /// Scope C1c: arb pin cache miss → deferred queue; retry after cache fill registers vaults.
+    #[test]
+    fn scope_c1c_arb_pin_cache_miss_retries_when_cache_filled() {
+        use ironcrab::metrics::{
+            MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_TOTAL, MARKET_DATA_ARB_TRACKED_VAULTS_GAUGE,
+        };
+        use ironcrab::nats::{
+            ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackReadiness, ArbTrackRequestsUpdate,
+        };
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+
+        let mut admission = test_admission_for(&ctx);
+        ctx.apply_arb_track_requests_update(
+            &mut admission,
+            &ArbTrackRequestsUpdate {
+                version: 1,
+                ts_unix_ms: 1,
+                active: vec![ArbTrackActiveEntry {
+                    pool: pool.to_string(),
+                    reason: ArbTrackActiveReason::MultiDex,
+                    readiness: ArbTrackReadiness::QuoteReady,
+                }],
+                removed: vec![],
+                reconcile: false,
+            },
+        );
+
+        assert!(ctx.hot_pool_registry.is_hot_pool(pool));
+        assert!(ctx
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(&pool));
+        assert!(ctx.tracked_vaults.read().is_empty());
+        assert_eq!(
+            MARKET_DATA_ARB_TRACKED_VAULTS_GAUGE.load(Ordering::Relaxed),
+            0
+        );
+
+        let cleared_before = MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_TOTAL.load(Ordering::Relaxed);
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            2,
+        );
+        assert!(ctx.retry_deferred_hot_pool_reserve_registrations(&mut admission));
+        assert!(!ctx
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(&pool));
+        assert!(
+            MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_TOTAL.load(Ordering::Relaxed) > cleared_before
+        );
+        let vs = ctx.tracked_vaults.read();
+        assert_eq!(
+            vs.get(&coin_vault).and_then(|v| v.pin),
+            Some(GeyserPinReason::ArbMultiDex)
+        );
+        assert_eq!(
+            MARKET_DATA_ARB_TRACKED_VAULTS_GAUGE.load(Ordering::Relaxed),
+            2
+        );
+    }
+
+    /// Scope C1c: warmable arb pin under admit suppress must note deferred (not silent skip).
+    #[test]
+    fn scope_c1c_arb_admit_suppress_warmable_notes_deferred() {
+        use ironcrab::metrics::{
+            set_market_data_exec_hot_admit_suppress,
+            MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_ADMIT_SUPPRESS,
+        };
+        use ironcrab::nats::{
+            ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackReadiness, ArbTrackRequestsUpdate,
+        };
+
+        set_market_data_exec_hot_admit_suppress(false, false, true);
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let suppress_before =
+            MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_ADMIT_SUPPRESS.load(Ordering::Relaxed);
+        let mut admission = test_admission_for(&ctx);
+        ctx.apply_arb_track_requests_update(
+            &mut admission,
+            &ArbTrackRequestsUpdate {
+                version: 1,
+                ts_unix_ms: 1,
+                active: vec![ArbTrackActiveEntry {
+                    pool: pool.to_string(),
+                    reason: ArbTrackActiveReason::TradeSignal,
+                    readiness: ArbTrackReadiness::Warmable,
+                }],
+                removed: vec![],
+                reconcile: false,
+            },
+        );
+        set_market_data_exec_hot_admit_suppress(false, false, false);
+
+        assert!(ctx
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(&pool));
+        assert!(
+            MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_ADMIT_SUPPRESS.load(Ordering::Relaxed)
+                > suppress_before
+        );
+    }
+
+    /// Scope C1c: must-hot arb pin bypasses admit suppress and still defers on cache miss.
+    #[test]
+    fn scope_c1c_arb_admit_suppress_must_hot_still_defers_on_cache_miss() {
+        use ironcrab::metrics::{
+            set_market_data_exec_hot_admit_suppress,
+            MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_LIVE_POOL_CACHE_MISS,
+        };
+        use ironcrab::nats::{
+            ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackReadiness, ArbTrackRequestsUpdate,
+        };
+
+        set_market_data_exec_hot_admit_suppress(false, false, true);
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let cache_miss_before = MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_LIVE_POOL_CACHE_MISS
+            .load(Ordering::Relaxed);
+        let mut admission = test_admission_for(&ctx);
+        ctx.apply_arb_track_requests_update(
+            &mut admission,
+            &ArbTrackRequestsUpdate {
+                version: 1,
+                ts_unix_ms: 1,
+                active: vec![ArbTrackActiveEntry {
+                    pool: pool.to_string(),
+                    reason: ArbTrackActiveReason::MultiDex,
+                    readiness: ArbTrackReadiness::Executable,
+                }],
+                removed: vec![],
+                reconcile: false,
+            },
+        );
+        set_market_data_exec_hot_admit_suppress(false, false, false);
+
+        assert!(ctx
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(&pool));
+        assert!(
+            MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_LIVE_POOL_CACHE_MISS
+                .load(Ordering::Relaxed)
+                > cache_miss_before,
+            "must-hot must attempt register and defer on cache miss, not admit_suppress skip"
+        );
     }
 }

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -5098,15 +5098,10 @@ impl MarketDataContext {
     }
 
     fn clear_arb_pin_deferred_with_metric(&self, pool: Pubkey) {
-        if self
-            .deferred_hot_pool_reserve_pins
-            .read()
-            .contains_key(&pool)
-        {
-            self.clear_deferred_hot_pool_reserve_registration(pool);
-            inc_market_data_arb_pin_deferred_cleared_total();
-        } else {
-            self.clear_deferred_hot_pool_reserve_registration(pool);
+        if let Some(pin) = self.deferred_hot_pool_reserve_pins.write().remove(&pool) {
+            if pin == GeyserPinReason::ArbMultiDex {
+                inc_market_data_arb_pin_deferred_cleared_total();
+            }
         }
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -303,8 +303,10 @@ pub static MARKET_DATA_ARB_TRACK_COALESCED_MESSAGES_TOTAL: Lazy<AtomicU64> =
 /// Merged `ApplyArbTrackRequests` batches enqueued to md-track-worker (Phase 3).
 pub static MARKET_DATA_ARB_TRACK_COALESCED_BATCHES_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
-/// Vaults registered via arb multi-dex admission (no momentum pin).
-pub static MARKET_DATA_ARB_REGISTERED_VAULTS_TOTAL: Lazy<AtomicU64> =
+/// Vault rows currently tracked with `GeyserPinReason::ArbMultiDex` (gauge, not cumulative).
+pub static MARKET_DATA_ARB_TRACKED_VAULTS_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// Successful arb pin vault/bin Geyser registrations (one increment per register call that changed tracking).
+pub static MARKET_DATA_ARB_PIN_VAULT_REGISTER_OK_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 /// Account worker dispatch: tracked vault pubkey classified HIGH.
 pub static MARKET_DATA_VAULT_HIGH_PRIORITY_DISPATCH_TOTAL: Lazy<AtomicU64> =
@@ -365,6 +367,21 @@ pub static MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_LIVE_POOL_CACHE_MISS: La
     Lazy::new(|| AtomicU64::new(0));
 /// Arb pin: Geyser reserve registration deferred because vault/bin register was a no-op.
 pub static MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_VAULT_NO_CHANGE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Arb pin: deferred because EXEC_HOT arb admit suppress rejected warmable pin.
+pub static MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_ADMIT_SUPPRESS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Arb pin: deferred queue entry cleared after successful reserve registration.
+pub static MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Arb pin: retry tick still unsatisfied — LivePoolCache miss persists.
+pub static MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_LIVE_POOL_CACHE_MISS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Arb pin: retry tick still unsatisfied — explicit admit rejected.
+pub static MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_ADMIT_FAIL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Arb pin: retry tick still unsatisfied — vault/bin register no-op.
+pub static MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_VAULT_NO_CHANGE: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
 /// Geyser explicit-tracked subscription list syncs coalesced from the TX trade path (debounced flush).
@@ -595,8 +612,37 @@ pub fn inc_market_data_arb_track_worker_enqueue_dropped_total() {
 }
 
 #[inline]
-pub fn inc_market_data_arb_registered_vaults_total() {
-    MARKET_DATA_ARB_REGISTERED_VAULTS_TOTAL.fetch_add(1, Ordering::Relaxed);
+pub fn set_market_data_arb_tracked_vaults_gauge(n: usize) {
+    MARKET_DATA_ARB_TRACKED_VAULTS_GAUGE.store(n as u64, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_arb_pin_vault_register_ok_total() {
+    MARKET_DATA_ARB_PIN_VAULT_REGISTER_OK_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_arb_pin_deferred_cleared_total() {
+    MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_arb_pin_deferred_still_unsatisfied_total(reason: &str) {
+    match reason {
+        "live_pool_cache_miss" => {
+            MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_LIVE_POOL_CACHE_MISS
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        "admit_fail" => {
+            MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_ADMIT_FAIL
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        "vault_register_no_change" => {
+            MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_VAULT_NO_CHANGE
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        _ => {}
+    }
 }
 
 #[inline]
@@ -720,6 +766,10 @@ pub fn inc_market_data_arb_pin_geyser_register_deferred_total(reason: &str) {
         }
         "vault_register_no_change" => {
             MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_VAULT_NO_CHANGE
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        "admit_suppress" => {
+            MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_ADMIT_SUPPRESS
                 .fetch_add(1, Ordering::Relaxed);
         }
         _ => {}
@@ -7800,8 +7850,16 @@ async fn metrics_response() -> Response<Body> {
         MARKET_DATA_ARB_TRACK_COALESCED_BATCHES_TOTAL.load(Ordering::Relaxed)
     );
     line!(
-        "market_data_arb_registered_vaults_total",
-        MARKET_DATA_ARB_REGISTERED_VAULTS_TOTAL.load(Ordering::Relaxed)
+        "market_data_arb_tracked_vaults",
+        MARKET_DATA_ARB_TRACKED_VAULTS_GAUGE.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_arb_pin_vault_register_ok_total",
+        MARKET_DATA_ARB_PIN_VAULT_REGISTER_OK_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_arb_pin_deferred_cleared_total",
+        MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_vault_high_priority_dispatch_total",
@@ -7858,6 +7916,38 @@ async fn metrics_response() -> Response<Body> {
     );
     out.push_str(
         &MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_VAULT_NO_CHANGE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("market_data_arb_pin_geyser_register_deferred_total{reason=\"admit_suppress\"} ");
+    out.push_str(
+        &MARKET_DATA_ARB_PIN_GEYSER_REGISTER_DEFERRED_ADMIT_SUPPRESS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str(
+        "market_data_arb_pin_deferred_still_unsatisfied_total{reason=\"live_pool_cache_miss\"} ",
+    );
+    out.push_str(
+        &MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_LIVE_POOL_CACHE_MISS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("market_data_arb_pin_deferred_still_unsatisfied_total{reason=\"admit_fail\"} ");
+    out.push_str(
+        &MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_ADMIT_FAIL
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str(
+        "market_data_arb_pin_deferred_still_unsatisfied_total{reason=\"vault_register_no_change\"} ",
+    );
+    out.push_str(
+        &MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_VAULT_NO_CHANGE
             .load(Ordering::Relaxed)
             .to_string(),
     );


### PR DESCRIPTION
## Summary
- Arb pin apply notes deferred hot-pool reserve registration on cache miss / register fail / admit reject / warmable admit-suppress
- Must-hot pins bypass admit-suppress and still get register + deferred retry
- Gauge for arb-tracked vaults + deferred cleared/still-unsatisfied metrics
- Unit tests for cache-miss retry and admit-suppress behavior

## Context
Supervisor Handoff C1c — Prod Opp=0 dominated by sell_missing_vault; deferred miss counter rose but queue was never filled.

## Test plan
- [ ] cargo fmt / clippy / test
- [ ] Eval L5
- [ ] After deploy: sell_missing_vault rate and arb vault gauge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes exec-hot arb admission and Geyser vault pin completeness on the market-data hot path; bounded retry only (no new RPC), but incorrect defer/clear logic could still leave arb without vault coverage or overload retries.
> 
> **Overview**
> Fixes **arb multi-dex pin completeness** when pools are pinned but Geyser vault rows never get registered—previously deferred counters rose while the **retry queue stayed empty** (`sell_missing_vault` / zero tracked vaults in prod).
> 
> **`apply_arb_active_entries`** now routes all failure paths through **`record_arb_active_pool_reserve_registration_outcome`**, which **enqueues deferred hot-pool reserve registration** on live-pool cache miss, register no-op, admit reject, and **warmable** exec-hot admit-suppress (with throttled WARN). **Must-hot** readiness **bypasses** admit-suppress and still attempts register + deferred retry on cache miss.
> 
> **`retry_deferred_hot_pool_reserve_registrations`** counts arb entries still unsatisfied (cache miss, admit fail, vault no-change) and clears deferred on success; **unpin** clears deferred. Metrics: **`market_data_arb_tracked_vaults`** gauge (replaces cumulative-only registered counter), deferred cleared / still-unsatisfied by reason, admit-suppress deferred, register-ok counter. **No RPC** on apply/retry (I-4/I-7). Unit tests cover cache-miss retry, warmable suppress → deferred, and must-hot under suppress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0b883bb2c908b9cb48f5b32b898e478d6a20f2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->