### PR TITLE
fix(market-data): scale PR167 ingest liveness grace with snapshot restore

### DIFF
--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -29,6 +29,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch, Mutex, Notify};
 use tracing::{debug, error, info, warn};
@@ -219,6 +220,11 @@ use ironcrab::storage::{JsonlWriterConfig, QueuedJsonlWriter};
 /// PR165: when false, `md-watchdog` stops `sd_notify(WATCHDOG)` so systemd can restart on Tokio stall.
 #[cfg(unix)]
 static MD_SYSTEMD_WATCHDOG_NOTIFY: AtomicBool = AtomicBool::new(true);
+
+/// PR167 post-incident 2026-08-08: snapshot pubkey count for scaled ingest-liveness startup grace.
+static MARKET_DATA_SNAPSHOT_RESTORE_PUBKEYS: AtomicU64 = AtomicU64::new(0);
+/// Shared Geyser connect barrier — ingest liveness skips stall detection while restore is pending.
+static MARKET_DATA_GEYSER_CONNECT_BARRIER: OnceLock<Arc<GeyserConnectBarrier>> = OnceLock::new();
 
 /// Default capacity for off-hot-path market-events JSONL queue.
 const MARKET_DATA_JSONL_QUEUE_CAP: usize = 16_384;
@@ -3936,6 +3942,7 @@ impl MarketDataContext {
         };
         let start = Instant::now();
         let pubkey_count = snapshot.explicit_pubkey_count() as u64;
+        MARKET_DATA_SNAPSHOT_RESTORE_PUBKEYS.store(pubkey_count, Ordering::Release);
         info!(
             path = %path.display(),
             pubkeys = pubkey_count,
@@ -8476,6 +8483,7 @@ async fn main() -> Result<()> {
         geyser_explicit_config_error: parking_lot::RwLock::new(None),
         geyser_prune_resume: parking_lot::Mutex::new(GeyserPruneResume::default()),
     });
+    let _ = MARKET_DATA_GEYSER_CONNECT_BARRIER.set(Arc::clone(&ctx.geyser_connect_barrier));
 
     // === Main Loop: Geyser subscription or simulation ===
 
@@ -8653,6 +8661,30 @@ fn spawn_market_data_metrics_runtime(addr: std::net::SocketAddr) {
         .expect("spawn md-metrics thread");
 }
 
