### PR TITLE
fix(arb): shrink DLMM↔PumpAmm atomic bundle under 1232 bytes

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -5512,7 +5512,7 @@ impl ExecutionContext {
                 let plan = tx_builder::TxPlan {
                     instructions: vec![close_ix],
                 };
-                let sim = simulate_transaction(ctx, wallet, &plan, None).await;
+                let sim = simulate_transaction(ctx, wallet, &plan, None, None).await;
                 if sim.success {
                     let config = ctx.get_config();
                     if config.send_enabled {
@@ -5650,7 +5650,7 @@ impl ExecutionContext {
                 instructions: vec![close_ix],
             };
 
-            let sim = simulate_transaction(ctx, wallet, &plan, None).await;
+            let sim = simulate_transaction(ctx, wallet, &plan, None, None).await;
             if !sim.success {
                 warn!(token_account = %token_account, mint = %mint, token_program = %token_program, error = ?sim.error_code, "Close empty token account simulation failed; not sending");
                 continue;
@@ -6094,7 +6094,7 @@ impl ExecutionContext {
             }
 
             let plan = tx_builder::TxPlan { instructions: ixs };
-            let sim = simulate_transaction(&ctx, wallet, &plan, None).await;
+            let sim = simulate_transaction(&ctx, wallet, &plan, None, None).await;
             if !sim.success {
                 warn!(request_id = %request_id, token_account = %token_account_pk, mint = %mint, error = ?sim.error_code, "Burn simulation failed; not sending");
                 let rec = BurnOpRecord {
@@ -11614,8 +11614,14 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
         info!(intent_id = %intent.intent_id, "Running simulation");
 
         let bundle_tip_exclude = bundle_tip_ix.as_ref().map(|ix| ix.accounts[1].pubkey);
-        let sim_result =
-            simulate_transaction(ctx, wallet_pubkey, &tx_plan_for_sim, bundle_tip_exclude).await;
+        let sim_result = simulate_transaction(
+            ctx,
+            wallet_pubkey,
+            &tx_plan_for_sim,
+            bundle_tip_exclude,
+            Some(&intent),
+        )
+        .await;
 
         if sim_result.success {
             break (
@@ -12210,14 +12216,15 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
             };
 
             if let Err(size_err) = check_versioned_tx_size(&versioned_tx) {
-                let serialized_len = versioned_tx_serialized_len(&versioned_tx).unwrap_or(0);
                 log_bundle_tx_size_rejection(
                     &intent,
-                    serialized_len,
+                    &versioned_tx,
                     &size_err,
+                    ctx.address_lookup_table.as_ref(),
                     ctx.address_lookup_table
                         .as_ref()
                         .is_some_and(|alt| alt.contains(&tip_account)),
+                    "before_jito_submit",
                 );
                 let reason = sim_failure_reject_reason(Some(&size_err));
                 checks.push(CheckResult {
@@ -13482,9 +13489,11 @@ fn check_versioned_tx_size(tx: &VersionedTransaction) -> Result<(), String> {
 
 fn log_bundle_tx_size_rejection(
     intent: &TradeIntent,
-    serialized_len: usize,
+    tx: &VersionedTransaction,
     size_err: &str,
+    alt: Option<&ironcrab::solana::address_lookup_table::LoadedAlt>,
     tip_filtered_from_alt: bool,
+    rejection_stage: &str,
 ) {
     let buy_dex = intent
         .metadata
@@ -13496,14 +13505,30 @@ fn log_bundle_tx_size_rejection(
         .get("sell_dex")
         .map(|s| s.as_str())
         .unwrap_or("?");
+    let serialized_len = versioned_tx_serialized_len(tx).unwrap_or(0);
+    let alt_configured = alt.is_some();
+    let analysis = ironcrab::solana::address_lookup_table::analyze_versioned_message_alt_usage(
+        &tx.message,
+        alt,
+    );
+    let static_not_in_alt: Vec<String> = analysis
+        .static_not_in_alt
+        .iter()
+        .map(|pk| pk.to_string())
+        .collect();
     warn!(
         intent_id = %intent.intent_id,
         serialized_len,
+        alt_configured,
+        alt_hit_count = analysis.alt_hit_count,
+        static_key_count = analysis.static_key_count,
         buy_dex,
         sell_dex,
         tip_filtered_from_alt,
+        static_not_in_alt = ?static_not_in_alt,
         error = %size_err,
-        "Bundle transaction exceeds Solana serialized size limit; rejecting before Jito submit"
+        rejection_stage,
+        "Bundle transaction exceeds Solana serialized size limit"
     );
     record_arb_bundle_tx_too_large();
 }
@@ -13533,6 +13558,7 @@ async fn simulate_transaction(
     wallet_pubkey: Pubkey,
     plan: &tx_builder::TxPlan,
     exclude_tip_from_alt: Option<Pubkey>,
+    bundle_size_intent: Option<&TradeIntent>,
 ) -> SimulationResult {
     let blockhash = match ctx.get_latest_blockhash().await {
         Ok(hash) => hash,
@@ -13547,30 +13573,63 @@ async fn simulate_transaction(
     };
 
     let tip_ref = exclude_tip_from_alt.as_ref();
-    let tx_result = prepare_unsigned_versioned_tx_for_simulation(
-        &wallet_pubkey,
-        plan,
-        blockhash,
-        ctx.address_lookup_table.as_ref(),
-        tip_ref,
-    );
-
-    let tx = match tx_result {
-        Ok(tx) => tx,
-        Err(e) => {
-            return SimulationResult {
-                success: false,
-                error_code: Some(e),
-                logs_preview: None,
-                compute_units_consumed: None,
-            };
+    let tx = if bundle_size_intent.is_some() {
+        match build_unsigned_versioned_tx(
+            &wallet_pubkey,
+            plan,
+            blockhash,
+            ctx.address_lookup_table.as_ref(),
+            tip_ref,
+        ) {
+            Ok(tx) => tx,
+            Err(e) => {
+                return SimulationResult {
+                    success: false,
+                    error_code: Some(e),
+                    logs_preview: None,
+                    compute_units_consumed: None,
+                };
+            }
+        }
+    } else {
+        match prepare_unsigned_versioned_tx_for_simulation(
+            &wallet_pubkey,
+            plan,
+            blockhash,
+            ctx.address_lookup_table.as_ref(),
+            tip_ref,
+        ) {
+            Ok(tx) => tx,
+            Err(e) => {
+                return SimulationResult {
+                    success: false,
+                    error_code: Some(e),
+                    logs_preview: None,
+                    compute_units_consumed: None,
+                };
+            }
         }
     };
 
-    if let Err(e) = check_versioned_tx_size(&tx) {
+    if let Err(size_err) = check_versioned_tx_size(&tx) {
+        if let Some(intent) = bundle_size_intent {
+            let tip_filtered_from_alt = exclude_tip_from_alt.as_ref().is_some_and(|tip| {
+                ctx.address_lookup_table
+                    .as_ref()
+                    .is_some_and(|alt| alt.contains(tip))
+            });
+            log_bundle_tx_size_rejection(
+                intent,
+                &tx,
+                &size_err,
+                ctx.address_lookup_table.as_ref(),
+                tip_filtered_from_alt,
+                "before_simulation_rpc",
+            );
+        }
         return SimulationResult {
             success: false,
-            error_code: Some(e),
+            error_code: Some(size_err),
             logs_preview: None,
             compute_units_consumed: None,
         };

--- a/src/solana/address_lookup_table.rs
+++ b/src/solana/address_lookup_table.rs
@@ -231,6 +231,62 @@ pub fn estimate_size_reduction(instructions: &[Instruction], alt: &LoadedAlt) ->
     (accounts_in_alt, bytes_saved)
 }
 
+/// Analysis of how a compiled v0 message uses (or misses) the loaded ALT.
+#[derive(Debug, Clone)]
+pub struct AltCompileAnalysis {
+    /// Static account keys in the v0 message header.
+    pub static_key_count: usize,
+    /// Instruction account indices that resolve via address lookup tables.
+    pub alt_hit_count: usize,
+    /// Static keys not present in the loaded ALT (top-N for ops `setup_alt --extra-addresses`).
+    pub static_not_in_alt: Vec<Pubkey>,
+}
+
+/// Analyze ALT usage for a compiled v0 message.
+pub fn analyze_v0_alt_usage(message: &v0::Message, alt: Option<&LoadedAlt>) -> AltCompileAnalysis {
+    let static_key_count = message.account_keys.len();
+    let mut alt_hit_count = 0usize;
+    for ix in &message.instructions {
+        for account_index in &ix.accounts {
+            if *account_index as usize >= static_key_count {
+                alt_hit_count += 1;
+            }
+        }
+    }
+
+    let static_not_in_alt: Vec<Pubkey> = match alt {
+        Some(loaded) => message
+            .account_keys
+            .iter()
+            .filter(|pk| !loaded.contains(pk))
+            .take(10)
+            .copied()
+            .collect(),
+        None => message.account_keys.clone(),
+    };
+
+    AltCompileAnalysis {
+        static_key_count,
+        alt_hit_count,
+        static_not_in_alt,
+    }
+}
+
+/// Analyze ALT usage from a versioned message (legacy messages have no lookups).
+pub fn analyze_versioned_message_alt_usage(
+    message: &VersionedMessage,
+    alt: Option<&LoadedAlt>,
+) -> AltCompileAnalysis {
+    match message {
+        VersionedMessage::V0(v0_msg) => analyze_v0_alt_usage(v0_msg, alt),
+        VersionedMessage::Legacy(legacy) => AltCompileAnalysis {
+            static_key_count: legacy.account_keys.len(),
+            alt_hit_count: 0,
+            static_not_in_alt: legacy.account_keys.clone(),
+        },
+    }
+}
+
 /// Parse common accounts from the constant list.
 pub fn get_common_accounts() -> Vec<Pubkey> {
     COMMON_ACCOUNTS
@@ -322,5 +378,47 @@ mod tests {
         .expect("compile with tip filtered from ALT");
 
         assert_ne!(with_tip_in_alt, tip_filtered);
+    }
+
+    #[test]
+    fn analyze_v0_alt_usage_counts_static_and_lookup_refs() {
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+        use solana_system_program;
+
+        let payer = Pubkey::new_unique();
+        let in_alt = Pubkey::new_unique();
+        let static_only = Pubkey::new_unique();
+        let blockhash = solana_sdk::hash::Hash::new_unique();
+        let loaded = LoadedAlt {
+            address: Pubkey::new_unique(),
+            accounts: vec![in_alt],
+        };
+        let mut data = vec![2, 0, 0, 0];
+        data.extend_from_slice(&1u64.to_le_bytes());
+        let ix = Instruction {
+            program_id: solana_system_program::id(),
+            accounts: vec![
+                AccountMeta::new(payer, true),
+                AccountMeta::new(in_alt, false),
+                AccountMeta::new(static_only, false),
+            ],
+            data,
+        };
+        let message = compile_v0_versioned_message(
+            &payer,
+            std::slice::from_ref(&ix),
+            Some(&loaded),
+            None,
+            blockhash,
+        )
+        .expect("compile");
+        let v0_msg = match message {
+            VersionedMessage::V0(m) => m,
+            _ => panic!("expected v0"),
+        };
+        let analysis = analyze_v0_alt_usage(&v0_msg, Some(&loaded));
+        assert!(analysis.static_key_count >= 2);
+        assert!(analysis.alt_hit_count >= 1);
+        assert!(analysis.static_not_in_alt.contains(&static_only));
     }
 }

--- a/src/solana/cross_dex_handler.rs
+++ b/src/solana/cross_dex_handler.rs
@@ -1374,6 +1374,12 @@ impl CrossDexHandler {
                 &format!("token_program:{}", token_mint),
                 &token_program_sdk.to_string(),
             );
+            if buy_dex == "meteora_dlmm" {
+                buy_connector.cache_extra_data(
+                    crate::solana::dex::meteora_swap_builder::METEORA_BIN_ARRAY_COVERAGE_KEY,
+                    crate::solana::dex::meteora_swap_builder::METEORA_BIN_ARRAY_COVERAGE_ACTIVE_ONLY,
+                );
+            }
 
             buy_connector
                 .build_swap_ix_async(SOL_MINT, token_mint, buy_amount_in, buy_min_out)
@@ -1411,6 +1417,12 @@ impl CrossDexHandler {
                 &format!("token_program:{}", token_mint),
                 &token_program_sdk.to_string(),
             );
+            if sell_dex == "meteora_dlmm" {
+                sell_connector.cache_extra_data(
+                    crate::solana::dex::meteora_swap_builder::METEORA_BIN_ARRAY_COVERAGE_KEY,
+                    crate::solana::dex::meteora_swap_builder::METEORA_BIN_ARRAY_COVERAGE_ACTIVE_ONLY,
+                );
+            }
 
             if let Some(ref accts) = sell_accounts {
                 if let Err(e) = sell_connector.set_pool_from_accounts(&sell_pool, accts) {

--- a/src/solana/dex/meteora_dlmm.rs
+++ b/src/solana/dex/meteora_dlmm.rs
@@ -905,7 +905,31 @@ impl Dex for MeteoraDlmm {
         let token_x_program_sdk = Pubkey::new_from_array(token_x_program_spl.to_bytes());
         let token_y_program_sdk = Pubkey::new_from_array(token_y_program_spl.to_bytes());
 
-        let ix = swap_builder.build_swap_with_bins_sync(
+        let bin_array_coverage = {
+            let use_active_only = self
+                .extra_data
+                .get(crate::solana::dex::meteora_swap_builder::METEORA_BIN_ARRAY_COVERAGE_KEY)
+                .is_some_and(|entry| {
+                    entry.value()
+                        == crate::solana::dex::meteora_swap_builder::METEORA_BIN_ARRAY_COVERAGE_ACTIVE_ONLY
+                });
+            if use_active_only {
+                crate::solana::dex::meteora_swap_builder::BinArrayCoverage::ActiveOnly
+            } else {
+                crate::solana::dex::meteora_swap_builder::BinArrayCoverage::AdjacentThree
+            }
+        };
+
+        if bin_array_coverage
+            == crate::solana::dex::meteora_swap_builder::BinArrayCoverage::ActiveOnly
+        {
+            debug!(
+                pool = %pool_addr,
+                "meteora_dlmm: using ActiveOnly bin-array coverage for atomic bundle TX size"
+            );
+        }
+
+        let ix = swap_builder.build_swap_with_bins_sync_coverage(
             &pool_addr,
             &pool.reserve_x,
             &pool.reserve_y,
@@ -921,6 +945,7 @@ impl Dex for MeteoraDlmm {
             direction,
             pool.active_id,
             pool.bin_step,
+            bin_array_coverage,
         )?;
 
         Ok(vec![ix])

--- a/src/solana/dex/meteora_swap_builder.rs
+++ b/src/solana/dex/meteora_swap_builder.rs
@@ -43,6 +43,20 @@ pub enum SwapDirection {
     YtoX,
 }
 
+/// Bin-array coverage for DLMM swap remaining accounts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinArrayCoverage {
+    /// Active bin array only — for size-constrained atomic bundles (small swaps).
+    ActiveOnly,
+    /// Active ± 1 — default for general swaps.
+    AdjacentThree,
+}
+
+/// Extra-data key for [`MeteoraDlmm`] bin-array coverage (cross-dex atomic bundles).
+pub const METEORA_BIN_ARRAY_COVERAGE_KEY: &str = "bin_array_coverage";
+/// Value: use [`BinArrayCoverage::ActiveOnly`] for minimal TX size.
+pub const METEORA_BIN_ARRAY_COVERAGE_ACTIVE_ONLY: &str = "active_only";
+
 /// Builder for Meteora DLMM swap instructions (GEYSER-FIRST: no RPC in hot path)
 pub struct MeteoraDlmmSwapBuilder {
     #[allow(dead_code)] // RPC kept for potential future use outside hot path
@@ -81,16 +95,31 @@ impl MeteoraDlmmSwapBuilder {
         lb_pair: &Pubkey,
         active_id: i32,
     ) -> Result<Vec<Pubkey>> {
+        Self::derive_bin_arrays_for_active_id_with_coverage(
+            lb_pair,
+            active_id,
+            BinArrayCoverage::AdjacentThree,
+        )
+    }
+
+    /// Derive bin-array PDAs with explicit coverage (GEYSER-FIRST: no RPC).
+    pub fn derive_bin_arrays_for_active_id_with_coverage(
+        lb_pair: &Pubkey,
+        active_id: i32,
+        coverage: BinArrayCoverage,
+    ) -> Result<Vec<Pubkey>> {
         let active_array_index = Self::bin_id_to_bin_array_index(active_id);
 
-        // Include active + adjacent bin arrays to handle edge cases
-        let indices: Vec<i64> = vec![
-            active_array_index - 1,
-            active_array_index,
-            active_array_index + 1,
-        ];
+        let indices: Vec<i64> = match coverage {
+            BinArrayCoverage::ActiveOnly => vec![active_array_index],
+            BinArrayCoverage::AdjacentThree => vec![
+                active_array_index - 1,
+                active_array_index,
+                active_array_index + 1,
+            ],
+        };
 
-        let mut bin_arrays = Vec::with_capacity(3);
+        let mut bin_arrays = Vec::with_capacity(indices.len());
         for index in indices {
             let pda = Self::derive_bin_array_pda(lb_pair, index)?;
             bin_arrays.push(pda);
@@ -100,6 +129,7 @@ impl MeteoraDlmmSwapBuilder {
             pool = %lb_pair,
             active_id = active_id,
             active_array_index = active_array_index,
+            coverage = ?coverage,
             bin_arrays_count = bin_arrays.len(),
             "Meteora: derived bin array PDAs (GEYSER-FIRST, no RPC)"
         );
@@ -249,6 +279,47 @@ impl MeteoraDlmmSwapBuilder {
         active_id: i32,
         _bin_step: u16,
     ) -> Result<Instruction> {
+        self.build_swap_with_bins_sync_coverage(
+            lb_pair,
+            reserve_x,
+            reserve_y,
+            user_token_x,
+            user_token_y,
+            token_x_mint,
+            token_y_mint,
+            token_x_program,
+            token_y_program,
+            user,
+            amount_in,
+            min_amount_out,
+            direction,
+            active_id,
+            _bin_step,
+            BinArrayCoverage::AdjacentThree,
+        )
+    }
+
+    /// Same as [`build_swap_with_bins_sync`] but with explicit bin-array coverage.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_swap_with_bins_sync_coverage(
+        &self,
+        lb_pair: &Pubkey,
+        reserve_x: &Pubkey,
+        reserve_y: &Pubkey,
+        user_token_x: &Pubkey,
+        user_token_y: &Pubkey,
+        token_x_mint: &Pubkey,
+        token_y_mint: &Pubkey,
+        token_x_program: &Pubkey,
+        token_y_program: &Pubkey,
+        user: &Pubkey,
+        amount_in: u64,
+        min_amount_out: u64,
+        direction: SwapDirection,
+        active_id: i32,
+        _bin_step: u16,
+        bin_array_coverage: BinArrayCoverage,
+    ) -> Result<Instruction> {
         ensure!(amount_in > 0, "Amount in must be positive");
         ensure!(min_amount_out > 0, "Min amount out must be positive");
 
@@ -294,7 +365,11 @@ impl MeteoraDlmmSwapBuilder {
 
         // Derive bin array PDAs (GEYSER-FIRST: no RPC to check existence!)
         // If a bin array doesn't exist, the TX simulation will fail with a clear error.
-        let bin_arrays = Self::derive_bin_arrays_for_active_id(lb_pair, active_id)?;
+        let bin_arrays = Self::derive_bin_arrays_for_active_id_with_coverage(
+            lb_pair,
+            active_id,
+            bin_array_coverage,
+        )?;
 
         // Log the derived bin arrays for debugging
         info!(
@@ -429,5 +504,24 @@ mod tests {
         // Different indices should give different PDAs
         let pda3 = MeteoraDlmmSwapBuilder::derive_bin_array_pda(&lb_pair, 1).unwrap();
         assert_ne!(pda1, pda3);
+    }
+
+    #[test]
+    fn active_only_bin_coverage_has_fewer_accounts_than_adjacent_three() {
+        let lb_pair = Pubkey::new_unique();
+        let active_only = MeteoraDlmmSwapBuilder::derive_bin_arrays_for_active_id_with_coverage(
+            &lb_pair,
+            100,
+            BinArrayCoverage::ActiveOnly,
+        )
+        .expect("active only");
+        let adjacent = MeteoraDlmmSwapBuilder::derive_bin_arrays_for_active_id_with_coverage(
+            &lb_pair,
+            100,
+            BinArrayCoverage::AdjacentThree,
+        )
+        .expect("adjacent three");
+        assert_eq!(active_only.len(), 1);
+        assert_eq!(adjacent.len(), 3);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Post-#374 deploy: DLMM↔PumpAmm arb bundles failed at sim size-gate with `tx_too_large:1245_bytes_max_1232` (13 bytes over). Route: meteora_dlmm buy + pump_amm cashback sell (24 accounts) + CU budget + tip, with tip-filtered ALT.

Ref: `Iron_crab-eval/docs/supervisor/findings_arb_sim_tx_too_large_post374_20260806.md`

## Changes

### A) Size reduction (P0)

- **Meteora DLMM `ActiveOnly` bin-array coverage** for cross-dex arb legs: only the active bin array is attached (1 vs 3 remaining accounts). Saves ~62+ bytes on typical static-key encoding — enough for the 13-byte margin.
- Cross-dex handler sets `bin_array_coverage=active_only` via extra_data for `meteora_dlmm` buy/sell legs.
- Non-arb Meteora swaps keep default `AdjacentThree` coverage.

### B) Observability (P0)

- `arb_bundle_tx_too_large_total` now increments on **sim size-gate** rejections (`before_simulation_rpc`), not only Jito send path.
- Structured warn log on size reject: `serialized_len`, `alt_configured`, `alt_hit_count`, `static_key_count`, `buy_dex`, `sell_dex`, `intent_id`, `tip_filtered_from_alt`, top-10 `static_not_in_alt` pubkeys for `setup_alt --extra-addresses`.
- New `analyze_versioned_message_alt_usage()` helper in `address_lookup_table.rs`.

## Invariants preserved

- No hot-path RPC / ALT extend (I-7)
- Sim form = send form with tip-filtered ALT (#373)
- Simulation gate unchanged (I-9)
- Pump program slot SSOT (#374) untouched

## Tests

- `active_only_bin_coverage_has_fewer_accounts_than_adjacent_three`
- `analyze_v0_alt_usage_counts_static_and_lookup_refs`
- Existing oversized-tx / sim-send parity tests pass

## Verification

```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90feb96b-c630-4c31-a6d9-ae6ca53390c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90feb96b-c630-4c31-a6d9-ae6ca53390c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

