### PR TITLE
fix(metrics): Prometheus double-brace regression (#386)

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4973,6 +4973,9 @@ pub fn record_arb_bundle_tx_too_large() {
 pub static ARB_BUNDLE_ATA_CREATE_SKIPPED_KNOWN_ATA: Lazy<AtomicU64> =
     Lazy::new(|| AtomicU64::new(0));
 
+const ARB_BUNDLE_ATA_CREATE_SKIPPED_KNOWN_ATA_LINE: &str =
+    "arb_bundle_ata_create_skipped_total{reason=\"known_ata\"}";
+
 pub fn record_arb_bundle_ata_create_skipped_known_ata() {
     ARB_BUNDLE_ATA_CREATE_SKIPPED_KNOWN_ATA.fetch_add(1, Ordering::Relaxed);
 }
@@ -10820,7 +10823,7 @@ async fn metrics_response() -> Response<Body> {
         ARB_BUNDLE_TX_TOO_LARGE.load(Ordering::Relaxed)
     );
     line!(
-        "arb_bundle_ata_create_skipped_total{{reason=\"known_ata\"}}",
+        ARB_BUNDLE_ATA_CREATE_SKIPPED_KNOWN_ATA_LINE,
         ARB_BUNDLE_ATA_CREATE_SKIPPED_KNOWN_ATA.load(Ordering::Relaxed)
     );
     line!(
@@ -12930,6 +12933,30 @@ mod arb_quote_pair_slot_skew_metrics_tests {
         assert_eq!(
             ARB_QUOTE_PAIR_SLOT_SKEW_LEG_SELL_TOTAL.load(Ordering::Relaxed),
             1
+        );
+    }
+}
+
+#[cfg(test)]
+mod arb_bundle_ata_create_skipped_metrics_tests {
+    use super::*;
+
+    #[test]
+    fn known_ata_metric_line_uses_single_brace_prometheus_labels() {
+        assert!(!ARB_BUNDLE_ATA_CREATE_SKIPPED_KNOWN_ATA_LINE.contains("{{"));
+        let label_start = ARB_BUNDLE_ATA_CREATE_SKIPPED_KNOWN_ATA_LINE
+            .find("{reason=")
+            .expect("metric must expose reason label");
+        assert_eq!(
+            ARB_BUNDLE_ATA_CREATE_SKIPPED_KNOWN_ATA_LINE[..label_start]
+                .matches('{')
+                .count(),
+            0,
+            "metric name must not contain braces before label set"
+        );
+        assert_eq!(
+            &ARB_BUNDLE_ATA_CREATE_SKIPPED_KNOWN_ATA_LINE[label_start..],
+            "{reason=\"known_ata\"}"
         );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PR #386 introduced an invalid Prometheus metric line via the `line!()` macro:

```
arb_bundle_ata_create_skipped_total{{reason="known_ata"}} 0
```

The `line!()` macro outputs its first argument literally (no `format!` escaping). `{{` is correct inside `format!()` strings but wrong here. Prometheus rejected all IronCrab scrape targets with:

```
expected label name, got "{" ("INVALID") while parsing: "arb_bundle_ata_create_skipped_total{{"
```

## Fix

- Replace `{{` with single `{` for the labeled counter
- Extract metric name to `ARB_BUNDLE_ATA_CREATE_SKIPPED_KNOWN_ATA_LINE` const to avoid drift
- Add unit test asserting single-brace Prometheus label syntax

## Scope

Observability-only hotfix in `src/metrics.rs`. No trading logic changes.

## Verification

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test arb_bundle_ata_create_skipped`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f54f31c8-14ee-4f14-a1ed-39fe3bc5d9e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f54f31c8-14ee-4f14-a1ed-39fe3bc5d9e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

