### PR TITLE
fix(arb): C1h2 freshness forensics + arb-pin SLAVE age sustain (post-#365)

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,13 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### FIX-ARB-C1h2: Freshness Forensics + Arb-Pin SLAVE Age Sustain (post-C1h)
+**Datum**: 2026-08-04  
+**Problem**: Post-#365/C1h: `sell_not_fresh` weiter ~74%; `state_stale` dominant. C1h refresh kopiert `LivePoolCache.age_ms` in `vault.updated_at` — wenn Cache-Eintrag > `STATE_TTL_MS` (120s), hilft Refresh nicht. Arb-only Pins hatten keinen Momentum-äquivalenten Balance-Heartbeat; `balance_updated_from_cache_skipped_for_live_feed` blockierte JetStream-Touch für Arb trotz Live-Vault-Feed.  
+**Fix**: (1) C1h2 Forensik: `sell_not_fresh` Split `{kind,cause}`, `state_stale` age buckets, `live_cache_age` bei seed/refresh, `no_fresh_buy_quote` Subreason. (2) H5 eng: Arb-Pins in MD Balance-Heartbeat + Live-Feed-Skip-Bypass (wie Momentum). **Invarianten**: I-4/I-7 kein RPC; TTL nicht erhöht.  
+**Evidence**: `findings_arb_zero_opp_post365_20260804.md`, Prod Tip `04e2dd8`.  
+**Dateien**: `src/arbitrage/pool_quote.rs`, `src/bin/arb_strategy.rs`, `src/bin/market_data.rs`, `src/metrics.rs`, `docs/BUGS_FIXES.md`
+
 ### FIX-ARB-C1h: Arb Quote Freshness — Live Vault Refresh at Screen (post-C1vault)
 **Datum**: 2026-08-04  
 **Problem**: Post-#364/C1vault: `sell_not_fresh` ~67% sell-fails; `state_stale` dominant in `sell_quote_none`. C1vault seed-if-missing filled vault rows but `snapshot_vault_bins_for_tracker` cloned stale `vault_balances` without refreshing when SLAVE LivePoolCache was newer. `arb_vault_balance_applied_total` ~14 (counter only on `is_new`).  

--- a/src/arbitrage/mod.rs
+++ b/src/arbitrage/mod.rs
@@ -48,17 +48,20 @@ pub use multi_hop_integration::{
 };
 pub use pool_graph::{GraphStats, PoolGraph};
 pub use pool_quote::{
-    classify_cross_dex_sell_failure, diagnose_sell_quote_none, dlmm_marginal_price_plausible,
-    dlmm_sol_output_from_bins, dlmm_token_output_from_bins, flatten_bin_array_bins, is_quote_fresh,
+    classify_cross_dex_sell_failure, diagnose_no_fresh_buy_quote, diagnose_quote_not_fresh,
+    diagnose_sell_quote_none, dlmm_marginal_price_plausible, dlmm_sol_output_from_bins,
+    dlmm_token_output_from_bins, flatten_bin_array_bins, freshness_age_bucket, is_quote_fresh,
     is_usable_quote_kind, quote_exact_in, quote_exact_in_with_freshness, quote_from_cached_pool,
     quote_sell_round_trip, quote_sol_per_token_for_screening, quotes_pairable,
     round_trip_profit_lamports, round_trip_profit_lamports_with_freshness, select_round_trip_pools,
     sol_quoted_seed_from_cached_state, state_fingerprint, token_decimals_from_cached_state,
-    CrossDexSellFailure, DlmmBinArrays, NoCrossDexSellDetailReason, PoolQuote,
-    QuoteFreshnessConfig, QuoteKind, QuotePoolInput, QuoteSide, QuoteVaultInput,
-    RoundTripInsufficient, RoundTripInsufficientSubreason, RoundTripLeg, RoundTripPoolCandidate,
-    RoundTripPoolSelection, RoundTripSelectFailure, SellQuoteNoneDetailReason, SolQuotedPoolSeed,
-    DLMM_PROBE_SOL_LAMPORTS, STATE_TTL_MS, TRADE_TTL_MS,
+    vault_state_age_ms, CrossDexSellFailure, DlmmBinArrays, FreshnessAgeBucket,
+    NoCrossDexSellDetailReason, NoFreshBuyQuoteSubreason, PoolQuote, QuoteFreshnessConfig,
+    QuoteKind, QuoteNotFreshCause, QuoteNotFreshDiagnosis, QuoteNotFreshKind, QuotePoolInput,
+    QuoteSide, QuoteVaultInput, RoundTripInsufficient, RoundTripInsufficientSubreason,
+    RoundTripLeg, RoundTripPoolCandidate, RoundTripPoolSelection, RoundTripSelectFailure,
+    SellQuoteNoneDetailReason, SolQuotedPoolSeed, DLMM_PROBE_SOL_LAMPORTS, STATE_TTL_MS,
+    TRADE_TTL_MS,
 };
 pub use pool_ranker::{PoolRanker, QuoteProvider, RankerConfig};
 pub use track_selection::{

--- a/src/arbitrage/pool_quote.rs
+++ b/src/arbitrage/pool_quote.rs
@@ -57,19 +57,197 @@ pub fn is_quote_fresh(
     current_vault: Option<&QuoteVaultInput>,
     now: Instant,
 ) -> bool {
+    diagnose_quote_not_fresh(quote, config, current_vault, now).is_none()
+}
+
+/// Age bucket for vault/state-stale forensics (C1h2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FreshnessAgeBucket {
+    Le30s,
+    Le120s,
+    Le300s,
+    Gt300s,
+}
+
+impl FreshnessAgeBucket {
+    pub fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::Le30s => "le_30s",
+            Self::Le120s => "le_120s",
+            Self::Le300s => "le_300s",
+            Self::Gt300s => "gt_300s",
+        }
+    }
+}
+
+/// Map elapsed milliseconds to freshness forensics buckets.
+pub fn freshness_age_bucket(age_ms: u64) -> FreshnessAgeBucket {
+    if age_ms <= 30_000 {
+        FreshnessAgeBucket::Le30s
+    } else if age_ms <= 120_000 {
+        FreshnessAgeBucket::Le120s
+    } else if age_ms <= 300_000 {
+        FreshnessAgeBucket::Le300s
+    } else {
+        FreshnessAgeBucket::Gt300s
+    }
+}
+
+/// Vault reserve snapshot age in milliseconds (for StateStale drill-down).
+pub fn vault_state_age_ms(vault: &QuoteVaultInput, now: Instant) -> u64 {
+    now.duration_since(vault.updated_at).as_millis() as u64
+}
+
+/// Quote kind label for NotFresh forensics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum QuoteNotFreshKind {
+    ExecutableMarginal,
+    LastTradeMid,
+}
+
+impl QuoteNotFreshKind {
+    pub fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::ExecutableMarginal => "executable_marginal",
+            Self::LastTradeMid => "last_trade_mid",
+        }
+    }
+
+    fn from_quote_kind(kind: QuoteKind) -> Self {
+        match kind {
+            QuoteKind::ExecutableMarginal => Self::ExecutableMarginal,
+            QuoteKind::LastTradeMid => Self::LastTradeMid,
+        }
+    }
+}
+
+/// Root cause when `is_quote_fresh` returns false.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum QuoteNotFreshCause {
+    AgeExceeded,
+    FingerprintMismatch,
+}
+
+impl QuoteNotFreshCause {
+    pub fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::AgeExceeded => "age_exceeded",
+            Self::FingerprintMismatch => "fingerprint_mismatch",
+        }
+    }
+}
+
+/// Drill-down for cross-DEX sell `NotFresh` (C1h2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct QuoteNotFreshDiagnosis {
+    pub kind: QuoteNotFreshKind,
+    pub cause: QuoteNotFreshCause,
+}
+
+/// Returns `Some(diagnosis)` when quote fails freshness re-check.
+pub fn diagnose_quote_not_fresh(
+    quote: &PoolQuote,
+    config: &QuoteFreshnessConfig,
+    current_vault: Option<&QuoteVaultInput>,
+    now: Instant,
+) -> Option<QuoteNotFreshDiagnosis> {
+    let kind = QuoteNotFreshKind::from_quote_kind(quote.kind);
     match quote.kind {
         QuoteKind::LastTradeMid => {
-            now.duration_since(quote.as_of_ts) <= Duration::from_millis(config.trade_ttl_ms)
+            if now.duration_since(quote.as_of_ts) <= Duration::from_millis(config.trade_ttl_ms) {
+                return None;
+            }
+            Some(QuoteNotFreshDiagnosis {
+                kind,
+                cause: QuoteNotFreshCause::AgeExceeded,
+            })
         }
         QuoteKind::ExecutableMarginal => {
             if now.duration_since(quote.as_of_ts) > Duration::from_millis(config.state_ttl_ms) {
-                return false;
+                return Some(QuoteNotFreshDiagnosis {
+                    kind,
+                    cause: QuoteNotFreshCause::AgeExceeded,
+                });
             }
             match current_vault {
-                Some(vault) => state_fingerprint(vault) == quote.state_fingerprint,
-                None => true,
+                Some(vault) if state_fingerprint(vault) != quote.state_fingerprint => {
+                    Some(QuoteNotFreshDiagnosis {
+                        kind,
+                        cause: QuoteNotFreshCause::FingerprintMismatch,
+                    })
+                }
+                _ => None,
             }
         }
+    }
+}
+
+/// Subreason when no candidate produces a fresh buy quote (C1h2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NoFreshBuyQuoteSubreason {
+    QuoteNone,
+    StateStale,
+    TradeStale,
+    NotFreshAfterQuote,
+}
+
+impl NoFreshBuyQuoteSubreason {
+    pub fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::QuoteNone => "quote_none",
+            Self::StateStale => "state_stale",
+            Self::TradeStale => "trade_stale",
+            Self::NotFreshAfterQuote => "not_fresh_after_quote",
+        }
+    }
+}
+
+/// Diagnose why a buy leg failed freshness for round-trip selection.
+pub fn diagnose_no_fresh_buy_quote(
+    pool: &QuotePoolInput,
+    vault: Option<&QuoteVaultInput>,
+    dlmm_bins: Option<&DlmmBinArrays>,
+    probe_lamports: u64,
+    freshness: &QuoteFreshnessConfig,
+    now: Instant,
+) -> NoFreshBuyQuoteSubreason {
+    let buy_quote = quote_exact_in_with_freshness(
+        pool,
+        vault,
+        dlmm_bins,
+        NATIVE_SOL_MINT,
+        &pool.token_mint,
+        probe_lamports,
+        freshness,
+    );
+    let Some(buy_quote) = buy_quote else {
+        if let Some(v) = vault {
+            if !state_fresh(v, now, freshness.state_ttl_ms) {
+                return NoFreshBuyQuoteSubreason::StateStale;
+            }
+        }
+        if trade_fresh(pool, now, freshness.trade_ttl_ms) {
+            return NoFreshBuyQuoteSubreason::QuoteNone;
+        }
+        return NoFreshBuyQuoteSubreason::TradeStale;
+    };
+    if is_quote_fresh(&buy_quote, freshness, vault, now) {
+        return NoFreshBuyQuoteSubreason::NotFreshAfterQuote;
+    }
+    match diagnose_quote_not_fresh(&buy_quote, freshness, vault, now) {
+        Some(QuoteNotFreshDiagnosis {
+            kind: QuoteNotFreshKind::LastTradeMid,
+            ..
+        }) => NoFreshBuyQuoteSubreason::TradeStale,
+        Some(QuoteNotFreshDiagnosis {
+            kind: QuoteNotFreshKind::ExecutableMarginal,
+            cause: QuoteNotFreshCause::AgeExceeded,
+        }) => NoFreshBuyQuoteSubreason::StateStale,
+        Some(QuoteNotFreshDiagnosis {
+            kind: QuoteNotFreshKind::ExecutableMarginal,
+            cause: QuoteNotFreshCause::FingerprintMismatch,
+        }) => NoFreshBuyQuoteSubreason::StateStale,
+        None => NoFreshBuyQuoteSubreason::NotFreshAfterQuote,
     }
 }
 
