### PR TITLE
fix(arb): C1g DLMM quote completeness — active bin touch + window refresh

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,13 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### FIX-ARB-C1g: DLMM Quote Completeness — Active Bin Touch + Window Refresh
+**Datum**: 2026-08-04  
+**Problem**: Post-C1f: `sell_quote_none` / `dlmm_active_bin_missing` dominant (~3k+); `sell_missing_vault` ~1.6–2k. MD publish filtert Bins mit `amount_x/y == 0` — Zero-Liquidity Active-Bin erscheint nie im `BinArrayUpdate` → `active_bin_present` false trotz bin cache hit. Bin-Fenster-Drift: Refresh nur bei `prev_id != active_id`, nicht bei untracked arrays; Deferred-Retry erst auf activity tick nach LivePoolCache-Fill.  
+**Fix**: (1) `filter_dlmm_bins_for_publish`: Active-Bin immer emittieren (zero-liquidity touch), Replay-Pfad analog. (2) `maybe_refresh_hot_dlmm_bin_window`: auch bei untracked bin window re-register (H1). (3) Sidefx: erster Hot-Pool-State + Deferred-Retry auf PoolState-Fill. (4) Forensik: `dlmm_bin_emit_active_zero_touch`, `dlmm_bin_window_refresh_untracked`, `deferred_retry_pool_state_fill`. (5) Quote-Test: zero-liquidity active bin → kein `DlmmActiveBinMissing`. **Invarianten**: I-4/I-7 kein RPC; Dual-Consumer/C1e/C1f unverändert.  
+**Evidence**: `findings_arb_zero_opp_post362_20260804.md`, Prod Tip `886dd4f`.  
+**Dateien**: `src/market_data/ingest/dlmm_bin_publish.rs`, `account_handler.rs`, `src/bin/market_data.rs`, `src/market_data/sidefx/{host,handlers}.rs`, `src/arbitrage/pool_quote.rs`, `src/metrics.rs`, `docs/BUGS_FIXES.md`
+
 ### FIX-ARB-C1f: Arb DLMM Bin Consume — Live Snapshot + Bin-Update Rescreen
 **Datum**: 2026-08-03  
 **Problem**: Post-C1e: MD `dlmm_bin_publish_exec_hot` ~7k+, aber Arb `sell_missing_dlmm_bins` dominant (~876/3.3k screens). `check_arbitrage_v2` nutzte `ApplyTrade`-Snapshot (`bin_arrays`) aus dem Writer-Thread; BinArrayUpdate landete oft erst danach im globalen Cache → `dlmm_bins.is_none()` trotz publizierter Bins. Zusätzlich: pinned DLMM-BinArrayUpdates ohne `known_pools`-Eintrag → LOW-Priority-Coalescer.  

--- a/src/arbitrage/pool_quote.rs
+++ b/src/arbitrage/pool_quote.rs
@@ -2415,6 +2415,63 @@ mod tests {
     }
 
     #[test]
