### PR TITLE
fix(pump_amm): SSOT-normalize global_config in v14 pool_accounts (P1 post-#391)

### DIFF
--- a/src/execution/live_pool_cache.rs
+++ b/src/execution/live_pool_cache.rs
@@ -47,7 +47,8 @@ use crate::ipc::DexPoolReadiness;
 use crate::solana::dex::meteora_dlmm_layout::DlmmPool;
 use crate::solana::dex::orca_whirlpool_layout::{self, WhirlpoolParsed};
 use crate::solana::dex::pumpfun_amm::{
-    pump_amm_sell_extended_layout_ready, PumpAmmSellExtendedReadinessParams,
+    pump_amm_normalize_v14_pool_accounts, pump_amm_sell_extended_layout_ready,
+    PumpAmmSellExtendedReadinessParams,
 };
 
 // ============================================================================
@@ -989,7 +990,10 @@ impl LivePoolCache {
     ///
     /// Without this, PumpAmm entries parsed from Geyser have empty pool_accounts,
     /// making them unusable for tx building.
-    pub fn set_pump_amm_pool_accounts(&self, pool: &Pubkey, accounts: Vec<Pubkey>) {
+    pub fn set_pump_amm_pool_accounts(&self, pool: &Pubkey, mut accounts: Vec<Pubkey>) {
+        if accounts.len() >= 14 {
+            pump_amm_normalize_v14_pool_accounts(pool, &mut accounts);
+        }
         if let Some(mut entry) = self.pools.get_mut(pool) {
             if let CachedPoolState::PumpAmm(ref mut s) = entry.value_mut().state {
                 let was_empty = s.pool_accounts.is_empty();
@@ -3509,13 +3513,22 @@ mod tests {
 
         cache.set_pump_amm_pool_accounts(&pool_market, accounts_to_set.clone());
 
+        let canonical_gc = crate::solana::dex::pumpfun_amm::pump_amm_canonical_global_config();
+        let canonical_ea =
+            crate::solana::dex::pumpfun_amm::pump_amm_canonical_event_authority_pub();
+        let mut expected = accounts_to_set.clone();
+        if expected.len() >= 14 {
+            expected[1] = canonical_gc;
+            expected[8] = canonical_ea;
+        }
+
         let result = cache.get_pump_amm_pool_accounts_by_base_mint(&base_mint);
         assert!(result.is_some());
-        assert_eq!(result.unwrap(), accounts_to_set);
+        assert_eq!(result.unwrap(), expected);
 
         let by_pool = cache.get_pump_amm_pool_accounts(&pool_market);
         assert!(by_pool.is_some());
-        assert_eq!(by_pool.unwrap(), accounts_to_set);
+        assert_eq!(by_pool.unwrap(), expected);
     }
 
     /// Discovery Request path must NOT degrade existing reserves/creator.
@@ -3548,6 +3561,15 @@ mod tests {
 
         cache.set_pump_amm_pool_accounts(&pool_market, new_accounts.clone());
 
+        let canonical_gc = crate::solana::dex::pumpfun_amm::pump_amm_canonical_global_config();
+        let canonical_ea =
+            crate::solana::dex::pumpfun_amm::pump_amm_canonical_event_authority_pub();
+        let mut expected = new_accounts.clone();
+        if expected.len() >= 14 {
+            expected[1] = canonical_gc;
+            expected[8] = canonical_ea;
+        }
+
         let (r_base, r_quote, _) = cache
             .get_pump_amm_reserves_by_base_mint(&base_mint)
             .expect("reserves must be preserved");
@@ -3557,7 +3579,7 @@ mod tests {
         let accounts = cache
             .get_pump_amm_pool_accounts_by_base_mint(&base_mint)
             .expect("pool_accounts must be set");
-        assert_eq!(accounts, new_accounts);
+        assert_eq!(accounts, expected);
 
         if let Some(CachedPoolState::PumpAmm(s)) = cache.get(&pool_market) {
             assert_eq!(s.creator, Some(creator));

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4921,6 +4921,22 @@ pub static ARB_POOL_ACCOUNTS_BACKFILL_CROSS_MINT: Lazy<AtomicU64> = Lazy::new(||
 /// DexPoolAccounts resolved from the global pool_address → accounts index.
 pub static ARB_POOL_ACCOUNTS_BACKFILL_INDEX: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
+/// PumpSwap v14 `pool_accounts[1]` replaced with canonical `global_config`.
+pub static PUMP_AMM_GLOBAL_CONFIG_NORMALIZED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+/// PumpSwap v14 `pool_accounts[8]` replaced with canonical `event_authority` PDA.
+pub static PUMP_AMM_EVENT_AUTHORITY_NORMALIZED_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+pub fn inc_pump_amm_global_config_normalized_total() {
+    PUMP_AMM_GLOBAL_CONFIG_NORMALIZED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn inc_pump_amm_event_authority_normalized_total() {
+    PUMP_AMM_EVENT_AUTHORITY_NORMALIZED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArbPoolAccountsBackfillSource {
     LiveCache,

--- a/src/solana/address_lookup_table.rs
+++ b/src/solana/address_lookup_table.rs
@@ -17,7 +17,9 @@ use solana_address_lookup_table_interface::{
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
-use solana_message::{v0, AddressLookupTableAccount, VersionedMessage};
+use solana_message::{
+    v0, v0::LoadedAddresses, AccountKeys, AddressLookupTableAccount, VersionedMessage,
+};
 use solana_sdk::{
     instruction::Instruction, pubkey::Pubkey, signature::Signer, transaction::VersionedTransaction,
 };
@@ -340,6 +342,61 @@ pub fn versioned_message_duplicate_static_keys(message: &VersionedMessage) -> Ve
     dupes.sort();
     dupes.dedup();
     dupes
+}
+
+/// Reconstruct loaded ALT addresses from a compiled v0 message and a known on-chain ALT snapshot.
+///
+/// Used for tests / diagnostics when verifying resolved instruction account pubkeys match ix metas.
+pub fn loaded_addresses_from_alt_lookups(
+    alt: &LoadedAlt,
+    message: &VersionedMessage,
+) -> Option<LoadedAddresses> {
+    let VersionedMessage::V0(v0) = message else {
+        return None;
+    };
+    if v0.address_table_lookups.is_empty() {
+        return Some(LoadedAddresses::default());
+    }
+    let mut writable = Vec::new();
+    let mut readonly = Vec::new();
+    for lookup in &v0.address_table_lookups {
+        if lookup.account_key != alt.address {
+            continue;
+        }
+        for &idx in &lookup.writable_indexes {
+            if let Some(pk) = alt.accounts.get(idx as usize) {
+                writable.push(*pk);
+            }
+        }
+        for &idx in &lookup.readonly_indexes {
+            if let Some(pk) = alt.accounts.get(idx as usize) {
+                readonly.push(*pk);
+            }
+        }
+    }
+    Some(LoadedAddresses { writable, readonly })
+}
+
+/// Resolve the pubkey at `meta_index` within compiled instruction `ix_index` of a versioned message.
+pub fn resolved_instruction_account_pubkey(
+    message: &VersionedMessage,
+    loaded_addresses: Option<&LoadedAddresses>,
+    ix_index: usize,
+    meta_index: usize,
+) -> Option<Pubkey> {
+    match message {
+        VersionedMessage::V0(v0) => {
+            let ix = v0.instructions.get(ix_index)?;
+            let key_index = *ix.accounts.get(meta_index)? as usize;
+            let keys = AccountKeys::new(&v0.account_keys, loaded_addresses);
+            keys.get(key_index).copied()
+        }
+        VersionedMessage::Legacy(legacy) => {
+            let ix = legacy.instructions.get(ix_index)?;
+            let key_index = *ix.accounts.get(meta_index)? as usize;
+            legacy.account_keys.get(key_index).copied()
+        }
+    }
 }
 
 /// Parse common accounts from the constant list.

--- a/src/solana/cross_dex_handler.rs
+++ b/src/solana/cross_dex_handler.rs
@@ -38,7 +38,8 @@ use crate::solana::dex::meteora_dlmm::MeteoraDlmm;
 use crate::solana::dex::meteora_swap_builder::MeteoraDlmmSwapBuilder;
 use crate::solana::dex::orca::Orca;
 use crate::solana::dex::pumpfun_amm::{
-    pump_amm_buy_program_ix_index, pump_amm_resolve_sell_pre_fee_meta_1_for_build,
+    pump_amm_buy_program_ix_index, pump_amm_canonical_global_config,
+    pump_amm_normalize_v14_pool_accounts, pump_amm_resolve_sell_pre_fee_meta_1_for_build,
     pump_amm_sell_ix_uses_global_fee_at, pump_amm_singleton_global_volume_accumulator_pub,
     PumpFunAmmDex, PUMPFUN_AMM_BUY_EXT_FEE_CONFIG_IX, PUMPFUN_AMM_BUY_EXT_FEE_PROGRAM_IX,
     PUMPFUN_AMM_BUY_TOTAL_ACCOUNTS, PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS,
@@ -346,6 +347,7 @@ impl CrossDexHandler {
                         parsed[0]
                     ));
                 }
+                pump_amm_normalize_v14_pool_accounts(&pool_pk, &mut parsed);
                 return Ok(parsed);
             }
         }
@@ -353,7 +355,9 @@ impl CrossDexHandler {
         if let Some(ref cache) = self.pool_cache {
             if let Some(CachedPoolState::PumpAmm(amm_state)) = cache.get(&pool_pk) {
                 if amm_state.pool_accounts.len() >= 14 {
-                    return Ok(amm_state.pool_accounts[..14].to_vec());
+                    let mut accounts = amm_state.pool_accounts[..14].to_vec();
+                    pump_amm_normalize_v14_pool_accounts(&pool_pk, &mut accounts);
+                    return Ok(accounts);
                 }
             }
         }
@@ -509,6 +513,19 @@ impl CrossDexHandler {
 
         if let Some(ix) = ixs.first() {
             let account_count = ix.accounts.len();
+            let canonical_gc = pump_amm_canonical_global_config();
+            if ix.accounts.len() <= 2 || ix.accounts[2].pubkey != canonical_gc {
+                return Err(anyhow!(
+                    "pump_amm {} leg: global_config meta #2 mismatch for pool {}: got {}, expected {}",
+                    if is_buy_leg { "BUY" } else { "SELL" },
+                    pool_str,
+                    ix.accounts
+                        .get(2)
+                        .map(|m| m.pubkey.to_string())
+                        .unwrap_or_else(|| "<missing>".to_string()),
+                    canonical_gc
+                ));
+            }
             let program_slot = if is_buy_leg {
                 pump_amm_buy_program_ix_index(account_count)
             } else {
@@ -1583,13 +1600,15 @@ mod tests {
     };
     use crate::solana::address_lookup_table::{
         analyze_versioned_message_alt_usage, compile_v0_versioned_message, get_common_accounts,
+        loaded_addresses_from_alt_lookups, resolved_instruction_account_pubkey,
         versioned_message_duplicate_static_keys, AltCompileAnalysis, LoadedAlt,
     };
     use crate::solana::compute_budget_helper;
     use crate::solana::dex::orca::ORCA_WHIRLPOOL_PROGRAM;
     use crate::solana::dex::pumpfun_amm::{
-        pump_amm_buy_program_ix_index, PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR,
-        PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR, PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS,
+        pump_amm_buy_program_ix_index, pump_amm_canonical_global_config,
+        PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR, PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR,
+        PUMPFUN_AMM_GLOBAL_CONFIG_STR, PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS,
         PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS,
     };
     use crate::solana::dex::router::Router;
@@ -2025,6 +2044,125 @@ mod tests {
             dupes.is_empty(),
             "compiled v0 message must not contain duplicate static keys (AccountLoadedTwice): {:?}",
             dupes.iter().map(|p| p.to_string()).collect::<Vec<_>>()
+        );
+    }
+
+    /// Prod incident: stale `pool_accounts[1]` (`T1pyya…`) must not leak into compiled SELL ix or static keys.
+    #[tokio::test]
+    async fn cross_dex_pump_sell_global_config_resolved_after_wrong_pool_accounts_v14() {
+        const WRONG_GLOBAL_CONFIG: &str = "T1pyyaTNZsKv2WcRAB8oVnk93mLJw2XzjtVYqCsaHqt";
+        let canonical_gc = pump_amm_canonical_global_config();
+        let wrong_gc = Pubkey::from_str(WRONG_GLOBAL_CONFIG).unwrap();
+        assert_ne!(wrong_gc, canonical_gc);
+
+        let wallet = Keypair::new();
+        let token_mint = Pubkey::new_unique();
+        let buy_pool = Pubkey::from_str("2TD1fMPg2w7Hjt8bASSdxi92YFNQFgvdznqVApe3NGpn").unwrap();
+        let sell_pool = Pubkey::new_unique();
+
+        let cache = Arc::new(LivePoolCache::new());
+        seed_prod_like_cross_dex_cache(&cache, buy_pool, sell_pool, token_mint);
+
+        // Inject prod-like wrong global_config into cache v14 row.
+        if let Some(CachedPoolState::PumpAmm(state)) = cache.get(&sell_pool) {
+            let mut accounts = state.pool_accounts;
+            accounts[1] = wrong_gc;
+            cache.set_pump_amm_pool_accounts(&sell_pool, accounts);
+        }
+
+        let rpc = Arc::new(SolanaRpc::new("http://127.0.0.1:0"));
+        let mut handler = CrossDexHandler::new(rpc.clone(), Some(wallet.pubkey()))
+            .with_rpc_url("http://127.0.0.1:0".to_string())
+            .with_pool_cache(cache);
+        handler.init_dexes().await.expect("init_dexes");
+
+        let mut intent = cross_dex_test_intent(&token_mint, &buy_pool, &sell_pool);
+        // Intent sell_pool_accounts also carry the wrong global_config at v14[1].
+        if let Some(start_idx) = intent
+            .resources
+            .accounts
+            .iter()
+            .position(|s| s.starts_with("sell_pool_accounts_start:"))
+        {
+            let count: usize = intent.resources.accounts[start_idx]
+                .strip_prefix("sell_pool_accounts_start:")
+                .and_then(|n| n.parse().ok())
+                .unwrap_or(0);
+            let first_account_idx = start_idx + 2; // v14[1] is first_account_idx + 1
+            if count >= 2 && first_account_idx < intent.resources.accounts.len() {
+                intent.resources.accounts[first_account_idx] = WRONG_GLOBAL_CONFIG.to_string();
+            }
+        }
+
+        let validation = cross_dex_validation_fixture(&token_mint);
+        let plan = handler
+            .build_swap_plan(
+                &intent,
+                &validation,
+                CrossDexPlanOptions {
+                    skip_token_ata_create: true,
+                },
+            )
+            .await
+            .expect("build_swap_plan with wrong pool_accounts[1] must succeed after normalization");
+
+        let sell_ix = plan.sell_instructions.first().expect("sell leg");
+        assert_eq!(
+            sell_ix.accounts.len(),
+            PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS,
+            "prod-like pump sell must use 24-account extended layout"
+        );
+        assert_eq!(
+            sell_ix.accounts[2].pubkey, canonical_gc,
+            "SELL ix meta #2 must be canonical global_config"
+        );
+        assert_eq!(
+            sell_ix.accounts[2].pubkey.to_string(),
+            PUMPFUN_AMM_GLOBAL_CONFIG_STR
+        );
+
+        let alt_accounts = get_common_accounts();
+        let (tx, _, _, _) =
+            compile_cross_dex_bundle_tx_with_alt(&wallet, &plan, alt_accounts.clone());
+        let dupes = versioned_message_duplicate_static_keys(&tx.message);
+        assert!(
+            dupes.is_empty(),
+            "wrong pool_accounts[1] must not produce duplicate static keys: {:?}",
+            dupes.iter().map(|p| p.to_string()).collect::<Vec<_>>()
+        );
+
+        let alt_address = match &tx.message {
+            solana_sdk::message::VersionedMessage::V0(v0) => v0
+                .address_table_lookups
+                .first()
+                .map(|l| l.account_key)
+                .unwrap_or_default(),
+            _ => Pubkey::default(),
+        };
+        let alt = LoadedAlt {
+            address: alt_address,
+            accounts: alt_accounts,
+        };
+        let loaded = loaded_addresses_from_alt_lookups(&alt, &tx.message)
+            .expect("loaded addresses from ALT lookups");
+        // Bundle: CU limit, CU price, Meteora buy, Pump sell, tip → sell at index 3.
+        let sell_ix_index = 3;
+        let resolved_gc =
+            resolved_instruction_account_pubkey(&tx.message, Some(&loaded), sell_ix_index, 2)
+                .expect("resolve SELL global_config from compiled v0 message");
+        assert_eq!(
+            resolved_gc, canonical_gc,
+            "compiled v0 message must resolve SELL global_config slot to canonical pubkey"
+        );
+
+        // Wrong pubkey must not appear as a static key when normalization replaced it.
+        let static_keys = match &tx.message {
+            solana_sdk::message::VersionedMessage::V0(v0) => &v0.account_keys,
+            solana_sdk::message::VersionedMessage::Legacy(l) => &l.account_keys,
+        };
+        assert!(
+            !static_keys.contains(&wrong_gc),
+            "wrong global_config must not be a static key in compiled bundle"
         );
     }
 

--- a/src/solana/dex/pumpfun_amm.rs
+++ b/src/solana/dex/pumpfun_amm.rs
@@ -63,6 +63,62 @@ fn pump_amm_canonical_event_authority(program_id: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"__event_authority"], program_id).0
 }
 
+/// Canonical PumpSwap `global_config` pubkey string (swap ix account #2, v14 `pool_accounts[1]`).
+pub const PUMPFUN_AMM_GLOBAL_CONFIG_STR: &str = PUMPFUN_AMM_GLOBAL_CONFIG;
+
+/// Canonical PumpSwap `global_config` pubkey (same for all pools).
+#[must_use]
+pub fn pump_amm_canonical_global_config() -> Pubkey {
+    Pubkey::from_str(PUMPFUN_AMM_GLOBAL_CONFIG).expect("PUMPFUN_AMM_GLOBAL_CONFIG is valid")
+}
+
+/// Canonical PumpSwap `event_authority` PDA (v14 `pool_accounts[8]`).
+#[must_use]
+pub fn pump_amm_canonical_event_authority_pub() -> Pubkey {
+    let program_id =
+        Pubkey::from_str(PUMPFUN_AMM_PROGRAM_ID).expect("PUMPFUN_AMM_PROGRAM_ID is valid");
+    pump_amm_canonical_event_authority(&program_id)
+}
+
+/// Normalize v14 `pool_accounts` globals in-place: `[1]` → canonical `global_config`, `[8]` → canonical
+/// `event_authority`. Does **not** touch `protocol_fee_recipient` (`[6]`/`[7]`) — Bug #35.
+///
+/// Returns `true` if any slot was replaced.
+pub fn pump_amm_normalize_v14_pool_accounts(pool: &Pubkey, accounts: &mut [Pubkey]) -> bool {
+    if accounts.len() < 14 {
+        return false;
+    }
+    let global_config = pump_amm_canonical_global_config();
+    let event_authority = pump_amm_canonical_event_authority_pub();
+    let mut replaced = false;
+
+    if accounts[1] != global_config {
+        warn!(
+            pool = %pool,
+            from = %accounts[1],
+            to = %global_config,
+            slot = 1,
+            "pump_amm: normalized v14 pool_accounts global_config"
+        );
+        crate::metrics::inc_pump_amm_global_config_normalized_total();
+        accounts[1] = global_config;
+        replaced = true;
+    }
+    if accounts[8] != event_authority {
+        warn!(
+            pool = %pool,
+            from = %accounts[8],
+            to = %event_authority,
+            slot = 8,
+            "pump_amm: normalized v14 pool_accounts event_authority"
+        );
+        crate::metrics::inc_pump_amm_event_authority_normalized_total();
+        accounts[8] = event_authority;
+        replaced = true;
+    }
+    replaced
+}
+
 /// Singleton `global_volume_accumulator` PDA — same address for all PumpSwap pools under the AMM program.
 ///
 /// When market-byte heuristics find no AMM-owned candidate and PDA probes fail (e.g. account owner
@@ -7965,6 +8021,38 @@ mod tests {
     }
 
     /// SELL path: instruction account #2 must be the canonical global_config (not pool_accounts[1]).
+    #[test]
+    fn test_pump_amm_normalize_v14_pool_accounts_replaces_globals_only() {
+        let pool = Pubkey::new_unique();
+        let canonical_gc = pump_amm_canonical_global_config();
+        let canonical_ea = pump_amm_canonical_event_authority_pub();
+        let wrong_pfr = Pubkey::new_unique();
+
+        let mut accounts: Vec<Pubkey> = vec![
+            pool,
+            Pubkey::from_str("T1pyyaTNZsKv2WcRAB8oVnk93mLJw2XzjtVYqCsaHqt").unwrap(),
+            Pubkey::new_unique(),
+            Pubkey::from_str(WSOL_MINT).unwrap(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            wrong_pfr,
+            Pubkey::new_unique(),
+            Pubkey::new_unique(), // wrong event_authority
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+        ];
+        assert!(pump_amm_normalize_v14_pool_accounts(&pool, &mut accounts));
+        assert_eq!(accounts[1], canonical_gc);
+        assert_eq!(accounts[8], canonical_ea);
+        assert_eq!(
+            accounts[6], wrong_pfr,
+            "protocol_fee_recipient must not be canonicalized"
+        );
+    }
+
     #[test]
     fn test_pumpswap_sell_global_config_meta_is_canonical() {
         let wsol = Pubkey::from_str(WSOL_MINT).unwrap();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Prod route `meteora_dlmm → pump_amm`: 18/18 SimFailed; **11×** `AccountOwnedByWrongProgram (3007)` on PumpSwap SELL `global_config` when stale `pool_accounts[1]` (e.g. `T1pyya…`) leaked from cache/intent into cross-DEX bundles despite `build_swap_ix_from_pool_accounts` using canonical ix meta #2.

## Fix

| Location | Change |
|----------|--------|
| `pumpfun_amm.rs` | `pump_amm_normalize_v14_pool_accounts` — canonicalize `[1]` → `ADyA8h…`, `[8]` → `__event_authority` PDA only (Bug #35: **not** `[6]`/`[7]`) |
| `cross_dex_handler.rs` | Normalize in `resolve_pump_amm_pool_accounts_v14`; post-build hard-check ix meta #2 |
| `live_pool_cache.rs` | Normalize on `set_pump_amm_pool_accounts` write |
| `address_lookup_table.rs` | `resolved_instruction_account_pubkey` + `loaded_addresses_from_alt_lookups` for compile verification |
| `metrics.rs` | `pump_amm_global_config_normalized_total`, `pump_amm_event_authority_normalized_total` |

## Tests

- `test_pump_amm_normalize_v14_pool_accounts_replaces_globals_only`
- `cross_dex_pump_sell_global_config_resolved_after_wrong_pool_accounts_v14` — wrong `pool_accounts[1]` (`T1pyya…`), realistic `COMMON_ACCOUNTS` ALT, asserts SELL ix meta #2 **and** resolved v0 message slot == `ADyA8h…`, no duplicate static keys
- Updated `test_set_pump_amm_pool_accounts*` for normalized cache writes

## STOP-CHECK (performed)

1. **I-7 Hot Path RPC**: No new RPC calls
2. **Pattern consistency**: Matches existing canonical global_config/event_authority pattern in `build_swap_ix_from_pool_accounts`
3. **Scope**: Only allowed files
4. **I-9 Simulation-Gate**: Pre-Sim fail on meta mismatch (no send without sim)
5. **Level-5**: No eval test reads

## Follow-ups (not in this PR)

- **AccountLoadedTwice (5×)**: Existing `cross_dex_meteora_pump_bundle_has_no_duplicate_static_keys` stays green; no blind dedup added
- **InsufficientFundsForRent idx 16 (2×)**: Likely ATA-create / wallet SOL — document for deploy verification
- **On-chain ALT**: Verify `ADyA8h…` present in ALT `2J74oVK…` per `docs/ALT_GLOBAL_KEYS_AUDIT.md` (no runtime extend in this PR)

## Verification

```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```

Eval Level 5 via CI.

**No prod-fixed claim** — requires deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cc0c1d1-96cf-46ea-a4e6-78e38b0671b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cc0c1d1-96cf-46ea-a4e6-78e38b0671b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