@@ -1198,7 +1376,7 @@ pub enum CrossDexSellFailure {
     MissingDlmmBins,
     MissingVault,
     QuoteNone(SellQuoteNoneDetailReason),
-    NotFresh,
+    NotFresh(QuoteNotFreshDiagnosis),
     ZeroOut,
 }
 
@@ -1211,7 +1389,7 @@ impl CrossDexSellFailure {
                 NoCrossDexSellDetailReason::SellNotFresh
             }
             Self::QuoteNone(_) => NoCrossDexSellDetailReason::SellQuoteNone,
-            Self::NotFresh => NoCrossDexSellDetailReason::SellNotFresh,
+            Self::NotFresh(_) => NoCrossDexSellDetailReason::SellNotFresh,
             Self::ZeroOut => NoCrossDexSellDetailReason::SellZeroOut,
         }
     }
@@ -1479,6 +1657,9 @@ pub struct RoundTripInsufficient {
     pub subreason: RoundTripInsufficientSubreason,
     pub no_cross_dex_sell_detail: Option<NoCrossDexSellDetailReason>,
     pub sell_quote_none_detail_counts: Option<HashMap<SellQuoteNoneDetailReason, usize>>,
+    pub sell_not_fresh_detail_counts: Option<HashMap<QuoteNotFreshDiagnosis, usize>>,
+    pub no_fresh_buy_quote_detail: Option<NoFreshBuyQuoteSubreason>,
+    pub state_stale_age_bucket_counts: Option<HashMap<FreshnessAgeBucket, usize>>,
 }
 
 impl RoundTripInsufficient {
@@ -1487,6 +1668,9 @@ impl RoundTripInsufficient {
             subreason,
             no_cross_dex_sell_detail: None,
             sell_quote_none_detail_counts: None,
+            sell_not_fresh_detail_counts: None,
+            no_fresh_buy_quote_detail: None,
+            state_stale_age_bucket_counts: None,
         }
     }
 }
