### PR TITLE
fix(arb): C1h3 SLAVE cache age sustain on stale-slot heartbeat (post-C1h2)

### DIFF
--- a/docs/BUGS_FIXES.md
+++ b/docs/BUGS_FIXES.md
@@ -6,6 +6,13 @@ Erstellt: 2026-02-13 | Branch: `architecture-rebuild`
 
 ## 1. BEHOBENE BUGS (Fixes deployed/committed)
 
+### FIX-ARB-C1h3: SLAVE Cache Age Sustain on Stale-Slot Heartbeat + NotFresh Detail Wiring (post-C1h2)
+**Datum**: 2026-08-04  
+**Problem**: Post-#366/C1h2: Seed/refresh `live_cache_age` ~95% `gt_300s`; `sell_not_fresh` ~72% bei `sell_not_fresh_detail_*` = 0. MD Heartbeat publisht BalanceUpdated mit MASTER-Slot; Arb-SLAVE kann durch lokalen Geyser voraus sein → `upsert` lehnt Slot-Regress ab und refresht `updated_at` nicht. `StateStale` → `sell_not_fresh` zählt ohne `sell_not_fresh_detail`. Vault-Seed ignorierte frischere Cache-`updated_at` wenn JetStream-Slot ≤ Geyser-Slot.  
+**Fix**: (1) `touch_freshness_on_existing_reserve_basis` bei BalanceUpdated mit Slot-Regress (SLAVE ahead of MASTER); MASTER `upsert` reject bleibt. (2) Vault-Seed: `updated_at` aus Cache wenn frischer als Vault-Slot. (3) H5: `StateStale` Sell-Pfad inkrementiert `sell_not_fresh_detail{executable_marginal,age_exceeded}`. **Invarianten**: I-4/I-7 kein RPC; I-ARB-4 Spoof-Guard bleibt; TTL nicht erhöht.  
+**Evidence**: `findings_arb_zero_opp_post366_20260804.md`, Prod Tip `aa78449`.  
+**Dateien**: `src/execution/live_pool_cache.rs`, `src/execution/pool_cache_sync.rs`, `src/bin/arb_strategy.rs`, `src/arbitrage/pool_quote.rs`, `docs/BUGS_FIXES.md`
+
 ### FIX-ARB-C1h2: Freshness Forensics + Arb-Pin SLAVE Age Sustain (post-C1h)
 **Datum**: 2026-08-04  
 **Problem**: Post-#365/C1h: `sell_not_fresh` weiter ~74%; `state_stale` dominant. C1h refresh kopiert `LivePoolCache.age_ms` in `vault.updated_at` — wenn Cache-Eintrag > `STATE_TTL_MS` (120s), hilft Refresh nicht. Arb-only Pins hatten keinen Momentum-äquivalenten Balance-Heartbeat; `balance_updated_from_cache_skipped_for_live_feed` blockierte JetStream-Touch für Arb trotz Live-Vault-Feed.  

