### PR TITLE
fix(alt): COMMON_ACCOUNTS audit + realistic meteora→pump bundle size test (Phase 1+2)

### DIFF
--- a/docs/ALT_GLOBAL_KEYS_AUDIT.md
+++ b/docs/ALT_GLOBAL_KEYS_AUDIT.md
@@ -1,0 +1,76 @@
+# ALT Global Keys Audit — meteora_dlmm → pump_amm (2026-08-09)
+
+Prod symptom: `tx_too_large:1245_bytes_max_1232`, `alt_hit_count=9`, `static_key_count=30`, `alt_configured=true`.
+
+On-chain ALT (prod): `2J74oVKaviWzVr9gaLDvmBf3VAVVpzy88i3YCnyDwvuX`
+
+EE loads **only** the on-chain ALT at startup (`load_alt`) — **no** runtime merge with `COMMON_ACCOUNTS`.
+
+## Root cause (Phase 2)
+
+| Finding | Explanation |
+|---------|-------------|
+| Low `alt_hit_count` | On-chain ALT missing several **global** keys that appear in every PumpSwap / Meteora bundle. Compiler can only use lookups for pubkeys present in the loaded table. |
+| Not a compile bug | Keys **in** the loaded ALT but still static are expected: fee payer (signer), Jito tip (`exclude_tip_from_alt`), program IDs the v0 compiler keeps static. See `alt_in_table_but_static_count` in size-rejection logs. |
+| Prod 1245 B vs 1111 B after fix | With corrected `COMMON_ACCOUNTS` and a fully extended on-chain ALT, the prod-pattern test (`cross_dex_meteora_pump_bundle_realistic_common_alt_size_audit`) serializes to **1111 B** (`alt_hit_count=12`, `static_key_count=26`). |
+
+## COMMON_ACCOUNTS changes
+
+| Pubkey | Action | Role |
+|--------|--------|------|
+| `ADyA8hdefvWN2dbGGWFotbzWxrAvLW83WG6QCVXvJKqw` | **Added** | PumpSwap `global_config` (swap ix account #2) — `PUMPFUN_AMM_GLOBAL_CONFIG` |
+| `GS4CU59F31iL7aR2Q8zVS8DRrcRnXX1yjQ66TqNVQnaR` | **Added** | PumpSwap `__event_authority` PDA (swap ix #15) |
+| `Ce6TQqeHC9p8KetsN6JsjHK7UTZk7nasjjnr7XxXp9F1` | **Added** | Pump.fun bonding-curve `event_authority` (other routes) |
+| `39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg` | **Removed** | Was labeled “PumpSwap Global Config” — **not** `global_config` |
+| `5PHirr8joyTMp9JMm6nW7hNDVyEYdkzDqazxPD7RaTjx` | Unchanged | PumpSwap fee config (already present) |
+| `C2aFPdENg4A2HQsmrd5rTw5TaYBX5Ku887cWjbFKtZpw` | Unchanged | `global_volume_accumulator` PDA (already present) |
+
+## On-chain ALT extend required (prod)
+
+After merging this PR, extend ALT `2J74oVKaviWzVr9gaLDvmBf3VAVVpzy88i3YCnyDwvuX` with **at minimum** the new/changed globals:
+
+```
+ADyA8hdefvWN2dbGGWFotbzWxrAvLW83WG6QCVXvJKqw
+GS4CU59F31iL7aR2Q8zVS8DRrcRnXX1yjQ66TqNVQnaR
+Ce6TQqeHC9p8KetsN6JsjHK7UTZk7nasjjnr7XxXp9F1
+```
+
+Verify with audit (no TX):
+
+```bash
+cargo run --bin setup-alt -- \
+  --rpc-url <RPC> \
+  --alt-address 2J74oVKaviWzVr9gaLDvmBf3VAVVpzy88i3YCnyDwvuX \
+  --audit-only
+```
+
+Then extend (cold path, user-operated):
+
+```bash
+cargo run --bin setup-alt -- \
+  --rpc-url <RPC> \
+  --keypair <AUTHORITY> \
+  --alt-address 2J74oVKaviWzVr9gaLDvmBf3VAVVpzy88i3YCnyDwvuX
+```
+
+`setup-alt` adds all `COMMON_ACCOUNTS` not already on-chain. **Restart execution-engine** after extend so `load_alt` picks up new indices.
+
+## Keys that must stay static (not ALT candidates)
+
+- Wallet / fee payer (signer)
+- User ATAs (per-wallet)
+- Pool PDAs, vaults, bin arrays, oracle PDAs
+- Jito tip account (filtered from ALT for writable static key — #373)
+
+## Observability
+
+Size rejection logs now include:
+
+- `alt_in_table_but_static_count` / `alt_in_table_but_static` (top 10)
+- `static_not_in_alt` (top 10) — use with `setup-alt --extra-addresses` only for **global** gaps, not per-pool keys
+
+Metric: `arb_bundle_tx_too_large_total` (unchanged).
+
+## Phase 3 (out of scope)
+
+ATA as separate TX at opportunity detection — only if Phase 1+2 + on-chain extend still insufficient. Current audit shows **1111 B** with realistic ALT after global fix.

--- a/docs/RUNBOOK_PROD.md
+++ b/docs/RUNBOOK_PROD.md
@@ -533,6 +533,45 @@ Logs: `journalctl -u arb-strategy | grep "Arb check rejected"`
 
 **PR235:** Watchdog `exit(1)` ist default **aus** (`MARKET_DATA_MD_STATE_STALL_EXIT_ENABLED=false`); Stalls werden als `market_data_md_state_stalls_total` + WARN geloggt. Restart-Loop durch md-state sollte nach Deploy verschwinden — bei anhaltenden Stalls Metriken `md_state_deferred_jobs_len`, `md_state_burst_in_progress`, `md_state_register_skipped_idempotent_total` prüfen.
 
+## On-Chain Address Lookup Table (ALT)
+
+Cross-DEX-Arb-Bundles (z. B. `meteora_dlmm → pump_amm`) nutzen v0-Transaktionen mit einer **on-chain ALT**. Der execution-engine lädt die ALT **nur beim Start** (`load_alt`) — es gibt **keinen** Runtime-Merge mit `COMMON_ACCOUNTS` aus dem Code.
+
+| Feld | Prod-Wert |
+|------|-----------|
+| ALT-Adresse | `2J74oVKaviWzVr9gaLDvmBf3VAVVpzy88i3YCnyDwvuX` |
+| Config-Key | `address_lookup_table` in `my_config.server.toml` |
+
+### Wann ALT extenden?
+
+Nach jedem Deploy, der `COMMON_ACCOUNTS` in `src/solana/address_lookup_table.rs` ändert (siehe `docs/ALT_GLOBAL_KEYS_AUDIT.md`).
+
+### Audit (read-only)
+
+```bash
+cargo run --bin setup-alt -- \
+  --rpc-url http://127.0.0.1:8899 \
+  --alt-address 2J74oVKaviWzVr9gaLDvmBf3VAVVpzy88i3YCnyDwvuX \
+  --audit-only
+```
+
+Listet alle `COMMON_ACCOUNTS`-Pubkeys, die **noch nicht** in der on-chain ALT sind.
+
+### Extend (Cold Path — manuell, nicht im Deploy-Script)
+
+```bash
+cargo run --bin setup-alt -- \
+  --rpc-url http://127.0.0.1:8899 \
+  --keypair /home/ironcrab/.config/solana/id.json \
+  --alt-address 2J74oVKaviWzVr9gaLDvmBf3VAVVpzy88i3YCnyDwvuX
+```
+
+Danach **execution-engine neu starten**, damit die erweiterte ALT geladen wird.
+
+### Diagnose bei `tx_too_large`
+
+Logs enthalten u. a. `alt_hit_count`, `static_key_count`, `alt_in_table_but_static_count`, `static_not_in_alt`. Hohe `static_not_in_alt` bei fehlenden **globalen** Keys → ALT extenden. Pool-PDAs/Vaults/Bin-Arrays gehören **nicht** in die ALT (Architektur-Entscheidung).
+
 ## Siehe auch
 
 - [Iron_crab-eval/docs/spec/](https://github.com/Exploratorsclub/Iron_crab-eval) — Spezifikation (TARGET_ARCHITECTURE, ROLE_SEPARATION, DEFINITION_OF_DONE, STORAGE_CONVENTIONS)

--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -13598,16 +13598,23 @@ fn log_bundle_tx_size_rejection(
         .iter()
         .map(|pk| pk.to_string())
         .collect();
+    let alt_in_table_but_static: Vec<String> = analysis
+        .alt_in_table_but_static
+        .iter()
+        .map(|pk| pk.to_string())
+        .collect();
     warn!(
         intent_id = %intent.intent_id,
         serialized_len,
         alt_configured,
         alt_hit_count = analysis.alt_hit_count,
         static_key_count = analysis.static_key_count,
+        alt_in_table_but_static_count = analysis.alt_in_table_but_static_count,
         buy_dex,
         sell_dex,
         tip_filtered_from_alt,
         static_not_in_alt = ?static_not_in_alt,
+        alt_in_table_but_static = ?alt_in_table_but_static,
         error = %size_err,
         rejection_stage,
         "Bundle transaction exceeds Solana serialized size limit"

--- a/src/bin/setup_alt.rs
+++ b/src/bin/setup_alt.rs
@@ -15,7 +15,8 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use ironcrab::solana::address_lookup_table::{
-    create_alt_instructions, extend_alt_instruction, get_common_accounts, load_alt,
+    common_accounts_missing_from_alt, create_alt_instructions, extend_alt_instruction,
+    get_common_accounts, load_alt, REMOVED_WRONG_PUMPSWAP_GLOBAL_CONFIG,
 };
 use ironcrab::wallet::Treasury;
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -52,6 +53,11 @@ struct Args {
     /// Dry run - don't actually send transactions
     #[arg(long)]
     dry_run: bool,
+
+    /// Compare on-chain ALT against `COMMON_ACCOUNTS` and print missing globals (no TX).
+    /// Requires `--alt-address`.
+    #[arg(long)]
+    audit_only: bool,
 }
 
 #[tokio::main]
@@ -76,6 +82,34 @@ async fn main() -> Result<()> {
     info!(authority = %authority, "Loaded keypair");
 
     let rpc = RpcClient::new_with_commitment(args.rpc_url.clone(), CommitmentConfig::confirmed());
+
+    if args.audit_only {
+        let alt_str = args
+            .alt_address
+            .as_deref()
+            .context("--audit-only requires --alt-address")?;
+        let alt_pubkey = Pubkey::from_str(alt_str).context("invalid ALT address")?;
+        let existing = load_alt(&rpc, &alt_pubkey).await?;
+        let missing = common_accounts_missing_from_alt(&existing);
+        println!("\n========================================");
+        println!("ALT AUDIT (COMMON_ACCOUNTS vs on-chain)");
+        println!("========================================");
+        println!("ALT Address: {}", alt_pubkey);
+        println!("On-chain entries: {}", existing.accounts.len());
+        println!("COMMON_ACCOUNTS entries: {}", get_common_accounts().len());
+        println!("Missing from on-chain ALT (must extend): {}", missing.len());
+        for pk in &missing {
+            println!("  {pk}");
+        }
+        if existing.contains(&Pubkey::from_str(REMOVED_WRONG_PUMPSWAP_GLOBAL_CONFIG)?) {
+            warn!(
+                removed = REMOVED_WRONG_PUMPSWAP_GLOBAL_CONFIG,
+                "On-chain ALT still contains removed wrong PumpSwap global_config entry"
+            );
+        }
+        println!("========================================\n");
+        return Ok(());
+    }
 
     // Check balance
     let balance = rpc.get_balance(&authority).await?;

--- a/src/solana/address_lookup_table.rs
+++ b/src/solana/address_lookup_table.rs
@@ -24,6 +24,16 @@ use solana_sdk::{
 use std::str::FromStr;
 use tracing::info;
 
+/// Well-known PumpSwap AMM global accounts (same for all pools).
+pub const PUMPSWAP_AMM_GLOBAL_CONFIG: &str = "ADyA8hdefvWN2dbGGWFotbzWxrAvLW83WG6QCVXvJKqw";
+/// PumpSwap `__event_authority` PDA under `pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA`.
+pub const PUMPSWAP_AMM_EVENT_AUTHORITY: &str = "GS4CU59F31iL7aR2Q8zVS8DRrcRnXX1yjQ66TqNVQnaR";
+/// Pump.fun bonding-curve event authority (not the PumpSwap AMM PDA).
+pub const PUMPFUN_BONDING_EVENT_AUTHORITY: &str = "Ce6TQqeHC9p8KetsN6JsjHK7UTZk7nasjjnr7XxXp9F1";
+/// Former COMMON_ACCOUNTS entry — not PumpSwap global_config; kept for audit diffs only.
+pub const REMOVED_WRONG_PUMPSWAP_GLOBAL_CONFIG: &str =
+    "39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg";
+
 /// Well-known program IDs and accounts that should be in every ALT.
 /// These are used in almost every transaction.
 pub const COMMON_ACCOUNTS: &[&str] = &[
@@ -43,13 +53,15 @@ pub const COMMON_ACCOUNTS: &[&str] = &[
     // ===== PumpSwap AMM =====
     "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA", // PumpSwap AMM Program
     "pfeeUxB6jkeY1Hxd7CsFCAjcbHA9rWtchMGdZ6VojVZ", // PumpSwap Fee Program
+    PUMPSWAP_AMM_GLOBAL_CONFIG,                    // PumpSwap global_config (swap ix account #2)
     "5PHirr8joyTMp9JMm6nW7hNDVyEYdkzDqazxPD7RaTjx", // PumpSwap Fee Config (global constant)
+    PUMPSWAP_AMM_EVENT_AUTHORITY,                  // PumpSwap __event_authority PDA (swap ix #15)
     "C2aFPdENg4A2HQsmrd5rTw5TaYBX5Ku887cWjbFKtZpw", // PumpSwap global_volume_accumulator PDA
-    "39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg", // PumpSwap Global Config
     // ===== Pump.fun Bonding Curve =====
     "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P", // Pump.fun Bonding Program
     "4wTV1YmiEkRvAtNtsSGPtUrqRYQMe5SKy2uB4Jjaxnjf", // Pump.fun Global Account
     "CebN5WGQ4jvEPvsVU4EoHEpgzq1VV7AbicfhtW4xC9iM", // Pump.fun Fee Account
+    PUMPFUN_BONDING_EVENT_AUTHORITY,               // Pump.fun bonding-curve event_authority
     // ===== Orca Whirlpool =====
     "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc", // Orca Whirlpool Program
     // ===== Raydium =====
@@ -241,6 +253,14 @@ pub struct AltCompileAnalysis {
     pub alt_hit_count: usize,
     /// Static keys not present in the loaded ALT (top-N for ops `setup_alt --extra-addresses`).
     pub static_not_in_alt: Vec<Pubkey>,
+    /// Static keys that are present in the loaded ALT but were not compiled as lookups.
+    ///
+    /// Expected cases: fee payer (signer), Jito tip when `exclude_tip_from_alt` is set, and any
+    /// account the v0 compiler must keep static (signers). A high count with low `alt_hit_count`
+    /// usually means the on-chain ALT is missing pool-specific keys, not a compile bug.
+    pub alt_in_table_but_static: Vec<Pubkey>,
+    /// Total static keys that exist in the loaded ALT table.
+    pub alt_in_table_but_static_count: usize,
 }
 
 /// Analyze ALT usage for a compiled v0 message.
@@ -266,10 +286,24 @@ pub fn analyze_v0_alt_usage(message: &v0::Message, alt: Option<&LoadedAlt>) -> A
         None => message.account_keys.clone(),
     };
 
+    let alt_in_table_but_static_all: Vec<Pubkey> = match alt {
+        Some(loaded) => message
+            .account_keys
+            .iter()
+            .filter(|pk| loaded.contains(pk))
+            .copied()
+            .collect(),
+        None => Vec::new(),
+    };
+    let alt_in_table_but_static_count = alt_in_table_but_static_all.len();
+    let alt_in_table_but_static = alt_in_table_but_static_all.into_iter().take(10).collect();
+
     AltCompileAnalysis {
         static_key_count,
         alt_hit_count,
         static_not_in_alt,
+        alt_in_table_but_static,
+        alt_in_table_but_static_count,
     }
 }
 
@@ -284,6 +318,8 @@ pub fn analyze_versioned_message_alt_usage(
             static_key_count: legacy.account_keys.len(),
             alt_hit_count: 0,
             static_not_in_alt: legacy.account_keys.clone(),
+            alt_in_table_but_static: Vec::new(),
+            alt_in_table_but_static_count: 0,
         },
     }
 }
@@ -296,9 +332,76 @@ pub fn get_common_accounts() -> Vec<Pubkey> {
         .collect()
 }
 
+/// Pubkeys in [`COMMON_ACCOUNTS`] that are missing from a loaded on-chain ALT.
+pub fn common_accounts_missing_from_alt(alt: &LoadedAlt) -> Vec<Pubkey> {
+    get_common_accounts()
+        .into_iter()
+        .filter(|pk| !alt.contains(pk))
+        .collect()
+}
+
+/// Collect unique pubkeys referenced by instructions (program IDs + account metas).
+pub fn collect_instruction_pubkeys(instructions: &[Instruction]) -> Vec<Pubkey> {
+    let mut keys = Vec::new();
+    for ix in instructions {
+        keys.push(ix.program_id);
+        for meta in &ix.accounts {
+            keys.push(meta.pubkey);
+        }
+    }
+    keys.sort();
+    keys.dedup();
+    keys
+}
+
+/// Global instruction pubkeys (from `COMMON_ACCOUNTS`) vs per-pool keys for bundle audits.
+pub fn partition_globals_vs_pool_specific(
+    instruction_keys: &[Pubkey],
+    alt: &LoadedAlt,
+) -> (Vec<Pubkey>, Vec<Pubkey>) {
+    let common = get_common_accounts();
+    let mut globals_missing = Vec::new();
+    let mut pool_specific = Vec::new();
+    for pk in instruction_keys {
+        if common.contains(pk) {
+            if !alt.contains(pk) {
+                globals_missing.push(*pk);
+            }
+        } else {
+            pool_specific.push(*pk);
+        }
+    }
+    globals_missing.sort();
+    globals_missing.dedup();
+    pool_specific.sort();
+    pool_specific.dedup();
+    (globals_missing, pool_specific)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_pumpswap_global_constants_match_pdas() {
+        let program = Pubkey::from_str("pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA").unwrap();
+        let (event_authority, _) = Pubkey::find_program_address(&[b"__event_authority"], &program);
+        let (gva, _) = Pubkey::find_program_address(&[b"global_volume_accumulator"], &program);
+        assert_eq!(
+            event_authority,
+            Pubkey::from_str(PUMPSWAP_AMM_EVENT_AUTHORITY).unwrap()
+        );
+        assert_eq!(
+            gva,
+            Pubkey::from_str("C2aFPdENg4A2HQsmrd5rTw5TaYBX5Ku887cWjbFKtZpw").unwrap()
+        );
+        assert!(get_common_accounts().contains(&event_authority));
+        assert!(
+            get_common_accounts().contains(&Pubkey::from_str(PUMPSWAP_AMM_GLOBAL_CONFIG).unwrap())
+        );
+        assert!(!get_common_accounts()
+            .contains(&Pubkey::from_str(REMOVED_WRONG_PUMPSWAP_GLOBAL_CONFIG).unwrap()));
+    }
 
     #[test]
     fn test_common_accounts_parse() {
@@ -421,5 +524,47 @@ mod tests {
         assert!(analysis.static_key_count >= 2);
         assert!(analysis.alt_hit_count >= 1);
         assert!(analysis.static_not_in_alt.contains(&static_only));
+    }
+
+    #[test]
+    fn analyze_v0_alt_usage_tracks_in_table_but_static() {
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+        use solana_system_program;
+
+        let payer = Pubkey::new_unique();
+        let in_alt = Pubkey::new_unique();
+        let blockhash = solana_sdk::hash::Hash::new_unique();
+        let loaded = LoadedAlt {
+            address: Pubkey::new_unique(),
+            accounts: vec![payer, in_alt],
+        };
+        let mut data = vec![2, 0, 0, 0];
+        data.extend_from_slice(&1u64.to_le_bytes());
+        let ix = Instruction {
+            program_id: solana_system_program::id(),
+            accounts: vec![
+                AccountMeta::new(payer, true),
+                AccountMeta::new(in_alt, false),
+            ],
+            data,
+        };
+        let message = compile_v0_versioned_message(
+            &payer,
+            std::slice::from_ref(&ix),
+            Some(&loaded),
+            None,
+            blockhash,
+        )
+        .expect("compile");
+        let v0_msg = match message {
+            VersionedMessage::V0(m) => m,
+            _ => panic!("expected v0"),
+        };
+        let analysis = analyze_v0_alt_usage(&v0_msg, Some(&loaded));
+        assert!(
+            analysis.alt_in_table_but_static_count >= 1,
+            "signer payer stays static even when present in ALT"
+        );
+        assert!(analysis.alt_in_table_but_static.contains(&payer));
     }
 }

--- a/src/solana/cross_dex_handler.rs
+++ b/src/solana/cross_dex_handler.rs
@@ -1543,7 +1543,7 @@ mod tests {
     };
     use crate::solana::address_lookup_table::{
         analyze_versioned_message_alt_usage, compile_v0_versioned_message, get_common_accounts,
-        LoadedAlt,
+        AltCompileAnalysis, LoadedAlt,
     };
     use crate::solana::compute_budget_helper;
     use crate::solana::dex::pumpfun_amm::{
@@ -1810,10 +1810,11 @@ mod tests {
         (plan, wallet, token_mint)
     }
 
-    fn compile_cross_dex_bundle_tx(
+    fn compile_cross_dex_bundle_tx_with_alt(
         wallet: &Keypair,
         plan: &CrossDexSwapPlan,
-    ) -> (VersionedTransaction, usize, usize) {
+        alt_accounts: Vec<Pubkey>,
+    ) -> (VersionedTransaction, usize, usize, AltCompileAnalysis) {
         let tip = Pubkey::from_str(JITO_TIP_ACCOUNT).unwrap();
         let mut ixs = Vec::new();
         ixs.push(compute_budget_helper::set_compute_unit_limit(450_000));
@@ -1831,6 +1832,41 @@ mod tests {
             data: tip_data,
         });
 
+        let alt = LoadedAlt {
+            address: Pubkey::new_unique(),
+            accounts: alt_accounts,
+        };
+        let blockhash = Hash::new_unique();
+        let message =
+            compile_v0_versioned_message(&wallet.pubkey(), &ixs, Some(&alt), Some(&tip), blockhash)
+                .expect("compile v0 message");
+        let tx = VersionedTransaction::try_new(message, &[wallet]).expect("sign tx");
+        let analysis = analyze_versioned_message_alt_usage(&tx.message, Some(&alt));
+        let size = versioned_tx_serialized_len(&tx);
+        (tx, size, analysis.alt_hit_count, analysis)
+    }
+
+    /// Optimistic ALT: every instruction account is in the table (not prod-realistic).
+    fn compile_cross_dex_bundle_tx_optimistic_alt(
+        wallet: &Keypair,
+        plan: &CrossDexSwapPlan,
+    ) -> (VersionedTransaction, usize, usize, AltCompileAnalysis) {
+        let tip = Pubkey::from_str(JITO_TIP_ACCOUNT).unwrap();
+        let mut ixs = Vec::new();
+        ixs.push(compute_budget_helper::set_compute_unit_limit(450_000));
+        ixs.push(compute_budget_helper::set_compute_unit_price(1_000));
+        ixs.extend(plan.buy_instructions.iter().cloned());
+        ixs.extend(plan.sell_instructions.iter().cloned());
+        let mut tip_data = vec![2, 0, 0, 0];
+        tip_data.extend_from_slice(&10_000u64.to_le_bytes());
+        ixs.push(Instruction {
+            program_id: Pubkey::from_str("11111111111111111111111111111111").unwrap(),
+            accounts: vec![
+                AccountMeta::new(wallet.pubkey(), true),
+                AccountMeta::new(tip, false),
+            ],
+            data: tip_data,
+        });
         let mut alt_pubkeys = get_common_accounts();
         for ix in &ixs {
             alt_pubkeys.push(ix.program_id);
@@ -1840,19 +1876,23 @@ mod tests {
         }
         alt_pubkeys.sort();
         alt_pubkeys.dedup();
+        compile_cross_dex_bundle_tx_with_alt(wallet, plan, alt_pubkeys)
+    }
 
-        let alt = LoadedAlt {
-            address: Pubkey::new_unique(),
-            accounts: alt_pubkeys,
-        };
-        let blockhash = Hash::new_unique();
-        let message =
-            compile_v0_versioned_message(&wallet.pubkey(), &ixs, Some(&alt), Some(&tip), blockhash)
-                .expect("compile v0 message");
-        let tx = VersionedTransaction::try_new(message, &[wallet]).expect("sign tx");
-        let analysis = analyze_versioned_message_alt_usage(&tx.message, Some(&alt));
-        let size = versioned_tx_serialized_len(&tx);
-        (tx, size, analysis.alt_hit_count)
+    /// Prod-realistic ALT: only `COMMON_ACCOUNTS` globals (EE loads on-chain ALT, no runtime merge).
+    fn compile_cross_dex_bundle_tx_realistic_alt(
+        wallet: &Keypair,
+        plan: &CrossDexSwapPlan,
+    ) -> (VersionedTransaction, usize, usize, AltCompileAnalysis) {
+        compile_cross_dex_bundle_tx_with_alt(wallet, plan, get_common_accounts())
+    }
+
+    fn compile_cross_dex_bundle_tx(
+        wallet: &Keypair,
+        plan: &CrossDexSwapPlan,
+    ) -> (VersionedTransaction, usize, usize) {
+        let (tx, size, alt_hits, _) = compile_cross_dex_bundle_tx_optimistic_alt(wallet, plan);
+        (tx, size, alt_hits)
     }
 
     #[tokio::test]
@@ -1888,11 +1928,49 @@ mod tests {
             "prod-like pump sell must use 24-account extended layout"
         );
 
-        let (_tx, size, alt_hits) = compile_cross_dex_bundle_tx(&wallet, &plan);
+        let (_tx, size, alt_hits, _) = compile_cross_dex_bundle_tx_optimistic_alt(&wallet, &plan);
         assert!(
             size <= MAX_SERIALIZED_TX_BYTES,
-            "serialized_len={size} alt_hit_count={alt_hits} (max {MAX_SERIALIZED_TX_BYTES})"
+            "optimistic ALT serialized_len={size} alt_hit_count={alt_hits} (max {MAX_SERIALIZED_TX_BYTES})"
         );
+    }
+
+    /// Prod-realistic: ALT contains only `COMMON_ACCOUNTS` (EE loads on-chain ALT, no runtime merge).
+    /// Documents remaining byte gap when globals are correct but pool-specific keys stay static.
+    #[tokio::test]
+    async fn cross_dex_meteora_pump_bundle_realistic_common_alt_size_audit() {
+        let (plan, wallet, _) = build_prod_pattern_cross_dex_plan(true).await;
+        let (tx, size, alt_hits, analysis) =
+            compile_cross_dex_bundle_tx_realistic_alt(&wallet, &plan);
+
+        eprintln!(
+            "realistic_common_alt: serialized_len={size} alt_hit_count={alt_hits} \
+             static_key_count={} alt_in_table_but_static_count={} \
+             static_not_in_alt={:?} alt_in_table_but_static={:?}",
+            analysis.static_key_count,
+            analysis.alt_in_table_but_static_count,
+            analysis
+                .static_not_in_alt
+                .iter()
+                .map(|p| p.to_string())
+                .collect::<Vec<_>>(),
+            analysis
+                .alt_in_table_but_static
+                .iter()
+                .map(|p| p.to_string())
+                .collect::<Vec<_>>(),
+        );
+
+        // With corrected COMMON_ACCOUNTS globals, prod ALT extend should bring this under 1232.
+        // Pool-specific keys (vaults, bin arrays, user ATAs) correctly remain static / not in ALT.
+        assert!(
+            size <= MAX_SERIALIZED_TX_BYTES,
+            "realistic COMMON_ACCOUNTS ALT still too large: serialized_len={size} \
+             alt_hit_count={alt_hits} static_key_count={} \
+             (extend on-chain ALT per docs/ALT_GLOBAL_KEYS_AUDIT.md)",
+            analysis.static_key_count
+        );
+        let _ = tx;
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

P0 fix for prod `tx_too_large:1245_bytes_max_1232` on `meteora_dlmm → pump_amm` routes.

**Root cause:** On-chain ALT missing corrected PumpSwap **global** keys. EE loads only on-chain ALT (no `COMMON_ACCOUNTS` runtime merge). Low `alt_hit_count=9` is expected until ALT extend — not a v0 compile bug.

## Phase 1 — COMMON_ACCOUNTS audit

| Pubkey | Action | Role |
|--------|--------|------|
| `ADyA8hdefvWN2dbGGWFotbzWxrAvLW83WG6QCVXvJKqw` | Added | PumpSwap `global_config` |
| `GS4CU59F31iL7aR2Q8zVS8DRrcRnXX1yjQ66TqNVQnaR` | Added | PumpSwap `__event_authority` PDA |
| `Ce6TQqeHC9p8KetsN6JsjHK7UTZk7nasjjnr7XxXp9F1` | Added | Pump.fun bonding event_authority |
| `39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg` | Removed | Wrong "PumpSwap Global Config" |

Full audit: `docs/ALT_GLOBAL_KEYS_AUDIT.md`

## Phase 2 — Compile / observability

- `AltCompileAnalysis`: `alt_in_table_but_static_count` + top-10 pubkeys (expected: signer, Jito tip, program IDs)
- `log_bundle_tx_size_rejection` logs new fields
- Prod-pattern test `cross_dex_meteora_pump_bundle_realistic_common_alt_size_audit` uses **only** `COMMON_ACCOUNTS` as ALT fixture → **1111 B** (≤1232), `alt_hit_count=12`

## Ops (post-merge, no deploy in this PR)

```bash
cargo run --bin setup-alt -- --rpc-url <RPC> \
  --alt-address 2J74oVKaviWzVr9gaLDvmBf3VAVVpzy88i3YCnyDwvuX --audit-only

cargo run --bin setup-alt -- --rpc-url <RPC> --keypair <AUTH> \
  --alt-address 2J74oVKaviWzVr9gaLDvmBf3VAVVpzy88i3YCnyDwvuX
```

Restart execution-engine after on-chain extend. See `docs/RUNBOOK_PROD.md`.

## STOP-CHECK

- I-7: No Hot Path RPC (setup-alt audit/extend is cold path only)
- I-9: Size gate unchanged; sim/send ALT tip parity preserved (#373)
- Phase 3 ATA-separate-TX: not implemented

## Verification

- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test` ✓

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de54c037-08ad-4cf0-bd56-f749f6120b18?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de54c037-08ad-4cf0-bd56-f749f6120b18&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

