### PR TITLE
fix(arb): Meteora pool hint + dynamic Jito tip and bundle confirm

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -134,7 +134,7 @@ use ironcrab::solana::dex::raydium::Raydium;
 use ironcrab::solana::dex::router::Router;
 use ironcrab::solana::dex::Dex;
 use ironcrab::solana::dex_parser::SOL_MINT;
-use ironcrab::solana::jito::{JitoClient, JitoRegion};
+use ironcrab::solana::jito::{BundleStatusValue, JitoClient, JitoRegion};
 use ironcrab::solana::rpc::SolanaRpc;
 use ironcrab::solana::token_utils::get_token_decimals_or_default;
 use ironcrab::solana::tx_sender::TxSender;
@@ -1526,6 +1526,9 @@ struct ExecutionConfig {
     /// Timeout for bundle confirmation (seconds)
     jito_timeout_secs: u64,
 
+    /// Timeout for cross-DEX arb bundle confirmation (seconds; longer than default)
+    jito_arb_timeout_secs: u64,
+
     // === P1: Fee/Compute Policies ===
     /// Centralized fee policy (engine owns compute budget and priority fees)
     fee_policy: FeePolicy,
@@ -1604,6 +1607,7 @@ impl Default for ExecutionConfig {
             jito_tip_lamports: 10_000, // 0.00001 SOL default tip
             jito_region: "frankfurt".to_string(),
             jito_timeout_secs: 30,
+            jito_arb_timeout_secs: 45,
             // P1: Fee/Compute Policy
             fee_policy: FeePolicy::default(),
             liquidation_priority_fee_micro_lamports: None,
@@ -10409,6 +10413,51 @@ fn simulation_result_on_rpc_timeout() -> SimulationResult {
     }
 }
 
+/// Minimum Jito bundle tip for cross-DEX arb (lamports).
+const BUNDLE_TIP_MIN_LAMPORTS: u64 = 100_000;
+/// Maximum Jito bundle tip for cross-DEX arb (lamports).
+const BUNDLE_TIP_MAX_LAMPORTS: u64 = 2_000_000;
+/// Default tip share of estimated arb profit when metadata has no explicit bps.
+const BUNDLE_TIP_DEFAULT_BPS: u64 = 750;
+
+fn is_cross_dex_arb_bundle(intent: &TradeIntent) -> bool {
+    CrossDexHandler::is_cross_dex_arb_intent(intent)
+        || intent
+            .metadata
+            .get("cross_dex_arb")
+            .is_some_and(|v| v == "true")
+}
+
+/// Dynamic bundle tip: scale from `estimated_profit_lamports` for cross-DEX arb when metadata present.
+fn effective_bundle_tip_lamports(intent: &TradeIntent, config: &ExecutionConfig) -> u64 {
+    if is_cross_dex_arb_bundle(intent) {
+        if let Some(profit) = intent
+            .metadata
+            .get("estimated_profit_lamports")
+            .and_then(|s| s.parse::<u64>().ok())
+        {
+            let tip_bps = intent
+                .metadata
+                .get("bundle_tip_bps")
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(BUNDLE_TIP_DEFAULT_BPS);
+            let scaled = (profit as u128 * tip_bps as u128 / 10_000) as u64;
+            return scaled.clamp(BUNDLE_TIP_MIN_LAMPORTS, BUNDLE_TIP_MAX_LAMPORTS);
+        }
+    }
+    intent
+        .bundle_tip_lamports
+        .unwrap_or(config.jito_tip_lamports)
+}
+
+fn bundle_confirm_timeout_secs(intent: &TradeIntent, config: &ExecutionConfig) -> u64 {
+    if is_cross_dex_arb_bundle(intent) {
+        config.jito_arb_timeout_secs
+    } else {
+        config.jito_timeout_secs
+    }
+}
+
 /// Process a single TradeIntent through the execution pipeline
 async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Result<()> {
     try_record_execution_intent_header_to_receive_ms(
@@ -11516,12 +11565,12 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
         let mut bundle_tip_ix: Option<solana_sdk::instruction::Instruction> = None;
         let mut bundle_tip_lamports: Option<u64> = None;
         if requires_bundle && config.send_enabled {
-            let tip_lamports = intent
-                .bundle_tip_lamports
-                .unwrap_or(config.jito_tip_lamports);
+            let tip_lamports = effective_bundle_tip_lamports(&intent, &config);
             info!(
                 intent_id = %intent.intent_id,
                 tip_lamports = %tip_lamports,
+                cross_dex_arb = is_cross_dex_arb_bundle(&intent),
+                estimated_profit = intent.metadata.get("estimated_profit_lamports"),
                 "Building Jito tip instruction for bundle"
             );
             let jito_client = ctx
@@ -12075,6 +12124,9 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
     // Track bundle result for decision record
     let mut bundle_id: Option<String> = None;
     let mut send_signature: Option<String> = None;
+    let mut bundle_wallet_confirm_rx: Option<
+        tokio::sync::oneshot::Receiver<WalletTxConfirmNotify>,
+    > = None;
     let mut send_method_used: Option<String> = None;
     let mut sent_tx: Option<VersionedTransaction> = None;
     let mut sent_anything = false;
@@ -12214,6 +12266,20 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                     return emit_rejected_decision(ctx, decision_id, &intent, checks, reason).await;
                 }
             };
+
+            if let Some(sig) = versioned_tx.signatures.first() {
+                if *sig != Signature::default() {
+                    let sig_str = sig.to_string();
+                    send_signature = Some(sig_str.clone());
+                    bundle_wallet_confirm_rx =
+                        Some(register_wallet_tx_confirm_waiter(ctx, &sig_str));
+                    info!(
+                        intent_id = %intent.intent_id,
+                        signature = %sig_str,
+                        "Bundle TX signature known pre-send; registered JetStream confirm waiter"
+                    );
+                }
+            }
 
             if let Err(size_err) = check_versioned_tx_size(&versioned_tx) {
                 log_bundle_tx_size_rejection(
@@ -12466,59 +12532,66 @@ async fn process_intent(ctx: &ExecutionContext, mut intent: TradeIntent) -> Resu
                         .as_ref()
                         .expect("bundle_config gate ensures jito_client is present");
 
-                    match jito_client
-                        .wait_for_bundle(bid, config.jito_timeout_secs)
-                        .await
+                    let bundle_timeout_secs = bundle_confirm_timeout_secs(&intent, &config);
+                    let tx_sig = sr.signature.as_deref().or(send_signature.as_deref());
+
+                    match confirm_bundle_landing(
+                        ctx,
+                        jito_client,
+                        bid,
+                        tx_sig,
+                        bundle_timeout_secs,
+                        slot_at_send,
+                        bundle_wallet_confirm_rx,
+                    )
+                    .await
                     {
-                        Ok(status) => {
-                            // Bundle landed successfully
+                        Ok(ConfirmOutcome::Confirmed { details, slot }) => {
                             JITO_BUNDLES_LANDED_TOTAL.fetch_add(1, Ordering::Relaxed);
                             TX_CONFIRMED_TOTAL.fetch_add(1, Ordering::Relaxed);
-
-                            // If Jito returned tx signatures, record the first as a convenience.
-                            if let Some(sig0) = status.transactions.first().cloned() {
-                                sr.signature = Some(sig0.clone());
+                            if let Some(sig) = tx_sig {
+                                sr.signature = Some(sig.to_string());
                             }
-
                             checks.push(CheckResult {
                                 check_name: "confirm".to_string(),
                                 passed: true,
                                 reason_code: None,
-                                details: Some(format!(
-                                    "bundle_id={bid} slot={} confirmation_status={} txs={}",
-                                    status.slot,
-                                    status.confirmation_status,
-                                    status.transactions.len()
-                                )),
+                                details: Some(details),
                             });
-                            tx_landing_slot = Some(status.slot);
+                            tx_landing_slot = slot;
                             final_outcome = DecisionOutcome::Confirmed;
                         }
-                        Err(e) => {
-                            let error_msg = format!("{e:?}");
-                            let is_timeout =
-                                error_msg.contains("timeout") || error_msg.contains("Timeout");
-
-                            if is_timeout {
-                                JITO_BUNDLES_TIMEOUT_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                TX_CONFIRM_TIMEOUT_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                checks.push(CheckResult {
-                                    check_name: "confirm".to_string(),
-                                    passed: false,
-                                    reason_code: Some(RejectReason::BundleTimeout.to_string()),
-                                    details: Some(error_msg),
-                                });
-                                final_outcome = DecisionOutcome::Sent;
-                            } else {
-                                JITO_BUNDLES_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
-                                checks.push(CheckResult {
-                                    check_name: "confirm".to_string(),
-                                    passed: false,
-                                    reason_code: Some(RejectReason::BundleFailed.to_string()),
-                                    details: Some(error_msg),
-                                });
-                                final_outcome = DecisionOutcome::FailedConfirmed;
-                            }
+                        Ok(ConfirmOutcome::FailedConfirmed { details, slot }) => {
+                            JITO_BUNDLES_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                            checks.push(CheckResult {
+                                check_name: "confirm".to_string(),
+                                passed: false,
+                                reason_code: Some(RejectReason::BundleFailed.to_string()),
+                                details: Some(details),
+                            });
+                            tx_landing_slot = slot;
+                            final_outcome = DecisionOutcome::FailedConfirmed;
+                        }
+                        Ok(ConfirmOutcome::TimeoutSent { details }) => {
+                            JITO_BUNDLES_TIMEOUT_TOTAL.fetch_add(1, Ordering::Relaxed);
+                            TX_CONFIRM_TIMEOUT_TOTAL.fetch_add(1, Ordering::Relaxed);
+                            checks.push(CheckResult {
+                                check_name: "confirm".to_string(),
+                                passed: false,
+                                reason_code: Some(RejectReason::BundleTimeout.to_string()),
+                                details: Some(details),
+                            });
+                            final_outcome = DecisionOutcome::Sent;
+                        }
+                        Err(error_msg) => {
+                            JITO_BUNDLES_REJECTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                            checks.push(CheckResult {
+                                check_name: "confirm".to_string(),
+                                passed: false,
+                                reason_code: Some(RejectReason::BundleFailed.to_string()),
+                                details: Some(error_msg),
+                            });
+                            final_outcome = DecisionOutcome::FailedConfirmed;
                         }
                     }
                 }
@@ -14137,6 +14210,151 @@ async fn publish_pre_confirm_execution_result(
             .await?;
     }
     Ok(())
+}
+
+/// Bundle landing: parallel Jito `getBundleStatuses` poll and JetStream WalletTxConfirmed when
+/// the signed bundle TX signature is known. On timeout, performs one final bundle status poll.
+async fn confirm_bundle_landing(
+    ctx: &ExecutionContext,
+    jito_client: &JitoClient,
+    bundle_id: &str,
+    tx_signature: Option<&str>,
+    timeout_secs: u64,
+    slot_at_send: Option<u64>,
+    pre_registered_rx: Option<tokio::sync::oneshot::Receiver<WalletTxConfirmNotify>>,
+) -> std::result::Result<ConfirmOutcome, String> {
+    let start = std::time::Instant::now();
+    let deadline = Duration::from_secs(timeout_secs.max(1));
+
+    enum BundleConfirmRace {
+        Jito(std::result::Result<BundleStatusValue, anyhow::Error>),
+        Geyser(std::result::Result<WalletTxConfirmNotify, tokio::sync::oneshot::error::RecvError>),
+    }
+
+    let race_result = tokio::time::timeout(
+        deadline,
+        async {
+            tokio::select! {
+                jito_res = jito_client.wait_for_bundle(bundle_id, timeout_secs) => {
+                    BundleConfirmRace::Jito(jito_res)
+                }
+                geyser_res = async {
+                    if let Some(sig) = tx_signature {
+                        let rx = match pre_registered_rx {
+                            Some(rx) => rx,
+                            None => register_wallet_tx_confirm_waiter(ctx, sig),
+                        };
+                        rx.await
+                    } else {
+                        futures::future::pending::<
+                            std::result::Result<WalletTxConfirmNotify, tokio::sync::oneshot::error::RecvError>,
+                        >()
+                        .await
+                    }
+                } => BundleConfirmRace::Geyser(geyser_res),
+            }
+        },
+    )
+    .await;
+
+    match race_result {
+        Ok(BundleConfirmRace::Jito(Ok(status))) => {
+            return Ok(ConfirmOutcome::Confirmed {
+                details: format!(
+                    "method=jito_bundle bundle_id={bundle_id} slot={} confirmation_status={} txs={}",
+                    status.slot,
+                    status.confirmation_status,
+                    status.transactions.len()
+                ),
+                slot: Some(status.slot),
+            });
+        }
+        Ok(BundleConfirmRace::Jito(Err(e))) => {
+            let msg = e.to_string();
+            if !msg.contains("timeout") && !msg.contains("Timeout") {
+                return Ok(ConfirmOutcome::FailedConfirmed {
+                    details: format!("method=jito_bundle bundle_id={bundle_id} {msg}"),
+                    slot: None,
+                });
+            }
+        }
+        Ok(BundleConfirmRace::Geyser(Ok(confirm))) => {
+            if confirm.err.is_none() {
+                TX_CONFIRM_JETSTREAM_TOTAL.fetch_add(1, Ordering::Relaxed);
+                record_confirm_latency_metrics(start, slot_at_send, Some(confirm.slot));
+                return Ok(ConfirmOutcome::Confirmed {
+                    details: format!(
+                        "method=jetstream_bundle bundle_id={bundle_id} slot={} elapsed_ms={}",
+                        confirm.slot,
+                        start.elapsed().as_millis()
+                    ),
+                    slot: Some(confirm.slot),
+                });
+            }
+            record_confirm_latency_metrics(start, slot_at_send, Some(confirm.slot));
+            return Ok(ConfirmOutcome::FailedConfirmed {
+                details: format!(
+                    "method=jetstream_bundle bundle_id={bundle_id} err={} slot={}",
+                    confirm.err.as_deref().unwrap_or("unknown"),
+                    confirm.slot
+                ),
+                slot: Some(confirm.slot),
+            });
+        }
+        Ok(BundleConfirmRace::Geyser(Err(_))) => {
+            debug!(
+                bundle_id = %bundle_id,
+                "JetStream confirm channel dropped during bundle wait"
+            );
+        }
+        Err(_) => {
+            debug!(
+                bundle_id = %bundle_id,
+                elapsed_ms = start.elapsed().as_millis(),
+                "Bundle confirm deadline elapsed; performing final status poll"
+            );
+        }
+    }
+
+    // Final poll: getBundleStatuses
+    if let Ok(statuses) = jito_client
+        .get_bundle_status(&[bundle_id.to_string()])
+        .await
+    {
+        if let Some(status) = statuses.into_iter().find(|s| s.bundle_id == bundle_id) {
+            if status.confirmation_status == "confirmed"
+                || status.confirmation_status == "finalized"
+            {
+                return Ok(ConfirmOutcome::Confirmed {
+                    details: format!(
+                        "method=jito_bundle_final_poll bundle_id={bundle_id} slot={} confirmation_status={}",
+                        status.slot, status.confirmation_status
+                    ),
+                    slot: Some(status.slot),
+                });
+            }
+            if status.err.is_some() {
+                return Ok(ConfirmOutcome::FailedConfirmed {
+                    details: format!(
+                        "method=jito_bundle_final_poll bundle_id={bundle_id} err={:?}",
+                        status.err
+                    ),
+                    slot: Some(status.slot),
+                });
+            }
+        }
+    }
+
+    if let Some(sig) = tx_signature {
+        ctx.pending_tx_confirms.write().remove(sig);
+    }
+
+    Ok(ConfirmOutcome::TimeoutSent {
+        details: format!(
+            "bundle_id={bundle_id} timeout_secs={timeout_secs} elapsed_ms={}",
+            start.elapsed().as_millis()
+        ),
+    })
 }
 
 /// PR3: JetStream WalletTxConfirmed wait (market-data Geyser → JetStream → EE).

--- a/src/solana/dex/meteora_dlmm.rs
+++ b/src/solana/dex/meteora_dlmm.rs
@@ -29,6 +29,9 @@ use crate::solana::rpc::SolanaRpc;
 /// Meteora DLMM Program ID
 pub const METEORA_DLMM_PROGRAM: &str = "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo";
 
+/// Key used by cross_dex_handler via [`Dex::cache_extra_data`] to pin the active LB pair.
+pub const POOL_ADDRESS_HINT_KEY: &str = "pool_address_hint";
+
 /// LB Pair account size (904 bytes)
 #[cfg(feature = "rpc_fallback")]
 const LB_PAIR_ACCOUNT_SIZE: usize = 904;
@@ -94,6 +97,53 @@ impl MeteoraDlmm {
     /// List all tracked pool addresses
     pub fn list_pools(&self) -> Vec<Pubkey> {
         self.pools.iter().map(|entry| *entry.key()).collect()
+    }
+
+    /// Resolve the LB pair for a swap, preferring an explicit pool hint from cross_dex_handler.
+    fn resolve_pool_for_swap(
+        &self,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+    ) -> Option<(Pubkey, PoolCache)> {
+        if let Some(hint_entry) = self.extra_data.get(POOL_ADDRESS_HINT_KEY) {
+            if let Ok(pool_pk) = Pubkey::from_str(hint_entry.value()) {
+                if let Some(pool_entry) = self.pools.get(&pool_pk) {
+                    let pool = pool_entry.value();
+                    let forward = pool.pool.token_x_mint == *input_mint
+                        && pool.pool.token_y_mint == *output_mint;
+                    let reverse = pool.pool.token_x_mint == *output_mint
+                        && pool.pool.token_y_mint == *input_mint;
+                    if forward || reverse {
+                        debug!(
+                            pool = %pool_pk,
+                            direction = if forward { "forward" } else { "reverse" },
+                            "meteora_dlmm pool resolved via pool_address_hint"
+                        );
+                        return Some((pool_pk, pool.clone()));
+                    }
+                    tracing::warn!(
+                        pool = %pool_pk,
+                        input = %input_mint,
+                        output = %output_mint,
+                        "pool_address_hint pool mints do not match swap pair; falling back to mint scan"
+                    );
+                } else {
+                    tracing::warn!(
+                        pool = %pool_pk,
+                        "pool_address_hint set but pool not in connector cache; falling back to mint scan"
+                    );
+                }
+            }
+        }
+
+        self.pools
+            .iter()
+            .find(|entry| {
+                let pool = &entry.value().pool;
+                (pool.token_x_mint == *input_mint && pool.token_y_mint == *output_mint)
+                    || (pool.token_x_mint == *output_mint && pool.token_y_mint == *input_mint)
+            })
+            .map(|entry| (*entry.key(), entry.value().clone()))
     }
 
     /// Find pools containing a specific mint
@@ -744,20 +794,10 @@ impl Dex for MeteoraDlmm {
         let input_mint_pk = Pubkey::from_str(input_mint)?;
         let output_mint_pk = Pubkey::from_str(output_mint)?;
 
-        // Find pool for this pair
-        let pool_entry = self
-            .pools
-            .iter()
-            .find(|entry| {
-                let pool = &entry.value().pool;
-                (pool.token_x_mint == input_mint_pk && pool.token_y_mint == output_mint_pk)
-                    || (pool.token_x_mint == output_mint_pk && pool.token_y_mint == input_mint_pk)
-            })
+        let (pool_addr, pool_cache) = self
+            .resolve_pool_for_swap(&input_mint_pk, &output_mint_pk)
             .ok_or_else(|| anyhow!("No pool found for {}/{}", input_mint, output_mint))?;
-
-        let pool_addr = *pool_entry.key();
-        let pool = pool_entry.value().pool.clone();
-        drop(pool_entry); // Release DashMap lock before async call
+        let pool = pool_cache.pool.clone();
 
         // Validate that we have real active_id/bin_step from DexPoolAccounts
         // If active_id is 0 and bin_step is default (10), the Intent may be missing data
@@ -964,6 +1004,7 @@ impl Dex for MeteoraDlmm {
     /// Used by cross_dex_handler to pass Token-2022 program info.
     ///
     /// Supported keys:
+    /// - [`POOL_ADDRESS_HINT_KEY`] -> LB pair address from cross-DEX arb intent
     /// - "token_program:<mint>" -> token program ID (SPL Token or Token-2022)
     fn cache_extra_data(&self, key: &str, value: &str) {
         debug!(
@@ -1009,6 +1050,63 @@ mod tests {
             err_msg.contains("GEYSER-ONLY"),
             "expected GEYSER-ONLY in error, got: {}",
             err_msg
+        );
+    }
+
+    /// Cross-DEX arb: explicit pool_address_hint + injected pool must build swap IX without mint-pair scan failure.
+    #[tokio::test]
+    async fn test_build_swap_ix_async_uses_pool_address_hint() {
+        use super::POOL_ADDRESS_HINT_KEY;
+        use crate::solana::dex::Dex;
+
+        const SOL_MINT: &str = "So11111111111111111111111111111111111111112";
+
+        let rpc = Arc::new(SolanaRpc::new("https://dummy"));
+        let mut meteora = MeteoraDlmm::new_with_live_cache(rpc, None, false);
+        meteora.set_user_authority(Pubkey::new_unique());
+
+        let pool_pk = Pubkey::new_unique();
+        let token_mint = Pubkey::new_unique();
+        let sol_mint = Pubkey::from_str(SOL_MINT).unwrap();
+        let reserve_x = Pubkey::new_unique();
+        let reserve_y = Pubkey::new_unique();
+
+        meteora
+            .set_pool_from_accounts(
+                &pool_pk.to_string(),
+                &[
+                    pool_pk.to_string(),
+                    sol_mint.to_string(),
+                    token_mint.to_string(),
+                    reserve_x.to_string(),
+                    reserve_y.to_string(),
+                    "active_id:100".to_string(),
+                    "bin_step:10".to_string(),
+                ],
+            )
+            .expect("set_pool_from_accounts");
+
+        meteora.cache_extra_data(POOL_ADDRESS_HINT_KEY, &pool_pk.to_string());
+        meteora.cache_extra_data(
+            &format!("token_program:{}", sol_mint),
+            &spl_token::id().to_string(),
+        );
+        meteora.cache_extra_data(
+            &format!("token_program:{}", token_mint),
+            &spl_token::id().to_string(),
+        );
+
+        let ixs = meteora
+            .build_swap_ix_async(SOL_MINT, &token_mint.to_string(), 1_000_000, 1)
+            .await
+            .expect("build_swap_ix_async with pool_address_hint");
+
+        assert!(!ixs.is_empty());
+        assert_eq!(ixs[0].program_id.to_string(), super::METEORA_DLMM_PROGRAM);
+        assert!(
+            ixs.iter()
+                .any(|ix| ix.accounts.iter().any(|a| a.pubkey == pool_pk)),
+            "swap ix must reference hinted LB pair"
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Post-#380 soak blockers:

1. **Meteora DLMM tx_plan** — `build_swap_ix_async` ignored explicit `buy_pool` from cross-DEX intents. Now resolves via `pool_address_hint` (Orca #380 pattern) before mint-pair scan.

2. **Jito bundle landing** — Cross-DEX arb bundles now use:
   - Dynamic tip from `estimated_profit_lamports` metadata (clamp 100k–2M lamports, default 7.5%)
   - Parallel confirm: Jito `wait_for_bundle` + JetStream `WalletTxConfirmed` when TX signature known pre-send
   - Final `getBundleStatuses` poll on timeout
   - `jito_arb_timeout_secs` default 45s (vs 30s generic)

## STOP-CHECK

- I-7: No new RPC in hot path (confirm uses Jito API + JetStream only)
- I-9: Simulation gate unchanged
- Pattern: matches Orca `POOL_ADDRESS_HINT_KEY` + `resolve_pool_for_swap`

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] `test_build_swap_ix_async_uses_pool_address_hint` (Meteora + Orca)

## Expected prod impact

- Meteora legs in cross-DEX arb should no longer fail with `No pool found for SOL/token`
- Arb bundle tip for ~8.83M profit intent scales to ~662k lamports (vs fixed 100k)
- Bundle confirm can succeed via Geyser path even if Jito status API is slow
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7914db6f-11ee-4a39-9ac9-12a73f9990b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7914db6f-11ee-4a39-9ac9-12a73f9990b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