+/// PR167: startup grace for ingest liveness — same budget as I-MD-6 restore barrier.
+fn market_data_ingest_liveness_startup_grace_duration(snapshot_pubkey_count: u64) -> Duration {
+    MarketDataContext::geyser_restore_barrier_timeout(snapshot_pubkey_count)
+}
+
+/// PR167 post-incident 2026-08-08: skip stall detection during snapshot restore or scaled warmup.
+fn market_data_ingest_liveness_in_startup_grace(
+    process_started: Instant,
+    snapshot_pubkey_count: u64,
+    barrier: Option<&GeyserConnectBarrier>,
+) -> bool {
+    if barrier.is_some_and(GeyserConnectBarrier::is_pending) {
+        return true;
+    }
+    process_started.elapsed()
+        < market_data_ingest_liveness_startup_grace_duration(snapshot_pubkey_count)
+}
+
+fn market_data_ingest_liveness_in_startup_grace_live(process_started: Instant) -> bool {
+    let snapshot_pubkey_count = MARKET_DATA_SNAPSHOT_RESTORE_PUBKEYS.load(Ordering::Acquire);
+    let barrier = MARKET_DATA_GEYSER_CONNECT_BARRIER.get().map(Arc::as_ref);
+    market_data_ingest_liveness_in_startup_grace(process_started, snapshot_pubkey_count, barrier)
+}
+
 /// PR167: detect global ingest stall (TX + account + head slot all frozen).
 /// PR233: OS thread — survives Tokio runtime freeze (same pattern as md-watchdog).
 fn spawn_market_data_global_ingest_liveness_task(process_started: Instant) {
@@ -8664,7 +8696,6 @@ fn spawn_market_data_global_ingest_liveness_task(process_started: Instant) {
             const CHECK_INTERVAL: Duration = Duration::from_secs(10);
             const STALL_WINDOW: Duration = Duration::from_secs(50);
             const RECOVERY_WAIT: Duration = Duration::from_secs(60);
-            const STARTUP_GRACE: Duration = Duration::from_secs(120);
             let mut last_tx = market_data_tx_handler_processed_value();
             let mut last_account = geyser_account_listener_account_updates_value();
             let mut last_head = market_data_geyser_head_slot_value();
@@ -8674,7 +8705,7 @@ fn spawn_market_data_global_ingest_liveness_task(process_started: Instant) {
             let mut recovery_requested_at: Option<Instant> = None;
             loop {
                 std::thread::sleep(CHECK_INTERVAL);
-                if process_started.elapsed() < STARTUP_GRACE {
+                if market_data_ingest_liveness_in_startup_grace_live(process_started) {
                     last_tx = market_data_tx_handler_processed_value();
                     last_account = geyser_account_listener_account_updates_value();
                     last_head = market_data_geyser_head_slot_value();
@@ -8775,7 +8806,6 @@ fn spawn_market_data_md_state_liveness_task(process_started: Instant) {
     std::thread::Builder::new()
         .name("md-state-liveness".into())
         .spawn(move || {
-            const STARTUP_GRACE: Duration = Duration::from_secs(120);
             let queue_saturation = ((MARKET_DATA_GEYSER_TRACKING_QUEUE_CAP as f64)
                 * MARKET_DATA_MD_STATE_STALL_QUEUE_FRAC)
                 as usize;
@@ -8785,7 +8815,7 @@ fn spawn_market_data_md_state_liveness_task(process_started: Instant) {
             let mut stalled_since: Option<Instant> = None;
             loop {
                 std::thread::sleep(MARKET_DATA_MD_STATE_STALL_CHECK_INTERVAL);
-                if process_started.elapsed() < STARTUP_GRACE {
+                if market_data_ingest_liveness_in_startup_grace_live(process_started) {
                     last_bursts = market_data_md_state_bursts_completed_value();
                     last_jobs = market_data_geyser_tracking_jobs_processed_value();
                     last_drops = market_data_geyser_tracking_enqueue_dropped_value();
@@ -19832,6 +19862,42 @@ mod pr_b_geyser_tracking_tests {
             "96k snapshot restore must have >=5min wait_ready budget, got {timeout_96k:?}"
         );
         assert_eq!(timeout_96k, Duration::from_secs(360));
+    }
+
+    #[test]
+    fn market_data_ingest_liveness_startup_grace_scales_with_snapshot_size() {
+        assert_eq!(
+            market_data_ingest_liveness_startup_grace_duration(0),
+            Duration::from_secs(120)
+        );
+        let grace_82k = market_data_ingest_liveness_startup_grace_duration(82_652);
+        assert!(
+            grace_82k >= Duration::from_secs(300),
+            "82k snapshot ingest grace must be >=5min, got {grace_82k:?}"
+        );
+        let grace_96k = market_data_ingest_liveness_startup_grace_duration(96_000);
+        assert!(
+            grace_96k >= Duration::from_secs(300),
+            "96k snapshot ingest grace must be >=5min, got {grace_96k:?}"
+        );
+        assert_eq!(grace_96k, Duration::from_secs(360));
+    }
+
+    #[test]
+    fn market_data_ingest_liveness_grace_while_barrier_pending() {
+        let barrier = GeyserConnectBarrier::new();
+        let process_started = Instant::now() - Duration::from_secs(600);
+        assert!(market_data_ingest_liveness_in_startup_grace(
+            process_started,
+            0,
+            Some(&barrier),
+        ));
+        barrier.mark_ready();
+        assert!(!market_data_ingest_liveness_in_startup_grace(
+            process_started,
+            0,
+            Some(&barrier),
+        ));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Post-incident 2026-08-08: After deploy #381, `market-data` entered a restart loop (~90 restarts, ~6h data outage).

PR167 global ingest liveness used a fixed `STARTUP_GRACE` of 120s. During I-MD-6 snapshot restore (~82k pubkeys), the Geyser connect barrier can legitimately take ~326s with no ingest events. PR167 declared stall → `exit(1)` → systemd restart → loop.

## Fix

- Reuse the same scaled timeout formula as `geyser_restore_barrier_timeout` (MIN 120s + count/400) for ingest liveness startup grace
- Skip stall detection while `geyser_connect_barrier` is pending (snapshot restore in flight)
- Publish snapshot pubkey count at restore start via atomic for scaled grace
- Apply same grace logic to `md-state-liveness` for consistency

## Tests

- `market_data_ingest_liveness_startup_grace_scales_with_snapshot_size` — 82k/96k grace >= 300s
- `market_data_ingest_liveness_grace_while_barrier_pending` — no stall exit during pending barrier

## STOP-CHECK

- I-7: No RPC added
- Pattern consistency: same formula as barrier timeout
- Scope: `market_data.rs` only
- I-9: N/A
- Level-5: No eval tests read

## Verification

- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test` ✓ (815+ tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1ab5dae-e5e5-4f91-a9d2-b12866b0d5b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1ab5dae-e5e5-4f91-a9d2-b12866b0d5b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

