### PR TITLE
fix(arb): reopen orca↔meteora_dlmm route gate post #380/#381

### DIFF
--- a/src/arbitrage/pool_quote.rs
+++ b/src/arbitrage/pool_quote.rs
@@ -582,12 +582,10 @@ pub const ARB_TOKEN_OUT_FLOOR_TRADE_AMOUNT_LAMPORTS: u64 = 10_000_000;
 /// Returns true when execution-engine can reliably build a cross-DEX swap plan for this pair.
 ///
 /// Strategy must not publish intents for unsupported pairs (I-12: log + metric, no silent drop).
-pub fn is_arb_route_executable(buy_dex: &str, sell_dex: &str) -> bool {
-    // Prod 2026-08-06: orca ↔ meteora_dlmm fails in EE `build_swap_plan` (Intent 000004).
-    !matches!(
-        (buy_dex, sell_dex),
-        ("orca", "meteora_dlmm") | ("meteora_dlmm", "orca")
-    )
+pub fn is_arb_route_executable(_buy_dex: &str, _sell_dex: &str) -> bool {
+    // Temporarily denied orca ↔ meteora_dlmm on 2026-08-06 (EE `build_swap_plan` failed; Intent 000004).
+    // Reopened post pool_address_hint fixes #380 (Orca) and #381 (Meteora).
+    true
 }
 
 /// Returns true when reserve/bin-walker `token_out` is plausible vs a price-based estimate.
@@ -3049,8 +3047,8 @@ mod tests {
 
     #[test]
     fn arb_route_gate_blocks_orca_meteora_dlmm_pairs() {
-        assert!(!is_arb_route_executable("orca", "meteora_dlmm"));
-        assert!(!is_arb_route_executable("meteora_dlmm", "orca"));
+        assert!(is_arb_route_executable("orca", "meteora_dlmm"));
+        assert!(is_arb_route_executable("meteora_dlmm", "orca"));
         assert!(is_arb_route_executable("meteora_dlmm", "pump_amm"));
         assert!(is_arb_route_executable("pump_amm", "meteora_dlmm"));
     }

--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -14103,7 +14103,8 @@ mod pool_accounts_coverage_tests {
             "orca DexPoolAccounts layout must include vaults + tick metadata"
         );
 
-        assert!(create_arb_intent(&ctx, &opp).is_none());
+        // Route gate reopened post #380/#381 — meteora_dlmm ↔ orca intents publish when accounts resolve.
+        assert!(create_arb_intent(&ctx, &opp).is_some());
         assert_eq!(
             ARB_REJECTED_MISSING_ACCOUNTS.load(Ordering::Relaxed),
             before_missing,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reopens the temporary `is_arb_route_executable` deny-list for `orca ↔ meteora_dlmm` pairs after EE `pool_address_hint` fixes in #380 (Orca) and #381 (Meteora).

**Prod symptom (2026-08-08):** 23 arb opportunities suppressed with `unsupported_route`, 0 intents published — all `meteora_dlmm → orca`.

## Changes

- `is_arb_route_executable` now returns `true` for all supported DEX pairs (deny-list removed)
- Unit test `arb_route_gate_blocks_orca_meteora_dlmm_pairs` updated to assert routes **are** executable
- Integration test `cold_start_backfill_resolves_meteora_orca_accounts_for_usdc` updated: intent publishes when accounts resolve

## STOP-CHECK

- I-7: No new RPC
- I-12: Other suppression gates (missing_accounts, plausibility) unchanged
- I-9: No simulation-gate changes

## Verification

```bash
cargo fmt --check && cargo clippy -- -D warnings && cargo test
```

All tests pass (815 lib + 121 arb-strategy + others).

## Acceptance

`is_arb_route_executable("meteora_dlmm", "orca") == true`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2de4d287-8634-4843-a8c1-2e5ba7ba585d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2de4d287-8634-4843-a8c1-2e5ba7ba585d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