@@ -1543,8 +1727,9 @@ pub fn classify_cross_dex_sell_failure(
         );
         return Some(CrossDexSellFailure::QuoteNone(sub));
     };
-    if !is_quote_fresh(&sell_quote, freshness, candidate.vault, now) {
-        return Some(CrossDexSellFailure::NotFresh);
+    if let Some(diagnosis) = diagnose_quote_not_fresh(&sell_quote, freshness, candidate.vault, now)
+    {
+        return Some(CrossDexSellFailure::NotFresh(diagnosis));
     }
     let sol_per_token = sol_per_token_from_sell_quote(&sell_quote, token_decimals);
     if sol_per_token <= Decimal::ZERO {
@@ -1563,6 +1748,7 @@ fn dominant_no_cross_dex_sell_detail(
 }
 
 /// I-ARB-5 evolution: enumerate valid cross-DEX (buy, sell) pairs and pick best round-trip.
+#[allow(clippy::result_large_err)]
 pub fn select_round_trip_pools(
     candidates: &[RoundTripPoolCandidate<'_>],
     probe_lamports: u64,
@@ -1620,8 +1806,31 @@ pub fn select_round_trip_pools(
     }
 
     if valid_buys.is_empty() {
+        let mut buy_fail_counts: HashMap<NoFreshBuyQuoteSubreason, usize> = HashMap::new();
+        for candidate in candidates {
+            let sub = diagnose_no_fresh_buy_quote(
+                candidate.pool,
+                candidate.vault,
+                candidate.dlmm_bins,
+                probe_lamports,
+                freshness,
+                now,
+            );
+            *buy_fail_counts.entry(sub).or_default() += 1;
+        }
+        let dominant_buy_detail = buy_fail_counts
+            .iter()
+            .max_by_key(|(_, count)| *count)
+            .map(|(reason, _)| *reason);
         return Err(RoundTripSelectFailure::InsufficientPools(
-            RoundTripInsufficient::new(RoundTripInsufficientSubreason::NoFreshBuyQuote),
+            RoundTripInsufficient {
+                subreason: RoundTripInsufficientSubreason::NoFreshBuyQuote,
+                no_cross_dex_sell_detail: None,
+                sell_quote_none_detail_counts: None,
+                sell_not_fresh_detail_counts: None,
+                no_fresh_buy_quote_detail: dominant_buy_detail,
+                state_stale_age_bucket_counts: None,
+            },
         ));
     }
 
@@ -1640,6 +1849,8 @@ pub fn select_round_trip_pools(
         std::collections::HashMap::new();
     let mut sell_quote_none_detail_counts: HashMap<SellQuoteNoneDetailReason, usize> =
         HashMap::new();
+    let mut sell_not_fresh_detail_counts: HashMap<QuoteNotFreshDiagnosis, usize> = HashMap::new();
+    let mut state_stale_age_bucket_counts: HashMap<FreshnessAgeBucket, usize> = HashMap::new();
 
     for buy in &valid_buys {
         for sell_candidate in candidates {
@@ -1677,6 +1888,12 @@ pub fn select_round_trip_pools(
                     now,
                 );
                 *sell_quote_none_detail_counts.entry(sub).or_default() += 1;
+                if sub == SellQuoteNoneDetailReason::StateStale {
+                    if let Some(vault) = sell_candidate.vault {
+                        let bucket = freshness_age_bucket(vault_state_age_ms(vault, now));
+                        *state_stale_age_bucket_counts.entry(bucket).or_default() += 1;
+                    }
+                }
                 let top = if sub == SellQuoteNoneDetailReason::StateStale {
                     NoCrossDexSellDetailReason::SellNotFresh
                 } else {
@@ -1685,7 +1902,10 @@ pub fn select_round_trip_pools(
                 *sell_fail_counts.entry(top).or_default() += 1;
                 continue;
             };
-            if !is_quote_fresh(&sell_quote, freshness, sell_candidate.vault, now) {
+            if let Some(diagnosis) =
+                diagnose_quote_not_fresh(&sell_quote, freshness, sell_candidate.vault, now)
+            {
+                *sell_not_fresh_detail_counts.entry(diagnosis).or_default() += 1;
                 *sell_fail_counts
                     .entry(NoCrossDexSellDetailReason::SellNotFresh)
                     .or_default() += 1;
@@ -1731,6 +1951,11 @@ pub fn select_round_trip_pools(
                 no_cross_dex_sell_detail: dominant_no_cross_dex_sell_detail(&sell_fail_counts),
                 sell_quote_none_detail_counts: (!sell_quote_none_detail_counts.is_empty())
                     .then_some(sell_quote_none_detail_counts),
+                sell_not_fresh_detail_counts: (!sell_not_fresh_detail_counts.is_empty())
+                    .then_some(sell_not_fresh_detail_counts),
+                no_fresh_buy_quote_detail: None,
+                state_stale_age_bucket_counts: (!state_stale_age_bucket_counts.is_empty())
+                    .then_some(state_stale_age_bucket_counts),
             },
         ));
     };
@@ -2230,6 +2455,9 @@ mod tests {
                 subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
                 no_cross_dex_sell_detail: Some(NoCrossDexSellDetailReason::SellMissingVault),
                 sell_quote_none_detail_counts: None,
+                sell_not_fresh_detail_counts: None,
+                no_fresh_buy_quote_detail: None,
+                state_stale_age_bucket_counts: None,
             })
         );
     }
@@ -2266,6 +2494,9 @@ mod tests {
                 subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
                 no_cross_dex_sell_detail: Some(NoCrossDexSellDetailReason::SellMissingDlmmBins),
                 sell_quote_none_detail_counts: None,
+                sell_not_fresh_detail_counts: None,
+                no_fresh_buy_quote_detail: None,
+                state_stale_age_bucket_counts: None,
             })
         );
     }
@@ -2519,6 +2750,119 @@ mod tests {
             sell_quote.is_some(),
             "large DLMM sell must not fail marginal probe gate"
         );
+    }
+
+    #[test]
+    fn diagnose_quote_not_fresh_trade_age_exceeded() {
+        let config = QuoteFreshnessConfig::default();
+        let quote = PoolQuote {
+            pool_address: "p".into(),
+            dex: "orca".into(),
+            kind: QuoteKind::LastTradeMid,
+            side: QuoteSide::Sell,
+            as_of_slot: 0,
+            as_of_ts: Instant::now() - Duration::from_secs(60),
+            fresh: false,
+            state_fingerprint: 0,
+            amount_in: 1,
+            amount_out: 2,
+        };
+        let diagnosis = diagnose_quote_not_fresh(&quote, &config, None, Instant::now())
+            .expect("stale trade quote");
+        assert_eq!(diagnosis.kind, QuoteNotFreshKind::LastTradeMid);
+        assert_eq!(diagnosis.cause, QuoteNotFreshCause::AgeExceeded);
+    }
+
+    #[test]
+    fn diagnose_quote_not_fresh_executable_fingerprint_mismatch() {
+        let config = QuoteFreshnessConfig::default();
+        let vault = sample_vault(1_000_000_000_000, 1_000_000_000);
+        let fingerprint = state_fingerprint(&vault);
+        let quote = PoolQuote {
+            pool_address: "p".into(),
+            dex: "orca".into(),
+            kind: QuoteKind::ExecutableMarginal,
+            side: QuoteSide::Sell,
+            as_of_slot: 1,
+            as_of_ts: Instant::now(),
+            fresh: true,
+            state_fingerprint: fingerprint,
+            amount_in: 1,
+            amount_out: 2,
+        };
+        let mut changed_vault = vault.clone();
+        changed_vault.reserve_base += 1;
+        let diagnosis =
+            diagnose_quote_not_fresh(&quote, &config, Some(&changed_vault), Instant::now())
+                .expect("fingerprint mismatch");
+        assert_eq!(diagnosis.kind, QuoteNotFreshKind::ExecutableMarginal);
+        assert_eq!(diagnosis.cause, QuoteNotFreshCause::FingerprintMismatch);
+    }
+
+    #[test]
+    fn freshness_age_bucket_boundaries() {
+        assert_eq!(freshness_age_bucket(15_000), FreshnessAgeBucket::Le30s);
+        assert_eq!(freshness_age_bucket(60_000), FreshnessAgeBucket::Le120s);
+        assert_eq!(freshness_age_bucket(200_000), FreshnessAgeBucket::Le300s);
+        assert_eq!(freshness_age_bucket(400_000), FreshnessAgeBucket::Gt300s);
+    }
+
+    #[test]
+    fn diagnose_no_fresh_buy_quote_state_stale_vault() {
+        let pool = sample_pool("orca", "staleBuy");
+        let mut vault = sample_vault(1_000_000_000_000, 1_000_000_000);
+        vault.updated_at = Instant::now() - Duration::from_secs(300);
+        let sub = diagnose_no_fresh_buy_quote(
+            &pool,
+            Some(&vault),
+            None,
+            DLMM_PROBE_SOL_LAMPORTS,
+            &QuoteFreshnessConfig::default(),
+            Instant::now(),
+        );
+        assert_eq!(sub, NoFreshBuyQuoteSubreason::StateStale);
+    }
+
+    #[test]
+    fn select_round_trip_pools_no_fresh_buy_records_subreason() {
+        let pool_a = sample_pool("orca", "poolA");
+        let pool_b = sample_pool("pump_amm", "poolB");
+        let mut vault_a = sample_vault(1_000_000_000_000, 900_000_000);
+        vault_a.updated_at = Instant::now() - Duration::from_secs(300);
+        let mut vault_b = sample_vault(1_000_000_000_000, 1_100_000_000);
+        vault_b.updated_at = Instant::now() - Duration::from_secs(300);
+        let candidates = [
+            RoundTripPoolCandidate {
+                pool: &pool_a,
+                vault: Some(&vault_a),
+                dlmm_bins: None,
+                dex: "orca",
+            },
+            RoundTripPoolCandidate {
+                pool: &pool_b,
+                vault: Some(&vault_b),
+                dlmm_bins: None,
+                dex: "pump_amm",
+            },
+        ];
+        let err = select_round_trip_pools(
+            &candidates,
+            DLMM_PROBE_SOL_LAMPORTS,
+            &QuoteFreshnessConfig::default(),
+        )
+        .unwrap_err();
+        if let RoundTripSelectFailure::InsufficientPools(insufficient) = err {
+            assert_eq!(
+                insufficient.subreason,
+                RoundTripInsufficientSubreason::NoFreshBuyQuote
+            );
+            assert_eq!(
+                insufficient.no_fresh_buy_quote_detail,
+                Some(NoFreshBuyQuoteSubreason::StateStale)
+            );
+        } else {
+            panic!("expected NoFreshBuyQuote");
+        }
     }
 
     #[test]

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 
 use ironcrab::arbitrage::{
     arb_track_removal_reason, classify_cross_dex_sell_failure, dlmm_marginal_price_plausible,
-    dlmm_sol_output_from_bins, dlmm_token_output_from_bins, is_quote_fresh,
+    dlmm_sol_output_from_bins, dlmm_token_output_from_bins, freshness_age_bucket, is_quote_fresh,
     populate_arb_slave_from_live_pool_cache, quote_exact_in, quote_exact_in_with_freshness,
     quote_sell_round_trip, quotes_pairable, round_trip_profit_lamports, select_arb_track_pools,
     select_round_trip_pools, sync_arb_slave_from_pool_cache_update, MultiHopArbitrage,
@@ -71,20 +71,22 @@ use ironcrab::metrics::{
     arb_two_hop_opportunity_inc, arb_two_hop_pool_gate_add, arb_two_hop_reject_subreason_inc,
     arb_two_hop_rejected_inc, arb_two_hop_tracker_seeded_pools_add,
     arb_two_hop_v2_incompatible_kind_inc, arb_two_hop_v2_insufficient_subreason_inc,
-    arb_two_hop_v2_no_cross_dex_sell_detail_inc, arb_two_hop_v2_rejected_inc,
-    arb_two_hop_v2_round_trip_formable_inc, arb_two_hop_v2_screen_inc,
+    arb_two_hop_v2_no_cross_dex_sell_detail_inc, arb_two_hop_v2_no_fresh_buy_quote_detail_inc,
+    arb_two_hop_v2_rejected_inc, arb_two_hop_v2_round_trip_formable_inc, arb_two_hop_v2_screen_inc,
     arb_two_hop_v2_screen_multi_dex_inc, arb_two_hop_v2_screen_skipped_inc,
-    arb_two_hop_v2_sell_quote_none_detail_inc, inc_arb_dlmm_bin_array_update_applied_total,
-    inc_arb_dlmm_bin_array_update_received_total, inc_arb_dlmm_bin_rescreen_scheduled_total,
-    inc_arb_pinned_meteora_pool_bin_cache_miss_total, inc_arb_v2_screen_meteora_sell_bin_hit_total,
-    inc_arb_v2_screen_meteora_sell_bin_miss_total, inc_arb_vault_balance_applied_total,
-    inc_arb_vault_live_snapshot_refreshed_total, inc_arb_vault_live_snapshot_seeded_total,
-    inc_arb_vault_rescreen_scheduled_total, record_arb_heartbeat_phase,
-    record_arb_price_freshness_stale_age_ms, record_arb_proactive_pin_first_publish,
-    record_arb_proactive_track_publish_total, record_arb_quote_pair_slot_delta,
-    record_arb_quote_shadow_round_trip, record_arb_track_publish_skipped_unchanged_total,
-    record_arb_track_removed_total, record_arb_track_requests_messages_total,
-    record_arb_track_requests_publish_chunks_total, record_arb_track_requests_publish_failed_total,
+    arb_two_hop_v2_sell_not_fresh_detail_inc, arb_two_hop_v2_sell_quote_none_detail_inc,
+    arb_two_hop_v2_state_stale_age_bucket_inc, arb_vault_live_snapshot_cache_age_bucket_inc,
+    inc_arb_dlmm_bin_array_update_applied_total, inc_arb_dlmm_bin_array_update_received_total,
+    inc_arb_dlmm_bin_rescreen_scheduled_total, inc_arb_pinned_meteora_pool_bin_cache_miss_total,
+    inc_arb_v2_screen_meteora_sell_bin_hit_total, inc_arb_v2_screen_meteora_sell_bin_miss_total,
+    inc_arb_vault_balance_applied_total, inc_arb_vault_live_snapshot_refreshed_total,
+    inc_arb_vault_live_snapshot_seeded_total, inc_arb_vault_rescreen_scheduled_total,
+    record_arb_heartbeat_phase, record_arb_price_freshness_stale_age_ms,
+    record_arb_proactive_pin_first_publish, record_arb_proactive_track_publish_total,
+    record_arb_quote_pair_slot_delta, record_arb_quote_shadow_round_trip,
+    record_arb_track_publish_skipped_unchanged_total, record_arb_track_removed_total,
+    record_arb_track_requests_messages_total, record_arb_track_requests_publish_chunks_total,
+    record_arb_track_requests_publish_failed_total,
     record_arb_track_selection_blocking_join_failed_total,
     record_arb_track_selection_queue_overflow_total, record_arb_track_selection_recompute_total,
     record_arb_writer_lock_wait, serve_metrics, set_arb_pool_cache_apply_batch_size_gauge,
@@ -455,6 +457,7 @@ fn try_seed_vault_from_live_cache(
     let Some(vault) = vault_balance_from_live_cache_state(&state, slot, age_ms) else {
         return false;
     };
+    record_live_cache_age_at_snapshot("seed", age_ms);
     vault_cache.insert(pool_address.to_string(), vault);
     true
 }
@@ -481,6 +484,7 @@ fn try_refresh_vault_from_live_cache(
     if !live_pool_cache_fresher_than_vault(slot, new_vault.updated_at, existing) {
         return false;
     }
+    record_live_cache_age_at_snapshot("refresh", age_ms);
     vault_cache.insert(pool_address.to_string(), new_vault);
     true
 }
@@ -2382,10 +2386,18 @@ fn v2_sell_quote_none_detail_to_metric(
     }
 }
 
+fn record_live_cache_age_at_snapshot(op: &str, age_ms: u64) {
+    let bucket = freshness_age_bucket(age_ms).as_metric_label();
+    arb_vault_live_snapshot_cache_age_bucket_inc(op, bucket);
+}
+
 fn record_v2_insufficient_subreason(insufficient: &RoundTripInsufficient) {
     arb_two_hop_v2_insufficient_subreason_inc(v2_insufficient_subreason_to_metric(
         insufficient.subreason,
     ));
+    if let Some(detail) = insufficient.no_fresh_buy_quote_detail {
+        arb_two_hop_v2_no_fresh_buy_quote_detail_inc(detail.as_metric_label());
+    }
     if let Some(detail) = insufficient.no_cross_dex_sell_detail {
         arb_two_hop_v2_no_cross_dex_sell_detail_inc(v2_no_cross_dex_sell_detail_to_metric(detail));
     }
@@ -2394,6 +2406,23 @@ fn record_v2_insufficient_subreason(insufficient: &RoundTripInsufficient) {
             let metric = v2_sell_quote_none_detail_to_metric(*reason);
             for _ in 0..*count {
                 arb_two_hop_v2_sell_quote_none_detail_inc(metric);
+            }
+        }
+    }
+    if let Some(counts) = &insufficient.sell_not_fresh_detail_counts {
+        for (diagnosis, count) in counts {
+            for _ in 0..*count {
+                arb_two_hop_v2_sell_not_fresh_detail_inc(
+                    diagnosis.kind.as_metric_label(),
+                    diagnosis.cause.as_metric_label(),
+                );
+            }
+        }
+    }
+    if let Some(counts) = &insufficient.state_stale_age_bucket_counts {
+        for (bucket, count) in counts {
+            for _ in 0..*count {
+                arb_two_hop_v2_state_stale_age_bucket_inc(bucket.as_metric_label());
             }
         }
     }
@@ -12598,6 +12627,9 @@ mod two_hop_price_tests {
             subreason: RoundTripInsufficientSubreason::NoCrossDexSell,
             no_cross_dex_sell_detail: Some(NoCrossDexSellDetailReason::SellMissingVault),
             sell_quote_none_detail_counts: None,
+            sell_not_fresh_detail_counts: None,
+            no_fresh_buy_quote_detail: None,
+            state_stale_age_bucket_counts: None,
         };
         assert_eq!(
             v2_insufficient_log_category(&cross_dex),

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4585,11 +4585,12 @@ impl MarketDataContext {
     }
 
     /// True when a live Geyser vault/bin feed makes cache-first JetStream publish redundant.
-    /// Momentum-hot / imminent pins bypass this guard so SLAVE `LivePoolCache` age keeps refreshing.
+    /// Momentum-hot / arb-pinned pins bypass this guard so SLAVE `LivePoolCache` age keeps refreshing.
     #[cfg_attr(not(test), allow(dead_code))]
     fn balance_updated_from_cache_skipped_for_live_feed(&self, pool: Pubkey) -> bool {
         self.pool_has_live_vault_geyser_feed(pool)
             && !self.hot_pool_registry.pool_has_momentum(pool)
+            && !self.hot_pool_registry.pool_has_arb(pool)
     }
 
     /// JetStream refresh from MASTER cache for momentum-hot / arb-pinned pools (cache-first, no RPC).
@@ -4609,19 +4610,25 @@ impl MarketDataContext {
         self.publish_hot_pool_balance_refresh_from_cache(pool);
     }
 
-    /// Periodic heartbeat for momentum-hot pins: sustain SLAVE `LivePoolCache` age during WaitHotSet.
+    /// Periodic heartbeat for momentum-hot / arb-pinned pools: sustain SLAVE `LivePoolCache` age.
     /// Returns `true` when explicit Geyser sync should be coalesced (registration remediation).
     fn tick_momentum_hot_balance_refresh_heartbeat(
         &self,
         admission: &mut FixedCapAdmission,
     ) -> bool {
-        if self.hot_pool_registry.hot_pool_count_momentum() == 0 {
+        if self.hot_pool_registry.hot_pool_count_momentum() == 0
+            && self.hot_pool_registry.arb_pool_count() == 0
+        {
             return false;
         }
         for pool in self.hot_pool_registry.snapshot_hot_pool_pubkeys() {
-            if self.hot_pool_registry.pool_has_momentum(pool) {
-                self.try_publish_balance_updated_from_cache(pool, false);
+            let is_momentum = self.hot_pool_registry.pool_has_momentum(pool);
+            let is_arb = self.hot_pool_registry.pool_has_arb(pool);
+            if !is_momentum && !is_arb {
+                continue;
             }
+            let force_arb_seed = is_arb && !is_momentum;
+            self.try_publish_balance_updated_from_cache(pool, force_arb_seed);
         }
         let batch_dirty = self.remediate_open_position_pumpfun_registration(admission);
         self.tick_open_position_pumpfun_registration_observability();
@@ -17237,7 +17244,7 @@ mod pr_b_geyser_tracking_tests {
     }
 
     #[test]
-    fn cache_publish_skipped_after_vault_pubkeys_in_last_synced_snapshot_non_momentum() {
+    fn cache_publish_not_skipped_for_arb_pin_with_live_vault_feed() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
         let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
@@ -17276,8 +17283,8 @@ mod pr_b_geyser_tracking_tests {
         );
         assert!(!ctx.hot_pool_registry.pool_has_momentum(pool));
         assert!(
-            ctx.balance_updated_from_cache_skipped_for_live_feed(pool),
-            "arb-only pool with live vault feed must skip cache-first publish"
+            !ctx.balance_updated_from_cache_skipped_for_live_feed(pool),
+            "arb-pinned pool with live vault feed must sustain SLAVE cache age (C1h2)"
         );
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4873,6 +4873,45 @@ pub static ARB_VAULT_LIVE_SNAPSHOT_SEEDED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| 
 /// v2 screen refreshed stale vault_balances from fresher SLAVE LivePoolCache (C1h).
 pub static ARB_VAULT_LIVE_SNAPSHOT_REFRESHED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+
+// --- C1h2: Freshness root-cause forensics ---
+pub static ARB_TWO_HOP_V2_SELL_NOT_FRESH_DETAIL_EM_AGE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_SELL_NOT_FRESH_DETAIL_EM_FP: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_SELL_NOT_FRESH_DETAIL_LTM_AGE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_STATE_STALE_AGE_LE_30S: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_STATE_STALE_AGE_LE_120S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_STATE_STALE_AGE_LE_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_STATE_STALE_AGE_GT_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_SEED_LE_30S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_SEED_LE_120S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_SEED_LE_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_SEED_GT_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_LE_30S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_LE_120S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_LE_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_GT_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_QUOTE_NONE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_STATE_STALE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_TRADE_STALE: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_NOT_FRESH_AFTER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// PoolStateUpdate scheduled off-hot-loop rescreen for selected mints (C1vault).
 pub static ARB_VAULT_RESCREEN_SCHEDULED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 pub static ARB_V2_SCREEN_METEORA_SELL_BIN_HIT_TOTAL: Lazy<AtomicU64> =
@@ -5422,6 +5461,59 @@ pub fn inc_arb_vault_live_snapshot_seeded_total() {
 /// Increment `arb_vault_live_snapshot_refreshed_total`.
 pub fn inc_arb_vault_live_snapshot_refreshed_total() {
     ARB_VAULT_LIVE_SNAPSHOT_REFRESHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// C1h2: `arb_two_hop_v2_sell_not_fresh_detail_total{kind,cause}`.
+pub fn arb_two_hop_v2_sell_not_fresh_detail_inc(kind: &str, cause: &str) {
+    let counter = match (kind, cause) {
+        ("executable_marginal", "age_exceeded") => &*ARB_TWO_HOP_V2_SELL_NOT_FRESH_DETAIL_EM_AGE,
+        ("executable_marginal", "fingerprint_mismatch") => {
+            &*ARB_TWO_HOP_V2_SELL_NOT_FRESH_DETAIL_EM_FP
+        }
+        ("last_trade_mid", "age_exceeded") => &*ARB_TWO_HOP_V2_SELL_NOT_FRESH_DETAIL_LTM_AGE,
+        _ => return,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+/// C1h2: `arb_two_hop_v2_state_stale_age_bucket_total{bucket}`.
+pub fn arb_two_hop_v2_state_stale_age_bucket_inc(bucket: &str) {
+    let counter = match bucket {
+        "le_30s" => &*ARB_TWO_HOP_V2_STATE_STALE_AGE_LE_30S,
+        "le_120s" => &*ARB_TWO_HOP_V2_STATE_STALE_AGE_LE_120S,
+        "le_300s" => &*ARB_TWO_HOP_V2_STATE_STALE_AGE_LE_300S,
+        "gt_300s" => &*ARB_TWO_HOP_V2_STATE_STALE_AGE_GT_300S,
+        _ => return,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+/// C1h2: `arb_vault_live_snapshot_cache_age_bucket_total{op,bucket}`.
+pub fn arb_vault_live_snapshot_cache_age_bucket_inc(op: &str, bucket: &str) {
+    let counter = match (op, bucket) {
+        ("seed", "le_30s") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_SEED_LE_30S,
+        ("seed", "le_120s") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_SEED_LE_120S,
+        ("seed", "le_300s") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_SEED_LE_300S,
+        ("seed", "gt_300s") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_SEED_GT_300S,
+        ("refresh", "le_30s") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_LE_30S,
+        ("refresh", "le_120s") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_LE_120S,
+        ("refresh", "le_300s") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_LE_300S,
+        ("refresh", "gt_300s") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_GT_300S,
+        _ => return,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+/// C1h2: `arb_two_hop_v2_no_fresh_buy_quote_detail_total{reason}`.
+pub fn arb_two_hop_v2_no_fresh_buy_quote_detail_inc(reason: &str) {
+    let counter = match reason {
+        "quote_none" => &*ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_QUOTE_NONE,
+        "state_stale" => &*ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_STATE_STALE,
+        "trade_stale" => &*ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_TRADE_STALE,
+        "not_fresh_after_quote" => &*ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_NOT_FRESH_AFTER,
+        _ => return,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Increment `arb_vault_rescreen_scheduled_total`.
@@ -6471,6 +6563,120 @@ fn append_arb_two_hop_v2_no_cross_dex_sell_detail_total(out: &mut String) {
             .to_string(),
     );
     out.push('\n');
+}
+
+fn append_arb_c1h2_freshness_forensics_total(out: &mut String) {
+    out.push_str(
+        "arb_two_hop_v2_sell_not_fresh_detail_total{kind=\"executable_marginal\",cause=\"age_exceeded\"} ",
+    );
+    out.push_str(
+        &ARB_TWO_HOP_V2_SELL_NOT_FRESH_DETAIL_EM_AGE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str(
+        "arb_two_hop_v2_sell_not_fresh_detail_total{kind=\"executable_marginal\",cause=\"fingerprint_mismatch\"} ",
+    );
+    out.push_str(
+        &ARB_TWO_HOP_V2_SELL_NOT_FRESH_DETAIL_EM_FP
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str(
+        "arb_two_hop_v2_sell_not_fresh_detail_total{kind=\"last_trade_mid\",cause=\"age_exceeded\"} ",
+    );
+    out.push_str(
+        &ARB_TWO_HOP_V2_SELL_NOT_FRESH_DETAIL_LTM_AGE
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    for (bucket, counter) in [
+        ("le_30s", &*ARB_TWO_HOP_V2_STATE_STALE_AGE_LE_30S),
+        ("le_120s", &*ARB_TWO_HOP_V2_STATE_STALE_AGE_LE_120S),
+        ("le_300s", &*ARB_TWO_HOP_V2_STATE_STALE_AGE_LE_300S),
+        ("gt_300s", &*ARB_TWO_HOP_V2_STATE_STALE_AGE_GT_300S),
+    ] {
+        out.push_str(&format!(
+            "arb_two_hop_v2_state_stale_age_bucket_total{{bucket=\"{bucket}\"}} "
+        ));
+        out.push_str(&counter.load(Ordering::Relaxed).to_string());
+        out.push('\n');
+    }
+    for (op, bucket, counter) in [
+        (
+            "seed",
+            "le_30s",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_SEED_LE_30S,
+        ),
+        (
+            "seed",
+            "le_120s",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_SEED_LE_120S,
+        ),
+        (
+            "seed",
+            "le_300s",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_SEED_LE_300S,
+        ),
+        (
+            "seed",
+            "gt_300s",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_SEED_GT_300S,
+        ),
+        (
+            "refresh",
+            "le_30s",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_LE_30S,
+        ),
+        (
+            "refresh",
+            "le_120s",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_LE_120S,
+        ),
+        (
+            "refresh",
+            "le_300s",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_LE_300S,
+        ),
+        (
+            "refresh",
+            "gt_300s",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_GT_300S,
+        ),
+    ] {
+        out.push_str(&format!(
+            "arb_vault_live_snapshot_cache_age_bucket_total{{op=\"{op}\",bucket=\"{bucket}\"}} "
+        ));
+        out.push_str(&counter.load(Ordering::Relaxed).to_string());
+        out.push('\n');
+    }
+    for (reason, counter) in [
+        (
+            "quote_none",
+            &*ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_QUOTE_NONE,
+        ),
+        (
+            "state_stale",
+            &*ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_STATE_STALE,
+        ),
+        (
+            "trade_stale",
+            &*ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_TRADE_STALE,
+        ),
+        (
+            "not_fresh_after_quote",
+            &*ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_NOT_FRESH_AFTER,
+        ),
+    ] {
+        out.push_str(&format!(
+            "arb_two_hop_v2_no_fresh_buy_quote_detail_total{{reason=\"{reason}\"}} "
+        ));
+        out.push_str(&counter.load(Ordering::Relaxed).to_string());
+        out.push('\n');
+    }
 }
 
 fn append_arb_two_hop_v2_sell_quote_none_detail_total(out: &mut String) {
@@ -10119,6 +10325,7 @@ async fn metrics_response() -> Response<Body> {
     append_arb_two_hop_v2_insufficient_subreason_total(&mut out);
     append_arb_two_hop_v2_no_cross_dex_sell_detail_total(&mut out);
     append_arb_two_hop_v2_sell_quote_none_detail_total(&mut out);
+    append_arb_c1h2_freshness_forensics_total(&mut out);
     append_momentum_latency_histogram_prometheus(
         &mut out,
         "arb_quote_pair_slot_delta_slots",
@@ -11851,6 +12058,38 @@ mod arb_two_hop_v2_sell_quote_none_detail_metrics_tests {
                 out.contains(&format!("reason=\"{label}\"")),
                 "missing sell_quote_none detail label {label}"
             );
+        }
+    }
+}
+
+#[cfg(test)]
+mod arb_c1h2_freshness_forensics_metrics_tests {
+    use super::*;
+
+    #[test]
+    fn c1h2_forensics_inc_and_prometheus_labels() {
+        let before = ARB_TWO_HOP_V2_SELL_NOT_FRESH_DETAIL_EM_AGE.load(Ordering::Relaxed);
+        arb_two_hop_v2_sell_not_fresh_detail_inc("executable_marginal", "age_exceeded");
+        assert_eq!(
+            ARB_TWO_HOP_V2_SELL_NOT_FRESH_DETAIL_EM_AGE.load(Ordering::Relaxed),
+            before + 1
+        );
+
+        arb_two_hop_v2_state_stale_age_bucket_inc("gt_300s");
+        arb_vault_live_snapshot_cache_age_bucket_inc("refresh", "le_120s");
+        arb_two_hop_v2_no_fresh_buy_quote_detail_inc("state_stale");
+
+        let mut out = String::new();
+        append_arb_c1h2_freshness_forensics_total(&mut out);
+        for needle in [
+            "kind=\"executable_marginal\",cause=\"age_exceeded\"",
+            "kind=\"executable_marginal\",cause=\"fingerprint_mismatch\"",
+            "kind=\"last_trade_mid\",cause=\"age_exceeded\"",
+            "state_stale_age_bucket_total{bucket=\"gt_300s\"}",
+            "cache_age_bucket_total{op=\"refresh\",bucket=\"le_120s\"}",
+            "no_fresh_buy_quote_detail_total{reason=\"state_stale\"}",
+        ] {
+            assert!(out.contains(needle), "missing c1h2 metric {needle}");
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Post-#365 prod: `sell_not_fresh` remains ~74% despite ~56k C1h live refreshes. Root cause analysis shows C1h copies `LivePoolCache.age_ms` into `vault.updated_at` — when cache age exceeds `STATE_TTL_MS` (120s), refresh cannot make vault state-fresh.

This PR ships **forensics first** (additive metrics, no TTL bump) plus a **narrow H5 fix** proven by code + prod evidence.

### A) Forensics (additive metrics)

| Metric | Labels |
|--------|--------|
| `arb_two_hop_v2_sell_not_fresh_detail_total` | `kind={executable_marginal,last_trade_mid}`, `cause={age_exceeded,fingerprint_mismatch}` |
| `arb_two_hop_v2_state_stale_age_bucket_total` | `bucket={le_30s,le_120s,le_300s,gt_300s}` |
| `arb_vault_live_snapshot_cache_age_bucket_total` | `op={seed,refresh}`, `bucket=...` |
| `arb_two_hop_v2_no_fresh_buy_quote_detail_total` | `reason={quote_none,state_stale,trade_stale,not_fresh_after_quote}` |

Unit tests cover diagnosis functions (`pool_quote.rs`) and counter paths (`metrics.rs`).

### B) Narrow fix (H5 — Geyser-only, no RPC)

**Evidence:** Momentum-hot pools already bypass `balance_updated_from_cache_skipped_for_live_feed` and get a periodic balance heartbeat to sustain SLAVE `LivePoolCache` age. Arb-only pins had neither — live vault Geyser feed blocked JetStream cache-touch, so SLAVE cache aged past `STATE_TTL_MS` and C1h refresh was ineffective.

**Fix:**
1. Arb-pinned pools bypass live-feed skip (same as momentum)
2. Balance refresh heartbeat includes arb-pinned pools (`force_arb_seed` when arb-only)

No TTL / cap / RPC / multihop changes. C1h/C1vault refresh paths preserved.

### Invariant compliance

- I-4 / I-7: Geyser-only / cache-first JetStream publish — no RPC
- I-ARB-4: TTL constants unchanged
- Dual-consumer: Mom + Arb pin priority unchanged

### Post-deploy validation

After user-approved deploy, expect:
- `arb_vault_live_snapshot_cache_age_bucket` shifts toward `le_120s`
- `sell_not_fresh` / `state_stale` share decreases
- Forensics counters confirm kind/cause split if residual failures remain

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [ ] Impl CI Eval (Level 5) on merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f00b8ade-aa11-43c5-a2d3-010ce245676b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f00b8ade-aa11-43c5-a2d3-010ce245676b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

