### PR TITLE
fix(ee): cross-DEX Meteora AdjacentThree bin arrays (Sim 3005)

### DIFF
--- a/src/solana/cross_dex_handler.rs
+++ b/src/solana/cross_dex_handler.rs
@@ -1380,12 +1380,6 @@ impl CrossDexHandler {
                 &format!("token_program:{}", token_mint),
                 &token_program_sdk.to_string(),
             );
-            if buy_dex == "meteora_dlmm" {
-                buy_connector.cache_extra_data(
-                    crate::solana::dex::meteora_swap_builder::METEORA_BIN_ARRAY_COVERAGE_KEY,
-                    crate::solana::dex::meteora_swap_builder::METEORA_BIN_ARRAY_COVERAGE_ACTIVE_ONLY,
-                );
-            }
 
             buy_connector
                 .build_swap_ix_async(SOL_MINT, token_mint, buy_amount_in, buy_min_out)
@@ -1427,12 +1421,6 @@ impl CrossDexHandler {
                 &format!("token_program:{}", token_mint),
                 &token_program_sdk.to_string(),
             );
-            if sell_dex == "meteora_dlmm" {
-                sell_connector.cache_extra_data(
-                    crate::solana::dex::meteora_swap_builder::METEORA_BIN_ARRAY_COVERAGE_KEY,
-                    crate::solana::dex::meteora_swap_builder::METEORA_BIN_ARRAY_COVERAGE_ACTIVE_ONLY,
-                );
-            }
 
             if let Some(ref accts) = sell_accounts {
                 sell_connector

--- a/src/solana/dex/meteora_dlmm.rs
+++ b/src/solana/dex/meteora_dlmm.rs
@@ -1110,6 +1110,108 @@ mod tests {
         );
     }
 
