### PR TITLE
fix(arb): C1vault pin vault completeness — publish, retry, consume

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,13 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### FIX-ARB-C1vault: Arb Pin Vault Completeness — Publish + Retry + Consume (post-C1g)
+**Datum**: 2026-08-04  
+**Problem**: Post-#363/C1g: `sell_missing_vault` ~67% sell-fails trotz `arb_tracked_vaults`~310. Root causes: (1) Arb apply ohne `retry_deferred` (Momentum hatte es). (2) Kein cache-first JetStream-Seed für arb-only nach Register (`publish_momentum_*` Mom-only). (3) Arb Consume-Gap: kein LivePoolCache-Vault-Seed beim v2-Screen und kein Rescreen auf `PoolStateUpdate`.  
+**Fix**: (1) Arb apply + track-worker retry deferred; admit_suppress retry gate + suppress-lift trigger. (2) `publish_hot_pool_balance_refresh_from_cache` Mom+Arb mit force-seed. (3) `try_seed_vault_from_live_cache` + vault rescreen. Forensik: deferred cleared by reason, `arb_pin_vault_published_total`, `arb_vault_*`. **Invarianten**: I-4/I-7 kein RPC.  
+**Evidence**: `findings_arb_zero_opp_post363_20260804.md`, Prod Tip `586a683`.  
+**Dateien**: `src/bin/market_data.rs`, `src/market_data/track/worker.rs`, `src/bin/arb_strategy.rs`, `src/metrics.rs`, `docs/BUGS_FIXES.md`
+
 ### FIX-ARB-C1g: DLMM Quote Completeness — Active Bin Touch + Window Refresh
 **Datum**: 2026-08-04  
 **Problem**: Post-C1f: `sell_quote_none` / `dlmm_active_bin_missing` dominant (~3k+); `sell_missing_vault` ~1.6–2k. MD publish filtert Bins mit `amount_x/y == 0` — Zero-Liquidity Active-Bin erscheint nie im `BinArrayUpdate` → `active_bin_present` false trotz bin cache hit. Bin-Fenster-Drift: Refresh nur bei `prev_id != active_id`, nicht bei untracked arrays; Deferred-Retry erst auf activity tick nach LivePoolCache-Fill.  

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -77,12 +77,14 @@ use ironcrab::metrics::{
     arb_two_hop_v2_sell_quote_none_detail_inc, inc_arb_dlmm_bin_array_update_applied_total,
     inc_arb_dlmm_bin_array_update_received_total, inc_arb_dlmm_bin_rescreen_scheduled_total,
     inc_arb_pinned_meteora_pool_bin_cache_miss_total, inc_arb_v2_screen_meteora_sell_bin_hit_total,
-    inc_arb_v2_screen_meteora_sell_bin_miss_total, record_arb_heartbeat_phase,
-    record_arb_price_freshness_stale_age_ms, record_arb_proactive_pin_first_publish,
-    record_arb_proactive_track_publish_total, record_arb_quote_pair_slot_delta,
-    record_arb_quote_shadow_round_trip, record_arb_track_publish_skipped_unchanged_total,
-    record_arb_track_removed_total, record_arb_track_requests_messages_total,
-    record_arb_track_requests_publish_chunks_total, record_arb_track_requests_publish_failed_total,
+    inc_arb_v2_screen_meteora_sell_bin_miss_total, inc_arb_vault_balance_applied_total,
+    inc_arb_vault_live_snapshot_seeded_total, inc_arb_vault_rescreen_scheduled_total,
+    record_arb_heartbeat_phase, record_arb_price_freshness_stale_age_ms,
+    record_arb_proactive_pin_first_publish, record_arb_proactive_track_publish_total,
+    record_arb_quote_pair_slot_delta, record_arb_quote_shadow_round_trip,
+    record_arb_track_publish_skipped_unchanged_total, record_arb_track_removed_total,
+    record_arb_track_requests_messages_total, record_arb_track_requests_publish_chunks_total,
+    record_arb_track_requests_publish_failed_total,
     record_arb_track_selection_blocking_join_failed_total,
     record_arb_track_selection_queue_overflow_total, record_arb_track_selection_recompute_total,
     record_arb_writer_lock_wait, serve_metrics, set_arb_pool_cache_apply_batch_size_gauge,
@@ -395,6 +397,51 @@ fn vault_dlmm_sol_is_x(vault: &VaultBalanceCache) -> bool {
         .as_deref()
         .map(|m| m == NATIVE_SOL_MINT)
         .unwrap_or(vault.dlmm_sol_is_x)
+}
+
+/// H3 / C1vault: seed missing vault row from SLAVE LivePoolCache (Geyser-only, all SOL-quoted DEXes).
+fn try_seed_vault_from_live_cache(
+    pool_address: &str,
+    live_pool_cache: &SharedLivePoolCache,
+    vault_cache: &mut HashMap<String, VaultBalanceCache>,
+) -> bool {
+    if vault_cache.contains_key(pool_address) {
+        return false;
+    }
+    let Ok(pool_pk) = Pubkey::from_str(pool_address) else {
+        return false;
+    };
+    let Some((state, slot, age_ms)) = live_pool_cache.get_with_metadata(&pool_pk) else {
+        return false;
+    };
+    let Some(warmup) = arb_warmup_pool_seed(&state) else {
+        return false;
+    };
+    if warmup.quote_kind != ArbWarmupQuoteKind::Sol {
+        return false;
+    }
+    let cache_updated_at = Instant::now()
+        .checked_sub(Duration::from_millis(age_ms))
+        .unwrap_or_else(Instant::now);
+    let dlmm_token_x_mint = match &state {
+        CachedPoolState::Meteora(s) => Some(s.token_x_mint.to_string()),
+        _ => None,
+    };
+    let dlmm_sol_is_x = dlmm_token_x_mint.as_deref() == Some(NATIVE_SOL_MINT);
+    vault_cache.insert(
+        pool_address.to_string(),
+        VaultBalanceCache {
+            reserve_base: warmup.reserve_base,
+            reserve_quote: warmup.reserve_quote,
+            update_slot: slot,
+            active_id: warmup.active_id,
+            bin_step: warmup.bin_step,
+            updated_at: cache_updated_at,
+            dlmm_sol_is_x,
+            dlmm_token_x_mint,
+        },
+    );
+    true
 }
 
 /// H3: seed missing DLMM vault row from SLAVE cache on BinArrayUpdate (Geyser-only).
@@ -5442,6 +5489,12 @@ impl ArbContext {
         for mint in &mints_with_pool {
             self.arb_track_selection.mark_dirty(mint);
         }
+        if is_new {
+            inc_arb_vault_balance_applied_total();
+        }
+        if !mints_with_pool.is_empty() {
+            self.schedule_arb_vault_rescreen_for_mints(pool_address, &mints_with_pool);
+        }
     }
 
     /// Handle BinArrayUpdate event - cache Meteora DLMM bin arrays from Geyser
@@ -5869,6 +5922,12 @@ impl ArbContext {
         for pool_key in &pool_keys {
             if let Some(entry) = vaults.get(pool_key) {
                 vault_balances.insert(pool_key.clone(), entry.clone());
+            } else if try_seed_vault_from_live_cache(
+                pool_key,
+                &self.live_pool_cache,
+                &mut vault_balances,
+            ) {
+                inc_arb_vault_live_snapshot_seeded_total();
             }
         }
         drop(vaults);
@@ -5946,6 +6005,39 @@ impl ArbContext {
                     mint = %mint,
                     pool = %pool_address,
                     "arb two-hop rescreen queue full; dropping bin-update rescreen"
+                );
+            }
+        }
+    }
+
+    /// Re-screen selected mints when vault balances arrive after the last trade-driven screen (C1vault).
+    fn schedule_arb_vault_rescreen_for_mints(&self, pool_address: &str, mints: &[String]) {
+        if mints.is_empty() || !self.config.read().two_hop_enabled {
+            return;
+        }
+        let selected = self.arb_selected_mints.read();
+        let trackers = self.trackers.read();
+        for mint in mints {
+            if !selected.contains(mint) {
+                continue;
+            }
+            let Some(tracker) = trackers.get(mint) else {
+                continue;
+            };
+            if !tracker.pools.contains_key(pool_address) {
+                continue;
+            }
+            if self
+                .two_hop_tx
+                .try_send(ArbTwoHopWorkerJob::Rescreen { mint: mint.clone() })
+                .is_ok()
+            {
+                inc_arb_vault_rescreen_scheduled_total();
+            } else {
+                debug!(
+                    mint = %mint,
+                    pool = %pool_address,
+                    "arb two-hop rescreen queue full; dropping vault-update rescreen"
                 );
             }
         }
@@ -9763,6 +9855,48 @@ mod two_hop_price_tests {
             bins_after.contains_key(dlmm_pool),
             "live scoped snapshot must include bins written by BinArrayUpdate"
         );
+    }
+
+    #[test]
+    fn scoped_snapshot_seeds_missing_vault_from_live_cache() {
+        use ironcrab::metrics::ARB_VAULT_LIVE_SNAPSHOT_SEEDED_TOTAL;
+        use std::sync::atomic::Ordering;
+
+        let cache = create_shared_cache();
+        let pool_pk = Pubkey::new_unique();
+        let token_mint = Pubkey::new_unique();
+        let sol = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        cache.upsert(
+            pool_pk,
+            CachedPoolState::Meteora(MeteoraState {
+                token_x_mint: token_mint,
+                token_y_mint: sol,
+                reserve_x: Pubkey::new_unique(),
+                reserve_y: Pubkey::new_unique(),
+                active_id: 10,
+                bin_step: 20,
+                reserve_x_balance: Some(500_000),
+                reserve_y_balance: Some(1_500_000_000),
+            }),
+            5,
+        );
+        let ctx = test_arb_context(cache);
+        let mint = "TokenMintScopedVaultSnap111111111111111111";
+        let pool_addr = pool_pk.to_string();
+        {
+            let mut trackers = ctx.trackers.write();
+            let mut tracker = TokenArbTracker::new(mint);
+            tracker.upsert_pool(sample_pool("meteora_dlmm", &pool_addr, None, None));
+            trackers.insert(mint.to_string(), tracker);
+        }
+        let tracker = ctx.trackers.read().get(mint).unwrap().clone();
+        let seeded_before = ARB_VAULT_LIVE_SNAPSHOT_SEEDED_TOTAL.load(Ordering::Relaxed);
+        let (vaults, _) = ctx.snapshot_vault_bins_for_tracker(&tracker);
+        assert!(
+            vaults.contains_key(&pool_addr),
+            "snapshot must seed vault from SLAVE cache when vault_balances empty"
+        );
+        assert!(ARB_VAULT_LIVE_SNAPSHOT_SEEDED_TOTAL.load(Ordering::Relaxed) > seeded_before);
     }
 
     #[test]

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -107,10 +107,12 @@ use ironcrab::metrics::{
     inc_market_data_account_low_priority_queue_depth,
     inc_market_data_account_recv_iterations_total, inc_market_data_account_updates_total,
     inc_market_data_account_worker_queue_depth, inc_market_data_arb_admission_admitted_total,
-    inc_market_data_arb_admission_rejected_total, inc_market_data_arb_pin_deferred_cleared_total,
+    inc_market_data_arb_admission_rejected_total,
+    inc_market_data_arb_pin_deferred_cleared_by_reason_total,
+    inc_market_data_arb_pin_deferred_cleared_total,
     inc_market_data_arb_pin_deferred_still_unsatisfied_total,
     inc_market_data_arb_pin_geyser_register_deferred_total,
-    inc_market_data_arb_pin_vault_register_ok_total,
+    inc_market_data_arb_pin_vault_published_total, inc_market_data_arb_pin_vault_register_ok_total,
     inc_market_data_balance_updated_from_cache_total,
     inc_market_data_dlmm_bin_early_drop_stashed_total, inc_market_data_dlmm_bin_register_ok_total,
     inc_market_data_exec_hot_hard_shed_steps_for_tier_reason,
@@ -1325,8 +1327,8 @@ struct MarketDataContext {
     dlmm_registered_active_id: parking_lot::RwLock<HashMap<Pubkey, i32>>,
     /// C1e: bin-array Geyser payloads stashed on early-drop before membership registration.
     dlmm_bin_geyser_stash: parking_lot::RwLock<HashMap<Pubkey, StashedDlmmBinGeyserUpdate>>,
-    /// Scope C: hot pools awaiting LivePoolCache layout for vault/bin Geyser registration.
-    deferred_hot_pool_reserve_pins: parking_lot::RwLock<HashMap<Pubkey, GeyserPinReason>>,
+    /// Scope C / C1vault: hot pools awaiting LivePoolCache layout or admit for vault/bin Geyser registration.
+    deferred_hot_pool_reserve_pins: parking_lot::RwLock<HashMap<Pubkey, DeferredHotPoolReserve>>,
     /// Open-position PumpFun pools with unsatisfied bonding-curve Geyser registration (observability).
     open_position_pumpfun_registration_unsatisfied_since:
         parking_lot::RwLock<HashMap<Pubkey, Instant>>,
@@ -1338,6 +1340,13 @@ struct MarketDataContext {
     geyser_explicit_config_error: parking_lot::RwLock<Option<String>>,
     /// Resume cursor for budgeted prune across `ContinueGeyserEvict` slices.
     geyser_prune_resume: parking_lot::Mutex<GeyserPruneResume>,
+}
+
+/// Deferred Geyser reserve registration for a hot pool (pin tier + original defer reason).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DeferredHotPoolReserve {
+    pin: GeyserPinReason,
+    reason: &'static str,
 }
 
 /// Max removals per budget slice when pruning tracked maps to admitted set.
@@ -4583,11 +4592,21 @@ impl MarketDataContext {
             && !self.hot_pool_registry.pool_has_momentum(pool)
     }
 
-    /// JetStream refresh from MASTER cache for momentum-hot pools (cache-first, no RPC).
-    fn publish_momentum_hot_balance_refresh_from_cache(&self, pool: Pubkey) {
-        if self.hot_pool_registry.pool_has_momentum(pool) {
-            self.try_publish_balance_updated_from_cache(pool);
+    /// JetStream refresh from MASTER cache for momentum-hot / arb-pinned pools (cache-first, no RPC).
+    fn publish_hot_pool_balance_refresh_from_cache(&self, pool: Pubkey) {
+        let is_momentum = self.hot_pool_registry.pool_has_momentum(pool);
+        let is_arb = self.hot_pool_registry.pool_has_arb(pool);
+        if !is_momentum && !is_arb {
+            return;
         }
+        // Arb-only: force cache seed so SLAVE vault_balances populate before first Geyser vault tick.
+        let force_arb_seed = is_arb && !is_momentum;
+        self.try_publish_balance_updated_from_cache(pool, force_arb_seed);
+    }
+
+    /// Back-compat alias for momentum-only call sites.
+    fn publish_momentum_hot_balance_refresh_from_cache(&self, pool: Pubkey) {
+        self.publish_hot_pool_balance_refresh_from_cache(pool);
     }
 
     /// Periodic heartbeat for momentum-hot pins: sustain SLAVE `LivePoolCache` age during WaitHotSet.
@@ -4601,7 +4620,7 @@ impl MarketDataContext {
         }
         for pool in self.hot_pool_registry.snapshot_hot_pool_pubkeys() {
             if self.hot_pool_registry.pool_has_momentum(pool) {
-                self.try_publish_balance_updated_from_cache(pool);
+                self.try_publish_balance_updated_from_cache(pool, false);
             }
         }
         let batch_dirty = self.remediate_open_position_pumpfun_registration(admission);
@@ -4623,6 +4642,7 @@ impl MarketDataContext {
                 self.note_deferred_hot_pool_reserve_registration(
                     pool,
                     GeyserPinReason::MomentumActive,
+                    "live_pool_cache_miss",
                 );
                 inc_market_data_open_position_pumpfun_remediate_still_unsatisfied_total();
                 continue;
@@ -4642,6 +4662,7 @@ impl MarketDataContext {
                 self.note_deferred_hot_pool_reserve_registration(
                     pool,
                     GeyserPinReason::MomentumActive,
+                    "live_pool_cache_miss",
                 );
                 inc_market_data_open_position_pumpfun_remediate_admit_fail_total();
                 continue;
@@ -4666,6 +4687,7 @@ impl MarketDataContext {
                 self.note_deferred_hot_pool_reserve_registration(
                     pool,
                     GeyserPinReason::MomentumActive,
+                    "live_pool_cache_miss",
                 );
                 inc_market_data_open_position_pumpfun_remediate_still_unsatisfied_total();
             }
@@ -4742,7 +4764,7 @@ impl MarketDataContext {
                 .iter()
                 .any(|pk| !prev_synced.contains(pk) && synced.contains(pk));
             if newly_live {
-                self.try_publish_balance_updated_from_cache(pool);
+                self.try_publish_balance_updated_from_cache(pool, false);
             }
         }
     }
@@ -4888,8 +4910,8 @@ impl MarketDataContext {
     }
 
     /// Cache-first JetStream BalanceUpdated for pools with fresh reserve basis (no vault Geyser sub required).
-    fn try_publish_balance_updated_from_cache(&self, pool: Pubkey) {
-        if self.balance_updated_from_cache_skipped_for_live_feed(pool) {
+    fn try_publish_balance_updated_from_cache(&self, pool: Pubkey, force_arb_seed: bool) {
+        if !force_arb_seed && self.balance_updated_from_cache_skipped_for_live_feed(pool) {
             return;
         }
         let Some(state) = self.live_pool_cache.get(&pool) else {
@@ -4973,16 +4995,22 @@ impl MarketDataContext {
         };
         if let Some(handle) = self.ingest_tokio_handle.read().clone() {
             inc_market_data_balance_updated_from_cache_total();
+            if force_arb_seed && self.hot_pool_registry.pool_has_arb(pool) {
+                inc_market_data_arb_pin_vault_published_total();
+            }
             handle.spawn(publish);
         } else if let Ok(handle) = tokio::runtime::Handle::try_current() {
             inc_market_data_balance_updated_from_cache_total();
+            if force_arb_seed && self.hot_pool_registry.pool_has_arb(pool) {
+                inc_market_data_arb_pin_vault_published_total();
+            }
             handle.spawn(publish);
         }
     }
 
     /// PR-B: after a parsed swap trade — cache-first BalanceUpdated; vault/bin registration only for hot pools.
     fn register_geyser_reserves_after_trade(&self, pool: Pubkey) -> bool {
-        self.try_publish_balance_updated_from_cache(pool);
+        self.try_publish_balance_updated_from_cache(pool, false);
         if !self.hot_pool_registry.pool_has_momentum(pool) {
             return false;
         }
@@ -5160,7 +5188,7 @@ impl MarketDataContext {
     /// PR169a: register vault ATAs from MASTER cache after account-path pool upsert (hot pools only).
     #[cfg_attr(not(test), allow(dead_code))]
     fn register_pool_vaults_from_account(&self, pool: Pubkey) -> bool {
-        self.try_publish_balance_updated_from_cache(pool);
+        self.try_publish_balance_updated_from_cache(pool, false);
         if !self.hot_pool_registry.is_hot_pool(pool) {
             return false;
         }
@@ -5374,20 +5402,26 @@ impl MarketDataContext {
     }
 
     fn clear_arb_pin_deferred_with_metric(&self, pool: Pubkey) {
-        if let Some(pin) = self.deferred_hot_pool_reserve_pins.write().remove(&pool) {
-            if pin == GeyserPinReason::ArbMultiDex {
+        if let Some(entry) = self.deferred_hot_pool_reserve_pins.write().remove(&pool) {
+            if entry.pin == GeyserPinReason::ArbMultiDex {
                 inc_market_data_arb_pin_deferred_cleared_total();
+                inc_market_data_arb_pin_deferred_cleared_by_reason_total(entry.reason);
             }
         }
     }
 
-    fn note_deferred_hot_pool_reserve_registration(&self, pool: Pubkey, pin: GeyserPinReason) {
+    fn note_deferred_hot_pool_reserve_registration(
+        &self,
+        pool: Pubkey,
+        pin: GeyserPinReason,
+        reason: &'static str,
+    ) {
         if !self.hot_pool_registry.is_hot_pool(pool) {
             return;
         }
         self.deferred_hot_pool_reserve_pins
             .write()
-            .insert(pool, pin);
+            .insert(pool, DeferredHotPoolReserve { pin, reason });
     }
 
     fn clear_deferred_hot_pool_reserve_registration(&self, pool: Pubkey) {
@@ -5419,19 +5453,29 @@ impl MarketDataContext {
             inc_market_data_arb_pin_vault_register_ok_total();
             self.clear_arb_pin_deferred_with_metric(pool);
             self.refresh_arb_tracked_vaults_gauge();
+            self.publish_hot_pool_balance_refresh_from_cache(pool);
             return;
         }
         if self.live_pool_cache.get(&pool).is_none() {
-            self.note_deferred_hot_pool_reserve_registration(pool, GeyserPinReason::ArbMultiDex);
+            self.note_deferred_hot_pool_reserve_registration(
+                pool,
+                GeyserPinReason::ArbMultiDex,
+                "live_pool_cache_miss",
+            );
             self.log_arb_pin_deferred_throttled(pool, "live_pool_cache_miss");
             return;
         }
         if self.hot_pool_reserve_registration_satisfied(pool) {
             self.clear_arb_pin_deferred_with_metric(pool);
             self.refresh_arb_tracked_vaults_gauge();
+            self.publish_hot_pool_balance_refresh_from_cache(pool);
             return;
         }
-        self.note_deferred_hot_pool_reserve_registration(pool, GeyserPinReason::ArbMultiDex);
+        self.note_deferred_hot_pool_reserve_registration(
+            pool,
+            GeyserPinReason::ArbMultiDex,
+            "vault_register_no_change",
+        );
         self.log_arb_pin_deferred_throttled(pool, "vault_register_no_change");
     }
 
@@ -5440,19 +5484,27 @@ impl MarketDataContext {
         &self,
         admission: &mut FixedCapAdmission,
     ) -> bool {
-        let pending: Vec<(Pubkey, GeyserPinReason)> = self
+        let pending: Vec<(Pubkey, DeferredHotPoolReserve)> = self
             .deferred_hot_pool_reserve_pins
             .read()
             .iter()
-            .map(|(pool, pin)| (*pool, *pin))
+            .map(|(pool, entry)| (*pool, *entry))
             .collect();
         if pending.is_empty() {
             return false;
         }
         let mut batch_dirty = false;
-        for (pool, pin) in pending {
+        for (pool, entry) in pending {
+            let pin = entry.pin;
             if !self.hot_pool_registry.is_hot_pool(pool) {
                 self.clear_deferred_hot_pool_reserve_registration(pool);
+                continue;
+            }
+            if pin == GeyserPinReason::ArbMultiDex
+                && market_data_exec_hot_arb_admit_suppress()
+                && !self.arb_pool_is_must_hot(pool)
+            {
+                inc_market_data_arb_pin_deferred_still_unsatisfied_total("admit_suppress");
                 continue;
             }
             if self.live_pool_cache.get(&pool).is_none() {
@@ -5487,7 +5539,7 @@ impl MarketDataContext {
                 if self.hot_pool_registry.is_position_pin_for_pool(pool) {
                     inc_market_data_open_position_pin_applied_total();
                 }
-                self.publish_momentum_hot_balance_refresh_from_cache(pool);
+                self.publish_hot_pool_balance_refresh_from_cache(pool);
                 if changed {
                     batch_dirty = true;
                 }
@@ -5523,7 +5575,7 @@ impl MarketDataContext {
             ironcrab::metrics::inc_market_data_momentum_pin_vault_register_total(
                 ironcrab::metrics::MomentumPinVaultRegisterResult::CacheMiss,
             );
-            self.note_deferred_hot_pool_reserve_registration(pool, pin);
+            self.note_deferred_hot_pool_reserve_registration(pool, pin, "live_pool_cache_miss");
             if is_position {
                 inc_market_data_open_position_pin_deferred_cache_miss_total();
             }
@@ -5540,7 +5592,7 @@ impl MarketDataContext {
         ironcrab::metrics::inc_market_data_momentum_pin_vault_register_total(
             ironcrab::metrics::MomentumPinVaultRegisterResult::Deferred,
         );
-        self.note_deferred_hot_pool_reserve_registration(pool, pin);
+        self.note_deferred_hot_pool_reserve_registration(pool, pin, "vault_register_no_change");
     }
 
     fn register_meteora_dlmm_bin_arrays(
@@ -6025,6 +6077,7 @@ impl MarketDataContext {
         }
         batch_dirty |= self.apply_arb_removed_entries(admission, &update.removed);
         batch_dirty |= self.apply_arb_active_entries(admission, &update.active);
+        batch_dirty |= self.retry_deferred_hot_pool_reserve_registrations(admission);
         if !batch_dirty {
             self.refresh_geyser_pins_gauge();
         }
@@ -6103,6 +6156,7 @@ impl MarketDataContext {
                 self.note_deferred_hot_pool_reserve_registration(
                     pool_pk,
                     GeyserPinReason::ArbMultiDex,
+                    "admit_suppress",
                 );
                 self.log_arb_pin_deferred_throttled(pool_pk, "admit_suppress");
                 self.sync_explicit_pool_admitted_from_admission(
@@ -9035,6 +9089,7 @@ fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
         let mut lag_alarm = false;
         let mut lag_clear_ticks = 0u32;
         let mut last_enqueued_tier: Option<ExecHotShedTier> = None;
+        let mut prev_arb_admit_suppress = market_data_exec_hot_arb_admit_suppress();
         let mut interval = tokio::time::interval(EXEC_HOT_SHED_CONTROLLER_INTERVAL);
         loop {
             interval.tick().await;
@@ -9139,6 +9194,13 @@ fn spawn_exec_hot_pressure_shed_controller(track_worker: TrackWorkerSender) {
                 momentum_admit_suppress,
                 arb_admit_suppress,
             );
+            if prev_arb_admit_suppress && !arb_admit_suppress {
+                let _ = track_worker_try_enqueue(
+                    &track_worker,
+                    TrackWorkerCommand::RetryDeferredHotPoolReserves,
+                );
+            }
+            prev_arb_admit_suppress = arb_admit_suppress;
 
             if soft_shed {
                 soft_shed_samples = soft_shed_samples.saturating_add(1);
@@ -13691,7 +13753,7 @@ mod pr_b_geyser_tracking_tests {
         ctx.hot_pool_registry.pin_pool(mint, pool);
 
         let counter_before = MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.load(Ordering::Relaxed);
-        ctx.try_publish_balance_updated_from_cache(pool);
+        ctx.try_publish_balance_updated_from_cache(pool, false);
         assert_eq!(
             MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.load(Ordering::Relaxed),
             counter_before,
@@ -15064,9 +15126,13 @@ mod pr_b_geyser_tracking_tests {
         }
         assert!(ctx.pool_vaults_fully_tracked_for_cache(pool, &state));
 
-        ctx.deferred_hot_pool_reserve_pins
-            .write()
-            .insert(pool, GeyserPinReason::MomentumActive);
+        ctx.deferred_hot_pool_reserve_pins.write().insert(
+            pool,
+            DeferredHotPoolReserve {
+                pin: GeyserPinReason::MomentumActive,
+                reason: "vault_register_no_change",
+            },
+        );
 
         let mut admission = test_admission_for(&ctx);
         ctx.retry_deferred_hot_pool_reserve_registrations(&mut admission);
@@ -15397,9 +15463,13 @@ mod pr_b_geyser_tracking_tests {
             );
         }
         assert!(ctx.pool_vaults_fully_tracked_for_cache(pool, &state));
-        ctx.deferred_hot_pool_reserve_pins
-            .write()
-            .insert(pool, GeyserPinReason::MomentumActive);
+        ctx.deferred_hot_pool_reserve_pins.write().insert(
+            pool,
+            DeferredHotPoolReserve {
+                pin: GeyserPinReason::MomentumActive,
+                reason: "vault_register_no_change",
+            },
+        );
 
         let mut admission = FixedCapAdmission::new(0);
         ctx.retry_deferred_hot_pool_reserve_registrations(&mut admission);
@@ -17158,7 +17228,7 @@ mod pr_b_geyser_tracking_tests {
         );
 
         let counter_before = MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.load(Ordering::Relaxed);
-        ctx.try_publish_balance_updated_from_cache(pool);
+        ctx.try_publish_balance_updated_from_cache(pool, false);
         assert_eq!(
             MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.load(Ordering::Relaxed),
             counter_before,
@@ -17336,7 +17406,7 @@ mod pr_b_geyser_tracking_tests {
             !ctx.balance_updated_from_cache_skipped_for_live_feed(pool),
             "register success must not be blocked by live curve feed"
         );
-        ctx.try_publish_balance_updated_from_cache(pool);
+        ctx.try_publish_balance_updated_from_cache(pool, false);
         assert_eq!(
             MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.load(Ordering::Relaxed),
             counter_before,
@@ -17385,7 +17455,7 @@ mod pr_b_geyser_tracking_tests {
             !ctx.balance_updated_from_cache_skipped_for_live_feed(pool),
             "already-satisfied pin must still allow JetStream refresh"
         );
-        ctx.try_publish_balance_updated_from_cache(pool);
+        ctx.try_publish_balance_updated_from_cache(pool, false);
         assert_eq!(
             MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.load(Ordering::Relaxed),
             counter_before,
@@ -21585,5 +21655,154 @@ mod pr_b_geyser_tracking_tests {
             Instant::now()
         ));
         assert!(ctx.tracked_membership.load().bin_arrays.contains(&bin_pda));
+    }
+
+    /// C1vault: arb apply must retry deferred pins (parity with momentum apply).
+    #[test]
+    fn scope_c1vault_arb_apply_retries_deferred_on_cache_fill() {
+        use ironcrab::metrics::{
+            set_market_data_exec_hot_admit_suppress, MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_TOTAL,
+            MARKET_DATA_ARB_TRACKED_VAULTS_GAUGE,
+        };
+        use ironcrab::nats::{
+            ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackReadiness, ArbTrackRequestsUpdate,
+        };
+        use std::sync::atomic::Ordering;
+
+        set_market_data_exec_hot_admit_suppress(false, false, true);
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let coin_vault = Pubkey::new_unique();
+        let pc_vault = Pubkey::new_unique();
+
+        let mut admission = test_admission_for(&ctx);
+        ctx.apply_arb_track_requests_update(
+            &mut admission,
+            &ArbTrackRequestsUpdate {
+                version: 1,
+                ts_unix_ms: 1,
+                active: vec![ArbTrackActiveEntry {
+                    pool: pool.to_string(),
+                    reason: ArbTrackActiveReason::TradeSignal,
+                    readiness: ArbTrackReadiness::Warmable,
+                }],
+                removed: vec![],
+                reconcile: false,
+            },
+        );
+        set_market_data_exec_hot_admit_suppress(false, false, false);
+        assert!(ctx
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(&pool));
+
+        let cleared_before = MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_TOTAL.load(Ordering::Relaxed);
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: coin_vault,
+                token_1_vault: pc_vault,
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            2,
+        );
+        ctx.apply_arb_track_requests_update(
+            &mut admission,
+            &ArbTrackRequestsUpdate {
+                version: 2,
+                ts_unix_ms: 2,
+                active: vec![ArbTrackActiveEntry {
+                    pool: pool.to_string(),
+                    reason: ArbTrackActiveReason::TradeSignal,
+                    readiness: ArbTrackReadiness::Warmable,
+                }],
+                removed: vec![],
+                reconcile: false,
+            },
+        );
+
+        assert!(!ctx
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(&pool));
+        assert!(
+            MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_TOTAL.load(Ordering::Relaxed) > cleared_before
+        );
+        assert!(
+            MARKET_DATA_ARB_TRACKED_VAULTS_GAUGE.load(Ordering::Relaxed) >= 2,
+            "arb vault rows must be tracked after retry"
+        );
+    }
+
+    /// C1vault: retry while admit suppress active must not try admit for warmable (still_unsatisfied).
+    #[test]
+    fn scope_c1vault_admit_suppress_retry_counts_still_unsatisfied() {
+        use ironcrab::metrics::{
+            set_market_data_exec_hot_admit_suppress,
+            MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_ADMIT_SUPPRESS,
+        };
+        use ironcrab::nats::{
+            ArbTrackActiveEntry, ArbTrackActiveReason, ArbTrackReadiness, ArbTrackRequestsUpdate,
+        };
+        use std::sync::atomic::Ordering;
+
+        set_market_data_exec_hot_admit_suppress(false, false, true);
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let mut admission = test_admission_for(&ctx);
+        ctx.apply_arb_track_requests_update(
+            &mut admission,
+            &ArbTrackRequestsUpdate {
+                version: 1,
+                ts_unix_ms: 1,
+                active: vec![ArbTrackActiveEntry {
+                    pool: pool.to_string(),
+                    reason: ArbTrackActiveReason::TradeSignal,
+                    readiness: ArbTrackReadiness::Warmable,
+                }],
+                removed: vec![],
+                reconcile: false,
+            },
+        );
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base_mint,
+                token_1_mint: quote,
+                token_0_vault: Pubkey::new_unique(),
+                token_1_vault: Pubkey::new_unique(),
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            1,
+        );
+        assert!(ctx
+            .deferred_hot_pool_reserve_pins
+            .read()
+            .contains_key(&pool));
+        set_market_data_exec_hot_admit_suppress(false, false, true);
+        let before =
+            MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_ADMIT_SUPPRESS.load(Ordering::Relaxed);
+        ctx.retry_deferred_hot_pool_reserve_registrations(&mut admission);
+        assert!(
+            MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_ADMIT_SUPPRESS.load(Ordering::Relaxed)
+                > before
+        );
+        set_market_data_exec_hot_admit_suppress(false, false, false);
     }
 }

--- a/src/market_data/track/worker.rs
+++ b/src/market_data/track/worker.rs
@@ -296,6 +296,7 @@ pub fn apply_arb_track_requests_on_track_worker<C: TrackWorkerContext>(
         batch_dirty |= ctx.apply_arb_active_entries(admission, chunk);
         std::thread::yield_now();
     }
+    batch_dirty |= ctx.retry_deferred_hot_pool_reserve_registrations(admission);
     if !batch_dirty {
         ctx.refresh_geyser_pins_gauge();
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -386,6 +386,19 @@ pub static MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_VAULT_NO_CHANGE: Lazy<
 /// Arb pin: retry tick still unsatisfied — DLMM bin PDAs tracked locally but not Geyser-flushed.
 pub static MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_BINS_NOT_SYNCED: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// Arb pin: retry tick still unsatisfied — EXEC_HOT arb admit suppress still active for warmable.
+pub static MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_ADMIT_SUPPRESS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Arb pin: deferred cleared after successful registration (by original defer reason).
+pub static MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_ADMIT_SUPPRESS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_LIVE_POOL_CACHE_MISS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_VAULT_REGISTER_NO_CHANGE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// Arb pin: cache-first JetStream vault seed published after arb register/retry success.
+pub static MARKET_DATA_ARB_PIN_VAULT_PUBLISHED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// Rows in `tracked_bin_arrays` (all pins).
 pub static MARKET_DATA_TRACKED_BIN_ARRAYS_GAUGE: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 /// Rows in `tracked_bin_arrays` pinned `ArbMultiDex`.
@@ -694,8 +707,35 @@ pub fn inc_market_data_arb_pin_deferred_still_unsatisfied_total(reason: &str) {
             MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_BINS_NOT_SYNCED
                 .fetch_add(1, Ordering::Relaxed);
         }
+        "admit_suppress" => {
+            MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_ADMIT_SUPPRESS
+                .fetch_add(1, Ordering::Relaxed);
+        }
         _ => {}
     }
+}
+
+#[inline]
+pub fn inc_market_data_arb_pin_deferred_cleared_by_reason_total(reason: &str) {
+    match reason {
+        "admit_suppress" => {
+            MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_ADMIT_SUPPRESS.fetch_add(1, Ordering::Relaxed);
+        }
+        "live_pool_cache_miss" => {
+            MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_LIVE_POOL_CACHE_MISS
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        "vault_register_no_change" => {
+            MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_VAULT_REGISTER_NO_CHANGE
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        _ => {}
+    }
+}
+
+#[inline]
+pub fn inc_market_data_arb_pin_vault_published_total() {
+    MARKET_DATA_ARB_PIN_VAULT_PUBLISHED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
@@ -4826,6 +4866,12 @@ pub static ARB_DLMM_BIN_ARRAY_UPDATE_RECEIVED_TOTAL: Lazy<AtomicU64> =
 pub static ARB_DLMM_BIN_ARRAY_UPDATE_APPLIED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_DLMM_BIN_RESCREEN_SCHEDULED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// PoolStateUpdate applied a new vault_balances row for arb screening.
+pub static ARB_VAULT_BALANCE_APPLIED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// v2 screen seeded missing vault from SLAVE LivePoolCache at snapshot time (C1vault).
+pub static ARB_VAULT_LIVE_SNAPSHOT_SEEDED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// PoolStateUpdate scheduled off-hot-loop rescreen for selected mints (C1vault).
+pub static ARB_VAULT_RESCREEN_SCHEDULED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static ARB_V2_SCREEN_METEORA_SELL_BIN_HIT_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_V2_SCREEN_METEORA_SELL_BIN_MISS_TOTAL: Lazy<AtomicU64> =
@@ -5358,6 +5404,21 @@ pub fn inc_arb_dlmm_bin_array_update_applied_total() {
 /// Increment `arb_dlmm_bin_rescreen_scheduled_total`.
 pub fn inc_arb_dlmm_bin_rescreen_scheduled_total() {
     ARB_DLMM_BIN_RESCREEN_SCHEDULED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Increment `arb_vault_balance_applied_total`.
+pub fn inc_arb_vault_balance_applied_total() {
+    ARB_VAULT_BALANCE_APPLIED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Increment `arb_vault_live_snapshot_seeded_total`.
+pub fn inc_arb_vault_live_snapshot_seeded_total() {
+    ARB_VAULT_LIVE_SNAPSHOT_SEEDED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Increment `arb_vault_rescreen_scheduled_total`.
+pub fn inc_arb_vault_rescreen_scheduled_total() {
+    ARB_VAULT_RESCREEN_SCHEDULED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Increment `arb_v2_screen_meteora_sell_bin_hit_total`.
@@ -8201,6 +8262,31 @@ async fn metrics_response() -> Response<Body> {
             .to_string(),
     );
     out.push('\n');
+    out.push_str(
+        "market_data_arb_pin_deferred_still_unsatisfied_total{reason=\"admit_suppress\"} ",
+    );
+    out.push_str(
+        &MARKET_DATA_ARB_PIN_DEFERRED_STILL_UNSATISFIED_ADMIT_SUPPRESS
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    line!(
+        "market_data_arb_pin_deferred_cleared_admit_suppress_total",
+        MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_ADMIT_SUPPRESS.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_arb_pin_deferred_cleared_live_pool_cache_miss_total",
+        MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_LIVE_POOL_CACHE_MISS.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_arb_pin_deferred_cleared_vault_register_no_change_total",
+        MARKET_DATA_ARB_PIN_DEFERRED_CLEARED_VAULT_REGISTER_NO_CHANGE.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_arb_pin_vault_published_total",
+        MARKET_DATA_ARB_PIN_VAULT_PUBLISHED_TOTAL.load(Ordering::Relaxed)
+    );
     line!(
         "market_data_arb_pin_budget_used",
         MARKET_DATA_ARB_PIN_BUDGET_USED_GAUGE.load(Ordering::Relaxed)
@@ -9939,6 +10025,18 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "arb_dlmm_bin_rescreen_scheduled_total",
         ARB_DLMM_BIN_RESCREEN_SCHEDULED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_vault_balance_applied_total",
+        ARB_VAULT_BALANCE_APPLIED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_vault_live_snapshot_seeded_total",
+        ARB_VAULT_LIVE_SNAPSHOT_SEEDED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_vault_rescreen_scheduled_total",
+        ARB_VAULT_RESCREEN_SCHEDULED_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "arb_v2_screen_meteora_sell_bin_hit_total",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the post-C1g vault completeness gap where `sell_missing_vault` remained the #1 arb funnel killer (~67% sell-fails) despite MD tracking ~310 arb vaults.

### Root causes

1. **MD admission/retry (H1/H2):** `apply_arb_track_requests_update` did not call `retry_deferred_hot_pool_reserve_registrations` (momentum apply did). Warmable pools deferred under `admit_suppress` stayed without vault register until a geyser coalesce tick.
2. **MD publish gap:** `publish_momentum_hot_balance_refresh_from_cache` was momentum-only. Arb-only pins got no cache-first JetStream vault seed after successful register — arb-strategy `vault_balances` stayed empty until a Geyser vault tick.
3. **Arb consume gap (H3 / C1f analog):** No LivePoolCache vault seed at v2 screen time and no rescreen when `PoolStateUpdate` arrives.

### Fixes

**market-data**
- `retry_deferred` after every arb apply (incl. chunked track-worker path)
- Retry skips warmable under active `admit_suppress` with `still_unsatisfied{admit_suppress}` forensics
- Suppress-lift enqueues `RetryDeferredHotPoolReserves`
- `publish_hot_pool_balance_refresh_from_cache` for Mom **and** Arb; force arb-only cache seed bypasses live-feed skip
- Register success + satisfied retry publish vault seed to JetStream
- Deferred map stores defer reason; cleared-by-reason metrics

**arb-strategy**
- `try_seed_vault_from_live_cache` in `snapshot_vault_bins_for_tracker` (all SOL-quoted DEXes)
- `schedule_arb_vault_rescreen_for_mints` on `PoolStateUpdate`

### Invarianten

- I-4 / I-7: Geyser-only, kein Hot-Path RPC
- I-MD-7: kein Cap-Bump
- Dual-consumer priority unverändert (Wallet > Mom > Arb)

### Tests

- `scope_c1vault_arb_apply_retries_deferred_on_cache_fill`
- `scope_c1vault_admit_suppress_retry_counts_still_unsatisfied`
- `scoped_snapshot_seeds_missing_vault_from_live_cache`
- Existing C1c/C1d/C1f/C1g tests green

### CI

- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test` ✓

Deploy **not** included — awaits user OK. Post-deploy expectation: `sell_missing_vault` share drops; Mom intents stable.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1dd5f147-f10f-4d4c-8521-fde637472285?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1dd5f147-f10f-4d4c-8521-fde637472285&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

