### PR TITLE
fix(arb): C1h4 arb-pin touch coverage after explicit sync + forensics

### DIFF
--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -76,17 +76,17 @@ use ironcrab::metrics::{
     arb_two_hop_v2_screen_multi_dex_inc, arb_two_hop_v2_screen_skipped_inc,
     arb_two_hop_v2_sell_not_fresh_detail_inc, arb_two_hop_v2_sell_quote_none_detail_inc,
     arb_two_hop_v2_state_stale_age_bucket_inc, arb_vault_live_snapshot_cache_age_bucket_inc,
-    inc_arb_dlmm_bin_array_update_applied_total, inc_arb_dlmm_bin_array_update_received_total,
-    inc_arb_dlmm_bin_rescreen_scheduled_total, inc_arb_pinned_meteora_pool_bin_cache_miss_total,
-    inc_arb_v2_screen_meteora_sell_bin_hit_total, inc_arb_v2_screen_meteora_sell_bin_miss_total,
-    inc_arb_vault_balance_applied_total, inc_arb_vault_live_snapshot_refreshed_total,
-    inc_arb_vault_live_snapshot_seeded_total, inc_arb_vault_rescreen_scheduled_total,
-    record_arb_heartbeat_phase, record_arb_price_freshness_stale_age_ms,
-    record_arb_proactive_pin_first_publish, record_arb_proactive_track_publish_total,
-    record_arb_quote_pair_slot_delta, record_arb_quote_shadow_round_trip,
-    record_arb_track_publish_skipped_unchanged_total, record_arb_track_removed_total,
-    record_arb_track_requests_messages_total, record_arb_track_requests_publish_chunks_total,
-    record_arb_track_requests_publish_failed_total,
+    arb_vault_live_snapshot_cache_age_pin_bucket_inc, inc_arb_dlmm_bin_array_update_applied_total,
+    inc_arb_dlmm_bin_array_update_received_total, inc_arb_dlmm_bin_rescreen_scheduled_total,
+    inc_arb_pinned_meteora_pool_bin_cache_miss_total, inc_arb_v2_screen_meteora_sell_bin_hit_total,
+    inc_arb_v2_screen_meteora_sell_bin_miss_total, inc_arb_vault_balance_applied_total,
+    inc_arb_vault_live_snapshot_refreshed_total, inc_arb_vault_live_snapshot_seeded_total,
+    inc_arb_vault_rescreen_scheduled_total, record_arb_heartbeat_phase,
+    record_arb_price_freshness_stale_age_ms, record_arb_proactive_pin_first_publish,
+    record_arb_proactive_track_publish_total, record_arb_quote_pair_slot_delta,
+    record_arb_quote_shadow_round_trip, record_arb_track_publish_skipped_unchanged_total,
+    record_arb_track_removed_total, record_arb_track_requests_messages_total,
+    record_arb_track_requests_publish_chunks_total, record_arb_track_requests_publish_failed_total,
     record_arb_track_selection_blocking_join_failed_total,
     record_arb_track_selection_queue_overflow_total, record_arb_track_selection_recompute_total,
     record_arb_writer_lock_wait, serve_metrics, set_arb_pool_cache_apply_batch_size_gauge,
@@ -444,6 +444,7 @@ fn try_seed_vault_from_live_cache(
     pool_address: &str,
     live_pool_cache: &SharedLivePoolCache,
     vault_cache: &mut HashMap<String, VaultBalanceCache>,
+    pin_class: &str,
 ) -> bool {
     if vault_cache.contains_key(pool_address) {
         return false;
@@ -457,7 +458,7 @@ fn try_seed_vault_from_live_cache(
     let Some(vault) = vault_balance_from_live_cache_state(&state, slot, age_ms) else {
         return false;
     };
-    record_live_cache_age_at_snapshot("seed", age_ms);
+    record_live_cache_age_at_snapshot("seed", age_ms, pin_class);
     vault_cache.insert(pool_address.to_string(), vault);
     true
 }
@@ -467,6 +468,7 @@ fn try_refresh_vault_from_live_cache(
     pool_address: &str,
     live_pool_cache: &SharedLivePoolCache,
     vault_cache: &mut HashMap<String, VaultBalanceCache>,
+    pin_class: &str,
 ) -> bool {
     let Ok(pool_pk) = Pubkey::from_str(pool_address) else {
         return false;
@@ -484,7 +486,7 @@ fn try_refresh_vault_from_live_cache(
     if !live_pool_cache_fresher_than_vault(slot, new_vault.updated_at, existing) {
         return false;
     }
-    record_live_cache_age_at_snapshot("refresh", age_ms);
+    record_live_cache_age_at_snapshot("refresh", age_ms, pin_class);
     vault_cache.insert(pool_address.to_string(), new_vault);
     true
 }
@@ -2391,9 +2393,10 @@ fn v2_sell_quote_none_detail_to_metric(
     }
 }
 
-fn record_live_cache_age_at_snapshot(op: &str, age_ms: u64) {
+fn record_live_cache_age_at_snapshot(op: &str, age_ms: u64, pin_class: &str) {
     let bucket = freshness_age_bucket(age_ms).as_metric_label();
     arb_vault_live_snapshot_cache_age_bucket_inc(op, bucket);
+    arb_vault_live_snapshot_cache_age_pin_bucket_inc(op, bucket, pin_class);
 }
 
 fn record_v2_insufficient_subreason(insufficient: &RoundTripInsufficient) {
@@ -5595,6 +5598,12 @@ impl ArbContext {
         // Bin liquidity updates are a valid DLMM price signal (H3): refresh vault + pool timestamps.
         let now = Instant::now();
         {
+            let pinned = self.arb_pinned_pools.read();
+            let pin_class = if pinned.contains(pool_address) {
+                "pin"
+            } else {
+                "cold"
+            };
             let mut vault_cache = self.vault_balances.write();
             try_seed_dlmm_vault_on_bin_update(
                 pool_address,
@@ -5607,6 +5616,7 @@ impl ArbContext {
                     pool_address,
                     &self.live_pool_cache,
                     &mut vault_cache,
+                    pin_class,
                 )
             {
                 if let Some(v) = vault_cache.get_mut(pool_address) {
@@ -5996,15 +6006,22 @@ impl ArbContext {
         HashMap<String, HashMap<i64, BinArrayCache>>,
     ) {
         let pool_keys: Vec<String> = tracker_snapshot.pools.keys().cloned().collect();
+        let pinned_pools = self.arb_pinned_pools.read();
         let vaults = self.vault_balances.read();
         let mut vault_balances = HashMap::with_capacity(pool_keys.len());
         for pool_key in &pool_keys {
+            let pin_class = if pinned_pools.contains(pool_key) {
+                "pin"
+            } else {
+                "cold"
+            };
             if let Some(entry) = vaults.get(pool_key) {
                 vault_balances.insert(pool_key.clone(), entry.clone());
                 if try_refresh_vault_from_live_cache(
                     pool_key,
                     &self.live_pool_cache,
                     &mut vault_balances,
+                    pin_class,
                 ) {
                     inc_arb_vault_live_snapshot_refreshed_total();
                 }
@@ -6012,11 +6029,13 @@ impl ArbContext {
                 pool_key,
                 &self.live_pool_cache,
                 &mut vault_balances,
+                pin_class,
             ) {
                 inc_arb_vault_live_snapshot_seeded_total();
             }
         }
         drop(vaults);
+        drop(pinned_pools);
 
         let bins = self.bin_arrays.read();
         let mut bin_arrays = HashMap::with_capacity(pool_keys.len());
@@ -11120,6 +11139,49 @@ mod two_hop_price_tests {
         assert!(
             age_ms <= 120_000,
             "screen seed should land in le_120s freshness bucket, got age_ms={age_ms}"
+        );
+    }
+
+    #[test]
+    fn live_snapshot_cache_age_records_pin_label() {
+        use ironcrab::metrics::{
+            ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_LE_120S,
+            ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_LE_30S,
+        };
+        use std::sync::atomic::Ordering;
+
+        let cache = create_shared_cache();
+        let pool = Pubkey::new_unique();
+        let pool_str = pool.to_string();
+        let seed_update = PoolCacheUpdate::new_balance_updated(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            pool_str.clone(),
+            "orca".to_string(),
+            Pubkey::new_unique().to_string(),
+            NATIVE_SOL_MINT.to_string(),
+            1_000_000_000_000,
+            2_000_000_000,
+            100,
+        );
+        ironcrab::execution::pool_cache_sync::apply_pool_cache_update(&cache, &seed_update);
+
+        let before_30s = ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_LE_30S.load(Ordering::Relaxed);
+        let before_120s =
+            ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_LE_120S.load(Ordering::Relaxed);
+        let mut vault_balances = HashMap::new();
+        assert!(try_seed_vault_from_live_cache(
+            &pool_str,
+            &cache,
+            &mut vault_balances,
+            "pin"
+        ));
+        let after_30s = ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_LE_30S.load(Ordering::Relaxed);
+        let after_120s = ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_LE_120S.load(Ordering::Relaxed);
+        assert!(
+            after_30s > before_30s || after_120s > before_120s,
+            "pin-labeled cache age bucket must increment for arb-pinned seed path"
         );
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -118,6 +118,8 @@ use ironcrab::metrics::{
     inc_market_data_exec_hot_hard_shed_steps_for_tier_reason,
     inc_market_data_exec_hot_pressure_admit_rejected_total,
     inc_market_data_geyser_sync_skipped_rate_limit_total,
+    inc_market_data_heartbeat_balance_refresh_published_total,
+    inc_market_data_heartbeat_balance_refresh_skipped_total,
     inc_market_data_ingest_membership_snapshot_hits_total,
     inc_market_data_jsonl_enqueue_dropped_total, inc_market_data_momentum_admission_admitted_total,
     inc_market_data_momentum_admission_rejected_total,
@@ -1788,6 +1790,19 @@ fn cached_pool_has_fresh_reserve_basis(state: &CachedPoolState) -> bool {
         CachedPoolState::PumpFun(s) => {
             !s.complete && s.virtual_sol_reserves > 0 && s.virtual_token_reserves > 0
         }
+    }
+}
+
+fn heartbeat_balance_refresh_coverage_label(
+    is_momentum: bool,
+    force_arb_seed: bool,
+) -> &'static str {
+    if force_arb_seed {
+        "arb_pin"
+    } else if is_momentum {
+        "momentum"
+    } else {
+        "other"
     }
 }
 
@@ -3863,7 +3878,7 @@ impl MarketDataContext {
         let prev_synced = self.last_synced_explicit_pubkeys.read().clone();
         *self.last_synced_explicit_pubkeys.write() =
             admission.snapshot_pubkeys().into_iter().collect();
-        self.publish_momentum_hot_balance_refresh_after_explicit_sync(&prev_synced);
+        self.publish_hot_pool_balance_refresh_after_explicit_sync(&prev_synced);
         self.publish_hot_bin_array_replay_after_explicit_sync(&prev_synced);
         self.clear_geyser_prune_resume();
         true
@@ -4628,7 +4643,12 @@ impl MarketDataContext {
                 continue;
             }
             let force_arb_seed = is_arb && !is_momentum;
-            self.try_publish_balance_updated_from_cache(pool, force_arb_seed);
+            let coverage = heartbeat_balance_refresh_coverage_label(is_momentum, force_arb_seed);
+            self.try_publish_balance_updated_from_cache_with_heartbeat_observability(
+                pool,
+                force_arb_seed,
+                Some(coverage),
+            );
         }
         let batch_dirty = self.remediate_open_position_pumpfun_registration(admission);
         self.tick_open_position_pumpfun_registration_observability();
@@ -4750,14 +4770,13 @@ impl MarketDataContext {
         }
     }
 
-    /// After explicit Geyser sync, refresh SLAVE age once when a momentum-hot pool's feed becomes live.
-    fn publish_momentum_hot_balance_refresh_after_explicit_sync(
-        &self,
-        prev_synced: &HashSet<Pubkey>,
-    ) {
+    /// After explicit Geyser sync, refresh SLAVE age once when a hot pool's vault/bin feed becomes live.
+    fn publish_hot_pool_balance_refresh_after_explicit_sync(&self, prev_synced: &HashSet<Pubkey>) {
         let synced = self.last_synced_explicit_pubkeys.read();
         for pool in self.hot_pool_registry.snapshot_hot_pool_pubkeys() {
-            if !self.hot_pool_registry.pool_has_momentum(pool) {
+            let is_momentum = self.hot_pool_registry.pool_has_momentum(pool);
+            let is_arb = self.hot_pool_registry.pool_has_arb(pool);
+            if !is_momentum && !is_arb {
                 continue;
             }
             if !self.hot_pool_reserve_registration_satisfied(pool) {
@@ -4771,7 +4790,8 @@ impl MarketDataContext {
                 .iter()
                 .any(|pk| !prev_synced.contains(pk) && synced.contains(pk));
             if newly_live {
-                self.try_publish_balance_updated_from_cache(pool, false);
+                let force_arb_seed = is_arb && !is_momentum;
+                self.try_publish_balance_updated_from_cache(pool, force_arb_seed);
             }
         }
     }
@@ -4918,18 +4938,49 @@ impl MarketDataContext {
 
     /// Cache-first JetStream BalanceUpdated for pools with fresh reserve basis (no vault Geyser sub required).
     fn try_publish_balance_updated_from_cache(&self, pool: Pubkey, force_arb_seed: bool) {
+        self.try_publish_balance_updated_from_cache_with_heartbeat_observability(
+            pool,
+            force_arb_seed,
+            None,
+        );
+    }
+
+    fn try_publish_balance_updated_from_cache_with_heartbeat_observability(
+        &self,
+        pool: Pubkey,
+        force_arb_seed: bool,
+        heartbeat_coverage: Option<&'static str>,
+    ) {
         if !force_arb_seed && self.balance_updated_from_cache_skipped_for_live_feed(pool) {
+            if let Some(coverage) = heartbeat_coverage {
+                inc_market_data_heartbeat_balance_refresh_skipped_total(coverage, "live_feed");
+            }
             return;
         }
         let Some(state) = self.live_pool_cache.get(&pool) else {
+            if let Some(coverage) = heartbeat_coverage {
+                inc_market_data_heartbeat_balance_refresh_skipped_total(coverage, "cache_miss");
+            }
             return;
         };
         if !cached_pool_has_fresh_reserve_basis(&state) {
+            if let Some(coverage) = heartbeat_coverage {
+                inc_market_data_heartbeat_balance_refresh_skipped_total(
+                    coverage,
+                    "no_reserve_basis",
+                );
+            }
             return;
         }
         let Some((base_mint, quote_mint, base_reserve, quote_reserve, dex)) =
             pool_cache_balance_fields_from_state(&state)
         else {
+            if let Some(coverage) = heartbeat_coverage {
+                inc_market_data_heartbeat_balance_refresh_skipped_total(
+                    coverage,
+                    "balance_fields_none",
+                );
+            }
             return;
         };
         let publish_slot = self
@@ -4942,6 +4993,9 @@ impl MarketDataContext {
             .as_ref()
             .map(NatsClient::clone_for_spawned_publish)
         else {
+            if let Some(coverage) = heartbeat_coverage {
+                inc_market_data_heartbeat_balance_refresh_skipped_total(coverage, "no_nats");
+            }
             return;
         };
         let run_id = self.run_id.clone();
@@ -5005,13 +5059,21 @@ impl MarketDataContext {
             if force_arb_seed && self.hot_pool_registry.pool_has_arb(pool) {
                 inc_market_data_arb_pin_vault_published_total();
             }
+            if let Some(coverage) = heartbeat_coverage {
+                inc_market_data_heartbeat_balance_refresh_published_total(coverage);
+            }
             handle.spawn(publish);
         } else if let Ok(handle) = tokio::runtime::Handle::try_current() {
             inc_market_data_balance_updated_from_cache_total();
             if force_arb_seed && self.hot_pool_registry.pool_has_arb(pool) {
                 inc_market_data_arb_pin_vault_published_total();
             }
+            if let Some(coverage) = heartbeat_coverage {
+                inc_market_data_heartbeat_balance_refresh_published_total(coverage);
+            }
             handle.spawn(publish);
+        } else if let Some(coverage) = heartbeat_coverage {
+            inc_market_data_heartbeat_balance_refresh_skipped_total(coverage, "no_runtime");
         }
     }
 
@@ -17285,6 +17347,109 @@ mod pr_b_geyser_tracking_tests {
         assert!(
             !ctx.balance_updated_from_cache_skipped_for_live_feed(pool),
             "arb-pinned pool with live vault feed must sustain SLAVE cache age (C1h2)"
+        );
+    }
+
+    #[test]
+    fn arb_pin_balance_refresh_after_explicit_sync_when_vault_becomes_live() {
+        use ironcrab::metrics::MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let pool = Pubkey::new_unique();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+        assert!(ctx.register_geyser_reserves_for_arb_active_pool(pool));
+        let mut admission = FixedCapAdmission::new(ctx.max_tracked_accounts());
+        ironcrab::market_data::track::converge_admission_from_ctx(ctx.as_ref(), &mut admission);
+        ctx.prune_tracked_maps_to_admitted(&admission);
+        ctx.publish_admitted_explicit_physical(&admission);
+        let prev_synced: HashSet<Pubkey> = HashSet::new();
+        *ctx.last_synced_explicit_pubkeys.write() =
+            admission.snapshot_pubkeys().into_iter().collect();
+
+        assert!(
+            ctx.hot_pool_reserve_registration_satisfied(pool),
+            "arb pin must have vault rows registered"
+        );
+        assert!(
+            ctx.pool_has_live_vault_geyser_feed(pool),
+            "vault pubkeys must be in synced explicit set"
+        );
+
+        let counter_before = MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.load(Ordering::Relaxed);
+        ctx.publish_hot_pool_balance_refresh_after_explicit_sync(&prev_synced);
+        // Without NATS/runtime the spawn path is a no-op, but arb pin must not be filtered out
+        // by the old momentum-only explicit-sync gate (C1h4 coverage).
+        assert!(
+            !ctx.balance_updated_from_cache_skipped_for_live_feed(pool),
+            "arb pin with live vault feed must remain eligible for explicit-sync refresh"
+        );
+        assert_eq!(
+            MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.load(Ordering::Relaxed),
+            counter_before,
+            "no NATS in test harness — publish is expected no-op after eligibility checks"
+        );
+    }
+
+    #[test]
+    fn arb_only_heartbeat_targets_arb_pin_with_force_seed() {
+        use ironcrab::metrics::MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_NO_NATS;
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let pool = Pubkey::new_unique();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: Some(1_000_000),
+                reserve_1: Some(2_000_000),
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+        assert!(!ctx.hot_pool_registry.pool_has_momentum(pool));
+        assert!(!ctx.balance_updated_from_cache_skipped_for_live_feed(pool));
+
+        let skipped_before =
+            MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_NO_NATS.load(Ordering::Relaxed);
+        let mut admission = test_admission_for(&ctx);
+        ctx.tick_momentum_hot_balance_refresh_heartbeat(&mut admission);
+        assert!(
+            MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_NO_NATS.load(Ordering::Relaxed)
+                > skipped_before,
+            "arb-only heartbeat must traverse publish path for arb_pin coverage"
         );
     }
 

--- a/src/execution/pool_cache_sync.rs
+++ b/src/execution/pool_cache_sync.rs
@@ -1147,6 +1147,9 @@ fn apply_pool_cache_update_outcome_inner(
                         crate::metrics::inc_pool_cache_apply_rejected_stale_slot_total();
                         let age_sustained = incoming_has_reserve_basis
                             && cache.touch_freshness_on_existing_reserve_basis(&addr);
+                        if age_sustained {
+                            crate::metrics::inc_pool_cache_touch_freshness_on_stale_slot_total();
+                        }
                         if !age_sustained {
                             return PoolCacheApplyOutcome::RejectedStaleSlot;
                         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -497,6 +497,41 @@ pub static MARKET_DATA_HOT_POOL_REGISTRY_POOLS_BOTH: Lazy<AtomicU64> =
 /// BalanceUpdated published from MASTER cache without vault Geyser subscription.
 pub static MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// C1h4: heartbeat BalanceUpdated publish attempts that spawned JetStream work.
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_PUBLISHED_ARB_PIN: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_PUBLISHED_MOMENTUM: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_PUBLISHED_OTHER: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// C1h4: heartbeat publish skipped before JetStream spawn.
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_LIVE_FEED: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_CACHE_MISS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_NO_RESERVE_BASIS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_BALANCE_FIELDS_NONE: Lazy<
+    AtomicU64,
+> = Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_NO_NATS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_NO_RUNTIME: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_MOMENTUM_LIVE_FEED: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_MOMENTUM_CACHE_MISS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_MOMENTUM_NO_RESERVE_BASIS: Lazy<
+    AtomicU64,
+> = Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_MOMENTUM_BALANCE_FIELDS_NONE: Lazy<
+    AtomicU64,
+> = Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_MOMENTUM_NO_NATS: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_MOMENTUM_NO_RUNTIME: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 /// P2: JetStream BalanceUpdated from enrichment cache upsert path.
 pub static MARKET_DATA_ENRICHMENT_BALANCE_UPDATED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
@@ -1038,6 +1073,59 @@ pub fn set_market_data_hot_pool_registry_pools_gauge(reason: &str, n: usize) {
 #[inline]
 pub fn inc_market_data_balance_updated_from_cache_total() {
     MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// C1h4: `market_data_heartbeat_balance_refresh_published_total{coverage}`.
+#[inline]
+pub fn inc_market_data_heartbeat_balance_refresh_published_total(coverage: &str) {
+    let counter = match coverage {
+        "arb_pin" => &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_PUBLISHED_ARB_PIN,
+        "momentum" => &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_PUBLISHED_MOMENTUM,
+        "other" => &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_PUBLISHED_OTHER,
+        _ => return,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+/// C1h4: `market_data_heartbeat_balance_refresh_skipped_total{coverage,reason}`.
+#[inline]
+pub fn inc_market_data_heartbeat_balance_refresh_skipped_total(coverage: &str, reason: &str) {
+    let counter = match (coverage, reason) {
+        ("arb_pin", "live_feed") => {
+            &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_LIVE_FEED
+        }
+        ("arb_pin", "cache_miss") => {
+            &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_CACHE_MISS
+        }
+        ("arb_pin", "no_reserve_basis") => {
+            &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_NO_RESERVE_BASIS
+        }
+        ("arb_pin", "balance_fields_none") => {
+            &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_BALANCE_FIELDS_NONE
+        }
+        ("arb_pin", "no_nats") => &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_NO_NATS,
+        ("arb_pin", "no_runtime") => {
+            &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_NO_RUNTIME
+        }
+        ("momentum", "live_feed") => {
+            &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_MOMENTUM_LIVE_FEED
+        }
+        ("momentum", "cache_miss") => {
+            &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_MOMENTUM_CACHE_MISS
+        }
+        ("momentum", "no_reserve_basis") => {
+            &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_MOMENTUM_NO_RESERVE_BASIS
+        }
+        ("momentum", "balance_fields_none") => {
+            &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_MOMENTUM_BALANCE_FIELDS_NONE
+        }
+        ("momentum", "no_nats") => &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_MOMENTUM_NO_NATS,
+        ("momentum", "no_runtime") => {
+            &*MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_MOMENTUM_NO_RUNTIME
+        }
+        _ => return,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
 }
 
 pub fn inc_market_data_enrichment_balance_updated_total() {
@@ -3552,6 +3640,15 @@ pub fn inc_pool_cache_apply_rejected_stale_slot_total() {
     POOL_CACHE_APPLY_REJECTED_STALE_SLOT_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+static POOL_CACHE_TOUCH_FRESHNESS_ON_STALE_SLOT_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// C1h4: stale-slot JetStream heartbeat sustained SLAVE cache age via reserve-basis touch.
+#[inline]
+pub fn inc_pool_cache_touch_freshness_on_stale_slot_total() {
+    POOL_CACHE_TOUCH_FRESHNESS_ON_STALE_SLOT_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
 static MOMENTUM_POOL_CACHE_APPLY_REJECTED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
 static MOMENTUM_POOL_CACHE_APPLY_OUTCOME_TOTAL: Lazy<RwLock<HashMap<(String, String), u64>>> =
@@ -4904,6 +5001,40 @@ pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_LE_300S: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_GT_300S: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// C1h4: pin-labeled cache age at screen snapshot (arb-pinned pools).
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_LE_30S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_LE_120S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_LE_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_GT_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_REFRESH_LE_30S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_REFRESH_LE_120S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_REFRESH_LE_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_REFRESH_GT_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// C1h4: non-pin tracker pools at screen snapshot (documented out-of-scope for heartbeat).
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_SEED_LE_30S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_SEED_LE_120S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_SEED_LE_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_SEED_GT_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_REFRESH_LE_30S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_REFRESH_LE_120S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_REFRESH_LE_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_REFRESH_GT_300S: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_QUOTE_NONE: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_STATE_STALE: Lazy<AtomicU64> =
@@ -5499,6 +5630,30 @@ pub fn arb_vault_live_snapshot_cache_age_bucket_inc(op: &str, bucket: &str) {
         ("refresh", "le_120s") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_LE_120S,
         ("refresh", "le_300s") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_LE_300S,
         ("refresh", "gt_300s") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_REFRESH_GT_300S,
+        _ => return,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+/// C1h4: `arb_vault_live_snapshot_cache_age_bucket_total{op,bucket,pin}`.
+pub fn arb_vault_live_snapshot_cache_age_pin_bucket_inc(op: &str, bucket: &str, pin: &str) {
+    let counter = match (op, bucket, pin) {
+        ("seed", "le_30s", "pin") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_LE_30S,
+        ("seed", "le_120s", "pin") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_LE_120S,
+        ("seed", "le_300s", "pin") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_LE_300S,
+        ("seed", "gt_300s", "pin") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_GT_300S,
+        ("refresh", "le_30s", "pin") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_REFRESH_LE_30S,
+        ("refresh", "le_120s", "pin") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_REFRESH_LE_120S,
+        ("refresh", "le_300s", "pin") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_REFRESH_LE_300S,
+        ("refresh", "gt_300s", "pin") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_REFRESH_GT_300S,
+        ("seed", "le_30s", "cold") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_SEED_LE_30S,
+        ("seed", "le_120s", "cold") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_SEED_LE_120S,
+        ("seed", "le_300s", "cold") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_SEED_LE_300S,
+        ("seed", "gt_300s", "cold") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_SEED_GT_300S,
+        ("refresh", "le_30s", "cold") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_REFRESH_LE_30S,
+        ("refresh", "le_120s", "cold") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_REFRESH_LE_120S,
+        ("refresh", "le_300s", "cold") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_REFRESH_LE_300S,
+        ("refresh", "gt_300s", "cold") => &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_REFRESH_GT_300S,
         _ => return,
     };
     counter.fetch_add(1, Ordering::Relaxed);
@@ -6649,6 +6804,50 @@ fn append_arb_c1h2_freshness_forensics_total(out: &mut String) {
     ] {
         out.push_str(&format!(
             "arb_vault_live_snapshot_cache_age_bucket_total{{op=\"{op}\",bucket=\"{bucket}\"}} "
+        ));
+        out.push_str(&counter.load(Ordering::Relaxed).to_string());
+        out.push('\n');
+    }
+    for (op, bucket, pin, counter) in [
+        (
+            "seed",
+            "le_120s",
+            "pin",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_LE_120S,
+        ),
+        (
+            "seed",
+            "gt_300s",
+            "pin",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_SEED_GT_300S,
+        ),
+        (
+            "refresh",
+            "le_120s",
+            "pin",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_REFRESH_LE_120S,
+        ),
+        (
+            "refresh",
+            "gt_300s",
+            "pin",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_PIN_REFRESH_GT_300S,
+        ),
+        (
+            "seed",
+            "gt_300s",
+            "cold",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_SEED_GT_300S,
+        ),
+        (
+            "refresh",
+            "gt_300s",
+            "cold",
+            &*ARB_VAULT_LIVE_SNAPSHOT_CACHE_AGE_COLD_REFRESH_GT_300S,
+        ),
+    ] {
+        out.push_str(&format!(
+            "arb_vault_live_snapshot_cache_age_bucket_total{{op=\"{op}\",bucket=\"{bucket}\",pin=\"{pin}\"}} "
         ));
         out.push_str(&counter.load(Ordering::Relaxed).to_string());
         out.push('\n');
@@ -8661,6 +8860,22 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "market_data_balance_updated_from_cache_total",
         MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_heartbeat_balance_refresh_published_total{coverage=\"arb_pin\"}",
+        MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_PUBLISHED_ARB_PIN.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_heartbeat_balance_refresh_published_total{coverage=\"momentum\"}",
+        MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_PUBLISHED_MOMENTUM.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_heartbeat_balance_refresh_skipped_total{coverage=\"arb_pin\",reason=\"cache_miss\"}",
+        MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_CACHE_MISS.load(Ordering::Relaxed)
+    );
+    line!(
+        "market_data_heartbeat_balance_refresh_skipped_total{coverage=\"arb_pin\",reason=\"no_reserve_basis\"}",
+        MARKET_DATA_HEARTBEAT_BALANCE_REFRESH_SKIPPED_ARB_PIN_NO_RESERVE_BASIS.load(Ordering::Relaxed)
     );
     line!(
         "market_data_enrichment_balance_updated_total",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scope **C1h4** — closes the touch-coverage gap that left arb-pinned sell legs with stale `LivePoolCache` age (`gt_300s`) despite C1h3 stale-slot sustain.

### Root cause (H2 — coverage, not TTL)

Post-explicit-sync `BalanceUpdated` cache publish ran **only for momentum-hot pools**. When an arb pin's vault/bin Geyser feed became live after registration, SLAVE age was not refreshed via JetStream — unlike momentum pins which got a one-shot publish. Periodic heartbeat covered arb pins in theory, but the explicit-sync path was a systematic miss at pin registration time.

Prod signal: `balance_updated_from_cache` ≫ `arb_pin_vault_published`; seed/refresh `gt_300s` ~96% unchanged after #367.

### Fix (eng)

1. **`publish_hot_pool_balance_refresh_after_explicit_sync`** — now covers Mom **and** Arb pins; arb-only uses `force_arb_seed`.
2. **Heartbeat forensics** — `market_data_heartbeat_balance_refresh_{published,skipped}_total{coverage,reason}` for arb_pin vs momentum.
3. **Screen forensics** — `arb_vault_live_snapshot_cache_age_bucket_total{op,bucket,pin}` splits pin vs cold tracker pools.
4. **Apply forensics** — `pool_cache_touch_freshness_on_stale_slot_total` when C1h3 reserve-basis touch succeeds.

### Out of scope (unchanged)

- No `STATE_TTL` / cap / RPC / multihop / deploy changes
- Non-pin (cold) tracker pools at screen: metric-labeled, no silent TTL fix
- `dlmm_active_bin_missing` / completeness: separate root cause if prod still shows gap post-deploy — bin replay path (C1e) already Mom+Arb

### Tests

- `arb_pin_balance_refresh_after_explicit_sync_when_vault_becomes_live`
- `arb_only_heartbeat_targets_arb_pin_with_force_seed`
- `live_snapshot_cache_age_records_pin_label`
- Existing C1h3 `balance_updated_stale_slot_sustains_slave_age_and_refreshes_vault` unchanged

### Verification

```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```

### Hypothesis map

| ID | Verdict |
|----|---------|
| H1 | Arb sell pools not in hot registry | Partial — pin/cold metrics now separate |
| H2 | Heartbeat/explicit-sync coverage gap | **Fixed** — arb explicit-sync publish |
| H3 | Stale-slot touch not applied | C1h3 ok; added touch counter |
| H4 | No reserve basis on MASTER | Forensics via `no_reserve_basis` skip |
| H5 | Completeness (DLMM bins) | Not proven same pools — follow-up if needed |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b31c75f1-23bb-4bf5-bffe-cd71bf029e0e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b31c75f1-23bb-4bf5-bffe-cd71bf029e0e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

