### PR TITLE
fix(arb): C1e DLMM BinArray publish path — stash + replay after membership

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,13 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### FIX-ARB-C1e: DLMM BinArray Publish Path — Stash + Replay nach Membership
+**Datum**: 2026-08-03  
+**Problem**: Post-C1d: `tracked_bin_arrays` und `dlmm_bin_register_ok_total` OK, aber `market_data_bin_array_publish_total=0`. METEORA-DLMM-Bin-PDAs liefen bereits über Program-Owner-Filter; vor Membership-Registrierung `EarlyDrop DexPoolNotEnrichment`. Nach Register keine erneute Geyser-Zustellung bei unveränderten Accounts → Handler/Publish nie.  
+**Fix**: (1) Forensik-Counter: owner/membership hit/miss, parse fail, empty skip, stash, replay, exec_hot/enrich publish. (2) Stash bin-array-förmiger Early-Drops (`maybe_stash_dlmm_bin_array_before_early_drop`). (3) Replay nach `register_meteora_dlmm_bin_arrays` und nach explicit sync (`publish_hot_bin_array_replay_after_explicit_sync`, Mom+Arb). (4) `publish_meteora_dlmm_bin_array_from_geyser` konsolidiert Handler-Gate. **Invarianten**: I-4/I-7 kein RPC; Dual-Consumer unverändert.  
+**Evidence**: `findings_arb_zero_opp_post360_20260803.md`, Prod Tip `4a9e133`.  
+**Dateien**: `src/market_data/ingest/{account_handler,account_filter}.rs`, `src/bin/market_data.rs`, `src/metrics.rs`, `docs/BUGS_FIXES.md`
+
 ### FIX-ARB-C1d: DLMM Bin-Array Completeness — Geyser-Flush Gate (Dual-Consumer)
 **Datum**: 2026-08-03  
 **Problem**: Post-C1c Soak: `market_data_bin_array_publish_total=0`, Arb `sell_missing_dlmm_bins` ~65–73% der Sell-Fails. `tracked_bin_arrays` hatte PDAs lokal, aber `hot_pool_reserve_registration_satisfied` prüfte nur Map-Präsenz — Deferred/Retry clearten bei Vault-OK, Geyser-Explicit-Flush für Bins blieb aus; Membership-Snapshot nach Bin-Register fehlte. `maybe_refresh_arb_dlmm_bin_window` nur Arb.  

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -14012,8 +14012,16 @@ mod pr_b_geyser_tracking_tests {
 
     /// Scope D: ENRICH account-parse sidefx skips redundant JetStream when vault feed is live.
     #[test]
+    #[serial_test::serial]
     fn scope_d_enrich_sidefx_skips_redundant_pool_discovered_under_vault_feed() {
         use ironcrab::metrics::MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL;
+
+        fn enrich_publish_skipped_delta<F: FnOnce()>(f: F) -> u64 {
+            let before = MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed);
+            f();
+            let after = MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed);
+            after.saturating_sub(before)
+        }
 
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
@@ -14054,7 +14062,6 @@ mod pr_b_geyser_tracking_tests {
             admission.snapshot_pubkeys().into_iter().collect();
         assert!(worker.pool_has_live_vault_geyser_feed(pool));
 
-        MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.store(0, Ordering::Relaxed);
         let mk_job =
             |slot: u64, class: SidefxUpdateClass| MdSidefxCommand::LivePoolCacheAccountUpdate {
                 run_id: "scope-d".into(),
@@ -14066,44 +14073,45 @@ mod pr_b_geyser_tracking_tests {
                 update_class: class,
             };
 
-        let mut scratch = MdSidefxBurstScratch::new();
-        md_sidefx_process_live_pool_cache_account_update(
-            &worker,
-            &mk_job(10, SidefxUpdateClass::Enrich),
-            &mut scratch,
-        );
-        let skipped_after_first =
-            MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed);
+        enrich_publish_skipped_delta(|| {
+            let mut scratch = MdSidefxBurstScratch::new();
+            md_sidefx_process_live_pool_cache_account_update(
+                &worker,
+                &mk_job(10, SidefxUpdateClass::Enrich),
+                &mut scratch,
+            );
+        });
 
-        let mut scratch2 = MdSidefxBurstScratch::new();
-        md_sidefx_process_live_pool_cache_account_update(
-            &worker,
-            &mk_job(11, SidefxUpdateClass::Enrich),
-            &mut scratch2,
-        );
+        let delta_second_enrich = enrich_publish_skipped_delta(|| {
+            let mut scratch = MdSidefxBurstScratch::new();
+            md_sidefx_process_live_pool_cache_account_update(
+                &worker,
+                &mk_job(11, SidefxUpdateClass::Enrich),
+                &mut scratch,
+            );
+        });
         assert!(
-            MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed)
-                > skipped_after_first,
+            delta_second_enrich > 0,
             "second ENRICH upsert with unchanged reserves under vault feed must skip JetStream"
         );
 
-        let skipped_before_exec_hot =
-            MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed);
-        let mut scratch3 = MdSidefxBurstScratch::new();
-        md_sidefx_process_live_pool_cache_account_update(
-            &worker,
-            &mk_job(12, SidefxUpdateClass::ExecHot),
-            &mut scratch3,
-        );
+        let delta_exec_hot = enrich_publish_skipped_delta(|| {
+            let mut scratch = MdSidefxBurstScratch::new();
+            md_sidefx_process_live_pool_cache_account_update(
+                &worker,
+                &mk_job(12, SidefxUpdateClass::ExecHot),
+                &mut scratch,
+            );
+        });
         assert_eq!(
-            MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed),
-            skipped_before_exec_hot,
+            delta_exec_hot, 0,
             "EXEC_HOT must not increment ENRICH skip counter (I-MD-4)"
         );
     }
 
     /// Bugbot: ENRICH JetStream skip must not skip MASTER readiness merge.
     #[test]