--- a/src/arbitrage/pool_quote.rs
+++ b/src/arbitrage/pool_quote.rs
@@ -1892,6 +1892,12 @@ pub fn select_round_trip_pools(
                     if let Some(vault) = sell_candidate.vault {
                         let bucket = freshness_age_bucket(vault_state_age_ms(vault, now));
                         *state_stale_age_bucket_counts.entry(bucket).or_default() += 1;
+                        // C1h3 H5: same classify path as `sell_not_fresh` top-level counter.
+                        let diagnosis = QuoteNotFreshDiagnosis {
+                            kind: QuoteNotFreshKind::ExecutableMarginal,
+                            cause: QuoteNotFreshCause::AgeExceeded,
+                        };
+                        *sell_not_fresh_detail_counts.entry(diagnosis).or_default() += 1;
                     }
                 }
                 let top = if sub == SellQuoteNoneDetailReason::StateStale {
@@ -2894,5 +2900,61 @@ mod tests {
         assert_eq!(selection.buy_pool_address, "poolA");
         assert_eq!(selection.sell_pool_address, "poolB");
         assert!(selection.sell_quote.amount_out > 0);
+    }
+
+    #[test]
+    fn select_round_trip_pools_state_stale_sell_records_not_fresh_detail() {
+        let pool_a = sample_pool("orca", "poolA");
+        let pool_b = sample_pool("pump_amm", "poolB");
+        let vault_a = sample_vault(1_000_000_000_000, 900_000_000);
+        let mut vault_b = sample_vault(1_000_000_000_000, 1_100_000_000);
+        vault_b.updated_at = Instant::now() - Duration::from_secs(300);
+        let candidates = [
+            RoundTripPoolCandidate {
+                pool: &pool_a,
+                vault: Some(&vault_a),
+                dlmm_bins: None,
+                dex: "orca",
+            },
+            RoundTripPoolCandidate {
+                pool: &pool_b,
+                vault: Some(&vault_b),
+                dlmm_bins: None,
+                dex: "pump_amm",
+            },
+        ];
+        let err = select_round_trip_pools(
+            &candidates,
+            DLMM_PROBE_SOL_LAMPORTS,
+            &QuoteFreshnessConfig::default(),
+        )
+        .unwrap_err();
+        if let RoundTripSelectFailure::InsufficientPools(insufficient) = err {
+            assert_eq!(
+                insufficient.subreason,
+                RoundTripInsufficientSubreason::NoCrossDexSell
+            );
+            assert_eq!(
+                insufficient.no_cross_dex_sell_detail,
+                Some(NoCrossDexSellDetailReason::SellNotFresh)
+            );
+            let detail = insufficient
+                .sell_not_fresh_detail_counts
+                .as_ref()
+                .and_then(|m| {
+                    m.get(&QuoteNotFreshDiagnosis {
+                        kind: QuoteNotFreshKind::ExecutableMarginal,
+                        cause: QuoteNotFreshCause::AgeExceeded,
+                    })
+                })
+                .copied()
+                .unwrap_or(0);
+            assert!(
+                detail > 0,
+                "StateStale sell path must increment sell_not_fresh_detail"
+            );
+        } else {
+            panic!("expected NoCrossDexSell");
+        }
     }
 }

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -1708,9 +1708,13 @@ fn seed_one_pool_from_live_cache(
     };
     let dlmm_sol_is_x = dlmm_token_x_mint.as_deref() == Some(NATIVE_SOL_MINT);
 
