### PR TITLE
fix(pump_amm): ALT index remap + compile audit for global_config (post-#392)

### DIFF
--- a/src/bin/execution_engine.rs
+++ b/src/bin/execution_engine.rs
@@ -74,7 +74,8 @@ use ironcrab::ipc::{
 use ironcrab::ipc::{ControlRequest, ControlRequestKind, ControlResponse, ControlResponseStatus};
 use ironcrab::metrics::{
     dec_execution_intent_rx_queue_depth, inc_execution_intent_rx_queue_depth,
-    inc_execution_pool_cache_messages_processed, record_arb_bundle_tx_too_large,
+    inc_execution_pool_cache_messages_processed,
+    inc_pump_amm_compile_global_config_resolve_mismatch_total, record_arb_bundle_tx_too_large,
     record_execution_engine_interval_tick_duration_ms, record_execution_intent_channel_wait_ms,
     record_execution_intent_jetstream_to_channel_ms, record_execution_process_intent_us,
     record_execution_slot_lag_at_send_slots, record_failed_confirmed_no_fill_accounting_total,
@@ -125,6 +126,7 @@ use ironcrab::position_authority::{
     PositionAuthority, PositionAuthorityChange, PositionAuthorityKvMetricsSink,
     PositionAuthorityKvPublisher,
 };
+use ironcrab::solana::address_lookup_table::audit_pump_amm_global_config_in_versioned_tx;
 use ironcrab::solana::cross_dex_handler::CrossDexHandler;
 use ironcrab::solana::dex::meteora_dlmm::MeteoraDlmm;
 use ironcrab::solana::dex::orca::Orca;
@@ -13622,6 +13624,35 @@ fn log_bundle_tx_size_rejection(
     record_arb_bundle_tx_too_large();
 }
 
+fn log_pump_amm_compile_global_config_mismatch(
+    intent: &TradeIntent,
+    err: &ironcrab::solana::address_lookup_table::PumpAmmGlobalConfigAuditError,
+    rejection_stage: &str,
+) {
+    let buy_dex = intent
+        .metadata
+        .get("buy_dex")
+        .map(|s| s.as_str())
+        .unwrap_or("?");
+    let sell_dex = intent
+        .metadata
+        .get("sell_dex")
+        .map(|s| s.as_str())
+        .unwrap_or("?");
+    warn!(
+        intent_id = %intent.intent_id,
+        ix_index = err.ix_index,
+        meta_pubkey = %err.meta_pubkey,
+        resolved_pubkey = %err.resolved_pubkey,
+        static_contains_bad = ?err.static_contains_bad.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
+        buy_dex,
+        sell_dex,
+        rejection_stage,
+        "PumpSwap global_config compile resolve mismatch (pre-sim gate)"
+    );
+    inc_pump_amm_compile_global_config_resolve_mismatch_total();
+}
+
 /// Build + size-gate the unsigned TX used for simulation (same form as send, no RPC yet).
 fn prepare_unsigned_versioned_tx_for_simulation(
     wallet_pubkey: &Pubkey,
@@ -13722,6 +13753,24 @@ async fn simulate_transaction(
             logs_preview: None,
             compute_units_consumed: None,
         };
+    }
+
+    if let (Some(alt), Some(intent)) = (ctx.address_lookup_table.as_ref(), bundle_size_intent) {
+        if let Err(audit_err) =
+            audit_pump_amm_global_config_in_versioned_tx(&tx.message, alt, &plan.instructions)
+        {
+            log_pump_amm_compile_global_config_mismatch(
+                intent,
+                &audit_err,
+                "before_simulation_rpc",
+            );
+            return SimulationResult {
+                success: false,
+                error_code: Some(audit_err.detail()),
+                logs_preview: None,
+                compute_units_consumed: None,
+            };
+        }
     }
 
     let cfg = RpcSimulateTransactionConfig {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4937,6 +4937,14 @@ pub fn inc_pump_amm_event_authority_normalized_total() {
     PUMP_AMM_EVENT_AUTHORITY_NORMALIZED_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+/// PumpSwap compiled v0 message: ix meta #2 `global_config` ≠ resolved on-chain ALT pubkey.
+pub static PUMP_AMM_COMPILE_GLOBAL_CONFIG_RESOLVE_MISMATCH_TOTAL: Lazy<AtomicU64> =
+    Lazy::new(|| AtomicU64::new(0));
+
+pub fn inc_pump_amm_compile_global_config_resolve_mismatch_total() {
+    PUMP_AMM_COMPILE_GLOBAL_CONFIG_RESOLVE_MISMATCH_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArbPoolAccountsBackfillSource {
     LiveCache,

--- a/src/solana/address_lookup_table.rs
+++ b/src/solana/address_lookup_table.rs
@@ -35,6 +35,16 @@ pub const PUMPFUN_BONDING_EVENT_AUTHORITY: &str = "Ce6TQqeHC9p8KetsN6JsjHK7UTZk7
 /// Former COMMON_ACCOUNTS entry — not PumpSwap global_config; kept for audit diffs only.
 pub const REMOVED_WRONG_PUMPSWAP_GLOBAL_CONFIG: &str =
     "39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg";
+/// BPF-loader program account observed as stale `pool_accounts[1]` in prod (not PumpSwap global_config).
+pub const PUMP_AMM_WRONG_LEGACY_GLOBAL_CONFIG: &str = "T1pyyaTNZsKv2WcRAB8oVnk93mLJw2XzjtVYqCsaHqt";
+/// Prod on-chain ALT address (`setup-alt` / EE config).
+pub const PROD_ON_CHAIN_ALT_ADDRESS: &str = "2J74oVKaviWzVr9gaLDvmBf3VAVVpzy88i3YCnyDwvuX";
+
+/// Pubkeys that must not appear as static keys when PumpSwap ix meta #2 is canonical `global_config`.
+pub const PUMP_AMM_KNOWN_BAD_GLOBAL_CONFIG_PUBKEYS: &[&str] = &[
+    PUMP_AMM_WRONG_LEGACY_GLOBAL_CONFIG,
+    REMOVED_WRONG_PUMPSWAP_GLOBAL_CONFIG,
+];
 
 /// Well-known program IDs and accounts that should be in every ALT.
 /// These are used in almost every transaction.
@@ -124,6 +134,57 @@ pub fn address_lookup_table_account(
     }
 }
 
+/// Map filtered-ALT lookup indices (tip excluded from compile LUT) to on-chain ALT indices.
+///
+/// `try_compile` indexes into the `AddressLookupTableAccount::addresses` slice passed at compile
+/// time. When the tip is removed so it stays a static writable key (#373), those indices drift
+/// vs the on-chain LUT that RPC `simulateTransaction` resolves — remap after compile.
+fn filtered_alt_index_to_on_chain_map(alt: &LoadedAlt, exclude_tip: &Pubkey) -> Option<Vec<u8>> {
+    if !alt.contains(exclude_tip) {
+        return None;
+    }
+    let map: Vec<u8> = alt
+        .accounts
+        .iter()
+        .filter(|pk| *pk != exclude_tip)
+        .filter_map(|pk| {
+            let idx = alt.index_of(pk)?;
+            u8::try_from(idx).ok()
+        })
+        .collect();
+    Some(map)
+}
+
+/// Rewrite v0 lookup indices from filtered-ALT positions to on-chain ALT positions.
+pub fn remap_v0_alt_lookup_indices_to_on_chain(
+    message: &mut v0::Message,
+    alt: &LoadedAlt,
+    exclude_tip: &Pubkey,
+) -> Result<(), String> {
+    let Some(index_map) = filtered_alt_index_to_on_chain_map(alt, exclude_tip) else {
+        return Ok(());
+    };
+    for lookup in &mut message.address_table_lookups {
+        if lookup.account_key != alt.address {
+            return Err(format!(
+                "alt_lookup_remap_unexpected_table:{}",
+                lookup.account_key
+            ));
+        }
+        for idx in lookup
+            .writable_indexes
+            .iter_mut()
+            .chain(lookup.readonly_indexes.iter_mut())
+        {
+            let filtered = *idx as usize;
+            *idx = *index_map
+                .get(filtered)
+                .ok_or_else(|| format!("alt_lookup_remap_oob:filtered_index_{filtered}"))?;
+        }
+    }
+    Ok(())
+}
+
 /// Compile a v0 `VersionedMessage` with optional ALT and tip filtering.
 pub fn compile_v0_versioned_message(
     payer: &Pubkey,
@@ -134,8 +195,13 @@ pub fn compile_v0_versioned_message(
 ) -> Result<VersionedMessage, String> {
     let message = if let Some(alt) = alt {
         let alt_account = address_lookup_table_account(alt, exclude_tip_from_alt);
-        v0::Message::try_compile(payer, instructions, &[alt_account], recent_blockhash)
-            .map_err(|e| format!("v0_compile_error:{e}"))?
+        let mut message =
+            v0::Message::try_compile(payer, instructions, &[alt_account], recent_blockhash)
+                .map_err(|e| format!("v0_compile_error:{e}"))?;
+        if let Some(tip) = exclude_tip_from_alt {
+            remap_v0_alt_lookup_indices_to_on_chain(&mut message, alt, tip)?;
+        }
+        message
     } else {
         v0::Message::try_compile(payer, instructions, &[], recent_blockhash)
             .map_err(|e| format!("v0_compile_error:{e}"))?
@@ -453,6 +519,138 @@ pub fn partition_globals_vs_pool_specific(
     (globals_missing, pool_specific)
 }
 
+/// Structured failure from pre-sim PumpSwap `global_config` compile audit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PumpAmmGlobalConfigAuditError {
+    pub ix_index: usize,
+    pub meta_pubkey: Pubkey,
+    pub resolved_pubkey: Pubkey,
+    pub static_contains_bad: Vec<Pubkey>,
+}
+
+impl PumpAmmGlobalConfigAuditError {
+    pub fn reason_code(&self) -> &'static str {
+        "pump_amm_compile_global_config_resolve_mismatch"
+    }
+
+    pub fn detail(&self) -> String {
+        format!(
+            "pump_amm_compile_global_config_resolve_mismatch:ix={}:meta={}:resolved={}:static_bad={:?}",
+            self.ix_index,
+            self.meta_pubkey,
+            self.resolved_pubkey,
+            self.static_contains_bad
+                .iter()
+                .map(|p| p.to_string())
+                .collect::<Vec<_>>()
+        )
+    }
+}
+
+/// Pre-sim audit: PumpSwap buy/sell ix meta #2 must resolve to the same pubkey in the compiled v0
+/// message when lookups are resolved against the **on-chain** ALT snapshot.
+pub fn audit_pump_amm_global_config_in_versioned_tx(
+    message: &VersionedMessage,
+    alt: &LoadedAlt,
+    plan_instructions: &[Instruction],
+) -> Result<(), PumpAmmGlobalConfigAuditError> {
+    use crate::solana::dex::pumpfun_amm::pump_amm_canonical_global_config;
+
+    let pump_program =
+        Pubkey::from_str("pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA").expect("pump amm program");
+    let canonical_gc = pump_amm_canonical_global_config();
+    let loaded = loaded_addresses_from_alt_lookups(alt, message);
+    let static_keys: Vec<Pubkey> = match message {
+        VersionedMessage::V0(v0) => v0.account_keys.clone(),
+        VersionedMessage::Legacy(l) => l.account_keys.clone(),
+    };
+    let bad_static: Vec<Pubkey> = PUMP_AMM_KNOWN_BAD_GLOBAL_CONFIG_PUBKEYS
+        .iter()
+        .filter_map(|s| Pubkey::from_str(s).ok())
+        .filter(|pk| static_keys.contains(pk))
+        .collect();
+
+    for (ix_index, plan_ix) in plan_instructions.iter().enumerate() {
+        if plan_ix.program_id != pump_program || plan_ix.accounts.len() <= 2 {
+            continue;
+        }
+        let meta_pk = plan_ix.accounts[2].pubkey;
+        let Some(resolved_pk) =
+            resolved_instruction_account_pubkey(message, loaded.as_ref(), ix_index, 2)
+        else {
+            return Err(PumpAmmGlobalConfigAuditError {
+                ix_index,
+                meta_pubkey: meta_pk,
+                resolved_pubkey: Pubkey::default(),
+                static_contains_bad: bad_static.clone(),
+            });
+        };
+        if meta_pk != resolved_pk {
+            return Err(PumpAmmGlobalConfigAuditError {
+                ix_index,
+                meta_pubkey: meta_pk,
+                resolved_pubkey: resolved_pk,
+                static_contains_bad: bad_static.clone(),
+            });
+        }
+        if meta_pk == canonical_gc && !bad_static.is_empty() {
+            return Err(PumpAmmGlobalConfigAuditError {
+                ix_index,
+                meta_pubkey: meta_pk,
+                resolved_pubkey: resolved_pk,
+                static_contains_bad: bad_static,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Exact 33-entry prod on-chain ALT snapshot (mainnet `2J74oVK…`, 2026-08-09).
+pub fn prod_on_chain_alt_fixture() -> LoadedAlt {
+    const ENTRIES: &[&str] = &[
+        "11111111111111111111111111111111",
+        "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+        "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+        "ComputeBudget111111111111111111111111111111",
+        "SysvarRent111111111111111111111111111111111",
+        "SysvarC1ock11111111111111111111111111111111",
+        "So11111111111111111111111111111111111111112",
+        "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P",
+        "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA",
+        "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",
+        "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo",
+        "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8",
+        "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK",
+        "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+        "D1ZN9Wj1fRSUQfCjhvnu1hqDMT7hzjzBBpi12nVniYD6",
+        "pfeeUxB6jkeY1Hxd7CsFCAjcbHA9rWtchMGdZ6VojVZ",
+        "C2aFPdENg4A2HQsmrd5rTw5TaYBX5Ku887cWjbFKtZpw",
+        REMOVED_WRONG_PUMPSWAP_GLOBAL_CONFIG,
+        "4wTV1YmiEkRvAtNtsSGPtUrqRYQMe5SKy2uB4Jjaxnjf",
+        "CebN5WGQ4jvEPvsVU4EoHEpgzq1VV7AbicfhtW4xC9iM",
+        "5quBtoiQqxF9Jv6KYKctB59NT3gtJD2Y65kdnB1Uev3h",
+        "96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5",
+        "HFqU5x63VTqvQss8hp11i4bVmyBkEr7SrFKerWRx5Qdr",
+        "Cw8CFyM9FkoMi7K7Crf6HNQqf4uEMzpKw6QNghXLvLkY",
+        "ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49",
+        "DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh",
+        "ADuUkR4vqLUMWXxW9gh6D6L8pMSawimctcNZ5pGwDcEt",
+        "DttWaMuVvTiduZRnguLF7jNxTgiMBZ1hyAumKUiL2KRL",
+        "3AVi9Tg9Uo68tJfuvoKvqKNWKkC5wPdSSdeBnizKZ6jT",
+        PUMPSWAP_AMM_GLOBAL_CONFIG,
+        "5PHirr8joyTMp9JMm6nW7hNDVyEYdkzDqazxPD7RaTjx",
+        PUMPSWAP_AMM_EVENT_AUTHORITY,
+        PUMPFUN_BONDING_EVENT_AUTHORITY,
+    ];
+    LoadedAlt {
+        address: Pubkey::from_str(PROD_ON_CHAIN_ALT_ADDRESS).expect("prod ALT address"),
+        accounts: ENTRIES
+            .iter()
+            .map(|s| Pubkey::from_str(s).expect("prod ALT entry"))
+            .collect(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -641,5 +839,117 @@ mod tests {
             "signer payer stays static even when present in ALT"
         );
         assert!(analysis.alt_in_table_but_static.contains(&payer));
+    }
+
+    #[test]
+    fn remap_v0_alt_lookup_indices_fixes_tip_filter_drift() {
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+        use solana_system_program;
+
+        let tip = Pubkey::from_str("96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5").unwrap();
+        let global_config = Pubkey::from_str(PUMPSWAP_AMM_GLOBAL_CONFIG).unwrap();
+        let alt = prod_on_chain_alt_fixture();
+        assert_eq!(alt.index_of(&tip), Some(21));
+        assert_eq!(alt.index_of(&global_config), Some(29));
+
+        let payer = Pubkey::new_unique();
+        let blockhash = solana_sdk::hash::Hash::new_unique();
+        let mut data = vec![2, 0, 0, 0];
+        data.extend_from_slice(&1u64.to_le_bytes());
+        let ix = Instruction {
+            program_id: solana_system_program::id(),
+            accounts: vec![
+                AccountMeta::new(payer, true),
+                AccountMeta::new_readonly(global_config, false),
+                AccountMeta::new(tip, false),
+            ],
+            data,
+        };
+
+        let without_remap = {
+            let alt_account = address_lookup_table_account(&alt, Some(&tip));
+            v0::Message::try_compile(&payer, &[ix.clone()], &[alt_account], blockhash).unwrap()
+        };
+        let mut with_remap = without_remap.clone();
+        remap_v0_alt_lookup_indices_to_on_chain(&mut with_remap, &alt, &tip).unwrap();
+
+        let loaded_before =
+            loaded_addresses_from_alt_lookups(&alt, &VersionedMessage::V0(without_remap.clone()))
+                .unwrap();
+        let resolved_before = resolved_instruction_account_pubkey(
+            &VersionedMessage::V0(without_remap),
+            Some(&loaded_before),
+            0,
+            1,
+        )
+        .unwrap();
+        assert_ne!(
+            resolved_before, global_config,
+            "unremapped filtered compile must drift vs on-chain ALT"
+        );
+
+        let loaded_after =
+            loaded_addresses_from_alt_lookups(&alt, &VersionedMessage::V0(with_remap.clone()))
+                .unwrap();
+        let resolved_after = resolved_instruction_account_pubkey(
+            &VersionedMessage::V0(with_remap),
+            Some(&loaded_after),
+            0,
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            resolved_after, global_config,
+            "remapped compile must resolve global_config against on-chain ALT"
+        );
+    }
+
+    #[test]
+    fn compile_v0_with_tip_filter_resolves_globals_against_on_chain_alt() {
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+        use solana_system_program;
+
+        let alt = prod_on_chain_alt_fixture();
+        let tip = Pubkey::from_str("96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5").unwrap();
+        let global_config = Pubkey::from_str(PUMPSWAP_AMM_GLOBAL_CONFIG).unwrap();
+        let payer = Pubkey::new_unique();
+        let blockhash = solana_sdk::hash::Hash::new_unique();
+        let mut data = vec![2, 0, 0, 0];
+        data.extend_from_slice(&1u64.to_le_bytes());
+        let ix = Instruction {
+            program_id: solana_system_program::id(),
+            accounts: vec![
+                AccountMeta::new(payer, true),
+                AccountMeta::new_readonly(global_config, false),
+                AccountMeta::new(tip, false),
+            ],
+            data,
+        };
+        let message = compile_v0_versioned_message(
+            &payer,
+            std::slice::from_ref(&ix),
+            Some(&alt),
+            Some(&tip),
+            blockhash,
+        )
+        .expect("compile with remap");
+        let loaded = loaded_addresses_from_alt_lookups(&alt, &message).unwrap();
+        let resolved = resolved_instruction_account_pubkey(&message, Some(&loaded), 0, 1).unwrap();
+        assert_eq!(resolved, global_config);
+    }
+
+    #[test]
+    fn prod_on_chain_alt_fixture_layout() {
+        let alt = prod_on_chain_alt_fixture();
+        assert_eq!(alt.accounts.len(), 33);
+        assert_eq!(
+            alt.accounts[17].to_string(),
+            REMOVED_WRONG_PUMPSWAP_GLOBAL_CONFIG
+        );
+        assert_eq!(alt.accounts[29].to_string(), PUMPSWAP_AMM_GLOBAL_CONFIG);
+        assert!(!alt
+            .accounts
+            .iter()
+            .any(|p| p.to_string() == PUMP_AMM_WRONG_LEGACY_GLOBAL_CONFIG));
     }
 }

--- a/src/solana/address_lookup_table.rs
+++ b/src/solana/address_lookup_table.rs
@@ -868,7 +868,8 @@ mod tests {
 
         let without_remap = {
             let alt_account = address_lookup_table_account(&alt, Some(&tip));
-            v0::Message::try_compile(&payer, &[ix.clone()], &[alt_account], blockhash).unwrap()
+            v0::Message::try_compile(&payer, std::slice::from_ref(&ix), &[alt_account], blockhash)
+                .unwrap()
         };
         let mut with_remap = without_remap.clone();
         remap_v0_alt_lookup_indices_to_on_chain(&mut with_remap, &alt, &tip).unwrap();

--- a/src/solana/cross_dex_handler.rs
+++ b/src/solana/cross_dex_handler.rs
@@ -1599,17 +1599,18 @@ mod tests {
         TradeSide, TradingRegime,
     };
     use crate::solana::address_lookup_table::{
-        analyze_versioned_message_alt_usage, compile_v0_versioned_message, get_common_accounts,
-        loaded_addresses_from_alt_lookups, resolved_instruction_account_pubkey,
+        analyze_versioned_message_alt_usage, audit_pump_amm_global_config_in_versioned_tx,
+        compile_v0_versioned_message, get_common_accounts, loaded_addresses_from_alt_lookups,
+        prod_on_chain_alt_fixture, resolved_instruction_account_pubkey,
         versioned_message_duplicate_static_keys, AltCompileAnalysis, LoadedAlt,
+        PUMP_AMM_WRONG_LEGACY_GLOBAL_CONFIG,
     };
     use crate::solana::compute_budget_helper;
     use crate::solana::dex::orca::ORCA_WHIRLPOOL_PROGRAM;
     use crate::solana::dex::pumpfun_amm::{
         pump_amm_buy_program_ix_index, pump_amm_canonical_global_config,
         PUMPFUN_AMM_BUILD_SWAP_FEE_CONFIG_STR, PUMPFUN_AMM_BUILD_SWAP_FEE_PROGRAM_STR,
-        PUMPFUN_AMM_GLOBAL_CONFIG_STR, PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS,
-        PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS,
+        PUMPFUN_AMM_SELL_CASHBACK_TOTAL_ACCOUNTS, PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS,
     };
     use crate::solana::dex::router::Router;
     use crate::solana::dex::Quote;
@@ -1872,11 +1873,17 @@ mod tests {
         (plan, wallet, token_mint)
     }
 
-    fn compile_cross_dex_bundle_tx_with_alt(
+    fn compile_cross_dex_bundle_tx_with_loaded_alt(
         wallet: &Keypair,
         plan: &CrossDexSwapPlan,
-        alt_accounts: Vec<Pubkey>,
-    ) -> (VersionedTransaction, usize, usize, AltCompileAnalysis) {
+        alt: LoadedAlt,
+    ) -> (
+        VersionedTransaction,
+        usize,
+        usize,
+        AltCompileAnalysis,
+        Vec<Instruction>,
+    ) {
         let tip = Pubkey::from_str(JITO_TIP_ACCOUNT).unwrap();
         let mut ixs = Vec::new();
         ixs.push(compute_budget_helper::set_compute_unit_limit(450_000));
@@ -1894,10 +1901,6 @@ mod tests {
             data: tip_data,
         });
 
-        let alt = LoadedAlt {
-            address: Pubkey::new_unique(),
-            accounts: alt_accounts,
-        };
         let blockhash = Hash::new_unique();
         let message =
             compile_v0_versioned_message(&wallet.pubkey(), &ixs, Some(&alt), Some(&tip), blockhash)
@@ -1905,7 +1908,76 @@ mod tests {
         let tx = VersionedTransaction::try_new(message, &[wallet]).expect("sign tx");
         let analysis = analyze_versioned_message_alt_usage(&tx.message, Some(&alt));
         let size = versioned_tx_serialized_len(&tx);
-        (tx, size, analysis.alt_hit_count, analysis)
+        (tx, size, analysis.alt_hit_count, analysis, ixs)
+    }
+
+    fn compile_cross_dex_bundle_tx_with_alt(
+        wallet: &Keypair,
+        plan: &CrossDexSwapPlan,
+        alt_accounts: Vec<Pubkey>,
+    ) -> (VersionedTransaction, usize, usize, AltCompileAnalysis) {
+        let alt = LoadedAlt {
+            address: Pubkey::new_unique(),
+            accounts: alt_accounts,
+        };
+        let (tx, size, alt_hits, analysis, _) =
+            compile_cross_dex_bundle_tx_with_loaded_alt(wallet, plan, alt);
+        (tx, size, alt_hits, analysis)
+    }
+
+    fn compile_cross_dex_bundle_tx_prod_alt(
+        wallet: &Keypair,
+        plan: &CrossDexSwapPlan,
+    ) -> (
+        VersionedTransaction,
+        usize,
+        usize,
+        AltCompileAnalysis,
+        Vec<Instruction>,
+    ) {
+        compile_cross_dex_bundle_tx_with_loaded_alt(wallet, plan, prod_on_chain_alt_fixture())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn assert_pump_global_config_prod_alt_compile(
+        tx: &VersionedTransaction,
+        plan_ixs: &[Instruction],
+        alt: &LoadedAlt,
+        pump_leg_ix_index: usize,
+        wrong_gc: Pubkey,
+        canonical_gc: Pubkey,
+    ) {
+        audit_pump_amm_global_config_in_versioned_tx(&tx.message, alt, plan_ixs)
+            .expect("compile audit must pass for pump global_config");
+        let dupes = versioned_message_duplicate_static_keys(&tx.message);
+        assert!(
+            dupes.is_empty(),
+            "compiled v0 message must not contain duplicate static keys: {:?}",
+            dupes.iter().map(|p| p.to_string()).collect::<Vec<_>>()
+        );
+        let loaded = loaded_addresses_from_alt_lookups(alt, &tx.message)
+            .expect("loaded addresses from ALT lookups");
+        let resolved_gc =
+            resolved_instruction_account_pubkey(&tx.message, Some(&loaded), pump_leg_ix_index, 2)
+                .expect("resolve pump global_config from compiled v0 message");
+        assert_eq!(
+            resolved_gc, canonical_gc,
+            "compiled v0 message must resolve pump global_config slot to canonical pubkey"
+        );
+        let static_keys = match &tx.message {
+            solana_sdk::message::VersionedMessage::V0(v0) => &v0.account_keys,
+            solana_sdk::message::VersionedMessage::Legacy(l) => &l.account_keys,
+        };
+        assert!(
+            !static_keys.contains(&wrong_gc),
+            "wrong global_config must not be a static key in compiled bundle"
+        );
+        assert!(
+            !static_keys
+                .iter()
+                .any(|p| p.to_string() == PUMP_AMM_WRONG_LEGACY_GLOBAL_CONFIG),
+            "T1pyya must not appear in static keys"
+        );
     }
 
     /// Optimistic ALT: every instruction account is in the table (not prod-realistic).
@@ -2050,7 +2122,7 @@ mod tests {
     /// Prod incident: stale `pool_accounts[1]` (`T1pyya…`) must not leak into compiled SELL ix or static keys.
     #[tokio::test]
     async fn cross_dex_pump_sell_global_config_resolved_after_wrong_pool_accounts_v14() {
-        const WRONG_GLOBAL_CONFIG: &str = "T1pyyaTNZsKv2WcRAB8oVnk93mLJw2XzjtVYqCsaHqt";
+        const WRONG_GLOBAL_CONFIG: &str = PUMP_AMM_WRONG_LEGACY_GLOBAL_CONFIG;
         let canonical_gc = pump_amm_canonical_global_config();
         let wrong_gc = Pubkey::from_str(WRONG_GLOBAL_CONFIG).unwrap();
         assert_ne!(wrong_gc, canonical_gc);
@@ -2063,7 +2135,6 @@ mod tests {
         let cache = Arc::new(LivePoolCache::new());
         seed_prod_like_cross_dex_cache(&cache, buy_pool, sell_pool, token_mint);
 
-        // Inject prod-like wrong global_config into cache v14 row.
         if let Some(CachedPoolState::PumpAmm(state)) = cache.get(&sell_pool) {
             let mut accounts = state.pool_accounts;
             accounts[1] = wrong_gc;
@@ -2077,7 +2148,6 @@ mod tests {
         handler.init_dexes().await.expect("init_dexes");
 
         let mut intent = cross_dex_test_intent(&token_mint, &buy_pool, &sell_pool);
-        // Intent sell_pool_accounts also carry the wrong global_config at v14[1].
         if let Some(start_idx) = intent
             .resources
             .accounts
@@ -2088,7 +2158,7 @@ mod tests {
                 .strip_prefix("sell_pool_accounts_start:")
                 .and_then(|n| n.parse().ok())
                 .unwrap_or(0);
-            let first_account_idx = start_idx + 2; // v14[1] is first_account_idx + 1
+            let first_account_idx = start_idx + 2;
             if count >= 2 && first_account_idx < intent.resources.accounts.len() {
                 intent.resources.accounts[first_account_idx] = WRONG_GLOBAL_CONFIG.to_string();
             }
@@ -2112,58 +2182,139 @@ mod tests {
             PUMPFUN_AMM_SELL_EXTENDED_TOTAL_ACCOUNTS,
             "prod-like pump sell must use 24-account extended layout"
         );
-        assert_eq!(
-            sell_ix.accounts[2].pubkey, canonical_gc,
-            "SELL ix meta #2 must be canonical global_config"
-        );
-        assert_eq!(
-            sell_ix.accounts[2].pubkey.to_string(),
-            PUMPFUN_AMM_GLOBAL_CONFIG_STR
-        );
+        assert_eq!(sell_ix.accounts[2].pubkey, canonical_gc);
 
-        let alt_accounts = get_common_accounts();
-        let (tx, _, _, _) =
-            compile_cross_dex_bundle_tx_with_alt(&wallet, &plan, alt_accounts.clone());
-        let dupes = versioned_message_duplicate_static_keys(&tx.message);
-        assert!(
-            dupes.is_empty(),
-            "wrong pool_accounts[1] must not produce duplicate static keys: {:?}",
-            dupes.iter().map(|p| p.to_string()).collect::<Vec<_>>()
-        );
-
-        let alt_address = match &tx.message {
-            solana_sdk::message::VersionedMessage::V0(v0) => v0
-                .address_table_lookups
-                .first()
-                .map(|l| l.account_key)
-                .unwrap_or_default(),
-            _ => Pubkey::default(),
-        };
-        let alt = LoadedAlt {
-            address: alt_address,
-            accounts: alt_accounts,
-        };
-        let loaded = loaded_addresses_from_alt_lookups(&alt, &tx.message)
-            .expect("loaded addresses from ALT lookups");
+        let alt = prod_on_chain_alt_fixture();
+        let (tx, _, _, _, plan_ixs) = compile_cross_dex_bundle_tx_prod_alt(&wallet, &plan);
         // Bundle: CU limit, CU price, Meteora buy, Pump sell, tip → sell at index 3.
-        let sell_ix_index = 3;
-        let resolved_gc =
-            resolved_instruction_account_pubkey(&tx.message, Some(&loaded), sell_ix_index, 2)
-                .expect("resolve SELL global_config from compiled v0 message");
-        assert_eq!(
-            resolved_gc, canonical_gc,
-            "compiled v0 message must resolve SELL global_config slot to canonical pubkey"
-        );
+        assert_pump_global_config_prod_alt_compile(&tx, &plan_ixs, &alt, 3, wrong_gc, canonical_gc);
+    }
 
-        // Wrong pubkey must not appear as a static key when normalization replaced it.
-        let static_keys = match &tx.message {
-            solana_sdk::message::VersionedMessage::V0(v0) => &v0.account_keys,
-            solana_sdk::message::VersionedMessage::Legacy(l) => &l.account_keys,
-        };
-        assert!(
-            !static_keys.contains(&wrong_gc),
-            "wrong global_config must not be a static key in compiled bundle"
+    /// Prod pattern: pump BUY leg (meteora sell) with wrong v14 `pool_accounts[1]`.
+    #[tokio::test]
+    async fn cross_dex_pump_buy_global_config_resolved_after_wrong_pool_accounts_v14() {
+        const WRONG_GLOBAL_CONFIG: &str = PUMP_AMM_WRONG_LEGACY_GLOBAL_CONFIG;
+        let canonical_gc = pump_amm_canonical_global_config();
+        let wrong_gc = Pubkey::from_str(WRONG_GLOBAL_CONFIG).unwrap();
+
+        let wallet = Keypair::new();
+        let token_mint = Pubkey::new_unique();
+        let buy_pool = Pubkey::new_unique();
+        let sell_pool = Pubkey::from_str("2TD1fMPg2w7Hjt8bASSdxi92YFNQFgvdznqVApe3NGpn").unwrap();
+
+        let cache = Arc::new(LivePoolCache::new());
+        let sol_mint = Pubkey::from_str(SOL_MINT).unwrap();
+        let mut buy_pool_accounts = pump_amm_v14_pool_accounts(buy_pool, token_mint);
+        buy_pool_accounts[1] = wrong_gc;
+        cache.upsert(
+            buy_pool,
+            CachedPoolState::PumpAmm(PumpAmmState {
+                base_mint: token_mint,
+                quote_mint: sol_mint,
+                pool_base_token_account: Pubkey::new_unique(),
+                pool_quote_token_account: Pubkey::new_unique(),
+                base_reserve: Some(1_000_000_000_000),
+                quote_reserve: Some(50_000_000_000),
+                pool_accounts: buy_pool_accounts,
+                creator: None,
+            }),
+            100,
         );
+        let third = Pubkey::from_str("HjQjngTDqoHE6aaGhUqfz9aQ7WZcBRjy5xB8PScLSr8i").unwrap();
+        cache.merge_pump_amm_sell_extended_layout(
+            &buy_pool,
+            true,
+            Some(third),
+            Some(Pubkey::from_str("5CXzL4rxA677oGhKUDBxxapLk6wLpRPLmackZDHGmZCQ").unwrap()),
+            Some(Pubkey::from_str("5YxQFdt3Tr9zJLvkFccqXVUwhdTWJQc1fFg2YPbxvxeD").unwrap()),
+            None,
+            None,
+            false,
+            false,
+            None,
+        );
+        cache.set_pump_amm_sell_layout_ready(&buy_pool, true);
+        cache.upsert(
+            sell_pool,
+            CachedPoolState::Meteora(MeteoraState {
+                token_x_mint: sol_mint,
+                token_y_mint: token_mint,
+                reserve_x: Pubkey::new_unique(),
+                reserve_y: Pubkey::new_unique(),
+                active_id: -281,
+                bin_step: 10,
+                reserve_x_balance: Some(50_000_000_000),
+                reserve_y_balance: Some(1_000_000_000_000),
+            }),
+            100,
+        );
+        cache.set_meteora_dlmm_has_bitmap_extension(&sell_pool, true);
+
+        let rpc = Arc::new(SolanaRpc::new("http://127.0.0.1:0"));
+        let mut handler = CrossDexHandler::new(rpc.clone(), Some(wallet.pubkey()))
+            .with_rpc_url("http://127.0.0.1:0".to_string())
+            .with_pool_cache(cache);
+        handler.init_dexes().await.expect("init_dexes");
+
+        let mut metadata = HashMap::new();
+        metadata.insert("buy_dex".to_string(), "pump_amm".to_string());
+        metadata.insert("sell_dex".to_string(), "meteora_dlmm".to_string());
+        metadata.insert("buy_pool".to_string(), buy_pool.to_string());
+        metadata.insert("sell_pool".to_string(), sell_pool.to_string());
+
+        let buy_accounts: Vec<String> = pump_amm_v14_pool_accounts(buy_pool, token_mint)
+            .into_iter()
+            .map(|p| p.to_string())
+            .collect();
+        let sell_accounts: Vec<String> = vec![
+            sell_pool.to_string(),
+            SOL_MINT.to_string(),
+            token_mint.to_string(),
+            Pubkey::new_unique().to_string(),
+            Pubkey::new_unique().to_string(),
+            "active_id:-281".to_string(),
+            "bin_step:10".to_string(),
+        ];
+        let mut accounts = Vec::new();
+        accounts.push(format!("buy_pool_accounts_start:{}", buy_accounts.len()));
+        accounts.extend(buy_accounts);
+        accounts.push(format!("sell_pool_accounts_start:{}", sell_accounts.len()));
+        accounts.extend(sell_accounts);
+
+        let mut intent = cross_dex_test_intent(&token_mint, &buy_pool, &sell_pool);
+        intent.metadata = metadata;
+        intent.resources.accounts = accounts;
+        if let Some(start_idx) = intent
+            .resources
+            .accounts
+            .iter()
+            .position(|s| s.starts_with("buy_pool_accounts_start:"))
+        {
+            let first_account_idx = start_idx + 2;
+            if first_account_idx < intent.resources.accounts.len() {
+                intent.resources.accounts[first_account_idx] = WRONG_GLOBAL_CONFIG.to_string();
+            }
+        }
+
+        let validation = cross_dex_validation_fixture(&token_mint);
+        let plan = handler
+            .build_swap_plan(
+                &intent,
+                &validation,
+                CrossDexPlanOptions {
+                    skip_token_ata_create: true,
+                },
+            )
+            .await
+            .expect("pump buy cross-dex plan");
+
+        let buy_ix = plan.buy_instructions.first().expect("pump buy leg");
+        assert_eq!(buy_ix.accounts[2].pubkey, canonical_gc);
+
+        let alt = prod_on_chain_alt_fixture();
+        let (tx, _, _, _, plan_ixs) = compile_cross_dex_bundle_tx_prod_alt(&wallet, &plan);
+        // Bundle: CU limit, CU price, Pump buy, Meteora sell, tip → buy at index 2.
+        assert_pump_global_config_prod_alt_compile(&tx, &plan_ixs, &alt, 2, wrong_gc, canonical_gc);
     }
 
     #[tokio::test]

--- a/src/solana/dex_parser.rs
+++ b/src/solana/dex_parser.rs
@@ -8,8 +8,8 @@
 
 use crate::solana::dex::pumpfun::{BondingCurveState, PUMPFUN_BUY_EXACT_SOL_IN_DISCRIMINATOR};
 use crate::solana::dex::pumpfun_amm::{
-    pump_amm_sell_extended_fields_from_ix_accounts, pump_amm_sell_ix_account_len_supported,
-    pump_amm_sell_ix_discriminator,
+    pump_amm_normalize_v14_pool_accounts, pump_amm_sell_extended_fields_from_ix_accounts,
+    pump_amm_sell_ix_account_len_supported, pump_amm_sell_ix_discriminator,
 };
 use crate::solana::geyser_listener::{GeyserAccountUpdate, GeyserTransactionUpdate};
 use rust_decimal::Decimal;
@@ -1451,22 +1451,26 @@ fn parse_pumpfun_amm_transaction(update: &GeyserTransactionUpdate) -> Option<Par
 
     // Pool static accounts in v1 format (14 accounts, includes global_volume_accumulator)
     // See docs/MOMENTUM_V2_SPEC.md section 9.2 and pumpfun_amm.rs build_swap_ix_from_pool_accounts
-    let pool_accounts = vec![
-        pool_market,                  // [0]
-        global_config,                // [1]
-        base_mint,                    // [2]
-        quote_mint,                   // [3]
-        pool_base_vault,              // [4]
-        pool_quote_vault,             // [5]
-        protocol_fee_recipient,       // [6]
-        protocol_fee_recipient_ta,    // [7]
-        event_authority,              // [8]
-        coin_creator_vault_ata,       // [9]
-        coin_creator_vault_authority, // [10]
-        global_volume_accumulator,    // [11] - singleton PDA for SELL; observed for BUY
-        fee_config,                   // [12]
-        fee_program,                  // [13]
-    ];
+    let pool_accounts = {
+        let mut accounts = vec![
+            pool_market,                  // [0]
+            global_config,                // [1]
+            base_mint,                    // [2]
+            quote_mint,                   // [3]
+            pool_base_vault,              // [4]
+            pool_quote_vault,             // [5]
+            protocol_fee_recipient,       // [6]
+            protocol_fee_recipient_ta,    // [7]
+            event_authority,              // [8]
+            coin_creator_vault_ata,       // [9]
+            coin_creator_vault_authority, // [10]
+            global_volume_accumulator,    // [11]
+            fee_config,                   // [12]
+            fee_program,                  // [13]
+        ];
+        pump_amm_normalize_v14_pool_accounts(&pool_market, &mut accounts);
+        accounts
+    };
 
     debug!(
         pool = %pool_market,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Prod run `850e5e06`: tx_plan post-build check passes (`global_config` meta #2 = `ADyA8h…`), but RPC simulation still resolves `T1pyya…` at Anchor slot `global_config` → Custom(3007) (13×).

## Root cause (H2 confirmed)

`address_lookup_table_account(alt, exclude_tip)` shrinks the ALT list for `try_compile`, but lookup indices in the v0 message must reference the **full on-chain LUT** that `simulateTransaction` resolves. With prod ALT (`2J74oVK…`), tip at idx 21, `ADyA8h` at idx 29 — filtered compile wrote index 28, RPC resolved on-chain[28] = wrong pubkey.

## Fix

1. **`remap_v0_alt_lookup_indices_to_on_chain`** — after tip-filter compile, rewrite lookup indices to on-chain positions (keeps Jito static-writable tip behavior from #373).
2. **`audit_pump_amm_global_config_in_versioned_tx`** — pre-sim gate in EE: ix meta #2 vs resolved pubkey + known-bad static keys (`T1pyya…`, `39azUY…`).
3. **Prod-realistic tests** — exact 33-entry mainnet ALT fixture + tip filter; meteora→pump SELL and pump→meteora BUY with wrong `pool_accounts[1]`.
4. **dex_parser** — `pump_amm_normalize_v14_pool_accounts` at write-time (P1b).
5. **Metric** — `pump_amm_compile_global_config_resolve_mismatch_total`.

## STOP-CHECK

- No Hot-Path RPC added (audit/compile only)
- No protocol_fee_recipient kanonisierung (Bug #35)
- #392 normalize preserved

## Verification

```
cargo fmt --check
cargo clippy -- -D warnings
cargo test
```

Eval Level 5 via CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91aea45f-3e26-4f3a-9dda-5555018888df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91aea45f-3e26-4f3a-9dda-5555018888df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