+    /// Cross-DEX arb must use AdjacentThree (active±1 bin arrays), not ActiveOnly.
+    /// Prod SimFail 3005 (AccountNotEnoughKeys) was caused by cross_dex_handler forcing ActiveOnly.
+    #[tokio::test]
+    async fn cross_dex_meteora_default_uses_adjacent_three_bin_arrays() {
+        use super::POOL_ADDRESS_HINT_KEY;
+        use crate::solana::dex::meteora_swap_builder::{
+            BinArrayCoverage, MeteoraDlmmSwapBuilder, METEORA_BIN_ARRAY_COVERAGE_ACTIVE_ONLY,
+            METEORA_BIN_ARRAY_COVERAGE_KEY,
+        };
+        use crate::solana::dex::Dex;
+
+        const SOL_MINT: &str = "So11111111111111111111111111111111111111112";
+        const METEORA_FIXED_ACCOUNTS: usize = 15;
+
+        let rpc = Arc::new(SolanaRpc::new("https://dummy"));
+        let mut meteora = MeteoraDlmm::new_with_live_cache(rpc, None, false);
+        meteora.set_user_authority(Pubkey::new_unique());
+
+        let pool_pk = Pubkey::from_str("2TD1fMPg2w7Hjt8bASSdxi92YFNQFgvdznqVApe3NGpn").unwrap();
+        let token_mint = Pubkey::new_unique();
+        let sol_mint = Pubkey::from_str(SOL_MINT).unwrap();
+        let reserve_x = Pubkey::new_unique();
+        let reserve_y = Pubkey::new_unique();
+        let active_id: i32 = -281;
+
+        meteora
+            .set_pool_from_accounts(
+                &pool_pk.to_string(),
+                &[
+                    pool_pk.to_string(),
+                    sol_mint.to_string(),
+                    token_mint.to_string(),
+                    reserve_x.to_string(),
+                    reserve_y.to_string(),
+                    format!("active_id:{active_id}"),
+                    "bin_step:10".to_string(),
+                ],
+            )
+            .expect("set_pool_from_accounts");
+
+        meteora.cache_extra_data(POOL_ADDRESS_HINT_KEY, &pool_pk.to_string());
+        meteora.cache_extra_data(
+            &format!("token_program:{}", sol_mint),
+            &spl_token::id().to_string(),
+        );
+        meteora.cache_extra_data(
+            &format!("token_program:{}", token_mint),
+            &spl_token::id().to_string(),
+        );
+
+        let ixs = meteora
+            .build_swap_ix_async(SOL_MINT, &token_mint.to_string(), 1_000_000, 1)
+            .await
+            .expect("build_swap_ix_async without ActiveOnly override");
+        let swap_ix = &ixs[0];
+        let bin_array_count = swap_ix
+            .accounts
+            .len()
+            .saturating_sub(METEORA_FIXED_ACCOUNTS);
+        assert!(
+            bin_array_count >= 3,
+            "cross-DEX default must include ≥3 bin arrays (AdjacentThree), got {bin_array_count}"
+        );
+
+        let expected_bins = MeteoraDlmmSwapBuilder::derive_bin_arrays_for_active_id_with_coverage(
+            &pool_pk,
+            active_id,
+            BinArrayCoverage::AdjacentThree,
+        )
+        .expect("derive adjacent three");
+        assert_eq!(expected_bins.len(), 3);
+        for (i, expected) in expected_bins.iter().enumerate() {
+            let actual = swap_ix
+                .accounts
+                .get(METEORA_FIXED_ACCOUNTS + i)
+                .map(|m| m.pubkey)
+                .unwrap_or_default();
+            assert_eq!(
+                actual, *expected,
+                "bin_array[{i}] mismatch for active_id={active_id}"
+            );
+        }
+
+        // ActiveOnly is still available via explicit extra_data (not used by cross_dex_handler).
+        meteora.cache_extra_data(
+            METEORA_BIN_ARRAY_COVERAGE_KEY,
+            METEORA_BIN_ARRAY_COVERAGE_ACTIVE_ONLY,
+        );
+        let active_only_ixs = meteora
+            .build_swap_ix_async(SOL_MINT, &token_mint.to_string(), 1_000_000, 1)
+            .await
+            .expect("build_swap_ix_async with ActiveOnly");
+        let active_only_count = active_only_ixs[0]
+            .accounts
+            .len()
+            .saturating_sub(METEORA_FIXED_ACCOUNTS);
+        assert_eq!(
+            active_only_count, 1,
+            "ActiveOnly should produce exactly 1 bin array"
+        );
+    }
+
     #[test]
     fn test_constant_product_quote() {
         let meteora = MeteoraDlmm::new(Arc::new(SolanaRpc::new("https://dummy")));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Prod 2026-08-08: 5× `meteora_dlmm → pump_amm` intents built `tx_plan` but Sim failed with `InstructionError(3, Custom(3005))` — Meteora DLMM `AccountNotEnoughKeys` on `bin_array`. EE logged `bin_array_count=1` (ActiveOnly).

Root cause: #375 forced `METEORA_BIN_ARRAY_COVERAGE_ACTIVE_ONLY` in `cross_dex_handler.rs` for TX ≤1232. Meteora on-chain requires ≥3 bin arrays (active±1).

## Fix

- Remove `ActiveOnly` override for Meteora buy + sell legs in `cross_dex_handler.rs`
- Default `AdjacentThree` (3 bin-array PDAs) restored — matches `meteora_swap_builder` / non-cross-DEX path
- Unit test with prod reference pool (`2TD1fMPg2w7Hjt8bASSdxi92YFNQFgvdznqVApe3NGpn`, `active_id=-281`) verifies ≥3 remaining bin_array metas and PDA derivation

## TX Size / Ops follow-up

Pre-#375 DLMM↔PumpAmm was ~1245 bytes with 1 bin array. +2 bin arrays as static keys ≈ +60–64 bytes → likely >1232 without ALT hits.

Existing `check_versioned_tx_size` + `static_not_in_alt` logging (#373/#375) remains the size gate — no silent send. If size fails after this fix, Ops should extend startup ALT with pool-specific bin-array PDAs via `setup_alt --extra-addresses` (cold path).

**Prod missing bin-array indices** (active_array_index=-5): **-6, -4** (adjacent to -5).

## STOP-CHECK

- I-7: No new RPC; bin-array PDAs derived deterministically from Geyser `active_id`
- I-4: Geyser-first unchanged
- I-9: Fix restores sim correctness; size gate unchanged
- No eval-test reads (Level-5)

## Tests

- `cross_dex_meteora_default_uses_adjacent_three_bin_arrays` (new)
- `active_only_bin_coverage_has_fewer_accounts_than_adjacent_three` (existing)
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8df155e2-99f4-4e93-8d47-f444e8a495f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8df155e2-99f4-4e93-8d47-f444e8a495f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

