### PR TITLE
fix(arb): C1h5 cold-start sell-leg freshness (post-#375)

### DIFF
--- a/src/arbitrage/track_selection.rs
+++ b/src/arbitrage/track_selection.rs
@@ -428,14 +428,14 @@ fn bundle_from_pinable_pair(
         selected_pool(
             mint,
             buy_pool,
-            bundle_priority,
+            TrackPoolReadiness::QuoteReady,
             ArbTrackActiveReason::MultiDex,
             per_pool_readiness,
         ),
         selected_pool(
             mint,
             sell_pool,
-            bundle_priority,
+            TrackPoolReadiness::QuoteReady,
             ArbTrackActiveReason::MultiDex,
             per_pool_readiness,
         ),
@@ -505,10 +505,13 @@ fn selected_pool(
     reason: ArbTrackActiveReason,
     per_pool_readiness: &HashMap<String, TrackPoolReadiness>,
 ) -> SelectedTrackPool {
-    let readiness = per_pool_readiness
+    let classified = per_pool_readiness
         .get(&pool.pool_address)
         .copied()
-        .unwrap_or(default_readiness);
+        .unwrap_or(TrackPoolReadiness::Rejected);
+    // C1h5: bundle default_readiness (e.g. QuoteReady for cross-dex legs) must not be
+    // downgraded by classify-only buy freshness — sell-leg pins need must_hot on cold start.
+    let readiness = classified.max(default_readiness);
     SelectedTrackPool {
         mint: mint.mint.clone(),
         pool: pool.pool_address.clone(),
@@ -548,7 +551,7 @@ fn classify_pool_readiness(
     if !is_structurally_quote_capable(pool) {
         return TrackPoolReadiness::Rejected;
     }
-    if can_fresh_buy_quote(pool, config, now) {
+    if can_fresh_buy_quote(pool, config, now) || can_fresh_sell_quote(pool, config, now) {
         TrackPoolReadiness::QuoteReady
     } else if is_warmable_pool(pool, config, now) {
         TrackPoolReadiness::Warmable
@@ -557,11 +560,46 @@ fn classify_pool_readiness(
     }
 }
 
+/// Probe token amount for sell-direction freshness (CPMM estimate from cached reserves).
+fn probe_token_amount_for_sell(pool: &TrackPoolInput, probe_lamports: u64) -> u64 {
+    let Some(vault) = &pool.vault else {
+        return 1;
+    };
+    if vault.reserve_base == 0 || vault.reserve_quote == 0 {
+        return 1;
+    }
+    let token = vault.reserve_base as u128;
+    let sol = vault.reserve_quote as u128;
+    let sol_in = probe_lamports as u128;
+    let out = token.saturating_mul(sol_in) / sol.saturating_add(sol_in);
+    out.max(1) as u64
+}
+
+fn can_fresh_sell_quote(
+    pool: &TrackPoolInput,
+    config: &TrackSelectionConfig,
+    now: Instant,
+) -> bool {
+    let probe_tokens = probe_token_amount_for_sell(pool, config.probe_lamports);
+    let Some(quote) = quote_exact_in_with_freshness(
+        &pool.quote_pool,
+        pool.vault.as_ref(),
+        pool.dlmm_bins.as_ref(),
+        &pool.quote_pool.token_mint,
+        NATIVE_SOL_MINT,
+        probe_tokens,
+        &config.freshness,
+    ) else {
+        return false;
+    };
+    is_quote_fresh(&quote, &config.freshness, pool.vault.as_ref(), now)
+}
+
 fn is_warmable_pool(pool: &TrackPoolInput, config: &TrackSelectionConfig, now: Instant) -> bool {
     if !pool.known || !is_structurally_quote_capable(pool) {
         return false;
     }
-    if can_fresh_buy_quote(pool, config, now) {
+    if can_fresh_buy_quote(pool, config, now) || can_fresh_sell_quote(pool, config, now) {
         return false;
     }
     // Known + structural DEX support; reserve/bin freshness may be missing.
@@ -1064,5 +1102,85 @@ mod tests {
         }
         let result = select_arb_track_pools(&mints, &default_config(10));
         assert!(result.selected.len() <= 10);
+    }
+
+    /// C1h5: cross-dex pinable bundles must emit QuoteReady on both legs (must_hot) even when
+    /// classify only sees warmable buy-side freshness (sell-leg cold-start).
+    #[test]
+    fn pinable_cross_dex_pair_promotes_warmable_legs_to_quote_ready() {
+        let mint = mint_input(
+            MINT,
+            vec![
+                pool_input(
+                    "meteora_dlmm",
+                    "dlmm_buy",
+                    MINT,
+                    true,
+                    true,
+                    Some(vault(RESERVE_BASE, RESERVE_QUOTE)),
+                    10,
+                ),
+                pool_input("pump_amm", "pump_sell", MINT, true, false, None, 5),
+            ],
+            10,
+            None,
+        );
+        let result = select_arb_track_pools(&[mint], &default_config(500));
+        assert_eq!(result.selected.len(), 2);
+        for entry in &result.selected {
+            assert_eq!(
+                entry.readiness,
+                TrackPoolReadiness::QuoteReady,
+                "pool {} must be quote_ready for must_hot pin",
+                entry.pool
+            );
+        }
+    }
+
+    #[test]
+    fn fresh_sell_quote_classifies_pool_quote_ready_without_fresh_buy() {
+        use std::time::{Duration, Instant};
+
+        let mut sell_vault = vault(RESERVE_BASE, RESERVE_QUOTE);
+        sell_vault.updated_at = Instant::now();
+        let pool = pool_input(
+            "pump_amm",
+            "sell_only_fresh",
+            MINT,
+            true,
+            true,
+            Some(sell_vault),
+            1,
+        );
+        let config = TrackSelectionConfig {
+            max_pools: 10,
+            max_pools_per_mint: 3,
+            probe_lamports: 10_000_000,
+            freshness: QuoteFreshnessConfig {
+                trade_ttl_ms: 30_000,
+                state_ttl_ms: 120_000,
+            },
+        };
+        assert!(can_fresh_sell_quote(&pool, &config, Instant::now()));
+        assert_eq!(
+            classify_pool_readiness(&pool, &config, Instant::now()),
+            TrackPoolReadiness::QuoteReady
+        );
+
+        let stale_vault = vault(RESERVE_BASE, RESERVE_QUOTE);
+        let stale_pool = pool_input(
+            "pump_amm",
+            "sell_stale",
+            MINT,
+            true,
+            true,
+            Some({
+                let mut v = stale_vault;
+                v.updated_at = Instant::now() - Duration::from_secs(400);
+                v
+            }),
+            1,
+        );
+        assert!(!can_fresh_sell_quote(&stale_pool, &config, Instant::now()));
     }
 }

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -81,7 +81,9 @@ use ironcrab::metrics::{
     arb_vault_live_snapshot_cache_age_pin_bucket_inc, inc_arb_dlmm_bin_array_update_applied_total,
     inc_arb_dlmm_bin_array_update_received_total, inc_arb_dlmm_bin_rescreen_scheduled_total,
     inc_arb_pinned_meteora_pool_bin_cache_miss_total, inc_arb_v2_screen_meteora_sell_bin_hit_total,
-    inc_arb_v2_screen_meteora_sell_bin_miss_total, inc_arb_vault_balance_applied_total,
+    inc_arb_v2_screen_meteora_sell_bin_miss_total,
+    inc_arb_v2_screen_sell_stale_recovery_scheduled_total,
+    inc_arb_v2_screen_sell_stale_then_fresh_after_pin_total, inc_arb_vault_balance_applied_total,
     inc_arb_vault_live_snapshot_refreshed_total, inc_arb_vault_live_snapshot_seeded_total,
     inc_arb_vault_rescreen_scheduled_total, record_arb_heartbeat_phase,
     record_arb_intent_suppressed_implausible_token_out,
@@ -507,6 +509,30 @@ fn try_refresh_vault_from_live_cache(
     record_live_cache_age_at_snapshot("refresh", age_ms, pin_class);
     vault_cache.insert(pool_address.to_string(), new_vault);
     true
+}
+
+/// C1h5: for pinned pools, re-seed from SLAVE when local vault row exceeds state TTL (cold-start).
+fn try_overwrite_stale_pinned_vault_from_live_cache(
+    pool_address: &str,
+    live_pool_cache: &SharedLivePoolCache,
+    vault_cache: &mut HashMap<String, VaultBalanceCache>,
+    pin_class: &str,
+    state_ttl_ms: u64,
+) -> bool {
+    if pin_class != "pin" {
+        return false;
+    }
+    let Some(existing) = vault_cache.get(pool_address) else {
+        return false;
+    };
+    if existing.updated_at.elapsed().as_millis() as u64 <= state_ttl_ms {
+        return false;
+    }
+    if try_refresh_vault_from_live_cache(pool_address, live_pool_cache, vault_cache, pin_class) {
+        return true;
+    }
+    vault_cache.remove(pool_address);
+    try_seed_vault_from_live_cache(pool_address, live_pool_cache, vault_cache, pin_class)
 }
 
 /// H3: seed missing DLMM vault row from SLAVE cache on BinArrayUpdate (Geyser-only).
@@ -4794,6 +4820,8 @@ struct ArbContext {
     tracker_write: ArbTrackerWriteHandle,
     /// Latest-wins coalescer for PoolStateUpdate / DexPoolAccounts before tracker-write queue.
     tracker_write_coalescer: parking_lot::Mutex<ArbTrackerWriteCoalescer>,
+    /// C1h5: mints where sell-leg stale recovery (track dirty + rescreen) was scheduled.
+    v2_sell_stale_recovery_mints: RwLock<HashSet<String>>,
 }
 
 /// Cached vault balances from PoolStateUpdate events
@@ -6074,6 +6102,7 @@ impl ArbContext {
     ) {
         let pool_keys: Vec<String> = tracker_snapshot.pools.keys().cloned().collect();
         let pinned_pools = self.arb_pinned_pools.read();
+        let state_ttl_ms = self.config.read().arb_quote_state_ttl_ms;
         let vaults = self.vault_balances.read();
         let mut vault_balances = HashMap::with_capacity(pool_keys.len());
         for pool_key in &pool_keys {
@@ -6091,6 +6120,14 @@ impl ArbContext {
                     pin_class,
                 ) {
                     inc_arb_vault_live_snapshot_refreshed_total();
+                } else if try_overwrite_stale_pinned_vault_from_live_cache(
+                    pool_key,
+                    &self.live_pool_cache,
+                    &mut vault_balances,
+                    pin_class,
+                    state_ttl_ms,
+                ) {
+                    inc_arb_vault_live_snapshot_seeded_total();
                 }
             } else if try_seed_vault_from_live_cache(
                 pool_key,
@@ -6126,7 +6163,7 @@ impl ArbContext {
         record_v2_meteora_pinned_sell_bin_coverage(tracker_snapshot, &bin_arrays, &pinned_pools);
         let known_pools = self.known_pools.read();
         let selected_mints = self.arb_selected_mints.read();
-        tracker_snapshot.check_arbitrage(
+        let opp = tracker_snapshot.check_arbitrage(
             config,
             &known_pools,
             &vault_balances,
@@ -6139,7 +6176,138 @@ impl ArbContext {
                 selected_mints: Some(&selected_mints),
                 pinned_pools: Some(&pinned_pools),
             },
-        )
+        );
+        if opp.is_none() && config.arb_two_hop_v2_enabled {
+            self.try_schedule_v2_sell_leg_recovery(
+                tracker_snapshot,
+                config,
+                &vault_balances,
+                &bin_arrays,
+                &pinned_pools,
+            );
+        }
+        if opp.is_some()
+            && self
+                .v2_sell_stale_recovery_mints
+                .write()
+                .remove(&tracker_snapshot.base_mint)
+        {
+            inc_arb_v2_screen_sell_stale_then_fresh_after_pin_total();
+        }
+        opp
+    }
+
+    /// C1h5: when v2 screen fails on cross-dex sell leg for pinned pools, re-pin + rescreen.
+    fn try_schedule_v2_sell_leg_recovery(
+        &self,
+        tracker_snapshot: &TokenArbTracker,
+        config: &ArbConfig,
+        vault_balances: &HashMap<String, VaultBalanceCache>,
+        bin_arrays: &HashMap<String, HashMap<i64, BinArrayCache>>,
+        pinned_pools: &HashSet<String>,
+    ) {
+        let token_decimals = match tracker_snapshot.token_decimals {
+            Some(d) => d,
+            None => return,
+        };
+        let known_pools = self.known_pools.read();
+        let freshness = TokenArbTracker::quote_freshness_config(config);
+        let probe = config.arb_probe_lamports;
+        let owned_candidates = tracker_snapshot.build_round_trip_candidates(
+            &known_pools,
+            vault_balances,
+            bin_arrays,
+            token_decimals,
+            Some(pinned_pools),
+        );
+        let candidates: Vec<RoundTripPoolCandidate<'_>> = owned_candidates
+            .iter()
+            .map(|(pool, vault, bins, dex)| RoundTripPoolCandidate {
+                pool,
+                vault: vault.as_ref(),
+                dlmm_bins: bins.as_ref(),
+                dex,
+            })
+            .collect();
+        let Err(RoundTripSelectFailure::InsufficientPools(insufficient)) =
+            select_round_trip_pools(&candidates, probe, &freshness)
+        else {
+            return;
+        };
+        if insufficient.subreason != RoundTripInsufficientSubreason::NoCrossDexSell {
+            return;
+        }
+        let recoverable = matches!(
+            insufficient.no_cross_dex_sell_detail,
+            Some(
+                NoCrossDexSellDetailReason::SellNotFresh
+                    | NoCrossDexSellDetailReason::SellMissingVault
+                    | NoCrossDexSellDetailReason::SellQuoteNone
+            )
+        );
+        if !recoverable {
+            return;
+        }
+
+        let now = Instant::now();
+        let mut has_pinned_sell_stale = false;
+        for buy in &candidates {
+            let Some(buy_quote) = quote_exact_in_with_freshness(
+                buy.pool,
+                buy.vault,
+                buy.dlmm_bins,
+                NATIVE_SOL_MINT,
+                &buy.pool.token_mint,
+                probe,
+                &freshness,
+            ) else {
+                continue;
+            };
+            if !is_quote_fresh(&buy_quote, &freshness, buy.vault, now) {
+                continue;
+            }
+            for sell in &candidates {
+                if sell.dex == buy.dex {
+                    continue;
+                }
+                if !pinned_pools.contains(&sell.pool.pool_address) {
+                    continue;
+                }
+                let failure = classify_cross_dex_sell_failure(
+                    sell,
+                    buy_quote.amount_out,
+                    &freshness,
+                    now,
+                    token_decimals,
+                );
+                if failure.is_some() {
+                    has_pinned_sell_stale = true;
+                    break;
+                }
+            }
+            if has_pinned_sell_stale {
+                break;
+            }
+        }
+        if !has_pinned_sell_stale {
+            return;
+        }
+
+        self.v2_sell_stale_recovery_mints
+            .write()
+            .insert(tracker_snapshot.base_mint.clone());
+        inc_arb_v2_screen_sell_stale_recovery_scheduled_total();
+        self.arb_track_selection
+            .mark_dirty(&tracker_snapshot.base_mint);
+        if self
+            .two_hop_tx
+            .try_send(ArbTwoHopWorkerJob::Rescreen {
+                mint: tracker_snapshot.base_mint.clone(),
+            })
+            .is_ok()
+        {
+            inc_arb_vault_rescreen_scheduled_total();
+        }
     }
 
     /// Re-screen selected mints when DLMM bins arrive after the last trade-driven screen (H4).
@@ -7684,6 +7852,7 @@ async fn main() -> Result<()> {
         two_hop_tx,
         tracker_write,
         tracker_write_coalescer: parking_lot::Mutex::new(ArbTrackerWriteCoalescer::new()),
+        v2_sell_stale_recovery_mints: RwLock::new(HashSet::new()),
     });
 
     spawn_arb_tracker_write_worker(Arc::clone(&ctx), tracker_write_rx);
@@ -8770,6 +8939,7 @@ mod event_pipeline_tests {
             two_hop_tx,
             tracker_write,
             tracker_write_coalescer: parking_lot::Mutex::new(ArbTrackerWriteCoalescer::new()),
+            v2_sell_stale_recovery_mints: RwLock::new(HashSet::new()),
         });
         spawn_arb_tracker_write_worker(ctx.clone(), tracker_write_rx);
 
@@ -8882,6 +9052,7 @@ mod event_pipeline_tests {
             two_hop_tx,
             tracker_write,
             tracker_write_coalescer: parking_lot::Mutex::new(ArbTrackerWriteCoalescer::new()),
+            v2_sell_stale_recovery_mints: RwLock::new(HashSet::new()),
         });
         spawn_arb_tracker_write_worker(ctx.clone(), tracker_write_rx);
 
@@ -8992,6 +9163,7 @@ mod event_pipeline_tests {
             two_hop_tx,
             tracker_write,
             tracker_write_coalescer: parking_lot::Mutex::new(ArbTrackerWriteCoalescer::new()),
+            v2_sell_stale_recovery_mints: RwLock::new(HashSet::new()),
         });
         spawn_arb_tracker_write_worker(ctx.clone(), tracker_write_rx);
 
@@ -9212,6 +9384,7 @@ mod event_pipeline_tests {
             two_hop_tx,
             tracker_write,
             tracker_write_coalescer: parking_lot::Mutex::new(ArbTrackerWriteCoalescer::new()),
+            v2_sell_stale_recovery_mints: RwLock::new(HashSet::new()),
         });
         spawn_arb_tracker_write_worker(ctx.clone(), tracker_write_rx);
 
@@ -9320,6 +9493,7 @@ mod event_pipeline_tests {
             two_hop_tx,
             tracker_write,
             tracker_write_coalescer: parking_lot::Mutex::new(ArbTrackerWriteCoalescer::new()),
+            v2_sell_stale_recovery_mints: RwLock::new(HashSet::new()),
         });
         spawn_arb_tracker_write_worker(ctx.clone(), tracker_write_rx);
 
@@ -9432,6 +9606,7 @@ mod event_pipeline_tests {
             two_hop_tx,
             tracker_write,
             tracker_write_coalescer: parking_lot::Mutex::new(ArbTrackerWriteCoalescer::new()),
+            v2_sell_stale_recovery_mints: RwLock::new(HashSet::new()),
         });
         spawn_arb_tracker_write_worker(ctx.clone(), tracker_write_rx);
 
@@ -9515,6 +9690,7 @@ mod event_pipeline_tests {
             two_hop_tx,
             tracker_write,
             tracker_write_coalescer: parking_lot::Mutex::new(ArbTrackerWriteCoalescer::new()),
+            v2_sell_stale_recovery_mints: RwLock::new(HashSet::new()),
         });
         spawn_arb_tracker_write_worker(ctx.clone(), tracker_write_rx);
 
@@ -9672,6 +9848,7 @@ mod two_hop_price_tests {
                 ArbTrackerWriteHandle { tx, capacity: 1 }
             },
             tracker_write_coalescer: parking_lot::Mutex::new(ArbTrackerWriteCoalescer::new()),
+            v2_sell_stale_recovery_mints: RwLock::new(HashSet::new()),
         }
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -5146,6 +5146,12 @@ pub static ARB_TWO_HOP_V2_NO_FRESH_BUY_QUOTE_DETAIL_NOT_FRESH_AFTER: Lazy<Atomic
     Lazy::new(|| AtomicU64::new(0));
 /// PoolStateUpdate scheduled off-hot-loop rescreen for selected mints (C1vault).
 pub static ARB_VAULT_RESCREEN_SCHEDULED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// C1h5: v2 screen scheduled sell-leg recovery (track dirty + rescreen) after sell_not_fresh.
