### PR TITLE
fix(arb): sell-leg vault completeness after Geyser cold-start

### DIFF
--- a/src/bin/arb_strategy.rs
+++ b/src/bin/arb_strategy.rs
@@ -86,7 +86,8 @@ use ironcrab::metrics::{
     inc_arb_v2_screen_sell_stale_then_fresh_after_pin_total,
     inc_arb_v2_sell_stale_recovery_outcome_total, inc_arb_vault_balance_applied_total,
     inc_arb_vault_live_snapshot_refreshed_total, inc_arb_vault_live_snapshot_seeded_total,
-    inc_arb_vault_rescreen_scheduled_total, record_arb_heartbeat_phase,
+    inc_arb_vault_rescreen_scheduled_total, inc_arb_vault_seed_from_cache_miss_total,
+    inc_arb_vault_seed_from_cache_ok_total, record_arb_heartbeat_phase,
     record_arb_intent_suppressed_implausible_token_out,
     record_arb_intent_suppressed_unsupported_route, record_arb_price_freshness_stale_age_ms,
     record_arb_proactive_pin_first_publish, record_arb_proactive_track_publish_total,
@@ -5760,6 +5761,62 @@ impl ArbContext {
         }
     }
 
+    /// P1: seed global `vault_balances` from SLAVE cache on JetStream PoolCacheUpdate for pinned pools.
+    fn consume_vault_seed_from_pool_cache_update(&self, update: &PoolCacheUpdate) -> bool {
+        if matches!(update.update_type, PoolCacheUpdateType::PoolRemoved) {
+            return false;
+        }
+        let pool_address = update.pool_address.as_str();
+        let is_pinned = self.arb_pinned_pools.read().contains(pool_address);
+        let mints_with_pool: Vec<String> = if is_pinned {
+            let selected = self.arb_selected_mints.read();
+            let trackers = self.trackers.read();
+            trackers
+                .iter()
+                .filter(|(mint, tracker)| {
+                    selected.contains(mint.as_str()) && tracker.pools.contains_key(pool_address)
+                })
+                .map(|(mint, _)| mint.clone())
+                .collect()
+        } else {
+            Vec::new()
+        };
+        if !is_pinned {
+            return false;
+        }
+        let pin_class = "pin";
+        let vault_wait = Instant::now();
+        let mut vault_cache = self.vault_balances.write();
+        record_arb_writer_lock_wait(ArbWriterLockKind::VaultBalancesWrite, vault_wait.elapsed());
+        let seeded = if try_refresh_vault_from_live_cache(
+            pool_address,
+            &self.live_pool_cache,
+            &mut vault_cache,
+            pin_class,
+        ) {
+            inc_arb_vault_live_snapshot_refreshed_total();
+            true
+        } else if try_seed_vault_from_live_cache(
+            pool_address,
+            &self.live_pool_cache,
+            &mut vault_cache,
+            pin_class,
+        ) {
+            inc_arb_vault_live_snapshot_seeded_total();
+            true
+        } else {
+            false
+        };
+        drop(vault_cache);
+        if seeded {
+            inc_arb_vault_seed_from_cache_ok_total();
+            self.schedule_arb_vault_rescreen_for_mints(pool_address, &mints_with_pool);
+        } else {
+            inc_arb_vault_seed_from_cache_miss_total();
+        }
+        seeded
+    }
+
     /// Handle PoolStateUpdate event - cache vault balances from Geyser
     /// This eliminates RPC calls to fetch vault balances during quoting.
     #[allow(clippy::too_many_arguments)]
