### PR TITLE
fix(ee): Orca pool_address_hint for cross-DEX arb TX plan

### DIFF
--- a/src/solana/cross_dex_handler.rs
+++ b/src/solana/cross_dex_handler.rs
@@ -1347,15 +1347,21 @@ impl CrossDexHandler {
                 .get(&buy_dex)
                 .ok_or_else(|| anyhow!("Unknown buy DEX: {}", buy_dex))?;
 
+            if buy_dex != "pump_amm" && !buy_pool.is_empty() {
+                buy_connector.cache_extra_data("pool_address_hint", &buy_pool);
+            }
+
             if let Some(ref accts) = buy_accounts {
-                if let Err(e) = buy_connector.set_pool_from_accounts(&buy_pool, accts) {
-                    warn!(
-                        pool = %buy_pool,
-                        dex = %buy_dex,
-                        error = %e,
-                        "Failed to set buy pool from intent accounts"
-                    );
-                }
+                buy_connector
+                    .set_pool_from_accounts(&buy_pool, accts)
+                    .map_err(|e| {
+                        anyhow!(
+                            "Failed to set buy pool from intent accounts (pool={}, dex={}): {}",
+                            buy_pool,
+                            buy_dex,
+                            e
+                        )
+                    })?;
             } else if !buy_pool.is_empty() {
                 let pool_pk = Pubkey::from_str(&buy_pool)
                     .map_err(|_| anyhow!("Invalid buy pool address: {}", buy_pool))?;
@@ -1413,6 +1419,10 @@ impl CrossDexHandler {
                 .get(&sell_dex)
                 .ok_or_else(|| anyhow!("Unknown sell DEX: {}", sell_dex))?;
 
+            if sell_dex != "pump_amm" && !sell_pool.is_empty() {
+                sell_connector.cache_extra_data("pool_address_hint", &sell_pool);
+            }
+
             sell_connector.cache_extra_data(
                 &format!("token_program:{}", token_mint),
                 &token_program_sdk.to_string(),
@@ -1425,14 +1435,16 @@ impl CrossDexHandler {
             }
 
             if let Some(ref accts) = sell_accounts {
-                if let Err(e) = sell_connector.set_pool_from_accounts(&sell_pool, accts) {
-                    warn!(
-                        pool = %sell_pool,
-                        dex = %sell_dex,
-                        error = %e,
-                        "Failed to set sell pool from intent accounts"
-                    );
-                }
+                sell_connector
+                    .set_pool_from_accounts(&sell_pool, accts)
+                    .map_err(|e| {
+                        anyhow!(
+                            "Failed to set sell pool from intent accounts (pool={}, dex={}): {}",
+                            sell_pool,
+                            sell_dex,
+                            e
+                        )
+                    })?;
             } else if !sell_pool.is_empty() {
                 let pool_pk = Pubkey::from_str(&sell_pool)
                     .map_err(|_| anyhow!("Invalid sell pool address: {}", sell_pool))?;

--- a/src/solana/dex/orca.rs
+++ b/src/solana/dex/orca.rs
@@ -17,6 +17,8 @@ pub const ORCA_WHIRLPOOL_PROGRAM: &str = "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3u
                                                                                         // Whirlpool account size is 653 bytes
 pub const WHIRLPOOL_ACCOUNT_MIN_SIZE: usize = 650; // lower bound
 pub const WHIRLPOOL_ACCOUNT_MAX_SIZE: usize = 653; // exact size
+/// Key used by cross_dex_handler via [`Dex::cache_extra_data`] to pin the active whirlpool.
+pub const POOL_ADDRESS_HINT_KEY: &str = "pool_address_hint";
 
 use super::orca_whirlpool_layout as layout;
 use dashmap::DashMap;
@@ -72,6 +74,8 @@ pub struct Orca {
     cache_misses: Arc<AtomicU64>,
     /// When true (Hot Path): skip get_multiple_accounts tick validation to avoid RPC
     skip_tick_array_rpc_validation: Arc<AtomicBool>,
+    /// Geyser-sourced extras from cross_dex_handler (e.g. pool_address_hint, token programs).
+    cached_data: Arc<DashMap<String, String>>,
 }
 
 impl Orca {
@@ -114,6 +118,7 @@ impl Orca {
             cache_hits: Arc::new(AtomicU64::new(0)),
             cache_misses: Arc::new(AtomicU64::new(0)),
             skip_tick_array_rpc_validation: Arc::new(AtomicBool::new(false)),
+            cached_data: Arc::new(DashMap::new()),
         }
     }
 
@@ -304,6 +309,43 @@ impl Orca {
             "No Orca pool found for pair"
         );
         None
+    }
+
+    /// Resolve the whirlpool for a swap, preferring an explicit pool hint from cross_dex_handler.
+    fn resolve_pool_for_swap(
+        &self,
+        input: &Pubkey,
+        output: &Pubkey,
+    ) -> Option<(Pubkey, bool, OrcaPool)> {
+        if let Some(hint_entry) = self.cached_data.get(POOL_ADDRESS_HINT_KEY) {
+            if let Ok(pool_pk) = Pubkey::from_str(hint_entry.value()) {
+                if let Some(pool_entry) = self.pools.get(&pool_pk) {
+                    let pool = pool_entry.clone();
+                    let forward = pool.base_mint == *input && pool.quote_mint == *output;
+                    let reverse = pool.base_mint == *output && pool.quote_mint == *input;
+                    if forward || reverse {
+                        tracing::debug!(
+                            pool = %pool_pk,
+                            direction = if forward { "forward" } else { "reverse" },
+                            "Orca pool resolved via pool_address_hint"
+                        );
+                        return Some((pool_pk, forward, pool));
+                    }
+                    tracing::warn!(
+                        pool = %pool_pk,
+                        input = %input,
+                        output = %output,
+                        "pool_address_hint pool mints do not match swap pair; falling back to find_pool"
+                    );
+                } else {
+                    tracing::warn!(
+                        pool = %pool_pk,
+                        "pool_address_hint set but pool not in connector cache; falling back to find_pool"
+                    );
+                }
+            }
+        }
+        self.find_pool(input, output)
     }
 
     /// Cold-path only: verifies the three Whirlpool tick-array PDAs used by
@@ -1028,7 +1070,7 @@ impl Dex for Orca {
         let in_pk = Pubkey::from_str(_input_mint).map_err(|_| anyhow!("bad input mint"))?;
         let out_pk = Pubkey::from_str(_output_mint).map_err(|_| anyhow!("bad output mint"))?;
         let (pool_id, forward, pool) = self
-            .find_pool(&in_pk, &out_pk)
+            .resolve_pool_for_swap(&in_pk, &out_pk)
             .ok_or_else(|| anyhow!("no orca pool for pair"))?;
 
         // Get user authority first (needed for ATAs)
@@ -1288,7 +1330,7 @@ impl Dex for Orca {
         let in_pk = Pubkey::from_str(input_mint).map_err(|_| anyhow!("bad input mint"))?;
         let out_pk = Pubkey::from_str(output_mint).map_err(|_| anyhow!("bad output mint"))?;
         let (pool_id, forward, pool) = self
-            .find_pool(&in_pk, &out_pk)
+            .resolve_pool_for_swap(&in_pk, &out_pk)
             .ok_or_else(|| anyhow!("no orca pool for pair"))?;
 
         let authority = self
@@ -1511,6 +1553,15 @@ impl Dex for Orca {
             accounts,
             data,
         }])
+    }
+
+    fn cache_extra_data(&self, key: &str, value: &str) {
+        tracing::debug!(
+            key = %key,
+            value = %value,
+            "orca: caching extra data"
+        );
+        self.cached_data.insert(key.to_string(), value.to_string());
     }
 
     fn list_pairs(&self) -> Vec<(String, String)> {
@@ -1870,5 +1921,53 @@ mod tests {
         assert_eq!(super::get_tick_array_start_index(338433, 128), 337920);
         assert_eq!(super::get_tick_array_start_index(-337409, 128), -337920);
         assert_ne!(super::get_tick_array_start_index(2354285, 8), 2353573);
+    }
+
+    /// Cross-DEX arb: explicit pool_address_hint + injected pool must build swap IX without mint-pair scan failure.
+    #[tokio::test]
+    async fn test_build_swap_ix_async_uses_pool_address_hint() {
+        use super::POOL_ADDRESS_HINT_KEY;
+        use crate::solana::dex::Dex;
+
+        const SOL_MINT: &str = "So11111111111111111111111111111111111111112";
+
+        let rpc = Arc::new(SolanaRpc::new("https://dummy"));
+        let orca = Orca::new(rpc);
+        orca.set_skip_tick_array_rpc_validation(true);
+        orca.set_user_authority(Pubkey::new_unique());
+
+        let pool_pk = Pubkey::new_unique();
+        let token_mint = Pubkey::new_unique();
+        let sol_mint = Pubkey::from_str(SOL_MINT).unwrap();
+        let vault_a = Pubkey::new_unique();
+        let vault_b = Pubkey::new_unique();
+
+        orca.set_pool_from_accounts(
+            &pool_pk.to_string(),
+            &[
+                pool_pk.to_string(),
+                sol_mint.to_string(),
+                token_mint.to_string(),
+                vault_a.to_string(),
+                vault_b.to_string(),
+                "tick_current_index:0".to_string(),
+                "tick_spacing:64".to_string(),
+            ],
+        )
+        .expect("set_pool_from_accounts");
+
+        orca.cache_extra_data(POOL_ADDRESS_HINT_KEY, &pool_pk.to_string());
+
+        let ixs = orca
+            .build_swap_ix_async(SOL_MINT, &token_mint.to_string(), 1_000_000, 1)
+            .await
+            .expect("build_swap_ix_async with pool_address_hint");
+
+        assert_eq!(ixs.len(), 1);
+        assert_eq!(ixs[0].program_id.to_string(), super::ORCA_WHIRLPOOL_PROGRAM);
+        assert!(
+            ixs[0].accounts.iter().any(|a| a.pubkey == pool_pk),
+            "swap ix must reference hinted whirlpool"
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Post-#379 arb soak: Intent `arb-933d42cd-000000` (orca buy → pump_amm sell) reached EE `tx_plan` but failed with `cross_dex_plan_error:no orca pool for pair`.

Root causes:
1. `set_pool_from_accounts` failures were logged and ignored (`warn` + continue), so `build_swap_ix_async` ran without a loaded whirlpool.
2. Orca had no `pool_address_hint` pattern (unlike pump_amm) to pin the explicit pool from intent metadata.

## Solution

### `src/solana/dex/orca.rs`
- Add `cached_data` + `POOL_ADDRESS_HINT_KEY` constant
- Implement `cache_extra_data` on `Dex` trait
- Add `resolve_pool_for_swap`: prefers hinted pool when present in connector cache, falls back to `find_pool`
- Use in `build_swap_ix` and `build_swap_ix_async`
- Unit test: injected pool + hint → swap IX builds successfully

### `src/solana/cross_dex_handler.rs`
- Cache `pool_address_hint` for non-`pump_amm` buy/sell legs before swap build
- `set_pool_from_accounts` errors → **hard fail** (`return Err`) instead of warn+continue

## Invariant checks (STOP-CHECK)
- **I-7**: No new RPC in hot path; existing cached tick/token program behavior unchanged
- **I-9**: Simulation gate untouched
- **I-12**: Decision record flow untouched
- **Pattern**: Aligns with pump_amm `pool_address_hint` via `cache_extra_data`

## Verification
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (incl. `test_build_swap_ix_async_uses_pool_address_hint`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-877c6f56-e4be-4fbc-a779-299622629f05?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-877c6f56-e4be-4fbc-a779-299622629f05&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

