### PR TITLE
fix(pump_amm): BUY extended cashback layout (24/26 tiers)

### DIFF
--- a/src/solana/cross_dex_handler.rs
+++ b/src/solana/cross_dex_handler.rs
@@ -39,7 +39,9 @@ use crate::solana::dex::orca::Orca;
 use crate::solana::dex::pumpfun_amm::{
     pump_amm_buy_program_ix_index, pump_amm_resolve_sell_pre_fee_meta_1_for_build,
     pump_amm_sell_ix_uses_global_fee_at, pump_amm_singleton_global_volume_accumulator_pub,
-    PumpFunAmmDex, PUMPFUN_AMM_BUY_TOTAL_ACCOUNTS, PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS,
+    PumpFunAmmDex, PUMPFUN_AMM_BUY_EXT_FEE_CONFIG_IX, PUMPFUN_AMM_BUY_EXT_FEE_PROGRAM_IX,
+    PUMPFUN_AMM_BUY_TOTAL_ACCOUNTS, PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS,
+    PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS, PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS,
     PUMPFUN_AMM_SELL_FEE_CONFIG_IX_V2, PUMPFUN_AMM_SELL_FEE_PROGRAM_IX_V2,
 };
 use crate::solana::dex::raydium::Raydium;
@@ -432,6 +434,17 @@ impl CrossDexHandler {
                 pool_str
             ));
         }
+        if is_buy_leg
+            && sell_requires_cashback_remaining
+            && !sell_requires_pre_fee_metas
+            && !sell_layout_ready
+            && sell_cashback_third_meta.is_none()
+        {
+            return Err(anyhow!(
+                "pump_amm BUY: extended layout required for pool {} but LivePoolCache layout not ready (missing third_meta/tails)",
+                pool_str
+            ));
+        }
 
         let global_volume_accumulator = pool_accounts
             .get(11)
