### PR TITLE
feat(arb): C1cfg probe↔max_position + profit/spread reject forensics

### DIFF
--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -10553,18 +10553,22 @@ mod two_hop_price_tests {
 
     #[test]
     fn max_position_update_syncs_probe_when_follows_enabled() {
-        let mut config = ArbConfig::default();
-        config.max_position_lamports = 250_000_000;
+        let mut config = ArbConfig {
+            max_position_lamports: 250_000_000,
+            ..Default::default()
+        };
         sync_arb_probe_to_max_position(&mut config);
         assert_eq!(config.arb_probe_lamports, 250_000_000);
     }
 
     #[test]
     fn explicit_arb_probe_override_preserves_custom_probe_on_max_position_update() {
-        let mut config = ArbConfig::default();
-        config.arb_probe_lamports = 42_000_000;
-        config.arb_probe_follows_max_position = false;
-        config.max_position_lamports = 500_000_000;
+        let mut config = ArbConfig {
+            arb_probe_lamports: 42_000_000,
+            arb_probe_follows_max_position: false,
+            max_position_lamports: 500_000_000,
+            ..Default::default()
+        };
         sync_arb_probe_to_max_position(&mut config);
         assert_eq!(config.arb_probe_lamports, 42_000_000);
     }

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -89,18 +89,19 @@ use ironcrab::metrics::{
     record_arb_track_requests_publish_chunks_total, record_arb_track_requests_publish_failed_total,
     record_arb_track_selection_blocking_join_failed_total,
     record_arb_track_selection_queue_overflow_total, record_arb_track_selection_recompute_total,
-    record_arb_writer_lock_wait, serve_metrics, set_arb_pool_cache_apply_batch_size_gauge,
-    set_arb_quote_shadow_legacy_spread_bps, set_arb_track_selected_pool_readiness_metrics,
-    set_arb_track_selection_metrics, set_arb_tracker_write_coalescer_pending,
-    set_arb_tracker_write_queue_depth, set_arb_two_hop_blocked_on_apply_trade,
-    set_readiness_nats_connected, tick_arb_heartbeat_seconds_since_last_finish,
-    tick_arb_tracker_write_seconds_since_last_finish,
+    record_arb_two_hop_v2_formable_gates, record_arb_writer_lock_wait, serve_metrics,
+    set_arb_pool_cache_apply_batch_size_gauge, set_arb_quote_shadow_legacy_spread_bps,
+    set_arb_track_selected_pool_readiness_metrics, set_arb_track_selection_metrics,
+    set_arb_tracker_write_coalescer_pending, set_arb_tracker_write_queue_depth,
+    set_arb_two_hop_blocked_on_apply_trade, set_readiness_nats_connected,
+    tick_arb_heartbeat_seconds_since_last_finish, tick_arb_tracker_write_seconds_since_last_finish,
     try_record_arb_track_pin_before_first_screen_ms, wall_clock_unix_ms_now, ArbHeartbeatPhase,
     ArbStrategyWarmupSkipReason, ArbTrackerWriteJobType, ArbTwoHopInsufficientSubreason,
     ArbTwoHopPoolGate, ArbTwoHopRejectReason, ArbTwoHopRejectSubreason,
-    ArbTwoHopV2InsufficientSubreason, ArbTwoHopV2NoCrossDexSellDetail, ArbTwoHopV2RejectReason,
-    ArbTwoHopV2ScreenSkipReason, ArbTwoHopV2SellQuoteNoneDetail, ArbWriterLockKind,
-    MetricsComponent, ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH, ARB_REJECTED_MISSING_ACCOUNTS,
+    ArbTwoHopV2FormableGateOutcome, ArbTwoHopV2InsufficientSubreason,
+    ArbTwoHopV2NoCrossDexSellDetail, ArbTwoHopV2RejectReason, ArbTwoHopV2ScreenSkipReason,
+    ArbTwoHopV2SellQuoteNoneDetail, ArbWriterLockKind, MetricsComponent,
+    ARB_HEARTBEAT_SECONDS_SINCE_LAST_FINISH, ARB_REJECTED_MISSING_ACCOUNTS,
     ARB_SUBSCRIBER_HIGH_PROCESSED_TOTAL, ARB_SUBSCRIBER_HIGH_QUEUE_DEPTH,
     ARB_TRACKER_WRITE_COALESCER_PENDING, ARB_TRACKER_WRITE_CURRENT_JOB_STARTED_UNIX_MS,
     ARB_TRACKER_WRITE_CURRENT_JOB_TYPE, ARB_TRACKER_WRITE_QUEUE_DEPTH,
@@ -205,8 +206,10 @@ struct ArbConfig {
     arb_quote_shadow_mode: bool,
     /// Profit-first 2-hop v2 (round-trip quotes). Default: false.
     arb_two_hop_v2_enabled: bool,
-    /// SOL probe for v2 round-trip screening. Default: 10_000_000 (0.01 SOL).
+    /// SOL probe for v2 round-trip screening. Default: follows max_position_lamports.
     arb_probe_lamports: u64,
+    /// When true, arb_probe_lamports tracks max_position_lamports on load/update.
+    arb_probe_follows_max_position: bool,
     /// LastTradeMid quote TTL for v2 freshness. Default: 30_000 ms.
     arb_quote_trade_ttl_ms: u64,
     /// ExecutableMarginal state TTL for v2 freshness. Default: 120_000 ms.
@@ -217,7 +220,7 @@ struct ArbConfig {
 
 impl Default for ArbConfig {
     fn default() -> Self {
-        Self {
+        let mut cfg = Self {
             min_spread_bps: 50,                   // 0.5% minimum spread
             min_profit_lamports: 10_000_000,      // 0.01 SOL min profit
             max_position_lamports: 1_000_000_000, // 1 SOL max position
@@ -231,10 +234,20 @@ impl Default for ArbConfig {
             arb_quote_shadow_mode: false,
             arb_two_hop_v2_enabled: false,
             arb_probe_lamports: DLMM_PROBE_SOL_LAMPORTS,
+            arb_probe_follows_max_position: true,
             arb_quote_trade_ttl_ms: 30_000,
             arb_quote_state_ttl_ms: 120_000,
             arb_max_leg_slot_delta: 2,
-        }
+        };
+        sync_arb_probe_to_max_position(&mut cfg);
+        cfg
+    }
+}
+
+/// Keep v2 screening probe aligned with max position unless explicitly overridden.
+fn sync_arb_probe_to_max_position(config: &mut ArbConfig) {
+    if config.arb_probe_follows_max_position && config.max_position_lamports > 0 {
+        config.arb_probe_lamports = config.max_position_lamports;
     }
 }
 
@@ -281,6 +294,7 @@ fn load_initial_arb_config(config_path: &Path) -> ArbConfig {
         }
     }
 
+    sync_arb_probe_to_max_position(&mut cfg);
     cfg
 }
 
@@ -3464,15 +3478,41 @@ impl TokenArbTracker {
             MAX_REASONABLE_SPREAD_BPS
         };
 
-        if spread_bps as i64 > max_spread || spread_bps < config.min_spread_bps as i32 {
-            arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::RoundTripUnprofitable);
+        if spread_bps < config.min_spread_bps as i32 {
+            record_arb_two_hop_v2_formable_gates(
+                spread_bps,
+                profit_lamports,
+                ArbTwoHopV2FormableGateOutcome::RejectedSpreadBelow,
+            );
+            arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::RoundTripSpreadBelowMin);
+            return None;
+        }
+
+        if spread_bps as i64 > max_spread {
+            record_arb_two_hop_v2_formable_gates(
+                spread_bps,
+                profit_lamports,
+                ArbTwoHopV2FormableGateOutcome::RejectedSpreadAbove,
+            );
+            arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::RoundTripSpreadAboveMax);
             return None;
         }
 
         if profit_lamports < effective_min_profit as i64 {
-            arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::RoundTripUnprofitable);
+            record_arb_two_hop_v2_formable_gates(
+                spread_bps,
+                profit_lamports,
+                ArbTwoHopV2FormableGateOutcome::RejectedProfitBelow,
+            );
+            arb_two_hop_v2_rejected_inc(ArbTwoHopV2RejectReason::RoundTripProfitBelowMin);
             return None;
         }