-    let should_update_vault = match vault_balances.get(&pool_addr) {
-        Some(existing) => slot >= existing.update_slot,
-        None => true,
+    let (should_replace_vault, should_touch_vault_updated_at) = match vault_balances.get(&pool_addr)
+    {
+        Some(existing) => (
+            slot >= existing.update_slot,
+            cache_updated_at > existing.updated_at,
+        ),
+        None => (true, false),
     };
 
     let tracker = trackers
@@ -1742,7 +1746,7 @@ fn seed_one_pool_from_live_cache(
         vault_reserves_for_comparable,
     ) = match warmup.quote_kind {
         ArbWarmupQuoteKind::Sol => {
-            if should_update_vault {
+            if should_replace_vault {
                 vault_balances.insert(
                     pool_addr.clone(),
                     VaultBalanceCache {
@@ -1756,6 +1760,10 @@ fn seed_one_pool_from_live_cache(
                         dlmm_token_x_mint,
                     },
                 );
+            } else if should_touch_vault_updated_at {
+                if let Some(vault) = vault_balances.get_mut(&pool_addr) {
+                    vault.updated_at = cache_updated_at;
+                }
             }
             let vault_ref = vault_balances
                 .get(&pool_addr)
@@ -1803,9 +1811,6 @@ fn seed_one_pool_from_live_cache(
     };
 
     let pool_last_update = match tracker.pools.get(&pool_addr) {
-        Some(p) if warmup.quote_kind == ArbWarmupQuoteKind::Sol && !should_update_vault => {
-            p.last_update.max(eff_updated_at)
-        }
         Some(p) => p.last_update.max(eff_updated_at),
         None => eff_updated_at,
     };
@@ -9429,7 +9434,7 @@ mod event_pipeline_tests {
 mod two_hop_price_tests {
     use super::*;
     use ironcrab::execution::live_pool_cache::{
-        create_shared_cache, CachedPoolState, MeteoraState, SharedLivePoolCache,
+        create_shared_cache, CachedPoolState, MeteoraState, OrcaWhirlpoolState, SharedLivePoolCache,
     };
     use ironcrab::ipc::PoolCacheUpdate;
     use rust_decimal::Decimal;
@@ -10950,7 +10955,9 @@ mod two_hop_price_tests {
     }
 
     #[test]
-    fn seed_skips_stale_jetstream_vault_when_geyser_slot_is_newer() {
+    fn seed_preserves_geyser_vault_when_jetstream_slot_is_stale() {
+        use std::time::Duration;
+
         let cache = create_shared_cache();
         let token_mint = Pubkey::new_unique();
         let pool = Pubkey::new_unique();
@@ -10971,7 +10978,7 @@ mod two_hop_price_tests {
         );
         ironcrab::execution::pool_cache_sync::apply_pool_cache_update(&cache, &stale_cache_update);
 
-        let fresher_updated_at = Instant::now();
+        let stale_vault_updated_at = Instant::now() - Duration::from_secs(400);
         let mut vault_balances = HashMap::from([(
             pool_str.clone(),
             VaultBalanceCache {
@@ -10980,7 +10987,7 @@ mod two_hop_price_tests {
                 update_slot: 100,
                 active_id: None,
                 bin_step: None,
-                updated_at: fresher_updated_at,
+                updated_at: stale_vault_updated_at,
                 dlmm_sol_is_x: false,
                 dlmm_token_x_mint: None,
             },
@@ -10999,7 +11006,121 @@ mod two_hop_price_tests {
         assert_eq!(vault.update_slot, 100);
         assert_eq!(vault.reserve_base, 9_999);
         assert_eq!(vault.reserve_quote, 8_888);
-        assert_eq!(vault.updated_at, fresher_updated_at);
+        assert!(
+            vault.updated_at > stale_vault_updated_at,
+            "stale vault.updated_at must follow fresher SLAVE cache age without slot regress"
+        );
+    }
+
+    #[test]
+    fn balance_updated_stale_slot_sustains_slave_age_and_refreshes_vault() {
+        use std::time::Duration;
+
+        let cache = create_shared_cache();
+        let token_mint = Pubkey::new_unique();
+        let pool = Pubkey::new_unique();
+        let mint_str = token_mint.to_string();
+        let pool_str = pool.to_string();
+
+        let seed_update = PoolCacheUpdate::new_balance_updated(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            pool_str.clone(),
+            "orca".to_string(),
+            mint_str.clone(),
+            NATIVE_SOL_MINT.to_string(),
+            1_000_000_000_000,
+            2_000_000_000,
+            100,
+        );
+        ironcrab::execution::pool_cache_sync::apply_pool_cache_update(&cache, &seed_update);
+
+        let ahead_state = cache.get(&pool).expect("seeded");
+        let CachedPoolState::Orca(ref orca) = ahead_state else {
+            panic!("expected orca");
+        };
+        let bumped = CachedPoolState::Orca(OrcaWhirlpoolState {
+            token_mint_a: orca.token_mint_a,
+            token_mint_b: orca.token_mint_b,
+            token_vault_a: orca.token_vault_a,
+            token_vault_b: orca.token_vault_b,
+            tick_current_index: orca.tick_current_index,
+            sqrt_price: orca.sqrt_price,
+            liquidity: orca.liquidity,
+            fee_rate: orca.fee_rate,
+            protocol_fee_rate: orca.protocol_fee_rate,
+            tick_spacing: orca.tick_spacing,
+            vault_a_balance: orca.vault_a_balance,
+            vault_b_balance: orca.vault_b_balance,
+            token_a_program: orca.token_a_program,
+            token_b_program: orca.token_b_program,
+        });
+        cache.upsert(pool, bumped, 200);
+
+        std::thread::sleep(Duration::from_millis(40));
+        let (_, _, age_before) = cache.get_with_metadata(&pool).expect("cached");
+        assert!(age_before >= 30, "cache must age before heartbeat sustain");
+
+        let stale_heartbeat = PoolCacheUpdate::new_balance_updated(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            pool_str.clone(),
+            "orca".to_string(),
+            mint_str.clone(),
+            NATIVE_SOL_MINT.to_string(),
+            1_000_000_000_000,
+            2_000_000_000,
+            100,
+        );
+        assert!(
+            ironcrab::execution::pool_cache_sync::apply_pool_cache_update(&cache, &stale_heartbeat),
+            "stale-slot heartbeat must apply age sustain"
+        );
+
+        let (_, slot_after, age_after) = cache.get_with_metadata(&pool).expect("cached");
+        assert_eq!(slot_after, 200, "local Geyser slot must not regress");
+        assert!(
+            age_after < 20,
+            "heartbeat BalanceUpdated must refresh SLAVE cache age"
+        );
+
+        let stale_vault_updated_at = Instant::now() - Duration::from_secs(400);
+        let mut vault_balances = HashMap::from([(
+            pool_str.clone(),
+            VaultBalanceCache {
+                reserve_base: 1_000_000_000_000,
+                reserve_quote: 2_000_000_000,
+                update_slot: 200,
+                active_id: None,
+                bin_step: None,
+                updated_at: stale_vault_updated_at,
+                dlmm_sol_is_x: false,
+                dlmm_token_x_mint: None,
+            },
+        )]);
+        let mut trackers = HashMap::new();
+
+        seed_token_tracker_from_live_pool_cache(
+            &mint_str,
+            &cache,
+            &mut trackers,
+            &mut vault_balances,
+            Some(&pool_str),
+        );
+
+        let vault = vault_balances.get(&pool_str).expect("vault");
+        assert_eq!(vault.update_slot, 200);
+        assert!(
+            vault.updated_at > stale_vault_updated_at,
+            "vault.updated_at must follow fresher cache age at seed"
+        );
+        let (_, _, age_ms) = cache.get_with_metadata(&pool).expect("cached");
+        assert!(
+            age_ms <= 120_000,
+            "screen seed should land in le_120s freshness bucket, got age_ms={age_ms}"
+        );
     }
 
     #[test]

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -630,6 +630,21 @@ impl LivePoolCache {
         }
     }
 
+    /// Refresh `updated_at` on an existing row with quotable reserve basis without changing slot/state.
+    ///
+    /// Used when a JetStream `BalanceUpdated` heartbeat arrives with a regressed slot (SLAVE ahead of
+    /// MASTER from local Geyser) — sustains age without spoofing 0/0 discovery rows.
+    pub fn touch_freshness_on_existing_reserve_basis(&self, pool: &Pubkey) -> bool {
+        if let Some(mut entry) = self.pools.get_mut(pool) {
+            if pool_state_has_reserve_basis(&entry.state) {
+                entry.updated_at = Instant::now();
+                self.updates_total.fetch_add(1, Ordering::Relaxed);
+                return true;
+            }
+        }
+        false
+    }
+
     /// Update vault balance for a pool
     pub fn update_vault_balance(&self, vault: &Pubkey, balance: u64, slot: u64) {
         if let Some(mapping) = self.vault_to_pool.get(vault) {
@@ -2564,6 +2579,78 @@ mod tests {
         assert!(
             age_after_quotable < 20,
             "quotable upsert must refresh cache age"
+        );
+    }
+
+    #[test]
+    fn touch_freshness_on_stale_slot_heartbeat_sustains_age_without_slot_regress() {
+        use std::time::Duration;
+
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let state = CachedPoolState::PumpAmm(PumpAmmState {
+            base_mint: Pubkey::new_unique(),
+            quote_mint: Pubkey::new_unique(),
+            pool_base_token_account: Pubkey::new_unique(),
+            pool_quote_token_account: Pubkey::new_unique(),
+            base_reserve: Some(1_000_000),
+            quote_reserve: Some(50_000_000_000),
+            pool_accounts: Vec::new(),
+            creator: None,
+        });
+
+        cache.upsert(pool, state.clone(), 100);
+        std::thread::sleep(Duration::from_millis(40));
+        let (_, slot_before, age_before) = cache.get_with_metadata(&pool).expect("cached");
+        assert_eq!(slot_before, 100);
+        assert!(age_before >= 30, "row must age before heartbeat sustain");
+
+        assert!(
+            !cache.upsert(pool, state, 50),
+            "stale slot upsert must still reject slot regress"
+        );
+        assert!(
+            cache.touch_freshness_on_existing_reserve_basis(&pool),
+            "heartbeat age sustain must touch existing quotable row"
+        );
+        let (_, slot_after, age_after) = cache.get_with_metadata(&pool).expect("cached");
+        assert_eq!(slot_after, 100, "slot must not regress on age-only sustain");
+        assert!(
+            age_after < 20,
+            "stale-slot heartbeat must refresh cache age when reserves are quotable"
+        );
+    }
+
+    #[test]
+    fn touch_freshness_skipped_for_zero_reserve_rows() {
+        use std::time::Duration;
+
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let zero_state = CachedPoolState::PumpAmm(PumpAmmState {
+            base_mint: Pubkey::new_unique(),
+            quote_mint: Pubkey::new_unique(),
+            pool_base_token_account: Pubkey::new_unique(),
+            pool_quote_token_account: Pubkey::new_unique(),
+            base_reserve: Some(0),
+            quote_reserve: Some(0),
+            pool_accounts: Vec::new(),
+            creator: None,
+        });
+
+        cache.upsert(pool, zero_state, 100);
+        std::thread::sleep(Duration::from_millis(40));
+        let (_, _, age_before) = cache.get_with_metadata(&pool).expect("cached");
+
+        assert!(
+            !cache.touch_freshness_on_existing_reserve_basis(&pool),
+            "0/0 row must not spoof age refresh"
+        );
+        let (_, slot_after, age_after) = cache.get_with_metadata(&pool).expect("cached");
+        assert_eq!(slot_after, 100);
+        assert!(
+            age_after >= age_before,
+            "spoof guard must keep stale age on 0/0 row"
         );
     }
 

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -21,8 +21,8 @@ use std::str::FromStr;
 use tracing::{debug, info, warn};
 
 use crate::execution::live_pool_cache::{
-    CachedPoolState, LivePoolCache, MeteoraCpmmState, MeteoraState, OrcaWhirlpoolState,
-    PumpAmmState, PumpFunState, RaydiumAmmState, RaydiumCpmmState,
+    pool_state_has_reserve_basis, CachedPoolState, LivePoolCache, MeteoraCpmmState, MeteoraState,
+    OrcaWhirlpoolState, PumpAmmState, PumpFunState, RaydiumAmmState, RaydiumCpmmState,
 };
 use crate::ipc::{
     PoolCacheUpdate, PoolCacheUpdateType, NATIVE_SOL_MINT,
@@ -1140,11 +1140,19 @@ fn apply_pool_cache_update_outcome_inner(
                         }
                     }
                 }
-                if !cache.upsert(addr, minimal_state, update.geyser_slot) {
+                let incoming_has_reserve_basis = pool_state_has_reserve_basis(&minimal_state);
+                let upserted = cache.upsert(addr, minimal_state, update.geyser_slot);
+                if !upserted {
                     if update.geyser_slot > 0 {
                         crate::metrics::inc_pool_cache_apply_rejected_stale_slot_total();
+                        let age_sustained = incoming_has_reserve_basis
+                            && cache.touch_freshness_on_existing_reserve_basis(&addr);
+                        if !age_sustained {
+                            return PoolCacheApplyOutcome::RejectedStaleSlot;
+                        }
+                    } else {
+                        return PoolCacheApplyOutcome::RejectedStaleSlot;
                     }
-                    return PoolCacheApplyOutcome::RejectedStaleSlot;
                 }
                 if update.dex == "pump_amm" {
                     cache.merge_pump_amm_sell_layout_from_metadata(&addr, update.metadata.as_ref());
@@ -3309,7 +3317,9 @@ mod tests {
     }
 
     #[test]
-    fn apply_rejects_stale_lower_slot_monotonic() {
+    fn apply_stale_lower_slot_sustains_age_when_reserve_basis() {
+        use std::time::Duration;
+
         let cache = LivePoolCache::new();
         let pool = Pubkey::new_unique();
         let base_mint = Pubkey::new_unique();
@@ -3329,6 +3339,8 @@ mod tests {
         );
         assert!(apply_pool_cache_update(&cache, &fresh));
 
+        std::thread::sleep(Duration::from_millis(40));
+
         let stale = PoolCacheUpdate::new_balance_updated(
             "test",
             "0.1.0",
@@ -3342,8 +3354,51 @@ mod tests {
             400,
         );
         assert!(
+            apply_pool_cache_update(&cache, &stale),
+            "stale-slot heartbeat with reserve basis must sustain age (C1h3)"
+        );
+        let (_, slot, age_ms) = cache.get_with_metadata(&pool).expect("cached");
+        assert_eq!(slot, 500, "slot must not regress");
+        assert!(age_ms < 20, "age must refresh on stale-slot sustain");
+    }
+
+    #[test]
+    fn apply_rejects_stale_lower_slot_without_reserve_basis() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let quote_mint = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+
+        let discovered = PoolCacheUpdate::new_pool_discovered(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "pump_amm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            0,
+            0,
+            None,
+            500,
+        );
+        assert!(apply_pool_cache_update(&cache, &discovered));
+
+        let stale = PoolCacheUpdate::new_balance_updated(
+            "test",
+            "0.1.0",
+            "run",
+            pool.to_string(),
+            "pump_amm".to_string(),
+            base_mint.to_string(),
+            quote_mint.to_string(),
+            0,
+            0,
+            400,
+        );
+        assert!(
             !apply_pool_cache_update(&cache, &stale),
-            "stale slot must be rejected"
+            "0/0 stale slot must not spoof age refresh"
         );
         let (_, slot, _) = cache.get_with_metadata(&pool).expect("cached");
         assert_eq!(slot, 500);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Post-#366 prod showed ~95% seed/refresh `live_cache_age` in `gt_300s` and `sell_not_fresh_detail_*` at 0 despite high `sell_not_fresh`.

**Root cause:** MD BalanceUpdated heartbeats publish MASTER cache slot. Arb SLAVE can be ahead via local Geyser vault updates → `upsert` rejected slot regress → `updated_at` never refreshed. `StateStale` sell failures counted as `sell_not_fresh` without detail wiring.

## Changes

### A) End-to-end age reset (P0)
- `LivePoolCache::touch_freshness_on_existing_reserve_basis` — refresh age without slot/state regress
- `pool_cache_sync` BalanceUpdated: on stale-slot reject + incoming reserve basis → age sustain, return `Applied` (tracker seed still runs)
- `seed_one_pool_from_live_cache`: touch `vault.updated_at` from fresher cache age without regressing Geyser slot/reserves

### B) Forensics H5
- `select_round_trip_pools`: `StateStale` sell path increments `sell_not_fresh_detail{executable_marginal,age_exceeded}`

### Preserved
- MASTER `upsert` slot-monotonic reject unchanged (ensure_pumpfun / cold path)
- 0/0 spoof guard unchanged
- No TTL/cap/RPC changes

## Tests
- `touch_freshness_on_stale_slot_heartbeat_sustains_age_without_slot_regress`
- `apply_stale_lower_slot_sustains_age_when_reserve_basis`
- `balance_updated_stale_slot_sustains_slave_age_and_refreshes_vault`
- `select_round_trip_pools_state_stale_sell_records_not_fresh_detail`

## CI
- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test` ✓

## Invarianten
I-4/I-7: Geyser-only, kein RPC. I-ARB-4: Spoof-Guard für 0/0 bleibt.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1eda7d1c-426a-4d06-a977-79a4f5c851ea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1eda7d1c-426a-4d06-a977-79a4f5c851ea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