@@ -479,7 +492,7 @@ impl CrossDexHandler {
             sell_extended_tail_1,
             sell_extended_fee_tail_0,
             sell_extended_fee_tail_1,
-            sell_requires_fee_tail && is_sell_leg,
+            sell_requires_fee_tail,
             false,
         )
         .map_err(|e| {
@@ -505,6 +518,13 @@ impl CrossDexHandler {
                 (
                     PUMPFUN_AMM_SELL_FEE_CONFIG_IX_V2,
                     PUMPFUN_AMM_SELL_FEE_PROGRAM_IX_V2,
+                )
+            } else if account_count == PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS
+                || account_count == PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS
+            {
+                (
+                    PUMPFUN_AMM_BUY_EXT_FEE_CONFIG_IX,
+                    PUMPFUN_AMM_BUY_EXT_FEE_PROGRAM_IX,
                 )
             } else {
                 (0, 0)
@@ -1547,7 +1567,8 @@ mod tests {
     };
     use crate::solana::compute_budget_helper;
     use crate::solana::dex::pumpfun_amm::{
-        PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR, PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR,
+        pump_amm_buy_program_ix_index, PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR,
+        PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR, PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS,
         PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS,
     };
     use crate::solana::dex::router::Router;
@@ -1983,6 +2004,74 @@ mod tests {
             size_without < size_with,
             "ATA skip should reduce size: with={size_with} without={size_without}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_cross_dex_handler_pump_amm_buy_extended_cashback_builds() {
+        let token_mint = Pubkey::new_unique();
+        let buy_pool = Pubkey::new_unique();
+        let cache = Arc::new(LivePoolCache::new());
+        let sol_mint = Pubkey::from_str(SOL_MINT).unwrap();
+        let buy_pool_accounts = pump_amm_v14_pool_accounts(buy_pool, token_mint);
+        cache.upsert(
+            buy_pool,
+            CachedPoolState::PumpAmm(PumpAmmState {
+                base_mint: token_mint,
+                quote_mint: sol_mint,
+                pool_base_token_account: Pubkey::new_unique(),
+                pool_quote_token_account: Pubkey::new_unique(),
+                base_reserve: Some(1_000_000_000_000),
+                quote_reserve: Some(50_000_000_000),
+                pool_accounts: buy_pool_accounts,
+                creator: None,
+            }),
+            100,
+        );
+        let third = Pubkey::new_unique();
+        let tail_0 = Pubkey::new_unique();
+        let tail_1 = Pubkey::new_unique();
+        let fee_0 = Pubkey::from_str(PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR).unwrap();
+        let fee_1 = Pubkey::from_str(PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR).unwrap();
+        cache.merge_pump_amm_sell_extended_layout(
+            &buy_pool,
+            true,
+            Some(third),
+            Some(tail_0),
+            Some(tail_1),
+            Some(fee_0),
+            Some(fee_1),
+            false,
+            false,
+            None,
+        );
+        cache.set_pump_amm_sell_layout_ready(&buy_pool, true);
+
+        let rpc = Arc::new(SolanaRpc::new("http://127.0.0.1:0"));
+        let wallet = Pubkey::new_unique();
+        let mut handler = CrossDexHandler::new(rpc, Some(wallet))
+            .with_rpc_url("http://127.0.0.1:0".to_string())
+            .with_pool_cache(cache);
+        handler.init_dexes().await.expect("init_dexes");
+
+        let ixs = handler
+            .build_pump_amm_arb_swap_ixs(
+                SOL_MINT,
+                &token_mint.to_string(),
+                100_000_000,
+                1,
+                &buy_pool.to_string(),
+                None,
+                None,
+                true,
+            )
+            .expect("pump_amm BUY leg must build with extended cashback layout");
+
+        assert_eq!(
+            ixs[0].accounts.len(),
+            PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS,
+            "cashback-only BUY must use 26-account extended layout"
+        );
+        assert!(pump_amm_buy_program_ix_index(ixs[0].accounts.len()).is_some());
     }
 
     #[tokio::test]

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -185,10 +185,16 @@ pub const PUMPFUN_AMM_BUY_TOTAL_ACCOUNTS: usize = 23;
 pub fn pump_amm_buy_program_ix_index(account_count: usize) -> Option<usize> {
     match account_count {
         PUMPFUN_AMM_BUY_TOTAL_ACCOUNTS => Some(PUMPFUN_AMM_BUY_PROGRAM_IX),
-        PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS => Some(PUMPFUN_AMM_BUY_PROGRAM_IX_V2),
+        PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS
+        | PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS
+        | PUMPFUN_AMM_SELL_EXTENDED_V2_TOTAL_ACCOUNTS => Some(PUMPFUN_AMM_BUY_PROGRAM_IX_V2),
         _ => None,
     }
 }
+
+/// FeeConfig / FeeProgram meta indices for extended cashback `buy_exact_quote_in` (24/26 accounts).
+pub const PUMPFUN_AMM_BUY_EXT_FEE_CONFIG_IX: usize = 19;
+pub const PUMPFUN_AMM_BUY_EXT_FEE_PROGRAM_IX: usize = 20;
 
 /// Trailing-meta writability for tier-26 cashback `sell` (mainnet ref `3wNpdTky…`, pool `GrgDaBg4…`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7135,7 +7141,37 @@ impl PumpFunAmmDex {
                     cold_path_prefer_derived_on_mismatch,
                 )?;
                 metas
-            } else if sell_requires_pre_fee_metas || sell_requires_cashback_remaining {
+            } else if sell_requires_cashback_remaining {
+                let Some(third) = sell_cashback_third_meta.filter(|p| *p != Pubkey::default())
+                else {
+                    return Err(anyhow!(
+                        "pump_amm BUY: extended layout required but sell_cashback_third_meta missing (Geyser/LivePoolCache observation required)"
+                    ));
+                };
+                let mut metas = buy_base;
+                metas.push(AccountMeta::new_readonly(program_id, false)); // 16
+                metas.push(AccountMeta::new(global_volume_accumulator, false)); // 17
+                metas.push(AccountMeta::new(coin_creator_vault_ata, false)); // 18
+                metas.push(AccountMeta::new_readonly(buy_fee_config, false)); // 19
+                metas.push(AccountMeta::new_readonly(buy_fee_program, false)); // 20
+                Self::push_pump_amm_sell_extended_trailing_metas(
+                    &mut metas,
+                    pool_market,
+                    base_mint,
+                    user,
+                    quote_mint,
+                    quote_tp,
+                    third,
+                    false,
+                    sell_requires_fee_tail,
+                    sell_extended_fee_tail_0,
+                    sell_extended_fee_tail_1,
+                    sell_extended_tail_0,
+                    sell_extended_tail_1,
+                    cold_path_prefer_derived_on_mismatch,
+                )?;
+                metas
+            } else if sell_requires_pre_fee_metas {
                 return Err(anyhow!(
                     "pump_amm BUY: partial extended layout flags (pre_fee={sell_requires_pre_fee_metas}, cashback={sell_requires_cashback_remaining}) — need authoritative v2 layout from LivePoolCache"
                 ));
@@ -9225,6 +9261,185 @@ mod tests {
         assert_eq!(
             ixs[0].accounts[PUMPFUN_AMM_SELL_PRE_FEE_0_IX_V2].pubkey,
             singleton_gva
+        );
+    }
+
+    /// Prod regression: cashback-only extended `buy_exact_quote_in` (pre_fee=false, cashback=true, 26 accounts).
+    #[test]
+    fn pump_amm_build_swap_26_account_buy_cashback_extended_pre_fee_false() {
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let third = Pubkey::new_unique();
+        let tail0 = Pubkey::new_unique();
+        let tail1 = Pubkey::new_unique();
+        let fee0 = Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG).unwrap();
+        let fee1 = Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).unwrap();
+        let program_id = Pubkey::from_str(PUMPFUN_AMM_PROGRAM_ID).unwrap();
+
+        let v14 = vec![
+            pool_market,
+            Pubkey::from_str(PUMPFUN_AMM_GLOBAL_CONFIG).unwrap(),
+            base_mint,
+            Pubkey::from_str(WSOL_MINT).unwrap(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            fee0,
+            fee1,
+        ];
+
+        let ixs = PumpFunAmmDex::build_swap_ix_from_pool_accounts_with_extended_tail(
+            WSOL_MINT,
+            &base_mint.to_string(),
+            1,
+            1,
+            user,
+            &v14,
+            None,
+            true,
+            Some(third),
+            false,
+            None,
+            Some(tail0),
+            Some(tail1),
+            Some(fee0),
+            Some(fee1),
+            true,
+            false,
+        )
+        .expect("26-account BUY cashback extended");
+
+        assert_eq!(
+            ixs[0].accounts.len(),
+            PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS
+        );
+        let program_ix = pump_amm_buy_program_ix_index(ixs[0].accounts.len()).expect("program ix");
+        assert_eq!(ixs[0].accounts[program_ix].pubkey, program_id);
+        assert_eq!(
+            ixs[0].accounts[PUMPFUN_AMM_BUY_EXT_FEE_CONFIG_IX].pubkey,
+            fee0
+        );
+        assert_eq!(
+            ixs[0].accounts[PUMPFUN_AMM_BUY_EXT_FEE_PROGRAM_IX].pubkey,
+            fee1
+        );
+    }
+
+    /// Cashback-only extended `buy_exact_quote_in` without fee tail (24 accounts).
+    #[test]
+    fn pump_amm_build_swap_24_account_buy_cashback_extended_no_fee_tail() {
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let third = Pubkey::new_unique();
+        let tail0 = Pubkey::new_unique();
+        let tail1 = Pubkey::new_unique();
+        let program_id = Pubkey::from_str(PUMPFUN_AMM_PROGRAM_ID).unwrap();
+
+        let v14 = vec![
+            pool_market,
+            Pubkey::from_str(PUMPFUN_AMM_GLOBAL_CONFIG).unwrap(),
+            base_mint,
+            Pubkey::from_str(WSOL_MINT).unwrap(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG).unwrap(),
+            Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).unwrap(),
+        ];
+
+        let ixs = PumpFunAmmDex::build_swap_ix_from_pool_accounts_with_extended_tail(
+            WSOL_MINT,
+            &base_mint.to_string(),
+            1,
+            1,
+            user,
+            &v14,
+            None,
+            true,
+            Some(third),
+            false,
+            None,
+            Some(tail0),
+            Some(tail1),
+            None,
+            None,
+            false,
+            false,
+        )
+        .expect("24-account BUY cashback extended");
+
+        assert_eq!(
+            ixs[0].accounts.len(),
+            PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS
+        );
+        let program_ix = pump_amm_buy_program_ix_index(ixs[0].accounts.len()).expect("program ix");
+        assert_eq!(ixs[0].accounts[program_ix].pubkey, program_id);
+    }
+
+    /// Missing third_meta must surface layout-not-ready error, not partial-flag error.
+    #[test]
+    fn pump_amm_build_swap_buy_cashback_extended_errors_without_third_meta() {
+        let pool_market = Pubkey::new_unique();
+        let base_mint = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let v14 = vec![
+            pool_market,
+            Pubkey::from_str(PUMPFUN_AMM_GLOBAL_CONFIG).unwrap(),
+            base_mint,
+            Pubkey::from_str(WSOL_MINT).unwrap(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::from_str(PUMPFUN_AMM_FEE_CONFIG).unwrap(),
+            Pubkey::from_str(PUMPFUN_AMM_FEE_PROGRAM_ID).unwrap(),
+        ];
+
+        let err = PumpFunAmmDex::build_swap_ix_from_pool_accounts_with_extended_tail(
+            WSOL_MINT,
+            &base_mint.to_string(),
+            1,
+            1,
+            user,
+            &v14,
+            None,
+            true,
+            None,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+        )
+        .expect_err("must fail without third_meta");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("sell_cashback_third_meta missing"),
+            "expected third_meta missing error, got: {msg}"
+        );
+        assert!(
+            !msg.contains("partial extended layout flags"),
+            "must not surface misleading partial-flag error: {msg}"
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Prod route `pump_amm → meteora_dlmm` (reverse arb): **32/65** intents rejected at pre-sim `tx_plan` with:

```
pump_amm BUY: partial extended layout flags (pre_fee=false, cashback=true)
— need authoritative v2 layout from LivePoolCache
```

The BUY builder only supported standard (23 accounts) and v2 (27 accounts). SELL already had 24/26 extended tiers.

## Fix

### `pumpfun_amm.rs` — BUY builder
- New path for `cashback=true && pre_fee=false` mirroring SELL 24/26 extended tiers
- Reuses `push_pump_amm_sell_extended_trailing_metas` (same trailing semantics as SELL)
- Layout: `buy_base (16) + program@16 + GVA + vault + fee pair + trailing`
- `pump_amm_buy_program_ix_index` extended for 24/26 account counts (program at #16)
- Missing `third_meta` → explicit layout-not-ready error (not misleading partial-flag error)

### `cross_dex_handler.rs`
- BUY gate: `layout not ready` when cashback-only extended layout missing `third_meta`
- Pass `sell_requires_fee_tail` for BUY legs (was SELL-only)
- Fee-slot logging for 24/26-account BUY layouts

## BUY tiers now supported

| Tier | Accounts | Flags |
|------|----------|-------|
| Standard | 23 | no extended |
| Cashback extended (no fee tail) | 24 | `cashback=true, pre_fee=false` |
| Cashback extended (fee tail) | 26 | `cashback=true, pre_fee=false, fee_tail=true` |
| v2 | 27 | `cashback=true, pre_fee=true` |

## Tests
- `pump_amm_build_swap_26_account_buy_cashback_extended_pre_fee_false`
- `pump_amm_build_swap_24_account_buy_cashback_extended_no_fee_tail`
- `pump_amm_build_swap_buy_cashback_extended_errors_without_third_meta`
- `test_cross_dex_handler_pump_amm_buy_extended_cashback_builds`

## STOP-CHECK
- I-7: No new RPC in hot path ✓
- I-4: Geyser/cache-only layout data ✓
- Pattern: mirrors existing SELL extended trailing metas ✓

## Verification
- `cargo fmt --check` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test` ✓
- Eval Level 5: not available in cloud agent VM (no sibling `ironcrab-eval` repo)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-634dbdbe-8bb8-415f-bbfa-b78109fe23c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-634dbdbe-8bb8-415f-bbfa-b78109fe23c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