+    fn dlmm_sell_quote_with_zero_liquidity_active_bin_uses_adjacent_bins() {
+        let active_id = 5i32;
+        let bin_step = 100u16;
+        let token_amount = 1_000_000_000u64;
+        let sol_amount = 500_000_000u64;
+        let array_index = 0i64;
+        let mut bins: DlmmBinArrays = HashMap::new();
+        bins.insert(
+            array_index,
+            vec![
+                BinData {
+                    offset: active_id as u8,
+                    amount_x: 0,
+                    amount_y: 0,
+                },
+                BinData {
+                    offset: 4,
+                    amount_x: token_amount,
+                    amount_y: sol_amount,
+                },
+            ],
+        );
+        let pool = sample_pool("meteora_dlmm", "dlmm");
+        let vault = QuoteVaultInput {
+            reserve_base: token_amount,
+            reserve_quote: sol_amount,
+            update_slot: 1,
+            updated_at: Instant::now(),
+            active_id: Some(active_id),
+            bin_step: Some(bin_step),
+            dlmm_sol_is_x: false,
+            dlmm_token_x_mint: Some(pool.token_mint.clone()),
+        };
+        let failure = classify_cross_dex_sell_failure(
+            &RoundTripPoolCandidate {
+                pool: &pool,
+                vault: Some(&vault),
+                dlmm_bins: Some(&bins),
+                dex: "meteora_dlmm",
+            },
+            1_000_000,
+            &QuoteFreshnessConfig::default(),
+            Instant::now(),
+            6,
+        );
+        assert!(
+            failure.is_none()
+                || failure
+                    != Some(CrossDexSellFailure::QuoteNone(
+                        SellQuoteNoneDetailReason::DlmmActiveBinMissing
+                    )),
+            "zero-liquidity active bin present must not yield DlmmActiveBinMissing: {:?}",
+            failure
+        );
+    }
+
+    #[test]
     fn dlmm_sell_large_token_amount_succeeds_without_marginal_probe_gate() {
         let active_id = 0i32;
         let bin_step = 100u16;

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -36,10 +36,9 @@ use uuid::Uuid;
 
 use ironcrab::config::{Config, MarketDataGeyserCfg, WalletTrackerCfg};
 use ironcrab::ipc::{
-    BinData, ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, ControlRequest,
-    ControlRequestKind, DexPoolReadiness, ExecutionResult, ExecutionStatus, IntentTier,
-    MarketEvent, MarketEventKind, PoolCacheUpdate, NATIVE_SOL_MINT,
-    POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
+    ConfigUpdate, ConfigUpdateResponse, ConfigUpdateStatus, ControlRequest, ControlRequestKind,
+    DexPoolReadiness, ExecutionResult, ExecutionStatus, IntentTier, MarketEvent, MarketEventKind,
+    PoolCacheUpdate, NATIVE_SOL_MINT, POOL_CACHE_UPDATE_RAYDIUM_CPMM_VAULTS_KEY,
 };
 use ironcrab::market_data::cold::{
     cold_path_rpc_refresh_meteora_cpmm_pool_row, cold_path_rpc_refresh_meteora_dlmm_pool_row,
@@ -676,6 +675,21 @@ impl SidefxWorkerHost for MarketDataSidefxHost {
             );
         }
         changed
+    }
+
+    fn maybe_retry_deferred_hot_pool_reserves_on_cache_fill(&self, pool: &Pubkey) {
+        if self
+            .ctx
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(pool)
+        {
+            ironcrab::metrics::inc_market_data_deferred_retry_pool_state_fill_total();
+            let _ = track_worker_try_enqueue(
+                &self.track_worker,
+                TrackWorkerCommand::RetryDeferredHotPoolReserves,
+            );
+        }
     }
 }
 
@@ -2500,6 +2514,13 @@ impl IngestHost for MarketDataContext {
 
     fn ingest_record_enrichment_relevance_hit(&self) {
         ironcrab::metrics::inc_market_data_account_relevance_enrichment_hit_total();
+    }
+
+    fn ingest_pool_dlmm_active_id(&self, pool: &Pubkey) -> Option<i32> {
+        match self.live_pool_cache.get(pool)? {
+            CachedPoolState::Meteora(s) => Some(s.active_id),
+            _ => None,
+        }
     }
 }
 
@@ -4780,25 +4801,32 @@ impl MarketDataContext {
             return;
         }
         let run_id = self.run_id.clone();