+
+        record_arb_two_hop_v2_formable_gates(
+            spread_bps,
+            profit_lamports,
+            ArbTwoHopV2FormableGateOutcome::PassedGates,
+        );
 
         let buy_price = Decimal::from(selection.buy_quote.amount_in)
             / Decimal::from(1_000_000_000u64)
@@ -4891,6 +4931,7 @@ impl ArbContext {
                     if let Some(v) = value.as_u64() {
                         if v > 0 {
                             config.max_position_lamports = v;
+                            sync_arb_probe_to_max_position(&mut config);
                             applied.push(key.clone());
                             info!(key = %key, new_value = %v, "Config updated");
                         } else {
@@ -5012,6 +5053,7 @@ impl ArbContext {
                     if let Some(v) = value.as_u64() {
                         if v > 0 {
                             config.arb_probe_lamports = v;
+                            config.arb_probe_follows_max_position = false;
                             applied.push(key.clone());
                             info!(key = %key, new_value = %v, "Config updated");
                         } else {
@@ -5019,6 +5061,18 @@ impl ArbContext {
                         }
                     } else {
                         rejected.push((key.clone(), "Invalid type, expected u64".to_string()));
+                    }
+                }
+                "arb_probe_follows_max_position" => {
+                    if let Some(v) = value.as_bool() {
+                        config.arb_probe_follows_max_position = v;
+                        if v {
+                            sync_arb_probe_to_max_position(&mut config);
+                        }
+                        applied.push(key.clone());
+                        info!(key = %key, new_value = %v, "Config updated");
+                    } else {
+                        rejected.push((key.clone(), "Invalid type, expected bool".to_string()));
                     }
                 }
                 "arb_quote_trade_ttl_ms" => {
@@ -9464,6 +9518,13 @@ mod two_hop_price_tests {
     const TEST_BUILD: &str = "0.0.0";
     const TEST_RUN: &str = "run-test";
 
+    /// Fixture pools are calibrated for the legacy 0.01 SOL screening probe.
+    fn with_small_v2_probe(mut config: ArbConfig) -> ArbConfig {
+        config.arb_probe_lamports = DLMM_PROBE_SOL_LAMPORTS;
+        config.arb_probe_follows_max_position = false;
+        config
+    }
+
     fn sample_pool(
         dex: &str,
         addr: &str,
@@ -10172,14 +10233,14 @@ mod two_hop_price_tests {
         let before_hit =
             ironcrab::metrics::ARB_V2_SCREEN_METEORA_SELL_BIN_HIT_TOTAL.load(Ordering::Relaxed);
         let tracker = ctx.trackers.read().get(mint).unwrap().clone();
-        let config = ArbConfig {
+        let config = with_small_v2_probe(ArbConfig {
             arb_two_hop_v2_enabled: true,
             two_hop_enabled: true,
             min_spread_bps: 1,
             min_profit_lamports: 1,
             est_tx_cost_lamports: 1,
             ..Default::default()
-        };
+        });
         let _ = ctx.check_arbitrage_for_tracker(&tracker, &config);
         assert!(
             ironcrab::metrics::ARB_V2_SCREEN_METEORA_SELL_BIN_HIT_TOTAL.load(Ordering::Relaxed)
@@ -10364,13 +10425,13 @@ mod two_hop_price_tests {
         assert_eq!(tracker.pools.len(), 2, "expected two seeded pools");
         assert_eq!(vault_balances.len(), 2, "expected two vault entries");
 
-        let config = ArbConfig {
+        let config = with_small_v2_probe(ArbConfig {
             arb_two_hop_v2_enabled: true,
             min_spread_bps: 1,
             min_profit_lamports: 1,
             est_tx_cost_lamports: 1,
             ..Default::default()
-        };
+        });
 
         let bin_arrays: HashMap<String, HashMap<i64, BinArrayCache>> = HashMap::new();
         let spread_warn_last = RwLock::new(HashMap::new());
@@ -10448,14 +10509,14 @@ mod two_hop_price_tests {
         let tracker = trackers.get_mut(&mint_str).unwrap();
         tracker.token_decimals = Some(6);
 
-        let config = ArbConfig {
+        let config = with_small_v2_probe(ArbConfig {
             arb_two_hop_v2_enabled: true,
             arb_max_leg_slot_delta: 2,
             min_spread_bps: 1,
             min_profit_lamports: 1,
             est_tx_cost_lamports: 1,
             ..Default::default()
-        };
+        });
 
         let bin_arrays: HashMap<String, HashMap<i64, BinArrayCache>> = HashMap::new();
         let spread_warn_last = RwLock::new(HashMap::new());
@@ -10480,6 +10541,207 @@ mod two_hop_price_tests {
         assert!(
             ironcrab::metrics::ARB_TWO_HOP_V2_REJECTED_SLOT_DELTA_EXCEEDED.load(Ordering::Relaxed)
                 > before
+        );
+    }
+
+    #[test]
+    fn sync_arb_probe_follows_max_position_by_default() {
+        let config = ArbConfig::default();
+        assert!(config.arb_probe_follows_max_position);
+        assert_eq!(config.arb_probe_lamports, config.max_position_lamports);
+    }
+
+    #[test]
+    fn max_position_update_syncs_probe_when_follows_enabled() {
+        let mut config = ArbConfig::default();
+        config.max_position_lamports = 250_000_000;
+        sync_arb_probe_to_max_position(&mut config);
+        assert_eq!(config.arb_probe_lamports, 250_000_000);
+    }
+
+    #[test]
+    fn explicit_arb_probe_override_preserves_custom_probe_on_max_position_update() {
+        let mut config = ArbConfig::default();
+        config.arb_probe_lamports = 42_000_000;
+        config.arb_probe_follows_max_position = false;
+        config.max_position_lamports = 500_000_000;
+        sync_arb_probe_to_max_position(&mut config);
+        assert_eq!(config.arb_probe_lamports, 42_000_000);
+    }
+
+    #[test]
+    fn check_arbitrage_v2_rejects_spread_below_min_with_split_reason() {
+        use ironcrab::metrics::ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_SPREAD_BELOW_MIN;
+
+        let cache = create_shared_cache();
+        let token_mint = Pubkey::new_unique();
+        let pool_a = Pubkey::new_unique();
+        let pool_b = Pubkey::new_unique();
+        let mint_str = token_mint.to_string();
+
+        let update_orca = PoolCacheUpdate::new_balance_updated(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            pool_a.to_string(),
+            "orca".to_string(),
+            mint_str.clone(),
+            NATIVE_SOL_MINT.to_string(),
+            1_000_000_000_000,
+            1_000_000_000,
+            1,
+        );
+        let update_pump = PoolCacheUpdate::new_balance_updated(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            pool_b.to_string(),
+            "pump_amm".to_string(),
+            mint_str.clone(),
+            NATIVE_SOL_MINT.to_string(),
+            1_000_000_000_000,
+            1_000_000_000,
+            2,
+        );
+        ironcrab::execution::pool_cache_sync::apply_pool_cache_update(&cache, &update_orca);
+        ironcrab::execution::pool_cache_sync::apply_pool_cache_update(&cache, &update_pump);
+
+        let mut trackers = HashMap::new();
+        let mut vault_balances = HashMap::new();
+        seed_token_tracker_from_live_pool_cache(
+            &mint_str,
+            &cache,
+            &mut trackers,
+            &mut vault_balances,
+            None,
+        );
+
+        let mut known_pools = HashSet::new();
+        known_pools.insert(pool_a.to_string());
+        known_pools.insert(pool_b.to_string());
+
+        let tracker = trackers.get_mut(&mint_str).unwrap();
+        tracker.token_decimals = Some(6);
+
+        let config = with_small_v2_probe(ArbConfig {
+            arb_two_hop_v2_enabled: true,
+            min_spread_bps: 10_000,
+            min_profit_lamports: 1,
+            est_tx_cost_lamports: 1,
+            ..Default::default()
+        });
+
+        let bin_arrays: HashMap<String, HashMap<i64, BinArrayCache>> = HashMap::new();
+        let spread_warn_last = RwLock::new(HashMap::new());
+        let data_quality_rejects = AtomicU64::new(0);
+        let reject_before =
+            ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_SPREAD_BELOW_MIN.load(Ordering::Relaxed);
+        let opp = tracker.check_arbitrage(
+            &config,
+            &known_pools,
+            &vault_balances,
+            &bin_arrays,
+            &ArbCheckContext {
+                spread_warn_last: &spread_warn_last,
+                data_quality_rejects: &data_quality_rejects,
+                forensics: None,
+                v2_forensics: None,
+                selected_mints: None,
+                pinned_pools: None,
+            },
+        );
+        assert!(opp.is_none(), "equal reserves should fail spread gate");
+        assert!(
+            ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_SPREAD_BELOW_MIN.load(Ordering::Relaxed)
+                > reject_before
+        );
+    }
+
+    #[test]
+    fn check_arbitrage_v2_rejects_profit_below_min_with_split_reason() {
+        use ironcrab::metrics::ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_PROFIT_BELOW_MIN;
+
+        let cache = create_shared_cache();
+        let token_mint = Pubkey::new_unique();
+        let pool_a = Pubkey::new_unique();
+        let pool_b = Pubkey::new_unique();
+        let mint_str = token_mint.to_string();
+
+        let update_orca = PoolCacheUpdate::new_balance_updated(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            pool_a.to_string(),
+            "orca".to_string(),
+            mint_str.clone(),
+            NATIVE_SOL_MINT.to_string(),
+            1_000_000_000_000,
+            980_000_000,
+            1,
+        );
+        let update_pump = PoolCacheUpdate::new_balance_updated(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            pool_b.to_string(),
+            "pump_amm".to_string(),
+            mint_str.clone(),
+            NATIVE_SOL_MINT.to_string(),
+            1_000_000_000_000,
+            1_020_000_000,
+            2,
+        );
+        ironcrab::execution::pool_cache_sync::apply_pool_cache_update(&cache, &update_orca);
+        ironcrab::execution::pool_cache_sync::apply_pool_cache_update(&cache, &update_pump);
+
+        let mut trackers = HashMap::new();
+        let mut vault_balances = HashMap::new();
+        seed_token_tracker_from_live_pool_cache(
+            &mint_str,
+            &cache,
+            &mut trackers,
+            &mut vault_balances,
+            None,
+        );
+
+        let mut known_pools = HashSet::new();
+        known_pools.insert(pool_a.to_string());
+        known_pools.insert(pool_b.to_string());
+
+        let tracker = trackers.get_mut(&mint_str).unwrap();
+        tracker.token_decimals = Some(6);
+
+        let config = with_small_v2_probe(ArbConfig {
+            arb_two_hop_v2_enabled: true,
+            min_spread_bps: 1,
+            min_profit_lamports: 1_000_000_000_000,
+            est_tx_cost_lamports: 1,
+            ..Default::default()
+        });
+
+        let bin_arrays: HashMap<String, HashMap<i64, BinArrayCache>> = HashMap::new();
+        let spread_warn_last = RwLock::new(HashMap::new());
+        let data_quality_rejects = AtomicU64::new(0);
+        let reject_before =
+            ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_PROFIT_BELOW_MIN.load(Ordering::Relaxed);
+        let opp = tracker.check_arbitrage(
+            &config,
+            &known_pools,
+            &vault_balances,
+            &bin_arrays,
+            &ArbCheckContext {
+                spread_warn_last: &spread_warn_last,
+                data_quality_rejects: &data_quality_rejects,
+                forensics: None,
+                v2_forensics: None,
+                selected_mints: None,
+                pinned_pools: None,
+            },
+        );
+        assert!(opp.is_none(), "tiny edge should fail profit gate");
+        assert!(
+            ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_PROFIT_BELOW_MIN.load(Ordering::Relaxed)
+                > reject_before
         );
     }
 
@@ -10534,14 +10796,14 @@ mod two_hop_price_tests {
         let tracker = trackers.get_mut(&mint_str).unwrap();
         tracker.token_decimals = Some(6);
 
-        let config = ArbConfig {
+        let config = with_small_v2_probe(ArbConfig {
             arb_two_hop_v2_enabled: true,
             arb_max_leg_slot_delta: 0,
             min_spread_bps: 1,
             min_profit_lamports: 1,
             est_tx_cost_lamports: 1,
             ..Default::default()
-        };
+        });
 
         let bin_arrays: HashMap<String, HashMap<i64, BinArrayCache>> = HashMap::new();
         let spread_warn_last = RwLock::new(HashMap::new());
@@ -11505,10 +11767,10 @@ mod two_hop_price_tests {
     ) -> Option<ArbOpportunity> {
         let spread_warn_last = RwLock::new(HashMap::new());
         let data_quality_rejects = AtomicU64::new(0);
-        let config = ArbConfig {
+        let config = with_small_v2_probe(ArbConfig {
             arb_two_hop_v2_enabled: true,
             ..Default::default()
-        };
+        });
         tracker.check_arbitrage(
             &config,
             known_pools,
@@ -11955,13 +12217,13 @@ mod two_hop_price_tests {
         tracker.token_decimals = Some(6);
         assert_eq!(tracker.pool_count_on_distinct_dexes(), 2);
 
-        let config = ArbConfig {
+        let config = with_small_v2_probe(ArbConfig {
             arb_two_hop_v2_enabled: true,
             min_spread_bps: 1,
             min_profit_lamports: 1,
             est_tx_cost_lamports: 1,
             ..Default::default()
-        };
+        });
         let spread_warn_last = RwLock::new(HashMap::new());
         let data_quality_rejects = AtomicU64::new(0);
         let _ = tracker.check_arbitrage(
@@ -12001,10 +12263,10 @@ mod two_hop_price_tests {
         let data_quality_rejects = AtomicU64::new(0);
         let selected_mints = HashSet::new();
         let pinned_pools = HashSet::new();
-        let config = ArbConfig {
+        let config = with_small_v2_probe(ArbConfig {
             arb_two_hop_v2_enabled: true,
             ..Default::default()
-        };
+        });
 
         let _ = tracker.check_arbitrage(
             &config,
@@ -12063,13 +12325,13 @@ mod two_hop_price_tests {
 
         let spread_warn_last = RwLock::new(HashMap::new());
         let data_quality_rejects = AtomicU64::new(0);
-        let config = ArbConfig {
+        let config = with_small_v2_probe(ArbConfig {
             arb_two_hop_v2_enabled: true,
             min_spread_bps: 1,
             min_profit_lamports: 1,
             est_tx_cost_lamports: 1,
             ..Default::default()
-        };
+        });
 
         let _ = tracker.check_arbitrage(
             &config,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4932,6 +4932,69 @@ pub static ARB_TWO_HOP_V2_REJECTED_INSUFFICIENT_POOLS: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TWO_HOP_V2_REJECTED_SLOT_DELTA_EXCEEDED: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_SPREAD_BELOW_MIN: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_SPREAD_ABOVE_MAX: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+pub static ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_PROFIT_BELOW_MIN: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+const ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_BUCKETS: &[i64] =
+    &[-100, -50, -10, 0, 10, 50, 100, 200, 500, 1000, 10000];
+const ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_BUCKETS: &[i64] = &[
+    -100_000_000,
+    -10_000_000,
+    -1_000_000,
+    0,
+    1_000_000,
+    10_000_000,
+    100_000_000,
+    1_000_000_000,
+];
+const ARB_TWO_HOP_V2_GATE_OUTCOME_COUNT: usize = 4;
+
+static ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_BUCKET_COUNTS: Lazy<Vec<Vec<AtomicU64>>> =
+    Lazy::new(|| {
+        (0..ARB_TWO_HOP_V2_GATE_OUTCOME_COUNT)
+            .map(|_| {
+                ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_BUCKETS
+                    .iter()
+                    .map(|_| AtomicU64::new(0))
+                    .collect()
+            })
+            .collect()
+    });
+static ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_SUM: Lazy<Vec<AtomicI64>> = Lazy::new(|| {
+    (0..ARB_TWO_HOP_V2_GATE_OUTCOME_COUNT)
+        .map(|_| AtomicI64::new(0))
+        .collect()
+});
+static ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_COUNT: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    (0..ARB_TWO_HOP_V2_GATE_OUTCOME_COUNT)
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
+static ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_BUCKET_COUNTS: Lazy<Vec<Vec<AtomicU64>>> =
+    Lazy::new(|| {
+        (0..ARB_TWO_HOP_V2_GATE_OUTCOME_COUNT)
+            .map(|_| {
+                ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_BUCKETS
+                    .iter()
+                    .map(|_| AtomicU64::new(0))
+                    .collect()
+            })
+            .collect()
+    });
+static ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_SUM: Lazy<Vec<AtomicI64>> = Lazy::new(|| {
+    (0..ARB_TWO_HOP_V2_GATE_OUTCOME_COUNT)
+        .map(|_| AtomicI64::new(0))
+        .collect()
+});
+static ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_COUNT: Lazy<Vec<AtomicU64>> = Lazy::new(|| {
+    (0..ARB_TWO_HOP_V2_GATE_OUTCOME_COUNT)
+        .map(|_| AtomicU64::new(0))
+        .collect()
+});
 pub static ARB_TWO_HOP_V2_INSUFFICIENT_CANDIDATES_LT2: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_TWO_HOP_V2_INSUFFICIENT_NO_FRESH_BUY_QUOTE: Lazy<AtomicU64> =
@@ -5548,10 +5611,42 @@ pub fn set_arb_quote_shadow_legacy_spread_bps(spread_bps: i64) {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArbTwoHopV2RejectReason {
     RoundTripUnprofitable,
+    RoundTripSpreadBelowMin,
+    RoundTripSpreadAboveMax,
+    RoundTripProfitBelowMin,
     QuoteStale,
     IncompatibleQuoteKind,
     InsufficientPools,
     SlotDeltaExceeded,
+}
+
+/// Outcome label for `arb_two_hop_v2_formable_spread_bps` / `arb_two_hop_v2_formable_probe_profit_lamports`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArbTwoHopV2FormableGateOutcome {
+    RejectedSpreadBelow,
+    RejectedSpreadAbove,
+    RejectedProfitBelow,
+    PassedGates,
+}
+
+impl ArbTwoHopV2FormableGateOutcome {
+    fn index(self) -> usize {
+        match self {
+            Self::RejectedSpreadBelow => 0,
+            Self::RejectedSpreadAbove => 1,
+            Self::RejectedProfitBelow => 2,
+            Self::PassedGates => 3,
+        }
+    }
+
+    fn prometheus_label(self) -> &'static str {
+        match self {
+            Self::RejectedSpreadBelow => "rejected_spread_below",
+            Self::RejectedSpreadAbove => "rejected_spread_above",
+            Self::RejectedProfitBelow => "rejected_profit_below",
+            Self::PassedGates => "passed_gates",
+        }
+    }
 }
 
 /// Increment `arb_two_hop_v2_screen_total`.
@@ -5804,11 +5899,60 @@ pub fn arb_two_hop_v2_incompatible_kind_inc() {
     ARB_TWO_HOP_V2_INCOMPATIBLE_KIND_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+#[inline]
+fn record_histogram_i64_into(
+    buckets: &[i64],
+    bucket_counts: &[AtomicU64],
+    sum: &AtomicI64,
+    count: &AtomicU64,
+    value: i64,
+) {
+    sum.fetch_add(value, Ordering::Relaxed);
+    count.fetch_add(1, Ordering::Relaxed);
+    for (i, b) in buckets.iter().enumerate() {
+        if value <= *b {
+            bucket_counts[i].fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Record spread/profit histograms for a formable v2 round-trip after the slot gate.
+pub fn record_arb_two_hop_v2_formable_gates(
+    spread_bps: i32,
+    probe_profit_lamports: i64,
+    outcome: ArbTwoHopV2FormableGateOutcome,
+) {
+    let idx = outcome.index();
+    record_histogram_i64_into(
+        ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_BUCKETS,
+        &ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_BUCKET_COUNTS[idx],
+        &ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_SUM[idx],
+        &ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_COUNT[idx],
+        i64::from(spread_bps),
+    );
+    record_histogram_i64_into(
+        ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_BUCKETS,
+        &ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_BUCKET_COUNTS[idx],
+        &ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_SUM[idx],
+        &ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_COUNT[idx],
+        probe_profit_lamports,
+    );
+}
+
 /// Increment `arb_two_hop_v2_rejected_total{reason=...}`.
 pub fn arb_two_hop_v2_rejected_inc(reason: ArbTwoHopV2RejectReason) {
     let counter = match reason {
         ArbTwoHopV2RejectReason::RoundTripUnprofitable => {
             &*ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_UNPROFITABLE
+        }
+        ArbTwoHopV2RejectReason::RoundTripSpreadBelowMin => {
+            &*ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_SPREAD_BELOW_MIN
+        }
+        ArbTwoHopV2RejectReason::RoundTripSpreadAboveMax => {
+            &*ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_SPREAD_ABOVE_MAX
+        }
+        ArbTwoHopV2RejectReason::RoundTripProfitBelowMin => {
+            &*ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_PROFIT_BELOW_MIN
         }
         ArbTwoHopV2RejectReason::QuoteStale => &*ARB_TWO_HOP_V2_REJECTED_QUOTE_STALE,
         ArbTwoHopV2RejectReason::IncompatibleQuoteKind => {
@@ -5867,6 +6011,46 @@ pub fn record_arb_quote_pair_slot_delta(buy_as_of_slot: u64, sell_as_of_slot: u6
         buy_as_of_slot,
         sell_as_of_slot,
     ));
+}
+
+#[cfg(any(test, feature = "test_helpers"))]
+pub fn arb_two_hop_v2_formable_spread_bps_count_for_test(
+    outcome: ArbTwoHopV2FormableGateOutcome,
+) -> u64 {
+    ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_COUNT[outcome.index()].load(Ordering::Relaxed)
+}
+
+#[cfg(any(test, feature = "test_helpers"))]
+pub fn arb_two_hop_v2_formable_probe_profit_count_for_test(
+    outcome: ArbTwoHopV2FormableGateOutcome,
+) -> u64 {
+    ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_COUNT[outcome.index()].load(Ordering::Relaxed)
+}
+
+#[cfg(any(test, feature = "test_helpers"))]
+pub fn reset_arb_two_hop_v2_formable_gate_metrics_for_test() {
+    for buckets in ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_BUCKET_COUNTS.iter() {
+        for bucket in buckets {
+            bucket.store(0, Ordering::Relaxed);
+        }
+    }
+    for sum in ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_SUM.iter() {
+        sum.store(0, Ordering::Relaxed);
+    }
+    for count in ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_COUNT.iter() {
+        count.store(0, Ordering::Relaxed);
+    }
+    for buckets in ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_BUCKET_COUNTS.iter() {
+        for bucket in buckets {
+            bucket.store(0, Ordering::Relaxed);
+        }
+    }
+    for sum in ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_SUM.iter() {
+        sum.store(0, Ordering::Relaxed);
+    }
+    for count in ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_COUNT.iter() {
+        count.store(0, Ordering::Relaxed);
+    }
 }
 
 #[cfg(any(test, feature = "test_helpers"))]
@@ -7957,6 +8141,70 @@ pub fn record_price_impact(_price_impact_bps: f64) {
 pub fn record_slippage(_slippage_bps: f64) {
     // For now, we'll just track in the trade success metrics
     // Could add a separate histogram for slippage if needed
+}
+
+/// Append `_bucket{le=...}`, `_sum`, `_count` lines with a single label dimension.
+#[allow(clippy::too_many_arguments)]
+fn append_labeled_i64_histogram_prometheus(
+    out: &mut String,
+    metric: &str,
+    label_key: &str,
+    label_value: &str,
+    buckets: &[i64],
+    bucket_counts: &[AtomicU64],
+    sum: &AtomicI64,
+    count: &AtomicU64,
+) {
+    let c = count.load(Ordering::Relaxed);
+    let s = sum.load(Ordering::Relaxed);
+    for (i, b) in buckets.iter().enumerate() {
+        let v = bucket_counts[i].load(Ordering::Relaxed);
+        out.push_str(&format!(
+            "{metric}_bucket{{{label_key}=\"{label_value}\",le=\"{b}\"}} {v}\n"
+        ));
+    }
+    out.push_str(&format!(
+        "{metric}_bucket{{{label_key}=\"{label_value}\",le=\"+Inf\"}} {c}\n"
+    ));
+    out.push_str(&format!(
+        "{metric}_sum{{{label_key}=\"{label_value}\"}} {s}\n"
+    ));
+    out.push_str(&format!(
+        "{metric}_count{{{label_key}=\"{label_value}\"}} {c}\n"
+    ));
+}
+
+fn append_arb_two_hop_v2_formable_gate_histograms(out: &mut String) {
+    let outcomes = [
+        ArbTwoHopV2FormableGateOutcome::RejectedSpreadBelow,
+        ArbTwoHopV2FormableGateOutcome::RejectedSpreadAbove,
+        ArbTwoHopV2FormableGateOutcome::RejectedProfitBelow,
+        ArbTwoHopV2FormableGateOutcome::PassedGates,
+    ];
+    for outcome in outcomes {
+        let idx = outcome.index();
+        let label = outcome.prometheus_label();
+        append_labeled_i64_histogram_prometheus(
+            out,
+            "arb_two_hop_v2_formable_spread_bps",
+            "outcome",
+            label,
+            ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_BUCKETS,
+            &ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_BUCKET_COUNTS[idx],
+            &ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_SUM[idx],
+            &ARB_TWO_HOP_V2_FORMABLE_SPREAD_BPS_COUNT[idx],
+        );
+        append_labeled_i64_histogram_prometheus(
+            out,
+            "arb_two_hop_v2_formable_probe_profit_lamports",
+            "outcome",
+            label,
+            ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_BUCKETS,
+            &ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_BUCKET_COUNTS[idx],
+            &ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_SUM[idx],
+            &ARB_TWO_HOP_V2_FORMABLE_PROBE_PROFIT_COUNT[idx],
+        );
+    }
 }
 
 /// Append `_bucket{le=...}`, `_sum`, `_count` lines (same layout as `tx_slot_to_send_ms`).
@@ -10522,6 +10770,27 @@ async fn metrics_response() -> Response<Body> {
             .to_string(),
     );
     out.push('\n');
+    out.push_str("arb_two_hop_v2_rejected_total{reason=\"round_trip_spread_below_min\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_SPREAD_BELOW_MIN
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_rejected_total{reason=\"round_trip_spread_above_max\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_SPREAD_ABOVE_MAX
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
+    out.push_str("arb_two_hop_v2_rejected_total{reason=\"round_trip_profit_below_min\"} ");
+    out.push_str(
+        &ARB_TWO_HOP_V2_REJECTED_ROUND_TRIP_PROFIT_BELOW_MIN
+            .load(Ordering::Relaxed)
+            .to_string(),
+    );
+    out.push('\n');
     line!(
         "arb_two_hop_v2_screen_multi_dex_total",
         ARB_TWO_HOP_V2_SCREEN_MULTI_DEX_TOTAL.load(Ordering::Relaxed)
@@ -10570,6 +10839,7 @@ async fn metrics_response() -> Response<Body> {
             .to_string(),
     );
     out.push('\n');
+    append_arb_two_hop_v2_formable_gate_histograms(&mut out);
     append_momentum_latency_histogram_prometheus(
         &mut out,
         "arb_track_pin_before_first_screen_ms",
@@ -12440,5 +12710,46 @@ mod arb_quote_pair_slot_skew_metrics_tests {
             ARB_QUOTE_PAIR_SLOT_SKEW_LEG_SELL_TOTAL.load(Ordering::Relaxed),
             1
         );
+    }
+}
+
+#[cfg(test)]
+mod arb_two_hop_v2_formable_gate_metrics_tests {
+    use super::*;
+
+    #[test]
+    fn formable_gate_histogram_records_spread_and_profit_per_outcome() {
+        reset_arb_two_hop_v2_formable_gate_metrics_for_test();
+        let spread_before = arb_two_hop_v2_formable_spread_bps_count_for_test(
+            ArbTwoHopV2FormableGateOutcome::RejectedSpreadBelow,
+        );
+        let profit_before = arb_two_hop_v2_formable_probe_profit_count_for_test(
+            ArbTwoHopV2FormableGateOutcome::RejectedSpreadBelow,
+        );
+
+        record_arb_two_hop_v2_formable_gates(
+            -5,
+            -25_000,
+            ArbTwoHopV2FormableGateOutcome::RejectedSpreadBelow,
+        );
+
+        assert_eq!(
+            arb_two_hop_v2_formable_spread_bps_count_for_test(
+                ArbTwoHopV2FormableGateOutcome::RejectedSpreadBelow
+            ),
+            spread_before + 1
+        );
+        assert_eq!(
+            arb_two_hop_v2_formable_probe_profit_count_for_test(
+                ArbTwoHopV2FormableGateOutcome::RejectedSpreadBelow
+            ),
+            profit_before + 1
+        );
+
+        let mut out = String::new();
+        append_arb_two_hop_v2_formable_gate_histograms(&mut out);
+        assert!(out.contains("arb_two_hop_v2_formable_spread_bps_bucket{outcome=\"rejected_spread_below\""));
+        assert!(out.contains("arb_two_hop_v2_formable_probe_profit_lamports_bucket{outcome=\"rejected_spread_below\""));
+        assert!(out.contains("outcome=\"passed_gates\""));
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -12748,7 +12748,9 @@ mod arb_two_hop_v2_formable_gate_metrics_tests {
 
         let mut out = String::new();
         append_arb_two_hop_v2_formable_gate_histograms(&mut out);
-        assert!(out.contains("arb_two_hop_v2_formable_spread_bps_bucket{outcome=\"rejected_spread_below\""));
+        assert!(out.contains(
+            "arb_two_hop_v2_formable_spread_bps_bucket{outcome=\"rejected_spread_below\""
+        ));
         assert!(out.contains("arb_two_hop_v2_formable_probe_profit_lamports_bucket{outcome=\"rejected_spread_below\""));
         assert!(out.contains("outcome=\"passed_gates\""));
     }

--- a/ui/src/pages/ComponentDetail.tsx
+++ b/ui/src/pages/ComponentDetail.tsx
@@ -230,6 +230,10 @@ const CONFIG_DESCRIPTIONS: Record<string, Record<string, string>> = {
     min_spread_bps: '2-HOP: Min spread between DEX prices (bps, 100=1%)',
     min_profit_lamports: '2-HOP: Min net profit after tx cost (lamports)',
     max_position_lamports: '2-HOP: Max notional per intent (lamports)',
+    arb_probe_lamports:
+      '2-HOP V2: Round-trip screening probe size (lamports); default follows max_position_lamports',
+    arb_probe_follows_max_position:
+      '2-HOP V2: When true, arb_probe_lamports tracks max_position_lamports',
     est_tx_cost_lamports: '2-HOP: Estimated tx cost for profit calc (lamports)',
     max_slippage_bps: '2-HOP: Max slippage included in intent (bps)',
     intent_cooldown_ms: '2-HOP: Cooldown per pair before next intent (ms)',
@@ -390,6 +394,8 @@ const CONFIG_GROUPS: Record<string, Record<string, string[]>> = {
       'min_profit_lamports',
       'est_tx_cost_lamports',
       'max_position_lamports',
+      'arb_probe_lamports',
+      'arb_probe_follows_max_position',
       'max_slippage_bps',
       'intent_cooldown_ms',
       'intent_ttl_ms',
@@ -542,6 +548,8 @@ const DEFAULT_CONFIGS: Record<string, ComponentConfig> = {
     min_spread_bps: 50,
     min_profit_lamports: 10_000_000,
     max_position_lamports: 1_000_000_000,
+    arb_probe_lamports: 1_000_000_000,
+    arb_probe_follows_max_position: true,
     est_tx_cost_lamports: 50_000,
     max_slippage_bps: 100,
     intent_cooldown_ms: 5_000,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enger Impl-Scope für Post-368 Soak-Forensik: v2-Screening-Probe an `max_position_lamports` koppeln und gemischtes `round_trip_unprofitable` in Spread- vs. Profit-Gates aufteilen.

### A) Probe an max_position

- Neues internes Flag `arb_probe_follows_max_position` (Default: **true**).
- `sync_arb_probe_to_max_position()` setzt `arb_probe_lamports = max_position_lamports` wenn `follows=true` und `max_position > 0`.
- **Override-Semantik:**
  - Default / TOML-Load / `max_position_lamports`-Update → Probe folgt Position (wenn `follows=true`).
  - Explizites Setzen von `arb_probe_lamports` via Config → `follows=false`, Probe bleibt fix bis Re-Enable.
  - `arb_probe_follows_max_position=true` → `follows=true` + sofortiger Re-Sync.
- UI: `arb_probe_lamports`, `arb_probe_follows_max_position` in arb-strategy Keys/Help/Defaults.

### B) Profit/Spread Reject-Split + Histogramme

Neue Reject-Reasons (Prometheus `arb_two_hop_v2_rejected_total{reason=...}`):

| Reason | Bedingung |
|--------|-----------|
| `round_trip_spread_below_min` | `spread_bps < min_spread_bps` |
| `round_trip_spread_above_max` | `spread_bps > max_reasonable` (stablecoin cap separat) |
| `round_trip_profit_below_min` | `profit < effective_min_profit` |
| `round_trip_unprofitable` | nur noch Restfälle (z.B. native SOL mint early-out) |

Histogramme (nach Formable + Slot-Gate):

- `arb_two_hop_v2_formable_spread_bps{outcome=...}` — Outcomes: `rejected_spread_below`, `rejected_spread_above`, `rejected_profit_below`, `passed_gates`
- `arb_two_hop_v2_formable_probe_profit_lamports{outcome=...}` — gleiche Outcome-Labels; Profit = `sell_out - probe - est_tx_cost` (wie Gate)

## Tests

- Probe-Sync: Default, max_position-Update, expliziter Override
- v2: spread-below / profit-below → getrennte Reject-Counter
- metrics: Histogram-Record + Prometheus-Export für Outcome-Labels
- `cargo fmt --check`, `clippy -D warnings`, `cargo test` grün

## Nicht im Scope

Hot-Path RPC, TTL/Slot/Cap, Momentum-Probe, Deploy, Min-Profit-bps-Umbau.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34e01ca0-1c5b-4621-87d1-5d0997e2b2f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34e01ca0-1c5b-4621-87d1-5d0997e2b2f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