+pub static ARB_V2_SCREEN_SELL_STALE_RECOVERY_SCHEDULED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+/// C1h5: rescreen succeeded after prior sell-leg stale on pinned pool (cold-start recovery).
+pub static ARB_V2_SCREEN_SELL_STALE_THEN_FRESH_AFTER_PIN_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
 pub static ARB_V2_SCREEN_METEORA_SELL_BIN_HIT_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 pub static ARB_V2_SCREEN_METEORA_SELL_BIN_MISS_TOTAL: Lazy<AtomicU64> =
@@ -5807,6 +5813,16 @@ pub fn arb_two_hop_v2_no_fresh_buy_quote_detail_inc(reason: &str) {
 /// Increment `arb_vault_rescreen_scheduled_total`.
 pub fn inc_arb_vault_rescreen_scheduled_total() {
     ARB_VAULT_RESCREEN_SCHEDULED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Increment `arb_v2_screen_sell_stale_recovery_scheduled_total`.
+pub fn inc_arb_v2_screen_sell_stale_recovery_scheduled_total() {
+    ARB_V2_SCREEN_SELL_STALE_RECOVERY_SCHEDULED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Increment `arb_v2_screen_sell_stale_then_fresh_after_pin_total`.
+pub fn inc_arb_v2_screen_sell_stale_then_fresh_after_pin_total() {
+    ARB_V2_SCREEN_SELL_STALE_THEN_FRESH_AFTER_PIN_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Increment `arb_v2_screen_meteora_sell_bin_hit_total`.
@@ -10779,6 +10795,14 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "arb_vault_rescreen_scheduled_total",
         ARB_VAULT_RESCREEN_SCHEDULED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_v2_screen_sell_stale_recovery_scheduled_total",
+        ARB_V2_SCREEN_SELL_STALE_RECOVERY_SCHEDULED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_v2_screen_sell_stale_then_fresh_after_pin_total",
+        ARB_V2_SCREEN_SELL_STALE_THEN_FRESH_AFTER_PIN_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "arb_v2_screen_meteora_sell_bin_hit_total",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause (H1–H5)

Post-#375 restart: `round_trip_formable` >> 0 but `opportunities_found` = 0. Funnel killer `no_cross_dex_sell` dominated by `sell_not_fresh` (`age_exceeded`), `sell_missing_vault`, and MD `admit_suppress` (~23.4M deferred).

| Hypothesis | Finding |
|------------|---------|
| **H1** | Track selection classified readiness via **buy-only** `can_fresh_buy_quote`; pump_amm sell legs stayed **Warmable** |
| **H2** | `selected_pool` used classify map only — **ignored** bundle `QuoteReady` default from `bundle_from_round_trip` / pinable pairs |
| **H3** | Screen snapshot seeded stale cold vault rows (`gt_300s`); refresh only when SLAVE strictly fresher |
| **H4** | No feedback from v2 `sell_not_fresh` → track dirty / rescreen for pinned sell legs |
| **H5** | Warmable arb pins hit `admit_suppress` → deferred Geyser register / JetStream publish never completes |

Reference mint: `9Pfync3ejPC9eHqVzq3nYQJAhyhjqpnB9UsaSfLxpump` (meteora_dlmm buy → pump_amm sell).

## Fix (eng, no hot-path RPC)

### `track_selection.rs`
- `can_fresh_sell_quote` — sell-direction freshness for readiness classify
- `selected_pool` uses `max(classified, bundle_default)` so cross-dex legs keep **QuoteReady** (must_hot)
- `bundle_from_pinable_pair` forces **QuoteReady** on both legs

### `arb_strategy.rs`
- `try_overwrite_stale_pinned_vault_from_live_cache` at screen snapshot (pinned + state TTL exceeded)
- `try_schedule_v2_sell_leg_recovery`: buy fresh + pinned sell stale → track dirty + rescreen
- Recovery success metric when opportunity follows scheduled recovery

### `metrics.rs`
- `arb_v2_screen_sell_stale_recovery_scheduled_total`
- `arb_v2_screen_sell_stale_then_fresh_after_pin_total`

## STOP-CHECK
- I-7: no RPC in hot path (Geyser/SLAVE cache only)
- I-9: send path untouched
- Pattern: existing must_hot / rescreen / try_refresh_vault_from_live_cache
- No TTL/cap/Spoof-Guard/Mom-filter changes

## Out of scope
- #375 execution TX-size (separate validation after Opp>0)
- Deploy
- `market_data.rs` (fix via QuoteReady → must_hot on wire; no MD logic change needed)

## Verification
- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test` ✓

## Abnahme (post-deploy, user OK)
- `sell_not_fresh` ↓; formable >> 0 → occasional Opp/Intent > 0
- Referenz-Mint `9Pfync…` reaches intent stage again
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00a58cd3-f89f-43fe-887c-25225d2c88b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00a58cd3-f89f-43fe-887c-25225d2c88b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