+    #[serial_test::serial]
     fn scope_d_enrich_skips_publish_but_merges_readiness() {
         use ironcrab::ipc::DexPoolReadiness;
         use ironcrab::metrics::MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL;
@@ -14150,7 +14158,7 @@ mod pr_b_geyser_tracking_tests {
             admission.snapshot_pubkeys().into_iter().collect();
         assert!(worker.pool_has_live_vault_geyser_feed(pool));
 
-        MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.store(0, Ordering::Relaxed);
+        let before = MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed);
         let mut scratch = MdSidefxBurstScratch::new();
         md_sidefx_process_live_pool_cache_account_update(
             &worker,
@@ -14167,7 +14175,7 @@ mod pr_b_geyser_tracking_tests {
         );
 
         assert!(
-            MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed) > 0,
+            MARKET_DATA_MD_SIDEFX_ENRICH_PUBLISH_SKIPPED_TOTAL.load(Ordering::Relaxed) > before,
             "ENRICH must skip redundant JetStream under vault feed + unchanged layout/reserves"
         );
         assert_eq!(
@@ -16643,6 +16651,7 @@ mod pr_b_geyser_tracking_tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn account_enrich_dispatch_upsert_and_flush_preserves_latest_wins() {
         use ironcrab::metrics::MARKET_DATA_ACCOUNT_ENRICH_COALESCE_TOTAL;
         let coalesce_before = MARKET_DATA_ACCOUNT_ENRICH_COALESCE_TOTAL.load(Ordering::Relaxed);
@@ -21477,6 +21486,7 @@ mod pr_b_geyser_tracking_tests {
 
     /// C1e: bin-array Geyser payloads stashed on early-drop replay after membership registration.
     #[test]
+    #[serial_test::serial]
     fn scope_c1e_dlmm_bin_stash_replay_after_register() {
         use ironcrab::metrics::MARKET_DATA_DLMM_BIN_EARLY_DROP_STASHED_TOTAL;
         use ironcrab::solana::dex::meteora_bin_array_layout::BinArray;

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -36,9 +36,10 @@ use uuid::Uuid;
 
 use ironcrab::config::{Config, MarketDataGeyserCfg, WalletTrackerCfg};
 use ironcrab::ipc::{
-    ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, ControlRequest, ControlRequestKind,
-    DexPoolReadiness, ExecutionResult, ExecutionStatus, IntentTier, MarketEvent, MarketEventKind,
-    PoolCacheUpdate, NATIVE_SOL_MINT, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    BinData, ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, ControlRequest,
+    ControlRequestKind, DexPoolReadiness, ExecutionResult, ExecutionStatus, IntentTier,
+    MarketEvent, MarketEventKind, PoolCacheUpdate, NATIVE_SOL_MINT,
+    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use ironcrab::market_data::cold::{
     cold_path_rpc_refresh_meteora_cpmm_pool_row, cold_path_rpc_refresh_meteora_dlmm_pool_row,
@@ -111,7 +112,8 @@ use ironcrab::metrics::{
     inc_market_data_arb_pin_deferred_still_unsatisfied_total,
     inc_market_data_arb_pin_geyser_register_deferred_total,
     inc_market_data_arb_pin_vault_register_ok_total,
-    inc_market_data_balance_updated_from_cache_total, inc_market_data_dlmm_bin_register_ok_total,
+    inc_market_data_balance_updated_from_cache_total,
+    inc_market_data_dlmm_bin_early_drop_stashed_total, inc_market_data_dlmm_bin_register_ok_total,
     inc_market_data_exec_hot_hard_shed_steps_for_tier_reason,
     inc_market_data_exec_hot_pressure_admit_rejected_total,
     inc_market_data_geyser_sync_skipped_rate_limit_total,
@@ -170,7 +172,7 @@ use ironcrab::metrics::{
     set_readiness_control_sub_active, set_readiness_mode, set_readiness_nats_connected,
     touch_market_data_global_ingest_progress,
     touch_market_data_tracked_membership_snapshot_refresh, update_readiness_market_data_current,
-    ExecHotShedTier, MarketDataLatencySegment, MetricsComponent,
+    ExecHotShedTier, MarketDataAccountEarlyDropReason, MarketDataLatencySegment, MetricsComponent,
     MARKET_DATA_ACCOUNT_BROADCAST_QUEUE_DEPTH_EXEC_HOT,
     MARKET_DATA_LAST_BONDING_CURVE_PUBLISH_TS_UNIX_MS, MARKET_EVENTS_RECEIVED_TOTAL,
     POOLS_TRACKED_GAUGE,
@@ -1307,6 +1309,8 @@ struct MarketDataContext {
     last_arb_snapshot_target: parking_lot::RwLock<Option<HashSet<Pubkey>>>,
     /// Last `active_id` used when registering DLMM bin-array window per pool (Fix B).
     dlmm_registered_active_id: parking_lot::RwLock<HashMap<Pubkey, i32>>,
+    /// C1e: bin-array Geyser payloads stashed on early-drop before membership registration.
+    dlmm_bin_geyser_stash: parking_lot::RwLock<HashMap<Pubkey, StashedDlmmBinGeyserUpdate>>,
     /// Scope C: hot pools awaiting LivePoolCache layout for vault/bin Geyser registration.
     deferred_hot_pool_reserve_pins: parking_lot::RwLock<HashMap<Pubkey, GeyserPinReason>>,
     /// Open-position PumpFun pools with unsatisfied bonding-curve Geyser registration (observability).
@@ -1570,6 +1574,15 @@ struct BinArrayInfo {
     pinned: bool,
     pin: Option<GeyserPinReason>,
 }
+
+/// Stashed DLMM bin-array Geyser payload for replay after membership registration.
+#[derive(Clone)]
+struct StashedDlmmBinGeyserUpdate {
+    data: Vec<u8>,
+    slot: u64,
+}
+
+const DLMM_BIN_GEYSER_STASH_MAX: usize = 4096;
 
 /// Phase1: lock-free vault metadata for ingest/sidefx (refreshed by md-state only).
 #[derive(Clone)]
@@ -3821,6 +3834,7 @@ impl MarketDataContext {
         *self.last_synced_explicit_pubkeys.write() =
             admission.snapshot_pubkeys().into_iter().collect();
         self.publish_momentum_hot_balance_refresh_after_explicit_sync(&prev_synced);
+        self.publish_hot_bin_array_replay_after_explicit_sync(&prev_synced);
         self.clear_geyser_prune_resume();
         true
     }
@@ -4712,6 +4726,139 @@ impl MarketDataContext {
         }
     }
 
+    /// C1e: stash bin-array Geyser payload dropped before membership registration (METEORA owner stream).
+    fn maybe_stash_dlmm_bin_array_before_early_drop(&self, update: &GeyserAccountUpdate) {
+        if !ironcrab::market_data::ingest::geyser_update_looks_like_meteora_bin_array(update) {
+            return;
+        }
+        let mut stash = self.dlmm_bin_geyser_stash.write();
+        while stash.len() >= DLMM_BIN_GEYSER_STASH_MAX {
+            if let Some(key) = stash.keys().next().copied() {
+                stash.remove(&key);
+            } else {
+                break;
+            }
+        }
+        stash.insert(
+            update.pubkey,
+            StashedDlmmBinGeyserUpdate {
+                data: update.data.clone(),
+                slot: update.slot,
+            },
+        );
+        inc_market_data_dlmm_bin_early_drop_stashed_total();
+    }
+
+    /// C1e: replay stashed bin-array updates after membership registration or explicit sync.
+    fn try_replay_stashed_dlmm_bin_updates(&self, pdas: &[Pubkey]) {
+        if pdas.is_empty() {
+            return;
+        }
+        let Some(nats) = self
+            .nats
+            .as_ref()
+            .map(NatsClient::clone_for_spawned_publish)
+        else {
+            return;
+        };
+        let membership = self.tracked_membership.load();
+        let mut replay_rows: Vec<(Pubkey, StashedDlmmBinGeyserUpdate, SnapshotBinArrayView)> =
+            Vec::new();
+        let mut replayed_keys = Vec::new();
+        {
+            let stash = self.dlmm_bin_geyser_stash.read();
+            for pda in pdas {
+                if let Some(s) = stash.get(pda) {
+                    if let Some(view) = membership.bin_array_by_pubkey.get(pda) {
+                        replay_rows.push((*pda, s.clone(), view.clone()));
+                        replayed_keys.push(*pda);
+                    }
+                }
+            }
+        }
+        if replay_rows.is_empty() {
+            return;
+        }
+        let run_id = self.run_id.clone();
+        let publish = async move {
+            use ironcrab::market_data::publish::publish_market_event_core_and_momentum_ex;
+            use ironcrab::solana::dex::meteora_bin_array_layout::BinArray;
+            let mut replay_seq = 0u64;
+            for (_pda, stashed, view) in replay_rows {
+                replay_seq += 1;
+                match BinArray::parse(&stashed.data, view.bin_step) {
+                    Ok(parsed_array) => {
+                        let bins: Vec<BinData> = parsed_array
+                            .bins
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, bin)| bin.amount_x > 0 || bin.amount_y > 0)
+                            .map(|(offset, bin)| BinData {
+                                offset: offset as u8,
+                                amount_x: bin.amount_x,
+                                amount_y: bin.amount_y,
+                            })
+                            .collect();
+                        if bins.is_empty() {
+                            ironcrab::metrics::inc_market_data_dlmm_bin_emit_skipped_empty_total();
+                            continue;
+                        }
+                        let event_id = format!("bin-replay-{}-{:06}", &run_id[..8], replay_seq);
+                        let bin_event = MarketEvent::new(
+                            "market-data",
+                            BUILD_VERSION,
+                            &run_id,
+                            event_id,
+                            "geyser_bin_array_replay",
+                            Some(stashed.slot),
+                            MarketEventKind::BinArrayUpdate {
+                                pool_address: view.pool_address.to_string(),
+                                bin_array_index: view.bin_array_index,
+                                bins,
+                                update_slot: stashed.slot,
+                            },
+                        );
+                        ironcrab::metrics::market_data_bin_array_publish_inc();
+                        ironcrab::metrics::inc_market_data_dlmm_bin_replay_publish_total();
+                        ironcrab::metrics::inc_market_data_dlmm_bin_publish_exec_hot_total();
+                        let _ = publish_market_event_core_and_momentum_ex(
+                            &nats, &bin_event, None, None,
+                        )
+                        .await;
+                    }
+                    Err(_) => {
+                        ironcrab::metrics::inc_market_data_dlmm_bin_parse_fail_total();
+                    }
+                }
+            }
+        };
+        if let Some(handle) = self.ingest_tokio_handle.read().clone() {
+            handle.spawn(publish);
+        } else if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(publish);
+        }
+        self.dlmm_bin_geyser_stash
+            .write()
+            .retain(|pk, _| !replayed_keys.contains(pk));
+    }
+
+    /// C1e: after explicit sync, replay stashed bin arrays for newly live hot-pool PDAs (Mom + Arb).
+    fn publish_hot_bin_array_replay_after_explicit_sync(&self, prev_synced: &HashSet<Pubkey>) {
+        let synced = self.last_synced_explicit_pubkeys.read();
+        let mut replay_pdas = Vec::new();
+        for pool in self.hot_pool_registry.snapshot_hot_pool_pubkeys() {
+            if !self.hot_pool_reserve_registration_satisfied(pool) {
+                continue;
+            }
+            for pk in self.pool_explicit_vault_bin_pubkeys(pool) {
+                if !prev_synced.contains(&pk) && synced.contains(&pk) {
+                    replay_pdas.push(pk);
+                }
+            }
+        }
+        self.try_replay_stashed_dlmm_bin_updates(&replay_pdas);
+    }
+
     /// Cache-first JetStream BalanceUpdated for pools with fresh reserve basis (no vault Geyser sub required).
     fn try_publish_balance_updated_from_cache(&self, pool: Pubkey) {
         if self.balance_updated_from_cache_skipped_for_live_feed(pool) {
@@ -5424,6 +5571,14 @@ impl MarketDataContext {
             inc_market_data_dlmm_bin_register_ok_total();
             self.refresh_tracked_membership_snapshot();
             self.refresh_tracked_bin_arrays_gauges();
+            let pool_bins: Vec<Pubkey> = self
+                .tracked_bin_arrays
+                .read()
+                .iter()
+                .filter(|(_, b)| b.pool_address == pool)
+                .map(|(pk, _)| *pk)
+                .collect();
+            self.try_replay_stashed_dlmm_bin_updates(&pool_bins);
         }
         bins_changed
     }
@@ -8152,6 +8307,7 @@ async fn main() -> Result<()> {
         last_momentum_snapshot_target: parking_lot::RwLock::new(None),
         last_arb_snapshot_target: parking_lot::RwLock::new(None),
         dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+        dlmm_bin_geyser_stash: parking_lot::RwLock::new(HashMap::new()),
         deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
         open_position_pumpfun_registration_unsatisfied_since: parking_lot::RwLock::new(
             HashMap::new(),
@@ -9063,6 +9219,9 @@ fn handle_account_broadcast_recv_ok(
 
     if let Some(reason) = early_drop_reason {
         if matches!(path, AccountBroadcastRecvPath::ExecHot) {
+            if reason == MarketDataAccountEarlyDropReason::DexPoolNotEnrichment {
+                ctx.maybe_stash_dlmm_bin_array_before_early_drop(&account_update);
+            }
             record_market_data_account_early_drop(reason);
             inc_market_data_account_updates_total(class.as_prometheus_label());
             record_market_data_account_recv_iteration_duration_us(
@@ -12702,6 +12861,7 @@ mod wallet_snapshot_stale_cleanup_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            dlmm_bin_geyser_stash: parking_lot::RwLock::new(HashMap::new()),
             deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
             open_position_pumpfun_registration_unsatisfied_since: parking_lot::RwLock::new(
                 HashMap::new(),
@@ -12935,6 +13095,7 @@ mod wallet_tx_meta_balance_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            dlmm_bin_geyser_stash: parking_lot::RwLock::new(HashMap::new()),
             deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
             open_position_pumpfun_registration_unsatisfied_since: parking_lot::RwLock::new(
                 HashMap::new(),
@@ -14532,6 +14693,7 @@ mod pr_b_geyser_tracking_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            dlmm_bin_geyser_stash: parking_lot::RwLock::new(HashMap::new()),
             deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
             open_position_pumpfun_registration_unsatisfied_since: parking_lot::RwLock::new(
                 HashMap::new(),
@@ -14617,6 +14779,7 @@ mod pr_b_geyser_tracking_tests {
             last_momentum_snapshot_target: parking_lot::RwLock::new(None),
             last_arb_snapshot_target: parking_lot::RwLock::new(None),
             dlmm_registered_active_id: parking_lot::RwLock::new(HashMap::new()),
+            dlmm_bin_geyser_stash: parking_lot::RwLock::new(HashMap::new()),
             deferred_hot_pool_reserve_pins: parking_lot::RwLock::new(HashMap::new()),
             open_position_pumpfun_registration_unsatisfied_since: parking_lot::RwLock::new(
                 HashMap::new(),
@@ -21310,5 +21473,52 @@ mod pr_b_geyser_tracking_tests {
         for (_pda, info) in bins.iter().filter(|(_, b)| b.pool_address == pool) {
             assert_eq!(info.pin, Some(GeyserPinReason::MomentumActive));
         }
+    }
+
+    /// C1e: bin-array Geyser payloads stashed on early-drop replay after membership registration.
+    #[test]
+    fn scope_c1e_dlmm_bin_stash_replay_after_register() {
+        use ironcrab::metrics::MARKET_DATA_DLMM_BIN_EARLY_DROP_STASHED_TOTAL;
+        use ironcrab::solana::dex::meteora_bin_array_layout::BinArray;
+        use std::sync::atomic::Ordering;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        ctx.live_pool_cache
+            .upsert(pool, test_meteora_dlmm_cached_state(42), 1);
+        let state = ctx.live_pool_cache.get(&pool).unwrap();
+        let bin_pdas = planned_meteora_dlmm_bin_pubkeys_for_cache(pool, &state);
+        let bin_pda = bin_pdas[0];
+
+        let mut data = vec![0u8; BinArray::ACCOUNT_SIZE];
+        data[56..64].copy_from_slice(&100u64.to_le_bytes());
+
+        let update = GeyserAccountUpdate {
+            pubkey: bin_pda,
+            slot: 42,
+            owner: Pubkey::from_str(METEORA_DLMM).unwrap(),
+            data,
+            lamports: 0,
+            grpc_recv_at: Instant::now(),
+        };
+        let before_stash = MARKET_DATA_DLMM_BIN_EARLY_DROP_STASHED_TOTAL.load(Ordering::Relaxed);
+        ctx.maybe_stash_dlmm_bin_array_before_early_drop(&update);
+        assert!(
+            MARKET_DATA_DLMM_BIN_EARLY_DROP_STASHED_TOTAL.load(Ordering::Relaxed) > before_stash
+        );
+        assert!(ctx.dlmm_bin_geyser_stash.read().contains_key(&bin_pda));
+
+        assert!(ctx.register_meteora_dlmm_bin_arrays(
+            pool,
+            42,
+            15,
+            GeyserPinReason::ArbMultiDex,
+            Instant::now()
+        ));
+        assert!(ctx.tracked_membership.load().bin_arrays.contains(&bin_pda));
     }
 }

--- a/src/market_data/ingest/account_filter.rs
+++ b/src/market_data/ingest/account_filter.rs
@@ -4,6 +4,8 @@ use super::host::IngestHost;
 use crate::metrics::{
     inc_market_data_account_relevance_enrichment_hit_total, MarketDataAccountEarlyDropReason,
 };
+use crate::solana::dex::meteora_bin_array_layout::BinArray;
+use crate::solana::dex::meteora_dlmm_layout::DlmmPool;
 use crate::solana::geyser_listener::GeyserAccountUpdate;
 use solana_sdk::pubkey::Pubkey;
 
@@ -22,6 +24,20 @@ const METEORA_DLMM_OWNER: Pubkey =
     solana_sdk::pubkey!("LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo");
 const METEORA_CPMM_OWNER: Pubkey =
     solana_sdk::pubkey!("cpmmpPFsKiR4eeYnGSuXgkhLLgGL1j5FUZoJBJU9t9D");
+
+/// Heuristic: METEORA DLMM owner + bin-array account size (not LB Pair pool state).
+#[inline]
+pub fn geyser_account_data_looks_like_meteora_bin_array(owner: &Pubkey, data: &[u8]) -> bool {
+    *owner == METEORA_DLMM_OWNER
+        && data.len() >= BinArray::ACCOUNT_SIZE
+        && data.len() != DlmmPool::ACCOUNT_SIZE
+}
+
+/// Heuristic for recv early-drop stash: bin-array-shaped METEORA account update.
+#[inline]
+pub fn geyser_update_looks_like_meteora_bin_array(u: &GeyserAccountUpdate) -> bool {
+    geyser_account_data_looks_like_meteora_bin_array(&u.owner, &u.data)
+}
 
 #[inline]
 pub fn account_geyser_update_is_dex_pool_owner(owner: &Pubkey) -> bool {
@@ -464,6 +480,24 @@ mod tests {
         let (class, early_drop_reason) = classify_account_geyser_update(&host, &u);
         assert_eq!(class, AccountUpdateClass::Enrich);
         assert_eq!(early_drop_reason, None);
+    }
+
+    #[test]
+    fn geyser_account_data_looks_like_meteora_bin_array_vs_lb_pair() {
+        let bin_data = vec![0u8; BinArray::ACCOUNT_SIZE];
+        assert!(geyser_account_data_looks_like_meteora_bin_array(
+            &METEORA_DLMM_OWNER,
+            &bin_data
+        ));
+        let pool_data = vec![0u8; DlmmPool::ACCOUNT_SIZE];
+        assert!(!geyser_account_data_looks_like_meteora_bin_array(
+            &METEORA_DLMM_OWNER,
+            &pool_data
+        ));
+        assert!(!geyser_account_data_looks_like_meteora_bin_array(
+            &RAYDIUM_CPMM_OWNER,
+            &bin_data
+        ));
     }
 
     #[test]

--- a/src/market_data/ingest/account_handler.rs
+++ b/src/market_data/ingest/account_handler.rs
@@ -3,8 +3,9 @@
 
 use super::account_filter::{
     account_geyser_update_is_dex_pool_owner, account_geyser_update_is_sidefx_only_pool_owner,
+    geyser_account_data_looks_like_meteora_bin_array,
 };
-use super::account_host::AccountIngestHost;
+use super::account_host::{AccountBinArrayView, AccountIngestHost};
 use super::account_parse::{
     account_publish_segment, try_parse_mint_account, try_parse_token_account_balance,
     wallet_geyser_snapshots_to_publish, wsol_ata_balance_lamports_from_geyser_data,
@@ -21,8 +22,12 @@ use crate::market_data::sidefx::{
     SidefxUpdateClass,
 };
 use crate::metrics::{
-    record_market_data_tokio_progress, record_market_data_unparsed_account_dropped,
-    MarketDataUnparsedAccountDropReason,
+    inc_market_data_dlmm_bin_emit_skipped_empty_total,
+    inc_market_data_dlmm_bin_membership_hit_total, inc_market_data_dlmm_bin_membership_miss_total,
+    inc_market_data_dlmm_bin_owner_update_total, inc_market_data_dlmm_bin_parse_fail_total,
+    inc_market_data_dlmm_bin_publish_enrich_total, inc_market_data_dlmm_bin_publish_exec_hot_total,
+    inc_market_data_dlmm_bin_replay_publish_total, record_market_data_tokio_progress,
+    record_market_data_unparsed_account_dropped, MarketDataUnparsedAccountDropReason,
 };
 use crate::nats::wallet_snapshot_subject;
 use crate::solana::dex::meteora_bin_array_layout::BinArray;
@@ -36,6 +41,132 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 use tracing::{debug, info, warn};
+
+/// Outcome of the DLMM bin-array publish gate (forensics + replay).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DlmmBinArrayPublishOutcome {
+    Published,
+    ParseFailed,
+    SkippedEmptyLiquidity,
+    SkippedNoNats,
+}
+
+/// Parse + publish one Meteora DLMM bin-array Geyser update for a tracked membership row.
+#[allow(clippy::too_many_arguments)]
+pub async fn publish_meteora_dlmm_bin_array_from_geyser<H: AccountIngestHost>(
+    host: &H,
+    run_id: &str,
+    account_geyser_recv_at: Instant,
+    account_update: &GeyserAccountUpdate,
+    bin_array_info: AccountBinArrayView,
+    publish_tx: Option<&AccountPublishSender>,
+    md_sidefx: Option<&MdSidefxSender>,
+    sidefx_class: SidefxUpdateClass,
+    update_class: AccountUpdateClass,
+    replay_from_stash: bool,
+) -> DlmmBinArrayPublishOutcome {
+    if let Some(md_sidefx) = md_sidefx {
+        md_sidefx_try_enqueue_classed(
+            md_sidefx,
+            sidefx_class,
+            MdSidefxCommand::TouchBinArrayTick {
+                pda: account_update.pubkey,
+                update_class: sidefx_class,
+            },
+        );
+    }
+    match BinArray::parse(&account_update.data, bin_array_info.bin_step) {
+        Ok(parsed_array) => {
+            let bins: Vec<BinData> = parsed_array
+                .bins
+                .iter()
+                .enumerate()
+                .filter(|(_, bin)| bin.amount_x > 0 || bin.amount_y > 0)
+                .map(|(offset, bin)| BinData {
+                    offset: offset as u8,
+                    amount_x: bin.amount_x,
+                    amount_y: bin.amount_y,
+                })
+                .collect();
+
+            if bins.is_empty() {
+                inc_market_data_dlmm_bin_emit_skipped_empty_total();
+                return DlmmBinArrayPublishOutcome::SkippedEmptyLiquidity;
+            }
+
+            let bin_event = MarketEvent::new(
+                "market-data",
+                host.account_build_version(),
+                run_id,
+                host.account_next_event_id(),
+                "geyser_bin_array",
+                Some(account_update.slot),
+                MarketEventKind::BinArrayUpdate {
+                    pool_address: bin_array_info.pool_address.to_string(),
+                    bin_array_index: bin_array_info.bin_array_index,
+                    bins,
+                    update_slot: account_update.slot,
+                },
+            );
+
+            host.account_write_market_event_jsonl(&bin_event);
+
+            if host.account_nats().is_some() {
+                match update_class {
+                    AccountUpdateClass::ExecHot => {
+                        inc_market_data_dlmm_bin_publish_exec_hot_total()
+                    }
+                    AccountUpdateClass::Enrich => inc_market_data_dlmm_bin_publish_enrich_total(),
+                    AccountUpdateClass::Drop => {}
+                }
+                if replay_from_stash {
+                    inc_market_data_dlmm_bin_replay_publish_total();
+                }
+                let seg = account_publish_segment(&bin_event.kind);
+                account_path_enqueue_core_market_event(
+                    publish_tx,
+                    host.account_nats(),
+                    host.account_publish_host(),
+                    bin_event,
+                    Some(MarketEventCorePublishTrace {
+                        recv_at: account_geyser_recv_at,
+                        cold_path: false,
+                        segment: seg,
+                    }),
+                )
+                .await;
+            } else {
+                return DlmmBinArrayPublishOutcome::SkippedNoNats;
+            }
+
+            if host.ingest_is_hot_pool(&bin_array_info.pool_address) {
+                if let Some(md_sidefx) = md_sidefx {
+                    md_sidefx_try_enqueue_classed(
+                        md_sidefx,
+                        SidefxUpdateClass::ExecHot,
+                        MdSidefxCommand::DlmmPoolStatePublishSignal {
+                            run_id: run_id.to_string(),
+                            pool_address: bin_array_info.pool_address,
+                            slot: account_update.slot,
+                            grpc_recv_at: account_geyser_recv_at,
+                            update_class: SidefxUpdateClass::ExecHot,
+                        },
+                    );
+                }
+            }
+            DlmmBinArrayPublishOutcome::Published
+        }
+        Err(e) => {
+            inc_market_data_dlmm_bin_parse_fail_total();
+            debug!(
+                error = %e,
+                pubkey = %account_update.pubkey,
+                "Failed to parse bin array account"
+            );
+            DlmmBinArrayPublishOutcome::ParseFailed
+        }
+    }
+}
 
 /// Geyser account ingest (dedizierte worker pool, siehe MARKET-DATA-ACCOUNT-THROUGHPUT-P0).
 /// STOP-CHECK: keine neuen RPC-Calls; gleiche Logik wie zuvor im Bin.
@@ -355,90 +486,35 @@ pub async fn handle_geyser_account_update<H: AccountIngestHost>(
     let dlmm_program =
         Pubkey::from_str(METEORA_DLMM_PROGRAM).expect("Invalid METEORA_DLMM_PROGRAM constant");
     if account_update.owner == dlmm_program {
+        if geyser_account_data_looks_like_meteora_bin_array(
+            &account_update.owner,
+            &account_update.data,
+        ) {
+            inc_market_data_dlmm_bin_owner_update_total();
+        }
         if let Some(bin_array_info) = host.account_membership_bin_array_info(&account_update.pubkey)
         {
-            md_sidefx_try_enqueue_classed(
-                md_sidefx,
+            inc_market_data_dlmm_bin_membership_hit_total();
+            publish_meteora_dlmm_bin_array_from_geyser(
+                host,
+                run_id,
+                account_geyser_recv_at,
+                &account_update,
+                bin_array_info,
+                publish_tx,
+                Some(md_sidefx),
                 sidefx_class,
-                MdSidefxCommand::TouchBinArrayTick {
-                    pda: account_update.pubkey,
-                    update_class: sidefx_class,
-                },
-            );
-            // Parse bin array to extract liquidity distribution
-            match BinArray::parse(&account_update.data, bin_array_info.bin_step) {
-                Ok(parsed_array) => {
-                    // Convert to compact BinData (only bins with liquidity)
-                    let bins: Vec<BinData> = parsed_array
-                        .bins
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, bin)| bin.amount_x > 0 || bin.amount_y > 0)
-                        .map(|(offset, bin)| BinData {
-                            offset: offset as u8,
-                            amount_x: bin.amount_x,
-                            amount_y: bin.amount_y,
-                        })
-                        .collect();
-
-                    // Only emit if there's any liquidity
-                    if !bins.is_empty() {
-                        let bin_event = MarketEvent::new(
-                            "market-data",
-                            host.account_build_version(),
-                            run_id,
-                            host.account_next_event_id(),
-                            "geyser_bin_array",
-                            Some(account_update.slot),
-                            MarketEventKind::BinArrayUpdate {
-                                pool_address: bin_array_info.pool_address.to_string(),
-                                bin_array_index: bin_array_info.bin_array_index,
-                                bins,
-                                update_slot: account_update.slot,
-                            },
-                        );
-
-                        host.account_write_market_event_jsonl(&bin_event);
-
-                        if host.account_nats().is_some() {
-                            let seg = account_publish_segment(&bin_event.kind);
-                            account_path_enqueue_core_market_event(
-                                publish_tx,
-                                host.account_nats(),
-                                host.account_publish_host(),
-                                bin_event,
-                                Some(MarketEventCorePublishTrace {
-                                    recv_at: account_geyser_recv_at,
-                                    cold_path: false,
-                                    segment: seg,
-                                }),
-                            )
-                            .await;
-                        }
-                        if host.ingest_is_hot_pool(&bin_array_info.pool_address) {
-                            md_sidefx_try_enqueue_classed(
-                                md_sidefx,
-                                SidefxUpdateClass::ExecHot,
-                                MdSidefxCommand::DlmmPoolStatePublishSignal {
-                                    run_id: run_id.to_string(),
-                                    pool_address: bin_array_info.pool_address,
-                                    slot: account_update.slot,
-                                    grpc_recv_at: account_geyser_recv_at,
-                                    update_class: SidefxUpdateClass::ExecHot,
-                                },
-                            );
-                        }
-                    }
-                }
-                Err(e) => {
-                    debug!(
-                        error = %e,
-                        pubkey = %account_update.pubkey,
-                        "Failed to parse bin array account"
-                    );
-                }
-            }
+                update_class,
+                false,
+            )
+            .await;
             return;
+        }
+        if geyser_account_data_looks_like_meteora_bin_array(
+            &account_update.owner,
+            &account_update.data,
+        ) {
+            inc_market_data_dlmm_bin_membership_miss_total();
         }
     }
 

--- a/src/market_data/ingest/mod.rs
+++ b/src/market_data/ingest/mod.rs
@@ -11,10 +11,14 @@ pub mod tx_parse;
 pub use account_filter::{
     account_geyser_dispatch_priority_high, account_geyser_enrich_path_needs_classify,
     account_geyser_update_is_dex_pool_owner, account_geyser_update_might_be_relevant,
-    account_geyser_update_relevance, classify_account_geyser_update, AccountGeyserRelevance,
-    AccountUpdateClass,
+    account_geyser_update_relevance, classify_account_geyser_update,
+    geyser_account_data_looks_like_meteora_bin_array, geyser_update_looks_like_meteora_bin_array,
+    AccountGeyserRelevance, AccountUpdateClass,
 };
-pub use account_handler::handle_geyser_account_update;
+pub use account_handler::{
+    handle_geyser_account_update, publish_meteora_dlmm_bin_array_from_geyser,
+    DlmmBinArrayPublishOutcome,
+};
 pub use account_host::{AccountBinArrayView, AccountIngestHost, AccountTrackedWalletView};
 pub use account_parse::{
     try_parse_mint_account, try_parse_token_account_balance, wallet_geyser_snapshots_to_publish,

--- a/src/market_data/sidefx/handlers.rs
+++ b/src/market_data/sidefx/handlers.rs
@@ -1515,14 +1515,17 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
         // Publish PoolCacheUpdate to JetStream (Single Source of Truth for pool state)
         let open_position_pumpfun_pin =
             md_sidefx_is_open_position_pumpfun_pin(host, pool_pubkey, &cached_state);
-        let should_publish_pool_cache = update_class.is_exec_hot()
-            || open_position_pumpfun_pin
-            || md_sidefx_should_publish_enrich_pool_cache_update(
+        // I-MD-4: EXEC_HOT must never evaluate ENRICH-only skip gate (no enrich skip counter bump).
+        let should_publish_pool_cache = if update_class.is_exec_hot() || open_position_pumpfun_pin {
+            true
+        } else {
+            md_sidefx_should_publish_enrich_pool_cache_update(
                 host,
                 pool_pubkey,
                 prev_state.as_ref(),
                 &cached_state,
-            );
+            )
+        };
         if should_publish_pool_cache && host.nats_enabled() {
             let mut pool_update = PoolCacheUpdate::new_pool_discovered(
                 "market-data",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -397,6 +397,32 @@ pub static MARKET_DATA_TRACKED_BIN_ARRAYS_MOMENTUM_GAUGE: Lazy<AtomicU64> =
 /// Successful DLMM bin-array window registrations (`register_meteora_dlmm_bin_arrays` changed tracking).
 pub static MARKET_DATA_DLMM_BIN_REGISTER_OK_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// DLMM bin-array account updates observed at ingest handler (bin-shaped METEORA owner).
+pub static MARKET_DATA_DLMM_BIN_OWNER_UPDATE_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// DLMM bin-array updates stashed on early-drop before membership registration.
+pub static MARKET_DATA_DLMM_BIN_EARLY_DROP_STASHED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// DLMM bin-array handler: membership snapshot hit.
+pub static MARKET_DATA_DLMM_BIN_MEMBERSHIP_HIT_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// DLMM bin-array handler: membership snapshot miss (update fell through).
+pub static MARKET_DATA_DLMM_BIN_MEMBERSHIP_MISS_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// DLMM bin-array parse failures at publish gate.
+pub static MARKET_DATA_DLMM_BIN_PARSE_FAIL_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// DLMM bin-array emit skipped: parsed but no non-zero liquidity bins.
+pub static MARKET_DATA_DLMM_BIN_EMIT_SKIPPED_EMPTY_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// DLMM bin-array publishes from stashed Geyser replay (post-register / post-sync).
+pub static MARKET_DATA_DLMM_BIN_REPLAY_PUBLISH_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// DLMM bin-array handler publishes on ExecHot lane.
+pub static MARKET_DATA_DLMM_BIN_PUBLISH_EXEC_HOT_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// DLMM bin-array handler publishes on Enrich lane.
+pub static MARKET_DATA_DLMM_BIN_PUBLISH_ENRICH_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 
 /// Geyser explicit-tracked subscription list syncs coalesced from the TX trade path (debounced flush).
 pub static MARKET_DATA_GEYSER_SYNC_BATCH_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
@@ -681,6 +707,51 @@ pub fn set_market_data_tracked_bin_arrays_momentum_gauge(n: usize) {
 #[inline]
 pub fn inc_market_data_dlmm_bin_register_ok_total() {
     MARKET_DATA_DLMM_BIN_REGISTER_OK_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_dlmm_bin_owner_update_total() {
+    MARKET_DATA_DLMM_BIN_OWNER_UPDATE_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_dlmm_bin_early_drop_stashed_total() {
+    MARKET_DATA_DLMM_BIN_EARLY_DROP_STASHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_dlmm_bin_membership_hit_total() {
+    MARKET_DATA_DLMM_BIN_MEMBERSHIP_HIT_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_dlmm_bin_membership_miss_total() {
+    MARKET_DATA_DLMM_BIN_MEMBERSHIP_MISS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_dlmm_bin_parse_fail_total() {
+    MARKET_DATA_DLMM_BIN_PARSE_FAIL_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_dlmm_bin_emit_skipped_empty_total() {
+    MARKET_DATA_DLMM_BIN_EMIT_SKIPPED_EMPTY_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_dlmm_bin_replay_publish_total() {
+    MARKET_DATA_DLMM_BIN_REPLAY_PUBLISH_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_dlmm_bin_publish_exec_hot_total() {
+    MARKET_DATA_DLMM_BIN_PUBLISH_EXEC_HOT_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_dlmm_bin_publish_enrich_total() {
+    MARKET_DATA_DLMM_BIN_PUBLISH_ENRICH_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -7906,6 +7977,42 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_dlmm_bin_register_ok_total",
         MARKET_DATA_DLMM_BIN_REGISTER_OK_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_dlmm_bin_owner_update_total",
+        MARKET_DATA_DLMM_BIN_OWNER_UPDATE_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_dlmm_bin_early_drop_stashed_total",
+        MARKET_DATA_DLMM_BIN_EARLY_DROP_STASHED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_dlmm_bin_membership_hit_total",
+        MARKET_DATA_DLMM_BIN_MEMBERSHIP_HIT_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_dlmm_bin_membership_miss_total",
+        MARKET_DATA_DLMM_BIN_MEMBERSHIP_MISS_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_dlmm_bin_parse_fail_total",
+        MARKET_DATA_DLMM_BIN_PARSE_FAIL_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_dlmm_bin_emit_skipped_empty_total",
+        MARKET_DATA_DLMM_BIN_EMIT_SKIPPED_EMPTY_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_dlmm_bin_replay_publish_total",
+        MARKET_DATA_DLMM_BIN_REPLAY_PUBLISH_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_dlmm_bin_publish_exec_hot_total",
+        MARKET_DATA_DLMM_BIN_PUBLISH_EXEC_HOT_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_dlmm_bin_publish_enrich_total",
+        MARKET_DATA_DLMM_BIN_PUBLISH_ENRICH_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_arb_pin_vault_register_ok_total",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Post-C1d (`4a9e133`): DLMM bin arrays were registered (`tracked_bin_arrays`, `dlmm_bin_register_ok_total`) but `market_data_bin_array_publish_total` stayed **0** — Arb never received `BinArrayUpdate` events.

**Root cause (H1/H2):** Meteora DLMM bin-array accounts already arrive on the program-owner Geyser stream. Before membership registration they are `EarlyDrop` (`DexPoolNotEnrichment`). After register, Geyser does not resend unchanged accounts → ingest handler never publishes.

## Fix

1. **Forensics** — additive counters at each gate:
   - `market_data_dlmm_bin_owner_update_total`
   - `market_data_dlmm_bin_early_drop_stashed_total`
   - `market_data_dlmm_bin_membership_hit_total` / `miss_total`
   - `market_data_dlmm_bin_parse_fail_total`
   - `market_data_dlmm_bin_emit_skipped_empty_total`
   - `market_data_dlmm_bin_replay_publish_total`
   - `market_data_dlmm_bin_publish_exec_hot_total` / `enrich_total`

2. **Stash** — bin-array-shaped METEORA updates on `DexPoolNotEnrichment` early-drop (bounded 4096).

3. **Replay** — after `register_meteora_dlmm_bin_arrays` and after explicit Geyser sync for newly-live hot-pool bin PDAs (Mom + Arb dual-consumer).

4. **Handler** — consolidated `publish_meteora_dlmm_bin_array_from_geyser` with forensic increments.

## Invarianten

- I-4 / I-7: kein RPC, kein Hot-Path-RPC
- Dual-Consumer: Pin-Priorität Wallet > Mom > Arb unverändert; replay für alle hot pools
- Kein blind empty-bin spam (empty-liquidity filter bleibt)

## Tests

- `scope_c1e_dlmm_bin_stash_replay_after_register`
- Existing `account_filter` bin-array / EarlyDrop regression tests

## CI

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de8d3761-8048-4566-a589-fa45f7903dec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de8d3761-8048-4566-a589-fa45f7903dec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