@@ -7609,7 +7666,9 @@ fn process_arb_tracker_write_job(ctx: Arc<ArbContext>, job: ArbTrackerWriteJob) 
 
     match job {
         ArbTrackerWriteJob::SeedPoolCache { update } => {
-            if ctx.seed_trackers_for_pool_cache_update(&update) {
+            let vault_seeded = ctx.consume_vault_seed_from_pool_cache_update(&update);
+            let tracker_seeded = ctx.seed_trackers_for_pool_cache_update(&update);
+            if tracker_seeded || vault_seeded {
                 arb_strategy_pool_cache_update_seeded_inc();
                 if let Some(mint) = arb_tracked_token_mint(&update.base_mint, &update.quote_mint) {
                     ctx.publish_proactive_arb_track_for_mint(mint);
@@ -12195,6 +12254,94 @@ mod two_hop_price_tests {
         assert!(
             age_ms <= 120_000,
             "screen seed should land in le_120s freshness bucket, got age_ms={age_ms}"
+        );
+    }
+
+    #[test]
+    fn pool_cache_update_consume_seeds_pinned_vault_and_metrics() {
+        use ironcrab::metrics::ARB_VAULT_SEED_FROM_CACHE_OK_TOTAL;
+        use std::sync::atomic::Ordering;
+
+        let cache = create_shared_cache();
+        let ctx = test_arb_context(cache.clone());
+        let token_mint = Pubkey::new_unique();
+        let pool = Pubkey::new_unique();
+        let mint_str = token_mint.to_string();
+        let pool_str = pool.to_string();
+
+        let update = PoolCacheUpdate::new_balance_updated(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            pool_str.clone(),
+            "orca".to_string(),
+            mint_str.clone(),
+            NATIVE_SOL_MINT.to_string(),
+            1_000_000_000_000,
+            2_000_000_000,
+            100,
+        );
+        ironcrab::execution::pool_cache_sync::apply_pool_cache_update(&cache, &update);
+
+        ctx.arb_pinned_pools.write().insert(pool_str.clone());
+        let ok_before = ARB_VAULT_SEED_FROM_CACHE_OK_TOTAL.load(Ordering::Relaxed);
+        assert!(ctx.consume_vault_seed_from_pool_cache_update(&update));
+        assert_eq!(
+            ARB_VAULT_SEED_FROM_CACHE_OK_TOTAL.load(Ordering::Relaxed),
+            ok_before + 1
+        );
+        assert!(ctx.vault_balances.read().contains_key(&pool_str));
+    }
+
+    #[test]
+    fn pool_cache_update_consume_miss_when_pinned_pool_lacks_reserve_basis() {
+        use ironcrab::metrics::ARB_VAULT_SEED_FROM_CACHE_MISS_TOTAL;
+        use std::sync::atomic::Ordering;
+
+        let cache = create_shared_cache();
+        let ctx = test_arb_context(cache.clone());
+        let token_mint = Pubkey::new_unique();
+        let pool = Pubkey::new_unique();
+        let pool_str = pool.to_string();
+        let mint_str = token_mint.to_string();
+        cache.upsert(
+            pool,
+            CachedPoolState::Orca(OrcaWhirlpoolState {
+                token_mint_a: token_mint,
+                token_mint_b: Pubkey::from_str(NATIVE_SOL_MINT).unwrap(),
+                token_vault_a: Pubkey::new_unique(),
+                token_vault_b: Pubkey::new_unique(),
+                tick_current_index: 0,
+                sqrt_price: 1,
+                liquidity: 1,
+                fee_rate: 300,
+                protocol_fee_rate: 100,
+                tick_spacing: 64,
+                vault_a_balance: None,
+                vault_b_balance: None,
+                token_a_program: None,
+                token_b_program: None,
+            }),
+            1,
+        );
+        let update = PoolCacheUpdate::new_balance_updated(
+            TEST_COMPONENT,
+            TEST_BUILD,
+            TEST_RUN,
+            pool_str.clone(),
+            "orca".to_string(),
+            mint_str,
+            NATIVE_SOL_MINT.to_string(),
+            0,
+            0,
+            1,
+        );
+        ctx.arb_pinned_pools.write().insert(pool_str);
+        let miss_before = ARB_VAULT_SEED_FROM_CACHE_MISS_TOTAL.load(Ordering::Relaxed);
+        assert!(!ctx.consume_vault_seed_from_pool_cache_update(&update));
+        assert_eq!(
+            ARB_VAULT_SEED_FROM_CACHE_MISS_TOTAL.load(Ordering::Relaxed),
+            miss_before + 1
         );
     }
 

--- a/src/bin/market_data.rs
+++ b/src/bin/market_data.rs
@@ -4622,9 +4622,65 @@ impl MarketDataContext {
         if !is_momentum && !is_arb {
             return;
         }
+        let _ = self.try_touch_live_pool_reserve_basis_for_hot_pool(pool);
         // Arb-only: force cache seed so SLAVE vault_balances populate before first Geyser vault tick.
         let force_arb_seed = is_arb && !is_momentum;
         self.try_publish_balance_updated_from_cache(pool, force_arb_seed);
+    }
+
+    /// Geyser-only: backfill MASTER reserve basis from tracked vault `last_balance` rows or touch age.
+    fn try_touch_live_pool_reserve_basis_for_hot_pool(&self, pool: Pubkey) -> bool {
+        let Some(state) = self.live_pool_cache.get(&pool) else {
+            return false;
+        };
+        if cached_pool_has_fresh_reserve_basis(&state) {
+            return self
+                .live_pool_cache
+                .touch_freshness_on_existing_reserve_basis(&pool);
+        }
+        if matches!(state, CachedPoolState::PumpFun(_)) {
+            return false;
+        }
+        let slot = self
+            .live_pool_cache
+            .get_with_metadata(&pool)
+            .map(|(_, slot, _)| slot)
+            .unwrap_or(0);
+        let mut base_vault: Option<Pubkey> = None;
+        let mut quote_vault: Option<Pubkey> = None;
+        let mut base_balance = 0u64;
+        let mut quote_balance = 0u64;
+        {
+            let vaults = self.tracked_vaults.read();
+            for (vault_pk, info) in vaults.iter() {
+                if info.pool_address != pool {
+                    continue;
+                }
+                let balance = info.last_balance.load(std::sync::atomic::Ordering::Relaxed);
+                if info.is_base_vault {
+                    base_vault = Some(*vault_pk);
+                    base_balance = balance;
+                } else {
+                    quote_vault = Some(*vault_pk);
+                    quote_balance = balance;
+                }
+            }
+        }
+        let (Some(base_vault), Some(quote_vault)) = (base_vault, quote_vault) else {
+            return false;
+        };
+        if base_balance == 0 && quote_balance == 0 {
+            return false;
+        }
+        self.live_pool_cache
+            .apply_vault_pair_balances_to_reserve_basis(
+                &pool,
+                &base_vault,
+                base_balance,
+                &quote_vault,
+                quote_balance,
+                slot,
+            )
     }
 
     /// Back-compat alias for momentum-only call sites.
@@ -5591,6 +5647,7 @@ impl MarketDataContext {
                 }
                 continue;
             }
+            let _ = self.try_touch_live_pool_reserve_basis_for_hot_pool(pool);
             let consumer = match pin {
                 GeyserPinReason::ArbMultiDex => ExplicitConsumer::Arb,
                 GeyserPinReason::MomentumActive | GeyserPinReason::Wallet => {
@@ -6246,6 +6303,7 @@ impl MarketDataContext {
             if self.try_admit_pool_consumer_group(admission, pool_pk, ExplicitConsumer::Arb) {
                 inc_market_data_arb_admission_admitted_total();
                 let registered = self.register_geyser_reserves_for_arb_active_pool(pool_pk);
+                let _ = self.try_touch_live_pool_reserve_basis_for_hot_pool(pool_pk);
                 self.record_arb_active_pool_reserve_registration_outcome(pool_pk, registered);
                 if registered || self.explicit_physical_publish_needed(admission) {
                     batch_dirty = true;
@@ -17332,6 +17390,77 @@ mod pr_b_geyser_tracking_tests {
             MARKET_DATA_BALANCE_UPDATED_FROM_CACHE_TOTAL.load(Ordering::Relaxed),
             counter_before,
             "without NATS the publish is a no-op, but pool_has_live=false proves no early skip"
+        );
+    }
+
+    #[test]
+    fn arb_pin_touch_reserve_basis_hydrates_from_tracked_vault_balances() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let jsonl_cfg = JsonlWriterConfig::new("market_events").with_log_dir(tmp.path());
+        let jsonl = QueuedJsonlWriter::spawn(jsonl_cfg, 256).expect("jsonl");
+        let ctx = minimal_market_data_context_for_pr_d_tests(jsonl);
+
+        let base = Pubkey::new_unique();
+        let quote = Pubkey::from_str(NATIVE_SOL_MINT).unwrap();
+        let pool = Pubkey::new_unique();
+        let coin = Pubkey::new_unique();
+        let pc = Pubkey::new_unique();
+
+        ctx.live_pool_cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: base,
+                token_1_mint: quote,
+                token_0_vault: coin,
+                token_1_vault: pc,
+                reserve_0: None,
+                reserve_1: None,
+            }),
+            1,
+        );
+        ctx.hot_pool_registry.pin_arb_pool(pool);
+        {
+            let mut vaults = ctx.tracked_vaults.write();
+            vaults.insert(
+                coin,
+                VaultInfo {
+                    pool_address: pool,
+                    dex: "raydium_cpmm".to_string(),
+                    base_mint: base,
+                    quote_mint: quote,
+                    is_base_vault: true,
+                    last_balance: std::sync::atomic::AtomicU64::new(1_000_000),
+                    last_used_at: Instant::now(),
+                    pinned: true,
+                    pin: Some(GeyserPinReason::ArbMultiDex),
+                    active_id: None,
+                    bin_step: None,
+                    sibling_vault: Some(pc),
+                },
+            );
+            vaults.insert(
+                pc,
+                VaultInfo {
+                    pool_address: pool,
+                    dex: "raydium_cpmm".to_string(),
+                    base_mint: base,
+                    quote_mint: quote,
+                    is_base_vault: false,
+                    last_balance: std::sync::atomic::AtomicU64::new(2_000_000),
+                    last_used_at: Instant::now(),
+                    pinned: true,
+                    pin: Some(GeyserPinReason::ArbMultiDex),
+                    active_id: None,
+                    bin_step: None,
+                    sibling_vault: Some(coin),
+                },
+            );
+        }
+
+        assert!(ctx.try_touch_live_pool_reserve_basis_for_hot_pool(pool));
+        assert!(
+            cached_pool_has_fresh_reserve_basis(&ctx.live_pool_cache.get(&pool).unwrap()),
+            "tracked vault last_balance must backfill MASTER reserve basis for arb pin"
         );
     }
 

--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -645,6 +645,29 @@ impl LivePoolCache {
         false
     }
 
+    /// Apply paired vault ATA balances into an existing pool row (Geyser-only, no RPC).
+    ///
+    /// Used on arb-pin admit when tracked vault rows already have `last_balance` but the
+    /// MASTER `LivePoolCache` row still lacks reserve basis after cold start.
+    pub fn apply_vault_pair_balances_to_reserve_basis(
+        &self,
+        pool: &Pubkey,
+        base_vault: &Pubkey,
+        base_balance: u64,
+        quote_vault: &Pubkey,
+        quote_balance: u64,
+        slot: u64,
+    ) -> bool {
+        if base_balance > 0 {
+            self.update_vault_balance(base_vault, base_balance, slot);
+        }
+        if quote_balance > 0 {
+            self.update_vault_balance(quote_vault, quote_balance, slot);
+        }
+        self.get(pool)
+            .is_some_and(|state| pool_state_has_reserve_basis(&state))
+    }
+
     /// Update vault balance for a pool
     pub fn update_vault_balance(&self, vault: &Pubkey, balance: u64, slot: u64) {
         if let Some(mapping) = self.vault_to_pool.get(vault) {
@@ -2619,6 +2642,41 @@ mod tests {
             age_after < 20,
             "stale-slot heartbeat must refresh cache age when reserves are quotable"
         );
+    }
+
+    #[test]
+    fn apply_vault_pair_balances_sets_reserve_basis_from_tracked_rows() {
+        let cache = LivePoolCache::new();
+        let pool = Pubkey::new_unique();
+        let base_vault = Pubkey::new_unique();
+        let quote_vault = Pubkey::new_unique();
+        let wsol = Pubkey::from_str(crate::ipc::NATIVE_SOL_MINT).unwrap();
+        let token = Pubkey::new_unique();
+        cache.upsert(
+            pool,
+            CachedPoolState::RaydiumCpmm(RaydiumCpmmState {
+                token_0_mint: token,
+                token_1_mint: wsol,
+                token_0_vault: base_vault,
+                token_1_vault: quote_vault,
+                reserve_0: None,
+                reserve_1: None,
+            }),
+            100,
+        );
+        assert!(
+            cache.apply_vault_pair_balances_to_reserve_basis(
+                &pool,
+                &base_vault,
+                1_000_000,
+                &quote_vault,
+                2_000_000,
+                100,
+            ),
+            "tracked vault balances must backfill reserve basis"
+        );
+        let state = cache.get(&pool).expect("cached");
+        assert!(pool_state_has_reserve_basis(&state));
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -5106,6 +5106,10 @@ pub static ARB_VAULT_LIVE_SNAPSHOT_SEEDED_TOTAL: Lazy<AtomicU64> = Lazy::new(|| 
 /// v2 screen refreshed stale vault_balances from fresher SLAVE LivePoolCache (C1h).
 pub static ARB_VAULT_LIVE_SNAPSHOT_REFRESHED_TOTAL: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
+/// P1: JetStream PoolCacheUpdate consumed into global vault_balances for pinned/tracked pool.
+pub static ARB_VAULT_SEED_FROM_CACHE_OK_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+/// P1: pinned pool PoolCacheUpdate arrived but SLAVE cache could not seed vault row.
+pub static ARB_VAULT_SEED_FROM_CACHE_MISS_TOTAL: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
 // --- C1h2: Freshness root-cause forensics ---
 pub static ARB_TWO_HOP_V2_SELL_NOT_FRESH_DETAIL_EM_AGE: Lazy<AtomicU64> =
@@ -5779,6 +5783,16 @@ pub fn inc_arb_vault_live_snapshot_seeded_total() {
 /// Increment `arb_vault_live_snapshot_refreshed_total`.
 pub fn inc_arb_vault_live_snapshot_refreshed_total() {
     ARB_VAULT_LIVE_SNAPSHOT_REFRESHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Increment `arb_vault_seed_from_cache_ok_total`.
+pub fn inc_arb_vault_seed_from_cache_ok_total() {
+    ARB_VAULT_SEED_FROM_CACHE_OK_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Increment `arb_vault_seed_from_cache_miss_total`.
+pub fn inc_arb_vault_seed_from_cache_miss_total() {
+    ARB_VAULT_SEED_FROM_CACHE_MISS_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
 /// C1h2: `arb_two_hop_v2_sell_not_fresh_detail_total{kind,cause}`.
@@ -10869,6 +10883,14 @@ async fn metrics_response() -> Response<Body> {
     line!(
         "arb_vault_live_snapshot_refreshed_total",
         ARB_VAULT_LIVE_SNAPSHOT_REFRESHED_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_vault_seed_from_cache_ok_total",
+        ARB_VAULT_SEED_FROM_CACHE_OK_TOTAL.load(Ordering::Relaxed)
+    );
+    line!(
+        "arb_vault_seed_from_cache_miss_total",
+        ARB_VAULT_SEED_FROM_CACHE_MISS_TOTAL.load(Ordering::Relaxed)
     );
     line!(
         "arb_vault_rescreen_scheduled_total",


### PR DESCRIPTION
## Summary
- market-data: backfill reserve basis from tracked Geyser vault balances when arb-pinned pool lacks reserve basis (no RPC)
- arb-strategy: seed global vault cache from JetStream PoolCacheUpdate for pinned pools
- Metrics: arb_vault_seed_from_cache_ok/miss for soak debug

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test (new unit tests)
- [ ] Soak: sell_missing_vault drops, arb_vault_seed_from_cache_ok rises post cold-start