+        let replay_active_ids: Vec<Option<i32>> = replay_rows
+            .iter()
+            .map(
+                |(_, _, view)| match self.live_pool_cache.get(&view.pool_address) {
+                    Some(CachedPoolState::Meteora(s)) => Some(s.active_id),
+                    _ => None,
+                },
+            )
+            .collect();
         let publish = async move {
+            use ironcrab::market_data::ingest::filter_dlmm_bins_for_publish;
             use ironcrab::market_data::publish::publish_market_event_core_and_momentum_ex;
             use ironcrab::solana::dex::meteora_bin_array_layout::BinArray;
             let mut replay_seq = 0u64;
-            for (_pda, stashed, view) in replay_rows {
+            for ((idx, (_pda, stashed, view)), active_id) in
+                replay_rows.into_iter().enumerate().zip(replay_active_ids)
+            {
+                let _ = idx;
                 replay_seq += 1;
                 match BinArray::parse(&stashed.data, view.bin_step) {
                     Ok(parsed_array) => {
-                        let bins: Vec<BinData> = parsed_array
-                            .bins
-                            .iter()
-                            .enumerate()
-                            .filter(|(_, bin)| bin.amount_x > 0 || bin.amount_y > 0)
-                            .map(|(offset, bin)| BinData {
-                                offset: offset as u8,
-                                amount_x: bin.amount_x,
-                                amount_y: bin.amount_y,
-                            })
-                            .collect();
+                        let bins = filter_dlmm_bins_for_publish(
+                            &parsed_array.bins,
+                            view.bin_array_index,
+                            active_id,
+                        );
                         if bins.is_empty() {
                             ironcrab::metrics::inc_market_data_dlmm_bin_emit_skipped_empty_total();
                             continue;
@@ -5583,18 +5611,25 @@ impl MarketDataContext {
         bins_changed
     }
 
-    /// C1d: when hot-pool DLMM `active_id` drifts, register new bin-array PDAs (Mom + Arb shared).
+    /// C1d/C1g: when hot-pool DLMM `active_id` drifts or bin window is untracked, register PDAs (Mom + Arb shared).
     fn maybe_refresh_hot_dlmm_bin_window(&self, pool: Pubkey, new_active_id: i32) -> bool {
         let Some(pin) = self.geyser_pin_for_hot_dlmm_pool(pool) else {
             return false;
         };
-        let prev = self.dlmm_registered_active_id.read().get(&pool).copied();
-        if prev == Some(new_active_id) {
-            return false;
-        }
-        let Some(CachedPoolState::Meteora(s)) = self.live_pool_cache.get(&pool) else {
+        let Some(state) = self.live_pool_cache.get(&pool) else {
             return false;
         };
+        let CachedPoolState::Meteora(s) = &state else {
+            return false;
+        };
+        let prev = self.dlmm_registered_active_id.read().get(&pool).copied();
+        let bins_untracked = !self.pool_geyser_bins_fully_tracked_for_cache(pool, &state);
+        if prev == Some(new_active_id) && !bins_untracked {
+            return false;
+        }
+        if bins_untracked && prev == Some(new_active_id) {
+            ironcrab::metrics::inc_market_data_dlmm_bin_window_refresh_untracked_total();
+        }
         self.register_meteora_dlmm_bin_arrays(pool, new_active_id, s.bin_step, pin, Instant::now())
     }
 
@@ -21482,6 +21517,26 @@ mod pr_b_geyser_tracking_tests {
         for (_pda, info) in bins.iter().filter(|(_, b)| b.pool_address == pool) {
             assert_eq!(info.pin, Some(GeyserPinReason::MomentumActive));
         }
+    }
+
+    /// C1g: hot DLMM bin window re-registers when tracked arrays miss current active window.
+    #[test]
+    fn scope_c1g_dlmm_bin_window_refreshes_when_untracked() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        ctx.hot_pool_registry.pin_pool(mint, pool);
+        ctx.live_pool_cache
+            .upsert(pool, test_meteora_dlmm_cached_state(800), 1);
+        ctx.dlmm_registered_active_id.write().insert(pool, 800);
+        let before = ctx.tracked_bin_arrays.read().len();
+
+        assert!(ctx.maybe_refresh_hot_dlmm_bin_window(pool, 800));
+        assert!(ctx.tracked_bin_arrays.read().len() >= before);
     }
 
     /// C1e: bin-array Geyser payloads stashed on early-drop replay after membership registration.

--- a/src/market_data/ingest/account_handler.rs
+++ b/src/market_data/ingest/account_handler.rs
@@ -11,7 +11,8 @@ use super::account_parse::{
     wallet_geyser_snapshots_to_publish, wsol_ata_balance_lamports_from_geyser_data,
     WalletGeyserUpdateSource,
 };
-use crate::ipc::{BinData, MarketEvent, MarketEventKind, NATIVE_SOL_MINT};
+use super::dlmm_bin_publish::filter_dlmm_bins_for_publish;
+use crate::ipc::{MarketEvent, MarketEventKind, NATIVE_SOL_MINT};
 use crate::market_data::ingest::AccountUpdateClass;
 use crate::market_data::md_state::MdStateSender;
 use crate::market_data::publish::{
@@ -77,17 +78,12 @@ pub async fn publish_meteora_dlmm_bin_array_from_geyser<H: AccountIngestHost>(
     }
     match BinArray::parse(&account_update.data, bin_array_info.bin_step) {
         Ok(parsed_array) => {
-            let bins: Vec<BinData> = parsed_array
-                .bins
-                .iter()
-                .enumerate()
-                .filter(|(_, bin)| bin.amount_x > 0 || bin.amount_y > 0)
-                .map(|(offset, bin)| BinData {
-                    offset: offset as u8,
-                    amount_x: bin.amount_x,
-                    amount_y: bin.amount_y,
-                })
-                .collect();
+            let active_id = host.ingest_pool_dlmm_active_id(&bin_array_info.pool_address);
+            let bins = filter_dlmm_bins_for_publish(
+                &parsed_array.bins,
+                bin_array_info.bin_array_index,
+                active_id,
+            );
 
             if bins.is_empty() {
                 inc_market_data_dlmm_bin_emit_skipped_empty_total();

--- a/src/market_data/ingest/dlmm_bin_publish.rs
+++ b/src/market_data/ingest/dlmm_bin_publish.rs
@@ -1,0 +1,113 @@
+//! DLMM bin-array publish filtering (C1g: active-bin touch policy).
+//! STOP-CHECK: no RPC; Geyser-only publish shaping.
+
+use crate::ipc::BinData;
+use crate::metrics::inc_market_data_dlmm_bin_emit_active_zero_touch_total;
+use crate::solana::dex::meteora_bin_array_layout::Bin;
+
+/// Bins per Meteora DLMM array (must match `BinArray::BINS_PER_ARRAY` and quote flatten).
+pub const DLMM_BINS_PER_ARRAY: i64 = 70;
+
+/// Offset of `active_id` within `bin_array_index`, if the active bin lies in this array.
+pub fn active_bin_offset_in_array(active_id: i32, bin_array_index: i64) -> Option<u8> {
+    let base = bin_array_index * DLMM_BINS_PER_ARRAY;
+    let offset = i64::from(active_id) - base;
+    if (0..DLMM_BINS_PER_ARRAY).contains(&offset) {
+        Some(offset as u8)
+    } else {
+        None
+    }
+}
+
+/// Filter parsed bins for publish: non-zero liquidity only, but always retain the active bin
+/// (even zero-liquidity) so arb/momentum quotes can walk adjacent bins (C1g H2).
+pub fn filter_dlmm_bins_for_publish(
+    parsed_bins: &[Bin],
+    bin_array_index: i64,
+    active_id: Option<i32>,
+) -> Vec<BinData> {
+    let mut out: Vec<BinData> = parsed_bins
+        .iter()
+        .enumerate()
+        .filter(|(_, bin)| bin.amount_x > 0 || bin.amount_y > 0)
+        .map(|(offset, bin)| BinData {
+            offset: offset as u8,
+            amount_x: bin.amount_x,
+            amount_y: bin.amount_y,
+        })
+        .collect();
+
+    if let Some(active_id) = active_id {
+        if let Some(active_offset) = active_bin_offset_in_array(active_id, bin_array_index) {
+            let already_present = out.iter().any(|b| b.offset == active_offset);
+            if !already_present {
+                let idx = active_offset as usize;
+                if let Some(bin) = parsed_bins.get(idx) {
+                    out.push(BinData {
+                        offset: active_offset,
+                        amount_x: bin.amount_x,
+                        amount_y: bin.amount_y,
+                    });
+                    out.sort_by_key(|b| b.offset);
+                    inc_market_data_dlmm_bin_emit_active_zero_touch_total();
+                }
+            }
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_bins() -> Vec<Bin> {
+        (0..DLMM_BINS_PER_ARRAY as usize)
+            .map(|_| Bin {
+                amount_x: 0,
+                amount_y: 0,
+                price: 0.0,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn active_bin_offset_in_array_positive_and_negative() {
+        assert_eq!(active_bin_offset_in_array(0, 0), Some(0));
+        assert_eq!(active_bin_offset_in_array(69, 0), Some(69));
+        assert_eq!(active_bin_offset_in_array(70, 1), Some(0));
+        assert_eq!(active_bin_offset_in_array(-1, -1), Some(69));
+        assert_eq!(active_bin_offset_in_array(100, 0), None);
+    }
+
+    #[test]
+    fn filter_includes_zero_liquidity_active_bin() {
+        let mut bins = empty_bins();
+        bins[5].amount_x = 1_000;
+        bins[5].amount_y = 2_000;
+        let active_id = 5i32;
+        let filtered = filter_dlmm_bins_for_publish(&bins, 0, Some(active_id));
+        assert!(filtered
+            .iter()
+            .any(|b| b.offset == 5 && b.amount_x == 1_000));
+    }
+
+    #[test]
+    fn filter_touches_empty_active_bin_for_quote_walker() {
+        let bins = empty_bins();
+        let active_id = 10i32;
+        let filtered = filter_dlmm_bins_for_publish(&bins, 0, Some(active_id));
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].offset, 10);
+        assert_eq!(filtered[0].amount_x, 0);
+        assert_eq!(filtered[0].amount_y, 0);
+    }
+
+    #[test]
+    fn filter_skips_active_touch_when_active_not_in_array() {
+        let bins = empty_bins();
+        let filtered = filter_dlmm_bins_for_publish(&bins, 0, Some(200));
+        assert!(filtered.is_empty());
+    }
+}

--- a/src/market_data/ingest/host.rs
+++ b/src/market_data/ingest/host.rs
@@ -50,4 +50,10 @@ pub trait IngestHost: Send + Sync {
     fn ingest_record_vault_high_priority_dispatch(&self);
 
     fn ingest_record_enrichment_relevance_hit(&self);
+
+    /// Cached Meteora DLMM `active_id` for publish shaping (Geyser-only; no RPC).
+    fn ingest_pool_dlmm_active_id(&self, pool: &Pubkey) -> Option<i32> {
+        let _ = pool;
+        None
+    }
 }

--- a/src/market_data/ingest/mod.rs
+++ b/src/market_data/ingest/mod.rs
@@ -2,6 +2,7 @@ pub mod account_filter;
 pub mod account_handler;
 pub mod account_host;
 pub mod account_parse;
+pub mod dlmm_bin_publish;
 pub mod host;
 pub mod tx_filter;
 pub mod tx_handler;
@@ -25,6 +26,7 @@ pub use account_parse::{
     wsol_ata_balance_lamports_from_geyser_data, WalletGeyserSnapshotMint,
     WalletGeyserSnapshotToPublish, WalletGeyserUpdateSource,
 };
+pub use dlmm_bin_publish::{active_bin_offset_in_array, filter_dlmm_bins_for_publish};
 pub use host::IngestHost;
 pub use tx_filter::geyser_tx_involves_wallet;
 pub use tx_handler::handle_geyser_transaction_update;

--- a/src/market_data/sidefx/handlers.rs
+++ b/src/market_data/sidefx/handlers.rs
@@ -1406,11 +1406,19 @@ pub fn md_sidefx_process_live_pool_cache_account_update(
             if meta_changed && host.is_hot_pool(pool_pubkey) {
                 scratch.note_dlmm_pool_state_signal(*pool_pubkey, run_id, *slot, *grpc_recv_at);
             }
-            if let Some((prev_id, _)) = prev_meteora_meta {
-                if prev_id != s.active_id {
+            if host.is_hot_pool(pool_pubkey) {
+                let should_refresh = match prev_meteora_meta {
+                    None => true,
+                    Some((prev_id, _)) => prev_id != s.active_id,
+                };
+                if should_refresh {
                     let _ = host.maybe_refresh_arb_dlmm_bin_window(*pool_pubkey, s.active_id);
                 }
             }
+        }
+
+        if host.is_hot_pool(pool_pubkey) {
+            host.maybe_retry_deferred_hot_pool_reserves_on_cache_fill(pool_pubkey);
         }
 
         // Phase1: sidefx only updates MASTER cache + JetStream; vault registration stays in md-state.

--- a/src/market_data/sidefx/host.rs
+++ b/src/market_data/sidefx/host.rs
@@ -84,8 +84,11 @@ pub trait SidefxWorkerHost: Send + Sync {
     /// True when vault/bin pubkeys for this pool were included in the last Geyser sync flush.
     fn pool_has_live_vault_geyser_feed(&self, pool: Pubkey) -> bool;
 
-    /// Re-register DLMM bin-array window when hot-pool `active_id` drifts (Mom + Arb, C1d).
+    /// Re-register DLMM bin-array window when hot-pool `active_id` drifts (Mom + Arb, C1d/C1g).
     fn maybe_refresh_arb_dlmm_bin_window(&self, pool: Pubkey, new_active_id: i32) -> bool;
+
+    /// C1g: enqueue deferred vault/bin registration retry after LivePoolCache gains layout.
+    fn maybe_retry_deferred_hot_pool_reserves_on_cache_fill(&self, pool: &Pubkey);
 }
 
 #[inline]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -414,6 +414,15 @@ pub static MARKET_DATA_DLMM_BIN_PARSE_FAIL_TOTAL: Lazy<AtomicU64> = Lazy::new(||
 /// DLMM bin-array emit skipped: parsed but no non-zero liquidity bins.
 pub static MARKET_DATA_DLMM_BIN_EMIT_SKIPPED_EMPTY_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// DLMM bin-array publish: zero-liquidity active bin retained for quote walker (C1g).
+pub static MARKET_DATA_DLMM_BIN_EMIT_ACTIVE_ZERO_TOUCH_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// DLMM hot-pool bin window re-registered because expected arrays were untracked (C1g).
+pub static MARKET_DATA_DLMM_BIN_WINDOW_REFRESH_UNTRACKED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Deferred hot-pool reserve retry enqueued after LivePoolCache fill (C1g).
+pub static MARKET_DATA_DEFERRED_RETRY_POOL_STATE_FILL_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// DLMM bin-array publishes from stashed Geyser replay (post-register / post-sync).
 pub static MARKET_DATA_DLMM_BIN_REPLAY_PUBLISH_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -737,6 +746,21 @@ pub fn inc_market_data_dlmm_bin_parse_fail_total() {
 #[inline]
 pub fn inc_market_data_dlmm_bin_emit_skipped_empty_total() {
     MARKET_DATA_DLMM_BIN_EMIT_SKIPPED_EMPTY_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_dlmm_bin_emit_active_zero_touch_total() {
+    MARKET_DATA_DLMM_BIN_EMIT_ACTIVE_ZERO_TOUCH_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_dlmm_bin_window_refresh_untracked_total() {
+    MARKET_DATA_DLMM_BIN_WINDOW_REFRESH_UNTRACKED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_market_data_deferred_retry_pool_state_fill_total() {
+    MARKET_DATA_DEFERRED_RETRY_POOL_STATE_FILL_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -8044,6 +8068,18 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_dlmm_bin_emit_skipped_empty_total",
         MARKET_DATA_DLMM_BIN_EMIT_SKIPPED_EMPTY_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_dlmm_bin_emit_active_zero_touch_total",
+        MARKET_DATA_DLMM_BIN_EMIT_ACTIVE_ZERO_TOUCH_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_dlmm_bin_window_refresh_untracked_total",
+        MARKET_DATA_DLMM_BIN_WINDOW_REFRESH_UNTRACKED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_deferred_retry_pool_state_fill_total",
+        MARKET_DATA_DEFERRED_RETRY_POOL_STATE_FILL_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "market_data_dlmm_bin_replay_publish_total",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scope C1g addresses dominant post-C1f sell-fail reasons: `dlmm_active_bin_missing` (~3k+) and `sell_missing_vault` (~1.6–2k).

### H2 — Active-bin empty-filter (P0)

MD publish filtered bins with `amount_x/y == 0`, so a zero-liquidity active bin never appeared in `BinArrayUpdate` events. Arb/momentum had bin arrays cached but `active_bin_present` failed.

- New `filter_dlmm_bins_for_publish` retains the active bin even when zero-liquidity (touch policy only — no spam of all empty bins)
- Applied to Geyser publish (`account_handler.rs`) and stash replay (`market_data.rs`)
- `ingest_pool_dlmm_active_id` reads active_id from LivePoolCache (Geyser-only)

### H1 — Bin window drift

- `maybe_refresh_hot_dlmm_bin_window` re-registers when expected bin arrays are untracked, not only when `active_id` changes
- Sidefx: refresh on first hot-pool PoolState + deferred reserve retry enqueue on LivePoolCache fill

### Forensics / tests

- Metrics: `dlmm_bin_emit_active_zero_touch`, `dlmm_bin_window_refresh_untracked`, `deferred_retry_pool_state_fill`
- Unit tests: publish filter, window refresh, quote gate (zero-liquidity active bin ≠ `DlmmActiveBinMissing`)

## Invarianten

- I-4 / I-7: kein Hot-Path RPC
- Dual-Consumer Pin-Priorität unverändert
- C1e stash/replay + C1f live-snapshot/rescreen nicht regressiert

## CI

- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test` ✓

## Deploy

Nicht in diesem PR — User-Freigabe erforderlich.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2708a696-96dc-4660-a03e-4581b3574958?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2708a696-96dc-4660-a03e-4581b3574958&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

